### PR TITLE
feat: show error when both run and watch have the same value

### DIFF
--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -1,4 +1,5 @@
 import cac from 'cac'
+import c from 'picocolors'
 import { execa } from 'execa'
 import type { UserConfig } from '../types'
 import { version } from '../../package.json'
@@ -76,6 +77,11 @@ async function run(cliFilters: string[], options: UserConfig) {
 
   if (typeof options.coverage === 'boolean')
     options.coverage = { enabled: options.coverage }
+
+  if (options.run === options.watch) {
+    console.error(c.red(`${c.inverse(c.red(' CLI '))} Run mode and Watch mode cannot be activated simultaneously`))
+    process.exit(1)
+  }
 
   const ctx = await createVitest(options)
 


### PR DESCRIPTION
This fixes part of #727. This makes vitest show error when `watch === run` which is not possible!