### PR TITLE
chore: update defineConfig to be imported from vitest

### DIFF
--- a/examples/react-enzyme/vite.config.ts
+++ b/examples/react-enzyme/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],

--- a/examples/react-enzyme/vite.config.ts
+++ b/examples/react-enzyme/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [react()],

--- a/examples/react-enzyme/vite.config.ts
+++ b/examples/react-enzyme/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import react from '@vitejs/plugin-react'
-import { defineConfig } from "vitest/config";
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
When I import the defineConfig from Vite it doesn't except test as an argument and I got the bellow error.
```
Argument of type '{ plugins: any[]; test: {}; }' is not assignable to parameter of type 'UserConfigExport'.
  Object literal may only specify known properties, and 'test' does not exist in type 'UserConfigExport'
```
I don't know why this is happens but I manged to get it to work by changing the import library to vitest/config