### PR TITLE
chore: team avatars tweak

### DIFF
--- a/docs/src/components/Avatar.vue
+++ b/docs/src/components/Avatar.vue
@@ -33,7 +33,7 @@ defineProps<{
     <br>
     <a
       v-if="sponsors"
-      class="btn mt-5 bg-pink-500 hover:bg-pink-600"
+      class="btn mt-1 bg-pink-500 hover:bg-pink-600"
       target="_blank"
       :href="`https://github.com/sponsors/${github}`"
     >

--- a/docs/src/components/Home.vue
+++ b/docs/src/components/Home.vue
@@ -52,7 +52,7 @@
     <h3 id="meet-the-team" op50 font-normal pt-5 pb-2>
       Meet The Team
     </h3>
-    <div grid="~ sm:cols-2 lg:cols-4 gap-x-8 gap-y-20 items-center" p-10>
+    <div grid="~ sm:cols-2 gap-x-8 gap-y-20 items-center" p-10>
       <Avatar
         name="Anthony Fu"
         avatar="https://antfu.me/avatar.png"


### PR DESCRIPTION
Avoid going to 4 cols for the team avatars. Now that we have the bios for all four, it looks unbalanced when using a wide screen. I think 2 cols looks better here. Also reduce a bit the sponsors button margin so it is more integrated with the bio