### PR TITLE
fix: don't rerun more then needed in watch mode (fix #442)

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -282,8 +282,8 @@ export class Vitest {
   private registerWatcher() {
     const onChange = (id: string) => {
       id = slash(id)
-      this.handleFileChanged(id)
-      if (this.changedTests.size)
+      const needsRerun = this.handleFileChanged(id)
+      if (needsRerun)
         this.scheduleRerun(id)
     }
     const onUnlink = (id: string) => {
@@ -315,25 +315,35 @@ export class Vitest {
     }
   }
 
-  private handleFileChanged(id: string) {
+  /**
+   * @returns A value indicating whether rerun is needed (changedTests was mutated)
+   */
+  private handleFileChanged(id: string): boolean {
     if (this.changedTests.has(id) || this.invalidates.has(id) || this.config.watchIgnore.some(i => id.match(i)))
-      return
+      return false
 
     const mod = this.server.moduleGraph.getModuleById(id)
     if (!mod)
-      return
+      return false
 
     this.invalidates.add(id)
 
     if (this.state.filesMap.has(id)) {
       this.changedTests.add(id)
-      return
+      return true
     }
 
+    let rerun = false
     mod.importers.forEach((i) => {
-      if (i.id)
-        this.handleFileChanged(i.id)
+      if (!i.id)
+        return
+
+      const heedsRerun = this.handleFileChanged(i.id)
+      if (heedsRerun)
+        rerun = true
     })
+
+    return rerun
   }
 
   async close() {


### PR DESCRIPTION
Fixes #442

What was happening with #442 is that `onChange` was called for a file. That adds it to `changedTests`. After that  `onChange` was triggered for a file in `.idea` folder. And because `changedTests` is not empty another rerun was scheduled.

https://github.com/vitest-dev/vitest/blob/2509e06cc7d94b1b0354867a3143babe65eeafa1/packages/vitest/src/node/core.ts#L285-L287

Fixed by returning from `handleFileChanged` indication whether `changedTests` was mutated and rerun it needed.