### PR TITLE
feat(snapshot): Use short match inline snapshot

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -154,7 +154,9 @@ You can also use `.skip`, `.only`, and `.todo` with concurrent suites and tests.
 
 [Jest Snapshot](https://jestjs.io/docs/snapshot-testing) support
 
-> A shortcut is available on `toMatchInlineSnapshot`, you can use `toMatchInline` instead.
+:::tip
+Instead of `toMatchInlineSnapshot`, you can also use `toMatchInline`.
+:::
 
 ## Chai and Jest expect compatibility
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -150,7 +150,7 @@ describe.concurrent("suite", () => {
 
 You can also use `.skip`, `.only`, and `.todo` with concurrent suites and tests. Read more in the [API Reference](../api/#concurrent)
 
-## Snaphot
+## Snapshot
 
 [Jest Snapshot](https://jestjs.io/docs/snapshot-testing) support
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -154,6 +154,8 @@ You can also use `.skip`, `.only`, and `.todo` with concurrent suites and tests.
 
 [Jest Snapshot](https://jestjs.io/docs/snapshot-testing) support
 
+> A shortcut is available on `toMatchInlineSnapshot`, you can use `toMatchInline` instead.
+
 ## Chai and Jest expect compatibility
 
 [Chai](https://www.chaijs.com/) built-in for assertions plus [Jest expect](https://jestjs.io/docs/expect) compatible APIs

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -44,6 +44,7 @@ declare global {
       // Snapshot
       toMatchSnapshot(message?: string): Assertion
       toMatchInlineSnapshot(snapshot?: string, message?: string): Assertion
+      toMatchInline(snapshot?: string, message?: string): Assertion
       matchSnapshot(message?: string): Assertion
 
       // Jest compact

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -20,12 +20,14 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
       },
     )
   }
-  utils.addMethod(
-    chai.Assertion.prototype,
-    'toMatchInlineSnapshot',
-    function(this: Record<string, unknown>, inlineSnapshot: string, message: string) {
-      const expected = utils.flag(this, 'object')
-      getSnapshotClient().assert(expected, message, true, inlineSnapshot)
-    },
-  )
+  for (const key of ['toMatchInlineSnapshot', 'toMatchInline']) {
+    utils.addMethod(
+      chai.Assertion.prototype,
+      key,
+      function(this: Record<string, unknown>, inlineSnapshot: string, message: string) {
+        const expected = utils.flag(this, 'object')
+        getSnapshotClient().assert(expected, message, true, inlineSnapshot)
+      },
+    )
+  }
 }

--- a/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
+++ b/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
@@ -33,7 +33,7 @@ export async function saveInlineSnapshots(
   }))
 }
 
-const startRegex = /toMatchInlineSnapshot\s*\(\s*(['"`\)])/m
+const startRegex = /toMatchInline(?:Snapshot)?\s*\(\s*(['"`\)])/m
 export function replaceInlineSnap(code: string, s: MagicString, index: number, newSnap: string, indent = '') {
   const startMatch = startRegex.exec(code.slice(index))
   if (!startMatch)

--- a/test/core/test/inline-snap.test.ts
+++ b/test/core/test/inline-snap.test.ts
@@ -20,4 +20,21 @@ expect('foo').toMatchInlineSnapshot(\`\\"bar
 foo\\"\`)
 "`)
   })
+  it('replaceInline', async() => {
+    const code = `
+expect('foo').toMatchInline('"foo"')
+expect('foo').toMatchInline(\`{
+  "foo": \\\`\\\`,
+}\`)
+`
+    const s = new MagicString(code)
+    replaceInlineSnap(code, s, 3, '"bar"')
+    replaceInlineSnap(code, s, 40, '"bar\nfoo"')
+    expect(s.toString()).toMatchInline(`
+"
+expect('foo').toMatchInline('\\"bar\\"')
+expect('foo').toMatchInline(\`\\"bar
+foo\\"\`)
+"`)
+  })
 })


### PR DESCRIPTION
Using `toMatchInlineSnapshot` is a bit long to write (for those which not use autocompletion). And as, the snapshot is readable inline, why just purpose a shortcut to that method by removing the `Snapshot` word.

So, here is the PR for letting the developer to choose `toMatchInline` instead of `toMatchInlineSnapshot`.