### PR TITLE
fix(api): generate valid module graph

### DIFF
--- a/packages/ui/client/composables/client.ts
+++ b/packages/ui/client/composables/client.ts
@@ -24,7 +24,7 @@ export const findById = (id: string) => {
 
 export const isConnected = computed(() => status.value === 'OPEN')
 export const isConnecting = computed(() => status.value === 'CONNECTING')
-export const isDisconned = computed(() => status.value === 'CLOSED')
+export const isDisconnected = computed(() => status.value === 'CLOSED')
 
 export function runAll() {
   return runFiles(client.state.getFiles())

--- a/packages/ui/client/composables/module-graph.ts
+++ b/packages/ui/client/composables/module-graph.ts
@@ -58,8 +58,6 @@ export function useModuleGraph(data: Ref<{
       .flatMap(([module, deps]) => deps.map((dep) => {
         const source = nodeMap[module]
         const target = nodeMap[dep]
-        if (source === undefined || target === undefined)
-          return undefined
 
         return defineLink({
           source,
@@ -69,7 +67,7 @@ export function useModuleGraph(data: Ref<{
           labelColor: 'var(--color-link-label)',
           showLabel: false,
         })
-      }).filter(link => link !== undefined) as ModuleLink[])
+      }))
     return { nodes, links }
   })
 }

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -1,11 +1,11 @@
-import type { File, Reporter, ResolvedConfig } from '../types'
+import type { File, ModuleGraphData, Reporter, ResolvedConfig } from '../types'
 
 export interface WebSocketHandlers {
   getFiles(): File[]
   getConfig(): ResolvedConfig
   readFile(id: string): Promise<string>
   writeFile(id: string, content: string): Promise<void>
-  getModuleGraph(id: string): Promise<{graph: Record<string, string[]>; externalized: string[]; inlined: string[]}>
+  getModuleGraph(id: string): Promise<ModuleGraphData>
   rerun(files: string[]): Promise<void>
 }
 

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -49,3 +49,9 @@ export interface ErrorWithDiff extends Error {
   expected?: any
   operator?: string
 }
+
+export interface ModuleGraphData {
+  graph: Record<string, string[]>
+  externalized: string[]
+  inlined: string[]
+}


### PR DESCRIPTION
Previously, the edges of a graph were not updated when a module was externalized (rewritten).

Closes #401