### PR TITLE
fix: `mockClear` doesn't clear `instances`

### DIFF
--- a/packages/vitest/src/integrations/jest-mock.ts
+++ b/packages/vitest/src/integrations/jest-mock.ts
@@ -152,7 +152,7 @@ function enhanceSpy<TArgs extends any[], TReturns>(
 
   let implementation: ((...args: TArgs) => TReturns) | undefined
 
-  const instances: any[] = []
+  let instances: any[] = []
 
   const mockContext = {
     get calls() {
@@ -185,7 +185,7 @@ function enhanceSpy<TArgs extends any[], TReturns>(
 
   stub.mockClear = () => {
     stub.reset()
-    instances.length = []
+    instances = []
     return stub
   }
 

--- a/packages/vitest/src/integrations/jest-mock.ts
+++ b/packages/vitest/src/integrations/jest-mock.ts
@@ -185,11 +185,12 @@ function enhanceSpy<TArgs extends any[], TReturns>(
 
   stub.mockClear = () => {
     stub.reset()
+    instances.length = []
     return stub
   }
 
   stub.mockReset = () => {
-    stub.reset()
+    stub.mockClear()
     implementation = () => undefined as unknown as TReturns
     onceImplementations = []
     return stub

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -21,12 +21,25 @@ describe('jest mock compat layer', () => {
     expect(spy.mock.calls[0]).toEqual(['hello'])
 
     spy('world')
-
     expect(spy.mock.calls).toEqual([['hello'], ['world']])
 
     spy.mockReset() // same as mockClear()
 
     expect(spy.mock.calls).toEqual([])
+  })
+
+  it('clearing instances', () => {
+    const Spy = vitest.fn(() => {})
+
+    expect(Spy.mock.instances).toHaveLength(0)
+    // @ts-expect-error In TypeScript you should use `new` only on classes
+    // eslint-disable-next-line no-new
+    new Spy()
+    expect(Spy.mock.instances).toHaveLength(1)
+
+    Spy.mockReset() // same as mockClear()
+
+    expect(Spy.mock.instances).toHaveLength(0)
   })
 
   it('implementation sync fn', () => {


### PR DESCRIPTION
Test case
```ts
  const SomeClass = vi.fn(() => {});
  expect(SomeClass.mock.instances.length).toBe(0);
  new SomeClass();
  expect(SomeClass.mock.instances.length).toBe(1);

  SomeClass.mockClear();
  expect(SomeClass.mock.instances.length).toBe(0); // AssertionError: expected 1 to equal 0
```