### PR TITLE
chore: update ws to 8.4.2

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -101,7 +101,7 @@
     "strip-ansi": "^7.0.1",
     "typescript": "^4.5.4",
     "vite-node": "workspace:*",
-    "ws": "8.4.0"
+    "ws": "^8.4.2"
   },
   "peerDependencies": {
     "@vitest/ui": "*",

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "birpc": "^0.1.0",
     "flatted": "^3.2.4",
-    "ws": "8.4.0"
+    "ws": "^8.4.2"
   },
   "devDependencies": {
     "rollup": "^2.64.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,7 +547,7 @@ importers:
       typescript: ^4.5.4
       vite: '>=2.7.13'
       vite-node: workspace:*
-      ws: 8.4.0
+      ws: ^8.4.2
     dependencies:
       '@types/chai': 4.3.0
       '@types/chai-subset': 1.3.3
@@ -594,18 +594,18 @@ importers:
       strip-ansi: 7.0.1
       typescript: 4.5.4
       vite-node: link:../vite-node
-      ws: 8.4.0
+      ws: 8.4.2
 
   packages/ws-client:
     specifiers:
       birpc: ^0.1.0
       flatted: ^3.2.4
       rollup: ^2.64.0
-      ws: 8.4.0
+      ws: ^8.4.2
     dependencies:
       birpc: 0.1.0
       flatted: 3.2.4
-      ws: 8.4.0
+      ws: 8.4.2
     devDependencies:
       rollup: 2.64.0
 
@@ -17038,18 +17038,6 @@ packages:
         optional: true
     dev: true
 
-  /ws/8.4.0:
-    resolution: {integrity: sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   /ws/8.4.2:
     resolution: {integrity: sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==}
     engines: {node: '>=10.0.0'}
@@ -17061,7 +17049,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /xml-name-validator/4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}


### PR DESCRIPTION
@d3lm deployed a fix for `ws` 8.4.1+ for StackBlitz. We should no longer need to fix the `ws` version to 8.4.0. We still need to release and confirm that SB works as expected.

I tested my reproduction (only using `ws`) and is now working:
https://stackblitz.com/edit/node-rw7h6i?file=index.mjs&terminal=start