### PR TITLE
feat(ui): use resize observer for module graph

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -64,7 +64,7 @@ const changeViewMode = (view: Params['view']) => {
       </div>
     </div>
     <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" :header-size="headerSize" />
-    <ViewEditor v-if="viewMode === 'editor'" :file="current" />
+    <ViewEditor v-if="viewMode === 'editor'" :file="current" :header-size="headerSize" />
     <ViewReport v-else-if="!viewMode" :file="current" />
   </div>
 </template>

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -6,11 +6,19 @@ import type { ModuleGraph } from '~/composables/module-graph'
 import { getModuleGraph } from '~/composables/module-graph'
 import type { ModuleGraphData } from '#types'
 
+const header = ref(null)
+const headerSize = ref<number>(0)
+
 function open() {
   const filePath = current.value?.filepath
   if (filePath)
     fetch(`/__open-in-editor?file=${encodeURIComponent(filePath)}`)
 }
+
+useResizeObserver(header, () => {
+  const clientHeight = unrefElement(header)?.clientHeight
+  headerSize.value = clientHeight ?? 0
+})
 
 const data = ref<ModuleGraphData>({ externalized: [], graph: {}, inlined: [] })
 const graph = ref<ModuleGraph>({ nodes: [], links: [] })
@@ -33,7 +41,7 @@ const changeViewMode = (view: Params['view']) => {
 
 <template>
   <div v-if="current" h-full>
-    <div>
+    <div ref="header">
       <div p="2" h-10 flex="~ gap-2" items-center bg-header border="b base">
         <StatusIcon :task="current" />
         <div flex-1 font-light op-50 ws-nowrap truncate text-sm>
@@ -55,15 +63,8 @@ const changeViewMode = (view: Params['view']) => {
         </button>
       </div>
     </div>
-    <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" class="file-details-graph" />
+    <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" :header-size="headerSize" />
     <ViewEditor v-if="viewMode === 'editor'" :file="current" />
     <ViewReport v-else-if="!viewMode" :file="current" />
   </div>
 </template>
-
-<style scoped>
-.file-details-graph {
-  /* The graph container is offset in its parent. Thus we can't use the default 100% height and have to subtract the offset. */
-  --graph-height: calc(100% - 78px - 39px);
-}
-</style>

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -9,11 +9,28 @@ const ext = computed(() => props.id?.split(/\./g).pop() || 'js')
 const source = computed(() => result.value?.source?.trim() || '')
 const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=.*\n/, '').trim() || '')
 // TODO: sourcemap https://evanw.github.io/source-map-visualization/
+
+const header = ref(null)
+const header2 = ref(null)
+const headerSize = ref(0)
+const header2Size = ref(0)
+useResizeObserver(header, () => {
+  const clientHeight = unrefElement(header)?.clientHeight
+  headerSize.value = clientHeight ?? 0
+})
+useResizeObserver(header2, () => {
+  const clientHeight = unrefElement(header2)?.clientHeight
+  header2Size.value = clientHeight ?? 0
+})
+const style = computed(() => {
+  const size = headerSize.value + header2Size.value
+  return size > 0 ? `--cm-scrolls-mod-info: calc(100vh - ${size + 3}px)` : null
+})
 </script>
 
 <template>
   <div w-350 max-w-screen>
-    <div p-4 relative>
+    <div ref="header" p-4 relative>
       <p>Module Info</p>
       <p op50 font-mono text-sm>
         {{ id }}
@@ -28,14 +45,14 @@ const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=
         <div p="x3 y-1" bg-overlay border="base b t r">
           Source
         </div>
-        <div p="x3 y-1" bg-overlay border="base b t">
+        <div ref="header2" p="x3 y-1" bg-overlay border="base b t">
           Transformed
         </div>
         <div>
-          <CodeMirror :model-value="source" v-bind="{ lineNumbers:true }" :mode="ext" />
+          <CodeMirror :model-value="source" v-bind="{ lineNumbers:true }" :mode="ext" :style="style" />
         </div>
         <div>
-          <CodeMirror :model-value="code" v-bind="{ lineNumbers:true }" :mode="ext" />
+          <CodeMirror :model-value="code" v-bind="{ lineNumbers:true }" :mode="ext" :style="style" />
         </div>
       </div>
       <pre>{{ result }}</pre>

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -24,7 +24,7 @@ useResizeObserver(header2, () => {
 })
 const style = computed(() => {
   const size = headerSize.value + header2Size.value
-  return size > 0 ? `--cm-scrolls-mod-info: calc(100vh - ${size + 3}px)` : null
+  return size > 0 ? `--cm-scrolls-height: calc(100vh - ${size + 3}px)` : null
 })
 </script>
 

--- a/packages/ui/client/components/TasksList.vue
+++ b/packages/ui/client/components/TasksList.vue
@@ -2,6 +2,14 @@
 import type { Task } from '#types'
 import { activeFileId } from '~/composables/params'
 
+const header = ref(null)
+const headerSize = ref<number>(0)
+
+const style = computed(() => {
+  const size = headerSize.value
+  return size > 0 ? `--cm-scrolls-height: calc(100vh - ${size}px - 1px)` : null
+})
+
 withDefaults(defineProps<{
   tasks: Task[]
   indent?: number
@@ -23,7 +31,7 @@ export default {
 
 <template>
   <div h="full">
-    <div>
+    <div ref="header">
       <div
         p="2"
         h-10

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -5,6 +5,7 @@ import type { File } from '#types'
 
 const props = defineProps<{
   file?: File
+  headerSize: number
 }>()
 
 const code = ref('')
@@ -23,6 +24,11 @@ const editor = ref<any>()
 
 const cm = computed<CodeMirror.EditorFromTextArea | undefined>(() => editor.value?.cm)
 const failed = computed(() => props.file?.tasks.filter(i => i.result?.state === 'fail') || [])
+
+const style = computed(() => {
+  const size = props.headerSize
+  return size > 0 ? `--cm-scrolls-height: calc(100vh - ${size}px - 1px)` : null
+})
 
 const widgets: CodeMirror.LineWidget[] = []
 const handles: CodeMirror.LineHandle[] = []
@@ -63,6 +69,7 @@ watch([cm, failed], () => {
     v-model="code"
     v-bind="{ lineNumbers: true }"
     :mode="ext"
+    :style="style"
     @save="onSave"
   />
 </template>

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -6,9 +6,23 @@ import type { ModuleGraph, ModuleGraphController, ModuleLink, ModuleNode, Module
 
 const props = defineProps<{
   graph: ModuleGraph
+  headerSize: number
 }>()
 
-const { graph } = toRefs(props)
+const header = ref(null)
+const thisHeaderSize = ref<number>(0)
+
+const { graph, headerSize } = toRefs(props)
+
+useResizeObserver(header, () => {
+  const clientHeight = unrefElement(header)?.clientHeight
+  thisHeaderSize.value = clientHeight ?? 0
+})
+
+const style = computed(() => {
+  const size = headerSize.value + thisHeaderSize.value
+  return `--graph-height: calc(100vh - ${size}px)`
+})
 
 const el = ref<HTMLDivElement>()
 
@@ -116,7 +130,7 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
 
 <template>
   <div h-full overflow="hidden">
-    <div>
+    <div ref="header">
       <div flex items-center gap-4 px-3 py-2>
         <div v-for="node of controller?.nodeTypes.sort()" :key="node" flex="~ gap-1" items-center select-none>
           <input
@@ -147,7 +161,7 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
         </div>
       </div>
     </div>
-    <div ref="el" class="graph" />
+    <div ref="el" class="graph" :style="style" />
     <Modal v-model="modalShow" direction="right">
       <template v-if="selectedModule">
         <Suspense>

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -21,7 +21,7 @@ useResizeObserver(header, () => {
 
 const style = computed(() => {
   const size = headerSize.value + thisHeaderSize.value
-  return `--graph-height: calc(100vh - ${size}px)`
+  return size > 0 ? `--graph-height: calc(100vh - ${size}px)` : null
 })
 
 const el = ref<HTMLDivElement>()

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -181,6 +181,7 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
   --color-node-root: #6e9aa5;
   --color-node-label: var(--color-text);
   --color-node-stroke: var(--color-text);
+  --graph-height: 100%;
 }
 
 html.dark {
@@ -192,7 +193,7 @@ html.dark {
 }
 
 .graph {
-  height: var(--graph-height, 100%) !important;
+  height: var(--graph-height) !important;
 }
 
 .graph .node {

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -52,6 +52,7 @@ html.dark {
   /* scrollbars colors */
   --cm-ttc-c-thumb: #eee;
   --cm-ttc-c-track: white;
+  --cm-scrolls-mod-info: calc(100vh - 78px);
 }
 
 html.dark {
@@ -132,10 +133,12 @@ html.dark {
 .CodeMirror-scroll,
 .scrolls {
   overflow: auto !important;
-  height: calc(100vh - 78px) !important;
+  height: var(--cm-scrolls-mod-info) !important;
   scrollbar-width: thin;
   scrollbar-color: var(--cm-ttc-c-thumb) var(--cm-ttc-c-track);
 }
+
+
 .CodeMirror-scroll::-webkit-scrollbar-track,
 .scrolls::-webkit-scrollbar-track {
   background: var(--cm-ttc-c-track);

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -52,7 +52,7 @@ html.dark {
   /* scrollbars colors */
   --cm-ttc-c-thumb: #eee;
   --cm-ttc-c-track: white;
-  --cm-scrolls-mod-info: calc(100vh - 78px);
+  --cm-scrolls-height: calc(100vh - 78px);
 }
 
 html.dark {
@@ -111,7 +111,8 @@ html.dark {
 }
 
 .splitpanes--vertical > .splitpanes__splitter:before {
-  left: -10px;
+  /* make vertical scroll usable */
+  /*left: -10px;*/
   right: -10px;
   height: 100%;
 }
@@ -133,7 +134,7 @@ html.dark {
 .CodeMirror-scroll,
 .scrolls {
   overflow: auto !important;
-  height: var(--cm-scrolls-mod-info) !important;
+  height: var(--cm-scrolls-height) !important;
   scrollbar-width: thin;
   scrollbar-color: var(--cm-ttc-c-thumb) var(--cm-ttc-c-track);
 }


### PR DESCRIPTION
From #478 request: the problem @antfu we need 2 resize observers, since the headers are on `FileDetails` and `ModuleGrapth`.

This PR also makes the horizontal scrolls on the source code editors on the new contextual modal visible, 2 more resize observers (maybe we can change the layout and use only 1 resize observer).