### PR TITLE
feat: add typeof assertion

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -442,6 +442,21 @@ TODO
   })
   ```
 
+### toBeTypeOf
+
+- **Type:** `(c: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined') => Awaitable<void>`
+
+  `toBeTypeOf` asserts if an actual value is of type of received type.
+
+  ```ts
+  import { test, expect } from 'vitest'
+  const actual = 'stock'
+
+  test('stock is type of string', () => {
+    expect(actual).toBeTypeOf('string')
+  })
+  ```
+
 ### toBeInstanceOf
 
 - **Type:** `(c: any) => Awaitable<void>`

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -97,6 +97,7 @@ declare global {
       toBeUndefined(): void
       toBeNull(): void
       toBeDefined(): void
+      toBeTypeOf(expected: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined'): void
       toBeInstanceOf<E>(expected: E): void
       toBeCalledTimes(times: number): void
       toHaveLength(length: number): void

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -227,6 +227,18 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
     return this.not.be.undefined
   })
+  def('toBeTypeOf', function(obj: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined') {
+    const equal = typeof this._obj === obj
+    const actual = typeof this._obj
+    const expected = obj
+    return this.assert(
+      equal,
+      'expected #{this} to be type of #{exp}',
+      'expected #{this} not to be type of #{exp}',
+      expected,
+      actual,
+    )
+  })
   def('toBeInstanceOf', function(obj: any) {
     return this.instanceOf(obj)
   })

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -227,10 +227,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
     return this.not.be.undefined
   })
-  def('toBeTypeOf', function(obj: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined') {
-    const equal = typeof this._obj === obj
+  def('toBeTypeOf', function(expected: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined') {
     const actual = typeof this._obj
-    const expected = obj
+    const equal = expected === actual
     return this.assert(
       equal,
       'expected #{this} to be type of #{exp}',

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -310,6 +310,33 @@ describe('.toStrictEqual()', () => {
   })
 })
 
+describe('toBeTypeOf()', () => {
+  it.each([
+    [1n, 'bigint'],
+    [true, 'boolean'],
+    [false, 'boolean'],
+    [() => {}, 'function'],
+    [function() {}, 'function'],
+    [1, 'number'],
+    [Infinity, 'number'],
+    [NaN, 'number'],
+    [0, 'number'],
+    [{}, 'object'],
+    [[], 'object'],
+    [null, 'object'],
+    ['', 'string'],
+    ['test', 'string'],
+    [Symbol('test'), 'symbol'],
+    [undefined, 'undefined'],
+  ] as const)('pass with typeof %s === %s', (actual, expected) => {
+    expect(actual).toBeTypeOf(expected)
+  })
+
+  it('pass with negotiation', () => {
+    expect('test').not.toBeTypeOf('number')
+  })
+})
+
 describe('async expect', () => {
   it('resolves', async() => {
     await expect((async() => 'true')()).resolves.toBe('true')


### PR DESCRIPTION
This adds a new assertion that replaces `expect(typeof actual).toBe('string')` with `expect(actual).toBeTypeOf('string')`

Please let me know where I need to add docs and/or tests, I'm very unfamiliar with the structure of the repo :sweat_smile: 

**Edit:**
Somehow there is a chai `typeOf` https://www.chaijs.com/api/assert/#method_typeof
But not sure how or if this is in any way accessible from vitest