### PR TITLE
fix: when toHaveBeenCalledWith/toBeCalledWith

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -208,6 +208,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       'expected spy to be called with arguments: #{exp}',
       'expected spy to not be called with arguments: #{exp}',
       args,
+      spy.calls,
     )
   })
   const ordinalOf = (i: number) => {

--- a/test/core/test/mock.test.ts
+++ b/test/core/test/mock.test.ts
@@ -27,6 +27,14 @@ describe('mock', () => {
     expect(fn).toHaveBeenCalledWith('Hi', 1)
   })
 
+  it('toHaveBeenCalledWith', () => {
+    const fn = vitest.fn()
+
+    fn('Hi', 2)
+
+    expect(fn).toHaveBeenCalledWith('Hi', 2)
+  })
+
   it('returns', () => {
     let i = 0
 


### PR DESCRIPTION
Fix: when toHaveBeenCalledWith/toBeCalledWith is not showing correct 'actual' value

Current: 

![toHaveBeenCalledWith](https://user-images.githubusercontent.com/8685132/146352163-a016eb0a-7917-4c55-890c-0df19bf0c298.png)

Now 

![fixed-toHaveBeenCalledWith](https://user-images.githubusercontent.com/8685132/146352196-794eefd3-845b-4e48-a05e-4a8b2452a3e9.png)

