### PR TITLE
fix: export Vitest type from 'vitest', fix #877

### DIFF
--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -15,3 +15,5 @@ export interface Reporter {
 
   onUserConsoleLog?: (log: UserConsoleLog) => Awaitable<void>
 }
+
+export { Vitest }

--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -16,4 +16,4 @@ export interface Reporter {
   onUserConsoleLog?: (log: UserConsoleLog) => Awaitable<void>
 }
 
-export { Vitest }
+export type { Vitest }


### PR DESCRIPTION
See #877 for details.