### PR TITLE
fix: escape $ characters in inline snapshots (fix #597)

### DIFF
--- a/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
+++ b/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
@@ -61,6 +61,7 @@ function prepareSnapString(snap: string, source: string, index: number) {
   const lines = snap
     .trim()
     .replace(/\\/g, '\\\\')
+    .replace(/\$/g, '\\$')
     .split(/\n/g)
     .map(i => i.trimEnd())
 


### PR DESCRIPTION
Fixes #597