### PR TITLE
Fix the order of arguments in the Jest matcher util

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-matcher-utils.ts
+++ b/packages/vitest/src/integrations/chai/jest-matcher-utils.ts
@@ -170,5 +170,5 @@ export interface DiffOptions {
 // TODO: do something with options
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function diff(a: any, b: any, options?: DiffOptions) {
-  return unifiedDiff(stringify(a), stringify(b))
+  return unifiedDiff(stringify(b), stringify(a))
 }

--- a/test/core/test/jest-matcher-utils.test.ts
+++ b/test/core/test/jest-matcher-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+describe('jest-matcher-utils', () => {
+  expect.extend({
+    toBeJestEqual(received: any, expected: any) {
+      return {
+        message: () => this.utils.diff(expected, received),
+        pass: received === expected,
+      }
+    },
+  })
+
+  it('diff', () => {
+    expect(() => {
+      // @ts-expect-error "toBeJestEqual" is a custom matcher we just created
+      expect('a').toBeJestEqual('b')
+    }).toThrowError(/Expected.*"b".*Received.*"a"/ms)
+  })
+})


### PR DESCRIPTION
Some custom matchers like those in `@testing-library/jest-dom` use `this.utils.diff` for the output. In Jest the order of arguments in that util is ["expected", then "received"](https://github.com/facebook/jest/blob/a5bb8848ba1cc6a764ef01b6c4144006922cc3a0/packages/jest-diff/src/index.ts#L68), so here I'm fixing the order of those arguments to match Jest's implementation.

Fixes #1239.