### PR TITLE
fix: remove process.env edge case in defines

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -27,8 +27,10 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
         const preOptions = deepMerge({}, configDefaults, options, viteConfig.test ?? {})
         preOptions.api = resolveApiConfig(preOptions)
 
-        if (viteConfig.define)
+        if (viteConfig.define) {
           delete viteConfig.define['import.meta.vitest']
+          delete viteConfig.define['process.env']
+        }
 
         // store defines for globalThis to make them
         // reassignable when running in worker in src/runtime/setup.ts


### PR DESCRIPTION
It is not uncommon to shim `process.env` with an empty object in Vite projects. This doesn't allow us to put `import.meta.env` variables on it, while running tests.

This PR removes this edge case.