### PR TITLE
fix: `.resolves` and `.rejects` expectations

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -61,6 +61,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
             throw object
           })
         }
+        else if (promise === 'resolves') {
+          utils.flag(this, 'object', () => {
+            return object
+          })
+        }
         _super.apply(this, args)
       }
     })

--- a/packages/vitest/src/integrations/utils.ts
+++ b/packages/vitest/src/integrations/utils.ts
@@ -5,3 +5,12 @@ export function getRunningMode() {
 export function isWatchMode() {
   return getRunningMode() === 'watch'
 }
+
+export function toString(value: any) {
+  try {
+    return `${value}`
+  }
+  catch (_error) {
+    return 'unknown'
+  }
+}

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -436,6 +436,33 @@ describe('async expect', () => {
     await expect((async () => 'true')()).resolves.toBe('true')
     await expect((async () => 'true')()).resolves.not.toBe('true22')
     await expect((async () => 'true')()).resolves.not.toThrow()
+    await expect((async () => new Error('msg'))()).resolves.not.toThrow() // calls chai assertion
+    await expect((async () => new Error('msg'))()).resolves.not.toThrow(Error) // calls our assertion
+    await expect((async () => () => {
+      throw new Error('msg')
+    })()).resolves.toThrow()
+    await expect((async () => () => {
+      return new Error('msg')
+    })()).resolves.not.toThrow()
+    await expect((async () => () => {
+      return new Error('msg')
+    })()).resolves.not.toThrow(Error)
+  })
+
+  it('resolves trows chai', async () => {
+    const assertion = async () => {
+      await expect((async () => new Error('msg'))()).resolves.toThrow()
+    }
+
+    await expect(assertion).rejects.toThrowError('expected promise to throw an error, but it didn\'t')
+  })
+
+  it('resolves trows jest', async () => {
+    const assertion = async () => {
+      await expect((async () => new Error('msg'))()).resolves.toThrow(Error)
+    }
+
+    await expect(assertion).rejects.toThrowError('expected promise to throw an error, but it didn\'t')
   })
 
   it('throws an error on .resolves when the argument is not a promise', () => {
@@ -455,6 +482,9 @@ describe('async expect', () => {
     await expect((async () => {
       throw new Error('err')
     })()).resolves.toBe('true')
+  })
+
+  it.fails('failed to throw', async () => {
     await expect((async () => {
       throw new Error('err')
     })()).resolves.not.toThrow()

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -435,6 +435,7 @@ describe('async expect', () => {
   it('resolves', async () => {
     await expect((async () => 'true')()).resolves.toBe('true')
     await expect((async () => 'true')()).resolves.not.toBe('true22')
+    await expect((async () => 'true')()).resolves.not.toThrow()
   })
 
   it('throws an error on .resolves when the argument is not a promise', () => {
@@ -454,6 +455,9 @@ describe('async expect', () => {
     await expect((async () => {
       throw new Error('err')
     })()).resolves.toBe('true')
+    await expect((async () => {
+      throw new Error('err')
+    })()).resolves.not.toThrow()
   })
 
   it('rejects', async () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -437,6 +437,19 @@ describe('async expect', () => {
     await expect((async () => 'true')()).resolves.not.toBe('true22')
   })
 
+  it('throws an error on .resolves when the argument is not a promise', () => {
+    expect.assertions(2)
+
+    const expectedError = new TypeError('You must provide a Promise to expect() when using .resolves, not \'number\'.')
+
+    try {
+      expect(1).resolves.toEqual(2)
+    }
+    catch (error) {
+      expect(error).toEqual(expectedError)
+    }
+  })
+
   it.fails('failed to resolve', async () => {
     await expect((async () => {
       throw new Error('err')
@@ -470,6 +483,26 @@ describe('async expect', () => {
 
   it.fails('failed to reject', async () => {
     await expect((async () => 'test')()).rejects.toBe('test')
+  })
+
+  it('throws an error on .rejects when the argument (or function result) is not a promise', () => {
+    expect.assertions(4)
+
+    const expectedError = new TypeError('You must provide a Promise to expect() when using .rejects, not \'number\'.')
+
+    try {
+      expect(1).rejects.toEqual(2)
+    }
+    catch (error) {
+      expect(error).toEqual(expectedError)
+    }
+
+    try {
+      expect(() => 1).rejects.toEqual(2)
+    }
+    catch (error) {
+      expect(error).toEqual(expectedError)
+    }
   })
 })
 


### PR DESCRIPTION
### Summary

The promise helpers, `.resolves` and `.rejects`, were throwing errors when the returned object could not be serialized. Additionally, the `.resolves` helper did not support a function argument even though a function was expected.

### Examples

#### 1. Promise resolution

With a happy-path test for resolving a promise...

```ts
// example1.test.ts
await expect(() => Promise.resolve(1)).resolves.toEqual(1)
```

##### Before

The following error occurs.

```
TypeError: obj.then is not a function
```

##### After

The test passes.

```
1 passed (1)
```

#### 2. Dynamic imports

With an alternate-path test expecting a dynamic import (promise) to error...

```ts
// example2.ts
export default {}
```

```ts
// example2.test.ts
await expect(() => import('./example')).rejects.toThrowError()
```

##### Before

The following error occurs.

```
TypeError: Cannot convert object to primitive value
```

##### After

The test passes.

```
1 passed (1)
```