### PR TITLE
docs: still in development warning

### DIFF
--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -1,5 +1,9 @@
 # Comparisons with Other Test Runners
 
+:::warning
+**Vitest is still in development and it isn't stable.**<br>It's not recommended to migrate your current testing setups yet.<br>You can try it out in new projects if you are willing to [get involved and help us](https://discord.com/invite/2zYZNngd7y).
+:::
+
 ## Jest
 
 [Jest](https://jestjs.io/) took over the Testing Framework space by providing out-of-the-box support for most JavaScript projects, a comfortable API (`it` and `expect`), and the full pack of testing features that most setups would require (snapshots, mocks, coverage). It is possible to use Jest in Vite setups. [@sodatea](https://twitter.com/haoqunjiang) is building [vite-jest](https://github.com/sodatea/vite-jest#readme), which aims to provide first-class Vite integration for [Jest](https://jestjs.io/). The last [blockers in Jest](https://github.com/sodatea/vite-jest/blob/main/packages/vite-jest/README.md#vite-jest) have been solved so this is a valid option for your unit tests. However, in a world where we have [Vite](https://vitejs.dev) providing support for the most common web tooling (typescript, JSX, most popular UI Frameworks), Jest represents a duplication of complexity. If your app is powered by Vite, having two different pipelines to configure and maintain is not justifiable. With Vitest you get to define the configuration for your dev, build and test environments as a single pipeline, sharing the same plugins and the same vite.config.js. Even if your library is not using Vite (for example, if it is built with esbuild or rollup), Vitest is an interesting option as it gives you a faster run for your unit tests and a jump in DX thanks to the default watch mode using Vite instant Hot Module Reload (HMR). Vitest offers compatibility with most of the Jest API and ecosystem libraries, so in most projects, it should be a drop-in replacement for Jest.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -2,6 +2,10 @@
 
 <FeaturesList class="!gap-1 text-lg" />
 
+:::warning
+**Vitest is still in development and it isn't stable.**<br>It's not recommended to migrate your current testing setups yet.<br>You can try it out in new projects if you are willing to [get involved and help us](https://discord.com/invite/2zYZNngd7y).
+:::
+
 ## Shared config between test, dev and build
 
 Vite's config, transformers, resolvers, and plugins. Use the same setup from your app to run the tests

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -8,15 +8,11 @@ Vitest is a blazing fast unit test framework powered by Vite.
 
 You can learn more about the rationale behind the project in the [Why Vite](./why) section.
 
-:::tip
-💖 **This project is currently in closed beta exclusively for Sponsors.**<br>
-Become a Sponsor of [@patak-dev](https://github.com/sponsors/patak-dev) or [@antfu](https://github.com/sponsors/antfu) to access the source code and issues tracker.
-
+:::warning
+**Vitest is still in development and it isn't stable.**<br>It's not recommended to migrate your current testing setups yet.<br>You can try it out in new projects if you are willing to [get involved and help us](https://discord.com/invite/2zYZNngd7y).
 :::
 
-:::warning
-⚠️ **DISCLAIMER**: Vitest is still in development and not stable yet. It's not recommended to use it in production.
-
+:::tip
 Vitest requires Vite v2.7 and Node v16
 :::
 

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -1,13 +1,10 @@
 # Why Vitest
 
 :::tip NOTE
-
 This guide assumes that you are familiar with Vite. A good way to start learning more is to read the [Why Vite Guide](https://vitejs.dev/guide/why.html), and [Next generation frontend tooling with ViteJS](https://www.youtube.com/watch?v=UJypSr8IhKY), a stream where [Evan You](https://twitter.com/youyuxi) did a demo explaining the main concepts.
-
 :::
 
 ## The need for a Vite native test runner
-
 
 Vite's out-of-the-box support for common web patterns, features like glob imports and SSR primitives, and its many plugins and integrations are fostering a vibrant ecosystem. Its dev and build story are key to its success. For docs, there are several SSG-based alternatives powered by Vite. Vite's Unit Testing story hasn't been clear though. Existing options like [Jest](https://jestjs.io/) were created in a different context. There is a lot of duplication between Jest and Vite, forcing users to configure two different pipelines. 
 
@@ -16,6 +13,10 @@ Using Vite dev server to transform your files during testing, enables the creati
 Given Jest's massive adoption, Vitest provides a compatible API that allows you to use it as a drop-in replacement in most projects. It also includes the most common features required when setting up your unit tests (mocking, snapshots, coverage). Vitest cares a lot about performance and uses Worker threads to run as much as possible in parallel. Some ports have seen test running an order of magnitude faster. Watch mode is enabled by default, aligning itself with the way Vite pushes for a dev first experience. Even with all these improvements in DX, Vitest stays lightweight by carefully choosing its dependencies (or directly inlining needed pieces). 
 
 **Vitest aims to position itself as the Test Runner of choice for Vite projects, and as a solid alternative even for projects not using Vite.**
+
+:::warning
+**Vitest is still in development and it isn't stable.**<br>It's not recommended to migrate your current testing setups yet.<br>You can try it out in new projects if you are willing to [get involved and help us](https://discord.com/invite/2zYZNngd7y).
+:::
 
 Continue reading in the [Getting Started Guide](./index)
 

--- a/docs/src/components/Home.vue
+++ b/docs/src/components/Home.vue
@@ -31,6 +31,14 @@
       </div>
     </div>
 
+    <p text="1.4em center yellow-500" leading-7 op60 font-normal tracking-wide>
+      Vitest is still in development and it isn't stable
+    </p>
+
+    <p text="1em center" leading-7 op60 font-normal tracking-wide>
+      It's not recommended to migrate your current testing setups yet<br>You can try it out in new projects if you are willing to get involved and help us
+    </p>
+
     <h3 op50 font-normal pt-10>
       Features
     </h3>


### PR DESCRIPTION
Removes closed beta banner and adds warnings in the docs and frontpage about Vitest being still in development