### PR TITLE
perf: use cpu cores more efficently

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -1,5 +1,6 @@
 import { MessageChannel } from 'worker_threads'
 import { pathToFileURL } from 'url'
+import { cpus } from 'os'
 import { resolve } from 'pathe'
 import type { Options as TinypoolOptions } from 'tinypool'
 import { Tinypool } from 'tinypool'
@@ -55,17 +56,20 @@ export function createFakePool(ctx: Vitest): WorkerPool {
 }
 
 export function createWorkerPool(ctx: Vitest): WorkerPool {
+  const threadsCount = ctx.config.watch
+    ? Math.max(cpus().length / 2, 1)
+    : Math.max(cpus().length - 1, 1)
+
   const options: TinypoolOptions = {
     filename: workerPath,
     // Disable this for now, for WebContainer capability
     // https://github.com/vitest-dev/vitest/issues/93
     // In future we could conditionally enable it based on the env
     useAtomics: false,
+
+    maxThreads: ctx.config.maxThreads ?? threadsCount,
+    minThreads: ctx.config.minThreads ?? threadsCount,
   }
-  if (ctx.config.maxThreads != null)
-    options.maxThreads = ctx.config.maxThreads
-  if (ctx.config.minThreads != null)
-    options.minThreads = ctx.config.minThreads
   if (ctx.config.isolate) {
     options.isolateWorkers = true
     options.concurrentTasksPerWorker = 1


### PR DESCRIPTION
Made adjustments to number of threads created. Vitest now uses more threads by default.

Implementation is just like in Jest:
> In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt.

 `minThreads` is the same as `maxThreads` for now because of https://github.com/Aslemammad/tinypool/issues/23. This will cause a really small slowdown if number of test files is less than number of CPU cores. When Tinypool is fixed to better handle `minThreads` and `maxThreads` in isolate mode `minThreads` can be adjusted.

This improved performance of https://github.com/EvHaus/jest-vs-jasmine tests suite by 30% on my machine (16 cores)