### PR TITLE
docs(example): add missing type reference

### DIFF
--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext"
+    "target": "esnext",
+    "moduleResolution": "node",
   }
 }

--- a/examples/vue/vitest.config.ts
+++ b/examples/vue/vitest.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest" />
+
 import { defineConfig } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 


### PR DESCRIPTION
### Description

<img width="866" alt="image" src="https://user-images.githubusercontent.com/73412177/153700859-b65ccf02-92f6-408e-bf12-479296b7076c.png">

The `vite.config.ts` in the vue example is missing the correct type reference.