### PR TITLE
fix: wait for onStack end

### DIFF
--- a/packages/vitest/src/reporters/error.ts
+++ b/packages/vitest/src/reporters/error.ts
@@ -104,7 +104,7 @@ async function printStack(
     const path = relative(ctx.config.root, frame.file)
 
     ctx.console.log(color(` ${c.dim(F_POINTER)} ${[frame.method, c.dim(`${path}:${pos.line}:${pos.column}`)].filter(Boolean).join(' ')}`))
-    onStack?.(frame, pos)
+    await onStack?.(frame, pos)
 
     // reached at test file, skip the follow stack
     if (frame.file in ctx.state.filesMap)


### PR DESCRIPTION
Before (with solid example)

![image](https://user-images.githubusercontent.com/2922851/145893517-5e4cc772-8e8b-4ef6-b029-9bf02aa66bd5.png)

After

![image](https://user-images.githubusercontent.com/2922851/145893675-22edb90b-c92f-4858-8c5e-a2a829f77914.png)
