### PR TITLE
fix(vite-node): use .mjs instead of .js for cli

### DIFF
--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -37,7 +37,7 @@
   "module": "./dist/index.js",
   "types": "./index.d.ts",
   "bin": {
-    "vite-node": "./vite-node.js"
+    "vite-node": "./vite-node.mjs"
   },
   "files": [
     "dist",


### PR DESCRIPTION
### Description

`./vite-node.js` doesn't exist, when I run `pnpm install` will cause error.

<img width="925" alt="image" src="https://user-images.githubusercontent.com/73412177/149652172-61719b71-5bb3-41a6-b6dc-d8ec77dbcbd9.png">
