### PR TITLE
Fix: prevent infinte loop when an error has circular references

### DIFF
--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -19,7 +19,7 @@ export function serializeError(val: any, seen = new WeakSet()): any {
   if (typeof val.asymmetricMatch === 'function')
     return `${val.toString()} ${format(val.sample)}`
 
-  if (!seen.has(val))
+  if (seen.has(val))
     return val
 
   seen.add(val)

--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -2,7 +2,7 @@ import { format } from 'util'
 import { stringify } from '../integrations/chai/jest-matcher-utils'
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
-export function serializeError(val: any): any {
+export function serializeError(val: any, seen = new WeakSet()): any {
   if (!val || typeof val === 'string')
     return val
 
@@ -10,6 +10,7 @@ export function serializeError(val: any): any {
     return `Function<${val.name}>`
   if (typeof val !== 'object')
     return val
+
   if (val instanceof Promise || 'then' in val || (val.constructor && val.constructor.prototype === 'AsyncFunction'))
     return 'Promise'
   if (typeof Element !== 'undefined' && val instanceof Element)
@@ -18,8 +19,13 @@ export function serializeError(val: any): any {
   if (typeof val.asymmetricMatch === 'function')
     return `${val.toString()} ${format(val.sample)}`
 
+  if (!seen.has(val))
+    return val
+
+  seen.add(val)
+
   Object.keys(val).forEach((key) => {
-    val[key] = serializeError(val[key])
+    val[key] = serializeError(val[key], seen)
   })
 
   return val


### PR DESCRIPTION
Relates to https://github.com/vitest-dev/vitest/issues/284

When there are no axios mock in `__mocks__` folder. Vitest do not mock axios module, so axios throw `Error: connect ECONNREFUSED 127.0.0.1:80`.

This error has Circular references to it so `serializeError` enters in a recursive call.

![image](https://user-images.githubusercontent.com/8685132/147392164-9256cd3a-5efa-48c8-9677-3b6f33cb7769.png)

Now:

![image](https://user-images.githubusercontent.com/8685132/147392170-26f9a490-0c8d-4b31-9da3-0d87238653cc.png)
 