### PR TITLE
fix: Wrong argument in `JestMockCompatContext`

### DIFF
--- a/packages/vitest/src/integrations/jest-mock.ts
+++ b/packages/vitest/src/integrations/jest-mock.ts
@@ -18,11 +18,11 @@ interface MockResultThrow {
 type MockResult<T> = MockResultReturn<T> | MockResultThrow | MockResultIncomplete
 
 export interface JestMockCompatContext<T, Y> {
-  calls: Y[]
-  instances: T[]
+  calls: T[]
+  instances: Y[]
   // TODO: doesn't work
   invocationCallOrder: number[]
-  results: MockResult<T>[]
+  results: MockResult<Y>[]
 }
 
 type Procedure = (...args: any[]) => any

--- a/packages/vitest/src/integrations/jest-mock.ts
+++ b/packages/vitest/src/integrations/jest-mock.ts
@@ -17,12 +17,12 @@ interface MockResultThrow {
 
 type MockResult<T> = MockResultReturn<T> | MockResultThrow | MockResultIncomplete
 
-export interface JestMockCompatContext<T, Y> {
-  calls: T[]
-  instances: Y[]
+export interface JestMockCompatContext<TArgs, TReturns> {
+  calls: TArgs[]
+  instances: TReturns[]
   // TODO: doesn't work
   invocationCallOrder: number[]
-  results: MockResult<Y>[]
+  results: MockResult<TReturns>[]
 }
 
 type Procedure = (...args: any[]) => any


### PR DESCRIPTION
It seems that the parameters `T` and `Y` were confused.

https://github.com/vitest-dev/vitest/blob/1a37c6eefc86df2cb723a3dde11cabfce65b361c/packages/vitest/src/integrations/jest-mock.ts#L20-L26

Test case:
```ts
const sum = vi.fn((a: number, b: number): string => `${a}${b}`)
```
Before:
```ts
sum.mock.calls //  string[]
sum.mock.results //  MockResult<[a: number, b: number]>[]
```

After:
```ts
sum.mock.calls; // [a: number, b: number][]
sum.mock.results; // MockResult<string>[]
```