### PR TITLE
docs: add `iconify` to the projects using `Vitest`

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -140,6 +140,7 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 - [Vitamin](https://github.com/wtchnm/Vitamin)
 - [neodrag](https://github.com/PuruVJ/neodrag)
 - [svelte-multiselect](https://github.com/janosh/svelte-multiselect)
+- [iconify](https://github.com/iconify/iconify)
 
 ## Using Unreleased Commits
 


### PR DESCRIPTION
We included `vitest` a few days ago on `@iconify/utils` package and will be also added to the rest of packages soon

EDIT: it is used only on `next` branch but `Vjacheslav Trushkin` is working to include `vitest`on the rest of packages and then will be merged to main.

@patak-dev on that repo I have `jest` and `vitest` configured to run on `cjs` and `esm` environments with the same codebase, just configuration: 
- https://github.com/iconify/iconify/blob/next/packages/utils/jest.shared.config.cjs
- https://github.com/iconify/iconify/blob/next/packages/utils/jest.config.cjs
- https://github.com/iconify/iconify/blob/next/packages/utils/jest.config.mjs
- https://github.com/iconify/iconify/blob/next/packages/utils/vitest.config.cjs
- https://github.com/iconify/iconify/blob/next/packages/utils/vitest.config.mjs