### PR TITLE
docs: update `exclude` documentation to match the latest implementation

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -33,7 +33,7 @@ Include globs for test files
 ### exclude
 
 - **Type:** `string[]`
-- **Default:** `['node_modules', 'dist', '.idea', '.git', '.cache']`
+- **Default:** `['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**']`
 
 Exclude globs for test files
 


### PR DESCRIPTION
https://github.com/vitest-dev/vitest/blob/a1e2b068e8aa12d603cf0bb252347a7109614283/packages/vitest/src/constants.ts#L7