### PR TITLE
fix: Move pretty-format to dependencies array

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -56,6 +56,7 @@
     "@types/chai-subset": "^1.3.3",
     "chai": "^4.3.4",
     "local-pkg": "^0.4.1",
+    "pretty-format": "^27.4.6",
     "tinypool": "^0.1.1",
     "tinyspy": "^0.2.8",
     "vite": ">=2.7.10"
@@ -90,7 +91,6 @@
     "pathe": "^0.2.0",
     "picocolors": "^1.0.0",
     "pkg-types": "^0.3.2",
-    "pretty-format": "^27.4.6",
     "prompts": "^2.4.2",
     "rollup": "^2.63.0",
     "source-map-js": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,7 @@ importers:
       '@types/chai-subset': 1.3.3
       chai: 4.3.4
       local-pkg: 0.4.1
+      pretty-format: 27.4.6
       tinypool: 0.1.1
       tinyspy: 0.2.8
       vite: 2.7.10
@@ -464,7 +465,6 @@ importers:
       pathe: 0.2.0
       picocolors: 1.0.0
       pkg-types: 0.3.2
-      pretty-format: 27.4.6
       prompts: 2.4.2
       rollup: 2.63.0
       source-map-js: 1.0.1
@@ -2825,7 +2825,6 @@ packages:
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-    dev: true
 
   /ansi-styles/6.1.0:
     resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
@@ -6679,7 +6678,7 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-    dev: true
+    dev: false
 
   /prismjs/1.25.0:
     resolution: {integrity: sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==}


### PR DESCRIPTION
The tsc compiler would fail with an error because it could not find the types for
pretty-format.

Fixes #473
