### PR TITLE
fix: use correct file paths in coverage reports (fix #691)

### DIFF
--- a/packages/vitest/src/integrations/coverage.ts
+++ b/packages/vitest/src/integrations/coverage.ts
@@ -84,9 +84,9 @@ export async function reportCoverage(ctx: Vitest) {
       }
       catch {}
 
-      const sources = map.sources.length
-        ? map.sources.map(i => pathToFileURL(i).href)
-        : [url]
+      // Vite does not report full path in sourcemap sources
+      // so use an actual file path
+      const sources = [url]
 
       sourceMapMata[url] = {
         source: result.code,


### PR DESCRIPTION
Fixes: #691