### PR TITLE
fix(ui): make navigation scrollable

### DIFF
--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -10,7 +10,7 @@ function onItemClick(task: Task) {
 </script>
 
 <template>
-  <nav border="r base">
+  <nav border="r base" overflow-y-auto>
     <TasksList
       :tasks="files"
       :on-item-click="onItemClick"


### PR DESCRIPTION
The navigation was not scrollable, which also prevented suites from being scrollable and thus cutting of long lists of tasks.

I noticed that the code mirror also cannot be scrolled vertically, but I didn't find a fix.
Adding `overflow-y: auto` to the appropriate element shows the scrollbar, but it's still not scrollable.
It may be an issue with the `CodeMirror` library.