### PR TITLE
fix: reset snapshot state between test reruns

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -220,6 +220,7 @@ export class Vitest {
 
       const invalidates = Array.from(this.invalidates)
       this.invalidates.clear()
+      this.snapshot.clear()
       await this.pool.runTests(files, invalidates)
 
       if (hasFailed(this.state.getFiles()))


### PR DESCRIPTION
Fixes #1161.

I'm not 100% sure whether `async runFiles()` is the correct place to clear snapshots, but it works.

Currently snapshots are only cleared in `async scheduleRerun(triggerId: string)`.

https://github.com/vitest-dev/vitest/blob/0c9137d9d3267be860a59c619e2eee981e51a64b/packages/vitest/src/node/core.ts#L319
