### PR TITLE
fix: assertions error message

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -15,7 +15,7 @@ if (!Object.prototype.hasOwnProperty.call(global, MATCHERS_OBJECT)) {
     isExpectingAssertions: false,
     isExpectingAssertionsError: null,
     expectedAssertionsNumber: null,
-    expectedAssertionsNumberError: null,
+    expectedAssertionsNumberErrorGen: null,
   }
   Object.defineProperty(global, MATCHERS_OBJECT, {
     value: {
@@ -558,13 +558,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     chai.expect,
     'assertions',
     function assertions(expected: number) {
-      const error = new Error(`expected number of assertions to be ${expected}, but got ${getState().assertionCalls}`)
+      const errorGen = () => new Error(`expected number of assertions to be ${expected}, but got ${getState().assertionCalls}`)
       if (Error.captureStackTrace)
-        Error.captureStackTrace(error, assertions)
+        Error.captureStackTrace(errorGen(), assertions)
 
       setState({
         expectedAssertionsNumber: expected,
-        expectedAssertionsNumberError: error,
+        expectedAssertionsNumberErrorGen: errorGen,
       })
     },
   )

--- a/packages/vitest/src/integrations/chai/types.ts
+++ b/packages/vitest/src/integrations/chai/types.ts
@@ -28,7 +28,7 @@ export interface MatcherState {
   ) => boolean
   expand?: boolean
   expectedAssertionsNumber?: number | null
-  expectedAssertionsNumberError?: Error | null
+  expectedAssertionsNumberErrorGen?: (() => Error) | null
   isExpectingAssertions?: boolean
   isExpectingAssertionsError?: Error | null
   isNot: boolean

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -90,14 +90,14 @@ export async function runTest(test: Test) {
       isExpectingAssertions: false,
       isExpectingAssertionsError: null,
       expectedAssertionsNumber: null,
-      expectedAssertionsNumberError: null,
+      expectedAssertionsNumberErrorGen: null,
       testPath: test.suite.file?.filepath,
       currentTestName: getFullName(test),
     })
     await getFn(test)()
-    const { assertionCalls, expectedAssertionsNumber, expectedAssertionsNumberError, isExpectingAssertions, isExpectingAssertionsError } = getState()
+    const { assertionCalls, expectedAssertionsNumber, expectedAssertionsNumberErrorGen, isExpectingAssertions, isExpectingAssertionsError } = getState()
     if (expectedAssertionsNumber !== null && assertionCalls !== expectedAssertionsNumber)
-      throw expectedAssertionsNumberError
+      throw expectedAssertionsNumberErrorGen!()
     if (isExpectingAssertions === true && assertionCalls === 0)
       throw isExpectingAssertionsError
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -124,7 +124,6 @@ describe('jest-expect', () => {
       { name: 'Mohammad' },
     ]))
 
-
     expect('Mohammad').toEqual(expect.stringMatching(/Moh/))
     expect('Mohammad').not.toEqual(expect.stringMatching(/jack/))
 
@@ -217,6 +216,25 @@ describe('jest-expect', () => {
     expect(1).toBe(1)
     expect(1).toBe(1)
     expect(1).toBe(1)
+  })
+
+  it('assertions when asynchronous code', async() => {
+    expect.assertions(3)
+    await Promise.all([
+      expect(1).toBe(1),
+      expect(1).toBe(1),
+      expect(1).toBe(1),
+    ])
+  })
+
+  it.fails('assertions when asynchronous code', async() => {
+    // Error: expected number of assertions to be 2, but got 3
+    expect.assertions(2)
+    await Promise.all([
+      expect(1).toBe(1),
+      expect(1).toBe(1),
+      expect(1).toBe(1),
+    ])
   })
 
   it.fails('has assertions', () => {


### PR DESCRIPTION
I find `expect.assertions` error message is inaccurate when it is asynchronous code.

The following example, it will throw a error that message is `Error: expected number of assertions to be 2, but got 0`.

But the accurate message is `Error: expected number of assertions to be 2, but got 3`.

```ts
test('assertions when asynchronous code', async() => {
  expect.assertions(2)
  await Promise.all([
    expect(1).toBe(1),
    expect(1).toBe(1),
    expect(1).toBe(1),
  ])
})
```

> Reproduction: [https://stackblitz.com/edit/node-misjca](https://stackblitz.com/edit/node-misjca)
