### PR TITLE
fix: improve file path handling in first level catalog (fix #535)

### DIFF
--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -27,7 +27,7 @@ export function isPrimitive(v: any) {
 export function toFilePath(id: string, root: string): string {
   let absolute = slash(id).startsWith('/@fs/')
     ? id.slice(4)
-    : id.startsWith(dirname(root))
+    : id.startsWith(dirname(root)) && dirname(root) !== '/'
       ? id
       : id.startsWith('/')
         ? slash(resolve(root, id.slice(1)))

--- a/test/core/test/file-path.test.ts
+++ b/test/core/test/file-path.test.ts
@@ -1,87 +1,80 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { isWindows, slash, toFilePath } from '../../../packages/vite-node/src/utils'
 
-const originalCwd = process.cwd()
-
-function mockCwd(cwd: string) {
-  Object.defineProperty(process, 'cwd', {
-    value: () => cwd,
-  })
-}
-
-function restoreCwd() {
-  Object.defineProperty(process, 'cwd', {
-    value: originalCwd,
-  })
-}
-
 describe('toFilePath', () => {
-  afterEach(() => {
-    restoreCwd()
-  })
-
+  // the following tests will work incorrectly on unix systems
   if (isWindows) {
-    // these test will work incorrectly on unix systems
     it('windows', () => {
       const root = 'C:/path/to/project'
-      mockCwd(root)
-
       const id = '/node_modules/pkg/file.js'
       const expected = 'C:/path/to/project/node_modules/pkg/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
       const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
+
       expect(slash(filePath)).toEqual(expected)
     })
 
     it('windows with /@fs/', () => {
       const root = 'C:/path/to/project'
-      mockCwd(root)
-
       const id = '/@fs/C:/path/to/project/node_modules/pkg/file.js'
       const expected = 'C:/path/to/project/node_modules/pkg/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
       const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
+
       expect(slash(filePath)).toEqual(expected)
     })
   }
 
+  // the following tests will work incorrectly on windows systems
   if (!isWindows) {
-    // these test will work incorrectly on windows systems
     it('unix', () => {
       const root = '/path/to/project'
-      mockCwd(root)
-
       const id = '/node_modules/pkg/file.js'
       const expected = '/path/to/project/node_modules/pkg/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
       const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
+
       expect(slash(filePath)).toEqual(expected)
     })
 
     it('unix with /@fs/', () => {
       const root = '/path/to/project'
-      mockCwd(root)
-
       const id = '/@fs//path/to/project/node_modules/pkg/file.js'
       const expected = '/path/to/project/node_modules/pkg/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
       const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
       expect(slash(filePath)).toEqual(expected)
     })
 
     it('unix in first level catalog', () => {
       const root = '/root'
-      mockCwd(root)
-
       const id = '/node_modules/pkg/file.js'
       const expected = '/root/node_modules/pkg/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
       const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
+
       expect(slash(filePath)).toEqual(expected)
     })
 
     it('unix with /@fs/ in first level catalog', () => {
       const root = '/root'
-      mockCwd(root)
-
       const id = '/@fs//root/node_modules/pkg/file.js'
       const expected = '/root/node_modules/pkg/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
       const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
+
       expect(slash(filePath)).toEqual(expected)
     })
   }

--- a/test/core/test/file-path.test.ts
+++ b/test/core/test/file-path.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { isWindows, slash, toFilePath } from '../../../packages/vite-node/src/utils'
+
+const originalCwd = process.cwd()
+
+function mockCwd(cwd: string) {
+  Object.defineProperty(process, 'cwd', {
+    value: () => cwd,
+  })
+}
+
+function restoreCwd() {
+  Object.defineProperty(process, 'cwd', {
+    value: originalCwd,
+  })
+}
+
+describe('toFilePath', () => {
+  afterEach(() => {
+    restoreCwd()
+  })
+
+  if (isWindows) {
+    // these test will work incorrectly on unix systems
+    it('windows', () => {
+      const root = 'C:/path/to/project'
+      mockCwd(root)
+
+      const id = '/node_modules/pkg/file.js'
+      const expected = 'C:/path/to/project/node_modules/pkg/file.js'
+      const filePath = toFilePath(id, root)
+      expect(slash(filePath)).toEqual(expected)
+    })
+
+    it('windows with /@fs/', () => {
+      const root = 'C:/path/to/project'
+      mockCwd(root)
+
+      const id = '/@fs/C:/path/to/project/node_modules/pkg/file.js'
+      const expected = 'C:/path/to/project/node_modules/pkg/file.js'
+      const filePath = toFilePath(id, root)
+      expect(slash(filePath)).toEqual(expected)
+    })
+  }
+
+  if (!isWindows) {
+    // these test will work incorrectly on windows systems
+    it('unix', () => {
+      const root = '/path/to/project'
+      mockCwd(root)
+
+      const id = '/node_modules/pkg/file.js'
+      const expected = '/path/to/project/node_modules/pkg/file.js'
+      const filePath = toFilePath(id, root)
+      expect(slash(filePath)).toEqual(expected)
+    })
+
+    it('unix with /@fs/', () => {
+      const root = '/path/to/project'
+      mockCwd(root)
+
+      const id = '/@fs//path/to/project/node_modules/pkg/file.js'
+      const expected = '/path/to/project/node_modules/pkg/file.js'
+      const filePath = toFilePath(id, root)
+      expect(slash(filePath)).toEqual(expected)
+    })
+
+    it('unix in first level catalog', () => {
+      const root = '/root'
+      mockCwd(root)
+
+      const id = '/node_modules/pkg/file.js'
+      const expected = '/root/node_modules/pkg/file.js'
+      const filePath = toFilePath(id, root)
+      expect(slash(filePath)).toEqual(expected)
+    })
+
+    it('unix with /@fs/ in first level catalog', () => {
+      const root = '/root'
+      mockCwd(root)
+
+      const id = '/@fs//root/node_modules/pkg/file.js'
+      const expected = '/root/node_modules/pkg/file.js'
+      const filePath = toFilePath(id, root)
+      expect(slash(filePath)).toEqual(expected)
+    })
+  }
+})


### PR DESCRIPTION
Fixes #535

This PR updates `toFilePath` to handle first level catalog in unix system and adding a test file for it.

- The `dirname(root)` call will return `'/'` when `root` is first level catalog (eg. `root = '/folder'`) which is the root cause of this issue
- The test/implementation will run differently on Windows and Unix, so I put a simple `if(isWindows)` to separate the test

https://github.com/vitest-dev/vitest/blob/9626fdef58f1e2cd5d3a77d94194d01b3d7c1d81/packages/vite-node/src/utils.ts#L27-L43