### PR TITLE
fix: compatibility with `jest`'s `toStrictEqual`

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -97,11 +97,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
 
   def('toStrictEqual', function(expected) {
-    const test1 = iterableEquality(this, expected)
-    if (typeof test1 === 'boolean') return test1
-    const test2 = typeEquality(this, expected)
-    if (typeof test2 === 'boolean') return test2
-    return this.toEqual(expected)
+    return iterableEquality(this, expected) ?? typeEquality(this, expected)
   })
   def('toBe', function(expected) {
     return this.equal(expected)

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -1,6 +1,6 @@
 import type { Spy } from 'tinyspy'
 import type { ChaiPlugin } from './types'
-import { equals as asymmetricEquals, hasAsymmetric } from './jest-utils'
+import { equals as asymmetricEquals, hasAsymmetric, iterableEquality, typeEquality } from './jest-utils'
 
 type MatcherState = {
   assertionCalls: number
@@ -97,7 +97,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
 
   def('toStrictEqual', function(expected) {
-    return this.chaiEqual(expected)
+    const test1 = iterableEquality(this, expected)
+    if (typeof test1 === 'boolean') return test1
+    const test2 = typeEquality(this, expected)
+    if (typeof test2 === 'boolean') return test2
+    return this.toEqual(expected)
   })
   def('toBe', function(expected) {
     return this.equal(expected)

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -1,6 +1,6 @@
 import type { Spy } from 'tinyspy'
 import type { ChaiPlugin } from './types'
-import { equals as asymmetricEquals, hasAsymmetric, iterableEquality, typeEquality } from './jest-utils'
+import { arrayBufferEquality, equals as asymmetricEquals, hasAsymmetric, iterableEquality, sparseArrayEquality, typeEquality } from './jest-utils'
 
 type MatcherState = {
   assertionCalls: number
@@ -97,7 +97,12 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
 
   def('toStrictEqual', function(expected) {
-    return iterableEquality(this, expected) ?? typeEquality(this, expected)
+    return (
+      iterableEquality(this, expected)
+      ?? typeEquality(this, expected)
+      ?? sparseArrayEquality(this, expected)
+      ?? arrayBufferEquality(this, expected)
+    )
   })
   def('toBe', function(expected) {
     return this.equal(expected)

--- a/packages/vitest/src/integrations/chai/jest-utils.ts
+++ b/packages/vitest/src/integrations/chai/jest-utils.ts
@@ -471,3 +471,41 @@ export const typeEquality = (a: any, b: any): boolean | undefined => {
 
   return false
 }
+
+export const arrayBufferEquality = (
+  a: unknown,
+  b: unknown,
+): boolean | undefined => {
+  if (!(a instanceof ArrayBuffer) || !(b instanceof ArrayBuffer))
+    return undefined
+
+  const dataViewA = new DataView(a)
+  const dataViewB = new DataView(b)
+
+  // Buffers are not equal when they do not have the same byte length
+  if (dataViewA.byteLength !== dataViewB.byteLength)
+    return false
+
+  // Check if every byte value is equal to each other
+  for (let i = 0; i < dataViewA.byteLength; i++) {
+    if (dataViewA.getUint8(i) !== dataViewB.getUint8(i))
+      return false
+  }
+
+  return true
+}
+
+export const sparseArrayEquality = (
+  a: unknown,
+  b: unknown,
+): boolean | undefined => {
+  if (!Array.isArray(a) || !Array.isArray(b))
+    return undefined
+
+  // A sparse array [, , 1] will have keys ["2"] whereas [undefined, undefined, 1] will have keys ["0", "1", "2"]
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  return (
+    equals(a, b, [iterableEquality, typeEquality], true) && equals(aKeys, bKeys)
+  )
+}

--- a/packages/vitest/src/integrations/chai/jest-utils.ts
+++ b/packages/vitest/src/integrations/chai/jest-utils.ts
@@ -464,3 +464,10 @@ export const subsetEquality = (
 
   return subsetEqualityWithContext()(object, subset)
 }
+
+export const typeEquality = (a: any, b: any): boolean | undefined => {
+  if (a == null || b == null || a.constructor === b.constructor)
+    return undefined
+
+  return false
+}

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable comma-spacing */
+/* eslint-disable no-sparse-arrays */
 import { describe, expect, it } from 'vitest'
 
 describe('jest-expect', () => {
@@ -125,9 +127,7 @@ describe('jest-expect', () => {
   // https://jestjs.io/docs/expect#tostrictequalvalue
 
   class LaCroix {
-    constructor(flavor) {
-      this.flavor = flavor
-    }
+    constructor(public flavor) {}
   }
 
   describe('the La Croix cans on my desk', () => {
@@ -159,6 +159,104 @@ describe('jest-expect', () => {
         bar: { foo: 'foo', bar: 100, arr: ['first', { zoo: 'monkey' }] },
       },
     ])
+  })
+})
+
+describe('.toStrictEqual()', () => {
+  class TestClassA {
+    constructor(public a, public b) {}
+  }
+
+  class TestClassB {
+    constructor(public a, public b) {}
+  }
+
+  const TestClassC = class Child extends TestClassA {
+    constructor(a, b) {
+      super(a, b)
+    }
+  }
+
+  const TestClassD = class Child extends TestClassB {
+    constructor(a, b) {
+      super(a, b)
+    }
+  }
+
+  it('does not ignore keys with undefined values', () => {
+    expect({
+      a: undefined,
+      b: 2,
+    }).not.toStrictEqual({ b: 2 })
+  })
+
+  it('does not ignore keys with undefined values inside an array', () => {
+    expect([{ a: undefined }]).not.toStrictEqual([{}])
+  })
+
+  it('does not ignore keys with undefined values deep inside an object', () => {
+    expect([{ a: [{ a: undefined }] }]).not.toStrictEqual([{ a: [{}] }])
+  })
+
+  it('does not consider holes as undefined in sparse arrays', () => {
+    expect([, , , 1, , ,]).not.toStrictEqual([, , , 1, undefined, ,])
+  })
+
+  it('passes when comparing same type', () => {
+    expect({
+      test: new TestClassA(1, 2),
+    }).toStrictEqual({ test: new TestClassA(1, 2) })
+  })
+
+  it('does not pass for different types', () => {
+    expect({
+      test: new TestClassA(1, 2),
+    }).not.toStrictEqual({ test: new TestClassB(1, 2) })
+  })
+
+  it('does not simply compare constructor names', () => {
+    const c = new TestClassC(1, 2)
+    const d = new TestClassD(1, 2)
+    expect(c.constructor.name).toEqual(d.constructor.name)
+    expect({ test: c }).not.toStrictEqual({ test: d })
+  })
+
+  it('passes for matching sparse arrays', () => {
+    expect([, 1]).toStrictEqual([, 1])
+  })
+
+  it('does not pass when sparseness of arrays do not match', () => {
+    expect([, 1]).not.toStrictEqual([undefined, 1])
+    expect([undefined, 1]).not.toStrictEqual([, 1])
+    expect([, , , 1]).not.toStrictEqual([, 1])
+  })
+
+  it('does not pass when equally sparse arrays have different values', () => {
+    expect([, 1]).not.toStrictEqual([, 2])
+  })
+
+  it('does not pass when ArrayBuffers are not equal', () => {
+    expect(Uint8Array.from([1, 2]).buffer).not.toStrictEqual(
+      Uint8Array.from([0, 0]).buffer,
+    )
+    expect(Uint8Array.from([2, 1]).buffer).not.toStrictEqual(
+      Uint8Array.from([2, 2]).buffer,
+    )
+    expect(Uint8Array.from([]).buffer).not.toStrictEqual(
+      Uint8Array.from([1]).buffer,
+    )
+  })
+
+  it('passes for matching buffers', () => {
+    expect(Uint8Array.from([1]).buffer).toStrictEqual(
+      Uint8Array.from([1]).buffer,
+    )
+    expect(Uint8Array.from([]).buffer).toStrictEqual(
+      Uint8Array.from([]).buffer,
+    )
+    expect(Uint8Array.from([9, 3]).buffer).toStrictEqual(
+      Uint8Array.from([9, 3]).buffer,
+    )
   })
 })
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -121,6 +121,45 @@ describe('jest-expect', () => {
     expect(1).toBe(1)
     expect(1).toBe(1)
   })
+
+  // https://jestjs.io/docs/expect#tostrictequalvalue
+
+  class LaCroix {
+    constructor(flavor) {
+      this.flavor = flavor
+    }
+  }
+
+  describe('the La Croix cans on my desk', () => {
+    it('are not semantically the same', () => {
+      expect(new LaCroix('lemon')).toEqual({ flavor: 'lemon' })
+      expect(new LaCroix('lemon')).not.toStrictEqual({ flavor: 'lemon' })
+    })
+  })
+
+  it('array', () => {
+    expect([]).toEqual([])
+    expect([]).not.toBe([])
+    expect([]).toStrictEqual([])
+
+    const foo = []
+
+    expect(foo).toBe(foo)
+    expect(foo).toStrictEqual(foo)
+
+    const complex = [
+      {
+        foo: 1,
+        bar: { foo: 'foo', bar: 100, arr: ['first', { zoo: 'monkey' }] },
+      },
+    ]
+    expect(complex).toStrictEqual([
+      {
+        foo: 1,
+        bar: { foo: 'foo', bar: 100, arr: ['first', { zoo: 'monkey' }] },
+      },
+    ])
+  })
 })
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, 500)))


### PR DESCRIPTION
Make `toStrictEqual` compatible with jest's version

https://jestjs.io/docs/expect#tostrictequalvalue