### PR TITLE
fix: hide ignored stacktrace on windows

### DIFF
--- a/packages/vitest/src/utils/source-map.ts
+++ b/packages/vitest/src/utils/source-map.ts
@@ -2,7 +2,7 @@ import { SourceMapConsumer } from 'source-map-js'
 import type { RawSourceMap } from 'vite-node'
 import type { ErrorWithDiff, ParsedStack, Position } from '../types'
 import type { Vitest } from '../node'
-import { notNullish } from './base'
+import { notNullish, slash } from './base'
 
 export const lineSplitRE = /\r?\n/
 
@@ -58,7 +58,7 @@ export function parseStacktrace(e: ErrorWithDiff, full = false): ParsedStack[] {
       if (!match)
         return null
 
-      let file = match[2]
+      let file = slash(match[2])
       if (file.startsWith('file://'))
         file = file.slice(7)
 


### PR DESCRIPTION
`stackIgnorePatterns` was not working on windows.
This PR simply fixes it.

### Before
```
 FAIL  expect.test.ts > hi
AssertionError: expected 2 to deeply equal 3
 ❯ expect.test.ts:4:16
      2| 
      3| test('hi', () => {
      4|   expect(1 + 1).toEqual(3)
       |                ^
      5| })
      6| 
 ❯ ../../../packages/vitest/dist/vendor-index.0d6b419a.js:82:26
 ❯ runTest ../../../packages/vitest/dist/entry.js:803:40
 ❯ async runSuite ../../../packages/vitest/dist/entry.js:868:13
 ❯ async runFiles ../../../packages/vitest/dist/entry.js:905:5
 ❯ async startTests ../../../packages/vitest/dist/entry.js:911:3
 ❯ async ../../../packages/vitest/dist/entry.js:938:7
 ❯ async withEnv ../../../packages/vitest/dist/entry.js:533:5
 ❯ async run ../../../packages/vitest/dist/entry.js:937:5

  - Expected   3
  + Received   2
```

### After
```
 FAIL  expect.test.ts > hi
AssertionError: expected 2 to deeply equal 3
 ❯ expect.test.ts:4:16
      2| 
      3| test('hi', () => {
      4|   expect(1 + 1).toEqual(3)
       |                ^
      5| })
      6| 

  - Expected   3
  + Received   2
```

