### PR TITLE
test: fix examples deps

### DIFF
--- a/examples/react-testing-lib-msw/package.json
+++ b/examples/react-testing-lib-msw/package.json
@@ -19,6 +19,7 @@
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "^1.1.4",
     "cross-fetch": "^3.1.4",
+    "jsdom": "^19.0.0",
     "msw": "^0.36.3",
     "vite": "^2.7.10",
     "vitest": "latest"

--- a/examples/react-testing-lib/package.json
+++ b/examples/react-testing-lib/package.json
@@ -20,7 +20,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "^1.1.4",
-    "happy-dom": "*",
+    "jsdom": "^19.0.0",
     "vite": "^2.7.10",
     "vitest": "latest"
   }

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.34",
     "@testing-library/svelte": "^3.0.3",
+    "jsdom": "^19.0.0",
     "svelte": "^3.45.0",
     "vitest": "latest"
   }

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -15,7 +15,7 @@
     "unplugin-vue2-script-setup": "^0.8.3",
     "vite": "^2.7.10",
     "vite-plugin-vue2": "^1.9.2",
-    "vitest": "../../packages/vitest",
+    "vitest": "latest",
     "vue-template-compiler": "2.6.14"
   }
 }

--- a/examples/vue2/pnpm-lock.yaml
+++ b/examples/vue2/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
       unplugin-vue2-script-setup: ^0.8.3
       vite: ^2.7.10
       vite-plugin-vue2: ^1.9.2
-      vitest: ../../packages/vitest
+      vitest: latest
       vue: 2.6.14
       vue-template-compiler: 2.6.14
     dependencies:
@@ -22,7 +22,7 @@ importers:
       unplugin-vue2-script-setup: 0.8.3_vite@2.7.10
       vite: 2.7.10
       vite-plugin-vue2: 1.9.2_0942e2da5dc468c8f4e6d1df85edc06f
-      vitest: link:../../packages/vitest
+      vitest: 0.1.12_happy-dom@2.24.5
       vue-template-compiler: 2.6.14
 
 packages:
@@ -364,6 +364,16 @@ packages:
       picomatch: 2.3.0
     dev: true
 
+  /@types/chai-subset/1.3.3:
+    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
+    dependencies:
+      '@types/chai': 4.3.0
+    dev: true
+
+  /@types/chai/4.3.0:
+    resolution: {integrity: sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==}
+    dev: true
+
   /@types/concat-stream/1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
@@ -590,6 +600,10 @@ packages:
 
   /asap/2.0.6:
     resolution: {integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=}
+    dev: true
+
+  /assertion-error/1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
   /asynckit/0.4.0:
@@ -1063,6 +1077,18 @@ packages:
     resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
     dev: true
 
+  /chai/4.3.4:
+    resolution: {integrity: sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.2
+      deep-eql: 3.0.1
+      get-func-name: 2.0.0
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chalk/1.1.3:
     resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
     engines: {node: '>=0.10.0'}
@@ -1081,6 +1107,10 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
+    dev: true
+
+  /check-error/1.0.2:
+    resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
     dev: true
 
   /color-convert/1.9.3:
@@ -1190,6 +1220,13 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
+
+  /deep-eql/3.0.1:
+    resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      type-detect: 4.0.8
     dev: true
 
   /defu/5.0.0:
@@ -1483,6 +1520,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /get-func-name/2.0.0:
+    resolution: {integrity: sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=}
+    dev: true
+
   /get-intrinsic/1.1.1:
     resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
     dependencies:
@@ -1704,6 +1745,11 @@ packages:
       is-buffer: 1.1.6
     dev: true
 
+  /local-pkg/0.4.1:
+    resolution: {integrity: sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==}
+    engines: {node: '>=14'}
+    dev: true
+
   /lodash.kebabcase/4.1.1:
     resolution: {integrity: sha1-hImxyw0p/4gZXM7KRI/21swpXDY=}
     dev: true
@@ -1814,6 +1860,10 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /pathval/1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
   /picocolors/0.2.1:
@@ -2087,6 +2137,16 @@ packages:
       qs: 6.10.2
     dev: true
 
+  /tinypool/0.1.1:
+    resolution: {integrity: sha512-sW2fQZ2BRb/GX5v55NkHiTrbMLx0eX0xNpP+VGhOe2f7Oo04+LeClDyM19zCE/WCy7jJ8kzIJ0Ojrxj3UhN9Sg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy/0.2.8:
+    resolution: {integrity: sha512-4VXqQzzh9gC5uOLk77cLr9R3wqJq07xJlgM9IUdCNJCet139r+046ETKbU1x7mGs7B0k7eopyH5U6yflbBXNyA==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /to-fast-properties/1.0.3:
     resolution: {integrity: sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=}
     engines: {node: '>=0.10.0'}
@@ -2103,6 +2163,11 @@ packages:
 
   /tslib/2.3.1:
     resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+    dev: true
+
+  /type-detect/4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
     dev: true
 
   /typedarray/0.0.6:
@@ -2221,6 +2286,39 @@ packages:
       rollup: 2.61.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitest/0.1.12_happy-dom@2.24.5:
+    resolution: {integrity: sha512-uiGDO1aKX2rUWtkR7iNedbtN3ij/qr4l1DwAbX5cIADUD7VBuFimaUrL8KyFw3eSxdA56xJyl8JpvSAsvvpN7w==}
+    engines: {node: '>=14.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@vitest/ui': '*'
+      c8: '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@vitest/ui':
+        optional: true
+      c8:
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.0
+      '@types/chai-subset': 1.3.3
+      chai: 4.3.4
+      happy-dom: 2.24.5
+      local-pkg: 0.4.1
+      tinypool: 0.1.1
+      tinyspy: 0.2.8
+      vite: 2.7.10
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
     dev: true
 
   /vue-template-compiler/2.6.14:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,7 +280,7 @@ importers:
       '@types/react': ^17.0.38
       '@types/react-dom': ^17.0.11
       '@vitejs/plugin-react': ^1.1.4
-      happy-dom: '*'
+      jsdom: ^19.0.0
       react: ^17.0.2
       react-dom: ^17.0.2
       vite: ^2.7.10
@@ -296,7 +296,7 @@ importers:
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
-      happy-dom: 2.25.1
+      jsdom: 19.0.0
       vite: 2.7.10
       vitest: link:../../packages/vitest
 
@@ -308,6 +308,7 @@ importers:
       '@types/react-dom': ^17.0.11
       '@vitejs/plugin-react': ^1.1.4
       cross-fetch: ^3.1.4
+      jsdom: ^19.0.0
       msw: ^0.36.3
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -323,6 +324,7 @@ importers:
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
       cross-fetch: 3.1.4
+      jsdom: 19.0.0
       msw: 0.36.3
       vite: 2.7.10
       vitest: link:../../packages/vitest
@@ -347,11 +349,13 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': ^1.0.0-next.34
       '@testing-library/svelte': ^3.0.3
+      jsdom: ^19.0.0
       svelte: ^3.45.0
       vitest: latest
     devDependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.34_svelte@3.45.0+vite@2.7.10
       '@testing-library/svelte': 3.0.3_svelte@3.45.0
+      jsdom: 19.0.0
       svelte: 3.45.0
       vitest: link:../../packages/vitest
 


### PR DESCRIPTION
Some examples rely on testing library break on stackblitz due to absence of jsdom. This PR adds JSDom as dev dependency to fix the issue.

Thanks to @patak-dev for the discussion on it