### PR TITLE
docs: escape dot to prevent parsing of title as url

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -326,7 +326,7 @@ Determine the transform method of modules
 Use SSR transform pipeline for the specified files.<br>
 Vite plugins will receive `ssr: true` flag when processing those files.
 
-#### transformMode.web
+#### transformMode&#46;web
 
 - **Type:** `RegExp[]`
 - **Default:** *modules other than those specified in `transformMode.ssr`*


### PR DESCRIPTION
Closes #617.

Another solution would be to wrap the heading in a  `span`. But this would alter the DOM. Using `h4` directly does not work.