### PR TITLE
feat(types): add generic parameter to toMatchObject

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -48,6 +48,10 @@ declare global {
       not: AsymmetricMatchersContaining
     }
 
+    type DeepPartial<T> = T extends object ? {
+      [K in keyof T]?: DeepPartial<T[K]>;
+    } : T;
+
     interface JestAssertions {
       // Snapshot
       toMatchSnapshot(snapshot: object, message?: string): void
@@ -63,7 +67,7 @@ declare global {
       toStrictEqual(expected: any): void
       toBe(expected: any): void
       toMatch(expected: string | RegExp): void
-      toMatchObject(expected: any): void
+      toMatchObject<T extends object>(expected: DeepPartial<T>): void
       toContain(item: any): void
       toContainEqual(item: any): void
       toBeTruthy(): void

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -50,7 +50,7 @@ declare global {
 
     type DeepPartial<T> = T extends object ? {
       [K in keyof T]?: DeepPartial<T[K]>;
-    } : T;
+    } : T
 
     interface JestAssertions {
       // Snapshot


### PR DESCRIPTION
I often use this generic parameter with Jest to have autocompletion on values to match, example : 
```ts
  expect(response).toMatchObject<
    _.PartialDeep<GraphQLSchema.AnnotateFileResult>
  >({
    __typename: "AnnotateFileErrors",
    errors: [
      {
        __typename: "FileFormatNotSupported",
      },
    ],
  });
});
```

One DX improvement I made compared to Jest's generic is that I apply the `DeepPartial` helper by default so the user doesn't have to think about it as we're always matching partial objects.

[Here](https://www.typescriptlang.org/play?#code/C4TwDgpgBAIhFgAoEMBOwCWyA2AeAKgHxQC8U+UEAHsBAHYAmAzlAPYBGAVhAMbBQB+KAG8AUFAlQA2gGkoGOlADWEEKwBm5ALoCAXLHhI0mHAVlbCAblEBfKPvzXRDXtjTR1AVzp8MrRcCsALLIwDwAFgDyXLzABJQ09MxsMXyEABTUkHwQDPpwCCjoWHhEAJT6AG6sGAxOgSFhUanA6QBEdKz8yIoc3HxtZdYNoRHR-a0ALABMQ6IjTeOx6cJQ6qys+m3hyJXQyFB0GDzQAO7wKoxtUDZzC2MtuFKr65tQTMCoCgDmNwA0Iig7DQ+g+XzovxsFnSzzWGy2Oz2UAORxOUHOEEuDGuULuwVGzQmTxe8Penx+-0BwNQoPJEJu0Nh1IRu32h2OZwuSRxWjxjQeRNWzLJ4O+ANetNFAOon2Q+nYG2wEB6NwyJLe21ZyPZaIxWJxfIJSz4uCFyAAXpKKTY1XCNYi2ajOZjuTchkA) is a usage example on TypeScript Playground.