### PR TITLE
feat(examples): added simple hook counter example

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,7 @@ importers:
     specifiers:
       '@testing-library/jest-dom': ^5.16.1
       '@testing-library/react': ^12.1.2
+      '@testing-library/react-hooks': ^7.0.2
       '@testing-library/user-event': ^13.5.0
       '@types/react': ^17.0.37
       '@types/react-dom': ^17.0.11
@@ -358,6 +359,7 @@ importers:
     devDependencies:
       '@testing-library/jest-dom': 5.16.1
       '@testing-library/react': 12.1.2_react-dom@17.0.2+react@17.0.2
+      '@testing-library/react-hooks': 7.0.2_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 13.5.0
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
@@ -1570,6 +1572,28 @@ packages:
       dom-accessibility-api: 0.5.10
       lodash: 4.17.21
       redent: 3.0.0
+    dev: true
+
+  /@testing-library/react-hooks/7.0.2_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+      react-test-renderer: '>=16.9.0'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.16.3
+      '@types/react': 17.0.37
+      '@types/react-dom': 17.0.11
+      '@types/react-test-renderer': 17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-error-boundary: 3.1.4_react@17.0.2
     dev: true
 
   /@testing-library/react/12.1.2_react-dom@17.0.2+react@17.0.2:
@@ -5742,6 +5766,16 @@ packages:
       react: 17.0.2
       scheduler: 0.20.2
     dev: false
+
+  /react-error-boundary/3.1.4_react@17.0.2:
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.16.3
+      react: 17.0.2
+    dev: true
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}

--- a/test/testing-lib-react/package.json
+++ b/test/testing-lib-react/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^13.5.0",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",

--- a/test/testing-lib-react/src/App.test.tsx
+++ b/test/testing-lib-react/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { describe, expect, it } from 'vitest'
 import { fireEvent, render, screen } from './utils/test-utils'
 import App from './App'

--- a/test/testing-lib-react/src/App.tsx
+++ b/test/testing-lib-react/src/App.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react'
+import { useCounter } from './hooks/useCounter'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { count, increment } = useCounter()
 
   return (
     <div className="App">
@@ -11,7 +11,7 @@ function App() {
         <p>
           <button
             type="button"
-            onClick={() => setCount(count => count + 1)}
+            onClick={increment}
           >
             count is: {count}
           </button>

--- a/test/testing-lib-react/src/hooks/useCounter.test.ts
+++ b/test/testing-lib-react/src/hooks/useCounter.test.ts
@@ -1,0 +1,12 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import { useCounter } from './useCounter'
+
+describe('useCounter', () => {
+  it('should increment counter', () => {
+    const { result } = renderHook(() => useCounter())
+    act(() => {
+      result.current.increment()
+    })
+    expect(result.current.count).toBe(1)
+  })
+})

--- a/test/testing-lib-react/src/hooks/useCounter.ts
+++ b/test/testing-lib-react/src/hooks/useCounter.ts
@@ -1,0 +1,7 @@
+import { useCallback, useState } from 'react'
+
+export const useCounter = () => {
+  const [count, setCount] = useState(0)
+  const increment = useCallback(() => setCount(x => x + 1), [])
+  return { count, increment }
+}


### PR DESCRIPTION
As per the title, added a simple useCounter example to the already existing react-testing-library setup.

Example was taken directly [from here](https://github.com/testing-library/react-hooks-testing-library) so I think it provides a solid starting point.