### PR TITLE
test: speed up timers.test.ts

### DIFF
--- a/test/core/test/timers.test.ts
+++ b/test/core/test/timers.test.ts
@@ -46,8 +46,8 @@ test('timeout', async() => {
 
   vi.useFakeTimers()
 
-  setTimeout(t, 1000)
-  const timeout = setTimeout(t, 1000)
+  setTimeout(t, 50)
+  const timeout = setTimeout(t, 50)
   clearTimeout(timeout)
 
   vi.runOnlyPendingTimers()
@@ -61,13 +61,13 @@ test('advance timeout', () => {
 
   vi.useFakeTimers()
 
-  setTimeout(t, 1000)
+  setTimeout(t, 50)
 
-  vi.advanceTimersByTime(500)
+  vi.advanceTimersByTime(25)
 
   expect(t).not.toBeCalled()
 
-  vi.advanceTimersByTime(500)
+  vi.advanceTimersByTime(25)
 
   expect(t).toBeCalledTimes(1)
 
@@ -75,41 +75,41 @@ test('advance timeout', () => {
 })
 
 test('advance nested timeout', () => {
-  const t600 = vi.fn()
-  const t100 = vi.fn(() => {
-    setTimeout(t600, 600)
+  const t60 = vi.fn()
+  const t10 = vi.fn(() => {
+    setTimeout(t60, 60)
   })
-  const t50 = vi.fn(() => {
-    setTimeout(t100, 100)
+  const t5 = vi.fn(() => {
+    setTimeout(t10, 10)
   })
   const t = vi.fn(() => {
-    setTimeout(t50, 50)
+    setTimeout(t5, 5)
   })
 
   vi.useFakeTimers()
 
   setTimeout(t, 0)
 
-  vi.advanceTimersByTime(30)
+  vi.advanceTimersByTime(3)
 
   expect(t).toBeCalled()
-  expect(t50).not.toBeCalled()
+  expect(t5).not.toBeCalled()
 
-  vi.advanceTimersByTime(200)
+  vi.advanceTimersByTime(20)
 
   expect(t).toBeCalledTimes(1)
-  expect(t50).toBeCalledTimes(1)
-  expect(t100).toBeCalledTimes(1)
+  expect(t5).toBeCalledTimes(1)
+  expect(t10).toBeCalledTimes(1)
 
-  expect(t600).not.toBeCalled()
+  expect(t60).not.toBeCalled()
 
-  vi.advanceTimersByTime(519)
+  vi.advanceTimersByTime(51)
 
-  expect(t600).not.toBeCalled()
+  expect(t60).not.toBeCalled()
 
   vi.advanceTimersByTime(1)
 
-  expect(t600).toBeCalledTimes(1)
+  expect(t60).toBeCalledTimes(1)
 })
 
 test('doesnt trigger twice', () => {
@@ -126,7 +126,7 @@ test('doesnt trigger twice', () => {
   expect(t).toBeCalledTimes(1)
 })
 
-test('timeout cyclic', async() => {
+test.skip('timeout cyclic', async() => {
   const t = vi.fn(() => {
     setTimeout(t, timeout)
   })
@@ -211,12 +211,12 @@ test('async timer', async() => {
   setTimeout(async() => {
     await Promise.resolve()
     res.push('item1')
-  }, 1000)
+  }, 100)
 
   setTimeout(async() => {
     await Promise.resolve()
     res.push('item2')
-  }, 1000)
+  }, 100)
 
   await vi.runAllTimers()
   vi.useRealTimers()


### PR DESCRIPTION
The timeout were not small enough, and this test makes it looks like the full test suite is slow. This also skips the `timeout cyclic` test. We should find another way to test it that doesn't blocks the full suite