### PR TITLE
share the same spy instance between local and global mocks

### DIFF
--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -82,9 +82,6 @@ async function run(options: CliOptions = {}) {
     fetchModule(id) {
       return node.fetchModule(id)
     },
-    resolveId(id, importer) {
-      return node.resolveId(id, importer)
-    },
   })
 
   for (const file of files)

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -9,7 +9,6 @@ export interface DepsHandlingOptions {
 }
 
 export type FetchFunction = (id: string) => Promise<{ code?: string; externalize?: string }>
-export type ResolveIdFunction = (id: string, importer?: string) => Promise<ViteNodeResolveId | null>
 
 export interface ModuleCache {
   promise?: Promise<any>
@@ -19,7 +18,6 @@ export interface ModuleCache {
 
 export interface ViteNodeRunnerOptions {
   fetchModule: FetchFunction
-  resolveId: ResolveIdFunction
   root: string
   base?: string
   moduleCache?: Map<string, ModuleCache>

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -18,6 +18,7 @@ const entries = [
   'src/node.ts',
   'src/runtime/worker.ts',
   'src/runtime/entry.ts',
+  'src/integrations/jest-mock.ts',
 ]
 
 const dtsEntries = [

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -164,19 +164,16 @@ class VitestUtils {
   }
 
   public clearAllMocks() {
-    this._mocker.clearMocks({ clearMocks: true })
     spies.forEach(spy => spy.mockClear())
     return this
   }
 
   public resetAllMocks() {
-    this._mocker.clearMocks({ mockReset: true })
     spies.forEach(spy => spy.mockReset())
     return this
   }
 
   public restoreAllMocks() {
-    this._mocker.clearMocks({ restoreMocks: true })
     spies.forEach(spy => spy.mockRestore())
     return this
   }

--- a/packages/vitest/src/node/execute.ts
+++ b/packages/vitest/src/node/execute.ts
@@ -1,11 +1,14 @@
 import { ViteNodeRunner } from 'vite-node/client'
-import type { ModuleCache, ViteNodeRunnerOptions } from 'vite-node'
+import type { ModuleCache, ViteNodeResolveId, ViteNodeRunnerOptions } from 'vite-node'
 import type { SuiteMocks } from './mocker'
 import { VitestMocker } from './mocker'
+
+export type ResolveIdFunction = (id: string, importer?: string) => Promise<ViteNodeResolveId | null>
 
 export interface ExecuteOptions extends ViteNodeRunnerOptions {
   files: string[]
   mockMap: SuiteMocks
+  resolveId: ResolveIdFunction
 }
 
 export async function executeInViteNode(options: ExecuteOptions) {

--- a/packages/vitest/src/node/mocker.ts
+++ b/packages/vitest/src/node/mocker.ts
@@ -3,8 +3,8 @@ import { isNodeBuiltin } from 'mlly'
 import { basename, dirname, join, resolve } from 'pathe'
 import type { ModuleCache } from 'vite-node'
 import { toFilePath } from 'vite-node/utils'
-import { spies, spyOn } from '../integrations/jest-mock'
 import { mergeSlashes, normalizeId } from '../utils'
+import { distDir } from '../constants'
 import type { ExecuteOptions } from './execute'
 
 export type SuiteMocks = Record<string, Record<string, string | null | (() => unknown)>>
@@ -22,7 +22,7 @@ function getObjectType(value: unknown): string {
   return Object.prototype.toString.apply(value).slice(8, -1)
 }
 
-function mockPrototype(proto: any) {
+function mockPrototype(spyOn: typeof import('../integrations/jest-mock')['spyOn'], proto: any) {
   if (!proto) return null
 
   const newProto: any = {}
@@ -46,9 +46,9 @@ export class VitestMocker {
   private request!: (dep: string) => unknown
 
   private root: string
-  // private mockMap: SuiteMocks
 
   private callbacks: Record<string, ((...args: any[]) => unknown)[]> = {}
+  private spy?: typeof import('../integrations/jest-mock')
 
   constructor(
     public options: ExecuteOptions,
@@ -56,7 +56,6 @@ export class VitestMocker {
     request?: (dep: string) => unknown,
   ) {
     this.root = this.options.root
-    // this.mockMap = options.mockMap
     this.request = request!
   }
 
@@ -171,12 +170,12 @@ export class VitestMocker {
 
     if (Array.isArray(obj))
       return []
-    else if (type !== 'Object' && type !== 'Module')
+    else if ((type !== 'Object' && type !== 'Module') || !this.spy)
       return obj
 
     const newObj = { ...obj }
 
-    const proto = mockPrototype(Object.getPrototypeOf(obj))
+    const proto = mockPrototype(this.spy.spyOn, Object.getPrototypeOf(obj))
     Object.setPrototypeOf(newObj, proto)
 
     // eslint-disable-next-line no-restricted-syntax
@@ -185,7 +184,7 @@ export class VitestMocker {
       const type = getObjectType(obj[k])
 
       if (type.includes('Function') && !obj[k].__isSpy) {
-        spyOn(newObj, k).mockImplementation(() => {})
+        this.spy.spyOn(newObj, k).mockImplementation(() => {})
         Object.defineProperty(newObj[k], 'length', { value: 0 }) // tinyspy retains length, but jest doesnt
       }
     }
@@ -226,6 +225,7 @@ export class VitestMocker {
       mock = this.resolveMockPath(path, external)
 
     if (mock === null) {
+      await this.ensureSpy()
       const fsPath = this.getActualPath(path, external)
       const mod = await this.request(fsPath)
       return this.mockObject(mod)
@@ -235,7 +235,13 @@ export class VitestMocker {
     return this.requestWithMock(mock)
   }
 
+  private async ensureSpy() {
+    if (this.spy) return
+    this.spy = await this.request(resolve(distDir, 'jest-mock.js')) as typeof import('../integrations/jest-mock')
+  }
+
   public async requestWithMock(dep: string) {
+    await this.ensureSpy()
     await this.resolveMocks()
 
     const mock = this.getDependencyMock(dep)
@@ -256,20 +262,6 @@ export class VitestMocker {
     if (typeof mock === 'string')
       dep = mock
     return this.request(dep)
-  }
-
-  public clearMocks({ clearMocks, mockReset, restoreMocks }: { clearMocks?: boolean; mockReset?: boolean; restoreMocks?: boolean }) {
-    if (!clearMocks && !mockReset && !restoreMocks)
-      return
-
-    spies.forEach((s) => {
-      if (restoreMocks)
-        s.mockRestore()
-      else if (mockReset)
-        s.mockReset()
-      else if (clearMocks)
-        s.mockClear()
-    })
   }
 
   public queueMock(id: string, importer: string, factory?: () => unknown) {


### PR DESCRIPTION
One of the main reasons is to remove ambiguity between `vi.mock` automatick mocking and calling local `vi.spyOn`.

Since we imported `spyOn` using vanilla node, it had it's own context of `jest-mock.ts` - that's why we had to call `clearMocks` twice.

Now I request it using `ViteNodeRunner`, so they should have the same context now and we don't need to call it twice.

Also this should fix a bug where `invocationOrder` was not in sync betwen global and local spies (since it's a global variable).