### PR TITLE
fix: toSatisfy never executes the matcher function

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -575,8 +575,8 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       callResult,
     )
   })
-  def('toSatisfy', function () {
-    return this.be.satisfy
+  def('toSatisfy', function (matcher: Function, message?: string) {
+    return this.be.satisfy(matcher, message)
   })
 
   utils.addProperty(chai.Assertion.prototype, 'resolves', function __VITEST_RESOLVES__(this: any) {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -433,6 +433,13 @@ describe('toSatisfy()', () => {
   it.fails('fail with missing negotiation', () => {
     expect(2).toSatisfy(isOdd)
   })
+
+  it('calls the function', () => {
+    const isOddMock = vi.fn(isOdd)
+    expect(isOddMock).not.toBeCalled()
+    expect(1).toSatisfy(isOddMock)
+    expect(isOddMock).toBeCalled()
+  })
 })
 
 describe('async expect', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -429,6 +429,10 @@ describe('toSatisfy()', () => {
   it('pass with negotiation', () => {
     expect(2).not.toSatisfy(isOdd)
   })
+
+  it.fails('fail with missing negotiation', () => {
+    expect(2).toSatisfy(isOdd)
+  })
 })
 
 describe('async expect', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable comma-spacing */
 /* eslint-disable no-sparse-arrays */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 class TestError extends Error {}
 


### PR DESCRIPTION
This PR fixes https://github.com/vitest-dev/vitest/pull/1172.

This was discovered in https://github.com/vitest-dev/vitest/pull/1172#issuecomment-1111950901 but never fixed.