### PR TITLE
fix: fixed toMatch not to maintain the regex state which has global flag

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -122,10 +122,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     )
   })
   def('toMatch', function(expected: string | RegExp) {
-    if (typeof expected === 'string')
-      return this.include(expected)
-    else
-      return this.match(expected)
+    if (typeof expected === 'string') { return this.include(expected) }
+    else {
+      const received = this._obj
+      return new RegExp(expected).test(received)
+    }
   })
   def('toContain', function(item) {
     return this.contain(item)

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -125,7 +125,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     if (typeof expected === 'string') { return this.include(expected) }
     else {
       const received = this._obj
-      return new RegExp(expected).test(received)
+      const pass = new RegExp(expected).test(received)
+      // `match` of chai doesn't seems to catch global flag in regex correctly.
+      return this.assert(pass, `expected '${received}' to match ${expected}`, `expected '${received}' not to match ${expected}`, expected)
     }
   })
   def('toContain', function(item) {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -107,6 +107,13 @@ describe('jest-expect', () => {
     // expect(new Set(['bar'])).not.toEqual(new Set([expect.stringContaining('zoo')]))
   })
 
+  it('does not maintain state when the Regex has global flag', () => {
+    const regex = /[f]\d+/ig
+    expect('f123').toMatch(regex)
+    expect('F1234').toMatch(regex)
+    expect('F1234 F1234').toMatch(regex)
+  })
+
   it('asymmetric matchers negate', () => {
     expect('bar').toEqual(expect.not.stringContaining('zoo'))
     expect('bar').toEqual(expect.not.stringMatching(/zoo/))


### PR DESCRIPTION
Using chai's `match`, `regex.lastIndex` is maintained even if global flag is raised. 

<img width="377" alt="スクリーンショット 2022-02-17 23 39 59" src="https://user-images.githubusercontent.com/62130798/154508353-81a10c0e-af29-409d-a776-9475ba2744c3.png">


This PR changed the truth check from chai's `match` to `RegExp` constructor.