### PR TITLE
feat: smarter default extensions for coverage

### DIFF
--- a/packages/vitest/src/coverage.ts
+++ b/packages/vitest/src/coverage.ts
@@ -106,6 +106,9 @@ export function resolveC8Options(options: C8Options, root: string): ResolvedC8Op
     exclude: defaultExcludes,
     reporter: ['text', 'html'],
     allowExternal: false,
+    // default extensions used by c8, plus '.vue' and '.svelte'
+    // see https://github.com/istanbuljs/schema/blob/master/default-extension.js
+    extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.vue', 'svelte'],
     ...options as any,
   }
 


### PR DESCRIPTION
Adds default extensions for c8 coverage to include `.svelte` and `.vue` out of the box.