### PR TITLE
feat: findRelatedTests flag, to run only changed tests

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -95,6 +95,7 @@ Run vitest in development mode.
 | `--run` | Do not watch |
 | `--global` | Inject APIs globally |
 | `--dom` | Mock browser api with happy-dom |
+| `--findRelatedTests <filepath>` | Run only tests that import specified file |
 | `--environment <env>` | Runner environment (default: node) |
 | `--passWithNoTests` | Pass when no tests found |
 | `-h, --help` | Display available CLI options |

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -27,6 +27,7 @@ cli
   .option('--run', 'do not watch')
   .option('--global', 'inject apis globally')
   .option('--dom', 'mock browser api with happy-dom')
+  .option('--findRelatedTests <filepath>', 'run only tests that import specified file')
   .option('--environment <env>', 'runner environment', { default: 'node' })
   .option('--passWithNoTests', 'pass when no tests found')
   .help()

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -68,10 +68,8 @@ export function resolveConfig(
   if (resolved.api === true)
     resolved.api = defaultPort
 
-  if (options.findRelatedTests) {
-    const sourcefiles = toArray(options.findRelatedTests)
-    resolved.relatedFiles = sourcefiles.map(file => resolve(resolved.root, file))
-  }
+  if (options.findRelatedTests)
+    resolved.findRelatedTests = toArray(options.findRelatedTests).map(file => resolve(resolved.root, file))
 
   return resolved
 }

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -3,7 +3,7 @@ import type { ResolvedConfig as ResolvedViteConfig } from 'vite'
 import type { ResolvedConfig, UserConfig } from '../types'
 import { defaultExclude, defaultInclude, defaultPort } from '../constants'
 import { resolveC8Options } from '../coverage'
-import { deepMerge } from '../utils'
+import { deepMerge, toArray } from '../utils'
 
 export function resolveConfig(
   options: UserConfig,
@@ -67,6 +67,11 @@ export function resolveConfig(
 
   if (resolved.api === true)
     resolved.api = defaultPort
+
+  if (options.findRelatedTests) {
+    const sourcefiles = toArray(options.findRelatedTests)
+    resolved.relatedFiles = sourcefiles.map(file => resolve(resolved.root, file))
+  }
 
   return resolved
 }

--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -15,6 +15,10 @@ function hash(str: string, length = 10) {
     .slice(0, length)
 }
 
+function inModuleGraph(files: string[]) {
+  return files.some(file => process.__vitest_worker__.moduleCache.has(file))
+}
+
 export async function collectTests(paths: string[], config: ResolvedConfig) {
   const files: File[] = []
 
@@ -34,6 +38,9 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
     try {
       await runSetupFiles(config)
       await import(filepath)
+
+      if (config.relatedFiles && !inModuleGraph(config.relatedFiles))
+        continue
 
       const defaultTasks = await defaultSuite.collect(file)
 

--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -39,7 +39,7 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
       await runSetupFiles(config)
       await import(filepath)
 
-      if (config.relatedFiles && !inModuleGraph(config.relatedFiles))
+      if (config.findRelatedTests && !inModuleGraph(config.findRelatedTests))
         continue
 
       const defaultTasks = await defaultSuite.collect(file)

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -231,7 +231,7 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
   config?: string
   filters?: string[]
   testNamePattern?: RegExp
-  relatedFiles?: string[]
+  findRelatedTests?: string[]
 
   depsInline: (string | RegExp)[]
   depsExternal: (string | RegExp)[]

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -220,12 +220,18 @@ export interface UserConfig extends InlineConfig {
    * Pass with no tests
    */
   passWithNoTests?: boolean
+
+  /**
+   * Run tests that cover a list of source files
+   */
+  findRelatedTests?: string[] | string
 }
 
-export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern'> {
+export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'findRelatedTests'> {
   config?: string
   filters?: string[]
   testNamePattern?: RegExp
+  relatedFiles?: string[]
 
   depsInline: (string | RegExp)[]
   depsExternal: (string | RegExp)[]


### PR DESCRIPTION
Related: https://github.com/vitest-dev/vitest/issues/280

CAC allows passing array as an argument only if you repeat option, like: 
```
vitest --findRelatedTests src/timeout.ts --findRelatedTests src/mockedA.ts
```

I personally think jest's way (using space as separator) is more convinient