### PR TITLE
fix: toBe/toEqual/toMatchObject expect compatability

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -249,10 +249,6 @@ When you use `test` in the top level of file, they are collected as part of the 
 
   Also, `expect` can be used statically to access matchers functions, described later, and more.
 
-  :::warning
-  To provide compatibility with [asymmetric matchers](#expectany), Vitest wraps `.eql` and `.equals` chai assertions, so if you need to use chai equality, you can use `.chaiEqual` matcher.
-  :::
-
 ### not
 
 TODO

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -127,8 +127,6 @@ declare global {
     interface VitestAssertion<T = any> extends VitestifyAssertion<Assertion>, JestAssertion<T> {
       resolves: Promisify<VitestAssertion<T>>
       rejects: Promisify<VitestAssertion<T>>
-
-      chaiEqual<E>(expected: E): void
     }
   }
 }

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -3,7 +3,7 @@ import { isMockFunction } from '../jest-mock'
 import { addSerializer } from '../snapshot/port/plugins'
 import type { Constructable } from '../../types'
 import type { ChaiPlugin, MatcherState } from './types'
-import { arrayBufferEquality, equals as asymmetricEquals, iterableEquality, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
+import { arrayBufferEquality, iterableEquality, equals as jestEquals, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
 import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 
 const MATCHERS_OBJECT = Symbol.for('matchers-object')
@@ -63,7 +63,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
   def('toEqual', function(expected) {
     const actual = utils.flag(this, 'object')
-    const equal = asymmetricEquals(
+    const equal = jestEquals(
       actual,
       expected,
       [iterableEquality],
@@ -80,7 +80,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
   def('toStrictEqual', function(expected) {
     const obj = utils.flag(this, 'object')
-    const equal = asymmetricEquals(
+    const equal = jestEquals(
       obj,
       expected,
       [
@@ -113,7 +113,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def('toMatchObject', function(expected) {
     const actual = this._obj
     return this.assert(
-      asymmetricEquals(actual, expected, [iterableEquality, subsetEquality]),
+      jestEquals(actual, expected, [iterableEquality, subsetEquality]),
       'expected #{this} to match object #{exp}',
       'expected #{this} to not match object #{exp}',
       expected,
@@ -132,7 +132,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def('toContainEqual', function(expected) {
     const obj = utils.flag(this, 'object')
     const index = Array.from(obj).findIndex((item) => {
-      return asymmetricEquals(item, expected)
+      return jestEquals(item, expected)
     })
 
     this.assert(
@@ -273,7 +273,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def(['toHaveBeenCalledWith', 'toBeCalledWith'], function(...args) {
     const spy = getSpy(this)
     const spyName = spy.getMockName()
-    const pass = spy.mock.calls.some(callArg => asymmetricEquals(callArg, args, [iterableEquality]))
+    const pass = spy.mock.calls.some(callArg => jestEquals(callArg, args, [iterableEquality]))
     return this.assert(
       pass,
       `expected "${spyName}" to be called with arguments: #{exp}`,
@@ -303,7 +303,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const nthCall = spy.mock.calls[times - 1]
 
     this.assert(
-      asymmetricEquals(nthCall, args, [iterableEquality]),
+      jestEquals(nthCall, args, [iterableEquality]),
       `expected ${ordinalOf(times)} "${spyName}" call to have been called with #{exp}`,
       `expected ${ordinalOf(times)} "${spyName}" call to not have been called with #{exp}`,
       args,
@@ -316,7 +316,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const lastCall = spy.mock.calls[spy.calls.length - 1]
 
     this.assert(
-      asymmetricEquals(lastCall, args, [iterableEquality]),
+      jestEquals(lastCall, args, [iterableEquality]),
       `expected last "${spyName}" call to have been called with #{exp}`,
       `expected last "${spyName}" call to not have been called with #{exp}`,
       args,
@@ -401,7 +401,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def(['toHaveReturnedWith', 'toReturnWith'], function(value: any) {
     const spy = getSpy(this)
     const spyName = spy.getMockName()
-    const pass = spy.mock.results.some(({ type, value: result }) => type === 'return' && asymmetricEquals(value, result))
+    const pass = spy.mock.results.some(({ type, value: result }) => type === 'return' && jestEquals(value, result))
     this.assert(
       pass,
       `expected "${spyName}" to be successfully called with #{exp}`,
@@ -413,7 +413,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const spy = getSpy(this)
     const spyName = spy.getMockName()
     const { value: lastResult } = spy.mock.results[spy.returns.length - 1]
-    const pass = asymmetricEquals(lastResult, value)
+    const pass = jestEquals(lastResult, value)
     this.assert(
       pass,
       `expected last "${spyName}" call to return #{exp}`,
@@ -432,7 +432,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     if (!isNot && callType === 'throw')
       chai.assert.fail(`expected ${ordinalCall} to return #{exp}, but instead it threw an error`)
 
-    const nthCallReturn = asymmetricEquals(callResult, value)
+    const nthCallReturn = jestEquals(callResult, value)
 
     this.assert(
       nthCallReturn,

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -123,7 +123,14 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     )
   })
   def('toBe', function(expected) {
-    return this.equal(expected)
+    const actual = this._obj
+    return this.assert(
+      Object.is(actual, expected),
+      'expected #{this} to be #{exp} // Object.is equality',
+      'expected #{this} not to be #{exp} // Object.is equality',
+      expected,
+      actual,
+    )
   })
   def('toMatchObject', function(expected) {
     const actual = this._obj

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -3,7 +3,7 @@ import { isMockFunction } from '../jest-mock'
 import { addSerializer } from '../snapshot/port/plugins'
 import type { Constructable } from '../../types'
 import type { ChaiPlugin, MatcherState } from './types'
-import { arrayBufferEquality, equals as asymmetricEquals, hasAsymmetric, iterableEquality, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
+import { arrayBufferEquality, equals as asymmetricEquals, iterableEquality, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
 import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 
 const MATCHERS_OBJECT = Symbol.for('matchers-object')
@@ -69,40 +69,30 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
 
   // overrides `.equal` and `.eql` to provide custom assertion for asymmetric equality
-  utils.overwriteMethod(chai.Assertion.prototype, 'equal', (_super: any) => {
+  utils.overwriteMethod(chai.Assertion.prototype, 'equal', () => {
     return function(this: Chai.Assertion & Chai.AssertionStatic, ...args: any[]) {
       const expected = args[0]
       const actual = utils.flag(this, 'object')
-      if (hasAsymmetric(expected)) {
-        this.assert(
-          asymmetricEquals(actual, expected, undefined, true),
-          'not match with #{act}',
-          'should not match with #{act}',
-          actual,
-          expected,
-        )
-      }
-      else {
-        _super.apply(this, args)
-      }
+      this.assert(
+        asymmetricEquals(actual, expected, undefined, true),
+        'not match with #{act}',
+        'should not match with #{act}',
+        actual,
+        expected,
+      )
     }
   })
-  utils.overwriteMethod(chai.Assertion.prototype, 'eql', (_super: any) => {
+  utils.overwriteMethod(chai.Assertion.prototype, 'eql', () => {
     return function(this: Chai.Assertion & Chai.AssertionStatic, ...args: any[]) {
       const expected = args[0]
       const actual = utils.flag(this, 'object')
-      if (hasAsymmetric(expected)) {
-        this.assert(
-          asymmetricEquals(actual, expected),
-          'not match with #{exp}',
-          'should not match with #{exp}',
-          expected,
-          actual,
-        )
-      }
-      else {
-        _super.apply(this, args)
-      }
+      this.assert(
+        asymmetricEquals(actual, expected),
+        'not match with #{exp}',
+        'should not match with #{exp}',
+        expected,
+        actual,
+      )
     }
   })
 

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -46,14 +46,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       addMethod(name)
   }
 
-  // we overrides the default `.equal`, keep original `.chaiEqual` in case need
-  // @ts-expect-error prototype
-  const chaiEqual = chai.Assertion.prototype.equal
-  def('chaiEqual', function(...args: any[]) {
-    return chaiEqual.apply(this, args)
-  })
-
-  ;(['throw', 'throws', 'Throw'] as const).forEach((m) => {
+  (['throw', 'throws', 'Throw'] as const).forEach((m) => {
     utils.overwriteMethod(chai.Assertion.prototype, m, (_super: any) => {
       return function(this: Chai.Assertion & Chai.AssertionStatic, ...args: any[]) {
         const promise = utils.flag(this, 'promise')
@@ -66,34 +59,6 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         _super.apply(this, args)
       }
     })
-  })
-
-  // overrides `.equal` and `.eql` to provide custom assertion for asymmetric equality
-  utils.overwriteMethod(chai.Assertion.prototype, 'equal', () => {
-    return function(this: Chai.Assertion & Chai.AssertionStatic, ...args: any[]) {
-      const expected = args[0]
-      const actual = utils.flag(this, 'object')
-      this.assert(
-        asymmetricEquals(actual, expected, undefined, true),
-        'not match with #{act}',
-        'should not match with #{act}',
-        actual,
-        expected,
-      )
-    }
-  })
-  utils.overwriteMethod(chai.Assertion.prototype, 'eql', () => {
-    return function(this: Chai.Assertion & Chai.AssertionStatic, ...args: any[]) {
-      const expected = args[0]
-      const actual = utils.flag(this, 'object')
-      this.assert(
-        asymmetricEquals(actual, expected),
-        'not match with #{exp}',
-        'should not match with #{exp}',
-        expected,
-        actual,
-      )
-    }
   })
 
   def('toEqual', function(expected) {

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -97,7 +97,20 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
 
   def('toEqual', function(expected) {
-    return this.eql(expected)
+    const actual = utils.flag(this, 'object')
+    const equal = asymmetricEquals(
+      actual,
+      expected,
+      [iterableEquality],
+    )
+
+    return this.assert(
+      equal,
+      'expected #{this} to deeply equal #{exp}',
+      'expected #{this} to not deeply equal #{exp}',
+      expected,
+      actual,
+    )
   })
 
   def('toStrictEqual', function(expected) {

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -3,7 +3,7 @@ import { isMockFunction } from '../jest-mock'
 import { addSerializer } from '../snapshot/port/plugins'
 import type { Constructable } from '../../types'
 import type { ChaiPlugin, MatcherState } from './types'
-import { arrayBufferEquality, equals as asymmetricEquals, hasAsymmetric, iterableEquality, sparseArrayEquality, typeEquality } from './jest-utils'
+import { arrayBufferEquality, equals as asymmetricEquals, hasAsymmetric, iterableEquality, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
 import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 
 const MATCHERS_OBJECT = Symbol.for('matchers-object')
@@ -136,7 +136,14 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     return this.equal(expected)
   })
   def('toMatchObject', function(expected) {
-    return this.containSubset(expected)
+    const actual = this._obj
+    return this.assert(
+      asymmetricEquals(actual, expected, [iterableEquality, subsetEquality]),
+      'expected #{this} to match object #{exp}',
+      'expected #{this} to not match object #{exp}',
+      expected,
+      actual,
+    )
   })
   def('toMatch', function(expected: string | RegExp) {
     if (typeof expected === 'string')

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -95,21 +95,6 @@ describe('jest-expect', () => {
     expect(['Bob', 'Eve']).toEqual(expect.not.arrayContaining(['Steve']))
   })
 
-  it('asymmetric matchers (chai style)', () => {
-    expect({ foo: 'bar' }).equal({ foo: expect.stringContaining('ba') })
-    expect('bar').equal(expect.stringContaining('ba'))
-    expect(['bar']).equal([expect.stringContaining('ba')])
-    expect({ foo: 'bar', bar: 'foo', hi: 'hello' }).equal({
-      foo: expect.stringContaining('ba'),
-      bar: expect.stringContaining('fo'),
-      hi: 'hello',
-    })
-
-    expect({ foo: 'bar' }).not.equal({ foo: expect.stringContaining('zoo') })
-    expect('bar').not.equal(expect.stringContaining('zoo'))
-    expect(['bar']).not.equal([expect.stringContaining('zoo')])
-  })
-
   it('object', () => {
     expect({}).toEqual({})
     expect({ apples: 13 }).toEqual({ apples: 13 })

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -126,6 +126,7 @@ describe('jest-expect', () => {
     expect([complex]).toMatchObject([{ foo: 1 }])
     expect(complex).not.toMatchObject({ foo: 2 })
     expect(complex).toMatchObject({ bar: { bar: 100 } })
+    expect(complex).toMatchObject({ foo: expect.any(Number) })
 
     expect(complex).toHaveProperty('foo')
     expect(complex).toHaveProperty('foo', 1)


### PR DESCRIPTION
This PR does a few things:

- Fixes #598
- Uses the same algorithm for `toBe`, `toMatchObject` and `toEqual` that jest uses
- Removes assymetric support for chai equality - this removes ambiguity. Example: when you have an assymetric mathcher in `toEqual` and THE SAME object, but without assymetric matcher, in another `toEqual`, the test might fail for one, but not for the other because we call different equality functions for each one
- Rename `asymmetricEquals` to `jestEquals` to better represent what it is