### PR TITLE
fix: asymmetric matcher diffting message

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-asymmetric-matchers.ts
+++ b/packages/vitest/src/integrations/chai/jest-asymmetric-matchers.ts
@@ -14,6 +14,8 @@ export abstract class AsymmetricMatcher<
   T,
   State extends MatcherState = MatcherState,
 > implements AsymmetricMatcherInterface {
+  $$typeof = Symbol.for('jest.asymmetricMatcher')
+
   constructor(protected sample: T, protected inverse = false) {}
 
   protected getMatcherContext(): State {


### PR DESCRIPTION
When we use `pretty-format` to display the error messages. It not applying the plugins correctly. 
Pretty-format will search for a plugin reading the `$$typeof` from [Asymmetric object](https://github.com/facebook/jest/blob/main/packages/pretty-format/src/plugins/AsymmetricMatcher.ts#L92)

Test example:

```javascript
expect('string').not.toEqual(expect.any(Number))
```

Generate this diff message:

![any-string](https://user-images.githubusercontent.com/8685132/147259180-bcc3f1fa-8cf2-47e6-8bda-c2f830648674.png)

Now:

![now-expect](https://user-images.githubusercontent.com/8685132/147259203-9c2ca581-9b0d-488e-b82a-df42796bf209.png)

And with objects

![expect-asymetric-object](https://user-images.githubusercontent.com/8685132/147259228-d7db98de-ce26-4b3f-b3dc-85d318ddb6ee.png)

Now:
![expect-now-object](https://user-images.githubusercontent.com/8685132/147259244-994392f8-8e13-42f0-a26a-3d3919a5e77a.png)



