### PR TITLE
fix(ui): router plugin in ui

### DIFF
--- a/packages/ui/client/main.ts
+++ b/packages/ui/client/main.ts
@@ -1,11 +1,11 @@
 import { createApp } from 'vue'
-import { directives, plugins } from './global-setup'
 import App from './App.vue'
+import { directives, plugins } from './global-setup'
 
 const app = createApp(App)
 
 plugins.forEach((plugin) => {
-  app.use(plugin)
+  app.use(plugin())
 })
 
 Object.entries(directives).forEach(([name, directive]) => {


### PR DESCRIPTION
With the latest update made here https://github.com/vitest-dev/vitest/pull/590 I get this error in the UI

<img width="955" alt="Screenshot 2022-03-23 at 11 00 10" src="https://user-images.githubusercontent.com/27342306/159662836-f8888508-4515-443a-a9aa-03de3436f950.png">

This happens because we pass a router factory function to the `app.use` call instead of the actual router https://github.com/vitest-dev/vitest/blob/main/packages/ui/client/global-setup.ts#L22-L27

I'm new to Vue so I might be wrong here @JessicaSachs can you please take a look 🙏

close https://github.com/vitest-dev/vitest/issues/1008