### PR TITLE
fix: do not merge options multiple times (fix #616)

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -4,7 +4,7 @@ import type { ResolvedConfig as ResolvedViteConfig, UserConfig as ViteUserConfig
 import type { ApiConfig, ResolvedConfig, UserConfig } from '../types'
 import { defaultExclude, defaultInclude, defaultPort } from '../constants'
 import { resolveC8Options } from '../coverage'
-import { deepMerge, toArray } from '../utils'
+import { toArray } from '../utils'
 
 export function resolveApiConfig<Options extends ApiConfig & UserConfig>(
   options: Options,

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -56,7 +56,7 @@ export function resolveConfig(
   const globals = options?.global ?? options.globals
 
   const resolved = {
-    ...deepMerge(options, viteConfig.test || {}),
+    ...options,
     root: viteConfig.root,
     globals,
     global: globals,


### PR DESCRIPTION
Fixes #616

Options were merged here already: https://github.com/vitest-dev/vitest/blob/b9d092b5fb098ec9836d8e8ca9088c042f945457/packages/vitest/src/node/plugins/index.ts#L22

This causes reporters array to have duplicate entries.