### PR TITLE
chore: update patak sponsors image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ $ npx vitest
 ### Patak Sponsors
 
 <p align="center">
-  <a href="https://patak.dev/sponsors.svg">
-    <img src='https://patak.dev/sponsors.svg'/>
+  <a href="https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg">
+    <img src='https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg'/>
   </a>
 </p>
 

--- a/docs/src/components/Home.vue
+++ b/docs/src/components/Home.vue
@@ -77,7 +77,7 @@ import { coreTeamMembers } from '../contributors'
       </div>
       <div class="flex flex-col">
         <a text-lg h="32px" href="https://github.com/sponsors/patak-dev" rel="noopener noreferrer">Patak's Sponsors</a>
-        <a href="https://patak.dev/sponsors.svg" target="_blank" rel="noopener noreferrer">
+        <a href="https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg" target="_blank" rel="noopener noreferrer">
           <img
             crossorigin="anonymous"
             width="768" height="722"


### PR DESCRIPTION
Use the same scheme as Anthony: https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg