### PR TITLE
fix: add vitest/globals to types

### DIFF
--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION
Since `vitest.config.ts` contains `test.globals: true`, the `vitest/globals` module is required in order to enable globals such as `test()` and `it()`.