### PR TITLE
chore: coverage remove restart vitest

### DIFF
--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -40,8 +40,17 @@ export async function startVitest(cliFilters: string[], options: CliOptions, vit
       return false
     }
 
-    if (!process.env.NODE_V8_COVERAGE)
+    if (!process.env.NODE_V8_COVERAGE) {
       process.env.NODE_V8_COVERAGE = ctx.config.coverage.tempDirectory
+      // thread enable test will exec in thread
+      // so don't need to restarting Vitest
+      if (!ctx.config.threads) {
+        await ctx.server.close()
+        const { exitCode } = await execa(process.argv0, process.argv.slice(1), { stdio: 'inherit', reject: false })
+        process.exitCode = exitCode
+        return false
+      }
+    }
   }
 
   if (ctx.config.environment && ctx.config.environment !== 'node') {

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -40,12 +40,8 @@ export async function startVitest(cliFilters: string[], options: CliOptions, vit
       return false
     }
 
-    if (!process.env.NODE_V8_COVERAGE) {
+    if (!process.env.NODE_V8_COVERAGE)
       process.env.NODE_V8_COVERAGE = ctx.config.coverage.tempDirectory
-      const { exitCode } = await execa(process.argv0, process.argv.slice(1), { stdio: 'inherit', reject: false })
-      process.exitCode = exitCode
-      return false
-    }
   }
 
   if (ctx.config.environment && ctx.config.environment !== 'node') {

--- a/test/coverage-test/coverage-test/coverage.test.ts
+++ b/test/coverage-test/coverage-test/coverage.test.ts
@@ -1,0 +1,11 @@
+import fs from 'fs'
+import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
+
+test('coverage', async() => {
+  const coveragePath = resolve('./coverage/tmp/')
+  const stat = fs.statSync(coveragePath)
+  expect(stat.isDirectory()).toBe(true)
+  const files = fs.readdirSync(coveragePath)
+  expect(files.length > 0).toBe(true)
+})

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -2,10 +2,12 @@
   "name": "@vitest/test-coverage",
   "private": true,
   "scripts": {
-    "test": "npm run coverage:thread && npm run test:coverage && npm run coverage && npm run test:coverage",
+    "test": "npm run test:thread && npm run test:nothread",
     "coverage": "vitest run --coverage",
     "coverage:thread": "cross-env THREAD=true vitest run --coverage",
-    "test:coverage": "vitest -c vitest.config-coverage.ts run"
+    "coverage-test": "vitest -c vitest.config-coverage.ts run",
+    "test:thread": "npm run coverage:thread && npm run coverage-test",
+    "test:nothread": "npm run coverage && npm run coverage-test"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.2.4",

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -2,8 +2,10 @@
   "name": "@vitest/test-coverage",
   "private": true,
   "scripts": {
-    "test": "npm run coverage",
-    "coverage": "vitest run --coverage"
+    "test": "npm run coverage:thread && npm run test:coverage && npm run coverage && npm run test:coverage",
+    "coverage": "vitest run --coverage",
+    "coverage:thread": "cross-env THREAD=true vitest run --coverage",
+    "test:coverage": "vitest -c vitest.config-coverage.ts run"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.2.4",

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -2,7 +2,7 @@
   "name": "@vitest/test-coverage",
   "private": true,
   "scripts": {
-    "test": "vitest",
+    "test": "npm run coverage",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -1,6 +1,13 @@
+import fs from 'fs'
+import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 import { pythagoras } from '../src'
 
 test('Math.sqrt()', async() => {
   expect(pythagoras(3, 4)).toBe(5)
+})
+
+test('coverage', async() => {
+  const stat = fs.statSync(resolve('./coverage/'))
+  expect(stat.isDirectory()).toBe(true)
 })

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -1,13 +1,6 @@
-import fs from 'fs'
-import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 import { pythagoras } from '../src'
 
 test('Math.sqrt()', async() => {
   expect(pythagoras(3, 4)).toBe(5)
-})
-
-test('coverage', async() => {
-  const stat = fs.statSync(resolve('./coverage/'))
-  expect(stat.isDirectory()).toBe(true)
 })

--- a/test/coverage-test/vitest.config-coverage.ts
+++ b/test/coverage-test/vitest.config-coverage.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    include: [
+      './coverage-test/*.test.ts',
+    ],
+  },
+})

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -9,5 +9,12 @@ export default defineConfig({
     MY_CONSTANT: '"my constant"',
   },
   test: {
+    threads: !!process.env.THREAD,
+    include: [
+      'test/*.test.ts',
+    ],
+    exclude: [
+      'coverage-test/*.test.ts',
+    ],
   },
 })


### PR DESCRIPTION
fix: #998

from https://nodejs.org/api/v8.html#v8takecoverage

> This method can be invoked multiple times during the lifetime of the process. Each time the execution counter will be reset and a new coverage report will be written to the directory specified by [NODE_V8_COVERAGE](https://nodejs.org/api/cli.html#node_v8_coveragedir).

~~This looks like NODE_V8_COVERAGE is reread every time `v8.takeCoverage` is executed.~~

`NODE_V8_COVERAGE` read once when nodejs start. 

> "It looks like the output is no different after removing that"

because thread enable test coverage run in sub-thread.

this PR restart Vitest when threads disabled.