### PR TITLE
docs: fix the link to Components testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Read the [documentation](https://vitest.dev/).
 - [Native code coverage](#coverage) via [c8](https://github.com/bcoe/c8)
 - [Tinyspy](https://github.com/Aslemammad/tinyspy) built-in for mocking, stubbing, and spies.
 - [JSDOM](https://github.com/jsdom/jsdom) and [happy-dom](https://github.com/capricorn86/happy-dom) for DOM and browser API mocking
-- Components testing ([Vue](./test/vue), [React](./test/react), [Lit](./test/lit), [Vitesse](./test/vitesse))
+- Components testing ([Vue](./examples/vue), [React](./examples/react), [Svelte](./examples/svelte), [Lit](./examples/lit), [Vitesse](./examples/vitesse))
 - Workers multi-threading via [tinypool](https://github.com/Aslemammad/tinypool) (a lightweight fork of [Piscina](https://github.com/piscinajs/piscina))
 - ESM first, top level await
 - Out-of-box TypeScript / JSX support


### PR DESCRIPTION
- Fixed links that were broken due to moving examples.
- Added a link to Svelte examples.