### PR TITLE
fix: export Window interface in jsdom environment

### DIFF
--- a/packages/vitest/src/integrations/env/jsdom-keys.ts
+++ b/packages/vitest/src/integrations/env/jsdom-keys.ts
@@ -221,6 +221,7 @@ const OTHER_KEYS = [
   'stop',
   /* 'toString', */
   'top',
+  'Window',
   'window',
 ]
 


### PR DESCRIPTION
Using the jsdom environment, some one of my dependencies has code such as `window instanceof Window` (specifically [recoil](https://github.com/facebookexperimental/Recoil/blob/304b468ef32c491e1ffa5726347028ff63b1b8bb/packages/shared/util/Recoil_Environment.js#L22)), and with vitest and jsdom it was giving a Window not defined error.

The jsdom environment should add the Window with a capital W interface to the global environment.