### PR TITLE
feat: add perfStats to json reporter

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -6,13 +6,20 @@ import { getSuites, getTests } from '../../utils'
 
 // for compatibility reasons, the reporter produces a JSON similar to the one produced by the Jest JSON reporter
 // the following types are extracted from the Jest repository (and simplified)
+type Milliseconds = number
 interface TestResult {
   displayName?: string
   failureMessage?: string | null
   skipped: boolean
   status?: string
   testFilePath?: string
+  perfStats: {
+    end?: Milliseconds
+    runtime?: Milliseconds
+    start?: Milliseconds
+  }
 }
+
 interface AggregatedResult {
   numFailedTests: number
   numFailedTestSuites: number
@@ -54,6 +61,11 @@ export class JsonReporter implements Reporter {
     const success = numFailedTestSuites === 0 && numFailedTests === 0
 
     const testResults: Array<TestResult> = tests.map(t => ({
+      perfStats: {
+        runtime: t.result?.duration,
+        start: t.result?.startTime,
+        end: t.result?.duration && t.result?.startTime && t.result.duration + t.result.startTime,
+      },
       displayName: t.name,
       failureMessage: t.result?.error?.message,
       skipped: t.mode === 'skip',

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -67,11 +67,11 @@ export async function runTest(test: Test) {
     return
   }
 
-  const startDate = Date.now()
   const start = performance.now()
 
   test.result = {
     state: 'run',
+    startTime: Date.now(),
   }
   updateTask(test)
 
@@ -128,7 +128,6 @@ export async function runTest(test: Test) {
 
   getSnapshotClient().clearTest()
 
-  test.result.startTime = startDate
   test.result.duration = performance.now() - start
 
   __vitest_worker__.current = undefined
@@ -152,11 +151,11 @@ export async function runSuite(suite: Suite) {
     return
   }
 
-  const startDate = Date.now()
   const start = performance.now()
 
   suite.result = {
     state: 'run',
+    startTime: Date.now(),
   }
 
   updateTask(suite)
@@ -188,7 +187,6 @@ export async function runSuite(suite: Suite) {
     }
   }
   suite.result.duration = performance.now() - start
-  suite.result.startTime = startDate
 
   if (suite.mode === 'run') {
     if (!hasTests(suite)) {

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -67,6 +67,7 @@ export async function runTest(test: Test) {
     return
   }
 
+  const startDate = Date.now()
   const start = performance.now()
 
   test.result = {
@@ -127,6 +128,7 @@ export async function runTest(test: Test) {
 
   getSnapshotClient().clearTest()
 
+  test.result.startTime = startDate
   test.result.duration = performance.now() - start
 
   __vitest_worker__.current = undefined
@@ -150,6 +152,7 @@ export async function runSuite(suite: Suite) {
     return
   }
 
+  const startDate = Date.now()
   const start = performance.now()
 
   suite.result = {
@@ -185,6 +188,7 @@ export async function runSuite(suite: Suite) {
     }
   }
   suite.result.duration = performance.now() - start
+  suite.result.startTime = startDate
 
   if (suite.mode === 'run') {
     if (!hasTests(suite)) {

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -18,6 +18,7 @@ export interface TaskBase {
 export interface TaskResult {
   state: TaskState
   duration?: number
+  startTime?: number
   error?: ErrorWithDiff
   hooks?: Partial<Record<keyof SuiteHooks, TaskState>>
 }

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -31,92 +31,91 @@ AssertionError: expected 2.23606797749979 to equal 2
 `;
 
 exports[`json reporter 1`] = `
-"{
-  \\"numTotalTestSuites\\": 3,
-  \\"numPassedTestSuites\\": 3,
-  \\"numFailedTestSuites\\": 0,
-  \\"numPendingTestSuites\\": 0,
-  \\"numTotalTests\\": 8,
-  \\"numPassedTests\\": 7,
-  \\"numFailedTests\\": 1,
-  \\"numPendingTests\\": 0,
-  \\"numTodoTests\\": 0,
-  \\"startTime\\": 1642587001759,
-  \\"success\\": false,
-  \\"testResults\\": [
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 1,
+  "numPassedTestSuites": 3,
+  "numPassedTests": 7,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 3,
+  "numTotalTests": 8,
+  "startTime": 1642587001759,
+  "success": false,
+  "testResults": [
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 1.4422860145568848
+      "displayName": "Math.sqrt()",
+      "failureMessage": "expected 2.23606797749979 to equal 2",
+      "perfStats": {
+        "runtime": 1.4422860145568848,
       },
-      \\"displayName\\": \\"Math.sqrt()\\",
-      \\"failureMessage\\": \\"expected 2.23606797749979 to equal 2\\",
-      \\"skipped\\": false,
-      \\"status\\": \\"fail\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "skipped": false,
+      "status": "fail",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 1.0237109661102295
+      "displayName": "JSON",
+      "perfStats": {
+        "runtime": 1.0237109661102295,
       },
-      \\"displayName\\": \\"JSON\\",
-      \\"skipped\\": false,
-      \\"status\\": \\"pass\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "skipped": false,
+      "status": "pass",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {},
-      \\"displayName\\": \\"async with timeout\\",
-      \\"skipped\\": true,
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "displayName": "async with timeout",
+      "perfStats": {},
+      "skipped": true,
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 100.50598406791687
+      "displayName": "timeout",
+      "perfStats": {
+        "runtime": 100.50598406791687,
       },
-      \\"displayName\\": \\"timeout\\",
-      \\"skipped\\": false,
-      \\"status\\": \\"pass\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "skipped": false,
+      "status": "pass",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 20.184875011444092
+      "displayName": "callback setup success ",
+      "perfStats": {
+        "runtime": 20.184875011444092,
       },
-      \\"displayName\\": \\"callback setup success \\",
-      \\"skipped\\": false,
-      \\"status\\": \\"pass\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "skipped": false,
+      "status": "pass",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 0.33245420455932617
+      "displayName": "callback test success ",
+      "perfStats": {
+        "runtime": 0.33245420455932617,
       },
-      \\"displayName\\": \\"callback test success \\",
-      \\"skipped\\": false,
-      \\"status\\": \\"pass\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "skipped": false,
+      "status": "pass",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 19.738605976104736
+      "displayName": "callback setup success done(false)",
+      "perfStats": {
+        "runtime": 19.738605976104736,
       },
-      \\"displayName\\": \\"callback setup success done(false)\\",
-      \\"skipped\\": false,
-      \\"status\\": \\"pass\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "skipped": false,
+      "status": "pass",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
     },
     {
-      \\"perfStats\\": {
-        \\"runtime\\": 0.1923508644104004
+      "displayName": "callback test success done(false)",
+      "perfStats": {
+        "runtime": 0.1923508644104004,
       },
-      \\"displayName\\": \\"callback test success done(false)\\",
-      \\"skipped\\": false,
-      \\"status\\": \\"pass\\",
-      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
-    }
-  ]
+      "skipped": false,
+      "status": "pass",
+      "testFilePath": "/vitest/test/core/test/basic.test.ts",
+    },
+  ],
 }
-"
 `;
 
 exports[`tap reporter 1`] = `

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -45,6 +45,9 @@ exports[`json reporter 1`] = `
   \\"success\\": false,
   \\"testResults\\": [
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 1.4422860145568848
+      },
       \\"displayName\\": \\"Math.sqrt()\\",
       \\"failureMessage\\": \\"expected 2.23606797749979 to equal 2\\",
       \\"skipped\\": false,
@@ -52,41 +55,60 @@ exports[`json reporter 1`] = `
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 1.0237109661102295
+      },
       \\"displayName\\": \\"JSON\\",
       \\"skipped\\": false,
       \\"status\\": \\"pass\\",
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {},
       \\"displayName\\": \\"async with timeout\\",
       \\"skipped\\": true,
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 100.50598406791687
+      },
       \\"displayName\\": \\"timeout\\",
       \\"skipped\\": false,
       \\"status\\": \\"pass\\",
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 20.184875011444092
+      },
       \\"displayName\\": \\"callback setup success \\",
       \\"skipped\\": false,
       \\"status\\": \\"pass\\",
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 0.33245420455932617
+      },
       \\"displayName\\": \\"callback test success \\",
       \\"skipped\\": false,
       \\"status\\": \\"pass\\",
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 19.738605976104736
+      },
       \\"displayName\\": \\"callback setup success done(false)\\",
       \\"skipped\\": false,
       \\"status\\": \\"pass\\",
       \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
     },
     {
+      \\"perfStats\\": {
+        \\"runtime\\": 0.1923508644104004
+      },
       \\"displayName\\": \\"callback test success done(false)\\",
       \\"skipped\\": false,
       \\"status\\": \\"pass\\",

--- a/test/reporters/tests/custom-reporter.spec.ts
+++ b/test/reporters/tests/custom-reporter.spec.ts
@@ -16,4 +16,4 @@ test('custom reporters work', async() => {
   })
 
   expect(stdout).toContain('hello from custom reporter')
-}, 20000)
+}, 40000)

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -67,5 +67,5 @@ test('json reporter', async() => {
   await reporter.onFinished(files)
 
   // Assert
-  expect(context.output).toMatchSnapshot()
+  expect(JSON.parse(context.output)).toMatchSnapshot()
 })


### PR DESCRIPTION
Add the missing field `perfStats` to JSON TestResult compared to [Jest test result type](https://github.com/facebook/jest/blob/e0b33b74b5afd738edc183858b5c34053cfc26dd/packages/jest-test-result/src/types.ts#L101-L106). 

```js
{  
  ...
  perfStats: {
    end?: Milliseconds
    runtime?: Milliseconds
    start?: Milliseconds
  },
  ...
}
```