### PR TITLE
fix: self exported module call stack error

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ node_modules
 *.d.ts
 coverage
 !.vitepress
+test/core/src/self

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -253,6 +253,13 @@ function proxyMethod(name: 'get' | 'set' | 'has' | 'deleteProperty', tryDefault:
 }
 
 function exportAll(exports: any, sourceModule: any) {
+  // #1120 when a module exports itself it causes
+  // call stack error
+  if (exports === sourceModule) {
+    // eslint-disable-next-line no-console
+    console.warn('[vite-node] module is being self exported', sourceModule)
+    return
+  }
   // eslint-disable-next-line no-restricted-syntax
   for (const key in sourceModule) {
     if (key !== 'default') {

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -255,11 +255,9 @@ function proxyMethod(name: 'get' | 'set' | 'has' | 'deleteProperty', tryDefault:
 function exportAll(exports: any, sourceModule: any) {
   // #1120 when a module exports itself it causes
   // call stack error
-  if (exports === sourceModule) {
-    // eslint-disable-next-line no-console
-    console.warn('[vite-node] module is being self exported', sourceModule)
+  if (exports === sourceModule)
     return
-  }
+
   // eslint-disable-next-line no-restricted-syntax
   for (const key in sourceModule) {
     if (key !== 'default') {

--- a/test/core/src/self/foo.ts
+++ b/test/core/src/self/foo.ts
@@ -1,0 +1,5 @@
+/* eslint-disable */
+
+export function foo(): true {
+  return true;
+}

--- a/test/core/src/self/index.ts
+++ b/test/core/src/self/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable */
+
+export * from './foo';
+export * from './index'; // <-- wrong

--- a/test/core/test/self.test.ts
+++ b/test/core/test/self.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from 'vitest'
+import { foo } from '../src/self'
+
+// #1220 self export module
+it('self export', () => {
+  expect(foo()).toBe(true)
+})


### PR DESCRIPTION
fix #1220 

exporting itself is wrong, but it can be exported by mistake, `vite` handles the export just fine.

note: eslint was crashing :D so I ignored the files for this specific test