### PR TITLE
doc: start migration guide documentation for Jest

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -127,7 +127,11 @@ export default defineConfig({
             {
               text: 'Comparisons',
               link: '/guide/comparisons'
-            }
+            },
+            {
+              text: 'Migration Guide',
+              link: '/guide/migration'
+            },
           ]
         },
         /* TODO

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1100,8 +1100,6 @@ Vitest provides utility functions to help you out through it's **vi** helper. Yo
   - If `__mocks__` folder with file of the same name exist, all imports will return its exports. For example, `vi.mock('axios')` with `<root>/__mocks__/axios.ts` folder will return everything exported from `axios.ts`.
   - If there is no `__mocks__` folder or a file with the same name inside, will call original module and mock it. (For the rules applied, see [algorithm](/guide/mocking#automocking-algorithm).)
 
-  Additionally, unlike Jest, mocked modules in `<root>/__mocks__` are not loaded unless `vi.mock()` is called. If you need them to be mocked in every test, like in Jest, you can mock them inside [`setupFiles`](/config/#setupfiles).
-
 ### vi.setSystemTime
 
 - **Type**: `(date: string | number | Date) => void`

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,0 +1,21 @@
+# Migration Guide
+
+<DevelopmentWarning/>
+
+## Migrating from Jest
+
+Vitest has been designed with a Jest compatible API, in order to make the migration from Jest as simple as possible. Despite those efforts, you may still run into the following differences:
+
+**Globals as a Default**
+
+Jest has their [globals API](https://jestjs.io/docs/api) enabled by default. Vitest does not. You can either enable globals via [the `globals` configuration setting](/config/#globals) or update your code to use imports from the `vitest` module instead.
+
+If you decide to keep globals disabled, be aware that common libraries like [`testing-library`](https://testing-library.com/) will not run auto DOM [cleanup](https://testing-library.com/docs/svelte-testing-library/api/#cleanup).
+
+**Auto-Mocking Behaviour**
+
+Unlike Jest, mocked modules in `<root>/__mocks__` are not loaded unless `vi.mock()` is called. If you need them to be mocked in every test, like in Jest, you can mock them inside [`setupFiles`](/config/#setupfiles).
+
+**Jasmine API**
+
+Jest exports various [`jasmine`](https://jasmine.github.io/) globals (such as `jasmine.any()`). Any such instances will need to be migrated to [their Vitest counterparts](/api/).


### PR DESCRIPTION
Adds a note about lack of DOM clean up when globals are off (as per https://github.com/vitest-dev/vitest/issues/682#issuecomment-1030984679), and restores the doc change added in https://github.com/vitest-dev/vitest/pull/467 which was removed.