### PR TITLE
Fix: when there are not __mocks__ folder

### DIFF
--- a/packages/vitest/src/node/mocker.ts
+++ b/packages/vitest/src/node/mocker.ts
@@ -14,9 +14,10 @@ function resolveMockPath(mockPath: string, root: string, nmName: string | null) 
   // all mocks should be inside <root>/__mocks__
   if (nmName) {
     const mockFolder = resolve(root, '__mocks__')
-    const files = readdirSync(mockFolder)
 
     if (!existsSync(mockFolder)) return null
+
+    const files = readdirSync(mockFolder)
 
     for (const file of files) {
       const [basename] = file.split('.')

--- a/packages/vitest/src/node/mocker.ts
+++ b/packages/vitest/src/node/mocker.ts
@@ -16,6 +16,8 @@ function resolveMockPath(mockPath: string, root: string, nmName: string | null) 
     const mockFolder = resolve(root, '__mocks__')
     const files = readdirSync(mockFolder)
 
+    if (!existsSync(mockFolder)) return null
+
     for (const file of files) {
       const [basename] = file.split('.')
       if (basename === nmName)


### PR DESCRIPTION
How to reproduce:

Remove `__mocks__` directory over `/test/mocks/__mocks__`. Then run only `mocks` tests. You will see:

![image](https://user-images.githubusercontent.com/8685132/147391736-401879db-4d8e-41d4-8a41-5756b7e37255.png)
