### PR TITLE
fix: don't reexport vi utils from vitest 

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -7,7 +7,7 @@ export * from './runtime/hooks'
 
 export { runOnce, isFirstRun } from './integrations/run-once'
 export * from './integrations/chai'
-export * from './integrations/spy'
+export type { EnhancedSpy, SpyInstance, SpyInstanceFn, SpyContext } from './integrations/spy'
 export * from './integrations/vi'
 export * from './integrations/utils'
 

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -201,7 +201,7 @@ class VitestUtils {
    * using jsdom/happy-dom and want to mock global variables, like
    * `IntersectionObserver`.
    */
-  public stubGlobal(name: string, value: any) {
+  public stubGlobal(name: string | symbol | number, value: any) {
     // @ts-expect-error we can do anything!
     globalThis[name] = value
     if (globalThis.window)


### PR DESCRIPTION
Closes #1092