### PR TITLE
feat(ui): show all failed tasks in report

### DIFF
--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -34,7 +34,7 @@ function relative(p: string) {
       <div v-for="task of failed" :key="task.id">
         <div bg="red-500/10" text="red-500 sm" p="x3 y2" m-2 rounded :style="{ 'margin-left': `${2 * task.level + 0.5}rem`}">
           {{ task.name }}
-          <div v-if="task.result?.error" class="scrolls task-error">
+          <div v-if="task.result?.error" class="scrolls scrolls-rounded task-error">
             <pre><b>{{ task.result.error.name || task.result.error.nameStr }}</b>: {{ task.result.error.message }}</pre>
             <pre v-for="stack, i of task.result.error.stacks || []" :key="i" op80> - {{ relative(stack.file) }}:{{ stack.line }}:{{ stack.column }}</pre>
           </div>

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -34,7 +34,7 @@ function relative(p: string) {
       <div v-for="task of failed" :key="task.id">
         <div bg="red-500/10" text="red-500 sm" p="x3 y2" m-2 rounded :style="{ 'margin-left': `${2 * task.level + 0.5}rem`}">
           {{ task.name }}
-          <div v-if="task.result?.error">
+          <div v-if="task.result?.error" overflow="x-auto">
             <pre><b>{{ task.result.error.name || task.result.error.nameStr }}</b>: {{ task.result.error.message }}</pre>
             <pre v-for="stack, i of task.result.error.stacks || []" :key="i" op80> - {{ relative(stack.file) }}:{{ stack.line }}:{{ stack.column }}</pre>
           </div>

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -34,7 +34,7 @@ function relative(p: string) {
       <div v-for="task of failed" :key="task.id">
         <div bg="red-500/10" text="red-500 sm" p="x3 y2" m-2 rounded :style="{ 'margin-left': `${2 * task.level + 0.5}rem`}">
           {{ task.name }}
-          <div v-if="task.result?.error" overflow="x-auto">
+          <div v-if="task.result?.error" class="scrolls task-error">
             <pre><b>{{ task.result.error.name || task.result.error.nameStr }}</b>: {{ task.result.error.message }}</pre>
             <pre v-for="stack, i of task.result.error.stacks || []" :key="i" op80> - {{ relative(stack.file) }}:{{ stack.line }}:{{ stack.column }}</pre>
           </div>
@@ -48,3 +48,12 @@ function relative(p: string) {
     </template>
   </div>
 </template>
+
+<style scoped>
+.task-error {
+  --cm-ttc-c-thumb: #CCC;
+}
+html.dark .task-error {
+  --cm-ttc-c-thumb: #444;
+}
+</style>

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -6,16 +6,20 @@ const props = defineProps<{
   file?: File
 }>()
 
-function collectFailed(task: Task): Task[] {
+type LeveledTask = Task & {
+  level: number
+}
+
+function collectFailed(task: Task, level: number): LeveledTask[] {
   if (task.result?.state !== 'fail') return []
 
   if (task.type === 'test')
-    return [task]
+    return [{ ...task, level }]
   else
-    return [task, ...task.tasks.flatMap(t => collectFailed(t))]
+    return [{ ...task, level }, ...task.tasks.flatMap(t => collectFailed(t, level + 1))]
 }
 
-const failed = computed(() => props.file?.tasks.flatMap(t => collectFailed(t)) || [])
+const failed = computed(() => props.file?.tasks.flatMap(t => collectFailed(t, 0)) || [])
 
 function relative(p: string) {
   if (p.startsWith(config.value.root))
@@ -28,9 +32,8 @@ function relative(p: string) {
   <div h-full class="scrolls">
     <template v-if="failed.length">
       <div v-for="task of failed" :key="task.id">
-        <div bg="red-500/10" text="red-500 sm" p="x3 y2" m-2 rounded>
+        <div bg="red-500/10" text="red-500 sm" p="x3 y2" m-2 rounded :style="{ 'margin-left': `${2 * task.level + 0.5}rem`}">
           {{ task.name }}
-
           <div v-if="task.result?.error">
             <pre><b>{{ task.result.error.name || task.result.error.nameStr }}</b>: {{ task.result.error.message }}</pre>
             <pre v-for="stack, i of task.result.error.stacks || []" :key="i" op80> - {{ relative(stack.file) }}:{{ stack.line }}:{{ stack.column }}</pre>

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -1,12 +1,21 @@
 <script setup lang="ts">
-import type { File } from '#types'
+import type { File, Task } from '#types'
 import { config } from '~/composables/client'
 
 const props = defineProps<{
   file?: File
 }>()
 
-const failed = computed(() => props.file?.tasks.filter(i => i.result?.state === 'fail') || [])
+function collectFailed(task: Task): Task[] {
+  if (task.result?.state !== 'fail') return []
+
+  if (task.type === 'test')
+    return [task]
+  else
+    return [task, ...task.tasks.flatMap(t => collectFailed(t))]
+}
+
+const failed = computed(() => props.file?.tasks.flatMap(t => collectFailed(t)) || [])
 
 function relative(p: string) {
   if (p.startsWith(config.value.root))

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -144,11 +144,14 @@ html.dark {
   background: var(--cm-ttc-c-track);
 }
 .CodeMirror-scroll::-webkit-scrollbar-thumb,
+.scrolls::-webkit-scrollbar-thumb {
+  background-color: var(--cm-ttc-c-thumb);
+  border: 2px solid var(--cm-ttc-c-thumb);
+}
+.CodeMirror-scroll::-webkit-scrollbar-thumb,
 .scrolls::-webkit-scrollbar-thumb,
 .scrolls-rounded::-webkit-scrollbar-track {
-  background-color: var(--cm-ttc-c-thumb);
   border-radius: 3px;
-  border: 2px solid var(--cm-ttc-c-thumb);
 }
 .CodeMirror-scroll::-webkit-scrollbar-corner,
 .scrolls::-webkit-scrollbar-corner {

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -144,7 +144,8 @@ html.dark {
   background: var(--cm-ttc-c-track);
 }
 .CodeMirror-scroll::-webkit-scrollbar-thumb,
-.scrolls::-webkit-scrollbar-thumb {
+.scrolls::-webkit-scrollbar-thumb,
+.scrolls-rounded::-webkit-scrollbar-track {
   background-color: var(--cm-ttc-c-thumb);
   border-radius: 3px;
   border: 2px solid var(--cm-ttc-c-thumb);


### PR DESCRIPTION
Closes #684 

This PR adds all failed tasks of a file to the report, instead of top-level tasks only.
It also fixes an overflow in a task's error message by making it scrollable.

![image](https://user-images.githubusercontent.com/7950094/152642744-64dfd37a-97ca-4802-a948-2fa1f60a5614.png)
