### PR TITLE
fix: re-export mock types

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -7,7 +7,7 @@ export * from './runtime/hooks'
 
 export { runOnce, isFirstRun } from './integrations/run-once'
 export * from './integrations/chai'
-export type { EnhancedSpy, SpyInstance, SpyInstanceFn, SpyContext } from './integrations/spy'
+export type { EnhancedSpy, MockedFunction, MockedObject, SpyInstance, SpyInstanceFn, SpyContext } from './integrations/spy'
 export * from './integrations/vi'
 export * from './integrations/utils'
 


### PR DESCRIPTION
They were no longer exported since #1100 which was a breaking change in v0.8.5

Maybe some other types should be re-exported as well, like `MaybeMocked` and the deep versions?