### PR TITLE
chore: don't publish sourcemaps

### DIFF
--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch --watch.include=src/**",
+    "dev": "rollup -c --watch --watch.include=src/** -m inline",
     "prepublishOnly": "nr build",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/vite-node/rollup.config.js
+++ b/packages/vite-node/rollup.config.js
@@ -52,7 +52,6 @@ export default () => [
     output: {
       dir: 'dist',
       format: 'esm',
-      sourcemap: 'inline',
       entryFileNames: '[name].js',
     },
     external,
@@ -64,7 +63,6 @@ export default () => [
     output: {
       dir: 'dist',
       format: 'cjs',
-      sourcemap: 'inline',
       entryFileNames: '[name].cjs',
     },
     external,

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch",
+    "dev": "rollup -c --watch -m inline",
     "prepublishOnly": "nr build"
   },
   "peerDependencies": {

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -61,7 +61,6 @@ export default ({ watch }) => [
     output: {
       dir: 'dist',
       format: 'esm',
-      sourcemap: 'inline',
       chunkFileNames: (chunkInfo) => {
         const id = chunkInfo.facadeModuleId || Object.keys(chunkInfo.modules).find(i => !i.includes('node_modules') && i.includes('src/'))
         if (id) {


### PR DESCRIPTION
Avoid publishing inline sourcemaps to npm, just like Vite