### PR TITLE
fix: improve cjs proxy

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -126,7 +126,7 @@ function hasNestedDefault(target: any) {
 function proxyMethod(name: 'get' | 'set' | 'has' | 'deleteProperty', tryDefault: boolean) {
   return function(target: any, key: string | symbol, ...args: [any?, any?]) {
     const result = Reflect[name](target, key, ...args)
-    if (typeof target.default !== 'object')
+    if (typeof target.default !== 'object' && typeof target.default !== 'function')
       return result
     if ((tryDefault && key === 'default') || typeof result === 'undefined')
       return Reflect[name](target.default, key, ...args)

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -2,7 +2,7 @@ import { builtinModules, createRequire } from 'module'
 import { fileURLToPath, pathToFileURL } from 'url'
 import vm from 'vm'
 import { dirname, resolve } from 'pathe'
-import { normalizeId, slash, toFilePath } from './utils'
+import { isPrimitive, normalizeId, slash, toFilePath } from './utils'
 import type { ModuleCache, ViteNodeRunnerOptions } from './types'
 
 export class ViteNodeRunner {
@@ -126,7 +126,7 @@ function hasNestedDefault(target: any) {
 function proxyMethod(name: 'get' | 'set' | 'has' | 'deleteProperty', tryDefault: boolean) {
   return function(target: any, key: string | symbol, ...args: [any?, any?]) {
     const result = Reflect[name](target, key, ...args)
-    if (typeof target.default !== 'object' && typeof target.default !== 'function')
+    if (isPrimitive(target.default))
       return result
     if ((tryDefault && key === 'default') || typeof result === 'undefined')
       return Reflect[name](target.default, key, ...args)

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -20,6 +20,10 @@ export function normalizeId(id: string, base?: string): string {
     .replace(/\?$/, '') // remove end query mark
 }
 
+export function isPrimitive(v: any) {
+  return v !== Object(v)
+}
+
 export function toFilePath(id: string, root: string): string {
   let absolute = slash(id).startsWith('/@fs/')
     ? id.slice(4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,7 @@ importers:
       fs-extra: ^10.0.0
       givens: 1.3.9
       history: ^5.2.0
+      lodash: ^4.17.21
       prettier: ^2.5.1
       temp-dir: ^2.0.0
       vitest: workspace:*
@@ -585,6 +586,7 @@ importers:
       fs-extra: 10.0.0
       givens: 1.3.9
       history: 5.2.0
+      lodash: 4.17.21
       prettier: 2.5.1
       temp-dir: 2.0.0
       vitest: link:../../packages/vitest

--- a/test/cjs/package.json
+++ b/test/cjs/package.json
@@ -11,6 +11,7 @@
     "fs-extra": "^10.0.0",
     "givens": "1.3.9",
     "history": "^5.2.0",
+    "lodash": "^4.17.21",
     "prettier": "^2.5.1",
     "temp-dir": "^2.0.0",
     "vitest": "workspace:*"

--- a/test/cjs/test/interpret-default.test.tsx
+++ b/test/cjs/test/interpret-default.test.tsx
@@ -2,10 +2,16 @@ import { expect, it } from 'vitest'
 import { format } from 'prettier'
 import givens from 'givens'
 import tempDir from 'temp-dir'
+import _, { isString } from 'lodash'
 
 it('prettier', () => {
   expect(format('const a :   A = \'t\'', { parser: 'typescript' }).trim())
     .toEqual('const a: A = "t";'.trim())
+})
+
+it('lodash', () => {
+  expect(typeof _.isString).toBe('function')
+  expect(typeof isString).toBe('function')
 })
 
 it('has nested default', () => {

--- a/test/cjs/test/lodash.test.ts
+++ b/test/cjs/test/lodash.test.ts
@@ -1,0 +1,12 @@
+import fs, { existsSync } from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+
+describe('fs-extra', () => {
+  it('default export', () => {
+    expect(fs.existsSync('test/fs-extra.test.ts')).toBe(true)
+  })
+
+  it('named export', () => {
+    expect(existsSync('test/fs-extra.test.ts')).toBe(true)
+  })
+})


### PR DESCRIPTION
Fix #507 

the fix of #479 added this
```diff
function proxyMethod(name: 'get' | 'set' | 'has' | 'deleteProperty', tryDefault: boolean) {
  return function(target: any, key: string | symbol, ...args: [any?, any?]) {
    const result = Reflect[name](target, key, ...args)
+    if (typeof target.default !== 'object')
+      return result
    if ((tryDefault && key === 'default') || typeof result === 'undefined')
      return Reflect[name](target.default, key, ...args)
    return result
  }
}
```

but for some library like `lodash` that export function with additional property will cause error
not sure what is the best strategy to handle this case ( maybe detect with `Object.keys` ?)