### PR TITLE
fix: remove invalid xml characters in junit reporter output (fix #1144)

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -23,13 +23,39 @@ function flattenTasks(task: Task, baseName = ''): Task[] {
   }
 }
 
+// https://gist.github.com/john-doherty/b9195065884cdbfd2017a4756e6409cc
+function removeXMLInvalidChars(str: string, removeDiscouragedChars: boolean) {
+  // eslint-disable-next-line no-control-regex
+  let regex = /((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))/g
+  str = String(str || '').replace(regex, '')
+
+  if (removeDiscouragedChars) {
+    // remove everything discouraged by XML 1.0 specifications
+    regex = new RegExp(
+      '([\\x7F-\\x84]|[\\x86-\\x9F]|[\\uFDD0-\\uFDEF]|(?:\\uD83F[\\uDFFE\\uDFFF])|(?:\\uD87F[\\uDF'
+    + 'FE\\uDFFF])|(?:\\uD8BF[\\uDFFE\\uDFFF])|(?:\\uD8FF[\\uDFFE\\uDFFF])|(?:\\uD93F[\\uDFFE\\uD'
+    + 'FFF])|(?:\\uD97F[\\uDFFE\\uDFFF])|(?:\\uD9BF[\\uDFFE\\uDFFF])|(?:\\uD9FF[\\uDFFE\\uDFFF])'
+    + '|(?:\\uDA3F[\\uDFFE\\uDFFF])|(?:\\uDA7F[\\uDFFE\\uDFFF])|(?:\\uDABF[\\uDFFE\\uDFFF])|(?:\\'
+    + 'uDAFF[\\uDFFE\\uDFFF])|(?:\\uDB3F[\\uDFFE\\uDFFF])|(?:\\uDB7F[\\uDFFE\\uDFFF])|(?:\\uDBBF'
+    + '[\\uDFFE\\uDFFF])|(?:\\uDBFF[\\uDFFE\\uDFFF])(?:[\\0-\\t\\x0B\\f\\x0E-\\u2027\\u202A-\\uD7FF\\'
+    + 'uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|'
+    + '(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF]))', 'g')
+
+    str = str.replace(regex, '')
+  }
+
+  return str
+}
+
 function escapeXML(value: any): string {
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return removeXMLInvalidChars(
+    String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;'),
+    true)
 }
 
 function getDuration(task: Task): string | undefined {

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -24,10 +24,10 @@ function flattenTasks(task: Task, baseName = ''): Task[] {
 }
 
 // https://gist.github.com/john-doherty/b9195065884cdbfd2017a4756e6409cc
-function removeXMLInvalidChars(str: string, removeDiscouragedChars: boolean) {
+function removeInvalidXMLCharacters(value: any, removeDiscouragedChars: boolean): string {
   // eslint-disable-next-line no-control-regex
   let regex = /((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))/g
-  str = String(str || '').replace(regex, '')
+  value = String(value || '').replace(regex, '')
 
   if (removeDiscouragedChars) {
     // remove everything discouraged by XML 1.0 specifications
@@ -41,14 +41,14 @@ function removeXMLInvalidChars(str: string, removeDiscouragedChars: boolean) {
     + 'uE000-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|'
     + '(?:[^\\uD800-\\uDBFF]|^)[\\uDC00-\\uDFFF]))', 'g')
 
-    str = str.replace(regex, '')
+    value = value.replace(regex, '')
   }
 
-  return str
+  return value
 }
 
 function escapeXML(value: any): string {
-  return removeXMLInvalidChars(
+  return removeInvalidXMLCharacters(
     String(value)
       .replace(/&/g, '&amp;')
       .replace(/"/g, '&quot;')

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -142,6 +142,14 @@ const tasks: Task[] = [
     fails: undefined,
     file,
     result: { state: 'pass', duration: 0.1923508644104004 },
+    logs: [
+      {
+        content: '[33merror[39m',
+        type: 'stderr',
+        time: 1642587001759,
+        size: 15,
+      },
+    ],
   },
 ]
 

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -24,6 +24,9 @@ AssertionError: expected 2.23606797749979 to equal 2
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
         </testcase>
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+            <system-err>
+[33merror[39m
+            </system-err>
         </testcase>
     </testsuite>
 </testsuites>
@@ -54,6 +57,9 @@ AssertionError: expected 2.23606797749979 to equal 2
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
         </testcase>
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+            <system-err>
+[33merror[39m
+            </system-err>
         </testcase>
     </testsuite>
 </testsuites>
@@ -89,6 +95,9 @@ AssertionError: expected 2.23606797749979 to equal 2
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
         </testcase>
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+            <system-err>
+[33merror[39m
+            </system-err>
         </testcase>
     </testsuite>
 </testsuites>
@@ -124,6 +133,9 @@ AssertionError: expected 2.23606797749979 to equal 2
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
         </testcase>
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+            <system-err>
+[33merror[39m
+            </system-err>
         </testcase>
     </testsuite>
 </testsuites>
@@ -159,6 +171,9 @@ AssertionError: expected 2.23606797749979 to equal 2
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
         </testcase>
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+            <system-err>
+[33merror[39m
+            </system-err>
         </testcase>
     </testsuite>
 </testsuites>
@@ -194,6 +209,9 @@ AssertionError: expected 2.23606797749979 to equal 2
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.0197386060\\">
         </testcase>
         <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+            <system-err>
+[33merror[39m
+            </system-err>
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
This line in [data.ts](https://github.com/ciddan/vitest/blob/5f70317748f316ed73b2604596ce3fb7486199a1/test/reporters/src/data.ts#L147) contains two control characters, visible in vs code:

![Screenshot from 2022-04-12 22-41-50](https://user-images.githubusercontent.com/1786344/163050169-781fb169-1f39-4970-ae76-d108a53a2326.png)

That line is scrubbed by the new `removeInvalidXMLCharacters` function, ensuring that the XML output doesn't contain the control characters.

### Reproduction

Reproduction [StackBlitz](https://stackblitz.com/edit/vitest-dev-vitest-pepxpq?file=test_result%2Fjunit.xml).

Let the tests run and open test_result/junit.xml. The file contains disallowed characters, specifically in the <system-err> tag.

You can use any XML validator to check, such as the one from [w3schools](https://www.w3schools.com/xml/xml_validator.asp).