### PR TITLE
fix(cli): allow user to override reporter via cli option

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -61,9 +61,10 @@ export class Vitest {
     this.state = new StateManager()
     this.snapshot = new SnapshotManager(resolved)
     // @ts-expect-error cli type
-    this.reporters = toArray(resolved.reporters || resolved.reporter)
+    this.reporters = toArray(resolved.reporter || resolved.reporters)
       .map((i) => {
         if (typeof i === 'string') {
+          // @ts-expect-error cli type
           const Reporter = ReportersMap[i]
           if (!Reporter)
             throw new Error(`Unknown reporter: ${i}`)


### PR DESCRIPTION
I think after this changes https://github.com/vitest-dev/vitest/pull/702 we are not able to override vitest reporter via cli options. Always use `default`

To test it 

```
npx vitest --api -r test/core --reporter dot
```