### PR TITLE
fix: typo in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: 🚀 New feature proposal
-description: Propose a new feature to be added to Vite
+description: Propose a new feature to be added to Vitest
 labels: ['enhancement: pending triage']
 body:
   - type: markdown


### PR DESCRIPTION
Fix the typo in the feature request issue template, where "Vite" is used instead of "Vitest."