### PR TITLE
fix: handle error during global setup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,6 +710,14 @@ importers:
     devDependencies:
       vitest: link:../../packages/vitest
 
+  test/global-setup-fail:
+    specifiers:
+      execa: ^6.1.0
+      vitest: workspace:*
+    devDependencies:
+      execa: 6.1.0
+      vitest: link:../../packages/vitest
+
   test/related:
     specifiers:
       vitest: workspace:*

--- a/test/global-setup-fail/fixtures/globalSetup/error.js
+++ b/test/global-setup-fail/fixtures/globalSetup/error.js
@@ -1,0 +1,3 @@
+export default function() {
+  throw new Error('error')
+}

--- a/test/global-setup-fail/fixtures/vitest.config.ts
+++ b/test/global-setup-fail/fixtures/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    globalSetup: [
+      './globalSetup/error.js',
+    ],
+  },
+})

--- a/test/global-setup-fail/package.json
+++ b/test/global-setup-fail/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-global-setup-fail",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "execa": "^6.1.0",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/global-setup-fail/test/runner.test.ts
+++ b/test/global-setup-fail/test/runner.test.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'pathe'
+import { execa } from 'execa'
+import { expect, it } from 'vitest'
+
+it('should fail', async() => {
+  const root = resolve(__dirname, '../fixtures')
+  let error: any
+  await execa('npx', ['vitest'], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CI: 'true',
+      NO_COLOR: 'true',
+    },
+  })
+    .catch((e) => {
+      error = e
+    })
+
+  expect(error).toBeTruthy()
+  const msg = String(error)
+    .split(/\n/g)
+    .reverse()
+    .find(i => i.includes('Error: '))
+    ?.trim()
+  expect(msg).toBe('Error: error')
+}, 10000)

--- a/test/global-setup-fail/vitest.config.ts
+++ b/test/global-setup-fail/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: ['test/*.test.ts'],
+  },
+})


### PR DESCRIPTION
When an error is thrown during global setup, the command does not end and does not show any error messages.
This PR adds try-catchs to prevent it.

refs #873 
