### PR TITLE
fix(config): correctly parse string values for `setupFiles`

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -104,7 +104,7 @@ export function resolveConfig(
   if (process.env.VITEST_MIN_THREADS)
     resolved.minThreads = parseInt(process.env.VITEST_MIN_THREADS)
 
-  const setupFilesArray = typeof resolved.setupFiles === 'string' ? [resolved.setupFiles] : Array.from(resolved.setupFiles)
+  const setupFilesArray = typeof resolved.setupFiles === 'string' ? [resolved.setupFiles] : Array.from(resolved.setupFiles || [])
   resolved.setupFiles = setupFilesArray.map(i => resolve(resolved.root, i))
 
   // the server has been created, we don't need to override vite.server options

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -104,8 +104,7 @@ export function resolveConfig(
   if (process.env.VITEST_MIN_THREADS)
     resolved.minThreads = parseInt(process.env.VITEST_MIN_THREADS)
 
-  const setupFilesArray = typeof resolved.setupFiles === 'string' ? [resolved.setupFiles] : Array.from(resolved.setupFiles || [])
-  resolved.setupFiles = setupFilesArray.map(i => resolve(resolved.root, i))
+  resolved.setupFiles = toArray(resolved.setupFiles || []).map(file => resolve(resolved.root, file))
 
   // the server has been created, we don't need to override vite.server options
   resolved.api = resolveApiConfig(options)

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -104,8 +104,8 @@ export function resolveConfig(
   if (process.env.VITEST_MIN_THREADS)
     resolved.minThreads = parseInt(process.env.VITEST_MIN_THREADS)
 
-  resolved.setupFiles = Array.from(resolved.setupFiles || [])
-    .map(i => resolve(resolved.root, i))
+  const setupFilesArray = typeof resolved.setupFiles === 'string' ? [resolved.setupFiles] : Array.from(resolved.setupFiles)
+  resolved.setupFiles = setupFilesArray.map(i => resolve(resolved.root, i))
 
   // the server has been created, we don't need to override vite.server options
   resolved.api = resolveApiConfig(options)


### PR DESCRIPTION
Was scratching my head a bit not knowing why there were import issues when providing a string value for `setupFiles`. Looks like the TS defs show that it accepts a string value, however providing one, such as:

```ts
{
  setupFiles: "./vitest.setup.ts"
}
```

would result in the following due to `Array.from("./vitest.setup.ts")`

```ts
resolved.setupFiles = [".", "/", "v", "i", ...]
```

The TS defs are listed here, so alternatively we could only accept string arrays, along with updating the docs.

https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/types/config.ts#L145-L148

https://github.com/vitest-dev/vitest/blob/main/docs/config/index.md?plain=1#L232-L236