### PR TITLE
fix: passing non array to reporters option did not effect

### DIFF
--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -63,7 +63,11 @@ export function toArray<T>(array?: Nullable<Arrayable<T>>): Array<T> {
 }
 
 export const toString = (v: any) => Object.prototype.toString.call(v)
-export const isPlainObject = (val: any): val is object => toString(val) === '[object Object]'
+export const isPlainObject = (val: any): val is object =>
+  // `Object.create(null).constructor` is `undefined`
+  // `{}.constructor.name` is `Object`
+  // `new (class A{})().constructor.name` is `A`
+  toString(val) === '[object Object]' && (!val.constructor || val.constructor.name === 'Object')
 
 export function isObject(item: unknown): boolean {
   return item != null && typeof item === 'object' && !Array.isArray(item)

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -22,16 +22,19 @@ describe('assertTypes', () => {
 
 describe('deepMerge', () => {
   test('non plain objects retain their prototype, arrays are not merging, plain objects are merging', () => {
-    class Test {
+    class TestA {
       baz = 'baz'
 
       get foo() {
         return 'foo'
       }
     }
+    class TestB {
+      bar = 'bar'
+    }
 
-    const testA = new Test()
-    const testB = new Test()
+    const testA = new TestA()
+    const testB = new TestB()
 
     const a = {
       test: testA,
@@ -53,7 +56,8 @@ describe('deepMerge', () => {
 
     const merged = deepMerge(a, b)
 
-    expect(merged.test instanceof Test).toBe(true)
+    expect(merged.test instanceof TestB).toBe(true)
+    expect(merged.test.baz).toBeUndefined()
     expect(merged.num).toBe(40)
     expect(merged.array).toEqual([3, 4])
     expect(merged.obj).toEqual({

--- a/test/reporters/custom-reporter.vitest.config.ts
+++ b/test/reporters/custom-reporter.vitest.config.ts
@@ -18,6 +18,6 @@ class TestReporter implements Reporter {
 export default defineConfig({
   test: {
     include: ['tests/reporters.spec.ts'],
-    reporters: ['default', new TestReporter()],
+    reporters: new TestReporter(),
   },
 })

--- a/test/reporters/tests/custom-reporter.spec.ts
+++ b/test/reporters/tests/custom-reporter.spec.ts
@@ -2,7 +2,7 @@ import { execa } from 'execa'
 import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 
-test.skip('custom reporters work with threads', async() => {
+test('custom reporters work', async() => {
   const root = resolve(__dirname, '..')
 
   const { stdout } = await execa('npx', ['vitest', 'run', '--config', 'custom-reporter.vitest.config.ts'], {


### PR DESCRIPTION
Passing non array to reporters option like below did not effect.
```ts
defineConfig({
  test: {
    reporters: new ReporterClass()
  }
})
```

This PR fixes this.

---

1. Here `{ reporters: [] }` and `{ reporters: new ReporterClass() }` will be deepmerged.
https://github.com/vitest-dev/vitest/blob/19f6052c41af12dfac2c5e4ffb3cc3d378143e89/packages/vitest/src/node/plugins/index.ts#L87-L92

1. Think about when `target = { reporters: [] }` and `source = { reporters: new ReporterClass() }`. Because `isMergableObject(new ReporterClass())` (Line 91) is `true` it tries to merge.
https://github.com/vitest-dev/vitest/blob/19f6052c41af12dfac2c5e4ffb3cc3d378143e89/packages/vitest/src/utils/base.ts#L91-L99

1. So `deepMerge([], new ReporterClass())` (Line 95) will be called. But since `isMergableObject([])` (Line 89) is `false`, it will not be merged.
https://github.com/vitest-dev/vitest/blob/19f6052c41af12dfac2c5e4ffb3cc3d378143e89/packages/vitest/src/utils/base.ts#L89
1. Then the result becomes `[]`.

---

I fixed by changing class instancies not to be detected as plain objects.
But it can be fixed by changing this line to `if ((isMergableObject(target[key]) || !target[key]) && isMergableObject(source[key])) {` which I feel correct.
https://github.com/vitest-dev/vitest/blob/19f6052c41af12dfac2c5e4ffb3cc3d378143e89/packages/vitest/src/utils/base.ts#L91
