### PR TITLE
fix: do not start node inspector (fix #620)

### DIFF
--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -191,7 +191,6 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
 
   let session!: inspector.Session
   if (config.coverage.enabled) {
-    inspector.open(0)
     session = new inspector.Session()
     session.connect()
 
@@ -207,12 +206,6 @@ export async function startTests(paths: string[], config: ResolvedConfig) {
     })
 
     session.disconnect()
-    try {
-      inspector.close()
-    }
-    catch {
-      // Fails inside workers for some reason
-    }
   }
 
   await getSnapshotClient().saveSnap()


### PR DESCRIPTION
Fixes #620

Turns out there is no need to start inspector when inspecting local process