### PR TITLE
fix: handle error during global setup

### DIFF
--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -1,7 +1,9 @@
 import cac from 'cac'
+import c from 'picocolors'
 import { version } from '../../package.json'
 import type { CliOptions } from './cli-api'
 import { startVitest } from './cli-api'
+import { divider } from './reporters/renderers/utils'
 
 const cli = cac('vitest')
 
@@ -66,6 +68,14 @@ async function run(cliFilters: string[], options: CliOptions) {
 }
 
 async function start(cliFilters: string[], options: CliOptions) {
-  if (await startVitest(cliFilters, options) === false)
-    process.exit()
+  try {
+    if (await startVitest(cliFilters, options) === false)
+      process.exit()
+  }
+  catch (e) {
+    process.exitCode = 1
+    console.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Error '))))}`)
+    console.error(e)
+    console.error('\n\n')
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,6 +710,14 @@ importers:
     devDependencies:
       vitest: link:../../packages/vitest
 
+  test/global-setup-fail:
+    specifiers:
+      execa: ^6.1.0
+      vitest: workspace:*
+    devDependencies:
+      execa: 6.1.0
+      vitest: link:../../packages/vitest
+
   test/related:
     specifiers:
       vitest: workspace:*

--- a/test/global-setup-fail/fixtures/globalSetup/error.js
+++ b/test/global-setup-fail/fixtures/globalSetup/error.js
@@ -1,0 +1,3 @@
+export default function() {
+  throw new Error('error')
+}

--- a/test/global-setup-fail/fixtures/vitest.config.ts
+++ b/test/global-setup-fail/fixtures/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    globalSetup: [
+      './globalSetup/error.js',
+    ],
+  },
+})

--- a/test/global-setup-fail/package.json
+++ b/test/global-setup-fail/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-global-setup-fail",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "execa": "^6.1.0",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/global-setup-fail/test/runner.test.ts
+++ b/test/global-setup-fail/test/runner.test.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'pathe'
+import { execa } from 'execa'
+import { expect, it } from 'vitest'
+
+it('should fail', async() => {
+  const root = resolve(__dirname, '../fixtures')
+  let error: any
+  await execa('npx', ['vitest'], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CI: 'true',
+      NO_COLOR: 'true',
+    },
+  })
+    .catch((e) => {
+      error = e
+    })
+
+  expect(error).toBeTruthy()
+  const msg = String(error)
+    .split(/\n/g)
+    .reverse()
+    .find(i => i.includes('Error: '))
+    ?.trim()
+  expect(msg).toBe('Error: error')
+}, 10000)

--- a/test/global-setup-fail/vitest.config.ts
+++ b/test/global-setup-fail/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['test/*.test.ts'],
+  },
+})


### PR DESCRIPTION
When an error is thrown during global setup, the command does not end and does not show any error messages.
This PR adds `try-catch`s to prevent it.

Also I have added a unhandled error handling which can catch more cases than this one.
https://github.com/vitest-dev/vitest/blob/4858541f36e65612a35cb7c5a0542aed03b23e30/packages/vitest/src/node/cli-api.ts#L70-L75
