### PR TITLE
fix(ui): prevent line wrapping for task items

### DIFF
--- a/packages/ui/client/components/TaskItem.vue
+++ b/packages/ui/client/components/TaskItem.vue
@@ -24,7 +24,7 @@ const duration = computed(() => {
     <StatusIcon :task="task" mr-2 />
     <div flex items-end gap-2 :text="task?.result?.state === 'fail' ? 'red-500' : ''">
       <span text-sm truncate font-light>{{ task.name }}</span>
-      <span v-if="typeof duration === 'number'" text="xs" op20>
+      <span v-if="typeof duration === 'number'" text="xs" op20 style="white-space: nowrap">
         {{ duration > 0 ? duration : '< 1' }}ms
       </span>
     </div>


### PR DESCRIPTION
Currently, the white-space in time info (like `< 1ms`) can cause a line wrap in a task item.
This in turn results in a much higher item.

![image](https://user-images.githubusercontent.com/7950094/151444600-10726ad4-7d01-4b4b-9b37-57e8e174b13b.png)
