### PR TITLE
fix: make automocking aware of symbol indexed methods

### DIFF
--- a/examples/mocks/package.json
+++ b/examples/mocks/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@vueuse/integrations": "^8.2.4",
     "axios": "^0.26.1",
-    "tinyspy": "^0.3.0"
+    "tinyspy": "^0.3.2"
   },
   "devDependencies": {
     "@vitest/ui": "latest",

--- a/examples/mocks/src/moduleWithSymbol.ts
+++ b/examples/mocks/src/moduleWithSymbol.ts
@@ -1,0 +1,12 @@
+const methodSymbol = Symbol('x')
+
+const moduleWithSymbol = {
+  warn() {
+    return this[methodSymbol]()
+  },
+  [methodSymbol]() {
+    return 'hello'
+  },
+}
+
+export { methodSymbol, moduleWithSymbol }

--- a/examples/mocks/test/automocking.spec.ts
+++ b/examples/mocks/test/automocking.spec.ts
@@ -48,14 +48,6 @@ test('automock properly restores mock', async() => {
 
   vi.restoreAllMocks()
 
-  // `spies` (on linux) is an empty Set()
-  // thus we need to restore manually
-  // however, on an external project or on windows,
-  // `spies` is a complete Set() of all (auto) mocks
-  // and the below two lines are not needed
-  vi.mocked(moduleWithSymbol[methodSymbol]).mockRestore()
-  vi.mocked(moduleWithSymbol.warn).mockRestore()
-
   expect(() => {
     log.warn()
   }).not.toThrow()

--- a/examples/mocks/test/automocking.spec.ts
+++ b/examples/mocks/test/automocking.spec.ts
@@ -1,8 +1,9 @@
 import type * as exampleModule from '../src/example'
-
 import log from '../src/log'
+import { methodSymbol, moduleWithSymbol } from '../src/moduleWithSymbol'
 
 vi.mock('../src/log')
+vi.mock('../src/moduleWithSymbol')
 
 test('all mocked are valid', async() => {
   const example = await vi.importMock<typeof exampleModule>('../src/example')
@@ -40,13 +41,25 @@ test('all mocked are valid', async() => {
   expect(example.symbol).toEqual(Symbol.for('a.b.c'))
 })
 
-test('automock doesn\'t throw when unmocked', () => {
-  // logger uses symbols on its prototype
-  // we are checking here that after unmocking
-  // these symbols are accessible
+test('automock properly restores mock', async() => {
+  expect(log.warn()).toBeUndefined()
+  expect(moduleWithSymbol.warn()).toBeUndefined()
+  expect(moduleWithSymbol[methodSymbol]()).toBeUndefined()
+
+  vi.restoreAllMocks()
+
+  // `spies` (on linux) is an empty Set()
+  // thus we need to restore manually
+  // however, on an external project or on windows,
+  // `spies` is a complete Set() of all (auto) mocks
+  // and the below two lines are not needed
+  vi.mocked(moduleWithSymbol[methodSymbol]).mockRestore()
+  vi.mocked(moduleWithSymbol.warn).mockRestore()
+
   expect(() => {
     log.warn()
-    vi.restoreAllMocks()
-    log.warn()
   }).not.toThrow()
+
+  expect(moduleWithSymbol[methodSymbol]()).toBe('hello')
+  expect(moduleWithSymbol.warn()).toBe('hello')
 })

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -85,7 +85,7 @@
     "chai": "^4.3.6",
     "local-pkg": "^0.4.1",
     "tinypool": "^0.1.2",
-    "tinyspy": "^0.3.0",
+    "tinyspy": "^0.3.2",
     "vite": "^2.9.1"
   },
   "devDependencies": {

--- a/packages/vitest/src/integrations/spy.ts
+++ b/packages/vitest/src/integrations/spy.ts
@@ -28,13 +28,13 @@ type Procedure = (...args: any[]) => any
 
 type Methods<T> = {
   [K in keyof T]: T[K] extends Procedure ? K : never
-}[keyof T] & string
+}[keyof T] & (string | symbol)
 type Properties<T> = {
   [K in keyof T]: T[K] extends Procedure ? never : K
-}[keyof T] & string
+}[keyof T] & (string | symbol)
 type Classes<T> = {
   [K in keyof T]: T[K] extends new (...args: any[]) => any ? K : never
-}[keyof T] & string
+}[keyof T] & (string | symbol)
 
 export interface SpyInstance<TArgs extends any[] = any[], TReturns = any> {
   getMockName(): string

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -3,7 +3,7 @@ import { isNodeBuiltin } from 'mlly'
 import { basename, dirname, resolve } from 'pathe'
 import { normalizeRequestId, toFilePath } from 'vite-node/utils'
 import type { ModuleCacheMap } from 'vite-node/client'
-import { getWorkerState, isWindows, mergeSlashes } from '../utils'
+import { getWorkerState, isWindows, mergeSlashes, slash } from '../utils'
 import { distDir } from '../constants'
 import type { PendingSuiteMock } from '../types/mocker'
 import type { ExecuteOptions } from './execute'
@@ -243,7 +243,7 @@ export class VitestMocker {
   private async ensureSpy() {
     if (VitestMocker.spyModule)
       return
-    VitestMocker.spyModule = await this.request(resolve(distDir, 'spy.js')) as typeof import('../integrations/spy')
+    VitestMocker.spyModule = await this.request(`/@fs/${slash(resolve(distDir, 'spy.js'))}`) as typeof import('../integrations/spy')
   }
 
   public async requestWithMock(dep: string) {

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -15,15 +15,19 @@ function getType(value: unknown): string {
 }
 
 function getAllProperties(obj: any) {
-  const allProps = new Set<string>()
+  const allProps = new Set<string | symbol>()
   let curr = obj
   do {
     // we don't need propterties from these
     if (curr === Object.prototype || curr === Function.prototype || curr === RegExp.prototype)
       break
     const props = Object.getOwnPropertyNames(curr)
+    const symbs = Object.getOwnPropertySymbols(curr)
+
     props.forEach(prop => allProps.add(prop))
-  // eslint-disable-next-line no-cond-assign
+    symbs.forEach(symb => allProps.add(symb))
+
+    // eslint-disable-next-line no-cond-assign
   } while (curr = Object.getPrototypeOf(curr))
   return Array.from(allProps)
 }
@@ -168,7 +172,7 @@ export class VitestMocker {
     else if (type !== 'Object' && type !== 'Module')
       return value
 
-    const newObj: any = {}
+    const newObj: Record<string | symbol, any> = {}
 
     const proproperties = getAllProperties(value)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,13 +151,13 @@ importers:
       '@vitest/ui': latest
       '@vueuse/integrations': ^8.2.4
       axios: ^0.26.1
-      tinyspy: ^0.3.0
+      tinyspy: ^0.3.2
       vite: ^2.9.1
       vitest: latest
     dependencies:
       '@vueuse/integrations': 8.2.4_axios@0.26.1+vue@3.2.31
       axios: 0.26.1
-      tinyspy: 0.3.0
+      tinyspy: 0.3.2
     devDependencies:
       '@vitest/ui': link:../../packages/ui
       vite: 2.9.1
@@ -637,7 +637,7 @@ importers:
       source-map-js: ^1.0.2
       strip-ansi: ^7.0.1
       tinypool: ^0.1.2
-      tinyspy: ^0.3.0
+      tinyspy: ^0.3.2
       typescript: ^4.6.3
       vite: ^2.9.1
       vite-node: workspace:*
@@ -648,7 +648,7 @@ importers:
       chai: 4.3.6
       local-pkg: 0.4.1
       tinypool: 0.1.2
-      tinyspy: 0.3.0
+      tinyspy: 0.3.2
       vite: 2.9.1
     devDependencies:
       '@antfu/install-pkg': 0.1.0
@@ -18418,8 +18418,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /tinyspy/0.3.0:
-    resolution: {integrity: sha512-c5uFHqtUp74R2DJE3/Efg0mH5xicmgziaQXMm/LvuuZn3RdpADH32aEGDRyCzObXT1DNfwDMqRQ/Drh1MlO12g==}
+  /tinyspy/0.3.2:
+    resolution: {integrity: sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==}
     engines: {node: '>=14.0.0'}
     dev: false
 


### PR DESCRIPTION
this PR intends to resolve #1082  by updating automocking to fully support symbol indexed methods (specifically, fixing the root issue which occurs when trying to restore and later use such methods)

## caveat

in a fresh project, i can get the below test snippet to fail for `vitest@0.9.0`. i can then get them to pass when linking vitest locally to this branch. however, when running the tests in `examples/mocks`, the below tests fail as the mock is not properly restored.

## local testing

in a fresh project, the following will fail for `v0.9.0` and pass on this PR

in `log.ts` 

```typescript
const sym = Symbol('x')

const logger = {
  warn() {
    return this[sym]()
  },
  [sym]() {
    return 'hello'
  }
}

export default logger
```

and in `log.test.ts` 

```typescript
import { vi, test, expect } from 'vitest'
import logger from './log'

vi.mock('./log')

test('auto mocked', () => {
  expect(logger.warn()).toBeUndefined()
})

test('restoring auto mock', () => {
  vi.restoreAllMocks()
  expect(logger.warn()).toBe('hello')
})
```

