### PR TITLE
fix: test.only in nested describe (fix #157)

### DIFF
--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -62,14 +62,6 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
   const tasks = files.reduce((tasks, file) => tasks.concat(file.tasks), [] as (Suite | Test)[])
 
   interpretOnlyMode(tasks)
-  tasks.forEach((i) => {
-    if (i.type === 'suite') {
-      if (i.mode === 'skip')
-        i.tasks.forEach(c => c.mode === 'run' && (c.mode = 'skip'))
-      else
-        interpretOnlyMode(i.tasks)
-    }
-  })
 
   return files
 }

--- a/packages/vitest/src/utils.ts
+++ b/packages/vitest/src/utils.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'module'
 import c from 'picocolors'
-import type { RunMode, Suite, Test, Task, Arrayable, Nullable } from './types'
+import type { Suite, Test, Task, Arrayable, Nullable } from './types'
 
 /**
  * Convert `Arrayable<T>` to `Array<T>`
@@ -44,17 +44,25 @@ export function partitionSuiteChildren(suite: Suite) {
 }
 
 /**
- * If any items been marked as `only`, mark all other items as `skip`.
+ * If any tasks been marked as `only`, mark all other tasks as `skip`.
  */
-export function interpretOnlyMode(items: { mode: RunMode }[]) {
-  if (items.some(i => i.mode === 'only')) {
-    items.forEach((i) => {
-      if (i.mode === 'run')
-        i.mode = 'skip'
-      else if (i.mode === 'only')
-        i.mode = 'run'
+export function interpretOnlyMode(tasks: Task[]) {
+  if (tasks.some(t => t.mode === 'only')) {
+    tasks.forEach((t) => {
+      if (t.mode === 'run')
+        t.mode = 'skip'
+      else if (t.mode === 'only')
+        t.mode = 'run'
     })
   }
+  tasks.forEach((t) => {
+    if (t.type === 'suite') {
+      if (t.mode === 'skip')
+        t.tasks.forEach(c => c.mode === 'run' && (c.mode = 'skip'))
+      else
+        interpretOnlyMode(t.tasks)
+    }
+  })
 }
 
 export function getTests(suite: Arrayable<Suite>): Test[] {

--- a/test/core/test/modes.test.ts
+++ b/test/core/test/modes.test.ts
@@ -76,3 +76,14 @@ describe.concurrent('concurrent suite', () => {
 })
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, timeout)))
+
+describe('test.only in nested described', () => {
+  describe('nested describe', () => {
+    it('skipped test', () => {
+      assert.equal(Math.sqrt(4), 3) // doesn't fails, as the next is it.only
+    })
+    it.only('focus test. Should fails', () => {
+      assert.equal(Math.sqrt(4), 2)
+    })
+  })
+})


### PR DESCRIPTION
We didn't make the `interpretOnlyMode` recursive when adding support for nested suites, test is a simplification from #157