### PR TITLE
fix(logs): collect logs per test

### DIFF
--- a/packages/ui/client/auto-imports.d.ts
+++ b/packages/ui/client/auto-imports.d.ts
@@ -86,6 +86,7 @@ declare global {
   const toRef: typeof import('vue')['toRef']
   const toRefs: typeof import('vue')['toRefs']
   const triggerRef: typeof import('vue')['triggerRef']
+  const tryOnBeforeMount: typeof import('@vueuse/core')['tryOnBeforeMount']
   const tryOnBeforeUnmount: typeof import('@vueuse/core')['tryOnBeforeUnmount']
   const tryOnMounted: typeof import('@vueuse/core')['tryOnMounted']
   const tryOnScopeDispose: typeof import('@vueuse/core')['tryOnScopeDispose']

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -29,6 +29,9 @@ const open = () => {
 const changeViewMode = (view: Params['view']) => {
   viewMode.value = view
 }
+const count = computed(() => {
+  return currentLogs.value?.map(l => l.size).reduce((s, a) => s + a, 0) ?? 0
+})
 </script>
 
 <template>
@@ -72,10 +75,10 @@ const changeViewMode = (view: Params['view']) => {
         </button>
         <button
           tab-button
-          :class="{ 'tab-button-active': viewMode === 'console', 'op20': viewMode !== 'console' && currentLogs?.length === 0 }"
+          :class="{ 'tab-button-active': viewMode === 'console', 'op20': viewMode !== 'console' && count === 0 }"
           @click="changeViewMode('console')"
         >
-          Console ({{ currentLogs?.length || 0 }})
+          Console ({{ count }})
         </button>
       </div>
     </div>

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -30,7 +30,7 @@ const changeViewMode = (view: Params['view']) => {
   viewMode.value = view
 }
 const consoleCount = computed(() => {
-  return currentLogs.value?.map(l => l.size).reduce((s, a) => s + a, 0) ?? 0
+  return currentLogs.value?.reduce((s, { size }) => s + size, 0) ?? 0
 })
 </script>
 

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -29,7 +29,7 @@ const open = () => {
 const changeViewMode = (view: Params['view']) => {
   viewMode.value = view
 }
-const count = computed(() => {
+const consoleCount = computed(() => {
   return currentLogs.value?.map(l => l.size).reduce((s, a) => s + a, 0) ?? 0
 })
 </script>
@@ -75,10 +75,10 @@ const count = computed(() => {
         </button>
         <button
           tab-button
-          :class="{ 'tab-button-active': viewMode === 'console', 'op20': viewMode !== 'console' && count === 0 }"
+          :class="{ 'tab-button-active': viewMode === 'console', 'op20': viewMode !== 'console' && consoleCount === 0 }"
           @click="changeViewMode('console')"
         >
-          Console ({{ count }})
+          Console ({{ consoleCount }})
         </button>
       </div>
     </div>

--- a/packages/vitest/src/runtime/setup.ts
+++ b/packages/vitest/src/runtime/setup.ts
@@ -61,7 +61,7 @@ export function setupConsoleLogSpy() {
   function sendStdout(taskId: string) {
     const buffer = stdoutBuffer.get(taskId)
     if (buffer) {
-      const timer = timers.get(taskId!)!
+      const timer = timers.get(taskId)!
       rpc().onUserConsoleLog({
         type: 'stdout',
         content: buffer.map(i => String(i)).join(''),
@@ -75,7 +75,7 @@ export function setupConsoleLogSpy() {
   function sendStderr(taskId: string) {
     const buffer = stderrBuffer.get(taskId)
     if (buffer) {
-      const timer = timers.get(taskId!)!
+      const timer = timers.get(taskId)!
       rpc().onUserConsoleLog({
         type: 'stderr',
         content: buffer.map(i => String(i)).join(''),

--- a/packages/vitest/src/runtime/setup.ts
+++ b/packages/vitest/src/runtime/setup.ts
@@ -68,7 +68,7 @@ export function setupConsoleLogSpy() {
         taskId,
         time: timer.stdoutTime || RealDate.now(),
       })
-      stdoutBuffer.set(taskId!, [])
+      stdoutBuffer.set(taskId, [])
       timer.stdoutTime = 0
     }
   }
@@ -82,7 +82,7 @@ export function setupConsoleLogSpy() {
         taskId,
         time: timer.stderrTime || RealDate.now(),
       })
-      stderrBuffer.set(taskId!, [])
+      stderrBuffer.set(taskId, [])
       timer.stderrTime = 0
     }
   }

--- a/packages/vitest/src/runtime/setup.ts
+++ b/packages/vitest/src/runtime/setup.ts
@@ -94,11 +94,13 @@ export function setupConsoleLogSpy() {
     write(data, encoding, callback) {
       const id = getWorkerState()?.current?.id ?? unknownTestId
       let timer = timers.get(id)
-      if (!timer) {
+      if (timer) {
+        timer.stdoutTime = timer.stdoutTime || RealDate.now()
+      }
+      else {
         timer = { stdoutTime: RealDate.now(), stderrTime: RealDate.now(), timer: 0 }
         timers.set(id, timer)
       }
-      timer.stdoutTime = timer.stdoutTime || RealDate.now()
       let buffer = stdoutBuffer.get(id)
       if (!buffer) {
         buffer = []
@@ -113,11 +115,13 @@ export function setupConsoleLogSpy() {
     write(data, encoding, callback) {
       const id = getWorkerState()?.current?.id ?? unknownTestId
       let timer = timers.get(id)
-      if (!timer) {
-        timer = { stdoutTime: RealDate.now(), stderrTime: RealDate.now(), timer: 0 }
+      if (timer) {
+        timer.stderrTime = timer.stderrTime || RealDate.now()
+      }
+      else {
+        timer = { stderrTime: RealDate.now(), stdoutTime: RealDate.now(), timer: 0 }
         timers.set(id, timer)
       }
-      timer.stderrTime = timer.stderrTime || RealDate.now()
       let buffer = stderrBuffer.get(id)
       if (!buffer) {
         buffer = []

--- a/packages/vitest/src/runtime/setup.ts
+++ b/packages/vitest/src/runtime/setup.ts
@@ -67,6 +67,7 @@ export function setupConsoleLogSpy() {
         content: buffer.map(i => String(i)).join(''),
         taskId,
         time: timer.stdoutTime || RealDate.now(),
+        size: buffer.length,
       })
       stdoutBuffer.set(taskId, [])
       timer.stdoutTime = 0
@@ -81,6 +82,7 @@ export function setupConsoleLogSpy() {
         content: buffer.map(i => String(i)).join(''),
         taskId,
         time: timer.stderrTime || RealDate.now(),
+        size: buffer.length,
       })
       stderrBuffer.set(taskId, [])
       timer.stderrTime = 0

--- a/packages/vitest/src/runtime/setup.ts
+++ b/packages/vitest/src/runtime/setup.ts
@@ -41,6 +41,7 @@ export function setupConsoleLogSpy() {
   const stdoutBuffer = new Map<string, any[]>()
   const stderrBuffer = new Map<string, any[]>()
   const timers = new Map<string, { stdoutTime: number; stderrTime: number; timer: any }>()
+  const unknownTestId = '__vitest__unknown_test__'
 
   // group sync console.log calls with macro task
   function schedule(taskId: string) {
@@ -91,7 +92,7 @@ export function setupConsoleLogSpy() {
 
   const stdout = new Writable({
     write(data, encoding, callback) {
-      const id = getWorkerState()?.current?.id ?? '__unknown_test__'
+      const id = getWorkerState()?.current?.id ?? unknownTestId
       let timer = timers.get(id)
       if (!timer) {
         timer = { stdoutTime: RealDate.now(), stderrTime: RealDate.now(), timer: 0 }
@@ -110,7 +111,7 @@ export function setupConsoleLogSpy() {
   })
   const stderr = new Writable({
     write(data, encoding, callback) {
-      const id = getWorkerState()?.current?.id ?? '__unknown_test__'
+      const id = getWorkerState()?.current?.id ?? unknownTestId
       let timer = timers.get(id)
       if (!timer) {
         timer = { stdoutTime: RealDate.now(), stderrTime: RealDate.now(), timer: 0 }

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -44,6 +44,7 @@ export interface UserConsoleLog {
   type: 'stdout' | 'stderr'
   taskId?: string
   time: number
+  size: number
 }
 
 export interface Position {


### PR DESCRIPTION
For context: 

The log spy currently uses a single buffer to collect all the logs from all the tests, when sending the logs to the reporters, there is no way of knowing which tests each of the logs correspond to, so as soon as are sent, all the logs that are collected in the corresponding tick are shown as corresponding to the current test:

![imagen](https://user-images.githubusercontent.com/6311119/161572204-6fc25f2e-8491-4211-95ac-9598c4d63e8e.png)

This PR also separates the timers by tests, since otherwise we can lose logs:

![imagen](https://user-images.githubusercontent.com/6311119/161571965-5e4050ce-48d5-431d-b50b-3e907d34cc0e.png)

PR #1086 by @sheremet-va fixed the identifier of the test to which the collected logs belong, but when they are sent we still have the problem that all the ones in the buffer are sent, so the logs of other tests will be included under the running test at tick.

This PR includes the current logic but separated by test, so that the logs are collected and included in their own buffer and thus, when sent to the reporters the logs are shown where they belong:

![imagen](https://user-images.githubusercontent.com/6311119/161572490-452385e1-1c83-4510-844f-869db9e3011e.png)

and for ui (the tab title on console should be 4, fixed also in this PR):

![imagen](https://user-images.githubusercontent.com/6311119/161572701-cc3dd152-e051-4693-a4b4-62e7d8e0eeb2.png)
