### PR TITLE
test: should handle object with getter/setter correctly

### DIFF
--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -30,4 +30,24 @@ describe('error serialize', () => {
 
     expect(serializeError(error)).toMatchSnapshot()
   })
+
+  it('Should handle object with getter/setter correctly', () => {
+    const user = {
+      name: 'John',
+      surname: 'Smith',
+
+      get fullName() {
+        return `${this.name} ${this.surname}`
+      },
+      set fullName(value) {
+        [this.name, this.surname] = value.split(' ')
+      },
+    }
+
+    expect(serializeError(user)).toEqual({
+      name: 'John',
+      surname: 'Smith',
+      fullName: 'John Smith',
+    })
+  })
 })


### PR DESCRIPTION
Hey :)

I was working to handle Array errors but I see @userquin fixed it with https://github.com/vitest-dev/vitest/pull/337 
So I add a test cases where an object has getter/setters attributes for output validation 👍🏽 
