### PR TITLE
feat: allow to mock date without fake timers (fix #621)

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -59,6 +59,7 @@
     "@types/chai-subset": "^1.3.3",
     "chai": "^4.3.4",
     "local-pkg": "^0.4.1",
+    "mockdate": "^3.0.5",
     "tinypool": "^0.1.1",
     "tinyspy": "^0.2.8",
     "vite": ">=2.7.13"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -59,7 +59,6 @@
     "@types/chai-subset": "^1.3.3",
     "chai": "^4.3.4",
     "local-pkg": "^0.4.1",
-    "mockdate": "^3.0.5",
     "tinypool": "^0.1.1",
     "tinyspy": "^0.2.8",
     "vite": ">=2.7.13"
@@ -91,6 +90,7 @@
     "magic-string": "^0.25.7",
     "micromatch": "^4.0.4",
     "mlly": "^0.3.19",
+    "mockdate": "^3.0.5",
     "natural-compare": "^1.4.0",
     "pathe": "^0.2.0",
     "picocolors": "^1.0.0",
@@ -111,6 +111,9 @@
     "jsdom": "*"
   },
   "peerDependenciesMeta": {
+    "@vitest/ui": {
+      "optional": true
+    },
     "c8": {
       "optional": true
     },
@@ -118,9 +121,6 @@
       "optional": true
     },
     "jsdom": {
-      "optional": true
-    },
-    "@vitest/ui": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
       lit: 2.1.1
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 2.30.0
+      happy-dom: 2.30.1
       vite: 2.7.13
       vitest: link:../../packages/vitest
 
@@ -395,7 +395,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue': 2.0.1_vite@2.7.13+vue@3.2.26
       '@vue/test-utils': 2.0.0-rc.18_vue@3.2.26
-      happy-dom: 2.30.0
+      happy-dom: 2.30.1
       unplugin-auto-import: 0.5.11_0300e2fc4592cc668512bad114c07138
       unplugin-vue-components: 0.17.14_19c514bd5e4e89f4f64a7d4f3f15a1ba
       vitest: link:../../packages/vitest
@@ -412,7 +412,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue': 2.0.1_vite@2.7.13+vue@3.2.26
       '@vue/test-utils': 2.0.0-rc.18_vue@3.2.26
-      happy-dom: 2.30.0
+      happy-dom: 2.30.1
       vitest: link:../../packages/vitest
 
   examples/vue-jsx:
@@ -428,7 +428,7 @@ importers:
       '@vitejs/plugin-vue': 2.0.1_vite@2.7.13+vue@3.2.26
       '@vitejs/plugin-vue-jsx': 1.3.3
       '@vue/test-utils': 2.0.0-rc.18_vue@3.2.26
-      happy-dom: 2.30.0
+      happy-dom: 2.30.1
       vite: 2.7.13
       vitest: link:../../packages/vitest
       vue: 3.2.26
@@ -533,6 +533,7 @@ importers:
       magic-string: ^0.25.7
       micromatch: ^4.0.4
       mlly: ^0.3.19
+      mockdate: ^3.0.5
       natural-compare: ^1.4.0
       pathe: ^0.2.0
       picocolors: ^1.0.0
@@ -553,6 +554,7 @@ importers:
       '@types/chai-subset': 1.3.3
       chai: 4.3.4
       local-pkg: 0.4.1
+      mockdate: 3.0.5
       tinypool: 0.1.1
       tinyspy: 0.2.8
       vite: 2.7.13
@@ -10785,8 +10787,8 @@ packages:
       whatwg-mimetype: 2.3.0
     dev: true
 
-  /happy-dom/2.30.0:
-    resolution: {integrity: sha512-//9pqe00RsVdBIR340bM8KRF0pYtwgVEo10pOpkCT3bIl45NjYFYg89ZV8dzu1j7rsP6ECTUy+OqNFf1h2wlaA==}
+  /happy-dom/2.30.1:
+    resolution: {integrity: sha512-Qz3Z/zn/VeUCtVEGoSCDD+zzPcyOEdIYz4p1BvsXvrTSx6vXyGadMDAsxOKf8ZFCRfuyLpLKfqdRHFFPF77qPA==}
     dependencies:
       he: 1.2.0
       node-fetch: 2.6.6
@@ -12596,6 +12598,10 @@ packages:
 
   /mlly/0.3.19:
     resolution: {integrity: sha512-zMq5n3cOf4fOzA4WoeulxagbAgMChdev3MgP6K51k7M0u2whTXxupfIY4VVzws4vxkiWhwH1rVQcsw7zDGfRhA==}
+
+  /mockdate/3.0.5:
+    resolution: {integrity: sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==}
+    dev: false
 
   /moment/2.29.1:
     resolution: {integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,7 +554,6 @@ importers:
       '@types/chai-subset': 1.3.3
       chai: 4.3.4
       local-pkg: 0.4.1
-      mockdate: 3.0.5
       tinypool: 0.1.1
       tinyspy: 0.2.8
       vite: 2.7.13
@@ -585,6 +584,7 @@ importers:
       magic-string: 0.25.7
       micromatch: 4.0.4
       mlly: 0.3.19
+      mockdate: 3.0.5
       natural-compare: 1.4.0
       pathe: 0.2.0
       picocolors: 1.0.0
@@ -12601,7 +12601,7 @@ packages:
 
   /mockdate/3.0.5:
     resolution: {integrity: sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==}
-    dev: false
+    dev: true
 
   /moment/2.29.1:
     resolution: {integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==}

--- a/test/core/test/date-mock.test.ts
+++ b/test/core/test/date-mock.test.ts
@@ -1,10 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 describe('testing date mock functionality', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   afterEach(() => {
     vi.useRealTimers()
   })

--- a/test/core/test/timers.test.ts
+++ b/test/core/test/timers.test.ts
@@ -845,5 +845,22 @@ describe('FakeTimers', () => {
 
       expect(timers.getTimerCount()).toEqual(0)
     })
+
+    it('throws when using useFakeTimers after setSystemTime', () => {
+      const timers = new FakeTimers({ global })
+
+      const timeStr = 'Fri Feb 20 2015 19:29:31 GMT+0530'
+      const timeStrMs = 1424440771000
+
+      timers.setSystemTime(timeStr)
+
+      expect(Date.now()).toBe(timeStrMs)
+
+      expect(() => timers.useFakeTimers()).toThrowError(/date was mocked/)
+
+      // Some test
+
+      timers.useRealTimers()
+    })
   })
 })

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -1,14 +1,10 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { JsonReporter } from '../../../packages/vitest/src/node/reporters/json'
 import { JUnitReporter } from '../../../packages/vitest/src/node/reporters/junit'
 import { TapReporter } from '../../../packages/vitest/src/node/reporters/tap'
 import { TapFlatReporter } from '../../../packages/vitest/src/node/reporters/tap-flat'
 import { getContext } from '../src/context'
 import { files } from '../src/data'
-
-beforeEach(() => {
-  vi.useFakeTimers()
-})
 
 afterEach(() => {
   vi.useRealTimers()


### PR DESCRIPTION
Fake timers are very intrusive and cause issues with promises.
This PR allows to call `vi.setSystemTime()` without enabling fake timers. This will mock just the current date using `mockdate`.

Fixes: #621