### PR TITLE
fix: broken expected and actual

### DIFF
--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -57,9 +57,9 @@ export function processError(err: any) {
   if (err.name)
     err.nameStr = String(err.name)
 
-  if (err.expected && typeof err.expected !== 'string')
+  if (err.expected !== undefined && err.expected !== null && typeof err.expected !== 'string')
     err.expected = stringify(err.expected)
-  if (err.actual && typeof err.actual !== 'string')
+  if (err.actual !== undefined && err.actual !== null && typeof err.actual !== 'string')
     err.actual = stringify(err.actual)
 
   return serializeError(err)


### PR DESCRIPTION
This PR fix the serialization error from #407 since `expected` and/or `actual` can be both boolean/falsy, `nr ci`, `pnpm run test:all` and `vitest -o --api` stop working on windows, also with some memory error on node:

```shell
file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:311
      linesAndNewlines = value.split(/(\n|\r\n)/); // Ignore the final empty token that occurs if the string ends with a new line
                               ^

TypeError: value.split is not a function
    at Diff.lineDiff.tokenize (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:311:32)
    at Diff.diff (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:32:39)
    at diffLines (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:336:19)
    at structuredPatch (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:508:14)
    at createTwoFilesPatch (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:656:22)
    at createPatch (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:659:10)
    at unifiedDiff (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:4717:15)
    at displayDiff (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:4627:24)
    at printError (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/diff-d71c4271.js:4596:5)
    at async DefaultReporter.printTaskErrors (file:///F:/work/projects/quini/GitHub/antfu/vitest-main/packages/vitest/dist/index-1326b2d0.js:7107:7)
```