### PR TITLE
fix: add async to onFinish report event

### DIFF
--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -146,7 +146,7 @@ class WebSocketReporter implements Reporter {
     })
   }
 
-  onFinished(files?: File[] | undefined) {
+  async onFinished(files?: File[] | undefined) {
     this.clients.forEach((client) => {
       client.onFinished?.(files)
     })

--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -4,7 +4,7 @@ import type { File, TaskResultPack } from './tasks'
 
 export interface Reporter {
   onInit?(ctx: Vitest): void
-  onCollected?: (files?: File[]) => Awaitable<void>
+  onCollected?: (files?: File[]) => void
   onFinished?: (files?: File[]) => Awaitable<void>
   onTaskUpdate?: (packs: TaskResultPack[]) => Awaitable<void>
 
@@ -13,5 +13,5 @@ export interface Reporter {
 
   onServerRestart?: () => Awaitable<void>
 
-  onUserConsoleLog?: (log: UserConsoleLog) => Awaitable<void>
+  onUserConsoleLog?: (log: UserConsoleLog) => void
 }


### PR DESCRIPTION
Error when using UI with Vitest
> (node:50984) UnhandledPromiseRejectionWarning: Error: listen EACCES: permission denied 127.0.0.1:51204
    at Server.setupListenHandle [as _listen2] (net.js:1301:21)
    at listenInCluster (net.js:1366:12)
    at doListen (net.js:1503:7)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:50984) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:50984) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, 
promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.