### PR TITLE
feat: allow extension option for coverage

### DIFF
--- a/packages/vitest/src/coverage.ts
+++ b/packages/vitest/src/coverage.ts
@@ -77,6 +77,7 @@ export interface C8Options {
   exclude?: string[]
   include?: string[]
   skipFull?: boolean
+  extension?: string | string[]
 
   // c8 options, not sure if we should expose them
   /**


### PR DESCRIPTION
c8 v7.11.0 introduced an `extension` option, allowing to specify extensions that aren't covered by default (default are defined via https://github.com/istanbuljs/schema/blob/master/default-extension.js). It's currently possible to use with an explicit cast in `vite.config.ts` but exposing it would remove the need for this workaround.

See https://github.com/bcoe/c8/commit/ff01cd832a155494892b24c30c5a1c8f0169fd8e