### PR TITLE
feat: add `allowOnly` option

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -116,7 +116,7 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 | `--dom` | Mock browser api with happy-dom |
 | `--environment <env>` | Runner environment (default: node) |
 | `--passWithNoTests` | Pass when no tests found |
-| `--failOnOnly` | Fail when a test or suite is marked as `only` |
+| `--allowOnly` | Allow tests and suites that are marked as `only` (default: false in CI, true otherwise) |
 | `-h, --help` | Display available CLI options |
 
 ## Examples

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -116,6 +116,7 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 | `--dom` | Mock browser api with happy-dom |
 | `--environment <env>` | Runner environment (default: node) |
 | `--passWithNoTests` | Pass when no tests found |
+| `--failOnOnly` | Fail when a test or suite is marked as `only` |
 | `-h, --help` | Display available CLI options |
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "release": "bumpp package.json packages/*/package.json --commit --push --tag && pnpm -r publish --access public",
     "test": "vitest --api -r test/core",
     "test:run": "vitest run -r test/core",
-    "test:all": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo run test --",
-    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !test-fails run test --",
+    "test:all": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo run test -- --allowOnly",
+    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !test-fails run test -- --allowOnly",
     "typecheck": "tsc --noEmit",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui"

--- a/packages/ui/client/components/StatusIcon.vue
+++ b/packages/ui/client/components/StatusIcon.vue
@@ -33,7 +33,7 @@ defineProps<{ task: Task }>()
     i-carbon:document-blank
   />
   <div
-    v-else-if="task.mode === 'skip'"
+    v-else-if="task.mode === 'skip' || task.result?.state === 'skip'"
     v-tooltip.right="'Skipped'"
     text-gray-500
     flex-shrink-0

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -30,6 +30,7 @@ cli
   .option('--dom', 'mock browser api with happy-dom')
   .option('--environment <env>', 'runner environment', { default: 'node' })
   .option('--passWithNoTests', 'pass when no tests found')
+  .option('--failOnOnly', 'fail when a test or suite is marked as only')
   .help()
 
 cli

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -30,7 +30,7 @@ cli
   .option('--dom', 'mock browser api with happy-dom')
   .option('--environment <env>', 'runner environment', { default: 'node' })
   .option('--passWithNoTests', 'pass when no tests found')
-  .option('--failOnOnly', 'fail when a test or suite is marked as only')
+  .option('--allowOnly', 'Allow tests and suites that are marked as only', { default: !process.env.CI })
   .help()
 
 cli

--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -133,7 +133,7 @@ function checkAllowOnly(task: TaskBase, allowOnly?: boolean) {
   if (allowOnly) return
   task.result = {
     state: 'fail',
-    error: processError(new Error('only is not allowed')),
+    error: processError(new Error('[Vitest] Unexpected .only modifier. Remove it or pass --allowOnly arguement to bypass this error')),
   }
 }
 

--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 import { relative } from 'pathe'
-import type { File, ResolvedConfig, Suite } from '../types'
+import type { File, ResolvedConfig, Suite, TaskBase } from '../types'
 import { clearContext, defaultSuite } from './suite'
 import { getHooks, setHooks } from './map'
 import { processError } from './error'
@@ -64,7 +64,8 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
 
     calculateHash(file)
 
-    interpretTaskModes(file, config.testNamePattern)
+    const hasOnlyTasks = someTasksAreOnly(file)
+    interpretTaskModes(file, config.testNamePattern, hasOnlyTasks, false, config.failOnOnly)
 
     files.push(file)
   }
@@ -72,26 +73,37 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
   return files
 }
 
+function checkFailOnOnly(task: TaskBase, failOnOnly?: boolean) {
+  if (failOnOnly) {
+    task.result = {
+      state: 'fail',
+      error: processError(new Error('failOnOnly is enabled')),
+    }
+  }
+}
+
 /**
  * If any tasks been marked as `only`, mark all other tasks as `skip`.
  */
-function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, onlyMode?: boolean, isIncluded?: boolean) {
-  if (onlyMode === undefined) {
-    onlyMode = someTasksAreOnly(suite)
-    isIncluded ||= suite.mode === 'only'
-  }
+function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, onlyMode?: boolean, parentIsOnly?: boolean, failOnOnly?: boolean) {
+  const suiteIsOnly = parentIsOnly || suite.mode === 'only'
 
   suite.tasks.forEach((t) => {
     // Check if either the parent suite or the task itself are marked as included
-    const includeTask = isIncluded || t.mode === 'only'
+    const includeTask = suiteIsOnly || t.mode === 'only'
     if (onlyMode) {
       if (t.type === 'suite' && (includeTask || someTasksAreOnly(t))) {
         // Don't skip this suite
-        if (t.mode === 'only')
+        if (t.mode === 'only') {
+          checkFailOnOnly(t, failOnOnly)
           t.mode = 'run'
+        }
       }
       else if (t.mode === 'run' && !includeTask) { t.mode = 'skip' }
-      else if (t.mode === 'only') { t.mode = 'run' }
+      else if (t.mode === 'only') {
+        checkFailOnOnly(t, failOnOnly)
+        t.mode = 'run'
+      }
     }
     if (t.type === 'test') {
       if (namePattern && !t.name.match(namePattern))
@@ -101,7 +113,7 @@ function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, onlyMod
       if (t.mode === 'skip')
         skipAllTasks(t)
       else
-        interpretTaskModes(t, namePattern, onlyMode, includeTask)
+        interpretTaskModes(t, namePattern, onlyMode, includeTask, failOnOnly)
     }
   })
 

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -44,7 +44,7 @@ async function sendTasksUpdate() {
 }
 
 export async function runTest(test: Test) {
-  if (test.mode !== 'run')
+  if (test.mode !== 'run' || test.result)
     return
 
   const start = performance.now()

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -114,9 +114,20 @@ export async function runTest(test: Test) {
   updateTask(test)
 }
 
+function markTasksAsSkipped(suite: Suite) {
+  suite.tasks.forEach((t) => {
+    t.mode = 'skip'
+    t.result = { ...t.result, state: 'skip' }
+    updateTask(t)
+    if (t.type === 'suite') markTasksAsSkipped(t)
+  })
+}
+
 export async function runSuite(suite: Suite) {
-  if (suite.result?.state === 'fail')
+  if (suite.result?.state === 'fail') {
+    markTasksAsSkipped(suite)
     return
+  }
 
   const start = performance.now()
 

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -44,8 +44,13 @@ async function sendTasksUpdate() {
 }
 
 export async function runTest(test: Test) {
-  if (test.mode !== 'run' || test.result)
+  if (test.mode !== 'run')
     return
+
+  if (test.result?.state === 'fail') {
+    updateTask(test)
+    return
+  }
 
   const start = performance.now()
 
@@ -126,6 +131,7 @@ function markTasksAsSkipped(suite: Suite) {
 export async function runSuite(suite: Suite) {
   if (suite.result?.state === 'fail') {
     markTasksAsSkipped(suite)
+    updateTask(suite)
     return
   }
 

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -306,6 +306,11 @@ export interface UserConfig extends InlineConfig {
   passWithNoTests?: boolean
 
   /**
+   * Fail when a test or suite is marked as only
+   */
+  failOnOnly?: boolean
+
+  /**
    * Run tests that cover a list of source files
    */
   related?: string[] | string

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -306,9 +306,9 @@ export interface UserConfig extends InlineConfig {
   passWithNoTests?: boolean
 
   /**
-   * Fail when a test or suite is marked as only
+   * Allow tests and suites that are marked as only
    */
-  failOnOnly?: boolean
+  allowOnly?: boolean
 
   /**
    * Run tests that cover a list of source files


### PR DESCRIPTION
Closes #668.

This PR adds a new option `allowOnly`. If this option is `false`, suites and tests marked as `only` will fail.
By default, the option is disabled if `process.env.CI` is `true` and enabled otherwise.