### PR TITLE
fix(vite-node): remove unsafe checks for inlining dependencies

### DIFF
--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -9,8 +9,6 @@ const ESM_FOLDER_RE = /\/esm\/(.*\.js)$/
 const defaultInline = [
   /virtual:/,
   /\.ts$/,
-  ESM_EXT_RE,
-  ESM_FOLDER_RE,
 ]
 
 const depsExternal = [


### PR DESCRIPTION
Fixes #1096

We don't need to inline based on the filename alone anymore, since we use `isValidNodeImport` anyway, which is more accurate.