### PR TITLE
fix: mock node builtins

### DIFF
--- a/packages/vitest/src/node/execute.ts
+++ b/packages/vitest/src/node/execute.ts
@@ -89,7 +89,7 @@ export async function executeInViteNode(options: ExecuteOptions) {
     if (cached)
       return cached
     const exports = await mock()
-    setCache(name, { exports, mocked: true })
+    setCache(name, { exports })
     return exports
   }
 
@@ -103,12 +103,12 @@ export async function executeInViteNode(options: ExecuteOptions) {
         if (mock === null) {
           const mockedKey = `${dep}__mock`
           const cache = moduleCache.get(mockedKey)
-          if (cache?.exports && cache.mocked)
+          if (cache?.exports)
             return cache.exports
           const cacheKey = toFilePath(dep, root)
           const mod = moduleCache.get(cacheKey)?.exports || await cachedRequest(dep, callstack)
           const exports = mockObject(mod)
-          setCache(mockedKey, { exports, mocked: true })
+          setCache(mockedKey, { exports })
           return exports
         }
         if (typeof mock === 'function')

--- a/packages/vitest/src/node/mocker.ts
+++ b/packages/vitest/src/node/mocker.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync } from 'fs'
+import { isNodeBuiltin } from 'mlly'
 import { basename, dirname, join, resolve } from 'pathe'
 import { spies, spyOn } from '../integrations/jest-mock'
 import { mergeSlashes } from '../utils'
@@ -9,12 +10,12 @@ export interface SuiteMocks {
   }
 }
 
-function resolveMockPath(mockPath: string, root: string, nmName: string | null) {
+function resolveMockPath(mockPath: string, root: string, external: string | null) {
   // it's a node_module alias
   // all mocks should be inside <root>/__mocks__
-  if (nmName) {
-    const mockDirname = dirname(nmName) // for nested mocks: @vueuse/integration/useJwt
-    const baseFilename = basename(nmName)
+  if (external || isNodeBuiltin(mockPath)) {
+    const mockDirname = dirname(external || mockPath) // for nested mocks: @vueuse/integration/useJwt
+    const baseFilename = basename(external || mockPath)
     const mockFolder = resolve(root, '__mocks__', mockDirname)
 
     if (!existsSync(mockFolder)) return null

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -8,6 +8,7 @@ export interface ModuleCache {
   promise?: Promise<any>
   exports?: any
   code?: string
+  mocked?: boolean
 }
 
 export interface EnvironmentReturn {

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -8,7 +8,6 @@ export interface ModuleCache {
   promise?: Promise<any>
   exports?: any
   code?: string
-  mocked?: boolean
 }
 
 export interface EnvironmentReturn {

--- a/test/core/__mocks__/timers.ts
+++ b/test/core/__mocks__/timers.ts
@@ -1,0 +1,3 @@
+export default {
+  clearInterval: () => 'foo',
+}

--- a/test/core/src/exec.ts
+++ b/test/core/src/exec.ts
@@ -1,11 +1,16 @@
 /* eslint-disable import/no-duplicates */
 import { exec } from 'child_process'
 import * as child_process from 'child_process'
+import defaultProcess from 'child_process'
 
 export function execHelloWorld() {
   exec('hello world')
 }
 
+export function execImportAll() {
+  child_process.exec('import all')
+}
+
 export function execDefault() {
-  child_process.exec('default')
+  defaultProcess.exec('default')
 }

--- a/test/core/test/mock-internals.test.ts
+++ b/test/core/test/mock-internals.test.ts
@@ -17,6 +17,6 @@ test('node internal is mocked', () => {
   expect(childProcess.exec).toHaveBeenCalledWith('default')
 })
 
-test('built int is mocked with __mocks__ folder', () => {
+test('builtin is mocked with __mocks__ folder', () => {
   expect(timers.clearInterval()).toBe('foo')
 })

--- a/test/core/test/mock-internals.test.ts
+++ b/test/core/test/mock-internals.test.ts
@@ -1,17 +1,16 @@
-import { exec } from 'child_process'
+import childProcess, { exec } from 'child_process'
 import { expect, test, vi } from 'vitest'
-import { execDefault, execHelloWorld } from '../src/exec'
+import { execDefault, execHelloWorld, execImportAll } from '../src/exec'
 
-vi.mock('child_process', () => {
-  return {
-    exec: vi.fn(),
-  }
-})
+vi.mock('child_process')
 
 test('node internal is mocked', () => {
   execHelloWorld()
   expect(exec).toHaveBeenCalledWith('hello world')
 
+  execImportAll()
+  expect(exec).toHaveBeenCalledWith('import all')
+
   execDefault()
-  expect(exec).toHaveBeenCalledWith('default')
+  expect(childProcess.exec).toHaveBeenCalledWith('default')
 })

--- a/test/core/test/mock-internals.test.ts
+++ b/test/core/test/mock-internals.test.ts
@@ -1,8 +1,10 @@
 import childProcess, { exec } from 'child_process'
+import timers from 'timers'
 import { expect, test, vi } from 'vitest'
 import { execDefault, execHelloWorld, execImportAll } from '../src/exec'
 
 vi.mock('child_process')
+vi.mock('timers') // node built in inside __mocks__
 
 test('node internal is mocked', () => {
   execHelloWorld()
@@ -13,4 +15,8 @@ test('node internal is mocked', () => {
 
   execDefault()
   expect(childProcess.exec).toHaveBeenCalledWith('default')
+})
+
+test('built int is mocked with __mocks__ folder', () => {
+  expect(timers.clearInterval()).toBe('foo')
 })


### PR DESCRIPTION
Automocking didn't work for node builtins, so I moved automocking before calling a module instead of after

Also `importMock` had cache, but I think it should be brand new every time you call it

Related: https://github.com/vitest-dev/vitest/issues/453