### PR TITLE
chore: stackblitz config in package.json

### DIFF
--- a/examples/basic/.stackblitzrc
+++ b/examples/basic/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -13,5 +13,8 @@
     "@vitest/ui": "latest",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/lit/.stackblitzrc
+++ b/examples/lit/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -19,5 +19,8 @@
     "happy-dom": "latest",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/mocks/.stackblitzrc
+++ b/examples/mocks/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/mocks/package.json
+++ b/examples/mocks/package.json
@@ -20,5 +20,8 @@
     "@vitest/ui": "latest",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/puppeteer/.stackblitzrc
+++ b/examples/puppeteer/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/puppeteer/package.json
+++ b/examples/puppeteer/package.json
@@ -12,5 +12,8 @@
     "puppeteer": "^13.0.0",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/react-enzyme/.stackblitzrc
+++ b/examples/react-enzyme/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/react-enzyme/package.json
+++ b/examples/react-enzyme/package.json
@@ -17,5 +17,8 @@
     "enzyme-adapter-react-16": "1.15.6",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/react-mui/.stackblitzrc
+++ b/examples/react-mui/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/react-mui/package.json
+++ b/examples/react-mui/package.json
@@ -30,5 +30,8 @@
     "jsdom": "^19.0.0",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/react-storybook-testing/.stackblitzrc
+++ b/examples/react-storybook-testing/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/react-storybook-testing/package.json
+++ b/examples/react-storybook-testing/package.json
@@ -40,5 +40,8 @@
   },
   "msw": {
     "workerDirectory": "public"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/react-testing-lib-msw/.stackblitzrc
+++ b/examples/react-testing-lib-msw/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/react-testing-lib-msw/package.json
+++ b/examples/react-testing-lib-msw/package.json
@@ -26,5 +26,8 @@
     "msw": "^0.38.1",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/react-testing-lib/.stackblitzrc
+++ b/examples/react-testing-lib/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/react-testing-lib/package.json
+++ b/examples/react-testing-lib/package.json
@@ -25,5 +25,8 @@
     "jsdom": "latest",
     "vite": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/react/.stackblitzrc
+++ b/examples/react/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -18,5 +18,8 @@
     "jsdom": "latest",
     "react-test-renderer": "17.0.2",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/ruby/.stackblitzrc
+++ b/examples/ruby/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test"
-}

--- a/examples/ruby/package.json
+++ b/examples/ruby/package.json
@@ -15,5 +15,8 @@
     "vite-plugin-ruby": "^3.0.8",
     "vitest": "latest",
     "vue": "^3.2.26"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test"
   }
 }

--- a/examples/svelte/.stackblitzrc
+++ b/examples/svelte/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test:ui"
-}

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -14,5 +14,8 @@
     "jsdom": "latest",
     "svelte": "^3.46.4",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test:ui"
   }
 }

--- a/examples/vitesse/.stackblitzrc
+++ b/examples/vitesse/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test"
-}

--- a/examples/vitesse/package.json
+++ b/examples/vitesse/package.json
@@ -15,5 +15,8 @@
     "unplugin-auto-import": "^0.6.1",
     "unplugin-vue-components": "^0.17.21",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test"
   }
 }

--- a/examples/vue-jsx/.stackblitzrc
+++ b/examples/vue-jsx/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test"
-}

--- a/examples/vue-jsx/package.json
+++ b/examples/vue-jsx/package.json
@@ -13,5 +13,8 @@
     "vite": "latest",
     "vitest": "latest",
     "vue": "^3.2.26"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test"
   }
 }

--- a/examples/vue/.stackblitzrc
+++ b/examples/vue/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test"
-}

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -13,5 +13,8 @@
     "@vue/test-utils": "^2.0.0-rc.18",
     "happy-dom": "latest",
     "vitest": "latest"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test"
   }
 }

--- a/examples/vue2/.stackblitzrc
+++ b/examples/vue2/.stackblitzrc
@@ -1,4 +1,0 @@
-{
-  "installDependencies": true,
-  "startCommand": "npm run test"
-}

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -17,5 +17,8 @@
     "vite-plugin-vue2": "^1.9.3",
     "vitest": "latest",
     "vue-template-compiler": "2.6.14"
+  },
+  "stackblitz": {
+    "startCommand": "npm run test"
   }
 }


### PR DESCRIPTION
@antfu you got this one :)

`"installDependencies": true` isn't needed because it is the default when there is a `package.json`


