### PR TITLE
fix: suite and task only mode

### DIFF
--- a/src/reporters/default.ts
+++ b/src/reporters/default.ts
@@ -89,7 +89,7 @@ export class DefaultReporter implements Reporter {
     const { tasks, suites, files } = ctx
     const failedFiles = files.filter(i => i.error)
     const failedSuites = suites.filter(i => i.error)
-    const runable = tasks.filter(i => i.state === 'pass' || i.state === 'fail')
+    const runnable = tasks.filter(i => i.state === 'pass' || i.state === 'fail')
     const passed = tasks.filter(i => i.state === 'pass')
     const failed = tasks.filter(i => i.state === 'fail')
     const skipped = tasks.filter(i => i.state === 'skip')
@@ -122,9 +122,9 @@ export class DefaultReporter implements Reporter {
       })
     }
 
-    console.log(c.bold(c.green(`Passed   ${passed.length} / ${runable.length}`)))
+    console.log(c.bold(c.green(`Passed   ${passed.length} / ${runnable.length}`)))
     if (failed.length)
-      console.log(c.bold(c.red(`Failed   ${failed.length} / ${runable.length}`)))
+      console.log(c.bold(c.red(`Failed   ${failed.length} / ${runnable.length}`)))
     if (skipped.length)
       console.log(c.yellow(`Skipped  ${skipped.length}`))
     if (todo.length)

--- a/src/suite.ts
+++ b/src/suite.ts
@@ -11,7 +11,7 @@ function createSuiteCollector(name: string, factory: TestFactory = () => {}, mod
   const queue: Task[] = []
   const factoryQueue: Task[] = []
 
-  const suiteBase: Pick<Suite, 'name' | 'mode' |'hooks'> = {
+  const suiteBase: Pick<Suite, 'name' | 'mode' | 'hooks'> = {
     name,
     mode,
     hooks: {
@@ -40,13 +40,13 @@ function createSuiteCollector(name: string, factory: TestFactory = () => {}, mod
       name,
       mode,
       suite: {} as Suite,
-      state: mode !== 'run' ? mode : undefined,
+      state: (mode !== 'run' && mode !== 'only') ? mode : undefined,
       fn,
     })
   }
 
   function test(name: string, fn: TestFunction) {
-    collectTask(name, fn, mode)
+    collectTask(name, fn, 'run')
   }
   test.skip = (name: string, fn: TestFunction) => collectTask(name, fn, 'skip')
   test.only = (name: string, fn: TestFunction) => collectTask(name, fn, 'only')


### PR DESCRIPTION
`suite.only` caused the tests to spin indefinitely
`test.only` wasn't working as expected

This PR makes `test.only` work scoped at the suite level (in Jest, at least in the docs is at the file level)

Note: corrected a few typos