### PR TITLE
fix: render original source if mapped in node

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -32,7 +32,7 @@ export async function printError(error: unknown, ctx: Vitest) {
   printErrorMessage(e, ctx.console)
   await printStack(ctx, stacks, nearest, async(s, pos) => {
     if (s === nearest && nearest) {
-      const file = nearest.sourcePos && nearest.sourcePos.source ? join(nearest.file, '../', nearest.sourcePos.source) : nearest.file
+      const file = nearest.sourcePos && nearest.sourcePos.source && nearest.sourcePos.source !== '.' ? join(nearest.file, '../', nearest.sourcePos.source) : nearest.file
       const sourceCode = await fs.readFile(file, 'utf-8')
       ctx.log(c.yellow(generateCodeFrame(sourceCode, 4, pos)))
     }
@@ -101,7 +101,7 @@ async function printStack(
   for (const frame of stack) {
     const pos = frame.sourcePos || frame
     const color = frame === highlight ? c.yellow : c.gray
-    const file = frame.sourcePos && frame.sourcePos.source ? join(frame.file, '../', frame.sourcePos.source) : frame.file
+    const file = frame.sourcePos && frame.sourcePos.source && frame.sourcePos.source !== '.' ? join(frame.file, '../', frame.sourcePos.source) : frame.file
     const path = relative(ctx.config.root, file)
 
     ctx.log(color(` ${c.dim(F_POINTER)} ${[frame.method, c.dim(`${path}:${pos.line}:${pos.column}`)].filter(Boolean).join(' ')}`))

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-template */
 /* eslint-disable no-template-curly-in-string */
 import { existsSync, promises as fs } from 'fs'
-import { relative } from 'pathe'
+import { join, relative } from 'pathe'
 import c from 'picocolors'
 import cliTruncate from 'cli-truncate'
 import type { ErrorWithDiff, ParsedStack, Position } from '../types'
@@ -32,7 +32,8 @@ export async function printError(error: unknown, ctx: Vitest) {
   printErrorMessage(e, ctx.console)
   await printStack(ctx, stacks, nearest, async(s, pos) => {
     if (s === nearest && nearest) {
-      const sourceCode = await fs.readFile(nearest.file, 'utf-8')
+      const file = nearest.sourcePos && nearest.sourcePos.source ? join(nearest.file, '../', nearest.sourcePos.source) : nearest.file
+      const sourceCode = await fs.readFile(file, 'utf-8')
       ctx.log(c.yellow(generateCodeFrame(sourceCode, 4, pos)))
     }
   })
@@ -100,7 +101,8 @@ async function printStack(
   for (const frame of stack) {
     const pos = frame.sourcePos || frame
     const color = frame === highlight ? c.yellow : c.gray
-    const path = relative(ctx.config.root, frame.file)
+    const file = frame.sourcePos && frame.sourcePos.source ? join(frame.file, '../', frame.sourcePos.source) : frame.file
+    const path = relative(ctx.config.root, file)
 
     ctx.log(color(` ${c.dim(F_POINTER)} ${[frame.method, c.dim(`${path}:${pos.line}:${pos.column}`)].filter(Boolean).join(' ')}`))
     await onStack?.(frame, pos)

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -10,6 +10,12 @@ import { F_POINTER } from '../utils/figures'
 import type { Vitest } from './core'
 import { unifiedDiff } from './diff'
 
+export function fileFromParsedStack(stack: ParsedStack) {
+  if (stack.sourcePos?.source && stack.sourcePos.source !== '.' && stack.sourcePos.source !== stack.file)
+    return join(stack.file, '../', stack.sourcePos.source)
+  return stack.file
+}
+
 export async function printError(error: unknown, ctx: Vitest) {
   let e = error as ErrorWithDiff
 
@@ -32,8 +38,7 @@ export async function printError(error: unknown, ctx: Vitest) {
   printErrorMessage(e, ctx.console)
   await printStack(ctx, stacks, nearest, async(s, pos) => {
     if (s === nearest && nearest) {
-      const file = nearest.sourcePos && nearest.sourcePos.source && nearest.sourcePos.source !== '.' ? join(nearest.file, '../', nearest.sourcePos.source) : nearest.file
-      const sourceCode = await fs.readFile(file, 'utf-8')
+      const sourceCode = await fs.readFile(fileFromParsedStack(nearest), 'utf-8')
       ctx.log(c.yellow(generateCodeFrame(sourceCode, 4, pos)))
     }
   })
@@ -101,7 +106,7 @@ async function printStack(
   for (const frame of stack) {
     const pos = frame.sourcePos || frame
     const color = frame === highlight ? c.yellow : c.gray
-    const file = frame.sourcePos && frame.sourcePos.source && frame.sourcePos.source !== '.' ? join(frame.file, '../', frame.sourcePos.source) : frame.file
+    const file = fileFromParsedStack(frame)
     const path = relative(ctx.config.root, file)
 
     ctx.log(color(` ${c.dim(F_POINTER)} ${[frame.method, c.dim(`${path}:${pos.line}:${pos.column}`)].filter(Boolean).join(' ')}`))

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -11,7 +11,8 @@ import type { Vitest } from './core'
 import { unifiedDiff } from './diff'
 
 export function fileFromParsedStack(stack: ParsedStack) {
-  if (stack.sourcePos?.source && stack.sourcePos.source !== '.' && stack.sourcePos.source !== stack.file)
+  // some files appear as /path with source /@fs/path
+  if (stack.sourcePos?.source && stack.sourcePos.source !== '.' && !stack.sourcePos.source.endsWith(stack.file))
     return join(stack.file, '../', stack.sourcePos.source)
   return stack.file
 }

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -11,8 +11,7 @@ import type { Vitest } from './core'
 import { unifiedDiff } from './diff'
 
 export function fileFromParsedStack(stack: ParsedStack) {
-  // some files appear as /path with source /@fs/path
-  if (stack.sourcePos?.source && stack.sourcePos.source !== '.' && !stack.sourcePos.source.endsWith(stack.file))
+  if (stack?.sourcePos?.source?.startsWith('..'))
     return join(stack.file, '../', stack.sourcePos.source)
   return stack.file
 }

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -47,6 +47,7 @@ export interface UserConsoleLog {
 }
 
 export interface Position {
+  source?: string
   line: number
   column: number
 }


### PR DESCRIPTION
Address the first phase of https://github.com/vitest-dev/vitest/issues/832 when a stack trace is interpreted in case of errors in node if a source map is present it ensures the proper file is rendered in the test summary.

This PR doesn't address the full scope of the issue as it would be better (arguably?) to also show the test file names correspondent to the mapped source if present but I don't yet understand how that could be achieved because at the point test file names are rendered source maps are not yet parsed

---

After this PR the repro code produces:
![Screenshot 2022-03-19 153140](https://user-images.githubusercontent.com/24249610/159127521-8723a69a-ce94-4f9c-826d-518ac15adff1.png)

While it still shows test files as before:
![Screenshot 2022-03-19 153243](https://user-images.githubusercontent.com/24249610/159127558-5e818f5c-07ee-4ba5-b1b9-ecfd491dc8bc.png)

