### PR TITLE
fix: resolveId resolves with SSR only if transformMode is SSR, resolved modules are the same instead of clones of each other

### DIFF
--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -24,7 +24,9 @@ export class ViteNodeServer {
   }
 
   async resolveId(id: string, importer?: string): Promise<ViteNodeResolveId | null> {
-    return this.server.pluginContainer.resolveId(id, importer, { ssr: true })
+    const mode = importer ? this.getTransformMode(importer) : 'ssr'
+
+    return this.server.pluginContainer.resolveId(id, importer, { ssr: mode === 'ssr' })
   }
 
   async fetchModule(id: string): Promise<FetchResult> {

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -4,6 +4,12 @@ import type { TransformResult } from 'vite'
 
 export const isWindows = process.platform === 'win32'
 
+export const queryRE = /\?.*$/s
+export const hashRE = /#.*$/s
+
+export const cleanUrl = (url: string): string =>
+  url.replace(hashRE, '').replace(queryRE, '')
+
 export function slash(str: string) {
   return str.replace(/\\/g, '/')
 }

--- a/packages/vitest/src/node/mocker.ts
+++ b/packages/vitest/src/node/mocker.ts
@@ -126,7 +126,7 @@ export class VitestMocker {
   }
 
   public normalizePath(path: string) {
-    return normalizeId(path.replace(this.root, '')).replace(/^\/@fs\//, isWindows ? '' : '/')
+    return path.replace(/^\/@fs\//, isWindows ? '' : '/')
   }
 
   public getFsPath(path: string, external: string | null) {

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -1,28 +1,28 @@
 import { expect, test } from 'vitest'
 
 test('dynamic relative import works', async() => {
-  const { timeout } = await import('./../src/timeout')
+  const importTimeout = await import('./../src/timeout')
 
   const timeoutPath = './../src/timeout'
-  const { timeout: dynamicTimeout } = await import(timeoutPath)
+  const dynamicTimeout = await import(timeoutPath)
 
-  expect(timeout).toBe(dynamicTimeout)
+  expect(importTimeout).toBe(dynamicTimeout)
 })
 
 test('dynamic aliased import works', async() => {
-  const { timeout } = await import('./../src/timeout')
+  const importTimeout = await import('./../src/timeout')
 
   const timeoutPath = '@/timeout'
-  const { timeout: dynamicTimeout } = await import(timeoutPath)
+  const dynamicTimeout = await import(timeoutPath)
 
-  expect(timeout).toBe(dynamicTimeout)
+  expect(importTimeout).toBe(dynamicTimeout)
 })
 
 test('dynamic absolute import works', async() => {
-  const { timeout } = await import('./../src/timeout')
+  const importTimeout = await import('./../src/timeout')
 
   const timeoutPath = '/src/timeout'
-  const { timeout: dynamicTimeout } = await import(timeoutPath)
+  const dynamicTimeout = await import(timeoutPath)
 
-  expect(timeout).toBe(dynamicTimeout)
+  expect(importTimeout).toBe(dynamicTimeout)
 })


### PR DESCRIPTION
Closes #813