### PR TITLE
docs: exclude prefetching images on build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "vitepress --port 3333 --open",
-    "build": "nr prefetch && vitepress build && esno scripts/build-pwa.ts",
+    "build": "vitepress build && esno scripts/build-pwa.ts",
     "serve": "vitepress serve",
     "preview-https": "pnpm run build && serve .vitepress/dist",
     "prefetch": "esno scripts/fetch-avatars.ts"


### PR DESCRIPTION
@antfu @patak-dev 

Since the main build will run this build as well, we may have some issues with local development and PR submission. I don't see a need to download all the images in every build, just the sponsor images.

I will do another PR including the CDN sponsors, the sw will update them when necessary.