### PR TITLE
fix: test context fixed on TypeScript

### DIFF
--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -48,7 +48,7 @@ To provide type for your custom context properties, you can aggregate the type `
 
 ```ts
 declare module 'vitest' {
-  export interface TestContext {
+  export interface Suite {
     foo?: string
   }
 }


### PR DESCRIPTION
Hi 👋
I've implemented some tests that need some asynchronous data before starting and passed the id's to the context, but the TestContext interface didn't work. 

<table>
<tr>
	<td>Before</td>
	<td>After</td>
<tr>
	<td><img width="895" alt="Screenshot 2022-05-17 at 3 13 37 PM" src="https://user-images.githubusercontent.com/22656541/168819419-6509ba72-75ab-4395-8369-176c93a8e8ad.png">
</td>
	<td><img width="948" alt="Screenshot 2022-05-17 at 3 13 43 PM" src="https://user-images.githubusercontent.com/22656541/168819411-e70a8dee-d17b-497d-aaf9-abc629ad0c3f.png">

</td>
</table>