### PR TITLE
feat: move matcher types to Vi namespace

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -16,8 +16,6 @@ export * from './integrations/vi'
 export * from './types'
 export * from './api/types'
 
-export type { Spy, SpyFn } from 'tinyspy'
-
 declare module 'vite' {
   interface UserConfig {
     /**
@@ -43,9 +41,10 @@ type Promisify<O> = {
 }
 
 declare global {
-  namespace Chai {
-    interface ExpectStatic extends AsymmetricMatchersContaining {
-      <T>(actual: T, message?: string): VitestAssertion<T>
+  namespace Vi {
+
+    interface ExpectStatic extends Chai.ExpectStatic, AsymmetricMatchersContaining {
+      <T>(actual: T, message?: string): Vi.Assertion<T>
 
       extend(expects: MatchersObject): void
       assertions(expected: number): void
@@ -117,18 +116,16 @@ declare global {
     }
 
     type VitestifyAssertion<A> = {
-      [K in keyof A]: A[K] extends Assertion
-        ? VitestAssertion<any>
+      [K in keyof A]: A[K] extends Chai.Assertion
+        ? Assertion<any>
         : A[K] extends (...args: any[]) => any
           ? A[K] // not converting function since they may contain overload
           : VitestifyAssertion<A[K]>
     }
 
-    interface VitestAssertion<T = any> extends VitestifyAssertion<Assertion>, JestAssertion<T> {
-      resolves: Promisify<VitestAssertion<T>>
-      rejects: Promisify<VitestAssertion<T>>
-
-      chaiEqual<E>(expected: E): void
+    interface Assertion<T = any> extends VitestifyAssertion<Chai.Assertion>, JestAssertion<T> {
+      resolves: Promisify<Assertion<T>>
+      rejects: Promisify<Assertion<T>>
     }
   }
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -126,6 +126,8 @@ declare global {
     interface Assertion<T = any> extends VitestifyAssertion<Chai.Assertion>, JestAssertion<T> {
       resolves: Promisify<Assertion<T>>
       rejects: Promisify<Assertion<T>>
+
+      chaiEqual<E>(expected: E): void
     }
   }
 }

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -3,11 +3,11 @@ import { getState, setState } from './jest-expect'
 
 export { assert, should } from 'chai'
 
-const expect = ((value: any, message?: string): Chai.VitestAssertion => {
+const expect = ((value: any, message?: string): Vi.Assertion => {
   const { assertionCalls } = getState()
   setState({ assertionCalls: assertionCalls + 1 })
-  return chai.expect(value, message)
-}) as Chai.ExpectStatic
+  return chai.expect(value, message) as unknown as Vi.Assertion
+}) as Vi.ExpectStatic
 expect.getState = getState
 expect.setState = setState
 

--- a/packages/vitest/src/integrations/chai/jest-asymmetric-matchers.ts
+++ b/packages/vitest/src/integrations/chai/jest-asymmetric-matchers.ts
@@ -294,7 +294,8 @@ export const JestAsymmetricMatchers: ChaiPlugin = (chai, utils) => {
     (expected: any) => new StringMatching(expected),
   )
 
-  chai.expect.not = {
+  // defineProperty does not work
+  ;(chai.expect as any).not = {
     stringContaining: (expected: string) => new StringContaining(expected, true),
     objectContaining: (expected: any) => new ObjectContaining(expected, true),
     arrayContaining: (expected: unknown[]) => new ArrayContaining(expected, true),

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -34,8 +34,8 @@ export const setState = <State extends MatcherState = MatcherState>(
 
 // Jest Expect Compact
 export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
-  function def(name: keyof Chai.VitestAssertion | (keyof Chai.VitestAssertion)[], fn: ((this: Chai.AssertionStatic & Chai.VitestAssertion, ...args: any[]) => any)) {
-    const addMethod = (n: keyof Chai.VitestAssertion) => {
+  function def(name: keyof Vi.Assertion | (keyof Vi.Assertion)[], fn: ((this: Chai.AssertionStatic & Vi.Assertion, ...args: any[]) => any)) {
+    const addMethod = (n: keyof Vi.Assertion) => {
       utils.addMethod(chai.Assertion.prototype, n, fn)
     }
 

--- a/packages/vitest/src/integrations/snapshot/client.ts
+++ b/packages/vitest/src/integrations/snapshot/client.ts
@@ -54,7 +54,7 @@ export class SnapshotClient {
       try {
         const pass = equals(received, properties, [iterableEquality, subsetEquality])
         if (!pass)
-          expect(received).toBe(properties)
+          expect(received).equals(properties)
         else
           received = deepMergeSnapshot(received, properties)
       }

--- a/packages/vitest/src/integrations/timers.ts
+++ b/packages/vitest/src/integrations/timers.ts
@@ -1,7 +1,7 @@
 // TODO setImmediate, nextTick, requestAnimationFrame, cancelAnimationFrame
 // TODO async timers
 
-import type { JestMockCompat } from './jest-mock'
+import type { SpyInstance } from './jest-mock'
 import { spyOn } from './jest-mock'
 
 const originalSetTimeout = global.setTimeout
@@ -57,11 +57,11 @@ const getNodeTimeout = (id: number): NodeJS.Timeout => {
 }
 
 export class FakeTimers {
-  private _setTimeout!: JestMockCompat<Arguments, NodeJS.Timeout>
-  private _setInterval!: JestMockCompat<Arguments, NodeJS.Timeout>
+  private _setTimeout!: SpyInstance<Arguments, NodeJS.Timeout>
+  private _setInterval!: SpyInstance<Arguments, NodeJS.Timeout>
 
-  private _clearTimeout!: JestMockCompat<[NodeJS.Timeout], void>
-  private _clearInterval!: JestMockCompat<[NodeJS.Timeout], void>
+  private _clearTimeout!: SpyInstance<[NodeJS.Timeout], void>
+  private _clearInterval!: SpyInstance<[NodeJS.Timeout], void>
 
   private _advancedTime = 0
   private _nestedTime: Record<string, number> = {}


### PR DESCRIPTION
I am using `Vi` namespace since as I saw from others in discord, this is preferred way to use vitest