### PR TITLE
feat: loading animation for `beforeEach`, `beforeAll`, `afterEach`, `afterAll`

### DIFF
--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -1,5 +1,5 @@
 import { performance } from 'perf_hooks'
-import type { File, HookListener, ResolvedConfig, Suite, SuiteHooks, Task, TaskResult, Test } from '../types'
+import type { File, HookListener, ResolvedConfig, Suite, SuiteHooks, Task, TaskResult, TaskState, Test } from '../types'
 import { vi } from '../integrations/vi'
 import { getSnapshotClient } from '../integrations/snapshot/chai'
 import { getFullName, hasFailed, hasTests, partitionSuiteChildren } from '../utils'
@@ -10,14 +10,24 @@ import { rpc } from './rpc'
 import { collectTests } from './collect'
 import { processError } from './error'
 
-export async function callSuiteHook<T extends keyof SuiteHooks>(suite: Suite, name: T, args: SuiteHooks[T][0] extends HookListener<infer A> ? A : never) {
-  if (name === 'beforeEach' && suite.suite)
-    await callSuiteHook(suite.suite, name, args)
+function updateSuiteHookState(suite: Task, name: keyof SuiteHooks, state: TaskState) {
+  const suiteHooks = suite.result?.hooks
+  if (suiteHooks) {
+    suiteHooks[name] = state
+    updateTask(suite)
+  }
+}
 
+export async function callSuiteHook<T extends keyof SuiteHooks>(suite: Suite, currentTask: Task, name: T, args: SuiteHooks[T][0] extends HookListener<infer A> ? A : never) {
+  if (name === 'beforeEach' && suite.suite)
+    await callSuiteHook(suite.suite, currentTask, name, args)
+
+  updateSuiteHookState(currentTask, name, 'run')
   await Promise.all(getHooks(suite)[name].map(fn => fn(...(args as any))))
+  updateSuiteHookState(currentTask, name, 'pass')
 
   if (name === 'afterEach' && suite.suite)
-    await callSuiteHook(suite.suite, name, args)
+    await callSuiteHook(suite.suite, currentTask, name, args)
 }
 
 const packs = new Map<string, TaskResult|undefined>()
@@ -57,6 +67,7 @@ export async function runTest(test: Test) {
 
   test.result = {
     state: 'run',
+    hooks: {},
   }
   updateTask(test)
 
@@ -67,7 +78,7 @@ export async function runTest(test: Test) {
   __vitest_worker__.current = test
 
   try {
-    await callSuiteHook(test.suite, 'beforeEach', [test, test.suite])
+    await callSuiteHook(test.suite, test, 'beforeEach', [test, test.suite])
     setState({
       assertionCalls: 0,
       isExpectingAssertions: false,
@@ -92,7 +103,7 @@ export async function runTest(test: Test) {
   }
 
   try {
-    await callSuiteHook(test.suite, 'afterEach', [test, test.suite])
+    await callSuiteHook(test.suite, test, 'afterEach', [test, test.suite])
   }
   catch (e) {
     test.result.state = 'fail'
@@ -140,6 +151,7 @@ export async function runSuite(suite: Suite) {
 
   suite.result = {
     state: 'run',
+    hooks: {},
   }
 
   updateTask(suite)
@@ -152,7 +164,7 @@ export async function runSuite(suite: Suite) {
   }
   else {
     try {
-      await callSuiteHook(suite, 'beforeAll', [suite])
+      await callSuiteHook(suite, suite, 'beforeAll', [suite])
 
       for (const tasksGroup of partitionSuiteChildren(suite)) {
         if (tasksGroup[0].concurrent === true) {
@@ -163,8 +175,7 @@ export async function runSuite(suite: Suite) {
             await runSuiteChild(c)
         }
       }
-
-      await callSuiteHook(suite, 'afterAll', [suite])
+      await callSuiteHook(suite, suite, 'afterAll', [suite])
     }
     catch (e) {
       suite.result.state = 'fail'

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -19,6 +19,7 @@ export interface TaskResult {
   state: TaskState
   duration?: number
   error?: ErrorWithDiff
+  hooks?: Partial<Record<keyof SuiteHooks, TaskState>>
 }
 
 export type TaskResultPack = [id: string, result: TaskResult | undefined]

--- a/test/global-setup/setupFiles/add-something-to-global.ts
+++ b/test/global-setup/setupFiles/add-something-to-global.ts
@@ -5,7 +5,23 @@ beforeAll(() => {
   global.something = 'something'
 })
 
+beforeAll(async() => {
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(null)
+    }, 300)
+  })
+})
+
 afterAll(() => {
   // @ts-expect-error type
   delete global.something
+})
+
+afterAll(async() => {
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(null)
+    }, 500)
+  })
 })

--- a/test/global-setup/test/global-setup.test.ts
+++ b/test/global-setup/test/global-setup.test.ts
@@ -1,5 +1,21 @@
 import fetch from 'node-fetch'
 
+beforeEach(async() => {
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(null)
+    }, 300)
+  })
+})
+
+afterEach(async() => {
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(null)
+    }, 300)
+  })
+})
+
 test('server running', async() => {
   const res = await (await fetch('http://localhost:9876')).text()
   expect(res).toBe('Hello Vitest\n')


### PR DESCRIPTION
fix: #338 Loading animation for `beforeEach`, `beforeAll`, `afterEach`, `afterAll`.

interface Task add `hooks` and use `hooks` save suite/test hook exec state.