### PR TITLE
docs(mocking): Fix Timers example

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -356,7 +356,6 @@ describe('delayed execution', () => {
   it('should execute every minute', () => {
     executeEveryMinute(mock)
     vi.advanceTimersToNextTimer()
-    vi.advanceTimersToNextTimer()
     expect(mock).toHaveBeenCalledTimes(1)
     vi.advanceTimersToNextTimer()
     expect(mock).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
The example in the docs had _two_ calls to `vi.advanceTimersToNextTimer()` before expecting the mock function to be called once. This resulted in the test failing (the mock function was called _twice_ instead of once, since the interval was executed twice).

Removing the duplicate call to `vi.advanceTimersToNextTimer()` fixes the test.