### PR TITLE
feat: implemented mock.instances

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1506,4 +1506,16 @@ If function returned `'result1`, then threw and error, then `mock.results` will 
 
 ### mock.instances
 
-Currently, this property is not implemented.
+This is an array that contains all of the instances that have been instantiated from this mock function using new.
+
+If a function was instantiated twice, then `mock.instances` will be:
+
+```js
+const Spy = vi.fn()
+
+const a = new Spy()
+const b = new Spy()
+
+mockFn.mock.instances[0] === a // true
+mockFn.mock.instances[1] === b // true
+```

--- a/packages/vitest/src/integrations/jest-mock.ts
+++ b/packages/vitest/src/integrations/jest-mock.ts
@@ -146,7 +146,6 @@ function enhanceSpy<TArgs extends any[], TReturns>(
 
   let implementation: ((...args: TArgs) => TReturns) | undefined
 
-  let instances: any[] = []
   let invocations: number[] = []
 
   const mockContext = {
@@ -154,7 +153,7 @@ function enhanceSpy<TArgs extends any[], TReturns>(
       return stub.calls
     },
     get instances() {
-      return instances
+      return stub.results.filter(r => r[0] === 'ok').map(r => r[1])
     },
     get invocationCallOrder() {
       return invocations
@@ -179,7 +178,6 @@ function enhanceSpy<TArgs extends any[], TReturns>(
 
   stub.mockClear = () => {
     stub.reset()
-    instances = []
     invocations = []
     return stub
   }
@@ -231,7 +229,6 @@ function enhanceSpy<TArgs extends any[], TReturns>(
   util.addProperty(stub, 'mock', () => mockContext)
 
   stub.willCall(function(this: unknown, ...args) {
-    instances.push(this)
     invocations.push(++callOrder)
     const impl = onceImplementations.shift() || implementation || stub.getOriginal() || (() => {})
     return impl.apply(this, args)

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -227,6 +227,40 @@ describe('jest mock compat layer', () => {
     ])
   })
 
+  it('instances', () => {
+    const Spy = vi.fn(() => ({}))
+
+    // @ts-expect-error ignore
+    // eslint-disable-next-line no-new
+    const a = new Spy()
+
+    // @ts-expect-error ignore
+    // eslint-disable-next-line no-new
+    const b = new Spy()
+
+    expect(Spy.mock.instances.length).toBe(2)
+    expect(Spy.mock.instances[0]).toBe(a)
+    expect(Spy.mock.instances[1]).toBe(b)
+  })
+
+  it('instances throwing', () => {
+    const Spy = vi.fn(() => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'error'
+    })
+
+    expect(Spy.mock.instances.length).toBe(0)
+
+    try {
+      // @ts-expect-error ignore
+      // eslint-disable-next-line no-new
+      new Spy()
+    }
+    catch {}
+
+    expect(Spy.mock.instances.length).toBe(0)
+  })
+
   it.todo('mockRejectedValue')
   it.todo('mockResolvedValue')
 })


### PR DESCRIPTION
Implemented basic support for `mock.instances`

This uses tinyspy's underlying `stub.results`.