### PR TITLE
fix: collect coverage using node inspector (fix #378)

### DIFF
--- a/packages/vitest/src/coverage.ts
+++ b/packages/vitest/src/coverage.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs } from 'fs'
 import { createRequire } from 'module'
 import { pathToFileURL } from 'url'
-import { resolve } from 'pathe'
+import { join, resolve } from 'pathe'
 import type { Arrayable } from './types'
 import type { Vitest } from './node'
 import { toArray } from './utils'
@@ -132,6 +132,14 @@ export async function cleanCoverage(options: ResolvedC8Options, clean = true) {
 const require = createRequire(import.meta.url)
 
 export async function reportCoverage(ctx: Vitest) {
+  // TODO: Would be nice if we could run c8 without writing files to disk
+  for (let i = 0; i < ctx.coverage.length; i++) {
+    const coverage = ctx.coverage[i]
+    const file = join(ctx.config.coverage.tempDirectory, `coverage-${i}.json`)
+
+    await fs.writeFile(file, JSON.stringify(coverage))
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const createReport = require('c8/lib/report')
   const report = createReport(ctx.config.coverage)

--- a/packages/vitest/src/coverage.ts
+++ b/packages/vitest/src/coverage.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fs } from 'fs'
 import { createRequire } from 'module'
 import { pathToFileURL } from 'url'
-import { join, resolve } from 'pathe'
+import { resolve } from 'pathe'
 import type { Arrayable } from './types'
 import type { Vitest } from './node'
 import { toArray } from './utils'
@@ -95,7 +95,6 @@ export interface C8Options {
 }
 
 export interface ResolvedC8Options extends Required<C8Options> {
-  tempDirectory: string
 }
 
 export function resolveC8Options(options: C8Options, root: string): ResolvedC8Options {
@@ -116,7 +115,6 @@ export function resolveC8Options(options: C8Options, root: string): ResolvedC8Op
 
   resolved.reporter = toArray(resolved.reporter)
   resolved.reportsDirectory = resolve(root, resolved.reportsDirectory)
-  resolved.tempDirectory = process.env.NODE_V8_COVERAGE || resolve(resolved.reportsDirectory, 'tmp')
 
   return resolved as ResolvedC8Options
 }
@@ -124,25 +122,16 @@ export function resolveC8Options(options: C8Options, root: string): ResolvedC8Op
 export async function cleanCoverage(options: ResolvedC8Options, clean = true) {
   if (clean && existsSync(options.reportsDirectory))
     await fs.rm(options.reportsDirectory, { recursive: true, force: true })
-
-  if (!existsSync(options.tempDirectory))
-    await fs.mkdir(options.tempDirectory, { recursive: true })
 }
 
 const require = createRequire(import.meta.url)
 
 export async function reportCoverage(ctx: Vitest) {
-  // TODO: Would be nice if we could run c8 without writing files to disk
-  for (let i = 0; i < ctx.coverage.length; i++) {
-    const coverage = ctx.coverage[i]
-    const file = join(ctx.config.coverage.tempDirectory, `coverage-${i}.json`)
-
-    await fs.writeFile(file, JSON.stringify(coverage))
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const createReport = require('c8/lib/report')
   const report = createReport(ctx.config.coverage)
+
+  report._loadReports = () => ctx.coverage
 
   const original = report._getMergedProcessCov
 

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -1,5 +1,4 @@
 import cac from 'cac'
-import { execa } from 'execa'
 import type { UserConfig } from '../types'
 import { version } from '../../package.json'
 import { ensurePackageInstalled } from '../utils'
@@ -80,12 +79,6 @@ async function run(cliFilters: string[], options: UserConfig) {
   if (ctx.config.coverage.enabled) {
     if (!await ensurePackageInstalled('c8'))
       process.exit(1)
-
-    if (!process.env.NODE_V8_COVERAGE) {
-      process.env.NODE_V8_COVERAGE = ctx.config.coverage.tempDirectory
-      const { exitCode } = await execa(process.argv0, process.argv.slice(1), { stdio: 'inherit' })
-      process.exit(exitCode)
-    }
   }
 
   if (ctx.config.environment && ctx.config.environment !== 'node') {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs'
+import type { Profiler } from 'inspector'
 import type { ViteDevServer } from 'vite'
 import fg from 'fast-glob'
 import mm from 'micromatch'
@@ -24,6 +25,7 @@ export class Vitest {
   server: ViteDevServer = undefined!
   state: StateManager = undefined!
   snapshot: SnapshotManager = undefined!
+  coverage: Profiler.TakePreciseCoverageReturnType[] = []
   reporters: Reporter[] = undefined!
   console: Console
   pool: WorkerPool | undefined
@@ -260,6 +262,7 @@ export class Vitest {
       //   })
       // }
       this.snapshot.clear()
+      this.coverage = []
       const files = Array.from(this.changedTests)
       this.changedTests.clear()
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -111,6 +111,9 @@ function createChannel(ctx: Vitest) {
       snapshotSaved(snapshot) {
         ctx.snapshot.add(snapshot)
       },
+      coverageCollected(coverage) {
+        ctx.coverage.push(coverage)
+      },
       async getSourceMap(id, force) {
         if (force) {
           const mod = ctx.server.moduleGraph.getModuleById(id)

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -191,7 +191,7 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
 
   let session!: inspector.Session
   if (config.coverage) {
-    inspector.open()
+    inspector.open(0)
     session = new inspector.Session()
     session.connect()
   

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -194,7 +194,7 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
     inspector.open(0)
     session = new inspector.Session()
     session.connect()
-  
+
     session.post('Profiler.enable')
     session.post('Profiler.startPreciseCoverage')
   }
@@ -209,7 +209,8 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
     session.disconnect()
     try {
       inspector.close()
-    } catch {
+    }
+    catch {
       // Fails inside workers for some reason
     }
   }

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -196,7 +196,7 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
     session.connect()
 
     session.post('Profiler.enable')
-    session.post('Profiler.startPreciseCoverage')
+    session.post('Profiler.startPreciseCoverage', { detailed: true })
   }
 
   await runSuites(files)

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -190,7 +190,7 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
   rpc().onCollected(files)
 
   let session!: inspector.Session
-  if (config.coverage) {
+  if (config.coverage.enabled) {
     inspector.open(0)
     session = new inspector.Session()
     session.connect()
@@ -201,7 +201,7 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
 
   await runSuites(files)
 
-  if (config.coverage) {
+  if (config.coverage.enabled) {
     session.post('Profiler.takePreciseCoverage', (_, coverage) => {
       rpc().coverageCollected(coverage)
     })

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -1,4 +1,5 @@
 import { performance } from 'perf_hooks'
+import inspector from 'inspector'
 import type { HookListener, ResolvedConfig, Suite, SuiteHooks, Task, TaskResult, Test } from '../types'
 import { vi } from '../integrations/vi'
 import { getSnapshotClient } from '../integrations/snapshot/chai'
@@ -188,7 +189,30 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
 
   rpc().onCollected(files)
 
+  let session!: inspector.Session
+  if (config.coverage) {
+    inspector.open()
+    session = new inspector.Session()
+    session.connect()
+  
+    session.post('Profiler.enable')
+    session.post('Profiler.startPreciseCoverage')
+  }
+
   await runSuites(files)
+
+  if (config.coverage) {
+    session.post('Profiler.takePreciseCoverage', (_, coverage) => {
+      rpc().coverageCollected(coverage)
+    })
+
+    session.disconnect()
+    try {
+      inspector.close()
+    } catch {
+      // Fails inside workers for some reason
+    }
+  }
 
   await getSnapshotClient().saveSnap()
 

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -1,3 +1,4 @@
+import type { Profiler } from 'inspector'
 import type { MessagePort } from 'worker_threads'
 import type { FetchFunction, ViteNodeResolveId } from 'vite-node'
 import type { RawSourceMap } from '../types'
@@ -27,4 +28,5 @@ export interface WorkerRPC {
   onTaskUpdate: (pack: TaskResultPack[]) => void
 
   snapshotSaved: (snapshot: SnapshotResult) => void
+  coverageCollected: (coverage: Profiler.TakePreciseCoverageReturnType) => void
 }


### PR DESCRIPTION
Fixes #378

For now this is just a proof of concept.
~~Tested on fluent-vue and vitest reports incorrect coverage for it.~~ With detailed coverage enabled it is much better now.
~~It still reports wrong code lines though.~~

edit:

Coverage is almost the same as it would be if Vitest waited for all coverage files to finish writing to disk. Tested on fluent-vue.

With "wait for coverage to be written" fix:

File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------|---------|----------|---------|---------|-------------------
All files               |   93.55 |    92.66 |   86.84 |   93.55 |                   
 src                    |   93.64 |    96.92 |      88 |   93.64 |                   
  TranslationContext.ts |     100 |      100 |     100 |     100 |                   
  composition.ts        |     100 |      100 |     100 |     100 |                   
  getContext.ts         |     100 |    94.73 |     100 |     100 | 27                
  index.ts              |   80.41 |       90 |   72.72 |   80.41 | 65-83             
  inheritBundle.ts      |     100 |      100 |     100 |     100 |                   
  symbols.ts            |     100 |      100 |     100 |     100 |                   
 src/util               |     100 |       80 |     100 |     100 |                   
  camelize.ts           |     100 |      100 |     100 |     100 |                   
  warn.ts               |     100 |    66.66 |     100 |     100 | 7                 
 src/vue                |   92.82 |    87.17 |   81.81 |   92.82 |                   
  component.ts          |     100 |      100 |     100 |     100 |                   
  directive.ts          |    88.8 |    81.48 |      75 |    88.8 | 52-55,98-107      

This implementation:

File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------|---------|----------|---------|---------|-------------------
All files               |    95.5 |    87.87 |   91.66 |    95.5 |                   
 src                    |   93.64 |    95.23 |      88 |   93.64 |                   
  TranslationContext.ts |     100 |      100 |     100 |     100 |                   
  composition.ts        |     100 |      100 |     100 |     100 |                   
  getContext.ts         |     100 |    91.66 |     100 |     100 | 27                
  index.ts              |   80.41 |    88.88 |   72.72 |   80.41 | 65-83             
  inheritBundle.ts      |     100 |      100 |     100 |     100 |                   
  symbols.ts            |     100 |      100 |     100 |     100 |                   
 src/util               |     100 |    66.66 |     100 |     100 |                   
  camelize.ts           |     100 |      100 |     100 |     100 |                   
  warn.ts               |     100 |       50 |     100 |     100 | 7                 
 src/vue                |   97.94 |    76.19 |     100 |   97.94 |                   
  component.ts          |     100 |      100 |     100 |     100 |                   
  directive.ts          |    96.8 |    64.28 |     100 |    96.8 | 52-55  