### PR TITLE
chore: antfu-sponsors -> vitest-dev

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -40,12 +40,12 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 
 ## Examples
 
-- [Unit Testing](https://github.com/antfu-sponsors/vitest/tree/main/test/core)
-- [Vue Component Testing](https://github.com/antfu-sponsors/vitest/tree/main/test/vue)
-- [React Component Testing](https://github.com/antfu-sponsors/vitest/tree/main/test/react)
-- [Svelte Component Testing](https://github.com/antfu-sponsors/vitest/tree/main/test/svelte)
-- [Lit Component Testing](https://github.com/antfu-sponsors/vitest/tree/main/test/lit)
-- [Vitesse Component Testing](https://github.com/antfu-sponsors/vitest/tree/main/test/vitesse)
+- [Unit Testing](https://github.com/vitest-dev/vitest/tree/main/test/core)
+- [Vue Component Testing](https://github.com/vitest-dev/vitest/tree/main/test/vue)
+- [React Component Testing](https://github.com/vitest-dev/vitest/tree/main/test/react)
+- [Svelte Component Testing](https://github.com/vitest-dev/vitest/tree/main/test/svelte)
+- [Lit Component Testing](https://github.com/vitest-dev/vitest/tree/main/test/lit)
+- [Vitesse Component Testing](https://github.com/vitest-dev/vitest/tree/main/test/vitesse)
 
 ## Projects using Vitest
 
@@ -56,10 +56,10 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 
 ## Using Unreleased Commits
 
-If you can't wait for a new release to test the latest features, you will need to clone the [vitest repo](https://github.com/antfu-sponsors/vitest) to your local machine and then build and link it yourself ([pnpm](https://pnpm.io/) is required):
+If you can't wait for a new release to test the latest features, you will need to clone the [vitest repo](https://github.com/vitest-dev/vitest) to your local machine and then build and link it yourself ([pnpm](https://pnpm.io/) is required):
 
 ```bash
-git clone https://github.com/antfu-sponsors/vitest.git
+git clone https://github.com/vitest-dev/vitest.git
 cd vite
 pnpm install
 cd packages/vitest
@@ -71,4 +71,4 @@ Then go to the project where you are using Vitest and run `pnpm link --global vi
 
 ## Community
 
-If you have questions or need help, reach out to the community at [Discord](https://chat.vitest.dev) and [GitHub Discussions](https://github.com/antfu-sponsors/vitest/discussions).
+If you have questions or need help, reach out to the community at [Discord](https://chat.vitest.dev) and [GitHub Discussions](https://github.com/vitest-dev/vitest/discussions).

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -58,7 +58,7 @@ export function createWorkerPool(ctx: Vitest): WorkerPool {
   const options: TinypoolOptions = {
     filename: workerPath,
     // Disable this for now, for WebContainer capability
-    // https://github.com/antfu-sponsors/vitest/issues/93
+    // https://github.com/vitest-dev/vitest/issues/93
     // In future we could conditionally enable it based on the env
     useAtomics: false,
   }

--- a/scripts/get-contributors.ts
+++ b/scripts/get-contributors.ts
@@ -9,7 +9,7 @@ type Contributor = {
 
 async function fetchContributors() {
   const collaborators: string[] = []
-  const res = await fetch('https://api.github.com/repos/antfu-sponsors/vitest/contributors', {
+  const res = await fetch('https://api.github.com/repos/vitest-dev/vitest/contributors', {
     method: 'get',
     headers: {
       'authorization': `bearer ${token}`,


### PR DESCRIPTION
Since the repo moved to vitest-dev, this PR replaces `antfu-sponsors/vitest` with `vitest-dev/vitest`.