### PR TITLE
test: fix `lit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "bumpp package.json packages/*/package.json --commit --push --tag && pnpm -r publish",
     "test": "vitest -r test/core",
     "test:all": "cross-env CI=true pnpm -r --stream --filter !vitest run test --",
-    "test:ci": "cross-env CI=true pnpm -r --stream --filter !vitest --filter !@vitest/test-fails --filter !@vitest/test-lit run test --",
+    "test:ci": "cross-env CI=true pnpm -r --stream --filter !vitest --filter !@vitest/test-fails run test --",
     "typecheck": "pnpm -r --parallel run typecheck",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui"

--- a/test/lit/test/basic.test.ts
+++ b/test/lit/test/basic.test.ts
@@ -9,12 +9,8 @@ declare global {
 
 describe('Button with increment', async() => {
   beforeEach(async() => {
+    // todo@to-be-removed: https://github.com/vitest-dev/vitest/pull/234
     Object.defineProperty(Element.prototype, 'localName', {
-      /**
-       * Local name.
-       *
-       * @returns Local name.
-       */
       get() {
         return this.tagName?.toLowerCase() ?? 'unknown'
       },

--- a/test/lit/test/basic.test.ts
+++ b/test/lit/test/basic.test.ts
@@ -9,6 +9,19 @@ declare global {
 
 describe('Button with increment', async() => {
   beforeEach(async() => {
+    Object.defineProperty(Element.prototype, 'localName', {
+      /**
+       * Local name.
+       *
+       * @returns Local name.
+       */
+      get() {
+        return this.tagName?.toLowerCase() ?? 'unknown'
+      },
+      enumerable: false,
+      configurable: true,
+    })
+
     document.body.innerHTML = ''
 
     await window.happyDOM.whenAsyncComplete()


### PR DESCRIPTION
After some testing it seems there is a problem on `happy-dom` with custom elements and `reactive-element` library.

`reactive-element` has a `DEV_MODE` flag that is initialized to `true` (`const DEV_MODE = true;`), that forces to eval the `localName` of the custom element (line 652 on `node_modules/.pnpm/@lit+reactive-element@1.0.2/node_modules/@lit/reactive-element/development/reactive-element.js`).

Since `happy-dom` uses `this.tagName.toLowerCase()` on the `localName` getter (line 112 on `node_modules/.pnpm/happy-dom@2.25.0/node_modules/happy-dom/lib/nodes/element/Element.js`), then we got the error `TypeError: Cannot read properties of null (reading 'toLowerCase')` because the `tagName` is missing from the custom element.

I will send also a PR to fix it on `happy-dom`.