### PR TITLE
Remove that wierd x-axis scrollbar in main page

### DIFF
--- a/docs/main.css
+++ b/docs/main.css
@@ -26,6 +26,7 @@ main.home ul > li:hover {
 
 main.home {
   position: relative;
+  overflow-x: hidden;
 }
 
 main.home::before {


### PR DESCRIPTION
Current behavior:
![0odUxxY](https://user-images.githubusercontent.com/35312043/146825882-44ce0bf7-d89f-49b5-a4b6-e20f6450eb83.png)

Expected behavior:
![image](https://user-images.githubusercontent.com/35312043/146825959-1aae63e6-fde9-47ea-9455-34b243fae2e6.png)
