### PR TITLE
fix(test:ci): reporters utils test is failing

### DIFF
--- a/test/reporters/tests/utils.test.ts
+++ b/test/reporters/tests/utils.test.ts
@@ -5,7 +5,7 @@ import { resolve } from 'pathe'
 import type { ViteNodeRunner } from 'vite-node/client'
 import { describe, expect, test } from 'vitest'
 import { createReporters } from 'vitest/src/node/reporters/utils'
-import { DefaultReporter } from '../../../../vitest/packages/vitest/src/node/reporters/default'
+import { DefaultReporter } from '../../../packages/vitest/src/node/reporters/default'
 import TestReporter from '../src/custom-reporter'
 
 const customReporterPath = resolve(__dirname, '../src/custom-reporter.js')


### PR DESCRIPTION
wrong `DefaultReporter` import path:

```shell
test/single-thread test$ vitest "--allowOnly"
test/reporters test: (node:11992) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
test/reporters test: (Use `node --trace-deprecation ...` to show where the warning was created)
test/reporters test:  ❯ tests/utils.test.ts  (0 test)
test/reporters test:  √ tests/reporters.spec.ts  (14 tests) 71ms
test/reporters test: ⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
test/reporters test:  FAIL  tests/utils.test.ts [ tests/utils.test.ts ]
test/reporters test: Error: [vite-node] Failed to load ../../../../vitest/packages/vitest/src/node/reporters/default
test/reporters test:  ❯ async tests/utils.test.ts:7:31
test/reporters test:       5| import type { ViteNodeRunner } from 'vite-node/client'
test/reporters test:       6| import { describe, expect, test } from 'vitest'
test/reporters test:       7| import { createReporters } from 'vitest/src/node/reporters/utils'
test/reporters test:        |                               ^
test/reporters test:       8| import { DefaultReporter } from '../../../../vitest/packages/vitest/sr…
test/reporters test:       9| import TestReporter from '../src/custom-reporter'
test/reporters test: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
test/reporters test: Test Files  1 failed | 1 passed | 1 skipped (3)
test/reporters test:      Tests  14 passed | 1 skipped (15)
test/reporters test:       Time  2.33s (in thread 71ms, 3285.89%)
test/reporters test: Failed
undefined
F:\work\projects\quini\GitHub\antfu\vitest-pnpm7\test\reporters:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @vitest/test-reporters@ test: `vitest "--allowOnly"`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```