### PR TITLE
fix: update inlineSnapshot should not remove end whitespace, close #922

### DIFF
--- a/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
+++ b/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
@@ -63,7 +63,6 @@ function prepareSnapString(snap: string, source: string, index: number) {
     .replace(/\\/g, '\\\\')
     .replace(/\$/g, '\\$')
     .split(/\n/g)
-    .map(i => i.trimEnd())
 
   const isOneline = lines.length <= 1
   const quote = isOneline ? '\'' : '`'

--- a/test/snapshots/test/shapshots.test.ts
+++ b/test/snapshots/test/shapshots.test.ts
@@ -23,3 +23,14 @@ test('non default snapshot format', () => {
 test('multiline strings ', () => {
   expect(println()).toMatchSnapshot()
 })
+
+test('updateInlineSnapshot should not remove end whitespace', () => {
+  // issue #922
+  expect(`
+my string 
+`).toMatchInlineSnapshot(`
+  "
+  my string 
+  "
+`)
+})


### PR DESCRIPTION
here is the issue #922 
and i notice when update inlineSnapshot, it will remove the end white space `trimEnd()`
and i add a test-case, it works
and i run all the tests, all done.