### PR TITLE
feat: basic example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,6 @@
 | Example | Source | Playground |
 |---|---|---|
+| `basic` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/basic) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/basic?terminal=test) |
 | `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/lit?terminal=test) |
 | `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/mocks?terminal=test) |
 | `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/puppeteer?terminal=test) |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,5 @@
+# Vitest Demo
+
+Run `npm test` and change a test or source code to see HMR in action!
+
+Learn more at https://vitest.dev

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "vitest-test",
+  "private": true,
+  "main": "index.js",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "test": "vitest --ui",
+    "test:run": "vitest run"
+  },
+  "devDependencies": {
+    "@vitest/ui": "latest",
+    "vite": "^2.7.10",
+    "vitest": "latest"
+  }
+}

--- a/examples/basic/test/__snapshots__/suite.test.ts.snap
+++ b/examples/basic/test/__snapshots__/suite.test.ts.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1
+
+exports[`suite name > snapshot 1`] = `
+{
+  "foo": "bar",
+}
+`;

--- a/examples/basic/test/basic.test.ts
+++ b/examples/basic/test/basic.test.ts
@@ -1,0 +1,21 @@
+import { assert, expect, test } from 'vitest'
+
+// Edit an assertion and save to see HMR in action
+
+test('Math.sqrt()', () => {
+  expect(Math.sqrt(4)).toBe(2)
+  expect(Math.sqrt(144)).toBe(12)
+  expect(Math.sqrt(2)).toBe(Math.SQRT2)
+})
+
+test('JSON', () => {
+  const input = {
+    foo: 'hello',
+    bar: 'world',
+  }
+
+  const output = JSON.stringify(input)
+
+  expect(output).eq('{"foo":"hello","bar":"world"}')
+  assert.deepEqual(JSON.parse(output), input, 'matches original')
+})

--- a/examples/basic/test/suite.test.ts
+++ b/examples/basic/test/suite.test.ts
@@ -1,0 +1,15 @@
+import { assert, describe, expect, it } from 'vitest'
+
+describe('suite name', () => {
+  it('foo', () => {
+    assert.equal(Math.sqrt(4), 2)
+  })
+
+  it('bar', () => {
+    expect(1 + 1).eq(2)
+  })
+
+  it('snapshot', () => {
+    expect({ foo: 'bar' }).toMatchSnapshot()
+  })
+})

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+
+// Configure Vitest (https://vitest.dev/config)
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    /* for example, use global to avoid globals imports (describe, test, expect): */
+    // global: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,16 @@ importers:
       unplugin-vue-components: 0.17.11_5f0e46dd90b19e6d0d01b34ab1022632
       vitepress: 0.21.4
 
+  examples/basic:
+    specifiers:
+      '@vitest/ui': latest
+      vite: ^2.7.10
+      vitest: latest
+    devDependencies:
+      '@vitest/ui': link:../../packages/ui
+      vite: 2.7.10
+      vitest: link:../../packages/vitest
+
   examples/lit:
     specifiers:
       happy-dom: '*'


### PR DESCRIPTION
Adds the example in https://vitest.dev/new to the examples folder, so we can point the starter to it and update it through github