### PR TITLE
fix: event target mismatch with global event

### DIFF
--- a/packages/vitest/src/integrations/env/utils.ts
+++ b/packages/vitest/src/integrations/env/utils.ts
@@ -2,6 +2,7 @@ import { KEYS } from './jsdom-keys'
 
 const allowRewrite = new Set([
   'Event',
+  'EventTarget',
 ])
 
 export function getWindowKeys(global: any, win: any) {

--- a/test/core/test/dom.test.ts
+++ b/test/core/test/dom.test.ts
@@ -13,7 +13,7 @@ it('jsdom', () => {
   expect(dom.outerHTML).toEqual('<a href="https://vitest.dev">&lt;Vitest&gt;</a>')
 })
 
-it('doesn\'t throw', () => {
+it('dispatchEvent doesn\'t throw', () => {
   const target = new EventTarget()
   const event = new Event('click')
   expect(() => target.dispatchEvent(event)).not.toThrow()

--- a/test/core/test/dom.test.ts
+++ b/test/core/test/dom.test.ts
@@ -12,3 +12,9 @@ it('jsdom', () => {
 
   expect(dom.outerHTML).toEqual('<a href="https://vitest.dev">&lt;Vitest&gt;</a>')
 })
+
+it('doesn\'t throw', () => {
+  const target = new EventTarget()
+  const event = new Event('click')
+  expect(() => target.dispatchEvent(event)).not.toThrow()
+})


### PR DESCRIPTION
Fixes error when creating custom EventTarget, and calling `dispatchEvent` on it: https://discord.com/channels/917386801235247114/918057998914568213/957344537171345449