### PR TITLE
chore: .stackblitzrc in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,18 @@
 | Example | Source | Playground |
 |---|---|---|
-| `basic` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/basic) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/basic?terminal=test:ui) |
-| `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/lit?terminal=test:ui) |
-| `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/mocks?terminal=test:ui) |
-| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/puppeteer?terminal=test:ui) |
-| `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react?terminal=test:ui) |
-| `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-enzyme?terminal=test:ui) |
-| `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-mui?terminal=test:ui) |
-| `react-storybook-testing` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-storybook-testing) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-storybook-testing?terminal=test:ui) |
-| `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib?terminal=test:ui) |
-| `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw?terminal=test:ui) |
-| `ruby` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/ruby) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/ruby?terminal=test) |
-| `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/svelte?terminal=test:ui) |
-| `vitesse` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vitesse) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vitesse?terminal=test) |
-| `vue` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue?terminal=test) |
-| `vue-jsx` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue-jsx) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue-jsx?terminal=test) |
-| `vue2` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue2) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue2?terminal=test) |
+| `basic` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/basic) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/basic) |
+| `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/lit) |
+| `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/mocks) |
+| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/puppeteer) |
+| `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react) |
+| `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-enzyme) |
+| `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-mui) |
+| `react-storybook-testing` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-storybook-testing) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-storybook-testing) |
+| `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib) |
+| `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) |
+| `ruby` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/ruby) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/ruby) |
+| `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/svelte) |
+| `vitesse` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vitesse) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vitesse) |
+| `vue` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue) |
+| `vue-jsx` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue-jsx) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue-jsx) |
+| `vue2` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/vue2) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue2) |

--- a/examples/basic/.stackblitzrc
+++ b/examples/basic/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/lit/.stackblitzrc
+++ b/examples/lit/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/mocks/.stackblitzrc
+++ b/examples/mocks/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/puppeteer/.stackblitzrc
+++ b/examples/puppeteer/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/react-enzyme/.stackblitzrc
+++ b/examples/react-enzyme/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/react-mui/.stackblitzrc
+++ b/examples/react-mui/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/react-storybook-testing/.stackblitzrc
+++ b/examples/react-storybook-testing/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/react-testing-lib-msw/.stackblitzrc
+++ b/examples/react-testing-lib-msw/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/react-testing-lib/.stackblitzrc
+++ b/examples/react-testing-lib/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/react/.stackblitzrc
+++ b/examples/react/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/ruby/.stackblitzrc
+++ b/examples/ruby/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test"
+}

--- a/examples/svelte/.stackblitzrc
+++ b/examples/svelte/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test:ui"
+}

--- a/examples/vitesse/.stackblitzrc
+++ b/examples/vitesse/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test"
+}

--- a/examples/vue-jsx/.stackblitzrc
+++ b/examples/vue-jsx/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test"
+}

--- a/examples/vue/.stackblitzrc
+++ b/examples/vue/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run test"
+}

--- a/scripts/update-examples.ts
+++ b/scripts/update-examples.ts
@@ -3,8 +3,6 @@ import { promises as fs } from 'fs'
 import { resolve } from 'pathe'
 import { notNullish } from '../packages/vitest/src/utils'
 
-const noUI = ['ruby', 'vitesse', 'vue', 'vue2', 'vue-jsx']
-
 async function run() {
   const examplesRoot = resolve(fileURLToPath(import.meta.url), '../../examples')
 
@@ -16,8 +14,7 @@ async function run() {
       return
 
     const github = `https://github.com/vitest-dev/vitest/tree/main/examples/${name}`
-    const test = noUI.includes(name) ? '' : ':ui'
-    const stackblitz = `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}?terminal=test${test}`
+    const stackblitz = `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}`
     return {
       name,
       path,


### PR DESCRIPTION
Adds a `.stackblitzrc` to each example so we can define what script should run (and later other options) in each of them, instead of having to maintain a separate list. This will also allow the SB folks to point a clean URL with a table on their side, and we can do updates without their intervention