### PR TITLE
fix: proxy nested default

### DIFF
--- a/packages/vitest/src/node/execute.ts
+++ b/packages/vitest/src/node/execute.ts
@@ -48,23 +48,29 @@ export const stubRequests: Record<string, any> = {
   },
 }
 
+function hasNestedDefault(target: any) {
+  return '__esModule' in target && target.__esModule && 'default' in target.default
+}
+
+function proxyMethod(name: 'get' | 'set' | 'has' | 'deleteProperty', isNested: boolean) {
+  return function(target: any, key: string | symbol, ...args: [any?, any?]) {
+    const result = Reflect[name](target, key, ...args)
+    if ((isNested && key === 'default') || !result)
+      return Reflect[name](target.default, key, ...args)
+    return result
+  }
+}
+
 export async function interpretedImport(path: string, interpretDefault: boolean) {
   const mod = await import(path)
 
   if (interpretDefault && 'default' in mod) {
+    const isNested = hasNestedDefault(mod)
     return new Proxy(mod, {
-      get(target, key, receiver) {
-        return Reflect.get(target, key, receiver) || Reflect.get(target.default, key, receiver)
-      },
-      set(target, key, value, receiver) {
-        return Reflect.set(target, key, value, receiver) || Reflect.set(target.default, key, value, receiver)
-      },
-      has(target, key) {
-        return Reflect.has(target, key) || Reflect.has(target.default, key)
-      },
-      deleteProperty(target, key) {
-        return Reflect.deleteProperty(target, key) || Reflect.deleteProperty(target.default, key)
-      },
+      get: proxyMethod('get', isNested),
+      set: proxyMethod('set', isNested),
+      has: proxyMethod('has', isNested),
+      deleteProperty: proxyMethod('deleteProperty', isNested),
     })
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,7 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@types/prettier': ^2.4.2
       fs-extra: ^10.0.0
+      givens: 1.3.9
       history: ^5.2.0
       prettier: ^2.5.1
       vitest: workspace:*
@@ -238,11 +239,18 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/prettier': 2.4.2
       fs-extra: 10.0.0
+      givens: 1.3.9
       history: 5.2.0
       prettier: 2.5.1
       vitest: link:../../packages/vitest
 
   test/core:
+    specifiers:
+      vitest: workspace:*
+    devDependencies:
+      vitest: link:../../packages/vitest
+
+  test/coverage-test:
     specifiers:
       vitest: workspace:*
     devDependencies:
@@ -4822,6 +4830,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.1
+    dev: true
+
+  /givens/1.3.9:
+    resolution: {integrity: sha512-4hYlStsEIaYeYvZTZwgD5yOS2WVP0dcDsOBqeImdEM8eLuclvv0IEMlQQ1kuA5DN4he7wVH1jsYtNe9uininxg==}
     dev: true
 
   /glob-parent/5.1.2:

--- a/test/cjs/package.json
+++ b/test/cjs/package.json
@@ -9,6 +9,7 @@
     "@types/fs-extra": "^9.0.13",
     "@types/prettier": "^2.4.2",
     "fs-extra": "^10.0.0",
+    "givens": "1.3.9",
     "history": "^5.2.0",
     "prettier": "^2.5.1",
     "vitest": "workspace:*"

--- a/test/cjs/test/interpret-default.test.tsx
+++ b/test/cjs/test/interpret-default.test.tsx
@@ -1,7 +1,13 @@
-import { it, expect } from 'vitest'
+import { expect, it } from 'vitest'
 import { format } from 'prettier'
+import givens from 'givens'
 
 it('prettier', () => {
   expect(format('const a :   A = \'t\'', { parser: 'typescript' }).trim())
     .toEqual('const a: A = "t";'.trim())
+})
+
+it('has nested default', () => {
+  expect(typeof givens).toBe('function')
+  expect(givens.name).toBe('getGiven')
 })


### PR DESCRIPTION
Should fix all `exports.default = {}` treated as `{ default: { default: {} } }` problems

Related: https://github.com/vitest-dev/vitest/issues/352, https://github.com/vitest-dev/vitest/issues/243