### PR TITLE
fix: add `vite-node` to root `dev` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "pnpm -r --filter {packages} run build",
     "ci": "ni && nr typecheck && nr lint && nr build && nr test:all",
-    "dev": "pnpm -r --parallel --filter vitest --filter ui --filter web-worker run dev",
+    "dev": "pnpm -r --parallel --filter vitest --filter ui --filter web-worker --filter vite-node run dev",
     "docs": "npm -C docs run dev",
     "docs:build": "npm -C docs run build",
     "docs:serve": "npm -C docs run serve",


### PR DESCRIPTION
If you run `pnpm run dev` on a shell and `cd test/web-worker && pnpm run test` in another, it will fail, since `vite-node` is not included on the `dev` script (if you haven't run `pnpm run build` before, for example on a fresh clone).

https://imgur.com/k8V1U0d