### PR TITLE
perf: disable vite file watcher

### DIFF
--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -378,6 +378,7 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
     plugins: [
       {
         name: 'vitest',
+        enforce: 'pre',
         async configureServer(server) {
           if (haveStarted)
             await ctx.report('onServerRestart')
@@ -386,6 +387,7 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
           if (options.api)
             (await import('../api/setup')).setup(ctx)
 
+          // #415, in run mode we don't need the watcher, close it would improve the performance
           if (!options.watch)
             await server.watcher.close()
         },

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -394,6 +394,7 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
       open: options.open ? '/__vitest__/' : undefined,
       strictPort: true,
       preTransformRequests: false,
+      watch: { ignored: ['**'] },
     },
     build: {
       sourcemap: true,

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -385,6 +385,9 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
           haveStarted = true
           if (options.api)
             (await import('../api/setup')).setup(ctx)
+
+          if (!options.watch)
+            server.watcher.close()
         },
       } as VitePlugin,
       MocksPlugin(),
@@ -394,7 +397,6 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
       open: options.open ? '/__vitest__/' : undefined,
       strictPort: true,
       preTransformRequests: false,
-      watch: { ignored: ['**'] },
     },
     build: {
       sourcemap: true,

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -387,7 +387,7 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
             (await import('../api/setup')).setup(ctx)
 
           if (!options.watch)
-            server.watcher.close()
+            await server.watcher.close()
         },
       } as VitePlugin,
       MocksPlugin(),


### PR DESCRIPTION
We don't use Vite watch functionality in run mode and setting up file watcher takes considerable time:
![image](https://user-images.githubusercontent.com/2339406/147922397-f54c3071-96ad-4a51-b4bd-e679666a4e71.png)


Before:

| name   | time  |
|---|---|
|  vitest:vue | '4.147s ± 12.89%' |
| jest:vue | '4.629s ± 1.96%'  |

After:
| name | time |
|---|---|
| vitest:vue | '3.438s ± 1.84%' |
| jest:vue | '4.658s ± 3.04%' |