### PR TITLE
fix(ui): ui improvements

### DIFF
--- a/packages/ui/client/components/CodeMirror.vue
+++ b/packages/ui/client/components/CodeMirror.vue
@@ -39,6 +39,7 @@ onMounted(async() => {
     ...props,
     ...attrs,
     mode: modeMap[props.mode || ''] || props.mode,
+    readOnly: props.readOnly ? 'nocursor' : undefined,
     extraKeys: {
       'Cmd-S': function(cm) {
         emit('save', cm.getValue())

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -40,20 +40,41 @@ const changeViewMode = (view: Params['view']) => {
           {{ current?.filepath }}
         </div>
         <div class="flex text-lg">
-          <IconButton v-tooltip.bottom="'Open in editor'" icon="i-carbon-launch" :disabled="!current?.filepath" @click="open" />
+          <IconButton
+            v-tooltip.bottom="'Open in editor'"
+            icon="i-carbon-launch"
+            :disabled="!current?.filepath"
+            @click="open"
+          />
         </div>
       </div>
       <div flex="~" items-center bg-header border="b base" text-sm h-37px>
-        <button tab-button :class="{ 'tab-button-active': viewMode == null }" @click="changeViewMode(null)">
+        <button
+          tab-button
+          :class="{ 'tab-button-active': viewMode == null }"
+          @click="changeViewMode(null)"
+        >
           Report
         </button>
-        <button tab-button :class="{ 'tab-button-active': viewMode === 'graph' }" @click="changeViewMode('graph')">
+        <button
+          tab-button
+          :class="{ 'tab-button-active': viewMode === 'graph' }"
+          @click="changeViewMode('graph')"
+        >
           Module Graph
         </button>
-        <button tab-button :class="{ 'tab-button-active': viewMode === 'editor' }" @click="changeViewMode('editor')">
+        <button
+          tab-button
+          :class="{ 'tab-button-active': viewMode === 'editor' }"
+          @click="changeViewMode('editor')"
+        >
           Code
         </button>
-        <button tab-button :class="{ 'tab-button-active': viewMode === 'console' }" @click="changeViewMode('console')">
+        <button
+          tab-button
+          :class="{ 'tab-button-active': viewMode === 'console', 'op20': viewMode !== 'console' && currentLogs?.length === 0 }"
+          @click="changeViewMode('console')"
+        >
           Console ({{ currentLogs?.length || 0 }})
         </button>
       </div>

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -82,7 +82,7 @@ const changeViewMode = (view: Params['view']) => {
 
     <div flex flex-col flex-1 overflow="hidden">
       <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" />
-      <ViewEditor v-if="viewMode === 'editor'" :file="current" />
+      <ViewEditor v-if="viewMode === 'editor'" :key="current.filepath" :file="current" />
       <ViewConsoleOutput v-else-if="viewMode === 'console'" :file="current" />
       <ViewReport v-else-if="!viewMode" :file="current" />
     </div>

--- a/packages/ui/client/components/Modal.vue
+++ b/packages/ui/client/components/Modal.vue
@@ -10,7 +10,7 @@
     />
     <div
       class="bg-base border-base absolute transition-all duration-200 ease-out"
-      :class="positionClass"
+      :class="[positionClass, 'scrolls']"
       :style="modelValue ? {}: {transform}"
     >
       <slot />

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -8,6 +8,10 @@ const ext = computed(() => props.id?.split(/\./g).pop() || 'js')
 
 const source = computed(() => result.value?.source?.trim() || '')
 const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=.*\n/, '').trim() || '')
+const sourceMap = computed(() => ({
+  mappings: result.value?.map?.mappings ?? '',
+  version: result.value?.map?.version,
+}))
 
 onKeyStroke('Escape', () => {
   emit('close')
@@ -42,7 +46,17 @@ onKeyStroke('Escape', () => {
           <CodeMirror :model-value="code" read-only v-bind="{ lineNumbers: true }" :mode="ext" />
         </div>
       </div>
-      <pre>{{ result }}</pre>
+      <template v-if="sourceMap.mappings !== ''">
+        <div p="x3 y-1" bg-overlay border="base b t">
+          Source map (v{{ sourceMap.version }})
+        </div>
+        <CodeMirror
+          :model-value="sourceMap.mappings"
+          read-only
+          v-bind="{ lineNumbers: true }"
+          :mode="ext"
+        />
+      </template>
     </template>
   </div>
 </template>

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { client } from '~/composables/client'
 const props = defineProps<{ id: string }>()
-defineEmits<{ (e: 'close'): void }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
 
 const result = asyncComputed(() => client.rpc.getTransformResult(props.id))
 const ext = computed(() => props.id?.split(/\./g).pop() || 'js')
 
 const source = computed(() => result.value?.source?.trim() || '')
 const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=.*\n/, '').trim() || '')
+
+onKeyStroke('Escape', () => {
+  emit('close')
+})
 // TODO: sourcemap https://evanw.github.io/source-map-visualization/
 </script>
 
@@ -18,7 +22,7 @@ const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=
       <p op50 font-mono text-sm>
         {{ id }}
       </p>
-      <IconButton absolute top-5px right-5px icon="i-carbon-close" text-2xl @click="$emit('close')" />
+      <IconButton icon="i-carbon-close" absolute top-5px right-5px text-2xl @click="emit('close')" />
     </div>
     <div v-if="!result" p-5>
       No transform result found for this module.
@@ -32,10 +36,10 @@ const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=
           Transformed
         </div>
         <div>
-          <CodeMirror :model-value="source" read-only v-bind="{ lineNumbers:true }" :mode="ext" />
+          <CodeMirror :model-value="source" read-only v-bind="{ lineNumbers: true }" :mode="ext" />
         </div>
         <div>
-          <CodeMirror :model-value="code" read-only v-bind="{ lineNumbers:true }" :mode="ext" />
+          <CodeMirror :model-value="code" read-only v-bind="{ lineNumbers: true }" :mode="ext" />
         </div>
       </div>
       <pre>{{ result }}</pre>

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -32,10 +32,10 @@ const code = computed(() => result.value?.code?.replace(/\/\/# sourceMappingURL=
           Transformed
         </div>
         <div>
-          <CodeMirror :model-value="source" v-bind="{ lineNumbers:true }" :mode="ext" />
+          <CodeMirror :model-value="source" read-only v-bind="{ lineNumbers:true }" :mode="ext" />
         </div>
         <div>
-          <CodeMirror :model-value="code" v-bind="{ lineNumbers:true }" :mode="ext" />
+          <CodeMirror :model-value="code" read-only v-bind="{ lineNumbers:true }" :mode="ext" />
         </div>
       </div>
       <pre>{{ result }}</pre>

--- a/packages/ui/client/components/views/ViewConsoleOutput.vue
+++ b/packages/ui/client/components/views/ViewConsoleOutput.vue
@@ -31,4 +31,7 @@ function getTaskName(id?: string) {
       </div>
     </div>
   </div>
+  <p v-else p6>
+    Log something in your test and it would print here. (e.g. <pre inline>console.log(foo)</pre>)
+  </p>
 </template>

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -23,11 +23,13 @@ const editor = ref<any>()
 
 const cm = computed<CodeMirror.EditorFromTextArea | undefined>(() => editor.value?.cm)
 const failed = computed(() => props.file?.tasks.filter(i => i.result?.state === 'fail') || [])
+const hasBeenEdited = ref(false)
 
 const widgets: CodeMirror.LineWidget[] = []
 const handles: CodeMirror.LineHandle[] = []
 
 async function onSave(content: string) {
+  hasBeenEdited.value = true
   await client.rpc.writeFile(props.file!.filepath, content)
 }
 
@@ -53,7 +55,7 @@ watch([cm, failed], () => {
         widgets.push(cm.value!.addLineWidget(pos.line - 1, el))
       }
     })
-    cm.value?.clearHistory() // Prevent getting access to initial state
+    if (!hasBeenEdited.value) cm.value?.clearHistory() // Prevent getting access to initial state
   }, 100)
 }, { flush: 'post' })
 </script>

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -16,6 +16,11 @@ const modalShow = ref(false)
 const selectedModule = ref<string | null>()
 const controller = ref<ModuleGraphController | undefined>()
 
+watchEffect(() => {
+  if (modalShow.value === false)
+    setTimeout(() => selectedModule.value = undefined, 300)
+}, { flush: 'post' })
+
 onMounted(() => {
   resetGraphController()
 })
@@ -118,7 +123,13 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
   <div h-full min-h-75 flex-1 overflow="hidden">
     <div>
       <div flex items-center gap-4 px-3 py-2>
-        <div v-for="node of controller?.nodeTypes.sort()" :key="node" flex="~ gap-1" items-center select-none>
+        <div
+          v-for="node of controller?.nodeTypes.sort()"
+          :key="node"
+          flex="~ gap-1"
+          items-center
+          select-none
+        >
           <input
             :id="`type-${node}`"
             type="checkbox"
@@ -131,19 +142,15 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
             ws-nowrap
             overflow-hidden
             capitalize
-            truncate :for="`type-${node}`"
+            truncate
+            :for="`type-${node}`"
             border-b-2
-            :style="{ 'border-color': `var(--color-node-${node})`}"
-          >
-            {{ node }} Modules
-          </label>
+            :style="{ 'border-color': `var(--color-node-${node})` }"
+          >{{ node }} Modules</label>
         </div>
         <div flex-auto />
         <div>
-          <IconButton
-            icon="i-carbon-reset"
-            @click="resetGraphController"
-          />
+          <IconButton v-tooltip.bottom="'Reset'" icon="i-carbon-reset" @click="resetGraphController" />
         </div>
       </div>
     </div>
@@ -151,7 +158,7 @@ function bindOnClick(selection: Selection<SVGCircleElement, ModuleNode, SVGGElem
     <Modal v-model="modalShow" direction="right">
       <template v-if="selectedModule">
         <Suspense>
-          <ModuleTransformResultView :id="selectedModule" @close="modalShow=false" />
+          <ModuleTransformResultView :id="selectedModule" @close="modalShow = false" />
         </Suspense>
       </template>
     </Modal>

--- a/packages/ui/client/directives/tooltip.ts
+++ b/packages/ui/client/directives/tooltip.ts
@@ -17,7 +17,6 @@ const tooltip: Directive = (el: Element, { value, oldValue, modifiers }) => {
     instance === undefined // mount if instance not yet created, else update content
       ? tippy(el, {
         delay: 200,
-        hideOnClick: false,
         ...config,
       })
       : value !== oldValue && instance.setProps(config)

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -163,5 +163,7 @@ html.dark {
   margin-right: unset !important;
   padding-bottom: unset !important;
 }
-
+.CodeMirror-sizer {
+  border-right: none;
+}
 


### PR DESCRIPTION
- Related to #526 
- fix: Make sure code editor cannot be blank even after several saves
- feat: Close Graph modal on escape key press
- feat: Render console tab more discrete + add info text when no logs is available 
- fix: Put graph code in readonly (no cursor)