### PR TITLE
fix(expect): toHaveProperty support array syntax like jest (fix #937)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -700,8 +700,8 @@ TODO
     expect(invoice).toHaveProperty('items[0].type', 'apples')
     expect(invoice).toHaveProperty('items.0.type', 'apples') // dot notation also works
 
-    // Wrap your key in an array so avoid it being parsed as a deep reference
-    expect(invoice).toHaveProperty(['P.O'], '12345');
+    // Wrap your key in an array to avoid the key from being parsed as a deep reference
+    expect(invoice).toHaveProperty(['P.O'], '12345')
   })
   ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -666,6 +666,7 @@ TODO
 
   const invoice = {
     isActive: true,
+    ['P.O']: '12345',
     customer: {
       first_name: 'John',
       last_name: 'Doe',
@@ -699,6 +700,8 @@ TODO
     expect(invoice).toHaveProperty('items[0].type', 'apples')
     expect(invoice).toHaveProperty('items.0.type', 'apples') // dot notation also works
 
+    // Wrap your key in an array so avoid it being parsed as a deep reference
+    expect(invoice).toHaveProperty(['P.O'], '12345');
   })
   ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -665,15 +665,15 @@ TODO
   import { expect, test } from 'vitest'
 
   const invoice = {
-    isActive: true,
-    ['P.O']: '12345',
-    customer: {
+    'isActive': true,
+    'P.O': '12345',
+    'customer': {
       first_name: 'John',
       last_name: 'Doe',
       location: 'China',
     },
-    total_amount: 5000,
-    items: [
+    'total_amount': 5000,
+    'items': [
       {
         type: 'apples',
         quantity: 10,

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -93,7 +93,7 @@ declare global {
       toBeInstanceOf<E>(expected: E): void
       toBeCalledTimes(times: number): void
       toHaveLength(length: number): void
-      toHaveProperty<E>(property: string, value?: E): void
+      toHaveProperty<E>(property: string | string[], value?: E): void
       toBeCloseTo(number: number, numDigits?: number): void
       toHaveBeenCalledTimes(times: number): void
       toHaveBeenCalledOnce(): void

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -245,8 +245,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     return this.have.length(length)
   })
   // destructuring, because it checks `arguments` inside, and value is passing as `undefined`
-  def('toHaveProperty', function(...args: [property: string, value?: any]) {
-    return this.have.deep.nested.property(...args)
+  def('toHaveProperty', function(...args: [property: string | string[], value?: any]) {
+    if (Array.isArray(args[0]))
+      args[0] = args[0].map(key => key.replace(/([.[\]])/g, '\\$1')).join('.')
+
+    return this.have.deep.nested.property(...args as [property: string, value?: any])
   })
   def('toBeCloseTo', function(received: number, precision = 2) {
     const expected = this._obj

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -175,7 +175,15 @@ describe('jest-expect', () => {
     expect({}).not.toBe({})
 
     const foo = {}
-    const complex = { foo: 1, bar: { foo: 'foo', bar: 100, arr: ['first', { zoo: 'monkey' }] } }
+    const complex = {
+      'foo': 1,
+      'foo.bar[0]': 'baz',
+      'bar': {
+        foo: 'foo',
+        bar: 100,
+        arr: ['first', { zoo: 'monkey' }],
+      },
+    }
 
     expect(foo).toBe(foo)
     expect(foo).toStrictEqual(foo)
@@ -193,6 +201,8 @@ describe('jest-expect', () => {
     expect(complex).toHaveProperty('bar.arr[1].zoo', 'monkey')
     expect(complex).toHaveProperty('bar.arr.0')
     expect(complex).toHaveProperty('bar.arr.1.zoo', 'monkey')
+    expect(complex).toHaveProperty(['bar', 'arr', '1', 'zoo'], 'monkey')
+    expect(complex).toHaveProperty(['foo.bar[0]'], 'baz')
   })
 
   it('assertions', () => {


### PR DESCRIPTION
Supporting array syntax when using toHaveProperty, I did have issues getting the typing right though had to resort to using as to assert that it won't be a string[] anymore. #937 explains more in detail the problem this PR addresses