### PR TITLE
feat: virtual scrolling task list

### DIFF
--- a/test/core/test/ui-generated-tasks.test.ts
+++ b/test/core/test/ui-generated-tasks.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+describe('Test UI root describe', () => {
+  for (let index_d = 1; index_d <= 50; index_d++) {
+    describe(`Test UI nested describe ${index_d}`, () => {
+      for (let index_i = 1; index_i <= 20; index_i++) {
+        it(`Test UI it ${index_d}-${index_i}`, () => {
+          expect(true).toBe(true)
+        })
+      }
+    })
+  }
+})


### PR DESCRIPTION
reference #604 

This doesn't work right now :slightly_frowning_face: 
I just tried a bit around and found out that the tasks are nested in each other,
and therefore it's not really possible to give each row a `itemHeight` cause the whole block (_describe_) is just one big item.

Also it looks like there are different groups if there are failing tests and so on, that makes this even harder...