### PR TITLE
fix: fixed typescript error when calling assertion

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -128,7 +128,7 @@ declare global {
         : A[K] extends (...args: any[]) => any
           ? A[K] // not converting function since they may contain overload
           : VitestAssertion<A[K]>
-    } & ((type: string, message?: string) => void)
+    } & ((type: string, message?: string) => Assertion)
 
     interface Assertion<T = any> extends VitestAssertion<Chai.Assertion>, JestAssertion<T> {
       resolves: Promisify<Assertion<T>>

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -128,7 +128,7 @@ declare global {
         : A[K] extends (...args: any[]) => any
           ? A[K] // not converting function since they may contain overload
           : VitestAssertion<A[K]>
-    }
+    } & ((type: string, message?: string) => void)
 
     interface Assertion<T = any> extends VitestAssertion<Chai.Assertion>, JestAssertion<T> {
       resolves: Promisify<Assertion<T>>

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -122,15 +122,15 @@ declare global {
 
     // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
     // @ts-ignore build namspace conflict
-    type VitestAssertion<A> = {
+    type VitestAssertion<A, T> = {
       [K in keyof A]: A[K] extends Chai.Assertion
-        ? Assertion<any>
+        ? Assertion<T>
         : A[K] extends (...args: any[]) => any
           ? A[K] // not converting function since they may contain overload
-          : VitestAssertion<A[K]>
+          : VitestAssertion<A[K], T>
     } & ((type: string, message?: string) => Assertion)
 
-    interface Assertion<T = any> extends VitestAssertion<Chai.Assertion>, JestAssertion<T> {
+    interface Assertion<T = any> extends VitestAssertion<Chai.Assertion, T>, JestAssertion<T> {
       resolves: Promisify<Assertion<T>>
       rejects: Promisify<Assertion<T>>
     }

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -1,5 +1,4 @@
 import { assert, expect, it, suite, test } from 'vitest'
-import { expect as chaiExpect } from 'chai'
 import { two } from '../src/submodule'
 import { timeout } from '../src/timeout'
 
@@ -28,7 +27,6 @@ test('JSON', () => {
 
 test('assertion is callable', () => {
   const str = '13'
-  chaiExpect(str).to.be('13')
   expect(str).to.be('13')
   expect(str).not.to.be('12')
 })

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -27,8 +27,8 @@ test('JSON', () => {
 
 test('assertion is callable', () => {
   const str = '13'
-  expect(str).to.be('13')
-  expect(str).not.to.be('12')
+  expect(str).to.be.a('string')
+  expect(str).not.to.be.a('number')
 })
 
 const hi = suite('suite')

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -1,4 +1,5 @@
 import { assert, expect, it, suite, test } from 'vitest'
+import { expect as chaiExpect } from 'chai'
 import { two } from '../src/submodule'
 import { timeout } from '../src/timeout'
 
@@ -23,6 +24,13 @@ test('JSON', () => {
   })
   expect(output).toEqual('{"foo":"hello","bar":"world"}')
   assert.deepEqual(JSON.parse(output), input, 'matches original')
+})
+
+test('assertion is callable', () => {
+  const str = '13'
+  chaiExpect(str).to.be('13')
+  expect(str).to.be('13')
+  expect(str).not.to.be('12')
 })
 
 const hi = suite('suite')


### PR DESCRIPTION
Fixes #707

This originally comes from: 

```ts
    interface TypeComparison {
        (type: string, message?: string): Assertion;
        instanceof: InstanceOf;
        instanceOf: InstanceOf;
    }
```
    
But we are overriding it, so