### PR TITLE
fix: default to failed tests and unchecked snapshots when updating snapshots

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -263,7 +263,10 @@ export class Vitest {
 
   async updateSnapshot(files?: string[]) {
     // default to failed files
-    files = files || this.state.getFailedFilepaths()
+    files = files || [
+      ...this.state.getFailedFilepaths(),
+      ...this.snapshot.summary.uncheckedKeysByFile.map(s => s.filePath),
+    ]
 
     this.configOverride = {
       snapshotOptions: {


### PR DESCRIPTION
Fixes #686

@antfu `u` updated obsolete snapshots, but still shows them tho, can you help me resolve this?