### PR TITLE
fix: augment jest matchers

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -41,6 +41,12 @@ type Promisify<O> = {
 }
 
 declare global {
+  // support augmenting jest.Matchers by other libraries
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface Matchers<R, T = {}> {}
+  }
+
   namespace Vi {
     interface ExpectStatic extends Chai.ExpectStatic, AsymmetricMatchersContaining {
       <T>(actual: T, message?: string): Vi.Assertion<T>
@@ -56,7 +62,7 @@ declare global {
       not: AsymmetricMatchersContaining
     }
 
-    interface JestAssertion<T = any> {
+    interface JestAssertion<T = any> extends jest.Matchers<void, T> {
       // Snapshot
       toMatchSnapshot<U extends { [P in keyof T]: any }>(snapshot: Partial<U>, message?: string): void
       toMatchSnapshot(message?: string): void


### PR DESCRIPTION
Closes #664

Vitest expect now can see external jest libraries matchers, namely `@testing-library/jest-dom` assertions are recognized when importing from `vitest`. (global `expect` is still overriden by jest's expect)

