### PR TITLE
chore: use fork for Stackblitz demo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,19 +1,19 @@
 | Example | Source | Playground |
 |---|---|---|
-| `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/lit?terminal=test) |
-| `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/mocks?terminal=test) |
-| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/puppeteer?terminal=test) |
-| `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/react?terminal=test) |
-| `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/react-enzyme?terminal=test) |
-| `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/react-mui?terminal=test) |
-| `react-storybook-testing` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-storybook-testing) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/react-storybook-testing?terminal=test) |
-| `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/react-testing-lib?terminal=test) |
-| `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw?terminal=test) |
-| `ruby` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/ruby) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/ruby?terminal=test) |
-| `solid` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/solid) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/solid?terminal=test) |
-| `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/svelte?terminal=test) |
-| `testing-library-jest-dom` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/testing-library-jest-dom) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/testing-library-jest-dom?terminal=test) |
-| `vitesse` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vitesse) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/vitesse?terminal=test) |
-| `vue` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/vue?terminal=test) |
-| `vue-jsx` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue-jsx) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/vue-jsx?terminal=test) |
-| `vue2` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue2) | [Play Online](https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/vue2?terminal=test) |
+| `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/lit?terminal=test) |
+| `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/mocks?terminal=test) |
+| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/puppeteer?terminal=test) |
+| `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react?terminal=test) |
+| `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-enzyme?terminal=test) |
+| `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-mui?terminal=test) |
+| `react-storybook-testing` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-storybook-testing) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-storybook-testing?terminal=test) |
+| `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib?terminal=test) |
+| `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw?terminal=test) |
+| `ruby` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/ruby) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/ruby?terminal=test) |
+| `solid` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/solid) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/solid?terminal=test) |
+| `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/svelte?terminal=test) |
+| `testing-library-jest-dom` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/testing-library-jest-dom) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/testing-library-jest-dom?terminal=test) |
+| `vitesse` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vitesse) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vitesse?terminal=test) |
+| `vue` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue?terminal=test) |
+| `vue-jsx` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue-jsx) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue-jsx?terminal=test) |
+| `vue2` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue2) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue2?terminal=test) |

--- a/scripts/update-examples.ts
+++ b/scripts/update-examples.ts
@@ -14,7 +14,7 @@ async function run() {
       return
 
     const github = `https://github.com/vitest-dev/vitest/tree/main/examples/${name}`
-    const stackblitz = `https://stackblitz.com/github/vitest-dev/vitest/tree/main/examples/${name}?terminal=test`
+    const stackblitz = `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}?terminal=test`
     return {
       name,
       path,


### PR DESCRIPTION
In examples page, when you click the *Play Online*, it opens up the example in Stackblitz. However, when user tries to edit something and save, there's generally a 5 second period where everything goes inactive for a while, then page reloads, forking the project. 

This is not great UX, hence this PR changes the behavior to fork when the project is being initialized