### PR TITLE
fix(ui): make graph data watch immediate

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -17,7 +17,7 @@ debouncedWatch(
       graph.value = getModuleGraph(data.value, c.filepath)
     }
   },
-  { debounce: 100 },
+  { debounce: 100, immediate: true },
 )
 
 const open = () => {


### PR DESCRIPTION
Without the immediate trigger, the graph was not updated on initial load.