### PR TITLE
fix: add a suggestion to the error message of timeout

### DIFF
--- a/packages/vitest/src/runtime/context.ts
+++ b/packages/vitest/src/runtime/context.ts
@@ -41,7 +41,7 @@ export function withTimeout<T extends((...args: any[]) => any)>(fn: T, { isHook,
 }
 
 function makeTimeoutMsg(isHook: boolean, timeout: number) {
-  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nPlease pass timeout value as last argument or configure globally with "${isHook ? 'hookTimeout' : 'testTimeout'}" in config, if this is a long-running test.`
+  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nIf this is a long-running test, pass a timeout value as the last argument or configure it globally with "${isHook ? 'hookTimeout' : 'testTimeout'}".`
 }
 
 function ensureAsyncTest(fn: TestFunction): () => Awaitable<void> {

--- a/packages/vitest/src/runtime/context.ts
+++ b/packages/vitest/src/runtime/context.ts
@@ -41,7 +41,7 @@ export function withTimeout<T extends((...args: any[]) => any)>(fn: T, { isHook,
 }
 
 function makeTimeoutMsg(isHook: boolean, timeout: number) {
-  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nPlease pass timeout value as arg or configure globally with "${isHook ? 'hookTimeout' : 'testTimeout'}" in config, if this is a long-running test.`
+  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nPlease pass timeout value as last argument or configure globally with "${isHook ? 'hookTimeout' : 'testTimeout'}" in config, if this is a long-running test.`
 }
 
 function ensureAsyncTest(fn: TestFunction): () => Awaitable<void> {

--- a/packages/vitest/src/runtime/context.ts
+++ b/packages/vitest/src/runtime/context.ts
@@ -24,7 +24,7 @@ export function getDefaultHookTimeout() {
   return __vitest_worker__!.config!.hookTimeout
 }
 
-export function withTimeout<T extends((...args: any[]) => any)>(fn: T, _timeout?: number): T {
+export function withTimeout<T extends((...args: any[]) => any)>(fn: T, { isHook, _timeout }: { isHook: boolean; _timeout?: number }): T {
   const timeout = _timeout ?? getDefaultTestTimeout()
   if (timeout <= 0 || timeout === Infinity)
     return fn
@@ -33,11 +33,15 @@ export function withTimeout<T extends((...args: any[]) => any)>(fn: T, _timeout?
     return Promise.race([fn(...args), new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         clearTimeout(timer)
-        reject(new Error(`Test timed out in ${timeout}ms.`))
+        reject(new Error(makeTimeoutMsg(isHook, timeout)))
       }, timeout)
       timer.unref()
     })]) as Awaitable<void>
   }) as T
+}
+
+function makeTimeoutMsg(isHook: boolean, timeout: number) {
+  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nPlease pass timeout value as arg or configure globally with "${isHook ? 'hookTimeout' : 'testTimeout'}" in config, if this is a long-running test.`
 }
 
 function ensureAsyncTest(fn: TestFunction): () => Awaitable<void> {
@@ -53,5 +57,5 @@ function ensureAsyncTest(fn: TestFunction): () => Awaitable<void> {
 }
 
 export function normalizeTest(fn: TestFunction, timeout?: number): () => Awaitable<void> {
-  return withTimeout(ensureAsyncTest(fn), timeout)
+  return withTimeout(ensureAsyncTest(fn), { _timeout: timeout, isHook: false })
 }

--- a/packages/vitest/src/runtime/context.ts
+++ b/packages/vitest/src/runtime/context.ts
@@ -24,8 +24,11 @@ export function getDefaultHookTimeout() {
   return __vitest_worker__!.config!.hookTimeout
 }
 
-export function withTimeout<T extends((...args: any[]) => any)>(fn: T, { isHook, _timeout }: { isHook: boolean; _timeout?: number }): T {
-  const timeout = _timeout ?? getDefaultTestTimeout()
+export function withTimeout<T extends((...args: any[]) => any)>(
+  fn: T,
+  timeout = getDefaultTestTimeout(),
+  isHook = false,
+): T {
   if (timeout <= 0 || timeout === Infinity)
     return fn
 
@@ -57,5 +60,5 @@ function ensureAsyncTest(fn: TestFunction): () => Awaitable<void> {
 }
 
 export function normalizeTest(fn: TestFunction, timeout?: number): () => Awaitable<void> {
-  return withTimeout(ensureAsyncTest(fn), { _timeout: timeout, isHook: false })
+  return withTimeout(ensureAsyncTest(fn), timeout)
 }

--- a/packages/vitest/src/runtime/hooks.ts
+++ b/packages/vitest/src/runtime/hooks.ts
@@ -3,7 +3,7 @@ import { getDefaultHookTimeout, withTimeout } from './context'
 import { getCurrentSuite } from './suite'
 
 // suite hooks
-export const beforeAll = (fn: SuiteHooks['beforeAll'][0], timeout?: number) => getCurrentSuite().on('beforeAll', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
-export const afterAll = (fn: SuiteHooks['afterAll'][0], timeout?: number) => getCurrentSuite().on('afterAll', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
-export const beforeEach = (fn: SuiteHooks['beforeEach'][0], timeout?: number) => getCurrentSuite().on('beforeEach', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
-export const afterEach = (fn: SuiteHooks['afterEach'][0], timeout?: number) => getCurrentSuite().on('afterEach', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
+export const beforeAll = (fn: SuiteHooks['beforeAll'][0], timeout?: number) => getCurrentSuite().on('beforeAll', withTimeout(fn, timeout ?? getDefaultHookTimeout(), true))
+export const afterAll = (fn: SuiteHooks['afterAll'][0], timeout?: number) => getCurrentSuite().on('afterAll', withTimeout(fn, timeout ?? getDefaultHookTimeout(), true))
+export const beforeEach = (fn: SuiteHooks['beforeEach'][0], timeout?: number) => getCurrentSuite().on('beforeEach', withTimeout(fn, timeout ?? getDefaultHookTimeout(), true))
+export const afterEach = (fn: SuiteHooks['afterEach'][0], timeout?: number) => getCurrentSuite().on('afterEach', withTimeout(fn, timeout ?? getDefaultHookTimeout(), true))

--- a/packages/vitest/src/runtime/hooks.ts
+++ b/packages/vitest/src/runtime/hooks.ts
@@ -3,7 +3,7 @@ import { getDefaultHookTimeout, withTimeout } from './context'
 import { getCurrentSuite } from './suite'
 
 // suite hooks
-export const beforeAll = (fn: SuiteHooks['beforeAll'][0], timeout?: number) => getCurrentSuite().on('beforeAll', withTimeout(fn, timeout ?? getDefaultHookTimeout()))
-export const afterAll = (fn: SuiteHooks['afterAll'][0], timeout?: number) => getCurrentSuite().on('afterAll', withTimeout(fn, timeout ?? getDefaultHookTimeout()))
-export const beforeEach = (fn: SuiteHooks['beforeEach'][0], timeout?: number) => getCurrentSuite().on('beforeEach', withTimeout(fn, timeout ?? getDefaultHookTimeout()))
-export const afterEach = (fn: SuiteHooks['afterEach'][0], timeout?: number) => getCurrentSuite().on('afterEach', withTimeout(fn, timeout ?? getDefaultHookTimeout()))
+export const beforeAll = (fn: SuiteHooks['beforeAll'][0], timeout?: number) => getCurrentSuite().on('beforeAll', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
+export const afterAll = (fn: SuiteHooks['afterAll'][0], timeout?: number) => getCurrentSuite().on('afterAll', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
+export const beforeEach = (fn: SuiteHooks['beforeEach'][0], timeout?: number) => getCurrentSuite().on('beforeEach', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))
+export const afterEach = (fn: SuiteHooks['afterEach'][0], timeout?: number) => getCurrentSuite().on('afterEach', withTimeout(fn, { isHook: true, _timeout: timeout ?? getDefaultHookTimeout() }))

--- a/test/fails/fixtures/hook-timeout.test.ts
+++ b/test/fails/fixtures/hook-timeout.test.ts
@@ -1,0 +1,10 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+describe('hooks should timeout', () => {
+  beforeEach(async() => {
+    await new Promise(resolve => setTimeout(resolve, 20))
+  }, 10)
+  it('hello', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`should fails > expect.test.ts > expect.test.ts 1`] = `"AssertionError: expected 2 to deeply equal 3"`;
 
+exports[`should fails > hook-timeout.test.ts > hook-timeout.test.ts 1`] = `"Error: Hook timed out in 10ms."`;
+
 exports[`should fails > nested-suite.test.ts > nested-suite.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
 
 exports[`should fails > stall.test.ts > stall.test.ts 1`] = `"TypeError: failure"`;


### PR DESCRIPTION
Added suggestion like 
```
test timed out in 10ms.
Please pass timeout value as arg or configure globally with "testTimeout" in config, if this is a long-running test.
```

- hooks(beforeEach, afterEach...etc) timed out
<img width="839" alt="screenshot" src="https://user-images.githubusercontent.com/62130798/155290014-0d2b220e-087d-4f87-a8a3-7d2fb48677aa.png">

- test timed out
<img width="888" alt="test" src="https://user-images.githubusercontent.com/62130798/155290273-e735d019-6b59-499c-bcdb-698135b6807f.png">


