### PR TITLE
fix: `process.stdout` could be undefined on Windows (fix #1292)

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -283,7 +283,7 @@ export class Vitest {
     if (this.server.config.clearScreen === false)
       return
 
-    const repeatCount = process.stdout.rows - 2
+    const repeatCount = (process.stdout?.rows ?? 0) - 2
     const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : ''
     this.console.log(blank)
     readline.cursorTo(process.stdout, 0, 0)

--- a/packages/vitest/src/node/diff.ts
+++ b/packages/vitest/src/node/diff.ts
@@ -3,7 +3,7 @@ import * as diff from 'diff'
 import cliTruncate from 'cli-truncate'
 
 export function formatLine(line: string, outputTruncateLength?: number) {
-  return cliTruncate(line, (outputTruncateLength ?? (process.stdout.columns || 80)) - 4)
+  return cliTruncate(line, (outputTruncateLength ?? (process.stdout?.columns || 80)) - 4)
 }
 
 export interface DiffOptions {

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -189,7 +189,7 @@ export function generateCodeFrame(
   let count = 0
   let res: string[] = []
 
-  const columns = process.stdout.columns || 80
+  const columns = process.stdout?.columns || 80
 
   function lineNo(no: number | string = '') {
     return c.gray(`${String(no).padStart(3, ' ')}| `)

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -12,7 +12,7 @@ export const pointer = c.yellow(F_POINTER)
 export const skipped = c.dim(c.gray(F_DOWN))
 
 export function getCols(delta = 0) {
-  let length = process.stdout.columns
+  let length = process.stdout?.columns
   if (!length || isNaN(length))
     length = 30
   return Math.max(length + delta, 0)


### PR DESCRIPTION
- fixes #1292 where `process.stdout` can be `undefined` on Windows platform and with this I am now able to see the real unit test errors instead of Vitest itself throwing error