### PR TITLE
feat: add commands to run tests depending on changed files

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -401,3 +401,12 @@ Format options for snapshot testing.
 - **Default:** `test`
 
 Overrides Vite mode.
+
+### changed
+
+- **Type**: `boolean | string`
+- **Default**: false
+
+Run tests only against changed files. If no value is provided, it will run tests against uncomitted changes (includes staged and unstaged).
+
+To run tests against changes made in last commit, you can use `--changed HEAD~1`. You can also pass commit hash or branch name.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -118,6 +118,9 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 | `--environment <env>` | Runner environment (default: `node`) |
 | `--passWithNoTests` | Pass when no tests found |
 | `--allowOnly` | Allow tests and suites that are marked as `only` (default: false in CI, true otherwise) |
+| `--onlyChanged` | Run tests that are affected by the changed files (default: false)
+| `--lastCommit` | Run tests that are affected by files changed in the last commit (default: false)'
+| `--changedSince <commit/branch>` | Run tests that are affected by files changed since commit hash or branch
 | `-h, --help` | Display available CLI options |
 
 ## Examples

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -118,9 +118,7 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 | `--environment <env>` | Runner environment (default: `node`) |
 | `--passWithNoTests` | Pass when no tests found |
 | `--allowOnly` | Allow tests and suites that are marked as `only` (default: false in CI, true otherwise) |
-| `--onlyChanged` | Run tests that are affected by the changed files (default: false)
-| `--lastCommit` | Run tests that are affected by files changed in the last commit (default: false)'
-| `--changedSince <commit/branch>` | Run tests that are affected by files changed since commit hash or branch
+| `--changed [since]` | Run tests that are affected by the changed files (default: false)
 | `-h, --help` | Display available CLI options |
 
 ## Examples

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -33,6 +33,9 @@ cli
   .option('--environment <env>', 'runner environment (default: node)')
   .option('--passWithNoTests', 'pass when no tests found')
   .option('--allowOnly', 'Allow tests and suites that are marked as only (default: !process.env.CI)')
+  .option('--onlyChanged', 'Run tests that are affected by the changed files (default: false)')
+  .option('--lastCommit', 'Run tests that are affected by files changed in the last commit (default: false)')
+  .option('--changedSince <commit>', 'Run tests that are affected by files changed since commit hash or branch')
   .help()
 
 cli

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -33,9 +33,7 @@ cli
   .option('--environment <env>', 'runner environment (default: node)')
   .option('--passWithNoTests', 'pass when no tests found')
   .option('--allowOnly', 'Allow tests and suites that are marked as only (default: !process.env.CI)')
-  .option('--onlyChanged', 'Run tests that are affected by the changed files (default: false)')
-  .option('--lastCommit', 'Run tests that are affected by files changed in the last commit (default: false)')
-  .option('--changedSince <commit>', 'Run tests that are affected by files changed since commit hash or branch')
+  .option('--changed [since]', 'Run tests that are affected by the changed files (default: false)')
   .help()
 
 cli

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -134,10 +134,8 @@ export function resolveConfig(
   if (!resolved.reporters.length)
     resolved.reporters.push('default')
 
-  if (resolved.changedSince || resolved.lastCommit || resolved.onlyChanged) {
-    resolved.onlyChanged = true
-    resolved.passWithNoTests = true
-  }
+  if (resolved.changed)
+    resolved.passWithNoTests ??= true
 
   return resolved
 }

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -134,5 +134,10 @@ export function resolveConfig(
   if (!resolved.reporters.length)
     resolved.reporters.push('default')
 
+  if (resolved.changedSince || resolved.lastCommit || resolved.onlyChanged) {
+    resolved.onlyChanged = true
+    resolved.passWithNoTests = true
+  }
+
   return resolved
 }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -157,17 +157,16 @@ export class Vitest {
   }
 
   async filterTestsBySource(tests: string[]) {
-    if (this.config.onlyChanged && !this.config.related) {
+    if (this.config.changed && !this.config.related) {
       const vitestGit = new VitestGit(this.config.root)
       const related = await vitestGit.findChangedFiles({
-        changedSince: this.config.changedSince,
-        lastCommit: this.config.lastCommit,
+        changedSince: this.config.changed,
       })
       if (!related) {
         this.error(c.red('Could not find Git root. Have you initialized git with `git init`?\n'))
         process.exit(1)
       }
-      this.config.related = related
+      this.config.related = Array.from(new Set(related))
     }
 
     const related = this.config.related

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -158,16 +158,16 @@ export class Vitest {
 
   async filterTestsBySource(tests: string[]) {
     if (this.config.onlyChanged && !this.config.related) {
-      const vitestGit = new VitestGit()
-      const root = await vitestGit.getRoot(this.config.root)
-      if (!root) {
-        this.error(c.red('Could not find Git root. Have you initialized git with `git init`?\n'))
-        process.exit(1)
-      }
-      this.config.related = await vitestGit.findChangedFiles(root, {
+      const vitestGit = new VitestGit(this.config.root)
+      const related = await vitestGit.findChangedFiles({
         changedSince: this.config.changedSince,
         lastCommit: this.config.lastCommit,
       })
+      if (!related) {
+        this.error(c.red('Could not find Git root. Have you initialized git with `git init`?\n'))
+        process.exit(1)
+      }
+      this.config.related = related
     }
 
     const related = this.config.related

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -403,7 +403,7 @@ export class Vitest {
 
     let testFiles = await fg(this.config.include, globOptions)
 
-    if (filters.length && process.arch === 'win32')
+    if (filters.length && process.platform === 'win32')
       filters = filters.map(f => toNamespacedPath(f))
 
     if (filters.length)

--- a/packages/vitest/src/node/git.ts
+++ b/packages/vitest/src/node/git.ts
@@ -1,0 +1,95 @@
+import { resolve } from 'pathe'
+import { execa } from 'execa'
+import type { ExecaReturnValue } from 'execa'
+
+export interface GitOptions {
+  lastCommit?: boolean
+  changedSince?: string
+}
+
+export class VitestGit {
+  private async resolveFilesWithGitCommand(
+    args: string[],
+    cwd: string,
+  ): Promise<string[]> {
+    let result: ExecaReturnValue
+
+    try {
+      result = await execa('git', args, { cwd })
+    }
+    catch (e: any) {
+      e.message = e.stderr
+
+      throw e
+    }
+
+    return result.stdout
+      .split('\n')
+      .filter(s => s !== '')
+      .map(changedPath => resolve(cwd, changedPath))
+  }
+
+  async findChangedFiles(cwd: string, options: GitOptions) {
+    const changedSince = options.changedSince
+
+    if (options && options.lastCommit) {
+      return this.resolveFilesWithGitCommand(
+        ['show', '--name-only', '--pretty=format:', 'HEAD', '--'],
+        cwd,
+      )
+    }
+    if (changedSince) {
+      const [committed, staged, unstaged] = await Promise.all([
+        this.resolveFilesWithGitCommand(
+          ['diff', '--name-only', `${changedSince}...HEAD`, '--'],
+          cwd,
+        ),
+        this.resolveFilesWithGitCommand(
+          ['diff', '--cached', '--name-only', '--'],
+          cwd,
+        ),
+        this.resolveFilesWithGitCommand(
+          [
+            'ls-files',
+            '--other',
+            '--modified',
+            '--exclude-standard',
+            '--',
+          ],
+          cwd,
+        ),
+      ])
+      return [...committed, ...staged, ...unstaged]
+    }
+    const [staged, unstaged] = await Promise.all([
+      this.resolveFilesWithGitCommand(
+        ['diff', '--cached', '--name-only', '--'],
+        cwd,
+      ),
+      this.resolveFilesWithGitCommand(
+        [
+          'ls-files',
+          '--other',
+          '--modified',
+          '--exclude-standard',
+          '--',
+        ],
+        cwd,
+      ),
+    ])
+    return [...staged, ...unstaged]
+  }
+
+  async getRoot(cwd: string) {
+    const options = ['rev-parse', '--show-cdup']
+
+    try {
+      const result = await execa('git', options, { cwd })
+
+      return resolve(cwd, result.stdout)
+    }
+    catch {
+      return null
+    }
+  }
+}

--- a/packages/vitest/src/node/git.ts
+++ b/packages/vitest/src/node/git.ts
@@ -3,8 +3,7 @@ import { execa } from 'execa'
 import type { ExecaReturnValue } from 'execa'
 
 export interface GitOptions {
-  lastCommit?: boolean
-  changedSince?: string
+  changedSince?: string | boolean
 }
 
 export class VitestGit {
@@ -40,11 +39,7 @@ export class VitestGit {
     this.root = root
 
     const changedSince = options.changedSince
-
-    if (options && options.lastCommit)
-      return this.getLastCommitFiles()
-
-    if (changedSince) {
+    if (typeof changedSince === 'string') {
       const [committed, staged, unstaged] = await Promise.all([
         this.getFilesSince(changedSince),
         this.getStagedFiles(),
@@ -61,19 +56,13 @@ export class VitestGit {
 
   private getFilesSince(hash: string) {
     return this.resolveFilesWithGitCommand(
-      ['diff', '--name-only', `${hash}...HEAD`, '--'],
-    )
-  }
-
-  private getLastCommitFiles() {
-    return this.resolveFilesWithGitCommand(
-      ['show', '--name-only', '--pretty=format:', 'HEAD', '--'],
+      ['diff', '--name-only', `${hash}...HEAD`],
     )
   }
 
   private getStagedFiles() {
     return this.resolveFilesWithGitCommand(
-      ['diff', '--cached', '--name-only', '--'],
+      ['diff', '--cached', '--name-only'],
     )
   }
 
@@ -84,7 +73,6 @@ export class VitestGit {
         '--other',
         '--modified',
         '--exclude-standard',
-        '--',
       ],
     )
   }

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -331,24 +331,11 @@ export interface UserConfig extends InlineConfig {
   mode?: string
 
   /**
-   * Runs tests that are affected by the changes in the repository
+   * Runs tests that are affected by the changes in the repository, or between specified branch or commit hash
    * Requires initialized git repository
    * @default false
    */
-  onlyChanged?: boolean
-
-  /**
-   * Runs tests that are affected by the changes in the last commit
-   * Requires initialized git repository
-   * @default false
-   */
-  lastCommit?: boolean
-
-  /**
-   * Runs tests that are affected by the changes between the specified branch or commit hash
-   * Requires initialized git repository
-   */
-  changedSince?: string
+  changed?: boolean | string
 }
 
 export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters'> {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -329,6 +329,26 @@ export interface UserConfig extends InlineConfig {
    * @default 'test'
    */
   mode?: string
+
+  /**
+   * Runs tests that are affected by the changes in the repository
+   * Requires initialized git repository
+   * @default false
+   */
+  onlyChanged?: boolean
+
+  /**
+   * Runs tests that are affected by the changes in the last commit
+   * Requires initialized git repository
+   * @default false
+   */
+  lastCommit?: boolean
+
+  /**
+   * Runs tests that are affected by the changes since the specified branch or commit hash
+   * Requires initialized git repository
+   */
+  changedSince?: string
 }
 
 export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters'> {


### PR DESCRIPTION
The code for getting files is based on jest implementation, but some of it was removed. Not sure how it will be working, if root and git is not the same? If someone can test in a monorepo, that would be cool. I am ashamed to admit, I am not familiar enough with git terminal commands 👀 

I was testing in in `tests/core` by changing code in `/src` and it worked fine. So i guess the solution should work for most people, using git.

I am getting the changed files and putting it into `related` array. Then the logic for related kicks in, and it tries to find tests based on related files. I have a guard `if (!related) { // find related }` in case `runTests` runs twice (bc of watch mode or else)