### PR TITLE
docs: update examples, support no online playground

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,9 +4,10 @@
 | `cjs` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/cjs) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/cjs?initialPath=__vitest__) |
 | `coverage-test` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/coverage-test) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/coverage-test?initialPath=__vitest__) |
 | `fails` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/fails) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/fails?initialPath=__vitest__) |
+| `graphql` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/graphql) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/graphql?initialPath=__vitest__) |
 | `lit` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/lit) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/lit?initialPath=__vitest__) |
 | `mocks` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/mocks) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/mocks?initialPath=__vitest__) |
-| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/puppeteer?initialPath=__vitest__) |
+| `puppeteer` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/puppeteer) | |
 | `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react?initialPath=__vitest__) |
 | `react-enzyme` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-enzyme) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-enzyme?initialPath=__vitest__) |
 | `react-mui` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-mui) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-mui?initialPath=__vitest__) |

--- a/scripts/update-examples.ts
+++ b/scripts/update-examples.ts
@@ -3,6 +3,10 @@ import { promises as fs } from 'fs'
 import { resolve } from 'pathe'
 import { notNullish } from '../packages/vitest/src/utils'
 
+const noOnlinePlayground = [
+  'puppeteer', // e2e doesn't work in StackBlitz
+]
+
 async function run() {
   const examplesRoot = resolve(fileURLToPath(import.meta.url), '../../examples')
 
@@ -14,7 +18,7 @@ async function run() {
       return
 
     const github = `https://github.com/vitest-dev/vitest/tree/main/examples/${name}`
-    const stackblitz = `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}?initialPath=__vitest__`
+    const stackblitz = noOnlinePlayground.includes(name) ? undefined : `https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/${name}?initialPath=__vitest__`
     return {
       name,
       path,
@@ -23,7 +27,7 @@ async function run() {
     }
   }))
 
-  const table = `| Example | Source | Playground |\n|---|---|---|\n${data.filter(notNullish).map(i => `| \`${i.name}\` | [GitHub](${i.github}) | [Play Online](${i.stackblitz}) |`).join('\n')}`
+  const table = `| Example | Source | Playground |\n|---|---|---|\n${data.filter(notNullish).map(i => `| \`${i.name}\` | [GitHub](${i.github}) | ${i.stackblitz ? `[Play Online](${i.stackblitz}) ` : ''}|`).join('\n')}`
 
   await fs.writeFile(resolve(examplesRoot, 'README.md'), `${table}\n`, 'utf-8')
 }


### PR DESCRIPTION
Run the examples update script to add the new graphql example.
Add a `noOnlinePlayground` list to the script so we can disable it for some examples, e2e doesn't currently work in StackBlitz for example 