### PR TITLE
feat: support `suite.each`, `test.each`, close #120

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
+    "@types/lodash": "^4.14.178",
     "@types/node": "^17.0.12",
     "bumpp": "^7.1.1",
     "c8": "^7.11.0",

--- a/packages/ui/client/auto-imports.d.ts
+++ b/packages/ui/client/auto-imports.d.ts
@@ -170,6 +170,7 @@ declare global {
   const useSpeechSynthesis: typeof import('@vueuse/core')['useSpeechSynthesis']
   const useStorage: typeof import('@vueuse/core')['useStorage']
   const useStorageAsync: typeof import('@vueuse/core')['useStorageAsync']
+  const useStyleTag: typeof import('@vueuse/core')['useStyleTag']
   const useSwipe: typeof import('@vueuse/core')['useSwipe']
   const useTemplateRefsList: typeof import('@vueuse/core')['useTemplateRefsList']
   const useTextSelection: typeof import('@vueuse/core')['useTextSelection']

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1231,6 +1231,35 @@ Repository: unjs/mlly
 
 ---------------------------------------
 
+## mockdate
+License: MIT
+By: Bob Lauer
+Repository: https://github.com/boblauer/MockDate.git
+
+> The MIT License (MIT)
+> 
+> Copyright (c) 2014 Bob Lauer
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+---------------------------------------
+
 ## natural-compare
 License: MIT
 By: Lauri Rooden

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -29,6 +29,7 @@ const external = [
   ...Object.keys(pkg.dependencies),
   ...Object.keys(pkg.peerDependencies),
   'worker_threads',
+  'inspector',
 ]
 
 export default ({ watch }) => [

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -42,7 +42,6 @@ type Promisify<O> = {
 
 declare global {
   namespace Vi {
-
     interface ExpectStatic extends Chai.ExpectStatic, AsymmetricMatchersContaining {
       <T>(actual: T, message?: string): Vi.Assertion<T>
 
@@ -115,15 +114,17 @@ declare global {
       nthReturnedWith<E>(nthCall: number, value: E): void
     }
 
-    type VitestifyAssertion<A> = {
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+    // @ts-ignore build namspace conflict
+    type VitestAssertion<A> = {
       [K in keyof A]: A[K] extends Chai.Assertion
         ? Assertion<any>
         : A[K] extends (...args: any[]) => any
           ? A[K] // not converting function since they may contain overload
-          : VitestifyAssertion<A[K]>
+          : VitestAssertion<A[K]>
     }
 
-    interface Assertion<T = any> extends VitestifyAssertion<Chai.Assertion>, JestAssertion<T> {
+    interface Assertion<T = any> extends VitestAssertion<Chai.Assertion>, JestAssertion<T> {
       resolves: Promisify<Assertion<T>>
       rejects: Promisify<Assertion<T>>
     }

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -44,12 +44,19 @@ export type Task = Test | Suite | File
 
 export type DoneCallback = (error?: any) => void
 export type TestFunction = (done: DoneCallback) => Awaitable<void>
+export type EachFunction = <T>(cases: T[]) => (name: string, fn: (...args: T extends any[] ? T : [T]) => void) => void
 
-export type TestCollector = ChainableFunction<
+export type TestAPI = ChainableFunction<
 'concurrent' | 'only' | 'skip' | 'todo' | 'fails',
 [name: string, fn?: TestFunction, timeout?: number],
 void
->
+> & { each: EachFunction }
+
+export type SuiteAPI = ChainableFunction<
+'concurrent' | 'only' | 'skip' | 'todo',
+[name: string, factory?: SuiteFactory],
+SuiteCollector
+> & { each: EachFunction }
 
 export type HookListener<T extends any[]> = (...args: T) => Awaitable<void>
 
@@ -64,14 +71,14 @@ export interface SuiteCollector {
   readonly name: string
   readonly mode: RunMode
   type: 'collector'
-  test: TestCollector
+  test: TestAPI
   tasks: (Suite | Test | SuiteCollector)[]
   collect: (file?: File) => Promise<Suite>
   clear: () => void
   on: <T extends keyof SuiteHooks>(name: T, ...fn: SuiteHooks[T]) => void
 }
 
-export type TestFactory = (test: (name: string, fn: TestFunction) => void) => Awaitable<void>
+export type SuiteFactory = (test: (name: string, fn: TestFunction) => void) => Awaitable<void>
 
 export interface RuntimeContext {
   tasks: (SuiteCollector | Test)[]

--- a/packages/ws-client/rollup.config.js
+++ b/packages/ws-client/rollup.config.js
@@ -14,6 +14,7 @@ const external = [
   'birpc',
   'worker_threads',
   'vitest',
+  'inspector',
 ]
 
 export default () => [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ importers:
       '@rollup/plugin-commonjs': ^21.0.1
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': ^13.1.3
+      '@types/lodash': ^4.14.178
       '@types/node': ^17.0.12
       bumpp: ^7.1.1
       c8: ^7.11.0
@@ -40,6 +41,7 @@ importers:
       '@rollup/plugin-commonjs': 21.0.1_rollup@2.66.1
       '@rollup/plugin-json': 4.1.0_rollup@2.66.1
       '@rollup/plugin-node-resolve': 13.1.3_rollup@2.66.1
+      '@types/lodash': 4.14.178
       '@types/node': 17.0.12
       bumpp: 7.1.1
       c8: 7.11.0
@@ -5649,6 +5651,10 @@ packages:
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
+    dev: true
+
+  /@types/lodash/4.14.178:
+    resolution: {integrity: sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==}
     dev: true
 
   /@types/mdast/3.0.10:

--- a/test/core/test/each.test.ts
+++ b/test/core/test/each.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add(%i, %i) -> %i', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})
+
+describe.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('describe add(%i, %i)', (a, b, expected) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected)
+  })
+
+  test(`returned value not be greater than ${expected}`, () => {
+    expect(a + b).not.toBeGreaterThan(expected)
+  })
+
+  test(`returned value not be less than ${expected}`, () => {
+    expect(a + b).not.toBeLessThan(expected)
+  })
+})
+
+describe.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('describe object add($a, $b)', ({ a, b, expected }) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected)
+  })
+
+  test(`returned value not be greater than ${expected}`, () => {
+    expect(a + b).not.toBeGreaterThan(expected)
+  })
+
+  test(`returned value not be less than ${expected}`, () => {
+    expect(a + b).not.toBeLessThan(expected)
+  })
+})

--- a/test/core/test/hoist-import.test.ts
+++ b/test/core/test/hoist-import.test.ts
@@ -12,6 +12,7 @@ vi.mock('../src/timeout.ts', () => {
 })
 
 test('"vi" can be used inside factory with empty lines', () => {
+  // @ts-expect-error no types
   expect(globalThis.vi).toBeUndefined()
   expect(timeout).toBe(10_000)
   expect(vi.isMockFunction(fn)).toBe(true)

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -158,7 +158,7 @@ describe('jest-expect', () => {
   // https://jestjs.io/docs/expect#tostrictequalvalue
 
   class LaCroix {
-    constructor(public flavor) {}
+    constructor(public flavor: any) {}
   }
 
   describe('the La Croix cans on my desk', () => {
@@ -173,7 +173,7 @@ describe('jest-expect', () => {
     expect([]).not.toBe([])
     expect([]).toStrictEqual([])
 
-    const foo = []
+    const foo: any[] = []
 
     expect(foo).toBe(foo)
     expect(foo).toStrictEqual(foo)
@@ -195,21 +195,21 @@ describe('jest-expect', () => {
 
 describe('.toStrictEqual()', () => {
   class TestClassA {
-    constructor(public a, public b) {}
+    constructor(public a: any, public b: any) {}
   }
 
   class TestClassB {
-    constructor(public a, public b) {}
+    constructor(public a: any, public b: any) {}
   }
 
   const TestClassC = class Child extends TestClassA {
-    constructor(a, b) {
+    constructor(a: any, b: any) {
       super(a, b)
     }
   }
 
   const TestClassD = class Child extends TestClassB {
-    constructor(a, b) {
+    constructor(a: any, b: any) {
       super(a, b)
     }
   }

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -32,6 +32,7 @@ describe('jest mock compat layer', () => {
     const Spy = vi.fn(() => {})
 
     expect(Spy.mock.instances).toHaveLength(0)
+    // @ts-expect-error ignore
     // eslint-disable-next-line no-new
     new Spy()
     expect(Spy.mock.instances).toHaveLength(1)

--- a/test/related/tests/not-related.test.ts
+++ b/test/related/tests/not-related.test.ts
@@ -1,6 +1,7 @@
+import { expect, test } from 'vitest'
 import { B } from '../src/sourceB'
 
-test('shouldnt run', () => {
+test('shouldn\'t run', () => {
   expect(B).toBe('B')
   expect.fail()
 })

--- a/test/related/tests/related.test.ts
+++ b/test/related/tests/related.test.ts
@@ -1,5 +1,6 @@
 import { access } from 'fs'
 import { sep } from 'pathe'
+import { expect, test } from 'vitest'
 import { A } from '../src/sourceA'
 
 test('A equals A', () => {

--- a/test/related/tsconfig.json
+++ b/test/related/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "types": ["vitest/global"],
-    }
-}

--- a/test/reporters/custom-reporter.vitest.config.ts
+++ b/test/reporters/custom-reporter.vitest.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite'
 class TestReporter implements Reporter {
   ctx!: Vitest
 
-  onInit(ctx) {
+  onInit(ctx: Vitest) {
     this.ctx = ctx
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
   },
   "exclude": [
     "**/dist/**",
+    "./packages/vitest/dist/**",
     "./packages/ui/client/**",
     "./examples/**/*.*",
     "./bench/**"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,6 @@
   "exclude": [
     "**/dist/**",
     "./packages/ui/client/**",
-    "./test/**/*.*",
     "./examples/**/*.*",
     "./bench/**"
   ]


### PR DESCRIPTION
Check supported usages: https://github.com/vitest-dev/vitest/blob/eed0a2d467531cebfeb62690e130a1227bcfc3e0/test/core/test/each.test.ts

Note that the template literal usage from Jest is NOT supported intentionally. Mainly due to its lack of type safety and introduces too much complexity. 