### PR TITLE
docs: fix watch and coverage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Read the [documentation](https://vitest.dev/).
 - [Vite](https://vitejs.dev/)'s config, transformers, resolvers, and plugins. Use the same setup from your app!
 - [Jest Snapshot](https://jestjs.io/docs/snapshot-testing)
 - [Chai](https://www.chaijs.com/) built-in for assertions, with [Jest expect](https://jestjs.io/docs/expect) compatible APIs.
-- [Smart & instant watch mode](#watch-mode), like HMR for tests!
-- [Native code coverage](#coverage) via [c8](https://github.com/bcoe/c8)
+- [Smart & instant watch mode](https://vitest.dev/guide/features.html#watch-mode), like HMR for tests!
+- [Native code coverage](https://vitest.dev/guide/features.html#coverage) via [c8](https://github.com/bcoe/c8)
 - [Tinyspy](https://github.com/Aslemammad/tinyspy) built-in for mocking, stubbing, and spies.
 - [JSDOM](https://github.com/jsdom/jsdom) and [happy-dom](https://github.com/capricorn86/happy-dom) for DOM and browser API mocking
 - Components testing ([Vue](./examples/vue), [React](./examples/react), [Svelte](./examples/svelte), [Lit](./examples/lit), [Vitesse](./examples/vitesse))


### PR DESCRIPTION
The links in the readme point to an anchor that doesn't exist any more.