### PR TITLE
docs: add missing c8 option `src`

### DIFF
--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -62,6 +62,7 @@ export interface C8Options {
   extension?: string | string[]
 
   all?: boolean
+  src?: string[]
 
   100?: boolean
   lines?: number


### PR DESCRIPTION
This PR adds the missing C8 option [`src`](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/index.d.ts#L22) to the typing. The runtime code doesn't need to modify. 

[C8 README](https://github.com/bcoe/c8/blob/main/README.md) provides more information about this option. 