### PR TITLE
feat: ignore cypress files in coverage by default

### DIFF
--- a/packages/vitest/src/integrations/coverage.ts
+++ b/packages/vitest/src/integrations/coverage.ts
@@ -10,6 +10,7 @@ const defaultExcludes = [
   'coverage/**',
   'packages/*/test{,s}/**',
   '**/*.d.ts',
+  'cypress/**',
   'test{,s}/**',
   'test{,-*}.{js,cjs,mjs,ts,tsx,jsx}',
   '**/*{.,-}test.{js,cjs,mjs,ts,tsx,jsx}',


### PR DESCRIPTION
Projects using Cypress often have e2e spec files in a `cypress` directory that currently needs to be manually ignored.
This is the case for `create-vue` projects for example.

This commit adds `cypress/**` to the default excludes of the code coverage config.