### PR TITLE
fix: C8 sourcemaps

### DIFF
--- a/packages/vitest/src/coverage.ts
+++ b/packages/vitest/src/coverage.ts
@@ -131,19 +131,17 @@ export async function reportCoverage(ctx: Vitest) {
   const createReport = require('c8/lib/report')
   const report = createReport(ctx.config.coverage)
 
-  await report.getCoverageMapFromAllCoverageFiles()
-
   // add source maps
   Array
     .from(ctx.visitedFilesMap.entries())
     .filter(i => !i[0].includes('/node_modules/'))
     .forEach(([file, map]) => {
       const url = pathToFileURL(file).href
+      const sources = map.sources.length
+        ? map.sources.map(i => pathToFileURL(i).href)
+        : [url]
       report.sourceMapCache[url] = {
-        data: {
-          ...map,
-          sources: map.sources.map(i => pathToFileURL(i).href) || [url],
-        },
+        data: { ...map, sources },
       }
     })
 


### PR DESCRIPTION
Honestly, I'm not exactly sure what black magic is happening with C8 and the like, but as far as I understand this is a needed change. I don't think C8 was actually _doing_ any source mapping prior to this, because it cached the coverage map when `report.getCoverageMapFromAllCoverageFiles()` was called.

Here is what Vitest is generating for source maps:
[sourcemapthingy.zip](https://github.com/vitest-dev/vitest/files/7785683/sourcemapthingy.zip)

use this site to view it: https://sokra.github.io/source-map-visualization

You'll notice that the source mapping seems pretty much perfect, at least to me. I think any further issues with coverage are related to C8 itself.

