### PR TITLE
fix: optimizeDeps.disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,14 +57,14 @@
     "rollup-plugin-esbuild": "^4.9.1",
     "rollup-plugin-license": "^2.7.0",
     "typescript": "^4.6.3",
-    "vite": "^2.9.1",
+    "vite": "^2.9.5",
     "vitepress": "^0.22.3",
     "vitest": "workspace:*",
     "vue": "^3.2.32"
   },
   "pnpm": {
     "overrides": {
-      "vite": "^2.9.1"
+      "vite": "^2.9.5"
     }
   },
   "vite": {

--- a/packages/ui/client/components.d.ts
+++ b/packages/ui/client/components.d.ts
@@ -2,7 +2,7 @@
 // We suggest you to commit this file into source control
 // Read more: https://github.com/vuejs/vue-next/pull/3399
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     CodeMirror: typeof import('./components/CodeMirror.vue')['default']
     ConnectionOverlay: typeof import('./components/ConnectionOverlay.vue')['default']
@@ -15,6 +15,8 @@ declare module 'vue' {
     ModuleTransformResultView: typeof import('./components/ModuleTransformResultView.vue')['default']
     Navigation: typeof import('./components/Navigation.vue')['default']
     ProgressBar: typeof import('./components/ProgressBar.vue')['default']
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
     StatusIcon: typeof import('./components/StatusIcon.vue')['default']
     Suites: typeof import('./components/Suites.vue')['default']
     TaskItem: typeof import('./components/TaskItem.vue')['default']

--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -67,7 +67,7 @@
     "minimist": "^1.2.6",
     "mlly": "^0.5.1",
     "pathe": "^0.2.0",
-    "vite": "^2.9.1"
+    "vite": "^2.9.5"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.2",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -86,7 +86,7 @@
     "local-pkg": "^0.4.1",
     "tinypool": "^0.1.2",
     "tinyspy": "^0.3.2",
-    "vite": "^2.9.1"
+    "vite": "^2.9.5"
   },
   "devDependencies": {
     "@antfu/install-pkg": "^0.1.0",

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -79,6 +79,8 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
           // disable deps optimization
           cacheDir: undefined,
           optimizeDeps: {
+            // experimental in Vite >2.9.2, entries remains to help with older versions
+            disabled: true,
             entries: [],
           },
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 overrides:
-  vite: ^2.9.1
+  vite: ^2.9.5
 
 importers:
 
@@ -35,7 +35,7 @@ importers:
       rollup-plugin-esbuild: ^4.9.1
       rollup-plugin-license: ^2.7.0
       typescript: ^4.6.3
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitepress: ^0.22.3
       vitest: workspace:*
       vue: ^3.2.32
@@ -68,7 +68,7 @@ importers:
       rollup-plugin-esbuild: 4.9.1_esbuild@0.14.36+rollup@2.70.1
       rollup-plugin-license: 2.7.0_rollup@2.70.1
       typescript: 4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
       vitepress: 0.22.3
       vitest: link:packages/vitest
       vue: 3.2.32
@@ -96,24 +96,24 @@ importers:
       '@iconify-json/carbon': 1.1.3
       '@types/node': 17.0.23
       '@unocss/reset': 0.31.2
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       esno: 0.14.1
       fast-glob: 3.2.11
       https-localhost: 4.7.1
-      unocss: 0.31.2_vite@2.9.1
-      unplugin-vue-components: 0.19.2_a85a21dab8be76a3330f4d7b2bf56cfa
-      vite-plugin-pwa: 0.11.13_vite@2.9.1
+      unocss: 0.31.2_vite@2.9.5
+      unplugin-vue-components: 0.19.2_1136d9a205d0203afd70a6e03df668e2
+      vite-plugin-pwa: 0.11.13_vite@2.9.5
       vitepress: 0.22.3
       workbox-window: 6.5.3
 
   examples/basic:
     specifiers:
       '@vitest/ui': latest
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/graphql:
@@ -121,14 +121,14 @@ importers:
       '@rollup/plugin-graphql': ^1.1.0
       '@vitest/ui': latest
       graphql: ^16.3.0
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       '@rollup/plugin-graphql': 1.1.0_graphql@16.3.0+rollup@2.70.1
       graphql: 16.3.0
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/lit:
@@ -136,14 +136,14 @@ importers:
       '@vitest/ui': latest
       happy-dom: latest
       lit: ^2.2.2
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       lit: 2.2.2
     devDependencies:
       '@vitest/ui': link:../../packages/ui
       happy-dom: 2.55.0
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/mocks:
@@ -152,7 +152,7 @@ importers:
       '@vueuse/integrations': ^8.2.5
       axios: ^0.26.1
       tinyspy: ^0.3.2
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       '@vueuse/integrations': 8.2.5_axios@0.26.1+vue@3.2.32
@@ -160,7 +160,7 @@ importers:
       tinyspy: 0.3.2
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/nextjs:
@@ -192,12 +192,12 @@ importers:
     specifiers:
       '@vitest/ui': latest
       puppeteer: ^13.5.2
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     devDependencies:
       '@vitest/ui': link:../../packages/ui
       puppeteer: 13.5.2
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/react:
@@ -233,7 +233,7 @@ importers:
       enzyme-adapter-react-16: 1.15.6
       react: ^17.0.2
       react-dom: ^17.0.2
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       react: 17.0.2
@@ -245,7 +245,7 @@ importers:
       '@vitest/ui': link:../../packages/ui
       enzyme: 3.11.0
       enzyme-adapter-react-16: 1.15.6_fae758709a8810ba97b4c03852dde4d0
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/react-mui:
@@ -267,7 +267,7 @@ importers:
       react-router-dom: ^6.3.0
       recharts: ^2.1.9
       swr: ^1.3.0
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       '@emotion/react': 11.9.0_react@17.0.2
@@ -288,7 +288,7 @@ importers:
       '@vitest/ui': link:../../packages/ui
       date-fns: 2.28.0
       jsdom: 19.0.0
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/react-storybook-testing:
@@ -316,7 +316,7 @@ importers:
       react-query: ^3.34.19
       storybook-builder-vite: ^0.1.23
       typescript: ^4.6.3
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       cross-fetch: 3.1.5
@@ -341,9 +341,9 @@ importers:
       jsdom: 19.0.0
       msw: 0.39.2
       msw-storybook-addon: 1.6.3_9499dcf549590b7305989652366d7951
-      storybook-builder-vite: 0.1.23_546fc62b469cbb0c46b48aaa3d11d6a0
+      storybook-builder-vite: 0.1.23_b234169f202737657ca6d7cd85261501
       typescript: 4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/react-testing-lib:
@@ -359,7 +359,7 @@ importers:
       jsdom: latest
       react: ^17.0.2
       react-dom: ^17.0.2
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       react: 17.0.2
@@ -374,7 +374,7 @@ importers:
       '@vitejs/plugin-react': 1.3.0
       '@vitest/ui': link:../../packages/ui
       jsdom: 19.0.0
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/react-testing-lib-msw:
@@ -391,7 +391,7 @@ importers:
       msw: ^0.39.2
       react: ^17.0.2
       react-dom: ^17.0.2
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
     dependencies:
       '@apollo/client': 3.5.10_react@17.0.2
@@ -407,7 +407,7 @@ importers:
       cross-fetch: 3.1.5
       jsdom: 19.0.0
       msw: 0.39.2
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
 
   examples/ruby:
@@ -419,10 +419,10 @@ importers:
       vitest: latest
       vue: ^3.2.32
     devDependencies:
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       '@vue/test-utils': 2.0.0-rc.20_vue@3.2.32
       jsdom: 19.0.0
-      vite-plugin-ruby: 3.0.9_vite@2.9.1
+      vite-plugin-ruby: 3.0.9_vite@2.9.5
       vitest: link:../../packages/vitest
       vue: 3.2.32
 
@@ -437,7 +437,7 @@ importers:
       solid-js: 1.3.14
     devDependencies:
       jsdom: 19.0.0
-      solid-start: 0.1.0-alpha.74_solid-js@1.3.14+vite@2.9.1
+      solid-start: 0.1.0-alpha.74_solid-js@1.3.14+vite@2.9.5
       solid-testing-library: 0.3.0_solid-js@1.3.14
       vitest: link:../../packages/vitest
 
@@ -450,7 +450,7 @@ importers:
       svelte: ^3.47.0
       vitest: latest
     devDependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.41_svelte@3.47.0+vite@2.9.1
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.41_svelte@3.47.0+vite@2.9.5
       '@testing-library/svelte': 3.1.1_svelte@3.47.0
       '@vitest/ui': link:../../packages/ui
       jsdom: 19.0.0
@@ -469,11 +469,11 @@ importers:
     dependencies:
       vue: 3.2.32
     devDependencies:
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       '@vue/test-utils': 2.0.0-rc.20_vue@3.2.32
       happy-dom: 2.55.0
-      unplugin-auto-import: 0.7.0_83dd4d1a11bf7faa2d41f89ea3fae952
-      unplugin-vue-components: 0.19.2_a85a21dab8be76a3330f4d7b2bf56cfa
+      unplugin-auto-import: 0.7.0_05062056c3506028f60dc849695a4e6b
+      unplugin-vue-components: 0.19.2_1136d9a205d0203afd70a6e03df668e2
       vitest: link:../../packages/vitest
 
   examples/vue:
@@ -486,7 +486,7 @@ importers:
     dependencies:
       vue: 3.2.32
     devDependencies:
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       '@vue/test-utils': 2.0.0-rc.20_vue@3.2.32
       jsdom: 19.0.0
       vitest: link:../../packages/vitest
@@ -497,15 +497,15 @@ importers:
       '@vitejs/plugin-vue-jsx': ^1.3.9
       '@vue/test-utils': ^2.0.0-rc.20
       jsdom: latest
-      vite: ^2.9.1
+      vite: ^2.9.5
       vitest: latest
       vue: ^3.2.32
     devDependencies:
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       '@vitejs/plugin-vue-jsx': 1.3.9
       '@vue/test-utils': 2.0.0-rc.20_vue@3.2.32
       jsdom: 19.0.0
-      vite: 2.9.1
+      vite: 2.9.5
       vitest: link:../../packages/vitest
       vue: 3.2.32
 
@@ -547,7 +547,7 @@ importers:
     dependencies:
       sirv: 2.0.2
     devDependencies:
-      '@cypress/vite-dev-server': 2.2.2_vite@2.9.1
+      '@cypress/vite-dev-server': 2.2.2_vite@2.9.5
       '@cypress/vue': 3.1.1_cypress@9.5.4+vue@3.2.32
       '@faker-js/faker': 6.1.2
       '@testing-library/cypress': 8.0.2_cypress@9.5.4
@@ -556,7 +556,7 @@ importers:
       '@types/d3-selection': 3.0.2
       '@types/ws': 8.5.3
       '@unocss/reset': 0.31.2
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       '@vitejs/plugin-vue-jsx': 1.3.9
       '@vitest/ws-client': link:../ws-client
       '@vueuse/core': 8.2.5_vue@3.2.32
@@ -571,12 +571,12 @@ importers:
       picocolors: 1.0.0
       rollup: 2.70.1
       splitpanes: 3.1.1
-      unocss: 0.31.2_vite@2.9.1
-      unplugin-auto-import: 0.7.0_2148f78c5474adce365c6a875cfdf6da
-      unplugin-vue-components: 0.19.2_a85a21dab8be76a3330f4d7b2bf56cfa
-      vite-plugin-optimize-persist: 0.1.2_e8535a6275298a6eb7d603176e126257
-      vite-plugin-package-config: 0.1.1_vite@2.9.1
-      vite-plugin-pages: 0.22.0_vite@2.9.1
+      unocss: 0.31.2_vite@2.9.5
+      unplugin-auto-import: 0.7.0_20ca0c17fde6bf5437d5dedd7e06991f
+      unplugin-vue-components: 0.19.2_1136d9a205d0203afd70a6e03df668e2
+      vite-plugin-optimize-persist: 0.1.2_3ffa6461a7336e598fca66c236cfe0d4
+      vite-plugin-package-config: 0.1.1_vite@2.9.5
+      vite-plugin-pages: 0.22.0_vite@2.9.5
       vue: 3.2.32
       vue-router: 4.0.14_vue@3.2.32
 
@@ -588,13 +588,13 @@ importers:
       mlly: ^0.5.1
       pathe: ^0.2.0
       rollup: ^2.70.1
-      vite: ^2.9.1
+      vite: ^2.9.5
     dependencies:
       kolorist: 1.5.1
       minimist: 1.2.6
       mlly: 0.5.1
       pathe: 0.2.0
-      vite: 2.9.1
+      vite: 2.9.5
     devDependencies:
       '@types/minimist': 1.2.2
       rollup: 2.70.1
@@ -643,7 +643,7 @@ importers:
       tinypool: ^0.1.2
       tinyspy: ^0.3.2
       typescript: ^4.6.3
-      vite: ^2.9.1
+      vite: ^2.9.5
       vite-node: workspace:*
       ws: ^8.5.0
     dependencies:
@@ -653,7 +653,7 @@ importers:
       local-pkg: 0.4.1
       tinypool: 0.1.2
       tinyspy: 0.3.2
-      vite: 2.9.1
+      vite: 2.9.5
     devDependencies:
       '@antfu/install-pkg': 0.1.0
       '@sinonjs/fake-timers': 9.1.1
@@ -750,7 +750,7 @@ importers:
       '@vue/test-utils': ^2.0.0-rc.20
       vitest: workspace:*
     devDependencies:
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       '@vue/test-utils': 2.0.0-rc.20_vue@3.2.32
       vitest: link:../../packages/vitest
 
@@ -3779,14 +3779,14 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@cypress/vite-dev-server/2.2.2_vite@2.9.1:
+  /@cypress/vite-dev-server/2.2.2_vite@2.9.5:
     resolution: {integrity: sha512-02y/Fm0N+CQjKbSjjRtktPgPbp91kOvtc8+WW2l2odIYQkKlG6IOCpmgc898muW0lBAcCszdEIHR/ItdZDiYPw==}
     peerDependencies:
       vite: '>= 2.1.3'
     dependencies:
       debug: 4.3.3
       get-port: 5.1.1
-      vite: 2.9.1
+      vite: 2.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4242,7 +4242,7 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@joshwooding/vite-plugin-react-docgen-typescript/0.0.2_typescript@4.6.3+vite@2.9.1:
+  /@joshwooding/vite-plugin-react-docgen-typescript/0.0.2_typescript@4.6.3+vite@2.9.5:
     resolution: {integrity: sha512-0hbsoX2c7Z3lJKY+88ToduiQDyh+Mggpd6Go0vVV3PchMRyE9iOCVUBiqd4FFfgNdFdk6iNKrO9bdIiHOpW6jA==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -4252,7 +4252,7 @@ packages:
       glob-promise: 4.2.2_glob@7.2.0
       react-docgen-typescript: 2.2.2_typescript@4.6.3
       typescript: 4.6.3
-      vite: 2.9.1
+      vite: 2.9.5
     dev: true
 
   /@jridgewell/resolve-uri/3.0.3:
@@ -6797,7 +6797,7 @@ packages:
       string.prototype.matchall: 4.0.6
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.41_svelte@3.47.0+vite@2.9.1:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.41_svelte@3.47.0+vite@2.9.5:
     resolution: {integrity: sha512-2kZ49mpi/YW1PIPvKaJNSSwIFgmw9QUf1+yaNa4U8yJD6AsfSHXAU3goscWbi1jfWnSg2PhvwAf+bvLCdp2F9g==}
     engines: {node: ^14.13.1 || >= 16}
     peerDependencies:
@@ -6814,7 +6814,7 @@ packages:
       magic-string: 0.26.1
       svelte: 3.47.0
       svelte-hmr: 0.14.11_svelte@3.47.0
-      vite: 2.9.1
+      vite: 2.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7602,7 +7602,7 @@ packages:
       '@unocss/core': 0.31.2
     dev: true
 
-  /@unocss/vite/0.31.2_vite@2.9.1:
+  /@unocss/vite/0.31.2_vite@2.9.5:
     resolution: {integrity: sha512-6aIGWNBYuhpokE3qWRCQqMjFwUoM91yLnInhpHQ4Q6W6Py8i8NZIUxnsp2qOmNHjrf5BwTnJlkFyisbQLCdvwg==}
     peerDependencies:
       vite: ^2.9.0
@@ -7614,7 +7614,7 @@ packages:
       '@unocss/scope': 0.31.2
       '@unocss/transformer-directives': 0.31.2
       magic-string: 0.26.1
-      vite: 2.9.1
+      vite: 2.9.5
     dev: true
 
   /@vitejs/plugin-react/1.3.0:
@@ -7647,14 +7647,14 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue/2.3.1_vite@2.9.1+vue@3.2.32:
+  /@vitejs/plugin-vue/2.3.1_vite@2.9.5+vue@3.2.32:
     resolution: {integrity: sha512-YNzBt8+jt6bSwpt7LP890U1UcTOIZZxfpE5WOJ638PNxSEKOqAi0+FSKS0nVeukfdZ0Ai/H7AFd6k3hayfGZqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       vite: ^2.5.10
       vue: ^3.2.25
     dependencies:
-      vite: 2.9.1
+      vite: 2.9.5
       vue: 3.2.32
     dev: true
 
@@ -10881,21 +10881,12 @@ packages:
     resolution: {integrity: sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==}
     dev: true
 
-  /esbuild-android-64/0.14.30:
-    resolution: {integrity: sha512-vdJ7t8A8msPfKpYUGUV/KaTQRiZ0vDa2XSTlzXVkGGVHLKPeb85PBUtYJcEgw3htW3IdX5i1t1IMdQCwJJgNAg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /esbuild-android-64/0.14.36:
     resolution: {integrity: sha512-jwpBhF1jmo0tVCYC/ORzVN+hyVcNZUWuozGcLHfod0RJCedTDTvR4nwlTXdx1gtncDqjk33itjO+27OZHbiavw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-android-arm64/0.13.8:
@@ -10906,21 +10897,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-arm64/0.14.30:
-    resolution: {integrity: sha512-BdgGfxeA5hBQNErLr7BWJUA8xjflEfyaARICy8e0OJYNSAwDbEzOf8LyiKWSrDcgV129mWhi3VpbNQvOIDEHcg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /esbuild-android-arm64/0.14.36:
     resolution: {integrity: sha512-/hYkyFe7x7Yapmfv4X/tBmyKnggUmdQmlvZ8ZlBnV4+PjisrEhAvC3yWpURuD9XoB8Wa1d5dGkTsF53pIvpjsg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-android-arm64/0.14.5:
@@ -10939,21 +10921,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-64/0.14.30:
-    resolution: {integrity: sha512-VRaOXMMrsG5n53pl4qFZQdXy2+E0NoLP/QH3aDUI0+bQP+ZHDmbINKcDy2IX7GVFI9kqPS18iJNAs5a6/G2LZg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /esbuild-darwin-64/0.14.36:
     resolution: {integrity: sha512-kkl6qmV0dTpyIMKagluzYqlc1vO0ecgpviK/7jwPbRDEv5fejRTaBBEE2KxEQbTHcLhiiDbhG7d5UybZWo/1zQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-64/0.14.5:
@@ -10972,21 +10945,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-arm64/0.14.30:
-    resolution: {integrity: sha512-qDez+fHMOrO9Oc9qjt/x+sy09RJVh62kik5tVybKRLmezeV4qczM9/sAYY57YN0aWLdHbcCj2YqJUWYJNsgKnw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /esbuild-darwin-arm64/0.14.36:
     resolution: {integrity: sha512-q8fY4r2Sx6P0Pr3VUm//eFYKVk07C5MHcEinU1BjyFnuYz4IxR/03uBbDwluR6ILIHnZTE7AkTUWIdidRi1Jjw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.14.5:
@@ -11005,21 +10969,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-64/0.14.30:
-    resolution: {integrity: sha512-mec1jENcImVVagddZlGWsdAUwBnzR5cgnhzCxv+9fSMxKbx1uZYLLUAnLPp8m/i934zrumR1xGjJ5VoWdPlI2w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
   /esbuild-freebsd-64/0.14.36:
     resolution: {integrity: sha512-Hn8AYuxXXRptybPqoMkga4HRFE7/XmhtlQjXFHoAIhKUPPMeJH35GYEUWGbjteai9FLFvBAjEAlwEtSGxnqWww==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-64/0.14.5:
@@ -11038,21 +10993,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-arm64/0.14.30:
-    resolution: {integrity: sha512-cpjbTs6Iok/AfeB0JgTzyUJTMStC1SQULmany5nHx6S4GTkSgaAHuJzZO0GcVWqghI4e0YL/bjXAhN5Mn6feNw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
   /esbuild-freebsd-arm64/0.14.36:
     resolution: {integrity: sha512-S3C0attylLLRiCcHiJd036eDEMOY32+h8P+jJ3kTcfhJANNjP0TNBNL30TZmEdOSx/820HJFgRrqpNAvTbjnDA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.14.5:
@@ -11071,21 +11017,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-32/0.14.30:
-    resolution: {integrity: sha512-liIONVT4F2kZmOMwtwASqZ8WkIjb5HHBR9HUffdHiuotSTF3CyZO+EJf+Og+SYYuuVIvt0qHNSFjBA/iSESteQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-32/0.14.36:
     resolution: {integrity: sha512-Eh9OkyTrEZn9WGO4xkI3OPPpUX7p/3QYvdG0lL4rfr73Ap2HAr6D9lP59VMF64Ex01LhHSXwIsFG/8AQjh6eNw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-32/0.14.5:
@@ -11104,21 +11041,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-64/0.14.30:
-    resolution: {integrity: sha512-LUnpzoMpRqFON5En4qEj6NWiyH6a1K+Y2qYNKrCy5qPTjDoG/EWeqMz69n8Uv7pRuvDKl3FNGJ1dufTrA5i0sw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-64/0.14.36:
     resolution: {integrity: sha512-vFVFS5ve7PuwlfgoWNyRccGDi2QTNkQo/2k5U5ttVD0jRFaMlc8UQee708fOZA6zTCDy5RWsT5MJw3sl2X6KDg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-64/0.14.5:
@@ -11137,21 +11065,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm/0.14.30:
-    resolution: {integrity: sha512-97T+bbXnpqf7mfIG49UR7ZSJFGgvc22byn74qw3Kx2GDCBSQoVFjyWuKOHGXp8nXk3XYrdFF+mQ8yQ7aNsgQvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-arm/0.14.36:
     resolution: {integrity: sha512-NhgU4n+NCsYgt7Hy61PCquEz5aevI6VjQvxwBxtxrooXsxt5b2xtOUXYZe04JxqQo+XZk3d1gcr7pbV9MAQ/Lg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm/0.14.5:
@@ -11170,21 +11089,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm64/0.14.30:
-    resolution: {integrity: sha512-DHZHn6FK5q/KL0fpNT/0jE38Nnyk2rXxKE9WENi95EXtqfOLPgE8tzjTZQNgpr61R95QX4ymQU26ni3IZk8buQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-arm64/0.14.36:
     resolution: {integrity: sha512-24Vq1M7FdpSmaTYuu1w0Hdhiqkbto1I5Pjyi+4Cdw5fJKGlwQuw+hWynTcRI/cOZxBcBpP21gND7W27gHAiftw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.14.5:
@@ -11203,21 +11113,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-mips64le/0.14.30:
-    resolution: {integrity: sha512-fLUzTFZ7uknC0aPTk7/lM7NmaG/9ZqE3SaHEphcaM009SZK/mDOvZugWi1ss6WGNhk13dUrhkfHcc4FSb9hYhg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-mips64le/0.14.36:
     resolution: {integrity: sha512-hZUeTXvppJN+5rEz2EjsOFM9F1bZt7/d2FUM1lmQo//rXh1RTFYzhC0txn7WV0/jCC7SvrGRaRz0NMsRPf8SIA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-mips64le/0.14.5:
@@ -11236,21 +11137,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-ppc64le/0.14.30:
-    resolution: {integrity: sha512-2Oudm2WEfj0dNU9bzIl5L/LrsMEmHWsOsYgJJqu8fDyUDgER+J1d33qz3cUdjsJk7gAENayIxDSpsuCszx0w3A==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-ppc64le/0.14.36:
     resolution: {integrity: sha512-1Bg3QgzZjO+QtPhP9VeIBhAduHEc2kzU43MzBnMwpLSZ890azr4/A9Dganun8nsqD/1TBcqhId0z4mFDO8FAvg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-linux-ppc64le/0.14.5:
@@ -11261,27 +11153,10 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-riscv64/0.14.30:
-    resolution: {integrity: sha512-RPMucPW47rV4t2jlelaE948iCRtbZf5RhifxSwzlpM1Mqdyu99MMNK0w4jFreGTmLN+oGomxIOxD6n+2E/XqHw==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-riscv64/0.14.36:
     resolution: {integrity: sha512-dOE5pt3cOdqEhaufDRzNCHf5BSwxgygVak9UR7PH7KPVHwSTDAZHDoEjblxLqjJYpc5XaU9+gKJ9F8mp9r5I4A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x/0.14.30:
-    resolution: {integrity: sha512-OZ68r7ok6qO7hdwrwQn2p5jbIRRcUcVaAykB7e0uCA0ODwfeGunILM6phJtq2Oz4dlEEFvd+tSuma3paQKwt+A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -11292,7 +11167,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.13.8:
@@ -11303,21 +11177,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-netbsd-64/0.14.30:
-    resolution: {integrity: sha512-iyejQUKn0TzpPkufq8pSCxOg9NheycQbMbPCmjefTe9wYuUlBt1TcHvdoJnYbQzsAhAh1BNq+s0ycRsIJFZzaQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    optional: true
-
   /esbuild-netbsd-64/0.14.36:
     resolution: {integrity: sha512-UB2bVImxkWk4vjnP62ehFNZ73lQY1xcnL5ZNYF3x0AG+j8HgdkNF05v67YJdCIuUJpBuTyCK8LORCYo9onSW+A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.14.5:
@@ -11342,21 +11207,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-openbsd-64/0.14.30:
-    resolution: {integrity: sha512-UyK1MTMcy4j5fH260fsE1o6MVgWNhb62eCK2yCKCRazZv8Nqdc2WiP9ygjWidmEdCDS+A6MuVp9ozk9uoQtQpA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    optional: true
-
   /esbuild-openbsd-64/0.14.36:
     resolution: {integrity: sha512-NvGB2Chf8GxuleXRGk8e9zD3aSdRO5kLt9coTQbCg7WMGXeX471sBgh4kSg8pjx0yTXRt0MlrUDnjVYnetyivg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.14.5:
@@ -11383,21 +11239,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-sunos-64/0.14.30:
-    resolution: {integrity: sha512-aQRtRTNKHB4YuG+xXATe5AoRTNY48IJg5vjE8ElxfmjO9+KdX7MHFkTLhlKevCD6rNANtB3qOlSIeAiXTwHNqw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    optional: true
-
   /esbuild-sunos-64/0.14.36:
     resolution: {integrity: sha512-VkUZS5ftTSjhRjuRLp+v78auMO3PZBXu6xl4ajomGenEm2/rGuWlhFSjB7YbBNErOchj51Jb2OK8lKAo8qdmsQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-sunos-64/0.14.5:
@@ -11416,21 +11263,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-32/0.14.30:
-    resolution: {integrity: sha512-9/fb1tPtpacMqxAXp3fGHowUDg/l9dVch5hKmCLEZC6PdGljh6h372zMdJwYfH0Bd5CCPT0Wx95uycBLJiqpXA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /esbuild-windows-32/0.14.36:
     resolution: {integrity: sha512-bIar+A6hdytJjZrDxfMBUSEHHLfx3ynoEZXx/39nxy86pX/w249WZm8Bm0dtOAByAf4Z6qV0LsnTIJHiIqbw0w==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-32/0.14.5:
@@ -11449,21 +11287,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-64/0.14.30:
-    resolution: {integrity: sha512-DHgITeUhPAnN9I5O6QBa1GVyPOhiYCn4S4TtQr7sO4+X0LNyqnlmA1M0qmGkUdDC1QQfjI8uQ4G/whdWb2pWIQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /esbuild-windows-64/0.14.36:
     resolution: {integrity: sha512-+p4MuRZekVChAeueT1Y9LGkxrT5x7YYJxYE8ZOTcEfeUUN43vktSn6hUNsvxzzATrSgq5QqRdllkVBxWZg7KqQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-64/0.14.5:
@@ -11482,21 +11311,12 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-arm64/0.14.30:
-    resolution: {integrity: sha512-F1kLyQH7zSgjh5eLxogGZN7C9+KNs9m+s7Q6WZoMmCWT/6j998zlaoECHyM8izJRRfsvw2eZlEa1jO6/IOU1AQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /esbuild-windows-arm64/0.14.36:
     resolution: {integrity: sha512-fBB4WlDqV1m18EF/aheGYQkQZHfPHiHJSBYzXIo8yKehek+0BtBwo/4PNwKGJ5T0YK0oc8pBKjgwPbzSrPLb+Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.14.5:
@@ -11531,33 +11351,6 @@ packages:
       esbuild-windows-arm64: 0.13.8
     dev: true
 
-  /esbuild/0.14.30:
-    resolution: {integrity: sha512-wCecQSBkIjp2xjuXY+wcXS/PpOQo9rFh4NAKPh4Pm9f3fuLcnxkR0rDzA+mYP88FtXIUcXUyYmaIgfrzRl55jA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      esbuild-android-64: 0.14.30
-      esbuild-android-arm64: 0.14.30
-      esbuild-darwin-64: 0.14.30
-      esbuild-darwin-arm64: 0.14.30
-      esbuild-freebsd-64: 0.14.30
-      esbuild-freebsd-arm64: 0.14.30
-      esbuild-linux-32: 0.14.30
-      esbuild-linux-64: 0.14.30
-      esbuild-linux-arm: 0.14.30
-      esbuild-linux-arm64: 0.14.30
-      esbuild-linux-mips64le: 0.14.30
-      esbuild-linux-ppc64le: 0.14.30
-      esbuild-linux-riscv64: 0.14.30
-      esbuild-linux-s390x: 0.14.30
-      esbuild-netbsd-64: 0.14.30
-      esbuild-openbsd-64: 0.14.30
-      esbuild-sunos-64: 0.14.30
-      esbuild-windows-32: 0.14.30
-      esbuild-windows-64: 0.14.30
-      esbuild-windows-arm64: 0.14.30
-
   /esbuild/0.14.36:
     resolution: {integrity: sha512-HhFHPiRXGYOCRlrhpiVDYKcFJRdO0sBElZ668M4lh2ER0YgnkLxECuFe7uWCf23FrcLc59Pqr7dHkTqmRPDHmw==}
     engines: {node: '>=12'}
@@ -11584,7 +11377,6 @@ packages:
       esbuild-windows-32: 0.14.36
       esbuild-windows-64: 0.14.36
       esbuild-windows-arm64: 0.14.36
-    dev: true
 
   /esbuild/0.14.5:
     resolution: {integrity: sha512-ofwgH4ITPXhkMo2AM39oXpSe5KIyWjxicdqYVy+tLa1lMgxzPCKwaepcrSRtYbgTUMXwquxB1C3xQYpUNaPAFA==}
@@ -17905,7 +17697,7 @@ packages:
       solid-js: 1.3.14
     dev: true
 
-  /solid-start-node/0.1.0-alpha.74_0c5a25f3d414050f68aab16d630bd2fb:
+  /solid-start-node/0.1.0-alpha.74_4b0d32444bb3495687fe087b06d3b6cf:
     resolution: {integrity: sha512-dvhlAly3xv+t1IODkDi25oN7Q3sKm0jOV3hqYBE5Y7roDjJaTlZbpSYzZpxc+hdNo5VcdYfiFXff5Xe5V2UILQ==}
     requiresBuild: true
     peerDependencies:
@@ -17920,13 +17712,13 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.70.1
       sirv: 1.0.19
-      solid-start: 0.1.0-alpha.74_solid-js@1.3.14+vite@2.9.1
+      solid-start: 0.1.0-alpha.74_solid-js@1.3.14+vite@2.9.5
       undici: 4.13.0
-      vite: 2.9.1
+      vite: 2.9.5
     dev: true
     optional: true
 
-  /solid-start/0.1.0-alpha.74_solid-js@1.3.14+vite@2.9.1:
+  /solid-start/0.1.0-alpha.74_solid-js@1.3.14+vite@2.9.5:
     resolution: {integrity: sha512-lkPHD8/1sHE1/FmbFvNPoFGw1RPPz8ZyvbMLAinr+CfKQvIKJja7QghGqu6bL7kuvuTDptWo8qMtBREICOX85Q==}
     hasBin: true
     peerDependencies:
@@ -17953,12 +17745,12 @@ packages:
       sirv: 1.0.19
       solid-js: 1.3.14
       undici: 4.13.0
-      vite: 2.9.1
-      vite-plugin-inspect: 0.3.14_vite@2.9.1
+      vite: 2.9.5
+      vite-plugin-inspect: 0.3.14_vite@2.9.5
       vite-plugin-solid: 2.2.6
       zx: 6.0.7
     optionalDependencies:
-      solid-start-node: 0.1.0-alpha.74_0c5a25f3d414050f68aab16d630bd2fb
+      solid-start-node: 0.1.0-alpha.74_4b0d32444bb3495687fe087b06d3b6cf
     transitivePeerDependencies:
       - less
       - sass
@@ -18201,14 +17993,14 @@ packages:
     resolution: {integrity: sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==}
     dev: true
 
-  /storybook-builder-vite/0.1.23_546fc62b469cbb0c46b48aaa3d11d6a0:
+  /storybook-builder-vite/0.1.23_b234169f202737657ca6d7cd85261501:
     resolution: {integrity: sha512-PmeeYKHaBNQgRVJEwhfyo4Psev1Y7Gj51nlYxUDIG3dpy1e1aGzFubDgsmg9W/BhyHKcLIKp98JBpa1DwL702A==}
     deprecated: storybook-builder-vite has been renamed to @storybook/builder-vite
     peerDependencies:
       '@storybook/core-common': ^6.4.3
       vite: '>=2.6.7'
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.2_typescript@4.6.3+vite@2.9.1
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.2_typescript@4.6.3+vite@2.9.5
       '@mdx-js/mdx': 1.6.22
       '@storybook/csf-tools': 6.4.19
       '@storybook/source-loader': 6.4.19_react-dom@17.0.2+react@17.0.2
@@ -18217,8 +18009,8 @@ packages:
       glob: 7.2.0
       glob-promise: 4.2.2_glob@7.2.0
       slash: 3.0.0
-      vite: 2.9.1
-      vite-plugin-mdx: 3.5.10_@mdx-js+mdx@1.6.22+vite@2.9.1
+      vite: 2.9.5
+      vite-plugin-mdx: 3.5.10_@mdx-js+mdx@1.6.22+vite@2.9.5
     transitivePeerDependencies:
       - react
       - react-dom
@@ -19250,7 +19042,7 @@ packages:
       detect-node: 2.1.0
     dev: false
 
-  /unocss/0.31.2_vite@2.9.1:
+  /unocss/0.31.2_vite@2.9.5:
     resolution: {integrity: sha512-ZPu14276pTa89o9b9mEcyh7/oK3lwiwESyyAIAvr5zrWgOiXv1GcoMbGUFnl9szj1GSZF2qo3z9nO8OTaAbWRQ==}
     engines: {node: '>=14'}
     dependencies:
@@ -19266,7 +19058,7 @@ packages:
       '@unocss/reset': 0.31.2
       '@unocss/transformer-directives': 0.31.2
       '@unocss/transformer-variant-group': 0.31.2
-      '@unocss/vite': 0.31.2_vite@2.9.1
+      '@unocss/vite': 0.31.2_vite@2.9.5
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -19278,7 +19070,29 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /unplugin-auto-import/0.7.0_2148f78c5474adce365c6a875cfdf6da:
+  /unplugin-auto-import/0.7.0_05062056c3506028f60dc849695a4e6b:
+    resolution: {integrity: sha512-40oC7bxzSyyvJI4mXmk8gDD7gKjR10gYkeWBu/UigK8TusXwUsJOjwvIr+REgzOMBGH/5pUiVMoBYEZrLejk3w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@vueuse/core': '*'
+    peerDependenciesMeta:
+      '@vueuse/core':
+        optional: true
+    dependencies:
+      '@antfu/utils': 0.5.0
+      '@rollup/pluginutils': 4.2.0
+      local-pkg: 0.4.1
+      magic-string: 0.26.1
+      resolve: 1.22.0
+      unplugin: 0.6.1_05062056c3506028f60dc849695a4e6b
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
+
+  /unplugin-auto-import/0.7.0_20ca0c17fde6bf5437d5dedd7e06991f:
     resolution: {integrity: sha512-40oC7bxzSyyvJI4mXmk8gDD7gKjR10gYkeWBu/UigK8TusXwUsJOjwvIr+REgzOMBGH/5pUiVMoBYEZrLejk3w==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -19293,7 +19107,7 @@ packages:
       local-pkg: 0.4.1
       magic-string: 0.26.1
       resolve: 1.22.0
-      unplugin: 0.6.1_83dd4d1a11bf7faa2d41f89ea3fae952
+      unplugin: 0.6.1_05062056c3506028f60dc849695a4e6b
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -19301,29 +19115,7 @@ packages:
       - webpack
     dev: true
 
-  /unplugin-auto-import/0.7.0_83dd4d1a11bf7faa2d41f89ea3fae952:
-    resolution: {integrity: sha512-40oC7bxzSyyvJI4mXmk8gDD7gKjR10gYkeWBu/UigK8TusXwUsJOjwvIr+REgzOMBGH/5pUiVMoBYEZrLejk3w==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@vueuse/core': '*'
-    peerDependenciesMeta:
-      '@vueuse/core':
-        optional: true
-    dependencies:
-      '@antfu/utils': 0.5.0
-      '@rollup/pluginutils': 4.2.0
-      local-pkg: 0.4.1
-      magic-string: 0.26.1
-      resolve: 1.22.0
-      unplugin: 0.6.1_83dd4d1a11bf7faa2d41f89ea3fae952
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-    dev: true
-
-  /unplugin-vue-components/0.19.2_a85a21dab8be76a3330f4d7b2bf56cfa:
+  /unplugin-vue-components/0.19.2_1136d9a205d0203afd70a6e03df668e2:
     resolution: {integrity: sha512-7DhQfTyHLyVIWR6VBQONLU6dDBOXtEYvZQYUpN9C+t11WOb5baIFoxfzDxkeFHTHGMhznyEOw6afHyV9JKWnig==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -19345,7 +19137,7 @@ packages:
       magic-string: 0.26.1
       minimatch: 5.0.1
       resolve: 1.22.0
-      unplugin: 0.6.1_83dd4d1a11bf7faa2d41f89ea3fae952
+      unplugin: 0.6.1_05062056c3506028f60dc849695a4e6b
       vue: 3.2.32
     transitivePeerDependencies:
       - esbuild
@@ -19355,7 +19147,7 @@ packages:
       - webpack
     dev: true
 
-  /unplugin/0.6.1_83dd4d1a11bf7faa2d41f89ea3fae952:
+  /unplugin/0.6.1_05062056c3506028f60dc849695a4e6b:
     resolution: {integrity: sha512-cQqRCgQ2v/Q4fPIWNVZ6sNIDdl5v8JXOnlsUOsGzT4fblTONoPWaytiYSpu5qJ9lvSDZYAQN6BRVo3XQoZMfUQ==}
     peerDependencies:
       esbuild: '>=0.13'
@@ -19375,7 +19167,7 @@ packages:
       chokidar: 3.5.3
       esbuild: 0.14.36
       rollup: 2.70.1
-      vite: 2.9.1
+      vite: 2.9.5
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.3
     dev: true
@@ -19578,7 +19370,7 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /vite-plugin-inspect/0.3.14_vite@2.9.1:
+  /vite-plugin-inspect/0.3.14_vite@2.9.5:
     resolution: {integrity: sha512-oRjltmm1nUgkHmlGLgfSAuPiXA/FqC7daURJ+faY498r3mwnXrtcfe6Bg5khANQ0iss9Cn1uV6+W9c85noVq0g==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -19589,12 +19381,12 @@ packages:
       kolorist: 1.5.1
       sirv: 2.0.2
       ufo: 0.7.10
-      vite: 2.9.1
+      vite: 2.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-mdx/3.5.10_@mdx-js+mdx@1.6.22+vite@2.9.1:
+  /vite-plugin-mdx/3.5.10_@mdx-js+mdx@1.6.22+vite@2.9.5:
     resolution: {integrity: sha512-tfGNRwkO23pln9EYqhbsOLEx9Qot5+enl+727gop7+HGEoC87+88hLRWGL+FU/It1Y0a5P3OAyDbTKKHX6tEJw==}
     peerDependencies:
       '@mdx-js/mdx': '*'
@@ -19605,10 +19397,10 @@ packages:
       esbuild: 0.13.8
       resolve: 1.22.0
       unified: 9.2.2
-      vite: 2.9.1
+      vite: 2.9.5
     dev: true
 
-  /vite-plugin-optimize-persist/0.1.2_e8535a6275298a6eb7d603176e126257:
+  /vite-plugin-optimize-persist/0.1.2_3ffa6461a7336e598fca66c236cfe0d4:
     resolution: {integrity: sha512-H/Ebn2kZO8PvwUF08SsT5K5xMJNCWKoGX71+e9/ER3yNj7GHiFjNQlvGg5ih/zEx09MZ9m7WCxOwmEKbeIVzww==}
     peerDependencies:
       vite: ^2.0.0
@@ -19616,24 +19408,24 @@ packages:
     dependencies:
       debug: 4.3.3
       fs-extra: 10.0.1
-      vite: 2.9.1
-      vite-plugin-package-config: 0.1.1_vite@2.9.1
+      vite: 2.9.5
+      vite-plugin-package-config: 0.1.1_vite@2.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-package-config/0.1.1_vite@2.9.1:
+  /vite-plugin-package-config/0.1.1_vite@2.9.5:
     resolution: {integrity: sha512-w9B3I8ZnqoyhlbzimXjXNk85imrMZgvI9m8f6j3zonK5IVA5KXzpT+PZOHlDz8lqh1vqvoEI1uhy+ZDoLAiA/w==}
     peerDependencies:
       vite: ^2.0.0
     dependencies:
       debug: 4.3.3
-      vite: 2.9.1
+      vite: 2.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-pages/0.22.0_vite@2.9.1:
+  /vite-plugin-pages/0.22.0_vite@2.9.5:
     resolution: {integrity: sha512-OeCtSKoQNjrjtlNgkF4JTU0UdiZsa0cSQJKFyRoUz5KMbGoXR8O29BB2fZx9tMSBPyQJgGvIpzdoofLDaRNcQQ==}
     peerDependencies:
       '@vue/compiler-sfc': '>=3'
@@ -19648,13 +19440,13 @@ packages:
       json5: 2.2.0
       local-pkg: 0.4.1
       picocolors: 1.0.0
-      vite: 2.9.1
+      vite: 2.9.5
       yaml: 2.0.0-10
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.11.13_vite@2.9.1:
+  /vite-plugin-pwa/0.11.13_vite@2.9.5:
     resolution: {integrity: sha512-Ssj14m3TRVLfkFEAWSMcFE2d1cSdEZyrVTzfY2lSL+umHYvcIFHVDAY143sygtBCb44OPczsAOmWwBTxwOvh7g==}
     peerDependencies:
       vite: ^2.0.0
@@ -19663,7 +19455,7 @@ packages:
       fast-glob: 3.2.11
       pretty-bytes: 5.6.0
       rollup: 2.68.0
-      vite: 2.9.1
+      vite: 2.9.5
       workbox-build: 6.5.0
       workbox-window: 6.5.3
     transitivePeerDependencies:
@@ -19672,14 +19464,14 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-ruby/3.0.9_vite@2.9.1:
+  /vite-plugin-ruby/3.0.9_vite@2.9.5:
     resolution: {integrity: sha512-MHAilPn1zLz5KL3hQodTl5PbeuNM5mxW1lXahr40lAhT4S3G7gPI5qSiCDq0MxmaPo/zrLoHYJj9u5xCAwNjmw==}
     peerDependencies:
       vite: '>=2.5.0'
     dependencies:
       debug: 4.3.4
       fast-glob: 3.2.11
-      vite: 2.9.1
+      vite: 2.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19693,7 +19485,7 @@ packages:
       merge-anything: 5.0.2
       solid-js: 1.3.14
       solid-refresh: 0.4.0_solid-js@1.3.14
-      vite: 2.9.1
+      vite: 2.9.5
     transitivePeerDependencies:
       - less
       - sass
@@ -19701,8 +19493,8 @@ packages:
       - supports-color
     dev: true
 
-  /vite/2.9.1:
-    resolution: {integrity: sha512-vSlsSdOYGcYEJfkQ/NeLXgnRv5zZfpAsdztkIrs7AZHV8RCMZQkwjo4DS5BnrYTqoWqLoUe1Cah4aVO4oNNqCQ==}
+  /vite/2.9.5:
+    resolution: {integrity: sha512-dvMN64X2YEQgSXF1lYabKXw3BbN6e+BL67+P3Vy4MacnY+UzT1AfkHiioFSi9+uiDUiaDy7Ax/LQqivk6orilg==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -19717,7 +19509,7 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.30
+      esbuild: 0.14.36
       postcss: 8.4.12
       resolve: 1.22.0
       rollup: 2.70.1
@@ -19731,9 +19523,9 @@ packages:
     dependencies:
       '@docsearch/css': 3.0.0-alpha.42
       '@docsearch/js': 3.0.0-alpha.42
-      '@vitejs/plugin-vue': 2.3.1_vite@2.9.1+vue@3.2.32
+      '@vitejs/plugin-vue': 2.3.1_vite@2.9.5+vue@3.2.32
       prismjs: 1.25.0
-      vite: 2.9.1
+      vite: 2.9.5
       vue: 3.2.32
     transitivePeerDependencies:
       - '@algolia/client-search'


### PR DESCRIPTION
Should fix #553

Use the new `optimizeDeps.disabled: true` option, experimental in Vite >2.9.2, `entries` remains to help with older versions.

Also updated to vite@2.9.5