### PR TITLE
fix: default reporters should be an array

### DIFF
--- a/packages/vitest/src/constants.ts
+++ b/packages/vitest/src/constants.ts
@@ -50,7 +50,7 @@ export const configDefaults: UserConfig = Object.freeze({
   watchIgnore: [/\/node_modules\//, /\/dist\//],
   update: false,
   watch: !process.env.CI,
-  reporters: 'default',
+  reporters: ['default'],
   silent: false,
   api: false,
   ui: false,


### PR DESCRIPTION
Fixes #718

This fixes the error `TypeError: target[key].push is not a function` that occurs when a config is defined with reporters.
This is because the deepMerge function tries to merge the given array of reporters with the default config, which is the string `"default"`.

By fixing the default config to be an array of reporters, only containing the default one, the issue is fixed.