### PR TITLE
Docs: Update JSDoc watch mode default to true

### DIFF
--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -107,7 +107,7 @@ export interface InlineConfig {
   /**
    * Watch mode
    *
-   * @default false
+   * @default true
    */
   watch?: boolean
 


### PR DESCRIPTION
The default behaviour of watch mode is true
But in jsDoc it shows false

![image](https://user-images.githubusercontent.com/23727670/152935095-04cace8a-e935-447f-bc81-052e942dfaa6.png)
