### PR TITLE
fix(ui): reduce graph container size

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -55,14 +55,14 @@ const changeViewMode = (view: Params['view']) => {
         </button>
       </div>
     </div>
-    <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" />
+    <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" class="file-details-graph" />
     <ViewEditor v-if="viewMode === 'editor'" :file="current" />
     <ViewReport v-else-if="!viewMode" :file="current" />
   </div>
 </template>
 
-<style>
-:root {
+<style scoped>
+.file-details-graph {
   /* The graph container is offset in its parent. Thus we can't use the default 100% height and have to subtract the offset. */
   --graph-height: calc(100% - 78px - 39px);
 }

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -60,3 +60,10 @@ const changeViewMode = (view: Params['view']) => {
     <ViewReport v-else-if="!viewMode" :file="current" />
   </div>
 </template>
+
+<style>
+:root {
+  /* The graph container is offset in its parent. Thus we can't use the default 100% height and have to subtract the offset. */
+  --graph-height: calc(100% - 78px - 39px);
+}
+</style>

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -185,6 +185,10 @@ html.dark {
   --color-node-root: #467d8b;
 }
 
+.graph {
+  height: var(--graph-height, 100%) !important;
+}
+
 .graph .node {
   stroke-width: 2px;
   stroke-opacity: 0.5;

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -16,10 +16,6 @@ const modalShow = ref(false)
 const selectedModule = ref<string | null>()
 const controller = ref<ModuleGraphController | undefined>()
 
-useResizeObserver(el, debounce(() => {
-  controller.value?.resize()
-}))
-
 onMounted(() => {
   resetGraphController()
 })
@@ -59,6 +55,7 @@ function resetGraphController() {
           return 0.25
         },
       },
+      autoResize: true,
       forces: {
         charge: {
           strength: -1,
@@ -67,6 +64,7 @@ function resetGraphController() {
           radiusMultiplier: 10,
         },
       },
+      marker: Markers.Arrow(2),
       modifiers: {
         node(selection: Selection<SVGCircleElement, ModuleNode, SVGGElement, undefined>) {
           bindOnClick(selection)
@@ -75,7 +73,10 @@ function resetGraphController() {
       positionInitializer: graph.value.nodes.length > 1
         ? PositionInitializers.Randomized
         : PositionInitializers.Centered,
-      marker: Markers.Arrow(2),
+      zoom: {
+        min: 0.5,
+        max: 2,
+      },
     }),
   )
 }
@@ -110,15 +111,6 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
       if (dx ** 2 + dy ** 2 < 100)
         setSelectedModule(node.id)
     })
-}
-
-// Without debouncing the resize method, resizing the component will result in flickering.
-function debounce(cb: () => void) {
-  let h = 0
-  return () => {
-    window.clearTimeout(h)
-    h = window.setTimeout(() => cb())
-  }
 }
 </script>
 


### PR DESCRIPTION
This PR re-adds the custom size for the graph container that is necessary because of its offset.

It also uses the new built-in automatic resizing.