### PR TITLE
fix: move config related methods to 'vitest/node'

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -24,7 +24,7 @@ export default defineConfig({
 You can retrieve Vitest's default options to expand them if needed:
 
 ```ts
-import { defineConfig, configDefaults } from 'vitest'
+import { defineConfig, configDefaults } from 'vitest/node'
 
 export default defineConfig({
   test: {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,4 +1,3 @@
-import type { UserConfig } from 'vite'
 import type { Plugin as PrettyFormatPlugin } from 'pretty-format'
 import type { Any, Anything } from './integrations/chai/jest-asymmetric-matchers'
 import type { MatcherState, MatchersObject } from './integrations/chai/types'
@@ -14,8 +13,6 @@ export * from './integrations/vi'
 export * from './types'
 export * from './api/types'
 
-export { configDefaults } from './defaults'
-
 type VitestInlineConfig = InlineConfig
 
 declare module 'vite' {
@@ -25,10 +22,6 @@ declare module 'vite' {
      */
     test?: VitestInlineConfig
   }
-}
-
-export function defineConfig(config: UserConfig) {
-  return config
 }
 
 interface AsymmetricMatchersContaining {

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -1,3 +1,10 @@
+import type { UserConfig } from 'vite'
+
+export { configDefaults } from '../defaults'
+export function defineConfig(config: UserConfig) {
+  return config
+}
+
 export type { Vitest } from './core'
 export { createVitest } from './create'
 export { VitestPlugin } from './plugins'


### PR DESCRIPTION
closes #764