### PR TITLE
fix: svelte wasn't included in code coverage by default

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -27,7 +27,7 @@ const coverageConfigDefaults = {
   allowExternal: false,
   // default extensions used by c8, plus '.vue' and '.svelte'
   // see https://github.com/istanbuljs/schema/blob/master/default-extension.js
-  extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.vue', 'svelte'],
+  extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.vue', '.svelte'],
 } as ResolvedC8Options
 
 export const configDefaults: UserConfig = Object.freeze({


### PR DESCRIPTION
👋🏻 I was poking around this part of the codebase and noticed a typo. This probably means svelte code coverage is broken. I didn't double check if it is or not because I don't have an easy environment setup.