### PR TITLE
feat: reporter output file

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -184,6 +184,12 @@ Custom reporters for output. Reporters can be [a Reporter instance](https://gith
   - `'dot'` -  show each task as a single dot
   - `'json'` -  give a simple JSON summary
 
+### outputFile
+
+- **Type:** `string`
+
+Write test results to a file when the `--reporter=json` option is also specified.
+
 ### threads
 
 - **Type:** `boolean`

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -24,6 +24,7 @@ cli
   .option('--silent', 'silent console output from tests')
   .option('--isolate', 'isolate environment for each test file', { default: true })
   .option('--reporter <name>', 'reporter')
+  .option('--outputFile <filename>', 'write test results to a file when the --reporter=json option is also specified')
   .option('--coverage', 'use c8 for coverage')
   .option('--run', 'do not watch')
   .option('--global', 'inject apis globally')

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -119,6 +119,11 @@ export interface InlineConfig {
   reporters?: Arrayable<BuiltinReporters | Reporter>
 
   /**
+   * Write test results to a file when the --reporter=json option is also specified
+   */
+  outputFile?: string
+
+  /**
    * Enable multi-threading
    *
    * @default true


### PR DESCRIPTION
This allows to write the JSON report to a file (similar to what Jest does with `--outputFile`, see https://jestjs.io/docs/cli#--outputfilefilename)

Usage:
```
pnpm test:run -- --reporter json --output-file report.json
```