### PR TITLE
feat: start tests with ui on stackblitz

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,19 +1,17 @@
 | Example | Source | Playground |
 |---|---|---|
-| `basic` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/basic) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/basic?terminal=test) |
-| `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/lit?terminal=test) |
-| `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/mocks?terminal=test) |
-| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/puppeteer?terminal=test) |
-| `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react?terminal=test) |
-| `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-enzyme?terminal=test) |
-| `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-mui?terminal=test) |
-| `react-storybook-testing` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-storybook-testing) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-storybook-testing?terminal=test) |
-| `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib?terminal=test) |
-| `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw?terminal=test) |
+| `basic` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/basic) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/basic?terminal=test:ui) |
+| `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/lit?terminal=test:ui) |
+| `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/mocks?terminal=test:ui) |
+| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/puppeteer?terminal=test:ui) |
+| `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react?terminal=test:ui) |
+| `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-enzyme?terminal=test:ui) |
+| `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-mui?terminal=test:ui) |
+| `react-storybook-testing` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-storybook-testing) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-storybook-testing?terminal=test:ui) |
+| `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib?terminal=test:ui) |
+| `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw?terminal=test:ui) |
 | `ruby` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/ruby) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/ruby?terminal=test) |
-| `solid` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/solid) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/solid?terminal=test) |
-| `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/svelte?terminal=test) |
-| `testing-library-jest-dom` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/testing-library-jest-dom) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/testing-library-jest-dom?terminal=test) |
+| `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/svelte?terminal=test:ui) |
 | `vitesse` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vitesse) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vitesse?terminal=test) |
 | `vue` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue?terminal=test) |
 | `vue-jsx` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue-jsx) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue-jsx?terminal=test) |

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "test": "vitest --ui",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
     "test:run": "vitest run"
   },
   "devDependencies": {

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -8,12 +8,14 @@
   "scripts": {
     "coverage": "vitest --coverage",
     "dev": "vite",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "lit": "^2.1.1"
   },
   "devDependencies": {
+    "@vitest/ui": "latest",
     "happy-dom": "*",
     "vite": "^2.7.10",
     "vitest": "latest"

--- a/examples/mocks/package.json
+++ b/examples/mocks/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "coverage": "vitest --coverage",
     "dev": "vite",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "@vueuse/integrations": "^7.5.3",
@@ -16,6 +17,7 @@
     "tinyspy": "^0.2.8"
   },
   "devDependencies": {
+    "@vitest/ui": "latest",
     "vite": "^2.7.10",
     "vitest": "latest"
   }

--- a/examples/puppeteer/package.json
+++ b/examples/puppeteer/package.json
@@ -4,9 +4,11 @@
   "scripts": {
     "build": "vite build",
     "coverage": "vitest --coverage",
-    "test": "vite build && vitest"
+    "test": "vite build && vitest",
+    "test:ui": "vite build && vitest --ui"
   },
   "devDependencies": {
+    "@vitest/ui": "latest",
     "puppeteer": "^13.0.0",
     "vite": "^2.7.10",
     "vitest": "latest"

--- a/examples/react-enzyme/package.json
+++ b/examples/react-enzyme/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@vitest/test-react",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "react": "^17.0.2",
@@ -11,6 +12,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "1.1.4",
+    "@vitest/ui": "latest",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "vite": "2.7.10",

--- a/examples/react-mui/package.json
+++ b/examples/react-mui/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "vitest",
+    "test:ui": "vitest --ui",
     "test:run": "vitest run"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "@vitest/ui": "latest",
     "date-fns": "^2.28.0",
     "jsdom": "^19.0.0",
     "vite": "^2.7.10",

--- a/examples/react-storybook-testing/package.json
+++ b/examples/react-storybook-testing/package.json
@@ -6,6 +6,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
+    "test:ui": "vitest --ui",
     "storybook": "start-storybook -p 6006"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
     "@vitejs/plugin-react": "^1.0.7",
+    "@vitest/ui": "latest",
     "babel-loader": "^8.2.3",
     "jsdom": "^19.0.0",
     "msw": "^0.36.3",

--- a/examples/react-testing-lib-msw/package.json
+++ b/examples/react-testing-lib-msw/package.json
@@ -6,7 +6,8 @@
     "coverage": "vitest --coverage",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "react": "^17.0.2",
@@ -18,6 +19,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "^1.1.4",
+    "@vitest/ui": "latest",
     "cross-fetch": "^3.1.4",
     "jsdom": "^19.0.0",
     "msw": "^0.36.3",

--- a/examples/react-testing-lib/package.json
+++ b/examples/react-testing-lib/package.json
@@ -6,7 +6,8 @@
     "coverage": "vitest --coverage",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "react": "^17.0.2",
@@ -20,6 +21,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "^1.1.4",
+    "@vitest/ui": "latest",
     "jsdom": "^19.0.0",
     "vite": "^2.7.10",
     "vitest": "latest"

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "coverage": "vitest --coverage",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "react": "^17.0.2"
@@ -12,6 +13,7 @@
     "@types/react": "^17.0.38",
     "@types/react-test-renderer": "^17.0.1",
     "@vitejs/plugin-react": "1.1.4",
+    "@vitest/ui": "latest",
     "happy-dom": "^2.25.2",
     "jsdom": "*",
     "react-test-renderer": "17.0.2",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -4,11 +4,13 @@
   "type": "module",
   "scripts": {
     "test": "vitest",
+    "test:ui": "vitest --ui",
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.34",
     "@testing-library/svelte": "^3.0.3",
+    "@vitest/ui": "latest",
     "jsdom": "^19.0.0",
     "svelte": "^3.45.0",
     "vitest": "latest"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docs": "npm -C docs run dev",
     "docs:build": "npm -C docs run build",
     "docs:serve": "npm -C docs run serve",
+    "docs:examples": "esno scripts/update-examples.ts",
     "postinstall": "pnpm -C examples/vue2 i",
     "lint": "eslint --ext .js,.vue,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.vue,.ts,.tsx . --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,7 @@ importers:
 
   examples/lit:
     specifiers:
+      '@vitest/ui': latest
       happy-dom: '*'
       lit: ^2.1.1
       vite: ^2.7.10
@@ -104,12 +105,14 @@ importers:
     dependencies:
       lit: 2.1.1
     devDependencies:
+      '@vitest/ui': link:../../packages/ui
       happy-dom: 2.25.1
       vite: 2.7.10
       vitest: link:../../packages/vitest
 
   examples/mocks:
     specifiers:
+      '@vitest/ui': latest
       '@vueuse/integrations': ^7.5.3
       axios: ^0.24.0
       tinyspy: ^0.2.8
@@ -120,15 +123,18 @@ importers:
       axios: 0.24.0
       tinyspy: 0.2.8
     devDependencies:
+      '@vitest/ui': link:../../packages/ui
       vite: 2.7.10
       vitest: link:../../packages/vitest
 
   examples/puppeteer:
     specifiers:
+      '@vitest/ui': latest
       puppeteer: ^13.0.0
       vite: ^2.7.10
       vitest: latest
     devDependencies:
+      '@vitest/ui': link:../../packages/ui
       puppeteer: 13.0.0
       vite: 2.7.10
       vitest: link:../../packages/vitest
@@ -138,6 +144,7 @@ importers:
       '@types/react': ^17.0.38
       '@types/react-test-renderer': ^17.0.1
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': latest
       happy-dom: ^2.25.2
       jsdom: '*'
       react: ^17.0.2
@@ -149,6 +156,7 @@ importers:
       '@types/react': 17.0.38
       '@types/react-test-renderer': 17.0.1
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': link:../../packages/ui
       happy-dom: 2.25.2
       jsdom: 19.0.0
       react-test-renderer: 17.0.2_react@17.0.2
@@ -159,6 +167,7 @@ importers:
       '@types/react': ^17.0.38
       '@types/react-dom': ^17.0.11
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': latest
       enzyme: 3.11.0
       enzyme-adapter-react-16: 1.15.6
       react: ^17.0.2
@@ -172,6 +181,7 @@ importers:
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': link:../../packages/ui
       enzyme: 3.11.0
       enzyme-adapter-react-16: 1.15.6_fae758709a8810ba97b4c03852dde4d0
       vite: 2.7.10
@@ -186,6 +196,7 @@ importers:
       '@testing-library/jest-dom': ^5.16.1
       '@testing-library/react': ^12.1.2
       '@testing-library/user-event': ^13.5.0
+      '@vitest/ui': latest
       date-fns: ^2.28.0
       history: ^5.2.0
       jsdom: ^19.0.0
@@ -213,6 +224,7 @@ importers:
       '@testing-library/jest-dom': 5.16.1
       '@testing-library/react': 12.1.2_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 13.5.0
+      '@vitest/ui': link:../../packages/ui
       date-fns: 2.28.0
       jsdom: 19.0.0
       vite: 2.7.10
@@ -232,6 +244,7 @@ importers:
       '@types/react': ^17.0.33
       '@types/react-dom': ^17.0.10
       '@vitejs/plugin-react': ^1.0.7
+      '@vitest/ui': latest
       babel-loader: ^8.2.3
       cross-fetch: ^3.1.4
       jsdom: ^19.0.0
@@ -262,6 +275,7 @@ importers:
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': link:../../packages/ui
       babel-loader: 8.2.3_@babel+core@7.16.7
       jsdom: 19.0.0
       msw: 0.36.3
@@ -280,6 +294,7 @@ importers:
       '@types/react': ^17.0.38
       '@types/react-dom': ^17.0.11
       '@vitejs/plugin-react': ^1.1.4
+      '@vitest/ui': latest
       jsdom: ^19.0.0
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -296,6 +311,7 @@ importers:
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': link:../../packages/ui
       jsdom: 19.0.0
       vite: 2.7.10
       vitest: link:../../packages/vitest
@@ -307,6 +323,7 @@ importers:
       '@types/react': ^17.0.38
       '@types/react-dom': ^17.0.11
       '@vitejs/plugin-react': ^1.1.4
+      '@vitest/ui': latest
       cross-fetch: ^3.1.4
       jsdom: ^19.0.0
       msw: ^0.36.3
@@ -323,6 +340,7 @@ importers:
       '@types/react': 17.0.38
       '@types/react-dom': 17.0.11
       '@vitejs/plugin-react': 1.1.4
+      '@vitest/ui': link:../../packages/ui
       cross-fetch: 3.1.4
       jsdom: 19.0.0
       msw: 0.36.3
@@ -349,12 +367,14 @@ importers:
     specifiers:
       '@sveltejs/vite-plugin-svelte': ^1.0.0-next.34
       '@testing-library/svelte': ^3.0.3
+      '@vitest/ui': latest
       jsdom: ^19.0.0
       svelte: ^3.45.0
       vitest: latest
     devDependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.34_svelte@3.45.0+vite@2.7.10
       '@testing-library/svelte': 3.0.3_svelte@3.45.0
+      '@vitest/ui': link:../../packages/ui
       jsdom: 19.0.0
       svelte: 3.45.0
       vitest: link:../../packages/vitest
@@ -6875,6 +6895,7 @@ packages:
 
   /bindings/1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -9972,6 +9993,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -12555,6 +12577,7 @@ packages:
 
   /nan/2.15.0:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
+    requiresBuild: true
     dev: true
     optional: true
 

--- a/scripts/update-examples.ts
+++ b/scripts/update-examples.ts
@@ -3,6 +3,8 @@ import { promises as fs } from 'fs'
 import { resolve } from 'pathe'
 import { notNullish } from '../packages/vitest/src/utils'
 
+const noUI = ['ruby', 'vitesse', 'vue', 'vue2', 'vue-jsx']
+
 async function run() {
   const examplesRoot = resolve(fileURLToPath(import.meta.url), '../../examples')
 
@@ -14,7 +16,8 @@ async function run() {
       return
 
     const github = `https://github.com/vitest-dev/vitest/tree/main/examples/${name}`
-    const stackblitz = `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}?terminal=test`
+    const test = noUI.includes(name) ? '' : ':ui'
+    const stackblitz = `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}?terminal=test${test}`
     return {
       name,
       path,


### PR DESCRIPTION
This PR modifies the links for StackBlizt examples on docs to run the UI: `ruby`, `vitesse` and all `vue` will not run on UI, sometimes first run works but next runs fail on UI.

I also add a new script on root `package.json` to generate the `REAMDE.md` for the examples on docs.

@antfu You should remove some folders from your local examples directory, there are 2 examples missing: `solid` and `testing-library-jest-dom` (moved to `react-testing-lib`)