### PR TITLE
fix: avoid calling buildStart twice (fix #679)

### DIFF
--- a/packages/vitest/src/node/create.ts
+++ b/packages/vitest/src/node/create.ts
@@ -23,10 +23,11 @@ export async function createVitest(options: UserConfig, viteOverrides: ViteUserC
   }
 
   const server = await createServer(mergeConfig(config, viteOverrides))
-  await server.pluginContainer.buildStart({})
 
   if (ctx.config.api?.port)
     await server.listen()
+  else
+    await server.pluginContainer.buildStart({})
 
   return ctx
 }


### PR DESCRIPTION
See #679 