### PR TITLE
fix: prevent crashing when directory of `outputFile` does not exist

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs'
-import { resolve } from 'pathe'
+import { existsSync, promises as fs } from 'fs'
+import { dirname, resolve } from 'pathe'
 import type { Vitest } from '../../node'
 import type { File, Reporter } from '../../types'
 import { getSuites, getTests } from '../../utils'
@@ -90,6 +90,11 @@ export class JsonReporter implements Reporter {
   async writeReport(report: string) {
     if (this.ctx.config.outputFile) {
       const reportFile = resolve(this.ctx.config.root, this.ctx.config.outputFile)
+
+      const outputDirectory = dirname(reportFile)
+      if (!existsSync(outputDirectory))
+        await fs.mkdir(outputDirectory, { recursive: true })
+
       await fs.writeFile(reportFile, report, 'utf-8')
       this.ctx.log(`JSON report written to ${reportFile}`)
     }

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -1,6 +1,6 @@
-import { promises as fs } from 'fs'
+import { existsSync, promises as fs } from 'fs'
 import { hostname } from 'os'
-import { relative, resolve } from 'pathe'
+import { dirname, relative, resolve } from 'pathe'
 
 import type { Vitest } from '../../node'
 import type { ErrorWithDiff, Reporter, Task } from '../../types'
@@ -46,6 +46,11 @@ export class JUnitReporter implements Reporter {
 
     if (this.ctx.config.outputFile) {
       this.reportFile = resolve(this.ctx.config.root, this.ctx.config.outputFile)
+
+      const outputDirectory = dirname(this.reportFile)
+      if (!existsSync(outputDirectory))
+        await fs.mkdir(outputDirectory, { recursive: true })
+
       const fileFd = await fs.open(this.reportFile, 'w+')
 
       this.baseLog = async(text: string) => await fs.writeFile(fileFd, `${text}\n`)

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -65,6 +65,41 @@ AssertionError: expected 2.23606797749979 to equal 2
 "
 `;
 
+exports[`JUnit reporter with outputFile in non-existing directory 1`] = `
+"JUNIT report written to <process-cwd>/junitReportDirectory/deeply/nested/report.xml
+"
+`;
+
+exports[`JUnit reporter with outputFile in non-existing directory 2`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<testsuites>
+    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"8\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"1\\" time=\\"0.1459928420\\">
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.0014422860\\">
+            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+AssertionError: expected 2.23606797749979 to equal 2
+ ❯ vitest/test/core/test/basic.test.ts:8:32
+            </failure>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.0010237110\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\">
+            <skipped/>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.0201848750\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
 exports[`json reporter 1`] = `
 {
   "numFailedTestSuites": 0,
@@ -159,6 +194,99 @@ exports[`json reporter with outputFile 1`] = `
 `;
 
 exports[`json reporter with outputFile 2`] = `
+"{
+  \\"numTotalTestSuites\\": 3,
+  \\"numPassedTestSuites\\": 3,
+  \\"numFailedTestSuites\\": 0,
+  \\"numPendingTestSuites\\": 0,
+  \\"numTotalTests\\": 8,
+  \\"numPassedTests\\": 7,
+  \\"numFailedTests\\": 1,
+  \\"numPendingTests\\": 0,
+  \\"numTodoTests\\": 0,
+  \\"startTime\\": 1642587001759,
+  \\"success\\": false,
+  \\"testResults\\": [
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 1.4422860145568848
+      },
+      \\"displayName\\": \\"Math.sqrt()\\",
+      \\"failureMessage\\": \\"expected 2.23606797749979 to equal 2\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"fail\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 1.0237109661102295
+      },
+      \\"displayName\\": \\"JSON\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {},
+      \\"displayName\\": \\"async with timeout\\",
+      \\"skipped\\": true,
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 100.50598406791687
+      },
+      \\"displayName\\": \\"timeout\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 20.184875011444092
+      },
+      \\"displayName\\": \\"callback setup success \\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 0.33245420455932617
+      },
+      \\"displayName\\": \\"callback test success \\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 19.738605976104736
+      },
+      \\"displayName\\": \\"callback setup success done(false)\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    },
+    {
+      \\"perfStats\\": {
+        \\"runtime\\": 0.1923508644104004
+      },
+      \\"displayName\\": \\"callback test success done(false)\\",
+      \\"skipped\\": false,
+      \\"status\\": \\"pass\\",
+      \\"testFilePath\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    }
+  ]
+}"
+`;
+
+exports[`json reporter with outputFile in non-existing directory 1`] = `
+"JSON report written to <process-cwd>/jsonReportDirectory/deeply/nested/report.json
+"
+`;
+
+exports[`json reporter with outputFile in non-existing directory 2`] = `
 "{
   \\"numTotalTestSuites\\": 3,
   \\"numPassedTestSuites\\": 3,


### PR DESCRIPTION
Fixes #985 