### PR TITLE
fix(vite-node): normalize relative paths to be from current working directory

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'module'
 import { fileURLToPath, pathToFileURL } from 'url'
 import vm from 'vm'
-import { dirname, extname, isAbsolute, normalize, resolve } from 'pathe'
+import { dirname, extname, isAbsolute, resolve } from 'pathe'
 import { isNodeBuiltin } from 'mlly'
 import { isPrimitive, normalizeId, slash, toFilePath } from './utils'
 import type { ModuleCache, ViteNodeRunnerOptions } from './types'
@@ -56,7 +56,6 @@ export class ViteNodeRunner {
       // probably means it was passed as variable
       // and wasn't transformed by Vite
       if (this.shouldResolveId(dep)) {
-        if (extname(dep)) dep = normalize(`${dirname(id)}/${dep}`)
         const resolvedDep = await this.options.resolveId(dep, id)
         dep = resolvedDep?.id?.replace(this.root, '') || dep
       }

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -56,11 +56,10 @@ export class ViteNodeRunner {
       // probably means it was passed as variable
       // and wasn't transformed by Vite
       if (this.shouldResolveId(dep)) {
+        if (extname(dep)) dep = normalize(`${dirname(id)}/${dep}`)
         const resolvedDep = await this.options.resolveId(dep, id)
         dep = resolvedDep?.id?.replace(this.root, '') || dep
       }
-      if (!isAbsolute(dep) && extname(dep))
-        dep = normalize(`${dirname(id)}/${dep}`)
 
       if (callstack.includes(dep)) {
         if (!this.moduleCache.get(dep)?.exports)

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'module'
 import { fileURLToPath, pathToFileURL } from 'url'
 import vm from 'vm'
-import { dirname, extname, isAbsolute, resolve } from 'pathe'
+import { dirname, extname, isAbsolute, normalize, resolve } from 'pathe'
 import { isNodeBuiltin } from 'mlly'
 import { isPrimitive, normalizeId, slash, toFilePath } from './utils'
 import type { ModuleCache, ViteNodeRunnerOptions } from './types'
@@ -59,6 +59,9 @@ export class ViteNodeRunner {
         const resolvedDep = await this.options.resolveId(dep, id)
         dep = resolvedDep?.id?.replace(this.root, '') || dep
       }
+      if (!isAbsolute(dep) && extname(dep))
+        dep = normalize(`${dirname(id)}/${dep}`)
+
       if (callstack.includes(dep)) {
         if (!this.moduleCache.get(dep)?.exports)
           throw new Error(`[vite-node] Circular dependency detected\nStack:\n${[...callstack, dep].reverse().map(p => `- ${p}`).join('\n')}`)

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -1,3 +1,4 @@
+import { join } from 'pathe'
 import type { TransformResult, ViteDevServer } from 'vite'
 import type { FetchResult, RawSourceMap, ViteNodeResolveId, ViteNodeServerOptions } from './types'
 import { shouldExternalize } from './externalize'
@@ -24,6 +25,8 @@ export class ViteNodeServer {
   }
 
   async resolveId(id: string, importer?: string): Promise<ViteNodeResolveId | null> {
+    if (importer && !importer.startsWith(this.server.config.root))
+      importer = join(this.server.config.root, importer)
     return this.server.pluginContainer.resolveId(id, importer, { ssr: true })
   }
 

--- a/test/core/src/relative-import.ts
+++ b/test/core/src/relative-import.ts
@@ -1,0 +1,3 @@
+export function dynamicRelativeImport(file) {
+  return import(`./${file}.ts`)
+}

--- a/test/core/src/relative-import.ts
+++ b/test/core/src/relative-import.ts
@@ -1,3 +1,3 @@
-export function dynamicRelativeImport(file) {
+export function dynamicRelativeImport(file: string) {
   return import(`./${file}.ts`)
 }

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { dynamicRelativeImport } from '../src/relative-import';
+import { dynamicRelativeImport } from '../src/relative-import'
 
 test('dynamic relative import works', async() => {
   const stringTimeoutMod = await import('./../src/timeout')
@@ -14,7 +14,6 @@ test('Relative imports in file work', async() => {
   const relativeImportFromFile = await dynamicRelativeImport('timeout')
   const directImport = await import('./../src/timeout')
 
-  console.log(directImport, relativeImportFromFile);
   expect(relativeImportFromFile).toBe(directImport)
 })
 

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -10,7 +10,7 @@ test('dynamic relative import works', async() => {
   expect(stringTimeoutMod).toBe(variableTimeoutMod)
 })
 
-test('Relative imports in file work', async() => {
+test('Relative imports in imported modules work', async() => {
   const relativeImportFromFile = await dynamicRelativeImport('timeout')
   const directImport = await import('./../src/timeout')
 

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest'
+import { dynamicRelativeImport } from '../src/relative-import';
 
 test('dynamic relative import works', async() => {
   const stringTimeoutMod = await import('./../src/timeout')
@@ -7,6 +8,14 @@ test('dynamic relative import works', async() => {
   const variableTimeoutMod = await import(timeoutPath)
 
   expect(stringTimeoutMod).toBe(variableTimeoutMod)
+})
+
+test('Relative imports in file work', async() => {
+  const relativeImportFromFile = await dynamicRelativeImport('timeout')
+  const directImport = await import('./../src/timeout')
+
+  console.log(directImport, relativeImportFromFile);
+  expect(relativeImportFromFile).toBe(directImport)
 })
 
 test('dynamic aliased import works', async() => {


### PR DESCRIPTION
If an imported file in a different directory is doing a dynamic import to a relative path that import is failing due to the relative import seeming to be from where we are running the tests from and not from where the file is imported from. I fixed this by just converting all relative imports with an extension to an absolute import. I don't see any issue with this, but I don't know the whole scope of this project.  All tests are passing and this fixed my issue for my use case.