### PR TITLE
feat: less verbose CI output by default

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -63,8 +63,13 @@ export abstract class BaseReporter implements Reporter {
       return
     for (const pack of packs) {
       const task = this.ctx.state.idMap.get(pack[0])
-      if (task && task.type === 'test' && task.result?.state && task.result?.state !== 'run') {
-        this.ctx.log(` ${getStateSymbol(task)} ${getFullName(task)}`)
+      if (task && 'filepath' in task && task.result?.state && task.result?.state !== 'run') {
+        const count = getTests(task).length
+        let suffix = c.dim(` (${getTests(task).length} test${count > 1 ? 's' : ''})`)
+        if (task.result.duration)
+          suffix += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
+
+        this.ctx.log(` ${getStateSymbol(task)} ${task.name} ${suffix}`)
         if (task.result.state === 'fail')
           this.ctx.log(c.red(`   ${F_RIGHT} ${(task.result.error as any)?.message}`))
       }

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -64,14 +64,21 @@ export abstract class BaseReporter implements Reporter {
     for (const pack of packs) {
       const task = this.ctx.state.idMap.get(pack[0])
       if (task && 'filepath' in task && task.result?.state && task.result?.state !== 'run') {
-        const count = getTests(task).length
+        const tests = getTests(task)
+        const count = tests.length
         let suffix = c.dim(` (${getTests(task).length} test${count > 1 ? 's' : ''})`)
         if (task.result.duration)
           suffix += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
 
         this.ctx.log(` ${getStateSymbol(task)} ${task.name} ${suffix}`)
-        if (task.result.state === 'fail')
-          this.ctx.log(c.red(`   ${F_RIGHT} ${(task.result.error as any)?.message}`))
+
+        // print short errors, full errors will be at the end in summary
+        if (task.result.state === 'fail') {
+          for (const test of tests) {
+            if (test.result?.state === 'fail')
+              this.ctx.log(c.red(`   ${F_RIGHT} ${(test.result.error as any)?.message}`))
+          }
+        }
       }
     }
   }

--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -1,8 +1,26 @@
+import c from 'picocolors'
+import type { TaskResultPack } from '../../types'
+import { getFullName } from '../../utils'
+import { F_RIGHT } from '../../utils/figures'
 import { DefaultReporter } from './default'
+import { getStateSymbol } from './renderers/utils'
 
 export class VerboseReporter extends DefaultReporter {
   constructor() {
     super()
     this.rendererOptions.renderSucceed = true
+  }
+
+  onTaskUpdate(packs: TaskResultPack[]) {
+    if (this.isTTY)
+      return
+    for (const pack of packs) {
+      const task = this.ctx.state.idMap.get(pack[0])
+      if (task && task.type === 'test' && task.result?.state && task.result?.state !== 'run') {
+        this.ctx.log(` ${getStateSymbol(task)} ${getFullName(task)}`)
+        if (task.result.state === 'fail')
+          this.ctx.log(c.red(`   ${F_RIGHT} ${(task.result.error as any)?.message}`))
+      }
+    }
   }
 }


### PR DESCRIPTION
<img width="651" alt="Снимок экрана 2022-04-03 в 14 19 56" src="https://user-images.githubusercontent.com/16173870/161425389-2cc4f34f-d252-4291-8059-009dcdf5cd47.png">

Closes #905 

Moved current implementation to `verbose` reporter. Now reporter only prints test files