### PR TITLE
fix(snapshot): received add prepareExpected

### DIFF
--- a/packages/vitest/src/integrations/snapshot/port/state.ts
+++ b/packages/vitest/src/integrations/snapshot/port/state.ts
@@ -193,7 +193,7 @@ export default class SnapshotState {
     const receivedSerialized = addExtraLineBreaks(serialize(received, undefined, this._snapshotFormat))
     const expected = isInline ? inlineSnapshot : this._snapshotData[key]
     const expectedTrimmed = prepareExpected(expected)
-    const pass = expectedTrimmed === receivedSerialized?.trim()
+    const pass = expectedTrimmed === prepareExpected(receivedSerialized)
     const hasSnapshot = expected !== undefined
     const snapshotIsPersisted = isInline || fs.existsSync(this._snapshotPath)
 

--- a/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
+++ b/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1
+
+exports[`multiline strings  1`] = `
+"
+export default function () {
+  function Foo() {
+  }
+
+  return Foo;
+}
+"
+`;

--- a/test/snapshots/test/shapshots.test.ts
+++ b/test/snapshots/test/shapshots.test.ts
@@ -6,10 +6,9 @@ export default function () {
 
   return Foo;
 }
-`;
-  return message;
+`
+  return message
 }
-
 
 test('non default snapshot format', () => {
   expect({ foo: ['bar'] }).toMatchInlineSnapshot(`
@@ -22,5 +21,5 @@ test('non default snapshot format', () => {
 })
 
 test('multiline strings ', () => {
-  expect(println()).toMatchSnapshot();
-});
+  expect(println()).toMatchSnapshot()
+})

--- a/test/snapshots/test/shapshots.test.ts
+++ b/test/snapshots/test/shapshots.test.ts
@@ -1,3 +1,16 @@
+const println = () => {
+  const message = `
+export default function () {
+  function Foo() {
+  }
+
+  return Foo;
+}
+`;
+  return message;
+}
+
+
 test('non default snapshot format', () => {
   expect({ foo: ['bar'] }).toMatchInlineSnapshot(`
   Object {
@@ -7,3 +20,7 @@ test('non default snapshot format', () => {
   }
   `)
 })
+
+test('multiline strings ', () => {
+  expect(println()).toMatchSnapshot();
+});


### PR DESCRIPTION
fix: #595


snapshot mulitline strings expected no use the method `prepareExpected` format, and the received formated.

the PR make their had the same behavior