### PR TITLE
fix(reporter): use italic instead of c.gray(c.dim())

### DIFF
--- a/packages/vitest/src/reporters/renderers/diff.ts
+++ b/packages/vitest/src/reporters/renderers/diff.ts
@@ -126,7 +126,7 @@ async function printStack(
     const color = frame === highlight ? c.yellow : c.gray
     const path = relative(ctx.config.root, frame.file)
 
-    ctx.log(color(` ${c.dim(F_POINTER)} ${[frame.method, c.dim(`${path}:${pos.line}:${pos.column}`)].filter(Boolean).join(' ')}`))
+    ctx.log(color(` ${c.dim(F_POINTER)} ${[frame.method, c.italic(`${path}:${pos.line}:${pos.column}`)].filter(Boolean).join(' ')}`))
     await onStack?.(frame, pos)
 
     // reached at test file, skip the follow stack


### PR DESCRIPTION
Resolves #383

c.gray(c.dim()) makes invisible text in some terminals, let's go with c.italic instead of c.dim

![image](https://user-images.githubusercontent.com/37929992/147831983-faf67acc-8bc3-4fec-8035-56259d2eca31.png)
