### PR TITLE
Revert: do not add expected/actual attributes in a object when does no exist

### DIFF
--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -57,9 +57,9 @@ export function processError(err: any) {
   if (err.name)
     err.nameStr = String(err.name)
 
-  if (err.expected !== undefined && err.expected !== null && typeof err.expected !== 'string')
+  if (typeof err.expected !== 'string')
     err.expected = stringify(err.expected)
-  if (err.actual !== undefined && err.actual !== null && typeof err.actual !== 'string')
+  if (typeof err.actual !== 'string')
     err.actual = stringify(err.actual)
 
   return serializeError(err)

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -150,6 +150,11 @@ describe('jest-expect', () => {
     expect(1).toBe(1)
   })
 
+  it.fails('toBe with null/undefined values', () => {
+    expect(undefined).toBe(true)
+    expect(null).toBe(true)
+  })
+
   // https://jestjs.io/docs/expect#tostrictequalvalue
 
   class LaCroix {

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -94,4 +94,3 @@ describe('error serialize', () => {
     })
   })
 })
-

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { processError, serializeError } from '../../../packages/vitest/src/runtime/error'
+import { serializeError } from '../../../packages/vitest/src/runtime/error'
 
 describe('error serialize', () => {
   it('works', () => {
@@ -95,13 +95,3 @@ describe('error serialize', () => {
   })
 })
 
-describe('Process Error', () => {
-  it('Do not add expected/actual attributes in a object when any of both attributes does not exists', () => {
-    const error = new Error('Ops something went wrong')
-
-    const result = processError(error)
-
-    expect(result.expected).not.toBeDefined()
-    expect(result.actual).not.toBeDefined()
-  })
-})


### PR DESCRIPTION
This reverts https://github.com/vitest-dev/vitest/pull/407 and https://github.com/vitest-dev/vitest/pull/409 because `null` or `undefined` could be `actual` or `expected` value.

Relates to https://github.com/vitest-dev/vitest/issues/411