### PR TITLE
fix: add Module symbol to export object

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -83,9 +83,8 @@ export class ViteNodeRunner {
 
     // disambiguate the `<UNIT>:/` on windows: see nodejs/node#31710
     const url = pathToFileURL(fsPath).href
-    const exports: any = {
-      [Symbol.toStringTag]: 'Module',
-    }
+    const exports: any = Object.create(null)
+    exports[Symbol.toStringTag] = 'Module'
 
     this.setCache(id, { code: transformed, exports })
 

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -83,7 +83,9 @@ export class ViteNodeRunner {
 
     // disambiguate the `<UNIT>:/` on windows: see nodejs/node#31710
     const url = pathToFileURL(fsPath).href
-    const exports: any = {}
+    const exports: any = {
+      [Symbol.toStringTag]: 'Module',
+    }
 
     this.setCache(id, { code: transformed, exports })
 

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -32,3 +32,16 @@ test('data with dynamic import works', async() => {
   const { default: hi } = await import(dataUri)
   expect(hi).toBe('hi')
 })
+
+test('dynamic import has Module symbol', async() => {
+  const stringTimeoutMod = await import('./../src/timeout')
+
+  // @ts-expect-error The symbol won't exist on the import type
+  expect(stringTimeoutMod[Symbol.toStringTag]).toBe('Module')
+})
+
+test('dynamic import has null prototype', async() => {
+  const stringTimeoutMod = await import('./../src/timeout')
+
+  expect(Object.getPrototypeOf(stringTimeoutMod)).toBe(null)
+})


### PR DESCRIPTION
This change doesn't appear to break anything, but when my component is dynamically importing a vue component, I pass that result to defineAsyncComponent. Looking through the source code vue is expecting the property `Symbo.toStringTag` to be equal to 'Module' otherwise it won't look at the .default property to get the default component import. I am not sure if it is fine setting it for all exports but since vitest is esm first figured it would be fine to add.