### PR TITLE
fix: make tap reporter compatible with mocha xunit transform

### DIFF
--- a/packages/vitest/src/reporters/tap.ts
+++ b/packages/vitest/src/reporters/tap.ts
@@ -25,7 +25,7 @@ export class TapReporter implements Reporter {
     this.ctx.log(`${currentIdent}1..${tasks.length}`)
 
     for (const task of tasks) {
-      const ok = task.result?.state === 'pass' ? 'ok' : 'not ok'
+      const ok = task.result?.state === 'pass' || task.mode === 'skip' || task.mode === 'todo' ? 'ok' : 'not ok'
 
       let comment = ''
       if (task.mode === 'skip')


### PR DESCRIPTION
This marks skipped and todo tests as 'ok' instead of 'not ok'