### PR TITLE
fix: json reporter detects `skip` mode correctly

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -56,7 +56,7 @@ export class JsonReporter implements Reporter {
     const testResults: Array<TestResult> = tests.map(t => ({
       displayName: t.name,
       failureMessage: t.result?.error?.message,
-      skipped: t.result?.state === 'skip',
+      skipped: t.mode === 'skip',
       status: t.result?.state,
       testFilePath: t.file?.filepath,
     }))

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -59,7 +59,7 @@ exports[`json reporter 1`] = `
     },
     {
       \\"displayName\\": \\"async with timeout\\",
-      \\"skipped\\": false,
+      \\"skipped\\": true,
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {


### PR DESCRIPTION
## Description

close #928 