### PR TITLE
docs: Add IntelliJ debug instructions

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -25,3 +25,15 @@ To debug a test file in VSCode, create the following launch configuration.
 ```
 
 Then in the debug tab ensure 'Debug Current Test File' is selected, you can then open the test file you want to debug and press F5 to start debugging.
+
+## IntelliJ IDEA
+
+Create a 'Node.js' run configuration. Use the following settings to run all tests in debug mode:
+
+Setting | Value
+ --- | ---
+Working directory | C:\path\to\your-project-root
+JavaScript file | .\node_modules\vitest\vitest.mjs
+Application parameters | run --threads false
+
+Then run this configuration in debug mode. The IDE will stop at JS/TS breakpoints set in the editor.

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -32,8 +32,8 @@ Create a 'Node.js' run configuration. Use the following settings to run all test
 
 Setting | Value
  --- | ---
-Working directory | C:\path\to\your-project-root
-JavaScript file | .\node_modules\vitest\vitest.mjs
+Working directory | /path/to/your-project-root
+JavaScript file | ./node_modules/vitest/vitest.mjs
 Application parameters | run --threads false
 
 Then run this configuration in debug mode. The IDE will stop at JS/TS breakpoints set in the editor.


### PR DESCRIPTION
The `--threads false` part is important, because the debugger
otherweise halts all worker threads upon start.
One would have to manually let those continue, which is quite annoying.