### PR TITLE
feat: json reporter

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -178,10 +178,11 @@ Project root
 - **Type:** `Reporter | Reporter[]`
 - **Default:** `'default'`
 
-Custom reporters for output. Reporters can be [a Reporter instance](https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/types/reporter.ts) or a string to select built in reporters: 
+Custom reporters for output. Reporters can be [a Reporter instance](https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/types/reporter.ts) or a string to select built in reporters:
   - `'default'` - collapse suites when they pass
   - `'verbose'` - keep the full task tree visible
   - `'dot'` -  show each task as a single dot
+  - `'json'` -  give a simple JSON summary
 
 ### threads
 
@@ -268,7 +269,7 @@ Isolate environment for each test file
 - **Default:** `undefined`
 
 Coverage options
-  
+
 ### open
 
 - **Type:** `boolean`

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -107,7 +107,7 @@ vitest related /src/index.ts /src/hello-world.js
 | `--api [api]` | Serve API, available options: `--api.port <port>`, `--api.host [host]` and `--api.strictPort` |
 | `--threads` | Enable Threads (default: true) |
 | `--silent` | Silent console output from tests |
-| `--reporter <name>` | Select reporter: `default`, `verbose`, or `dot` |
+| `--reporter <name>` | Select reporter: `default`, `verbose`, `dot` or `json` |
 | `--coverage` | Use c8 for coverage |
 | `--run` | Do not watch |
 | `--global` | Inject APIs globally |

--- a/packages/vitest/src/reporters/index.ts
+++ b/packages/vitest/src/reporters/index.ts
@@ -1,5 +1,6 @@
 import { DefaultReporter } from './default'
 import { DotReporter } from './dot'
+import { JsonReporter } from './json'
 import { VerboseReporter } from './verbose'
 import { TapReporter } from './tap'
 import { TapFlatReporter } from './tap-flat'
@@ -10,6 +11,7 @@ export const ReportersMap = {
   'default': DefaultReporter,
   'verbose': VerboseReporter,
   'dot': DotReporter,
+  'json': JsonReporter,
   'tap': TapReporter,
   'tap-flat': TapFlatReporter,
 }

--- a/packages/vitest/src/reporters/json.ts
+++ b/packages/vitest/src/reporters/json.ts
@@ -1,0 +1,70 @@
+import type { Vitest } from '../node'
+import type { File, Reporter } from '../types'
+import { getSuites, getTests } from '../utils'
+
+// for compatibility reasons, the reporter produces a JSON similar to the one produced by the Jest JSON reporter
+// the following types are extracted from the Jest repository (and simplified)
+interface TestResult {
+  displayName?: string
+  failureMessage?: string | null
+  skipped: boolean
+  status?: string
+  testFilePath?: string
+}
+interface AggregatedResult {
+  numFailedTests: number
+  numFailedTestSuites: number
+  numPassedTests: number
+  numPassedTestSuites: number
+  numPendingTests: number
+  numTodoTests: number
+  numPendingTestSuites: number
+  numTotalTests: number
+  numTotalTestSuites: number
+  startTime: number
+  success: boolean
+  testResults: Array<TestResult>
+}
+
+export class JsonReporter implements Reporter {
+  start = 0
+  ctx!: Vitest
+
+  onInit(ctx: Vitest): void {
+    this.ctx = ctx
+    this.start = performance.now()
+  }
+
+  protected logTasks(files: File[]) {
+    const suites = getSuites(files)
+    const numTotalTestSuites = suites.length
+    const tests = getTests(files)
+    const numTotalTests = tests.length
+
+    const numFailedTestSuites = suites.filter(s => s.result?.error).length
+    const numPassedTestSuites = numTotalTestSuites - numFailedTestSuites
+    const numPendingTestSuites = suites.filter(s => s.result?.state === 'run').length
+    const numFailedTests = tests.filter(t => t.result?.state === 'fail').length
+    const numPassedTests = numTotalTests - numFailedTests
+    const numPendingTests = tests.filter(t => t.result?.state === 'run').length
+    const numTodoTests = tests.filter(t => t.mode === 'todo').length
+
+    const success = numFailedTestSuites === 0 && numFailedTests === 0
+
+    const testResults: Array<TestResult> = tests.map(t => ({
+      displayName: t.name,
+      failureMessage: t.result?.error?.message,
+      skipped: t.result?.state === 'skip',
+      status: t.result?.state,
+      testFilePath: t.file?.filepath,
+    }))
+
+    const result: AggregatedResult = { numTotalTestSuites, numPassedTestSuites, numFailedTestSuites, numPendingTestSuites, numTotalTests, numPassedTests, numFailedTests, numPendingTests, numTodoTests, startTime: this.start, success, testResults }
+
+    this.ctx.log(JSON.stringify(result))
+  }
+
+  async onFinished(files = this.ctx.state.getFiles()) {
+    this.logTasks(files)
+  }
+}


### PR DESCRIPTION
Fixes #108

Adds a JSON reporter, available with `--reporter json`.

It produces a JSON report of the test run in a similar format to the default Jest one (produced with `--json`, see https://jestjs.io/docs/cli#--json).

The Jest result format is defined [here](https://github.com/facebook/jest/blob/fe5e91c1b86323ab02b3de9d322b77e65a64e75a/packages/jest-test-result/src/types.ts#L58-L75).

Vitest JSON reporter uses a simplified version of this format:

```ts
interface TestResult {
  displayName?: string
  failureMessage?: string | null
  skipped: boolean
  status?: string
  testFilePath?: string
}
interface AggregatedResult {
  numFailedTests: number
  numFailedTestSuites: number
  numPassedTests: number
  numPassedTestSuites: number
  numPendingTests: number
  numTodoTests: number
  numPendingTestSuites: number
  numTotalTests: number
  numTotalTestSuites: number
  startTime: number
  success: boolean
  testResults: Array<TestResult>
}
```