### PR TITLE
fix: update `vitest` filter on `test:*` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint:fix": "eslint --ext .js,.vue,.ts . --fix",
     "release": "bumpp package.json packages/*/package.json --commit --push --tag && pnpm -r publish",
     "test": "vitest -r test/core",
-    "test:all": "cross-env CI=true pnpm -r --stream --filter !vitest run test --",
-    "test:ci": "cross-env CI=true pnpm -r --stream --filter !vitest --filter !@vitest/test-fails run test --",
+    "test:all": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo run test --",
+    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !@vitest/test-fails run test --",
     "typecheck": "pnpm -r --parallel run typecheck",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui"


### PR DESCRIPTION
It seems there was a renaming on the package name, and the scripts for `test:ci` and `test:all` are still filtering the old name, causing problem on windows.