### PR TITLE
fix(dev): fix 404 configure vitest link in basic example

### DIFF
--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 
-// Configure Vitest (https://vitest.dev/config)
+// Configure Vitest (https://vitest.dev/config/)
 
 import { defineConfig } from 'vite'
 


### PR DESCRIPTION
Fixes the broken link in the basic vitest example when opening in StackBlitz.

https://user-images.githubusercontent.com/50255197/162484340-d421a73f-5e02-44c4-a45a-91f89a39bb5a.mp4