### PR TITLE
fix: prevent tests from stalling if an error occurs (fix #374)

### DIFF
--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -1,8 +1,10 @@
 import { format } from 'util'
 import { stringify } from '../integrations/chai/jest-matcher-utils'
 
+const OBJECT_PROTO = Object.getPrototypeOf({})
+
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
-export function serializeError(val: any, seen = new WeakSet()): any {
+export function serializeError(val: any, seen = new WeakMap()): any {
   if (!val || typeof val === 'string')
     return val
   if (typeof val === 'function')
@@ -17,20 +19,32 @@ export function serializeError(val: any, seen = new WeakSet()): any {
     return `${val.toString()} ${format(val.sample)}`
 
   if (seen.has(val))
-    return val
-  seen.add(val)
+    return seen.get(val)
 
   if (Array.isArray(val)) {
-    val = val.map((e) => {
-      return serializeError(e, seen)
+    const clone: any[] = new Array(val.length)
+    seen.set(val, clone)
+    val.forEach((e, i) => {
+      clone[i] = serializeError(e, seen)
     })
+    return clone
   }
   else {
-    Object.keys(val).forEach((key) => {
-      val[key] = serializeError(val[key], seen)
-    })
+    // Objects with `Error` constructors appear to cause problems during worker communication
+    // using `MessagePort`, so the serialized error object is being recreated as plain object.
+    const clone = Object.create(null)
+    seen.set(val, clone)
+
+    let obj = val
+    while (obj && obj !== OBJECT_PROTO) {
+      Object.getOwnPropertyNames(obj).forEach((key) => {
+        if (!(key in clone))
+          clone[key] = serializeError(obj[key], seen)
+      })
+      obj = Object.getPrototypeOf(obj)
+    }
+    return clone
   }
-  return val
 }
 
 export function processError(err: any) {

--- a/test/core/test/__snapshots__/serialize.test.ts.snap
+++ b/test/core/test/__snapshots__/serialize.test.ts.snap
@@ -8,11 +8,20 @@ exports[`error serialize > Should skip circular references to prevent hit the ca
     [Circular],
     [Circular],
   ],
+  "whateverArrayClone": [
+    [Circular],
+    [Circular],
+  ],
 }
 `;
 
 exports[`error serialize > works 1`] = `
 {
+  "array": [
+    1,
+    ,
+    3,
+  ],
   "fn": "Function<fn>",
   "foo": "hi",
   "nested": {

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -16,6 +16,9 @@ describe('error serialize', () => {
         false: false,
         class: class {},
       },
+      // Intentionally test with a sparse array to verify it remains sparse during serialization.
+      // eslint-disable-next-line no-sparse-arrays
+      array: [1,, 3],
     })).toMatchSnapshot()
   })
 
@@ -27,6 +30,7 @@ describe('error serialize', () => {
     }
     error.whatever = error
     error.whateverArray = [error, error]
+    error.whateverArrayClone = error.whateverArray
 
     expect(serializeError(error)).toMatchSnapshot()
   })
@@ -48,6 +52,45 @@ describe('error serialize', () => {
       name: 'John',
       surname: 'Smith',
       fullName: 'John Smith',
+    })
+  })
+
+  it('Should copy the full prototype chain including non-enumerable properties', () => {
+    const user = {
+      name: 'John',
+      surname: 'Smith',
+    }
+    Object.setPrototypeOf(user, {
+      name: 'Mr',
+      base: true,
+    })
+
+    Object.defineProperty(user, 'fullName', { enumerable: false, value: 'John Smith' })
+
+    const serialized = serializeError(user)
+    expect(serialized).not.toBe(user)
+    expect(serialized).toEqual({
+      name: 'John',
+      surname: 'Smith',
+      fullName: 'John Smith',
+      base: true,
+    })
+  })
+
+  it('Should not retain the constructor of an object', () => {
+    // https://github.com/vitest-dev/vitest/issues/374
+    // Objects with `Error` constructors appear to cause problems during worker communication using
+    // `MessagePort`, so the serialized error object should have been recreated as plain object.
+    const error = new Error('test')
+
+    const serialized = serializeError(error)
+    expect(Object.getPrototypeOf(serialized)).toBe(null)
+    expect(serialized).toEqual({
+      constructor: 'Function<Error>',
+      name: 'Error',
+      message: 'test',
+      stack: expect.any(String),
+      toString: 'Function<toString>',
     })
   })
 })

--- a/test/fails/fixtures/stall.test.ts
+++ b/test/fails/fixtures/stall.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'vitest'
+
+// https://github.com/vitest-dev/vitest/issues/374
+// Passing `Error` instances across message channels could cause the test runner to stall, if
+// multiple tests fail. This suite is successful if it does not timeout, which is verified by the
+// test runner.
+
+test('test 1', () => {
+  throw new TypeError('failure')
+})
+test('test 2', () => {
+  throw new TypeError('failure')
+})
+test('test 3', () => {
+  throw new TypeError('failure')
+})
+test('test 4', () => {
+  throw new TypeError('failure')
+})

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -4,4 +4,6 @@ exports[`should fails > expect.test.ts > expect.test.ts 1`] = `"AssertionError: 
 
 exports[`should fails > nested-suite.test.ts > nested-suite.test.ts 1`] = `"AssertionError: expected true to equal false"`;
 
+exports[`should fails > stall.test.ts > stall.test.ts 1`] = `"TypeError: failure"`;
+
 exports[`should fails > timeout.test.ts > timeout.test.ts 1`] = `"Error: Test timed out in 10ms."`;


### PR DESCRIPTION
The serialization logic of error objects would mutate the error object in-place,
retaining its original constructor and leaving non-enumerable properties intact.
When an object of type `Error` is sent over a `MessagePort` an issue may occur
which resulted in the tests stalling. The exact reason as to why the tests get
stuck before this fix are unclear, but serializing the `Error` instance into
a plain object avoids the issue.

This commit changes the serialization logic to create a new object without
its original constructor and then copies over all properties to the clone, which
prevents the tests from stalling. An integration fixture is added in the `fails`
workspace to prevent regressions.

These changes make the custom `nameStr` and `stackStr` properties redundant,
as `name` and `stack` are now copied over when traversing the prototype chain of
an `Error` object. These properties are not removed as that would be cleanup work
outside the scope of this fix.

Fixes #374