### PR TITLE
docs: Fix styles for "Sponsored by" block on homepage

### DIFF
--- a/docs/src/components/Home.vue
+++ b/docs/src/components/Home.vue
@@ -101,13 +101,13 @@
       Sponsored by
     </h3>
     <div grid="~ cols-1 lg:cols-2" w-screen text-center mt-10>
-      <div>
+      <div class="flex flex-col">
         <a text-lg href="https://github.com/sponsors/antfu">Anthony's Sponsors</a>
         <a href="https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg" target="_blank">
           <img src="https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg">
         </a>
       </div>
-      <div>
+      <div class="flex flex-col">
         <a text-lg href="https://github.com/sponsors/patak-dev">Patak's Sponsors</a>
         <a href="https://patak.dev/sponsors.svg" target="_blank">
           <img src="https://patak.dev/sponsors.svg">


### PR DESCRIPTION
Bug on big screens(More than ~1940px)
![alt](https://i.imgur.com/izCWRND.png)