### PR TITLE
feat: add function/promise forms of defineConfig()

### DIFF
--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -1,4 +1,4 @@
-import type { UserConfig as ViteUserConfig } from 'vite'
+import type { ConfigEnv, UserConfig as ViteUserConfig } from 'vite'
 
 export interface UserConfig extends ViteUserConfig {
   test?: ViteUserConfig['test']
@@ -7,6 +7,10 @@ export interface UserConfig extends ViteUserConfig {
 // will import vitest declare test in module 'vite'
 export { configDefaults } from './defaults'
 
-export function defineConfig(config: UserConfig) {
+export type { ConfigEnv }
+export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>
+export type UserConfigExport = UserConfig | Promise<UserConfig> | UserConfigFn
+
+export function defineConfig(config: UserConfigExport) {
   return config
 }


### PR DESCRIPTION
Make `defineConfig()` accept a callback or promise that resolves to a config. This matches the signature of `defineConfig()` from Vite:

https://github.com/vitejs/vite/blob/0858450b2a258b216ae9aa797cc02e9a0d4eb0af/packages/vite/src/node/config.ts#L53-L64

Resolves #1301