### PR TITLE
Fix: do not add expected/actual attributes in a object when does not exist

### DIFF
--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -43,9 +43,9 @@ export function processError(err: any) {
   if (err.name)
     err.nameStr = String(err.name)
 
-  if (typeof err.expected !== 'string')
+  if (err.expected && typeof err.expected !== 'string')
     err.expected = stringify(err.expected)
-  if (typeof err.actual !== 'string')
+  if (err.actual && typeof err.actual !== 'string')
     err.actual = stringify(err.actual)
 
   return serializeError(err)

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -53,7 +53,7 @@ describe('error serialize', () => {
 })
 
 describe('Process Error', () => {
-  it('Do not add expected/actual attributes in a object when both attributes does not exists', () => {
+  it('Do not add expected/actual attributes in a object when any of both attributes does not exists', () => {
     const error = new Error('Ops something went wrong')
 
     const result = processError(error)

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { serializeError } from '../../../packages/vitest/src/runtime/error'
+import { processError, serializeError } from '../../../packages/vitest/src/runtime/error'
 
 describe('error serialize', () => {
   it('works', () => {
@@ -49,5 +49,16 @@ describe('error serialize', () => {
       surname: 'Smith',
       fullName: 'John Smith',
     })
+  })
+})
+
+describe('Process Error', () => {
+  it('Do not add expected/actual attributes in a object when both attributes does not exists', () => {
+    const error = new Error('Ops something went wrong')
+
+    const result = processError(error)
+
+    expect(result.expected).not.toBeDefined()
+    expect(result.actual).not.toBeDefined()
   })
 })


### PR DESCRIPTION
When we parse a Error object without expected or actual. `processError` add any of both attributes with `'undefined'` as a value.