### PR TITLE
fix: append inline sourcemap to executed modules

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@antfu/install-pkg": "^0.1.0",
+    "@types/convert-source-map": "^1.5.2",
     "@types/diff": "^5.0.2",
     "@types/jsdom": "^16.2.14",
     "@types/micromatch": "^4.0.2",
@@ -72,6 +73,7 @@
     "cac": "^6.7.12",
     "chai-subset": "^1.6.0",
     "cli-truncate": "^3.1.0",
+    "convert-source-map": "^1.8.0",
     "diff": "^5.0.0",
     "execa": "^6.0.0",
     "fast-glob": "^3.2.7",

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -1,3 +1,4 @@
+import * as convertSourceMap from 'convert-source-map'
 import { MessageChannel } from 'worker_threads'
 import { pathToFileURL } from 'url'
 import { resolve } from 'pathe'
@@ -124,7 +125,9 @@ function createChannel(ctx: Vitest) {
       },
       async fetch(id) {
         const r = await transformRequest(ctx, id)
-        return r?.code
+        if (r) {
+          return r.code + (r.map ? convertSourceMap.fromObject(r.map).toComment() : '')
+        }
       },
       onCollected(files) {
         ctx.state.collectFiles(files)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,7 @@ importers:
       '@antfu/install-pkg': ^0.1.0
       '@types/chai': ^4.3.0
       '@types/chai-subset': ^1.3.3
+      '@types/convert-source-map': ^1.5.2
       '@types/diff': ^5.0.2
       '@types/jsdom': ^16.2.14
       '@types/micromatch': ^4.0.2
@@ -145,6 +146,7 @@ importers:
       chai: ^4.3.4
       chai-subset: ^1.6.0
       cli-truncate: ^3.1.0
+      convert-source-map: ^1.8.0
       diff: ^5.0.0
       execa: ^6.0.0
       fast-glob: ^3.2.7
@@ -180,6 +182,7 @@ importers:
       tinyspy: 0.2.6
     devDependencies:
       '@antfu/install-pkg': 0.1.0
+      '@types/convert-source-map': 1.5.2
       '@types/diff': 5.0.2
       '@types/jsdom': 16.2.14
       '@types/micromatch': 4.0.2
@@ -191,6 +194,7 @@ importers:
       cac: 6.7.12
       chai-subset: 1.6.0
       cli-truncate: 3.1.0
+      convert-source-map: 1.8.0
       diff: 5.0.0
       execa: 6.0.0
       fast-glob: 3.2.7
@@ -1755,6 +1759,10 @@ packages:
       '@types/node': 17.0.5
     dev: true
 
+  /@types/convert-source-map/1.5.2:
+    resolution: {integrity: sha512-tHs++ZeXer40kCF2JpE51Hg7t4HPa18B1b1Dzy96S0eCw8QKECNMYMfwa1edK/x8yCN0r4e6ewvLcc5CsVGkdg==}
+    dev: true
+
   /@types/cookie/0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
@@ -3056,6 +3064,12 @@ packages:
     resolution: {integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==}
     dependencies:
       safe-buffer: 5.1.2
+
+  /convert-source-map/1.8.0:
+    resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
+    dependencies:
+      safe-buffer: 5.1.2
+    dev: true
 
   /cookie/0.4.1:
     resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
@@ -7297,7 +7311,7 @@ packages:
     engines: {node: '>=10.12.0'}
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
-      convert-source-map: 1.7.0
+      convert-source-map: 1.8.0
       source-map: 0.7.3
     dev: true
 


### PR DESCRIPTION
This allows the step debugger to find/open the original file and trigger breakpoints properly.