### PR TITLE
fix: unhandled error handler

### DIFF
--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -2,8 +2,8 @@
   "name": "@vitest/test-solid",
   "private": true,
   "scripts": {
-    "test": "vitest",
-    "coverage": "vitest --coverage"
+    "test": "if-node-version \">14\" vitest",
+    "coverage": "if-node-version \">14\" vitest --coverage"
   },
   "dependencies": {
     "solid-js": "^1.3.8"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "vitest --api -r test/core",
     "test:run": "vitest run -r test/core",
     "test:all": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo run test -- --allowOnly",
-    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !test-fails --filter !test-solid run test -- --allowOnly",
+    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !test-fails run test -- --allowOnly",
     "typecheck": "tsc --noEmit",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui"
@@ -42,6 +42,7 @@
     "eslint": "^8.10.0",
     "esno": "^0.14.1",
     "fast-glob": "^3.2.11",
+    "if-node-version": "^1.1.1",
     "magic-string": "^0.25.7",
     "node-fetch": "^3.2.0",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "vitest --api -r test/core",
     "test:run": "vitest run -r test/core",
     "test:all": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo run test -- --allowOnly",
-    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !test-fails run test -- --allowOnly",
+    "test:ci": "cross-env CI=true pnpm -r --stream --filter !@vitest/monorepo --filter !test-fails --filter !test-solid run test -- --allowOnly",
     "typecheck": "tsc --noEmit",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui"

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -1,7 +1,9 @@
 import cac from 'cac'
+import c from 'picocolors'
 import { version } from '../../package.json'
 import type { CliOptions } from './cli-api'
 import { startVitest } from './cli-api'
+import { divider } from './reporters/renderers/utils'
 
 const cli = cac('vitest')
 
@@ -66,6 +68,14 @@ async function run(cliFilters: string[], options: CliOptions) {
 }
 
 async function start(cliFilters: string[], options: CliOptions) {
-  if (await startVitest(cliFilters, options) === false)
-    process.exit()
+  try {
+    if (await startVitest(cliFilters, options) === false)
+      process.exit()
+  }
+  catch (e) {
+    process.exitCode = 1
+    console.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Error '))))}`)
+    console.error(e)
+    console.error('\n\n')
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ importers:
       eslint: ^8.10.0
       esno: ^0.14.1
       fast-glob: ^3.2.11
+      if-node-version: ^1.1.1
       magic-string: ^0.25.7
       node-fetch: ^3.2.0
       npm-run-all: ^4.1.5
@@ -53,6 +54,7 @@ importers:
       eslint: 8.10.0
       esno: 0.14.1
       fast-glob: 3.2.11
+      if-node-version: 1.1.1
       magic-string: 0.25.7
       node-fetch: 3.2.0
       npm-run-all: 4.1.5
@@ -9359,6 +9361,14 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /cross-spawn/5.1.0:
+    resolution: {integrity: sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=}
+    dependencies:
+      lru-cache: 4.1.5
+      shebang-command: 1.2.0
+      which: 1.3.1
+    dev: true
+
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -12637,6 +12647,15 @@ packages:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
 
+  /if-node-version/1.1.1:
+    resolution: {integrity: sha1-f76fteuEJWIOOylEnfooayPDdyY=}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 5.1.0
+      semver: 5.7.1
+    dev: true
+
   /iferr/0.1.5:
     resolution: {integrity: sha1-xg7taebY/bazEEofy8ocGS3FtQE=}
     dev: true
@@ -13764,6 +13783,13 @@ packages:
     dependencies:
       fault: 1.0.4
       highlight.js: 10.7.3
+    dev: true
+
+  /lru-cache/4.1.5:
+    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
+    dependencies:
+      pseudomap: 1.0.2
+      yallist: 2.1.2
     dev: true
 
   /lru-cache/5.1.1:
@@ -15401,6 +15427,10 @@ packages:
 
   /prr/1.0.1:
     resolution: {integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=}
+    dev: true
+
+  /pseudomap/1.0.2:
+    resolution: {integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=}
     dev: true
 
   /psl/1.8.0:
@@ -19220,6 +19250,10 @@ packages:
   /y18n/5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yallist/2.1.2:
+    resolution: {integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=}
     dev: true
 
   /yallist/3.1.1:

--- a/test/global-setup-fail/test/runner.test.ts
+++ b/test/global-setup-fail/test/runner.test.ts
@@ -24,4 +24,4 @@ it('should fail', async() => {
     .find(i => i.includes('Error: '))
     ?.trim()
   expect(msg).toBe('Error: error')
-}, 10000)
+}, 20000)


### PR DESCRIPTION
This PR adds a unhandled error handling which can catch more cases than this one.
https://github.com/vitest-dev/vitest/blob/4858541f36e65612a35cb7c5a0542aed03b23e30/packages/vitest/src/node/cli-api.ts#L70-L75

refs #873 

---

`solid-start` does not work with node 14 because it uses `stream/web` which is implemented node 16+.
https://github.com/solidjs/solid-start/blob/9ef4c5bff3aef765251f64268d7cf767d2acfd46/packages/start/runtime/devServer.js#L2

I have excluded from `pnpm test:ci`. Should I write some scripts to exclude it only from node 14?
