### PR TITLE
chore(test-fails): update nested suite snapshot

### DIFF
--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should fails > expect.test.ts > expect.test.ts 1`] = `"AssertionError: expected 2 to deeply equal 3"`;
 
-exports[`should fails > nested-suite.test.ts > nested-suite.test.ts 1`] = `"AssertionError: expected true to equal false"`;
+exports[`should fails > nested-suite.test.ts > nested-suite.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
 
 exports[`should fails > stall.test.ts > stall.test.ts 1`] = `"TypeError: failure"`;
 


### PR DESCRIPTION
It seems the expect result for `toBe` has changed and the snapshot has not be updated.