### PR TITLE
fix(mock): generating source map with `hires: true`

### DIFF
--- a/packages/vitest/src/plugins/mock.ts
+++ b/packages/vitest/src/plugins/mock.ts
@@ -132,7 +132,7 @@ export const MocksPlugin = (): Plugin => {
       if (m) {
         return {
           code: m.toString(),
-          map: m.generateMap(),
+          map: m.generateMap({ hires: true }),
         }
       }
     },


### PR DESCRIPTION
Does what it says on the tin.

`hires: true` is important for code coverage.