### PR TITLE
fix(ui): disabled icon buttons + codemirror scrolls + minor addons

### DIFF
--- a/packages/ui/client/components/CodeMirror.vue
+++ b/packages/ui/client/components/CodeMirror.vue
@@ -60,7 +60,7 @@ onMounted(async() => {
     relative
     font-mono
     text-sm
-    class="scrolls"
+    class="codemirror-scrolls"
   >
     <textarea ref="el" />
   </div>

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -45,13 +45,14 @@ const consoleCount = computed(() => {
         <div class="flex text-lg">
           <IconButton
             v-tooltip.bottom="'Open in editor'"
+            title="Open in editor"
             icon="i-carbon-launch"
             :disabled="!current?.filepath"
             @click="open"
           />
         </div>
       </div>
-      <div flex="~" items-center bg-header border="b-2 base" text-sm h-38px>
+      <div flex="~" items-center bg-header border="b-2 base" text-sm h-41px>
         <button
           tab-button
           :class="{ 'tab-button-active': viewMode == null }"

--- a/packages/ui/client/components/IconButton.vue
+++ b/packages/ui/client/components/IconButton.vue
@@ -8,6 +8,7 @@ defineProps<{ icon?: `i-${string}` | `dark:i-${string}`; title?: string; disable
     role="button"
     :opacity="disabled ? 10 : 70"
     rounded
+    :disabled="disabled"
     :hover="disabled ? '' : 'bg-active op100'"
     class="w-1.4em h-1.4em flex"
   >

--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -22,7 +22,7 @@ const toggleMode = computed(() => isDark.value ? 'light' : 'dark')
 <template>
   <TasksList border="r base" :tasks="files" :on-item-click="onItemClick" :group-by-type="true" @run="runAll">
     <template #header="{ filteredTests }">
-      <img w-6 h-6 src="/favicon.svg">
+      <img w-6 h-6 src="/favicon.svg" alt="Vitest logo">
       <span font-light text-sm flex-1>Vitest</span>
       <div class="flex text-lg">
         <IconButton

--- a/packages/ui/client/components/TasksList.vue
+++ b/packages/ui/client/components/TasksList.vue
@@ -22,6 +22,7 @@ const emit = defineEmits<{
 }>()
 
 const search = ref('')
+const searchBox = ref<HTMLInputElement | undefined>()
 const isFiltered = computed(() => search.value.trim() !== '')
 
 const matchTasks = (tasks: Task[], search: string): boolean => {
@@ -63,6 +64,14 @@ const running = computed(() => filtered.value.filter(task =>
   && !skipped.value.includes(task),
 ))
 const throttledRunning = useThrottle(running, 250)
+
+const clearSearch = (focus: boolean) => {
+  search.value = ''
+  focus && searchBox.value?.focus()
+}
+const disableClearSearch = computed(() => {
+  return search.value === ''
+})
 </script>
 
 <script lang="ts">
@@ -78,14 +87,15 @@ export default {
         <slot name="header" :filteredTests="isFiltered ? filteredTests : undefined" />
       </div>
       <div
-        p="x3 y2"
+        p="l3 y2 r2"
         flex="~ gap-2"
         items-center
         bg-header
         border="b-2 base"
       >
-        <div i-carbon:search flex-shrink-0 />
+        <div class="i-carbon:search" flex-shrink-0 />
         <input
+          ref="searchBox"
           v-model="search"
           placeholder="Search..."
           outline="none"
@@ -95,9 +105,16 @@ export default {
           flex-1
           pl-1
           :op="search.length ? '100' : '50'"
-          @keydown.esc="search = ''"
+          @keydown.esc="clearSearch(false)"
           @keydown.enter="emit('run', isFiltered ? filteredTests : undefined)"
         >
+        <IconButton
+          v-tooltip.bottom="'Clear search'"
+          :disabled="disableClearSearch"
+          title="Clear search"
+          icon="i-carbon:filter-remove"
+          @click.passive="clearSearch(true)"
+        />
       </div>
     </div>
 
@@ -153,7 +170,7 @@ export default {
         </DetailsPanel>
         <DetailsPanel v-if="skipped.length">
           <template #summary>
-            <div text-purple5:50>
+            <div class="text-purple5:50">
               SKIP ({{ skipped.length }})
             </div>
           </template>
@@ -194,7 +211,7 @@ export default {
             border="~ gray-400/50 rounded"
             p="x2 y0.5"
             m="t2"
-            @click="search = ''"
+            @click.passive="clearSearch(true)"
           >
             Clear
           </button>

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -40,6 +40,10 @@ const clearListeners = () => {
   listeners.length = 0
 }
 
+useResizeObserver(editor, () => {
+  cm.value?.refresh()
+})
+
 watch([cm, failed], () => {
   if (!cm.value) {
     clearListeners()
@@ -65,7 +69,7 @@ watch([cm, failed], () => {
         pre.textContent = `${' '.repeat(pos.column)}^ ${e?.nameStr}: ${e?.message}`
         div.appendChild(pre)
         const span = document.createElement('span')
-        span.className = 'i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer'
+        span.className = 'i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer min-w-1em min-h-1em'
         span.tabIndex = 0
         span.ariaLabel = 'Open in Editor'
         const tooltip = createTooltip(span, {

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -43,7 +43,7 @@ function relative(p: string) {
               <div
                 v-if="shouldOpenInEditor(efile, props.file?.name)"
                 v-tooltip.bottom="'Open in Editor'"
-                class="i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer"
+                class="i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer min-w-1em min-h-1em"
                 tabindex="0"
                 aria-label="Open in Editor"
                 @click.passive="openInEditor(efile, line, column)"

--- a/packages/ui/client/composables/codemirror.ts
+++ b/packages/ui/client/composables/codemirror.ts
@@ -7,6 +7,8 @@ import 'codemirror/mode/xml/xml'
 // import 'codemirror/mode/htmlmixed/htmlmixed'
 import 'codemirror/mode/jsx/jsx'
 import 'codemirror/addon/display/placeholder'
+import 'codemirror/addon/scroll/simplescrollbars'
+import 'codemirror/addon/scroll/simplescrollbars.css'
 
 export function useCodeMirror(
   textarea: Ref<HTMLTextAreaElement | null | undefined>,
@@ -18,6 +20,7 @@ export function useCodeMirror(
     {
       theme: 'vars',
       ...options,
+      scrollbarStyle: 'simple',
     },
   )
 

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -113,13 +113,13 @@ html.dark {
 
 .splitpanes--vertical > .splitpanes__splitter:before {
   /* make vertical scroll usable */
-  left: -10px;
+  left: 0;
   right: -10px;
   height: 100%;
 }
 
 .splitpanes--horizontal > .splitpanes__splitter:before {
-  top: -10px;
+  top: 0;
   bottom: -10px;
   width: 100%;
 }
@@ -128,34 +128,33 @@ html.dark {
   transition: none !important;
   height: 100%;
 }
+
+/* CODEMIRROR SCROLLS */
 .CodeMirror-scroll::-webkit-scrollbar,
-.scrolls::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+.codemirror-scrolls::-webkit-scrollbar {
+  display: none;
 }
-.CodeMirror-scroll,
-.scrolls {
+.codemirror-scrolls {
   overflow: auto !important;
   scrollbar-width: thin;
   scrollbar-color: var(--cm-ttc-c-thumb) var(--cm-ttc-c-track);
 }
-.CodeMirror-scroll::-webkit-scrollbar-track,
-.scrolls::-webkit-scrollbar-track {
-  background: var(--cm-ttc-c-track);
+/* the horizontal/vertical background */
+.CodeMirror-simplescroll-horizontal,
+.CodeMirror-simplescroll-vertical {
+  background-color: var(--cm-ttc-c-track) !important;
+  border: none !important;
 }
-.CodeMirror-scroll::-webkit-scrollbar-thumb,
-.scrolls::-webkit-scrollbar-thumb {
-  background-color: var(--cm-ttc-c-thumb);
-  border: 2px solid var(--cm-ttc-c-thumb);
+/* the horizontal/vertical bubble background */
+.CodeMirror-simplescroll-horizontal div,
+.CodeMirror-simplescroll-vertical div {
+  background-color: var(--cm-ttc-c-thumb) !important;
+  border: none !important;
 }
-.CodeMirror-scroll::-webkit-scrollbar-thumb,
-.scrolls::-webkit-scrollbar-thumb,
-.scrolls-rounded::-webkit-scrollbar-track {
-  border-radius: 3px;
-}
-.CodeMirror-scroll::-webkit-scrollbar-corner,
-.scrolls::-webkit-scrollbar-corner {
-  background-color: var(--cm-ttc-c-track);
+/* the right bottom corner background*/
+.CodeMirror-scrollbar-filler,
+.CodeMirror-gutter-filler {
+  background-color: var(--cm-ttc-c-track) !important;
 }
 .CodeMirror {
   overflow: unset !important;
@@ -169,9 +168,33 @@ html.dark {
   margin-right: unset !important;
   padding-bottom: unset !important;
 }
-.CodeMirror-sizer {
-  border-right: none;
+/* END CODEMIRROR SCROLLS */
+
+/* SCROLLS */
+.scrolls::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
 }
+.scrolls {
+  overflow: auto !important;
+  scrollbar-width: thin;
+  scrollbar-color: var(--cm-ttc-c-thumb) var(--cm-ttc-c-track);
+}
+.scrolls::-webkit-scrollbar-track {
+  background: var(--cm-ttc-c-track);
+}
+.scrolls::-webkit-scrollbar-thumb {
+  background-color: var(--cm-ttc-c-thumb);
+  border: 2px solid var(--cm-ttc-c-thumb);
+}
+.scrolls::-webkit-scrollbar-thumb,
+.scrolls-rounded::-webkit-scrollbar-track {
+  border-radius: 3px;
+}
+.scrolls::-webkit-scrollbar-corner {
+  background-color: var(--cm-ttc-c-track);
+}
+/* END SCROLLS */
 
 .v-popper__popper .v-popper__inner {
   font-size: 12px;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,6 +76,7 @@
         "birpc",
         "codemirror",
         "codemirror/addon/display/placeholder",
+        "codemirror/addon/scroll/simplescrollbars",
         "codemirror/mode/javascript/javascript",
         "codemirror/mode/jsx/jsx",
         "codemirror/mode/xml/xml",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,7 +437,7 @@ importers:
       solid-js: 1.3.13
     devDependencies:
       jsdom: 19.0.0
-      solid-start: 0.1.0-alpha.73_solid-js@1.3.13+vite@2.8.6
+      solid-start: 0.1.0-alpha.74_solid-js@1.3.13+vite@2.8.6
       solid-testing-library: 0.3.0_solid-js@1.3.13
       vitest: link:../../packages/vitest
 
@@ -7117,6 +7117,10 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /@types/which/2.0.1:
+    resolution: {integrity: sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==}
+    dev: true
+
   /@types/ws/8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
@@ -9064,6 +9068,11 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /chalk/5.0.1:
+    resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
   /character-entities-legacy/1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
     dev: true
@@ -10629,15 +10638,6 @@ packages:
     resolution: {integrity: sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==}
     dev: true
 
-  /esbuild-android-64/0.14.28:
-    resolution: {integrity: sha512-A52C3zq+9tNwCqZ+4kVLBxnk/WnrYM8P2+QNvNE9B6d2OVPs214lp3g6UyO+dKDhUdefhfPCuwkP8j2A/+szNA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-android-64/0.14.30:
     resolution: {integrity: sha512-vdJ7t8A8msPfKpYUGUV/KaTQRiZ0vDa2XSTlzXVkGGVHLKPeb85PBUtYJcEgw3htW3IdX5i1t1IMdQCwJJgNAg==}
     engines: {node: '>=12'}
@@ -10661,15 +10661,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /esbuild-android-arm64/0.14.28:
-    resolution: {integrity: sha512-sm0fDEGElZhMC3HLZeECI2juE4aG7uPfMBMqNUhy9CeX399Pz8rC6e78OXMXInGjSdEAwQmCOHmfsP7uv3Q8rA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-android-arm64/0.14.30:
@@ -10705,15 +10696,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-darwin-64/0.14.28:
-    resolution: {integrity: sha512-nzDd7mQ44FvsFHtOafZdBgn3Li5SMsnMnoz1J2MM37xJmR3wGNTFph88KypjHgWqwbxCI7MXS1U+sN4qDeeW6Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-darwin-64/0.14.30:
     resolution: {integrity: sha512-VRaOXMMrsG5n53pl4qFZQdXy2+E0NoLP/QH3aDUI0+bQP+ZHDmbINKcDy2IX7GVFI9kqPS18iJNAs5a6/G2LZg==}
     engines: {node: '>=12'}
@@ -10745,15 +10727,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /esbuild-darwin-arm64/0.14.28:
-    resolution: {integrity: sha512-XEq/bLR/glsUl+uGrBimQzOVs/CmwI833fXUhP9xrLI3IJ+rKyrZ5IA8u+1crOEf1LoTn8tV+hInmX6rGjbScw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.14.30:
@@ -10789,15 +10762,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-freebsd-64/0.14.28:
-    resolution: {integrity: sha512-rTKLgUj/HEcPeE5XZ7IZwWpFx7IWMfprN7QRk/TUJE1s1Ipb58esboIesUpjirJz/BwrgHq+FDG9ChAI8dZAtQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-freebsd-64/0.14.30:
     resolution: {integrity: sha512-mec1jENcImVVagddZlGWsdAUwBnzR5cgnhzCxv+9fSMxKbx1uZYLLUAnLPp8m/i934zrumR1xGjJ5VoWdPlI2w==}
     engines: {node: '>=12'}
@@ -10829,15 +10793,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    optional: true
-
-  /esbuild-freebsd-arm64/0.14.28:
-    resolution: {integrity: sha512-sBffxD1UMOsB7aWMoExmipycjcy3HJGwmqE4GQZUTZvdiH4GhjgUiVdtPyt7kSCdL40JqnWQJ4b1l8Y51oCF4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.14.30:
@@ -10873,15 +10828,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-32/0.14.28:
-    resolution: {integrity: sha512-+Wxidh3fBEQ9kHcCsD4etlBTMb1n6QY2uXv3rFhVn88CY/JP782MhA57/ipLMY4kOLeSKEuFGN4rtjHuhmRMig==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-32/0.14.30:
     resolution: {integrity: sha512-liIONVT4F2kZmOMwtwASqZ8WkIjb5HHBR9HUffdHiuotSTF3CyZO+EJf+Og+SYYuuVIvt0qHNSFjBA/iSESteQ==}
     engines: {node: '>=12'}
@@ -10913,15 +10859,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-64/0.14.28:
-    resolution: {integrity: sha512-7+xgsC4LvR6cnzaBdiljNnPDjbkwzahogN+S9uy9AoYw7ZjPnnXc6sjQAVCbqGb7MEgrWdpa6u/Tao79i4lWxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-64/0.14.30:
@@ -10957,15 +10894,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-arm/0.14.28:
-    resolution: {integrity: sha512-L5isjmlLbh9E0WVllXiVETbScgMbth/+XkXQii1WwgO1RvLIfaGrVFz8d2n6EH/ImtgYxPYGx+OcvIKQBc91Rg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-arm/0.14.30:
     resolution: {integrity: sha512-97T+bbXnpqf7mfIG49UR7ZSJFGgvc22byn74qw3Kx2GDCBSQoVFjyWuKOHGXp8nXk3XYrdFF+mQ8yQ7aNsgQvg==}
     engines: {node: '>=12'}
@@ -10997,15 +10925,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-arm64/0.14.28:
-    resolution: {integrity: sha512-EjRHgwg+kgXABzyoPGPOPg4d5wZqRnZ/ZAxBDzLY+i6DS8OUfTSlZHWIOZzU4XF7125WxRBg9ULbrFJBl+57Eg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.14.30:
@@ -11041,15 +10960,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-mips64le/0.14.28:
-    resolution: {integrity: sha512-krx9SSg7yfiUKk64EmjefOyiEF6nv2bRE4um/LiTaQ6Y/6FP4UF3/Ou/AxZVyR154uSRq63xejcAsmswXAYRsw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-mips64le/0.14.30:
     resolution: {integrity: sha512-fLUzTFZ7uknC0aPTk7/lM7NmaG/9ZqE3SaHEphcaM009SZK/mDOvZugWi1ss6WGNhk13dUrhkfHcc4FSb9hYhg==}
     engines: {node: '>=12'}
@@ -11083,15 +10993,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-ppc64le/0.14.28:
-    resolution: {integrity: sha512-LD0Xxu9g+DNuhsEBV5QuVZ4uKVBMup0xPIruLweuAf9/mHXFnaCuNXUBF5t0DxKl7GQ5MSioKtnb92oMo+QXEw==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-ppc64le/0.14.30:
     resolution: {integrity: sha512-2Oudm2WEfj0dNU9bzIl5L/LrsMEmHWsOsYgJJqu8fDyUDgER+J1d33qz3cUdjsJk7gAENayIxDSpsuCszx0w3A==}
     engines: {node: '>=12'}
@@ -11117,15 +11018,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-riscv64/0.14.28:
-    resolution: {integrity: sha512-L/DWfRh2P0vxq4Y+qieSNXKGdMg+e9Qe8jkbN2/8XSGYDTPzO2OcAxSujob4qIh7iSl+cknbXV+BvH0YFR0jbg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-linux-riscv64/0.14.30:
     resolution: {integrity: sha512-RPMucPW47rV4t2jlelaE948iCRtbZf5RhifxSwzlpM1Mqdyu99MMNK0w4jFreGTmLN+oGomxIOxD6n+2E/XqHw==}
     engines: {node: '>=12'}
@@ -11141,15 +11033,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-s390x/0.14.28:
-    resolution: {integrity: sha512-rrgxmsbmL8QQknWGnAL9bGJRQYLOi2AzXy5OTwfhxnj9eqjo5mSVbJXjgiq5LPUAMQZGdPH5yaNK0obAXS81Zw==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-s390x/0.14.30:
@@ -11175,15 +11058,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    optional: true
-
-  /esbuild-netbsd-64/0.14.28:
-    resolution: {integrity: sha512-h8wntIyOR8/xMVVM6TvJxxWKh4AjmLK87IPKpuVi8Pq0kyk0RMA+eo4PFGk5j2XK0D7dj8PcSF5NSlP9kN/j0A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.14.30:
@@ -11223,15 +11097,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    optional: true
-
-  /esbuild-openbsd-64/0.14.28:
-    resolution: {integrity: sha512-HBv18rVapbuDx52/fhZ/c/w6TXyaQAvRxiDDn5Hz/pBcwOs3cdd2WxeIKlWmDoqm2JMx5EVlq4IWgoaRX9mVkw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.14.30:
@@ -11275,15 +11140,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-sunos-64/0.14.28:
-    resolution: {integrity: sha512-zlIxePhZxKYheR2vBCgPVvTixgo/ozOfOMoP6RZj8dxzquU1NgeyhjkcRXucbLCtmoNJ+i4PtWwPZTLuDd3bGg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-sunos-64/0.14.30:
     resolution: {integrity: sha512-aQRtRTNKHB4YuG+xXATe5AoRTNY48IJg5vjE8ElxfmjO9+KdX7MHFkTLhlKevCD6rNANtB3qOlSIeAiXTwHNqw==}
     engines: {node: '>=12'}
@@ -11315,15 +11171,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /esbuild-windows-32/0.14.28:
-    resolution: {integrity: sha512-am9DIJxXlld1BOAY/VlvBQHMUCPL7S3gB/lnXIY3M4ys0gfuRqPf4EvMwZMzYUbFKBY+/Qb8SRgPRRGhwnJ8Kg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-32/0.14.30:
@@ -11359,15 +11206,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-windows-64/0.14.28:
-    resolution: {integrity: sha512-78PhySDnmRZlsPNp/W/5Fim8iivlBQQxfhBFIqR7xwvfDmCFUSByyMKP7LCHgNtb04yNdop8nJJkJaQ8Xnwgiw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-windows-64/0.14.30:
     resolution: {integrity: sha512-DHgITeUhPAnN9I5O6QBa1GVyPOhiYCn4S4TtQr7sO4+X0LNyqnlmA1M0qmGkUdDC1QQfjI8uQ4G/whdWb2pWIQ==}
     engines: {node: '>=12'}
@@ -11399,15 +11237,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /esbuild-windows-arm64/0.14.28:
-    resolution: {integrity: sha512-VhXGBTo6HELD8zyHXynV6+L2jWx0zkKnGx4TmEdSBK7UVFACtOyfUqpToG0EtnYyRZ0HESBhzPSVpP781ovmvA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.14.30:
@@ -11476,34 +11305,6 @@ packages:
       esbuild-windows-32: 0.14.21
       esbuild-windows-64: 0.14.21
       esbuild-windows-arm64: 0.14.21
-
-  /esbuild/0.14.28:
-    resolution: {integrity: sha512-YLNprkCcMVKQ5sekmCKEQ3Obu/L7s6+iij38xNKyBeSmSsTWur4Ky/9zB3XIGT8SCJITG/bZwAR2l7YOAXch4Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      esbuild-android-64: 0.14.28
-      esbuild-android-arm64: 0.14.28
-      esbuild-darwin-64: 0.14.28
-      esbuild-darwin-arm64: 0.14.28
-      esbuild-freebsd-64: 0.14.28
-      esbuild-freebsd-arm64: 0.14.28
-      esbuild-linux-32: 0.14.28
-      esbuild-linux-64: 0.14.28
-      esbuild-linux-arm: 0.14.28
-      esbuild-linux-arm64: 0.14.28
-      esbuild-linux-mips64le: 0.14.28
-      esbuild-linux-ppc64le: 0.14.28
-      esbuild-linux-riscv64: 0.14.28
-      esbuild-linux-s390x: 0.14.28
-      esbuild-netbsd-64: 0.14.28
-      esbuild-openbsd-64: 0.14.28
-      esbuild-sunos-64: 0.14.28
-      esbuild-windows-32: 0.14.28
-      esbuild-windows-64: 0.14.28
-      esbuild-windows-arm64: 0.14.28
-    dev: true
 
   /esbuild/0.14.30:
     resolution: {integrity: sha512-wCecQSBkIjp2xjuXY+wcXS/PpOQo9rFh4NAKPh4Pm9f3fuLcnxkR0rDzA+mYP88FtXIUcXUyYmaIgfrzRl55jA==}
@@ -11972,6 +11773,18 @@ packages:
   /etag/1.8.1:
     resolution: {integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /event-stream/3.3.4:
+    resolution: {integrity: sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=}
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
     dev: true
 
   /eventemitter2/6.4.5:
@@ -12575,6 +12388,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /from/0.1.7:
+    resolution: {integrity: sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=}
+    dev: true
+
   /from2/2.3.0:
     resolution: {integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=}
     dependencies:
@@ -12893,6 +12710,17 @@ packages:
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
+
+  /globby/13.1.1:
+    resolution: {integrity: sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      dir-glob: 3.0.1
+      fast-glob: 3.2.11
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 4.0.0
     dev: true
 
   /globby/9.2.0:
@@ -14669,6 +14497,10 @@ packages:
     resolution: {integrity: sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=}
     dev: true
 
+  /map-stream/0.1.0:
+    resolution: {integrity: sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=}
+    dev: true
+
   /map-visit/1.0.0:
     resolution: {integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=}
     engines: {node: '>=0.10.0'}
@@ -15956,6 +15788,12 @@ packages:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: false
 
+  /pause-stream/0.0.11:
+    resolution: {integrity: sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=}
+    dependencies:
+      through: 2.3.8
+    dev: true
+
   /pbkdf2/3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
@@ -16353,6 +16191,14 @@ packages:
 
   /prr/1.0.1:
     resolution: {integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=}
+    dev: true
+
+  /ps-tree/1.2.0:
+    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+    dependencies:
+      event-stream: 3.3.4
     dev: true
 
   /pseudomap/1.0.2:
@@ -17737,6 +17583,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /slash/4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
+    dev: true
+
   /slice-ansi/3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -17807,8 +17658,8 @@ packages:
       solid-js: 1.3.13
     dev: true
 
-  /solid-start-node/0.1.0-alpha.73_0d3860186103958aa17ca74f9c3ed8ac:
-    resolution: {integrity: sha512-gFJaT7l4jp1ox3TODQVG2PlvrVEAuugZR5QkkMFTZObGqSEay3tBn3VyWG6QWYsGBJwNc5Z2xmrkqhd17Ufmwg==}
+  /solid-start-node/0.1.0-alpha.74_c538f5c0165749d2367bbd0b82b4ef80:
+    resolution: {integrity: sha512-dvhlAly3xv+t1IODkDi25oN7Q3sKm0jOV3hqYBE5Y7roDjJaTlZbpSYzZpxc+hdNo5VcdYfiFXff5Xe5V2UILQ==}
     requiresBuild: true
     peerDependencies:
       solid-start: next
@@ -17822,18 +17673,18 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.70.1
       sirv: 1.0.19
-      solid-start: 0.1.0-alpha.73_solid-js@1.3.13+vite@2.8.6
+      solid-start: 0.1.0-alpha.74_solid-js@1.3.13+vite@2.8.6
       undici: 4.13.0
       vite: 2.8.6
     dev: true
     optional: true
 
-  /solid-start/0.1.0-alpha.73_solid-js@1.3.13+vite@2.8.6:
-    resolution: {integrity: sha512-43D6qHcmZUd4p0D//GS6YVBUrzQ8BC1Pi+oo5hE5iKVP1KbVVzDJAsZpz4hWPRjl1enSwZBrA/PjPD8wUryTHA==}
+  /solid-start/0.1.0-alpha.74_solid-js@1.3.13+vite@2.8.6:
+    resolution: {integrity: sha512-lkPHD8/1sHE1/FmbFvNPoFGw1RPPz8ZyvbMLAinr+CfKQvIKJja7QghGqu6bL7kuvuTDptWo8qMtBREICOX85Q==}
     hasBin: true
     peerDependencies:
-      solid-app-router: ^0.3.0
-      solid-js: ^1.3.5
+      solid-app-router: ^0.3.1
+      solid-js: ^1.3.13
       solid-meta: ^0.27.2
       vite: ^2.8.6
     dependencies:
@@ -17845,7 +17696,7 @@ packages:
       cookie: 0.4.2
       cookie-signature: 1.2.0
       es-module-lexer: 0.9.3
-      esbuild: 0.14.28
+      esbuild: 0.14.30
       fast-glob: 3.2.11
       parse-multipart-data: 1.2.1
       picocolors: 1.0.0
@@ -17858,8 +17709,9 @@ packages:
       vite: 2.8.6
       vite-plugin-inspect: 0.3.14_vite@2.8.6
       vite-plugin-solid: 2.2.6
+      zx: 6.0.7
     optionalDependencies:
-      solid-start-node: 0.1.0-alpha.73_0d3860186103958aa17ca74f9c3ed8ac
+      solid-start-node: 0.1.0-alpha.74_c538f5c0165749d2367bbd0b82b4ef80
     transitivePeerDependencies:
       - less
       - sass
@@ -18025,6 +17877,12 @@ packages:
       extend-shallow: 3.0.2
     dev: true
 
+  /split/0.3.3:
+    resolution: {integrity: sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=}
+    dependencies:
+      through: 2.3.8
+    dev: true
+
   /splitpanes/3.1.1:
     resolution: {integrity: sha512-VUkxDJfIGSvTM/fm/+OSrx8ha9URwE/9B8FPvfzoBuAxVELIHBWpsfnJXIXv77zVwuex//QQL4kTU9SDBPeHjA==}
     dev: true
@@ -18126,6 +17984,12 @@ packages:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.7
+    dev: true
+
+  /stream-combiner/0.0.4:
+    resolution: {integrity: sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=}
+    dependencies:
+      duplexer: 0.1.2
     dev: true
 
   /stream-each/1.2.3:
@@ -20314,4 +20178,23 @@ packages:
 
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
+    dev: true
+
+  /zx/6.0.7:
+    resolution: {integrity: sha512-aJTTKN4m9m8wM02yQ4jMOXMp53Ni+r+VDAs0D+bo9l9x9nCMhOocNWeTjoaancHkb7LpNb4oLILp58HzTy0GpQ==}
+    engines: {node: '>= 16.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      '@types/minimist': 1.2.2
+      '@types/node': 17.0.23
+      '@types/which': 2.0.1
+      chalk: 5.0.1
+      fs-extra: 10.0.1
+      globby: 13.1.1
+      minimist: 1.2.6
+      node-fetch: 3.2.3
+      ps-tree: 1.2.0
+      which: 2.0.2
+      yaml: 1.10.2
     dev: true


### PR DESCRIPTION
This PR includes:
- fix disabled on `IconButton`: avoid get focus when it is disabled, just configured the disabled prop on the button
- added buttons for clearing search on navigation and suite panels. It also focus the input once cleared: the clear button on the task list also focus the input once clicked: https://streamable.com/ok3fa4 (on the video the button is shown/hidden, this PR just enable/disable the button)
- fix codemirror scrolls, when scrolling (on click for scroll on thumb) the editor jumps (on horizontal scroll it has a huge impact): I included simplescrolls addon, it requires a resize observer to refresh the scrolls
- fix min w/h for open in editor links on codemirror source code when error is present: https://streamable.com/kba255
- make vertical scroll usable with mouse on thumb: the split left/top updated to 0 (right now with -10px, so the separator prevents use the scrolls, we only can use mouse wheel)