### PR TITLE
fix(vitest): respect process.exitCode when exit method is called

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -360,7 +360,7 @@ export class Vitest {
     Promise.race([closePromise, timeoutPromise]).then(
       () => {
         clearTimeout(timeout)
-        process.exit(0)
+        process.exit(process.exitCode ?? 0)
       },
       (err) => {
         clearTimeout(timeout)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -360,7 +360,7 @@ export class Vitest {
     Promise.race([closePromise, timeoutPromise]).then(
       () => {
         clearTimeout(timeout)
-        process.exit(process.exitCode ?? 0)
+        process.exit()
       },
       (err) => {
         clearTimeout(timeout)


### PR DESCRIPTION
This PR will fix the problem in https://github.com/vitest-dev/vitest/issues/277#issuecomment-1013925043.