### PR TITLE
feat(cli): add isolate option

### DIFF
--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -22,6 +22,7 @@ cli
   .option('--api', 'listen to port and serve API')
   .option('--threads', 'enabled threads', { default: true })
   .option('--silent', 'silent console output from tests')
+  .option('--isolate', 'isolate environment for each test file', { default: true })
   .option('--reporter <name>', 'reporter')
   .option('--coverage', 'use c8 for coverage')
   .option('--run', 'do not watch')


### PR DESCRIPTION
Tiny PR to allow defining `isolate` option with the CLI. Currently it can only be configured through a config file.