### PR TITLE
fix: done(false) should succeed

### DIFF
--- a/packages/vitest/src/runtime/context.ts
+++ b/packages/vitest/src/runtime/context.ts
@@ -45,7 +45,7 @@ function ensureAsyncTest(fn: TestFunction): () => Awaitable<void> {
     return fn as () => Awaitable<void>
 
   return () => new Promise((resolve, reject) => {
-    const done: DoneCallback = (...args: any[]) => args[0] != null
+    const done: DoneCallback = (...args: any[]) => args[0] // rejest on truthy values
       ? reject(args[0])
       : resolve()
     fn(done)

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -48,16 +48,23 @@ test.skip('async with timeout', async() => {
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, timeout)))
 
-let callbackAwaited = false
+function callbackTest(name: string, doneValue: any) {
 
-it('callback setup', (done) => {
-  setTimeout(() => {
-    expect({}).toBeTruthy()
-    callbackAwaited = true
-    done()
-  }, 20)
-})
+  let callbackAwaited = false
 
-it('callback test', () => {
-  expect(callbackAwaited).toBe(true)
-})
+  it('callback setup ' + name, (done) => {
+    setTimeout(() => {
+      expect({}).toBeTruthy()
+      callbackAwaited = true
+      done(doneValue)
+    }, 20)
+  })
+
+  it('callback test ' + name, () => {
+    expect(callbackAwaited).toBe(true)
+  })
+}
+
+callbackTest('success ', undefined)
+
+callbackTest('success done(false)', false)


### PR DESCRIPTION
In [the Jest docs](https://jestjs.io/docs/api#testname-fn-timeout) it says 
> Jest will also wait if you provide an argument to the test function, usually called done.

This is why I used `args.length` instead of `args[0] != null` in #148. 

But testing Jest, it seems that they do a truthy check instead. See [repro](https://stackblitz.com/edit/jest-example-qapj48?file=sum.test.js&view=editor&terminal=test)