### PR TITLE
test(reporters): add outputFile tests

### DIFF
--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -30,6 +30,41 @@ AssertionError: expected 2.23606797749979 to equal 2
 "
 `;
 
+exports[`JUnit reporter with outputFile 1`] = `
+"JUNIT report written to <process-cwd>/report.xml
+"
+`;
+
+exports[`JUnit reporter with outputFile 2`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<testsuites>
+    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"8\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"1\\" time=\\"0.1459928420\\">
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.0014422860\\">
+            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+AssertionError: expected 2.23606797749979 to equal 2
+ ❯ vitest/test/core/test/basic.test.ts:8:32
+            </failure>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.0010237110\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\">
+            <skipped/>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.0201848750\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
 exports[`json reporter 1`] = `
 {
   "numFailedTestSuites": 0,
@@ -116,6 +151,99 @@ exports[`json reporter 1`] = `
     },
   ],
 }
+`;
+
+exports[`json reporter with outputFile 1`] = `
+"JSON report written to <process-cwd>/report.json
+"
+`;
+
+exports[`json reporter with outputFile 2`] = `
+"{
+  \\"numTotalTestSuites\\": 3,
+  \\"numPassedTestSuites\\": 3,
+  \\"numFailedTestSuites\\": 0,
+  \\"numPendingTestSuites\\": 0,
+  \\"numTotalTests\\": 8,
+  \\"numPassedTests\\": 7,
+  \\"numFailedTests\\": 1,
+  \\"numPendingTests\\": 0,
+  \\"numTodoTests\\": 0,
+  \\"startTime\\": 1642587001759,
+  \\"success\\": false,
+  \\"testResults\\": [
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 1.4422860145568848
+      },
+      \\"displayName\\": \\"Math.sqrt()\\",
+      \\"failureMessage\\": \\"expected 2.23606797749979 to equal 2\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"fail\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 1.0237109661102295
+      },
+      \\"displayName\\": \\"JSON\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {},
+      \\"displayName\\": \\"async with timeout\\",
+      \\"skipped\\": true,
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 100.50598406791687
+      },
+      \\"displayName\\": \\"timeout\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 20.184875011444092
+      },
+      \\"displayName\\": \\"callback setup success \\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 0.33245420455932617
+      },
+      \\"displayName\\": \\"callback test success \\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 19.738605976104736
+      },
+      \\"displayName\\": \\"callback setup success done(false)\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 0.1923508644104004
+      },
+      \\"displayName\\": \\"callback test success done(false)\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    }
+  ]
+}"
 `;
 
 exports[`tap reporter 1`] = `

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -1,4 +1,6 @@
+import { existsSync, readFileSync, rmSync } from 'fs'
 import { afterEach, expect, test, vi } from 'vitest'
+import { normalize, resolve } from 'pathe'
 import { JsonReporter } from '../../../packages/vitest/src/node/reporters/json'
 import { JUnitReporter } from '../../../packages/vitest/src/node/reporters/junit'
 import { TapReporter } from '../../../packages/vitest/src/node/reporters/tap'
@@ -48,11 +50,38 @@ test('JUnit reporter', async() => {
   vi.setSystemTime(1642587001759)
 
   // Act
-  reporter.onInit(context.vitest)
+  await reporter.onInit(context.vitest)
   await reporter.onFinished(files)
 
   // Assert
   expect(context.output).toMatchSnapshot()
+})
+
+test('JUnit reporter with outputFile', async() => {
+  // Arrange
+  const reporter = new JUnitReporter()
+  const outputFile = resolve('report.xml')
+  const context = getContext()
+  context.vitest.config.outputFile = outputFile
+
+  vi.mock('os', () => ({
+    hostname: () => 'hostname',
+  }))
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  await reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  const output = context.output.replace(normalize(process.cwd()), '<process-cwd>')
+  expect(output).toMatchSnapshot()
+  expect(existsSync(outputFile)).toBe(true)
+  expect(readFileSync(outputFile, 'utf8')).toMatchSnapshot()
+
+  // Cleanup
+  rmSync(outputFile)
 })
 
 test('json reporter', async() => {
@@ -68,4 +97,27 @@ test('json reporter', async() => {
 
   // Assert
   expect(JSON.parse(context.output)).toMatchSnapshot()
+})
+
+test('json reporter with outputFile', async() => {
+  // Arrange
+  const reporter = new JsonReporter()
+  const outputFile = resolve('report.json')
+  const context = getContext()
+  context.vitest.config.outputFile = outputFile
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  const output = context.output.replace(normalize(process.cwd()), '<process-cwd>')
+  expect(output).toMatchSnapshot()
+  expect(existsSync(outputFile)).toBe(true)
+  expect(readFileSync(outputFile, 'utf8')).toMatchSnapshot()
+
+  // Cleanup
+  rmSync(outputFile)
 })


### PR DESCRIPTION
Adds missing test cases for `outputFile` configuration.

I'm working on another bug fix and thought let's merge these ones first. 