### PR TITLE
fix(ui): make module graph more stable

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
-import { current } from '~/composables/client'
+import { client, current } from '~/composables/client'
 import { viewMode } from '~/composables/params'
+import { useModuleGraph } from '~/composables/module-graph'
 
 function open() {
   if (current.value?.filepath)
     fetch(`/__open-in-editor?file=${encodeURIComponent(current.value.filepath)}`)
 }
+
+const data = asyncComputed(async() => {
+  const filepath = current.value?.filepath
+  return filepath
+    ? await client.rpc.getModuleGraph(filepath)
+    : { externalized: [], graph: {}, inlined: [] }
+})
+
+const graph = useModuleGraph(data)
 </script>
 
 <template>
@@ -30,7 +40,7 @@ function open() {
         Code
       </button>
     </div>
-    <ViewModuleGraph v-if="viewMode === 'graph'" :file="current" />
+    <ViewModuleGraph v-if="viewMode === 'graph'" :graph="graph" />
     <ViewEditor v-else-if="viewMode === 'editor'" :file="current" />
     <ViewReport v-else :file="current" />
   </div>

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -37,23 +37,17 @@
 
 <script setup lang="ts">
 import { GraphController } from 'd3-graph-controller'
-import type { File } from '#types'
-import { client } from '~/composables/client'
-import type { ModuleGraphController, ModuleType } from '~/composables/module-graph'
-import { useModuleGraph, useModuleGraphConfig } from '~/composables/module-graph'
+import type { ModuleGraph, ModuleGraphController, ModuleType } from '~/composables/module-graph'
+import { useModuleGraphConfig } from '~/composables/module-graph'
 
 const props = defineProps<{
-  file?: File
+  graph: ModuleGraph
 }>()
 
-const data = asyncComputed(async() => {
-  return props.file?.filepath
-    ? await client.rpc.getModuleGraph(props.file.filepath)
-    : { externalized: [], graph: {}, inlined: [] }
-})
+const { graph } = toRefs(props)
 
 const el = ref<HTMLDivElement>()
-const graph = useModuleGraph(data)
+
 const config = useModuleGraphConfig(graph)
 const controller = ref<ModuleGraphController | undefined>()
 
@@ -65,7 +59,7 @@ onMounted(() => {
   resetGraphController()
 })
 
-onMounted(() => {
+onUnmounted(() => {
   controller.value?.shutdown()
 })
 
@@ -95,21 +89,6 @@ function debounce(cb: () => void) {
   }
 }
 </script>
-
-<style scoped>
-.type-checkbox {
-  align-items: center;
-  display: flex;
-  gap: 0.25em;
-}
-
-.type-circle {
-  display: inline;
-  border-radius: 50%;
-  width: 0.75rem;
-  height: 0.75rem;
-}
-</style>
 
 <style>
 :root {

--- a/packages/ui/client/composables/module-graph.ts
+++ b/packages/ui/client/composables/module-graph.ts
@@ -55,14 +55,21 @@ export function useModuleGraph(data: Ref<{
     const nodeMap = Object.fromEntries(nodes.map(node => [node.id, node]))
     const links = Object
       .entries(data.value.graph)
-      .flatMap(([module, deps]) => deps.map(dep => defineLink({
-        source: nodeMap[module],
-        target: nodeMap[dep],
-        color: 'var(--color-link)',
-        label: '',
-        labelColor: 'var(--color-link-label)',
-        showLabel: false,
-      })))
+      .flatMap(([module, deps]) => deps.map((dep) => {
+        const source = nodeMap[module]
+        const target = nodeMap[dep]
+        if (source === undefined || target === undefined)
+          return undefined
+
+        return defineLink({
+          source,
+          target,
+          color: 'var(--color-link)',
+          label: '',
+          labelColor: 'var(--color-link-label)',
+          showLabel: false,
+        })
+      }).filter(link => link !== undefined) as ModuleLink[])
     return { nodes, links }
   })
 }
@@ -74,11 +81,14 @@ export function useModuleGraphConfig(graph: Ref<ModuleGraph>): Ref<ModuleGraphCo
       getNodeRadius: (node: ModuleNode) => node.label.length * 4.5,
       forces: {
         charge: {
-          strength: -100,
+          strength: -1,
         },
         collision: {
           radiusMultiplier: 2,
         },
+      },
+      initial: {
+        includeUnlinked: false,
       },
       positionInitializer: graph.value.nodes.length > 1
         ? PositionInitializers.Randomized


### PR DESCRIPTION
This PR makes the module graph more stable by not recreating the graph model every time the component loads.
Node positions are only initialized if they were not set before, this approach saves them.

I also noticed that the provided graph data is invalid (in particular for the test `inline-snap.test.ts`.
Some modules list imports that are neither included in `externalized` nor `inlined`.
Those imports and all nodes without edges are filtered, for now, preventing crashes.

Node positioning can still be a bit unstable when opening the module graph view.
This is caused by the d3 simulation kicking in and re-applying all forces, including centering.
The same thing applies when (un-)focusing a node.

I'll update my library to make the alpha value of the simulation customizable sometime soon. Then I'll have another look at node positioning.