### PR TITLE
docs: collaborators

### DIFF
--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -5,6 +5,8 @@
 declare module 'vue' {
   export interface GlobalComponents {
     Avatar: typeof import('./src/components/Avatar.vue')['default']
+    CollaboratorAvatar: typeof import('./src/components/CollaboratorAvatar.vue')['default']
+    Collaborators: typeof import('./src/components/Collaborators.vue')['default']
     FeaturesList: typeof import('./src/components/FeaturesList.vue')['default']
     Home: typeof import('./src/components/Home.vue')['default']
     ListItem: typeof import('./src/components/ListItem.vue')['default']

--- a/docs/src/collaborators.json
+++ b/docs/src/collaborators.json
@@ -1,0 +1,22 @@
+[
+    {
+        "login": "antfu",
+        "name": "Anthony Fu",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/11247099"
+    },
+    {
+        "login": "patak-dev",
+        "name": "patak",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/583075"
+    },
+    {
+        "login": "Aslemammad",
+        "name": "M. Bagher Abiat",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/37929992"
+    },
+    {
+        "login": "sheremet-va",
+        "name": "Vladimir",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/16173870"
+    }
+]

--- a/docs/src/components/CollaboratorAvatar.vue
+++ b/docs/src/components/CollaboratorAvatar.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineProps<{
+  avatar: string
+  name: string
+  login: string
+}>()
+</script>
+
+<template>
+  <a :href="`https://github.com/${login}`" target="_blank">
+    <img :title="name" :src="avatar" rounded-full h-16 w-16>
+  </a>
+</template>

--- a/docs/src/components/Collaborators.vue
+++ b/docs/src/components/Collaborators.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import collaborators from '../collaborators.json'
+</script>
+
+<template>
+  <div flex="~ wrap gap-5" justify-center p-5>
+    <CollaboratorAvatar v-for="c in collaborators" :key="c.login" :login="c.login" :name="c.name" :avatar="c.avatarUrl" />
+  </div>
+</template>

--- a/docs/src/components/Home.vue
+++ b/docs/src/components/Home.vue
@@ -39,25 +39,7 @@
     <h3 id="made-by" op50 font-normal pt-5 pb-2>
       Made by
     </h3>
-    <div grid="~ sm:cols-2 gap-x-10 gap-y-20" p-10>
-      <Avatar
-        name="Anthony Fu"
-        desc=""
-        avatar="https://antfu.me/avatar.png"
-        github="antfu"
-        twitter="antfu7"
-      >
-        A fanatical open sourceror.<br>Core team member of Vite & Vue.<br>Working at NuxtLabs.
-      </Avatar>
-      <Avatar
-        name="Patak"
-        avatar="https://patak.dev/images/patak.jpg"
-        github="patak-dev"
-        twitter="patak_dev"
-      >
-        A collaborative being.<br>Core team member of Vite.<br>Team member of Vue.
-      </Avatar>
-    </div>
+    <Collaborators />
     <p op80 text-lg max-w-150 text-center leading-7>
       ...and the Vitest <a href="https://github.com/antfu-sponsors/vitest/network/dependencies" target="_blank">contributors</a>.<br><br>
       <a href="https://discord.com/invite/2zYZNngd7y">Join the community</a> and get involved!


### PR DESCRIPTION
Replace big avatars with sponsoring call to action with a collaborators list, that links to the github profile of each contributor. Right now I added the top 4 contributors by hand, but a possible idea is to auto-generate the collaborators.json with the top N (or the ones that have at least M commits). When auto-generating, the avatarUrl should be base64 encoded. 