### PR TITLE
fix(ui): open in IDE and error styles

### DIFF
--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -28,13 +28,13 @@ const failed = computed(() => props.file?.tasks.filter(i => i.result?.state === 
 
 const widgets: CodeMirror.LineWidget[] = []
 const handles: CodeMirror.LineHandle[] = []
-const listeners: [el: HTMLSpanElement, l: Record<string, EventListener>, t: () => void][] = []
+const listeners: [el: HTMLSpanElement, l: EventListener, t: () => void][] = []
 
 const hasBeenEdited = ref(false)
 
 const clearListeners = () => {
   listeners.forEach(([el, l, t]) => {
-    Object.keys(l).forEach(e => el.removeEventListener(e, l[e]))
+    el.removeEventListener('click', l)
     t()
   })
   listeners.length = 0
@@ -75,20 +75,8 @@ watch([cm, failed], () => {
         const el: EventListener = async() => {
           await openInEditor(stacks[0].file, pos.line, pos.column)
         }
-        const me: EventListener = () => tooltip.show()
-        const mo: EventListener = () => tooltip.hide()
-        span.addEventListener('click', el)
-        span.addEventListener('mouseenter', me)
-        span.addEventListener('mouseout', mo)
         div.appendChild(span)
-        listeners.push([
-          span, {
-            click: el,
-            mouseenter: me,
-            mouseout: mo,
-          },
-          () => destroyTooltip(span),
-        ])
+        listeners.push([span, el, () => destroyTooltip(span)])
         handles.push(cm.value!.addLineClass(pos.line - 1, 'wrap', 'bg-red-500/10'))
         widgets.push(cm.value!.addLineWidget(pos.line - 1, div))
       }

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type CodeMirror from 'codemirror'
-import { useCodeError } from '../../composables/error'
+import { openInEditor } from '../../composables/error'
 import { client } from '~/composables/client'
 import type { File } from '#types'
 
@@ -25,7 +25,60 @@ const editor = ref<any>()
 const cm = computed<CodeMirror.EditorFromTextArea | undefined>(() => editor.value?.cm)
 const failed = computed(() => props.file?.tasks.filter(i => i.result?.state === 'fail') || [])
 
-const { hasBeenEdited } = useCodeError(props, cm, failed)
+const widgets: CodeMirror.LineWidget[] = []
+const handles: CodeMirror.LineHandle[] = []
+const listeners: [el: HTMLSpanElement, l: EventListener][] = []
+
+const hasBeenEdited = ref(false)
+
+const clearListeners = () => {
+  listeners.forEach(([el, l]) => {
+    el.removeEventListener('click', l)
+  })
+  listeners.length = 0
+}
+
+watch([cm, failed], () => {
+  if (!cm.value) {
+    clearListeners()
+    return
+  }
+
+  setTimeout(() => {
+    clearListeners()
+    widgets.forEach(widget => widget.clear())
+    handles.forEach(h => cm.value?.removeLineClass(h, 'wrap'))
+    widgets.length = 0
+    handles.length = 0
+
+    failed.value.forEach((i) => {
+      const e = i.result?.error
+      const stacks = (e?.stacks || []).filter(i => i.file && i.file === props.file?.filepath)
+      if (stacks.length) {
+        const pos = stacks[0].sourcePos || stacks[0]
+        const div = document.createElement('div')
+        div.className = 'op80 flex gap-x-2 items-center'
+        const pre = document.createElement('pre')
+        pre.className = 'c-red-600 dark:c-red-400'
+        pre.textContent = `${' '.repeat(pos.column)}^ ${e?.nameStr}: ${e?.message}`
+        div.appendChild(pre)
+        const span = document.createElement('span')
+        span.className = 'i-carbon-launch text-red-900 hover:cursor-pointer'
+        span.tabIndex = 0
+        span.title = 'Open in IDE'
+        const el: EventListener = async() => {
+          await openInEditor(stacks[0].file, pos.line, pos.column)
+        }
+        listeners.push([span, el])
+        span.addEventListener('click', el)
+        div.appendChild(span)
+        handles.push(cm.value!.addLineClass(pos.line - 1, 'wrap', 'bg-red-500/10'))
+        widgets.push(cm.value!.addLineWidget(pos.line - 1, div))
+      }
+    })
+    if (!hasBeenEdited.value) cm.value?.clearHistory() // Prevent getting access to initial state
+  }, 100)
+}, { flush: 'post' })
 
 async function onSave(content: string) {
   hasBeenEdited.value = true

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -41,9 +41,10 @@ function relative(p: string) {
               <pre> - {{ relative(efile) }}:{{ line }}:{{ column }}</pre>
               <div
                 v-if="shouldOpenInEditor(efile, props.file?.name)"
-                class="i-carbon-launch text-red-900 hover:cursor-pointer"
+                v-tooltip.bottom="'Open in Editor'"
+                class="i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer"
                 tabindex="0"
-                title="Open in IDE"
+                aria-label="Open in Editor"
                 @click.passive="openInEditor(efile, line, column)"
               />
             </div>

--- a/packages/ui/client/composables/error.ts
+++ b/packages/ui/client/composables/error.ts
@@ -1,7 +1,3 @@
-import type { Ref } from 'vue'
-import type CodeMirror from 'codemirror'
-import type { File, Task } from '#types'
-
 export function shouldOpenInEditor(name: string, fileName?: string) {
   return fileName && name.endsWith(fileName)
 }
@@ -9,67 +5,4 @@ export function shouldOpenInEditor(name: string, fileName?: string) {
 export async function openInEditor(name: string, line: number, column: number) {
   const url = encodeURI(`${name}:${line}:${column}`)
   await fetch(`/__open-in-editor?file=${url}`)
-}
-
-export function useCodeError(
-  props: Readonly<{ file?: File | undefined }>,
-  cm: Ref<CodeMirror.EditorFromTextArea | undefined>,
-  failed: Ref<Task[]>,
-) {
-  const widgets: CodeMirror.LineWidget[] = []
-  const handles: CodeMirror.LineHandle[] = []
-  const listeners: [el: HTMLSpanElement, l: EventListenerOrEventListenerObject][] = []
-
-  const hasBeenEdited = ref(false)
-
-  const clearListeners = () => {
-    listeners.forEach(([el, l]) => {
-      el.removeEventListener('click', l)
-    })
-    listeners.length = 0
-  }
-
-  watch([cm, failed], () => {
-    if (!cm.value) {
-      clearListeners()
-      return
-    }
-
-    setTimeout(() => {
-      clearListeners()
-      widgets.forEach(widget => widget.clear())
-      handles.forEach(h => cm.value?.removeLineClass(h, 'wrap'))
-      widgets.length = 0
-      handles.length = 0
-
-      failed.value.forEach((i) => {
-        const e = i.result?.error
-        const stacks = (e?.stacks || []).filter(i => i.file && i.file === props.file?.filepath)
-        if (stacks.length) {
-          const pos = stacks[0].sourcePos || stacks[0]
-          const div = document.createElement('div')
-          div.className = 'op80 flex gap-x-2 items-center'
-          const pre = document.createElement('pre')
-          pre.className = 'c-red-600 dark:c-red-400'
-          pre.textContent = `${' '.repeat(pos.column)}^ ${e?.nameStr}: ${e?.message}`
-          div.appendChild(pre)
-          const span = document.createElement('span')
-          span.className = 'i-carbon-launch text-red-900 hover:cursor-pointer'
-          span.tabIndex = 0
-          span.title = 'Open in IDE'
-          const el: EventListenerOrEventListenerObject = async() => {
-            await openInEditor(stacks[0].file, pos.line, pos.column)
-          }
-          listeners.push([span, el])
-          span.addEventListener('click', el)
-          div.appendChild(span)
-          handles.push(cm.value!.addLineClass(pos.line - 1, 'wrap', 'bg-red-500/10'))
-          widgets.push(cm.value!.addLineWidget(pos.line - 1, div))
-        }
-      })
-      if (!hasBeenEdited.value) cm.value?.clearHistory() // Prevent getting access to initial state
-    }, 100)
-  }, { flush: 'post' })
-
-  return { hasBeenEdited }
 }


### PR DESCRIPTION
Moved the `useCodeError` logic to the `ViewEditor.vue` component from `error.ts` module, we would need to include `@unocss-include` on the `error.ts` module to style the elements created.

Anyway, on stackblitz I cannot make it working (missing links, it seems using oldest version), tested with `0.7.11` and `0.7.12` but still not working, it seems stackblitz doing strange things, for example: `taze` not showing `vitest 0.7.12`, I need to run `taze major`.

![imagen](https://user-images.githubusercontent.com/6311119/160277727-47349eea-8a3c-4597-a1b7-b977224a1b06.png)

The repo I use with `0.7.12` with almost all core tests included: https://stackblitz.com/edit/vitejs-vite-nfjsbi