### PR TITLE
refactor: split deepMerge and deepMergeSnapshot

### DIFF
--- a/packages/vitest/src/integrations/snapshot/client.ts
+++ b/packages/vitest/src/integrations/snapshot/client.ts
@@ -2,8 +2,9 @@ import path from 'pathe'
 import { expect } from 'chai'
 import type { SnapshotResult, Test } from '../../types'
 import { rpc } from '../../runtime/rpc'
-import { deepMerge, getNames } from '../../utils'
+import { getNames } from '../../utils'
 import { equals, iterableEquality, subsetEquality } from '../chai/jest-utils'
+import { deepMergeSnapshot } from './port/utils'
 import SnapshotState from './port/state'
 
 export interface Context {
@@ -55,7 +56,7 @@ export class SnapshotClient {
         if (!pass)
           expect(received).toBe(properties)
         else
-          received = deepMerge(received, properties)
+          received = deepMergeSnapshot(received, properties)
       }
       catch (err: any) {
         err.message = 'Snapshot mismatched'

--- a/packages/vitest/src/integrations/snapshot/port/utils.ts
+++ b/packages/vitest/src/integrations/snapshot/port/utils.ts
@@ -201,7 +201,7 @@ function deepMergeArray(target: any[] = [], source: any[] = []) {
 /**
  * Deep merge, but considers asymmetric matchers. Unlike base util's deep merge,
  * will merge any object-like instance.
- * Compatible with Jest's snapshot matcher.
+ * Compatible with Jest's snapshot matcher. Should not be used outside of snapshot.
  *
  * @example
  * ```ts

--- a/packages/vitest/src/integrations/snapshot/port/utils.ts
+++ b/packages/vitest/src/integrations/snapshot/port/utils.ts
@@ -204,15 +204,14 @@ function deepMergeArray(target: any[] = [], source: any[] = []) {
  * Compatible with Jest's snapshot matcher.
  *
  * @example
+ * ```ts
  * toMatchSnapshot({
  *   name: expect.stringContaining('text')
  * })
+ * ```
  */
 export function deepMergeSnapshot(target: any, source: any): any {
   if (isObject(target) && isObject(source)) {
-    if (target instanceof RegExp || source instanceof RegExp)
-      return target
-
     const mergedOutput = { ...target }
     Object.keys(source).forEach((key) => {
       if (isObject(source[key]) && !source[key].$$typeof) {

--- a/packages/vitest/src/integrations/snapshot/port/utils.ts
+++ b/packages/vitest/src/integrations/snapshot/port/utils.ts
@@ -13,6 +13,7 @@ import {
   format as prettyFormat,
 } from 'pretty-format'
 import type { SnapshotData, SnapshotUpdateState } from '../../../types'
+import { isObject } from '../../../utils'
 import { getSerializers } from './plugins'
 
 // TODO: rewrite and clean up
@@ -174,4 +175,62 @@ export function prepareExpected(expected?: string) {
   }
 
   return expectedTrimmed
+}
+
+function deepMergeArray(target: any[] = [], source: any[] = []) {
+  const mergedOutput = Array.from(target)
+
+  source.forEach((sourceElement, index) => {
+    const targetElement = mergedOutput[index]
+
+    if (Array.isArray(target[index])) {
+      mergedOutput[index] = deepMergeArray(target[index], sourceElement)
+    }
+    else if (isObject(targetElement)) {
+      mergedOutput[index] = deepMergeSnapshot(target[index], sourceElement)
+    }
+    else {
+      // Source does not exist in target or target is primitive and cannot be deep merged
+      mergedOutput[index] = sourceElement
+    }
+  })
+
+  return mergedOutput
+}
+
+/**
+ * Deep merge, but considers asymmetric matchers. Unlike base util's deep merge,
+ * will merge any object-like instance.
+ * Compatible with Jest's snapshot matcher.
+ *
+ * @example
+ * toMatchSnapshot({
+ *   name: expect.stringContaining('text')
+ * })
+ */
+export function deepMergeSnapshot(target: any, source: any): any {
+  if (isObject(target) && isObject(source)) {
+    if (target instanceof RegExp || source instanceof RegExp)
+      return target
+
+    const mergedOutput = { ...target }
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key]) && !source[key].$$typeof) {
+        if (!(key in target)) Object.assign(mergedOutput, { [key]: source[key] })
+        else mergedOutput[key] = deepMergeSnapshot(target[key], source[key])
+      }
+      else if (Array.isArray(source[key])) {
+        mergedOutput[key] = deepMergeArray(target[key], source[key])
+      }
+      else {
+        Object.assign(mergedOutput, { [key]: source[key] })
+      }
+    })
+
+    return mergedOutput
+  }
+  else if (Array.isArray(target) && Array.isArray(source)) {
+    return deepMergeArray(target, source)
+  }
+  return target
 }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -92,7 +92,7 @@ export class Vitest {
 
   getConfig() {
     if (this.configOverride)
-      return deepMerge(clone(this.config), this.configOverride)
+      return deepMerge(clone(this.config), this.configOverride) as ResolvedConfig
     return this.config
   }
 

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -3,6 +3,21 @@ export type Nullable<T> = T | null | undefined
 export type Arrayable<T> = T | Array<T>
 export type ArgumentsType<T> = T extends (...args: infer U) => any ? U : never
 
+export type MergeInsertions<T> =
+  T extends object
+    ? { [K in keyof T]: MergeInsertions<T[K]> }
+    : T
+
+export type DeepMerge<F, S> = MergeInsertions<{
+  [K in keyof F | keyof S]: K extends keyof S & keyof F
+    ? DeepMerge<F[K], S[K]>
+    : K extends keyof S
+      ? S[K]
+      : K extends keyof F
+        ? F[K]
+        : never;
+}>
+
 export interface Constructable {
   new (...args: any[]): any
 }

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -87,6 +87,12 @@ export function deepMerge<T extends object = object, S extends object = T>(targe
 
         deepMerge(target[key] as any, source[key] as any)
       }
+      else if (Array.isArray(source[key])) {
+        if (!target[key])
+          target[key] = [] as any
+
+        (target[key] as any).push(...source[key] as any)
+      }
       else {
         target[key] = source[key] as any
       }

--- a/test/core/test/snapshot.test.ts
+++ b/test/core/test/snapshot.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
+import { deepMergeSnapshot } from '../../../packages/vitest/src/integrations/snapshot/port/utils'
 import { testOutsideInlineSnapshot } from './snapshots-outside'
 
 test('snapshot', () => {
@@ -130,4 +131,40 @@ test('properties inline snapshot', () => {
       "name": "LeBron James",
     }
     `)
+})
+
+describe('utils test', () => {
+  test('deepMergeSnapshot considers asymmetric matcher', () => {
+    class Test {
+      zoo = 'zoo'
+      get bar() {
+        return 'name'
+      }
+    }
+
+    const obj = deepMergeSnapshot({
+      regexp: /test/,
+      test: new Test(),
+      name: 'name',
+      foo: 5,
+      array: [/test/, 'test'],
+    }, {
+      name: expect.stringContaining('name'),
+      foo: 88,
+      array: [/test2/],
+      test: { baz: 'baz' },
+    })
+
+    expect(obj.regexp instanceof RegExp).toBe(true)
+    expect(obj.test instanceof Test).toBe(false)
+    expect(obj.array[0] instanceof RegExp).toBe(false)
+
+    expect(obj).toEqual({
+      regexp: /test/,
+      test: { baz: 'baz', zoo: 'zoo' },
+      name: expect.stringContaining('name'),
+      foo: 88,
+      array: [{}, 'test'],
+    })
+  })
 })

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+import { deepMerge } from '../../../packages/vitest/src/utils'
+
+describe('deepMerge', () => {
+  test('non plain objects retain their prototype, arrays are merging, plain objects are merging', () => {
+    class Test {
+      baz = 'baz'
+
+      get foo() {
+        return 'foo'
+      }
+    }
+
+    const testA = new Test()
+    const testB = new Test()
+
+    const a = {
+      test: testA,
+      num: 30,
+      array: [1, 2],
+      obj: {
+        foo: 'foo',
+      },
+    }
+
+    const b = {
+      test: testB,
+      num: 40,
+      array: [3, 4],
+      obj: {
+        baz: 'baz',
+      },
+    }
+
+    const merged = deepMerge(a, b)
+
+    expect(merged.test instanceof Test).toBe(true)
+    expect(merged.num).toBe(40)
+    expect(merged.array).toEqual([1, 2, 3, 4])
+    expect(merged.obj).toEqual({
+      foo: 'foo',
+      baz: 'baz',
+    })
+  })
+})


### PR DESCRIPTION
Current `deepMerge` is not suitable for common cases, it was designed with `jest-snapshot` in mind.

This pr splits `deepMerge` into to functions: one for snapshots, and one for common usage. Snapshot merge function will merge any objects so it can then be serialized, so types don't matter to it