### PR TITLE
feat: extend `config.outputFile` to allow objects, close #1068

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -230,9 +230,10 @@ Custom reporters for output. Reporters can be [a Reporter instance](https://gith
 
 ### outputFile
 
-- **Type:** `string`
+- **Type:** `string | Record<string, string>`
 
 Write test results to a file when the `--reporter=json` or `--reporter=junit` option is also specified.
+By providing an object instead of a string you can define individual outputs when using multiple reporters.
 
 ### threads
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -108,7 +108,7 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 | `--silent` | Silent console output from tests |
 | `--isolate` | Isolate environment for each test file (default: `true`) |
 | `--reporter <name>` | Select reporter: `default`, `verbose`, `dot`, `junit` or `json` |
-| `--outputFile <filename>` | Write test results to a file when the `--reporter=json` or `--reporter=junit` option is also specified |
+| `--outputFile <filename/-s>` | Write test results to a file when the `--reporter=json` or `--reporter=junit` option is also specified <br /> Via [cac's dot notation] you can specify individual outputs for multiple reporters |
 | `--coverage` | Use c8 for coverage |
 | `--run` | Do not watch |
 | `--mode` | Override Vite mode (default: `test`) |
@@ -162,3 +162,5 @@ Then go to the project where you are using Vitest and run `pnpm link --global vi
 ## Community
 
 If you have questions or need help, reach out to the community at [Discord](https://chat.vitest.dev) and [GitHub Discussions](https://github.com/vitest-dev/vitest/discussions).
+
+[cac's dot notation]: https://github.com/cacjs/cac#dot-nested-options

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -23,7 +23,7 @@ cli
   .option('--isolate', 'isolate environment for each test file (default: true)')
   .option('--reporter <name>', 'reporter')
   .option('--outputTruncateLength <length>', 'diff output length')
-  .option('--outputFile <filename>', 'write test results to a file when the --reporter=json or --reporter=junit option is also specified')
+  .option('--outputFile <filename/-s>', 'write test results to a file when the --reporter=json or --reporter=junit option is also specified, use cac\'s dot notation for individual outputs of mutliple reporters')
   .option('--coverage', 'use c8 for coverage')
   .option('--run', 'do not watch')
   .option('--mode <name>', 'override Vite mode (default: test)')

--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'pathe'
 import type { Vitest } from '../../node'
 import type { File, Reporter, Suite, TaskState } from '../../types'
 import { getSuites, getTests } from '../../utils'
+import { getOutputFile } from '../../utils/config-helpers'
 
 // for compatibility reasons, the reporter produces a JSON similar to the one produced by the Jest JSON reporter
 // the following types are extracted from the Jest repository (and simplified)
@@ -159,8 +160,10 @@ export class JsonReporter implements Reporter {
    * @param report
    */
   async writeReport(report: string) {
-    if (this.ctx.config.outputFile) {
-      const reportFile = resolve(this.ctx.config.root, this.ctx.config.outputFile)
+    const outputFile = getOutputFile(this.ctx, 'json')
+
+    if (outputFile) {
+      const reportFile = resolve(this.ctx.config.root, outputFile)
 
       const outputDirectory = dirname(reportFile)
       if (!existsSync(outputDirectory))

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -6,8 +6,8 @@ import type { Vitest } from '../../node'
 import type { ErrorWithDiff, Reporter, Task } from '../../types'
 import { parseStacktrace } from '../../utils/source-map'
 import { F_POINTER } from '../../utils/figures'
-import { IndentedLogger } from './renderers/indented-logger'
 import { getOutputFile } from '../../utils/config-helpers'
+import { IndentedLogger } from './renderers/indented-logger'
 
 function flattenTasks(task: Task, baseName = ''): Task[] {
   const base = baseName ? `${baseName} > ` : ''

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -7,6 +7,7 @@ import type { ErrorWithDiff, Reporter, Task } from '../../types'
 import { parseStacktrace } from '../../utils/source-map'
 import { F_POINTER } from '../../utils/figures'
 import { IndentedLogger } from './renderers/indented-logger'
+import { getOutputFile } from '../../utils/config-helpers'
 
 function flattenTasks(task: Task, baseName = ''): Task[] {
   const base = baseName ? `${baseName} > ` : ''
@@ -44,8 +45,10 @@ export class JUnitReporter implements Reporter {
   async onInit(ctx: Vitest): Promise<void> {
     this.ctx = ctx
 
-    if (this.ctx.config.outputFile) {
-      this.reportFile = resolve(this.ctx.config.root, this.ctx.config.outputFile)
+    const outputFile = getOutputFile(this.ctx, 'junit')
+
+    if (outputFile) {
+      this.reportFile = resolve(this.ctx.config.root, outputFile)
 
       const outputDirectory = dirname(this.reportFile)
       if (!existsSync(outputDirectory))

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -139,8 +139,9 @@ export interface InlineConfig {
 
   /**
    * Write test results to a file when the --reporter=json` or `--reporter=junit` option is also specified.
+   * Also definable individually per reporter by using an object instead.
    */
-  outputFile?: string
+  outputFile?: string | (Partial<Record<BuiltinReporters, string>> & Record<string, string>)
 
   /**
    * Enable multi-threading

--- a/packages/vitest/src/utils/config-helpers.ts
+++ b/packages/vitest/src/utils/config-helpers.ts
@@ -1,11 +1,12 @@
 import type { Vitest } from '../node/core'
 import type { BuiltinReporters } from '../node/reporters'
 
-
 export const getOutputFile = ({ config }: Vitest, reporter: BuiltinReporters) => {
-  if (!config.outputFile) return
+  if (!config.outputFile)
+    return
 
-  if (typeof config.outputFile === 'string') return config.outputFile
+  if (typeof config.outputFile === 'string')
+    return config.outputFile
 
   return config.outputFile[reporter]
 }

--- a/packages/vitest/src/utils/config-helpers.ts
+++ b/packages/vitest/src/utils/config-helpers.ts
@@ -1,0 +1,11 @@
+import type { Vitest } from '../node/core'
+import type { BuiltinReporters } from '../node/reporters'
+
+
+export const getOutputFile = ({ config }: Vitest, reporter: BuiltinReporters) => {
+  if (!config.outputFile) return
+
+  if (typeof config.outputFile === 'string') return config.outputFile
+
+  return config.outputFile[reporter]
+}

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -131,7 +131,7 @@ AssertionError: expected 2.23606797749979 to equal 2
 `;
 
 exports[`JUnit reporter with outputFile object 1`] = `
-"JUNIT report written to <process-cwd>/report.xml
+"JUNIT report written to <process-cwd>/report_object.xml
 "
 `;
 
@@ -166,7 +166,7 @@ AssertionError: expected 2.23606797749979 to equal 2
 `;
 
 exports[`JUnit reporter with outputFile object in non-existing directory 1`] = `
-"JUNIT report written to <process-cwd>/junitReportDirectory/deeply/nested/report.xml
+"JUNIT report written to <process-cwd>/junitReportDirectory_object/deeply/nested/report.xml
 "
 `;
 
@@ -647,7 +647,7 @@ exports[`json reporter with outputFile in non-existing directory 2`] = `
 `;
 
 exports[`json reporter with outputFile object 1`] = `
-"JSON report written to <process-cwd>/report.json
+"JSON report written to <process-cwd>/report_object.json
 "
 `;
 
@@ -761,7 +761,7 @@ exports[`json reporter with outputFile object 2`] = `
 `;
 
 exports[`json reporter with outputFile object in non-existing directory 1`] = `
-"JSON report written to <process-cwd>/jsonReportDirectory/deeply/nested/report.json
+"JSON report written to <process-cwd>/jsonReportDirectory_object/deeply/nested/report.json
 "
 `;
 

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -1,5 +1,35 @@
 // Vitest Snapshot v1
 
+exports[`JUnit reporter (no outputFile entry) 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<testsuites>
+    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"8\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"1\\" time=\\"0.1459928420\\">
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.0014422860\\">
+            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+AssertionError: expected 2.23606797749979 to equal 2
+ ❯ vitest/test/core/test/basic.test.ts:8:32
+            </failure>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.0010237110\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\">
+            <skipped/>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.0201848750\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
 exports[`JUnit reporter 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
 <testsuites>
@@ -98,6 +128,185 @@ AssertionError: expected 2.23606797749979 to equal 2
     </testsuite>
 </testsuites>
 "
+`;
+
+exports[`JUnit reporter with outputFile object 1`] = `
+"JUNIT report written to <process-cwd>/report.xml
+"
+`;
+
+exports[`JUnit reporter with outputFile object 2`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<testsuites>
+    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"8\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"1\\" time=\\"0.1459928420\\">
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.0014422860\\">
+            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+AssertionError: expected 2.23606797749979 to equal 2
+ ❯ vitest/test/core/test/basic.test.ts:8:32
+            </failure>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.0010237110\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\">
+            <skipped/>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.0201848750\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
+exports[`JUnit reporter with outputFile object in non-existing directory 1`] = `
+"JUNIT report written to <process-cwd>/junitReportDirectory/deeply/nested/report.xml
+"
+`;
+
+exports[`JUnit reporter with outputFile object in non-existing directory 2`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<testsuites>
+    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"8\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"1\\" time=\\"0.1459928420\\">
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.0014422860\\">
+            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+AssertionError: expected 2.23606797749979 to equal 2
+ ❯ vitest/test/core/test/basic.test.ts:8:32
+            </failure>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.0010237110\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\">
+            <skipped/>
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.0201848750\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
+        </testcase>
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
+exports[`json reporter (no outputFile entry) 1`] = `
+{
+  "numFailedTestSuites": 0,
+  "numFailedTests": 1,
+  "numPassedTestSuites": 3,
+  "numPassedTests": 7,
+  "numPendingTestSuites": 0,
+  "numPendingTests": 0,
+  "numTodoTests": 0,
+  "numTotalTestSuites": 3,
+  "numTotalTests": 8,
+  "startTime": 1642587001759,
+  "success": false,
+  "testResults": [
+    {
+      "assertionResults": [
+        {
+          "ancestorTitles": [
+            "suite",
+            "inner suite",
+          ],
+          "duration": 1.4422860145568848,
+          "failureMessages": [
+            "expected 2.23606797749979 to equal 2",
+          ],
+          "fullName": "suite inner suite Math.sqrt()",
+          "status": "failed",
+          "title": "Math.sqrt()",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "duration": 1.0237109661102295,
+          "failureMessages": [],
+          "fullName": "suite JSON",
+          "status": "passed",
+          "title": "JSON",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "failureMessages": [],
+          "fullName": "suite async with timeout",
+          "status": "skipped",
+          "title": "async with timeout",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "duration": 100.50598406791687,
+          "failureMessages": [],
+          "fullName": "suite timeout",
+          "status": "passed",
+          "title": "timeout",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "duration": 20.184875011444092,
+          "failureMessages": [],
+          "fullName": "suite callback setup success ",
+          "status": "passed",
+          "title": "callback setup success ",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "duration": 0.33245420455932617,
+          "failureMessages": [],
+          "fullName": "suite callback test success ",
+          "status": "passed",
+          "title": "callback test success ",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "duration": 19.738605976104736,
+          "failureMessages": [],
+          "fullName": "suite callback setup success done(false)",
+          "status": "passed",
+          "title": "callback setup success done(false)",
+        },
+        {
+          "ancestorTitles": [
+            "suite",
+          ],
+          "duration": 0.1923508644104004,
+          "failureMessages": [],
+          "fullName": "suite callback test success done(false)",
+          "status": "passed",
+          "title": "callback test success done(false)",
+        },
+      ],
+      "endTime": 1642587001759,
+      "message": "",
+      "name": "/vitest/test/core/test/basic.test.ts",
+      "startTime": 1642587001759,
+      "status": "failed",
+    },
+  ],
+}
 `;
 
 exports[`json reporter 1`] = `
@@ -329,6 +538,234 @@ exports[`json reporter with outputFile in non-existing directory 1`] = `
 `;
 
 exports[`json reporter with outputFile in non-existing directory 2`] = `
+"{
+  \\"numTotalTestSuites\\": 3,
+  \\"numPassedTestSuites\\": 3,
+  \\"numFailedTestSuites\\": 0,
+  \\"numPendingTestSuites\\": 0,
+  \\"numTotalTests\\": 8,
+  \\"numPassedTests\\": 7,
+  \\"numFailedTests\\": 1,
+  \\"numPendingTests\\": 0,
+  \\"numTodoTests\\": 0,
+  \\"startTime\\": 1642587001759,
+  \\"success\\": false,
+  \\"testResults\\": [
+    {
+      \\"assertionResults\\": [
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\",
+            \\"inner suite\\"
+          ],
+          \\"fullName\\": \\"suite inner suite Math.sqrt()\\",
+          \\"status\\": \\"failed\\",
+          \\"title\\": \\"Math.sqrt()\\",
+          \\"duration\\": 1.4422860145568848,
+          \\"failureMessages\\": [
+            \\"expected 2.23606797749979 to equal 2\\"
+          ]
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite JSON\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"JSON\\",
+          \\"duration\\": 1.0237109661102295,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite async with timeout\\",
+          \\"status\\": \\"skipped\\",
+          \\"title\\": \\"async with timeout\\",
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite timeout\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"timeout\\",
+          \\"duration\\": 100.50598406791687,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback setup success \\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback setup success \\",
+          \\"duration\\": 20.184875011444092,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback test success \\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback test success \\",
+          \\"duration\\": 0.33245420455932617,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback setup success done(false)\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback setup success done(false)\\",
+          \\"duration\\": 19.738605976104736,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback test success done(false)\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback test success done(false)\\",
+          \\"duration\\": 0.1923508644104004,
+          \\"failureMessages\\": []
+        }
+      ],
+      \\"startTime\\": 1642587001759,
+      \\"endTime\\": 1642587001759,
+      \\"status\\": \\"failed\\",
+      \\"message\\": \\"\\",
+      \\"name\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    }
+  ]
+}"
+`;
+
+exports[`json reporter with outputFile object 1`] = `
+"JSON report written to <process-cwd>/report.json
+"
+`;
+
+exports[`json reporter with outputFile object 2`] = `
+"{
+  \\"numTotalTestSuites\\": 3,
+  \\"numPassedTestSuites\\": 3,
+  \\"numFailedTestSuites\\": 0,
+  \\"numPendingTestSuites\\": 0,
+  \\"numTotalTests\\": 8,
+  \\"numPassedTests\\": 7,
+  \\"numFailedTests\\": 1,
+  \\"numPendingTests\\": 0,
+  \\"numTodoTests\\": 0,
+  \\"startTime\\": 1642587001759,
+  \\"success\\": false,
+  \\"testResults\\": [
+    {
+      \\"assertionResults\\": [
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\",
+            \\"inner suite\\"
+          ],
+          \\"fullName\\": \\"suite inner suite Math.sqrt()\\",
+          \\"status\\": \\"failed\\",
+          \\"title\\": \\"Math.sqrt()\\",
+          \\"duration\\": 1.4422860145568848,
+          \\"failureMessages\\": [
+            \\"expected 2.23606797749979 to equal 2\\"
+          ]
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite JSON\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"JSON\\",
+          \\"duration\\": 1.0237109661102295,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite async with timeout\\",
+          \\"status\\": \\"skipped\\",
+          \\"title\\": \\"async with timeout\\",
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite timeout\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"timeout\\",
+          \\"duration\\": 100.50598406791687,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback setup success \\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback setup success \\",
+          \\"duration\\": 20.184875011444092,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback test success \\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback test success \\",
+          \\"duration\\": 0.33245420455932617,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback setup success done(false)\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback setup success done(false)\\",
+          \\"duration\\": 19.738605976104736,
+          \\"failureMessages\\": []
+        },
+        {
+          \\"ancestorTitles\\": [
+            \\"suite\\"
+          ],
+          \\"fullName\\": \\"suite callback test success done(false)\\",
+          \\"status\\": \\"passed\\",
+          \\"title\\": \\"callback test success done(false)\\",
+          \\"duration\\": 0.1923508644104004,
+          \\"failureMessages\\": []
+        }
+      ],
+      \\"startTime\\": 1642587001759,
+      \\"endTime\\": 1642587001759,
+      \\"status\\": \\"failed\\",
+      \\"message\\": \\"\\",
+      \\"name\\": \\"/vitest/test/core/test/basic.test.ts\\"
+    }
+  ]
+}"
+`;
+
+exports[`json reporter with outputFile object in non-existing directory 1`] = `
+"JSON report written to <process-cwd>/jsonReportDirectory/deeply/nested/report.json
+"
+`;
+
+exports[`json reporter with outputFile object in non-existing directory 2`] = `
 "{
   \\"numTotalTestSuites\\": 3,
   \\"numPassedTestSuites\\": 3,

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -57,12 +57,60 @@ test('JUnit reporter', async() => {
   expect(context.output).toMatchSnapshot()
 })
 
+test('JUnit reporter (no outputFile entry)', async() => {
+  // Arrange
+  const reporter = new JUnitReporter()
+  const context = getContext()
+  context.vitest.config.outputFile = {}
+
+  vi.mock('os', () => ({
+    hostname: () => 'hostname',
+  }))
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  await reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  expect(context.output).toMatchSnapshot()
+})
+
 test('JUnit reporter with outputFile', async() => {
   // Arrange
   const reporter = new JUnitReporter()
   const outputFile = resolve('report.xml')
   const context = getContext()
   context.vitest.config.outputFile = outputFile
+
+  vi.mock('os', () => ({
+    hostname: () => 'hostname',
+  }))
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  await reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  expect(normalizeCwd(context.output)).toMatchSnapshot()
+  expect(existsSync(outputFile)).toBe(true)
+  expect(readFileSync(outputFile, 'utf8')).toMatchSnapshot()
+
+  // Cleanup
+  rmSync(outputFile)
+})
+
+test('JUnit reporter with outputFile object', async() => {
+  // Arrange
+  const reporter = new JUnitReporter()
+  const outputFile = resolve('report.xml')
+  const context = getContext()
+  context.vitest.config.outputFile = {
+    junit: outputFile,
+  }
 
   vi.mock('os', () => ({
     hostname: () => 'hostname',
@@ -110,10 +158,55 @@ test('JUnit reporter with outputFile in non-existing directory', async() => {
   rmdirSync(rootDirectory, { recursive: true })
 })
 
+test('JUnit reporter with outputFile object in non-existing directory', async() => {
+  // Arrange
+  const reporter = new JUnitReporter()
+  const rootDirectory = resolve('junitReportDirectory')
+  const outputFile = `${rootDirectory}/deeply/nested/report.xml`
+  const context = getContext()
+  context.vitest.config.outputFile = {
+    junit: outputFile
+  }
+
+  vi.mock('os', () => ({
+    hostname: () => 'hostname',
+  }))
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  await reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  expect(normalizeCwd(context.output)).toMatchSnapshot()
+  expect(existsSync(outputFile)).toBe(true)
+  expect(readFileSync(outputFile, 'utf8')).toMatchSnapshot()
+
+  // Cleanup
+  rmdirSync(rootDirectory, { recursive: true })
+})
+
 test('json reporter', async() => {
   // Arrange
   const reporter = new JsonReporter()
   const context = getContext()
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  expect(JSON.parse(context.output)).toMatchSnapshot()
+})
+
+test('json reporter (no outputFile entry)', async() => {
+  // Arrange
+  const reporter = new JsonReporter()
+  const context = getContext()
+  context.vitest.config.outputFile = {}
 
   vi.setSystemTime(1642587001759)
 
@@ -147,6 +240,30 @@ test('json reporter with outputFile', async() => {
   rmSync(outputFile)
 })
 
+test('json reporter with outputFile object', async() => {
+  // Arrange
+  const reporter = new JsonReporter()
+  const outputFile = resolve('report.json')
+  const context = getContext()
+  context.vitest.config.outputFile = {
+    json: outputFile,
+  }
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  expect(normalizeCwd(context.output)).toMatchSnapshot()
+  expect(existsSync(outputFile)).toBe(true)
+  expect(readFileSync(outputFile, 'utf8')).toMatchSnapshot()
+
+  // Cleanup
+  rmSync(outputFile)
+})
+
 test('json reporter with outputFile in non-existing directory', async() => {
   // Arrange
   const reporter = new JsonReporter()
@@ -154,6 +271,31 @@ test('json reporter with outputFile in non-existing directory', async() => {
   const outputFile = `${rootDirectory}/deeply/nested/report.json`
   const context = getContext()
   context.vitest.config.outputFile = outputFile
+
+  vi.setSystemTime(1642587001759)
+
+  // Act
+  reporter.onInit(context.vitest)
+  await reporter.onFinished(files)
+
+  // Assert
+  expect(normalizeCwd(context.output)).toMatchSnapshot()
+  expect(existsSync(outputFile)).toBe(true)
+  expect(readFileSync(outputFile, 'utf8')).toMatchSnapshot()
+
+  // Cleanup
+  rmdirSync(rootDirectory, { recursive: true })
+})
+
+test('json reporter with outputFile object in non-existing directory', async() => {
+  // Arrange
+  const reporter = new JsonReporter()
+  const rootDirectory = resolve('jsonReportDirectory')
+  const outputFile = `${rootDirectory}/deeply/nested/report.json`
+  const context = getContext()
+  context.vitest.config.outputFile = {
+    json: outputFile
+  }
 
   vi.setSystemTime(1642587001759)
 

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -106,7 +106,7 @@ test('JUnit reporter with outputFile', async() => {
 test('JUnit reporter with outputFile object', async() => {
   // Arrange
   const reporter = new JUnitReporter()
-  const outputFile = resolve('report.xml')
+  const outputFile = resolve('report_object.xml')
   const context = getContext()
   context.vitest.config.outputFile = {
     junit: outputFile,
@@ -161,7 +161,7 @@ test('JUnit reporter with outputFile in non-existing directory', async() => {
 test('JUnit reporter with outputFile object in non-existing directory', async() => {
   // Arrange
   const reporter = new JUnitReporter()
-  const rootDirectory = resolve('junitReportDirectory')
+  const rootDirectory = resolve('junitReportDirectory_object')
   const outputFile = `${rootDirectory}/deeply/nested/report.xml`
   const context = getContext()
   context.vitest.config.outputFile = {
@@ -243,7 +243,7 @@ test('json reporter with outputFile', async() => {
 test('json reporter with outputFile object', async() => {
   // Arrange
   const reporter = new JsonReporter()
-  const outputFile = resolve('report.json')
+  const outputFile = resolve('report_object.json')
   const context = getContext()
   context.vitest.config.outputFile = {
     json: outputFile,
@@ -290,7 +290,7 @@ test('json reporter with outputFile in non-existing directory', async() => {
 test('json reporter with outputFile object in non-existing directory', async() => {
   // Arrange
   const reporter = new JsonReporter()
-  const rootDirectory = resolve('jsonReportDirectory')
+  const rootDirectory = resolve('jsonReportDirectory_object')
   const outputFile = `${rootDirectory}/deeply/nested/report.json`
   const context = getContext()
   context.vitest.config.outputFile = {

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -165,7 +165,7 @@ test('JUnit reporter with outputFile object in non-existing directory', async() 
   const outputFile = `${rootDirectory}/deeply/nested/report.xml`
   const context = getContext()
   context.vitest.config.outputFile = {
-    junit: outputFile
+    junit: outputFile,
   }
 
   vi.mock('os', () => ({
@@ -294,7 +294,7 @@ test('json reporter with outputFile object in non-existing directory', async() =
   const outputFile = `${rootDirectory}/deeply/nested/report.json`
   const context = getContext()
   context.vitest.config.outputFile = {
-    json: outputFile
+    json: outputFile,
   }
 
   vi.setSystemTime(1642587001759)


### PR DESCRIPTION
related #1068 