### PR TITLE
fix: close node.js server correctly in the puppeteer example

### DIFF
--- a/examples/puppeteer/test/basic.test.ts
+++ b/examples/puppeteer/test/basic.test.ts
@@ -17,7 +17,9 @@ describe('basic', async () => {
 
   afterAll(async () => {
     await browser.close()
-    await server.httpServer.close()
+    await new Promise<void>((resolve, reject) => {
+      server.httpServer.close(error => error ? reject(error) : resolve())
+    })
   })
 
   test('should have the correct title', async () => {


### PR DESCRIPTION
`server.httpServer.close` does not return a Promise.

Docs: https://nodejs.org/docs/latest-v14.x/api/net.html#net_server_close_callback
