### PR TITLE
feat: error log improvements

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -21,8 +21,15 @@ class VitestUtils {
     this._mocker = typeof __vitest_mocker__ !== 'undefined' ? __vitest_mocker__ : null
     this._mockedDate = null
 
-    if (!this._mocker)
-      throw new Error('Vitest was initialized with native Node instead of Vite Node')
+    if (!this._mocker) {
+      const errorMsg = 'Vitest was initialized with native Node instead of Vite Node.'
+      + '\n\nOne of the following is possible:'
+      + '\n- "vitest" is imported outside of your tests (in that case, use "vitest/node" or import.meta.vitest)'
+      + '\n- "vitest" is imported inside "globalSetup" (use "setupFiles", because "globalSetup" runs in a different context)'
+      + '\n- Your dependency inside "node_modules" imports "vitest" directly (in that case, inline that dependency, using "deps.inline" config)'
+      + '\n- Otherwise, it might be a Vitest bug. Please report it to https://github.com/vitest-dev/vitest/issues\n'
+      throw new Error(errorMsg)
+    }
   }
 
   // timers

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -1,11 +1,9 @@
 import { execa } from 'execa'
 import type { UserConfig as ViteUserConfig } from 'vite'
-import c from 'picocolors'
 import type { UserConfig } from '../types'
 import { ensurePackageInstalled } from '../utils'
 import { createVitest } from './create'
 import { registerConsoleShortcuts } from './stdin'
-import { divider } from './reporters/renderers/utils'
 
 export interface CliOptions extends UserConfig {
   /**
@@ -75,8 +73,7 @@ export async function startVitest(cliFilters: string[], options: CliOptions, vit
   }
   catch (e) {
     process.exitCode = 1
-    ctx.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Error '))))}`)
-    await ctx.printError(e, true)
+    await ctx.printError(e, true, 'Unhandled Error')
     ctx.error('\n\n')
     return false
   }

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -76,7 +76,7 @@ export async function startVitest(cliFilters: string[], options: CliOptions, vit
   catch (e) {
     process.exitCode = 1
     ctx.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Error '))))}`)
-    await ctx.printError(e)
+    await ctx.printError(e, true)
     ctx.error('\n\n')
     return false
   }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -493,8 +493,8 @@ export class Vitest {
     return code.includes('import.meta.vitest')
   }
 
-  printError(err: unknown) {
-    return printError(err, this)
+  printError(err: unknown, fullStack = false) {
+    return printError(err, fullStack, this)
   }
 
   onServerRestarted(fn: () => void) {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -499,7 +499,7 @@ export class Vitest {
   }
 
   printError(err: unknown, fullStack = false, type?: string) {
-    return printError(err, type, fullStack, this)
+    return printError(err, type, fullStack, true, this)
   }
 
   onServerRestarted(fn: () => void) {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -499,7 +499,11 @@ export class Vitest {
   }
 
   printError(err: unknown, fullStack = false, type?: string) {
-    return printError(err, type, fullStack, true, this)
+    return printError(err, this, {
+      fullStack,
+      type,
+      showCodeFrame: true,
+    })
   }
 
   onServerRestarted(fn: () => void) {

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -88,6 +88,8 @@ function getErrorProperties(e: ErrorWithDiff) {
     'showDiff',
     'actual',
     'expected',
+    'constructor',
+    'toString',
   ]
   for (const key of Object.getOwnPropertyNames(e)) {
     if (!skip.includes(key))

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -89,7 +89,7 @@ function getErrorProperties(e: ErrorWithDiff) {
     'actual',
     'expected',
   ]
-  for (const key in e) {
+  for (const key of Object.getOwnPropertyNames(e)) {
     if (!skip.includes(key))
       errorObject[key] = e[key as keyof ErrorWithDiff]
   }

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -18,7 +18,14 @@ export function fileFromParsedStack(stack: ParsedStack) {
   return stack.file
 }
 
-export async function printError(error: unknown, type: string | undefined, fullStack: boolean, showCodeFrame, ctx: Vitest) {
+interface PrintErrorOptions {
+  type?: string
+  fullStack?: boolean
+  showCodeFrame?: boolean
+}
+
+export async function printError(error: unknown, ctx: Vitest, options: PrintErrorOptions = {}) {
+  const { showCodeFrame = true, fullStack = false, type } = options
   let e = error as ErrorWithDiff
 
   if (typeof error === 'string') {
@@ -51,7 +58,7 @@ export async function printError(error: unknown, type: string | undefined, fullS
 
   if (e.cause) {
     e.cause.name = `Caused by: ${e.cause.name}`
-    await printError(e.cause, undefined, fullStack, false, ctx)
+    await printError(e.cause, ctx, { fullStack, showCodeFrame: false })
   }
 
   handleImportOutsideModuleError(e.stack || e.stackStr || '', ctx)

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -148,8 +148,11 @@ function createChannel(ctx: Vitest) {
         ctx.state.updateUserLog(log)
         ctx.report('onUserConsoleLog', log)
       },
+      onUnhandledRejection(err) {
+        ctx.state.catchError(err, 'Unhandled Rejection')
+      },
       onFinished(files) {
-        ctx.report('onFinished', files)
+        ctx.report('onFinished', files, ctx.state.getUnhandledErrors())
       },
     },
     {

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -102,7 +102,8 @@ export abstract class BaseReporter implements Reporter {
 
   async onWatcherStart() {
     const files = this.ctx.state.getFiles()
-    const failed = hasFailed(files)
+    const errors = this.ctx.state.getUnhandledErrors()
+    const failed = errors.length > 0 || hasFailed(files)
     const failedSnap = hasFailedSnapshot(files)
     if (failed)
       this.ctx.log(WAIT_FOR_CHANGE_FAIL)

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -53,9 +53,22 @@ export abstract class BaseReporter implements Reporter {
     return relative(this.ctx.config.root, path)
   }
 
-  async onFinished(files = this.ctx.state.getFiles()) {
+  async onFinished(files = this.ctx.state.getFiles(), errors = this.ctx.state.getUnhandledErrors()) {
     this.end = performance.now()
     await this.reportSummary(files)
+    if (errors.length) {
+      process.exitCode = 1
+      const errorMessage = c.red(c.bold(
+        `\nVitest catched ${errors.length} unhandled error${errors.length > 1 ? 's' : ''} during the test run. This might cause false positive tests.`
+        + '\nPlease, resolve all the errors to make sure your tests are not affected.',
+      ))
+      this.ctx.log(c.red(divider(c.bold(c.inverse(' Unhandled Errors ')))))
+      this.ctx.log(errorMessage)
+      await Promise.all(errors.map(async (err) => {
+        await this.ctx.printError(err, true, (err as ErrorWithDiff).type || 'Unhandled Error')
+      }))
+      this.ctx.log(c.red(divider()))
+    }
   }
 
   onTaskUpdate(packs: TaskResultPack[]) {
@@ -108,6 +121,7 @@ export abstract class BaseReporter implements Reporter {
   async onWatcherRerun(files: string[], trigger?: string) {
     this.watchFilters = files
 
+    this.ctx.state.clearErrors()
     this.ctx.clearScreen()
     this.ctx.log(`\n${c.inverse(c.bold(c.blue(' RERUN ')))}${trigger ? c.dim(` ${this.relative(trigger)}\n`) : ''}`)
     this.start = performance.now()
@@ -209,8 +223,7 @@ export abstract class BaseReporter implements Reporter {
   registerUnhandledRejection() {
     process.on('unhandledRejection', async (err) => {
       process.exitCode = 1
-      this.ctx.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Rejection '))))}`)
-      await this.ctx.printError(err, true)
+      await this.ctx.printError(err, true, 'Unhandled Rejection')
       this.ctx.error('\n\n')
       process.exit(1)
     })

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -210,7 +210,7 @@ export abstract class BaseReporter implements Reporter {
     process.on('unhandledRejection', async (err) => {
       process.exitCode = 1
       this.ctx.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Rejection '))))}`)
-      await this.ctx.printError(err)
+      await this.ctx.printError(err, true)
       this.ctx.error('\n\n')
       process.exit(1)
     })

--- a/packages/vitest/src/node/reporters/default.ts
+++ b/packages/vitest/src/node/reporters/default.ts
@@ -30,10 +30,10 @@ export class DefaultReporter extends BaseReporter {
     }
   }
 
-  async onFinished(files = this.ctx.state.getFiles()) {
+  async onFinished(files = this.ctx.state.getFiles(), errors = this.ctx.state.getUnhandledErrors()) {
     await this.stopListRender()
     this.ctx.log()
-    await super.onFinished(files)
+    await super.onFinished(files, errors)
   }
 
   async onWatcherStart() {

--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -17,10 +17,10 @@ export class DotReporter extends BaseReporter {
     }
   }
 
-  async onFinished(files = this.ctx.state.getFiles()) {
+  async onFinished(files = this.ctx.state.getFiles(), errors = this.ctx.state.getUnhandledErrors()) {
     await this.stopListRender()
     this.ctx.log()
-    await super.onFinished(files)
+    await super.onFinished(files, errors)
   }
 
   async onWatcherStart() {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -1,9 +1,23 @@
-import type { File, Task, TaskResultPack, UserConsoleLog } from '../types'
+import type { ErrorWithDiff, File, Task, TaskResultPack, UserConsoleLog } from '../types'
 
 export class StateManager {
   filesMap = new Map<string, File>()
   idMap = new Map<string, Task>()
   taskFileMap = new WeakMap<Task, File>()
+  errorsSet = new Set<unknown>()
+
+  catchError(err: unknown, type: string) {
+    (err as ErrorWithDiff).type = type
+    this.errorsSet.add(err)
+  }
+
+  clearErrors() {
+    this.errorsSet.clear()
+  }
+
+  getUnhandledErrors() {
+    return Array.from(this.errorsSet.values())
+  }
 
   getFiles(keys?: string[]): File[] {
     if (keys)

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -31,6 +31,10 @@ async function startViteNode(ctx: WorkerContext) {
     return processExit(code)
   }
 
+  process.on('unhandledRejection', (err) => {
+    rpc().onUnhandledRejection(err)
+  })
+
   const { config } = ctx
 
   const { run, collect } = (await executeInViteNode({

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -71,6 +71,7 @@ export interface ErrorWithDiff extends Error {
   actual?: any
   expected?: any
   operator?: string
+  type?: string
 }
 
 export interface ModuleGraphData {

--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -5,7 +5,7 @@ import type { File, TaskResultPack } from './tasks'
 export interface Reporter {
   onInit?(ctx: Vitest): void
   onCollected?: (files?: File[]) => Awaitable<void>
-  onFinished?: (files?: File[]) => Awaitable<void>
+  onFinished?: (files?: File[], errors?: unknown[]) => Awaitable<void>
   onTaskUpdate?: (packs: TaskResultPack[]) => Awaitable<void>
 
   onTestRemoved?: (trigger?: string) => Awaitable<void>

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -22,9 +22,10 @@ export interface WorkerRPC {
   resolveId: ResolveIdFunction
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>
 
-  onFinished: (files: File[]) => void
+  onFinished: (files: File[], errors?: unknown[]) => void
   onWorkerExit: (code?: number) => void
   onUserConsoleLog: (log: UserConsoleLog) => void
+  onUnhandledRejection: (err: unknown) => void
   onCollected: (files: File[]) => void
   onTaskUpdate: (pack: TaskResultPack[]) => void
 

--- a/packages/vitest/src/utils/source-map.ts
+++ b/packages/vitest/src/utils/source-map.ts
@@ -26,6 +26,8 @@ const stackBarePathRE = /at ?(.*) (.+):(\d+):(\d+)$/
 
 export async function interpretSourcePos(stackFrames: ParsedStack[], ctx: Vitest): Promise<ParsedStack[]> {
   for (const frame of stackFrames) {
+    if ('sourcePos' in frame)
+      continue
     const transformResult = ctx.server.moduleGraph.getModuleById(frame.file)?.ssrTransformResult
     if (!transformResult)
       continue


### PR DESCRIPTION
Closes: #1132, #884, #1201
Fixes: #1165, #1203

- Errors show full stacktrace, since it's really hard to debug errors without an actual stacktrace (sometimes it has none, or look at #1201)
- Unhandled errors don't exit process, but fail the whole suite
- Unhandled errors are shown after the summary with a warning
- Clarified error message for "Vitest was initialized with Native Node"
- If errors have custom properties, they are shown under "Serialized Error" - previously I wanted to show them like Node does, but it looks bad, if error has only one stack trace with a code frame, so I decided to split it
- If error has "cause", print the case as the error without a code frame