### PR TITLE
refactor!: renaming mockdate methods

### DIFF
--- a/docs/guide/mocking-date.md
+++ b/docs/guide/mocking-date.md
@@ -4,7 +4,7 @@ Vitest comes with [`mockdate`](https://www.npmjs.com/package/mockdate) package t
 
 All useful methods are located on `vi` object that you can import from `vitest` package or access globally, if you have [`global`](/config/#global) config enabled.
 
-## setSystemDate
+## mockCurrentDate
 
 - **Type**: `(date: string | number | Date) => void`
 
@@ -15,18 +15,18 @@ Useful if you need to test anything that depends on the current date - for examp
 ```ts
 const date = new Date(1998, 11, 19)
 
-vi.setSystemDate(date)
+vi.mockCurrentDate(date)
 
 expect(Date.now()).toBe(date.valueOf())
 ```
 
-## getSystemDate
+## getMockedDate
 
 - **Type**: `() => string | number | Date`
 
-Returns current date that was set using `setSystemDate`. If date is not mocked, will return real date in milliseconds.
+Returns mocked current date that was set using `mockCurrentDate`. If date is not mocked, will return `null`.
 
-## resetSystemDate
+## restoreCurrentDate
 
 - **Type**: `() => void`
 

--- a/packages/vitest/src/integrations/utils.ts
+++ b/packages/vitest/src/integrations/utils.ts
@@ -7,11 +7,11 @@ import { fn, spies, spyOn } from './jest-mock'
 
 class VitestUtils {
   private _timers: FakeTimers
-  private _systemDate: string | number | Date | null
+  private _mockedDate: string | number | Date | null
 
   constructor() {
     this._timers = new FakeTimers()
-    this._systemDate = null
+    this._mockedDate = null
   }
 
   // timers
@@ -46,18 +46,18 @@ class VitestUtils {
 
   // date
 
-  public setSystemDate(date: string | number | Date) {
-    this._systemDate = date
+  public mockCurrentDate(date: string | number | Date) {
+    this._mockedDate = date
     mockdate.set(date)
   }
 
-  public resetSystemDate() {
-    this._systemDate = null
+  public restoreCurrentDate() {
+    this._mockedDate = null
     mockdate.reset()
   }
 
-  public getSystemDate() {
-    return this._systemDate || Date.now()
+  public getMockedDate() {
+    return this._mockedDate
   }
 
   // mocks

--- a/test/core/test/date-mock.test.ts
+++ b/test/core/test/date-mock.test.ts
@@ -2,34 +2,34 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 
 describe('testing date mock functionality', () => {
   afterEach(() => {
-    vi.resetSystemDate()
+    vi.restoreCurrentDate()
   })
 
   test('seting time in the past', () => {
     const date = new Date(2000, 1, 1)
 
-    vi.setSystemDate(date)
+    vi.mockCurrentDate(date)
 
     expect(Date.now()).toBe(date.valueOf())
-    expect(vi.getSystemDate()).toBe(date)
+    expect(vi.getMockedDate()).toBe(date)
 
-    vi.resetSystemDate()
+    vi.restoreCurrentDate()
 
     expect(Date.now()).not.toBe(date.valueOf())
-    expect(vi.getSystemDate()).not.toBe(date)
+    expect(vi.getMockedDate()).not.toBe(date)
   })
 
   test('setting time in different types', () => {
     const time = 1234567890
 
-    vi.setSystemDate(time)
+    vi.mockCurrentDate(time)
 
     expect(Date.now()).toBe(time)
 
     const timeStr = 'Fri Feb 20 2015 19:29:31 GMT+0530'
     const timeStrMs = 1424440771000
 
-    vi.setSystemDate(timeStr)
+    vi.mockCurrentDate(timeStr)
 
     expect(Date.now()).toBe(timeStrMs)
   })


### PR DESCRIPTION
Renaming mockdate methods to inline them with timer mocks.

Also now they should not confuse people coming from jest and using theirs `jest.setSystemTime` method, that works with timer mocks and not `Date`.