### PR TITLE
docs: fix mock return value

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -92,7 +92,7 @@ fn.mockImplementation(arg => arg)
 
 fn('world', 2)
 
-expect(fn.mock.results[1]).toBe('world')
+expect(fn.mock.results[1].value).toBe('world')
 ```
 
 Vitest supports both [happy-dom](https://github.com/capricorn86/happy-dom) or [jsdom](https://github.com/jsdom/jsdom) for mocking DOM and browser APIs. They don't come with Vitest, you might need to install them:


### PR DESCRIPTION
The return value of `fn.mock.results[1]` seems to be and object of the shape {value: 'world', ...rest}