### PR TITLE
fix: vitest run do not normalize paths on windows x64 platforms

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -403,7 +403,7 @@ export class Vitest {
 
     let testFiles = await fg(this.config.include, globOptions)
 
-    if (filters.length && process.arch === 'win32')
+    if (filters.length && process.platform === 'win32')
       filters = filters.map(f => toNamespacedPath(f))
 
     if (filters.length)


### PR DESCRIPTION
### Description

Close https://github.com/vitest-dev/vitest/issues/1023