### PR TITLE
fix: handle error from pool.run

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -8,8 +8,8 @@ import { createBirpc } from 'birpc'
 import type { RawSourceMap } from 'vite-node'
 import type { WorkerContext, WorkerRPC } from '../types'
 import { distDir } from '../constants'
-import type { Vitest } from './core'
 import { AggregateError } from '../utils'
+import type { Vitest } from './core'
 
 export type RunWithFiles = (files: string[], invalidates?: string[]) => Promise<void>
 
@@ -44,7 +44,8 @@ export function createFakePool(ctx: Vitest): WorkerPool {
 
       try {
         await worker[name](data, { transferList: [workerPort] })
-      } finally {
+      }
+      finally {
         port.close()
         workerPort.close()
       }
@@ -96,16 +97,16 @@ export function createWorkerPool(ctx: Vitest): WorkerPool {
 
         try {
           await pool.run(data, { transferList: [workerPort], name })
-        } finally {
+        }
+        finally {
           port.close()
           workerPort.close()
         }
       }))
 
       const errors = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected').map(r => r.reason)
-      if (errors.length > 0) {
+      if (errors.length > 0)
         throw new AggregateError(errors)
-      }
     }
   }
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -9,6 +9,7 @@ import type { RawSourceMap } from 'vite-node'
 import type { WorkerContext, WorkerRPC } from '../types'
 import { distDir } from '../constants'
 import type { Vitest } from './core'
+import { AggregateError } from '../utils'
 
 export type RunWithFiles = (files: string[], invalidates?: string[]) => Promise<void>
 
@@ -41,10 +42,12 @@ export function createFakePool(ctx: Vitest): WorkerPool {
         id: 1,
       }
 
-      await worker[name](data, { transferList: [workerPort] })
-
-      port.close()
-      workerPort.close()
+      try {
+        await worker[name](data, { transferList: [workerPort] })
+      } finally {
+        port.close()
+        workerPort.close()
+      }
     }
   }
 
@@ -80,7 +83,7 @@ export function createWorkerPool(ctx: Vitest): WorkerPool {
     return async (files, invalidates) => {
       let id = 0
       const config = ctx.getSerializableConfig()
-      await Promise.all(files.map(async (file) => {
+      const results = await Promise.allSettled(files.map(async (file) => {
         const { workerPort, port } = createChannel(ctx)
 
         const data: WorkerContext = {
@@ -91,10 +94,18 @@ export function createWorkerPool(ctx: Vitest): WorkerPool {
           id: ++id,
         }
 
-        await pool.run(data, { transferList: [workerPort], name })
-        port.close()
-        workerPort.close()
+        try {
+          await pool.run(data, { transferList: [workerPort], name })
+        } finally {
+          port.close()
+          workerPort.close()
+        }
       }))
+
+      const errors = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected').map(r => r.reason)
+      if (errors.length > 0) {
+        throw new AggregateError(errors)
+      }
     }
   }
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -106,7 +106,7 @@ export function createWorkerPool(ctx: Vitest): WorkerPool {
 
       const errors = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected').map(r => r.reason)
       if (errors.length > 0)
-        throw new AggregateError(errors)
+        throw new AggregateError(errors, 'Errors occurred while running tests. For more information, see serialized error.')
     }
   }
 

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -130,6 +130,7 @@ export function getCallLastIndex(code: string) {
 
 export { resolve as resolvePath }
 
+// AggregateError is supported in Node.js 15.0.0+
 class AggregateErrorPonyfill extends Error {
   errors: unknown[]
   constructor(errors: Iterable<unknown>, message = '') {
@@ -137,6 +138,4 @@ class AggregateErrorPonyfill extends Error {
     this.errors = [...errors]
   }
 }
-
-// AggregateError is supported in Node.js 15.0.0+
-export const AggregateError = global.AggregateError || AggregateErrorPonyfill
+export { AggregateErrorPonyfill as AggregateError }

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -129,3 +129,14 @@ export function getCallLastIndex(code: string) {
 }
 
 export { resolve as resolvePath }
+
+class AggregateErrorPonyfill extends Error {
+  errors: unknown[]
+  constructor(errors: Iterable<unknown>, message = '') {
+    super(message)
+    this.errors = [...errors]
+  }
+}
+
+// AggregateError is supported in Node.js 15.0.0+
+export const AggregateError = global.AggregateError || AggregateErrorPonyfill


### PR DESCRIPTION
When an error was thrown from `pool.run`, vitest finished without any error messages.
This PR handles that error.

I found this while implementing https://github.com/vitejs/vite/pull/8049.

### Before
```text
 RUN  v0.12.8 D:/documents/GitHub/vite

····*···---******************************---------··········***····································******···*********·····*·**··········***
```
There was no error message.

### After
```text
 RUN  v0.12.8 D:/documents/GitHub/vite

stderr | unknown test
"default" is imported from external module "path" but never used in "playground-temp/ssr-vue/src/entry-server.js".

················································---································································---------··················-----------··············································--·*··························-··································-****·············································································-------··---····································----------·······················································*·············************··

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 FAIL  playground/react-emotion/__tests__/react.spec.ts [ playground/react-emotion/__tests__/react.spec.ts ]
Error: Cannot find package '@emotion/babel-plugin' imported from D:\documents\GitHub\vite\babel-virtual-resolve-base.js
 ❯ new NodeError node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:2669:5
 ❯ packageResolve node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:3325:9
 ❯ moduleResolve node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:3359:18
 ❯ defaultResolve node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:3398:13
 ❯ node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:3421:14
 ❯ asyncGeneratorStep node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:63:103
 ❯ _next node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:65:194
 ❯ node_modules/.pnpm/@babel+core@7.17.10/node_modules/@babel/core/lib/vendor/import-meta-resolve.js:65:364

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯Serialized Error: {
  "code": "PLUGIN_ERROR",
  "hook": "transform",
  "id": "D:/documents/GitHub/vite/playground-temp/react-emotion/index.html?html-proxy&index=0.js",
  "plugin": "vite:react-babel",
  "pluginCode": "ERR_MODULE_NOT_FOUND",
  "watchFiles": [
    "D:/documents/GitHub/vite/playground-temp/react-emotion/index.html",
    "vite/modulepreload-polyfill",
    "D:/documents/GitHub/vite/playground-temp/react-emotion/index.html?html-proxy&index=0.js",
  ],
}
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
Test Files  1 failed | 57 passed | 3 skipped (64)
     Tests  422 passed | 47 skipped (487)
      Time  22.63s (in thread 174.57s, 12.97%)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Vitest caught 1 unhandled error during the test run. This might cause false positive tests.
Please, resolve all the errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯AggregateError: 
 ❯ Object.runTests ../../../../file:/D:/documents/GitHub/vitest/packages/vitest/dist/vendor-cli-api.bcfd31a5.js:8250:15
 ❯ processTicksAndRejections ../../../../node:internal/process/task_queues:96:5        
 ❯ async ../../../../file:/D:/documents/GitHub/vitest/packages/vitest/dist/vendor-cli-api.bcfd31a5.js:10440:9
 ❯ async Vitest.runFiles ../../../../file:/D:/documents/GitHub/vitest/packages/vitest/dist/vendor-cli-api.bcfd31a5.js:10450:12
 ❯ async Vitest.start ../../../../file:/D:/documents/GitHub/vitest/packages/vitest/dist/vendor-cli-api.bcfd31a5.js:10377:5
 ❯ async startVitest ../../../../file:/D:/documents/GitHub/vitest/packages/vitest/dist/vendor-cli-api.bcfd31a5.js:11113:5
 ❯ async start ../../../../file:/D:/documents/GitHub/vitest/packages/vitest/dist/cli.js:665:9
js:661:3

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯Serialized Error: {
  "errors": [
    [Error: ENOENT: no such file or directory, open 'D:\documents\GitHub\vite\playground-temp\js-sourcemap\dist\assets\index.704baece.js'],
    [Error: ENOENT: no such file or directory, open 'D:\documents\GitHub\vite\playground-temp\worker\dist\iife\index.html'],
    [Error: ENOENT: no such file or directory, open 'D:\documents\GitHub\vite\playground-temp\worker\dist\iife-sourcemap\assets\my-worker.b928aeec.js'],
  ],
}
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```
It shows as a Unhandled Error but it is now much better than no error message.
To be honest, I don't know where it should be handled.
