### PR TITLE
chore: improve type definition to avoid any

### DIFF
--- a/scripts/get-contributors.ts
+++ b/scripts/get-contributors.ts
@@ -4,8 +4,8 @@ import fetch from 'node-fetch'
 const { GITHUB_TOKEN: token } = process.env
 
 type Contributor = {
-  login: string;
-};
+  login: string
+}
 
 async function fetchContributors() {
   const collaborators: string[] = []
@@ -16,8 +16,8 @@ async function fetchContributors() {
       'content-type': 'application/json',
     },
   })
-  const data = await res.json() as Contributor[];
-  collaborators.push(...data.map((i) => i.login))
+  const data = await res.json() as Contributor[]
+  collaborators.push(...data.map(i => i.login))
   return collaborators
 }
 

--- a/scripts/get-contributors.ts
+++ b/scripts/get-contributors.ts
@@ -3,6 +3,28 @@ import fetch from 'node-fetch'
 
 const { GITHUB_TOKEN: token } = process.env
 
+type Contributor = {
+  login: string;
+  id: number;
+  node_id: string;
+  avatar_url: string;
+  gravatar_id: string;
+  url: string;
+  html_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  starred_url: string;
+  subscriptions_url: string;
+  organizations_url: string;
+  repos_url: string;
+  events_url: string;
+  received_events_url: string;
+  type: string;
+  site_admin: boolean;
+  contributions: number;
+};
+
 async function fetchContributors() {
   const collaborators: string[] = []
   const res = await fetch('https://api.github.com/repos/antfu-sponsors/vitest/contributors', {
@@ -12,8 +34,8 @@ async function fetchContributors() {
       'content-type': 'application/json',
     },
   })
-  const data: any = await res.json()
-  collaborators.push(...data.map((i: any) => i.login))
+  const data = await res.json() as Contributor[];
+  collaborators.push(...data.map((i) => i.login))
   return collaborators
 }
 

--- a/scripts/get-contributors.ts
+++ b/scripts/get-contributors.ts
@@ -5,24 +5,6 @@ const { GITHUB_TOKEN: token } = process.env
 
 type Contributor = {
   login: string;
-  id: number;
-  node_id: string;
-  avatar_url: string;
-  gravatar_id: string;
-  url: string;
-  html_url: string;
-  followers_url: string;
-  following_url: string;
-  gists_url: string;
-  starred_url: string;
-  subscriptions_url: string;
-  organizations_url: string;
-  repos_url: string;
-  events_url: string;
-  received_events_url: string;
-  type: string;
-  site_admin: boolean;
-  contributions: number;
 };
 
 async function fetchContributors() {


### PR DESCRIPTION
According to the GitHub Rest API [doc](https://docs.github.com/en/rest/reference/repos#list-repository-contributors), add response data type to avoid any.