### PR TITLE
feat: make `isolate` default to false

### DIFF
--- a/examples/react-testing-lib-msw/vite.config.ts
+++ b/examples/react-testing-lib-msw/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
+    isolate: true,
     environment: 'jsdom',
     setupFiles: ['./src/setup.ts'],
   },

--- a/examples/react-testing-lib/vite.config.ts
+++ b/examples/react-testing-lib/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
+    isolate: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
   },

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -43,7 +43,7 @@ export const configDefaults: UserConfig = Object.freeze({
   exclude: defaultExclude,
   testTimeout: 5000,
   hookTimeout: 10000,
-  isolate: true,
+  isolate: false,
   watchIgnore: [/\/node_modules\//, /\/dist\//],
   update: false,
   reporters: [],

--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -6,6 +6,8 @@ import { startTests } from './run'
 
 export async function run(files: string[], config: ResolvedConfig): Promise<void> {
   await setupGlobalEnv(config)
+  const workerState = getWorkerState()
+  workerState.mockMap.clear()
 
   for (const file of files) {
     const code = await fs.readFile(file, 'utf-8')
@@ -15,7 +17,6 @@ export async function run(files: string[], config: ResolvedConfig): Promise<void
     if (!['node', 'jsdom', 'happy-dom'].includes(env))
       throw new Error(`Unsupported environment: ${env}`)
 
-    const workerState = getWorkerState()
     workerState.filepath = file
 
     await withEnv(env as BuiltinEnvironment, config.environmentOptions || {}, async() => {

--- a/packages/vitest/src/runtime/setup.ts
+++ b/packages/vitest/src/runtime/setup.ts
@@ -11,6 +11,7 @@ let globalSetup = false
 export async function setupGlobalEnv(config: ResolvedConfig) {
   resetRunOnceCounter()
 
+  // for `import.meta.vitest` injection
   Object.defineProperty(globalThis, '__vitest_index__', {
     value: VitestIndex,
     enumerable: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,7 +437,7 @@ importers:
       solid-js: 1.3.12
     devDependencies:
       jsdom: 19.0.0
-      solid-start: 0.1.0-alpha.66_solid-js@1.3.12+vite@2.8.6
+      solid-start: 0.1.0-alpha.68_solid-js@1.3.12+vite@2.8.6
       solid-testing-library: 0.3.0_solid-js@1.3.12
       vitest: link:../../packages/vitest
 
@@ -17139,8 +17139,8 @@ packages:
       solid-js: 1.3.12
     dev: true
 
-  /solid-start-node/0.1.0-alpha.66_0ea384134918338f1c5b6cb6cab097e3:
-    resolution: {integrity: sha512-K70hiZzTzKmA6RSBYOODFpYKGkzNBwattiFSHBFdhucvQiEHGyP3IsaCs5TKXuav/oX4pWRzE3ssUcPF5B6N7A==}
+  /solid-start-node/0.1.0-alpha.68_eff5a7601ff8a6e482f1c876291835be:
+    resolution: {integrity: sha512-/wsB7KXj7JKPbXLI+kNWeWS8i43iRFZbLhzzHIQuT5uLcM1UbVrmoRlsOLHsm0Jo2sD105FltYW/TULAW3Tagw==}
     requiresBuild: true
     peerDependencies:
       solid-start: next
@@ -17154,14 +17154,14 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.70.1
       sirv: 1.0.19
-      solid-start: 0.1.0-alpha.66_solid-js@1.3.12+vite@2.8.6
+      solid-start: 0.1.0-alpha.68_solid-js@1.3.12+vite@2.8.6
       undici: 4.13.0
       vite: 2.8.6
     dev: true
     optional: true
 
-  /solid-start/0.1.0-alpha.66_solid-js@1.3.12+vite@2.8.6:
-    resolution: {integrity: sha512-HGJUQy2FIxfwQZTFpfx2ibjBoLT8fTCKpGvGwl215RSl7zDve9DFMuSTqRZiay0l4ERbu6uziS+gFg6tk3V0CA==}
+  /solid-start/0.1.0-alpha.68_solid-js@1.3.12+vite@2.8.6:
+    resolution: {integrity: sha512-cfpOWolqSlwfQzDEXFLPox9NtlPsg7/1VWPZN4FfwB+eAmnvc4wg78fcrl92mOpITdM1AusqryHibzrErz9ksA==}
     hasBin: true
     peerDependencies:
       solid-app-router: ^0.3.0
@@ -17191,7 +17191,7 @@ packages:
       vite-plugin-inspect: 0.3.14_vite@2.8.6
       vite-plugin-solid: 2.2.6
     optionalDependencies:
-      solid-start-node: 0.1.0-alpha.66_0ea384134918338f1c5b6cb6cab097e3
+      solid-start-node: 0.1.0-alpha.68_eff5a7601ff8a6e482f1c876291835be
     transitivePeerDependencies:
       - less
       - sass

--- a/test/fails/fixtures/vite.config.ts
+++ b/test/fails/fixtures/vite.config.ts
@@ -3,6 +3,5 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   test: {
     threads: false,
-    isolate: false,
   },
 })


### PR DESCRIPTION
Discussed with the team and here is the gist of the switch:

- An isolated env is ideal, but it also means you need to **execute all the dependencies for every file** in order to get a clear state in a separate worker. With the cost of performance.
- For most cases, we do unit tests that have no or minimal side-effects, the isolation might not be necessary.
- We should advocate the tests to be side-effects free (with proper mocking) when it's possible.

Instead of opt-out, we think it's better to be opt-in for ppl who absolutely need the isolation and willing to pay the extra performance cost for it.