### PR TITLE
chore: cleaning up test for ViewReport.cy.tsx

### DIFF
--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -106,7 +106,7 @@ function relative(p: string) {
           </div>
           <div v-else-if="task.result?.error" class="scrolls scrolls-rounded task-error">
             <pre><b>{{ task.result.error.name || task.result.error.nameStr }}</b>: {{ task.result.error.message }}</pre>
-            <div v-for="({ file: efile, line, column }, i) of task.result.error.stacks || []" :key="i" class="op80 flex gap-x-2 items-center">
+            <div v-for="({ file: efile, line, column }, i) of task.result.error.stacks || []" :key="i" class="op80 flex gap-x-2 items-center" data-testid="stack">
               <pre> - {{ relative(efile) }}:{{ line }}:{{ column }}</pre>
               <div
                 v-if="shouldOpenInEditor(efile, props.file?.name)"

--- a/packages/ui/cypress/support/index.ts
+++ b/packages/ui/cypress/support/index.ts
@@ -1,4 +1,5 @@
 import faker from '@faker-js/faker'
+import '@testing-library/cypress/add-commands'
 import '../../client/global-setup'
 
 import { registerMount } from './mount'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,6 +40,7 @@
     "@cypress/vite-dev-server": "^2.2.2",
     "@cypress/vue": "^3.1.1",
     "@faker-js/faker": "^6.1.1",
+    "@testing-library/cypress": "^8.0.2",
     "@types/codemirror": "^5.60.5",
     "@types/d3-force": "^3.0.3",
     "@types/d3-selection": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,7 @@ importers:
       '@cypress/vite-dev-server': ^2.2.2
       '@cypress/vue': ^3.1.1
       '@faker-js/faker': ^6.1.1
+      '@testing-library/cypress': ^8.0.2
       '@types/codemirror': ^5.60.5
       '@types/d3-force': ^3.0.3
       '@types/d3-selection': ^3.0.2
@@ -549,6 +550,7 @@ importers:
       '@cypress/vite-dev-server': 2.2.2_vite@2.9.1
       '@cypress/vue': 3.1.1_cypress@9.5.3+vue@3.2.31
       '@faker-js/faker': 6.1.1
+      '@testing-library/cypress': 8.0.2_cypress@9.5.3
       '@types/codemirror': 5.60.5
       '@types/d3-force': 3.0.3
       '@types/d3-selection': 3.0.2
@@ -6698,6 +6700,17 @@ packages:
       vite: 2.9.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@testing-library/cypress/8.0.2_cypress@9.5.3:
+    resolution: {integrity: sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      cypress: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+    dependencies:
+      '@babel/runtime': 7.17.2
+      '@testing-library/dom': 8.11.1
+      cypress: 9.5.3
     dev: true
 
   /@testing-library/dom/7.31.2:


### PR DESCRIPTION
This PR cleans up the tests for **`ViewReport.cy.tsx`** and begins to add faker in for more realistic test data.

There is one loss of coverage: we no longer check that a **b** tag is the element used in the DOM. For this, we should be using Percy for making sure that the styles are correct. Percy has a free, open-source plan.