### PR TITLE
docs: fixing Getting Started url on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A blazing fast unit test framework powered by Vite.
 
 > Vitest requires Vite >=v2.7.10 and Node >=v14
 
-Follow the [Getting Started Guide](https://vitest.dev/guide) or learn [why we are building a new test runner](https://vitest.dev/guide/why).
+Follow the [Getting Started Guide](https://vitest.dev/guide/) or learn [why we are building a new test runner](https://vitest.dev/guide/why).
 
 ## Documentation
 


### PR DESCRIPTION
**What**
The Getting Started URL on Readme is incorrect and are returning a 404 error. There's a missing / at the end.

**How it has been fixed**
I've added the missing /.