### PR TITLE
fix: improve test name escaping in TAP reporters

### DIFF
--- a/packages/vitest/src/node/reporters/tap.ts
+++ b/packages/vitest/src/node/reporters/tap.ts
@@ -8,9 +8,10 @@ function yamlString(str: string): string {
 }
 
 function tapString(str: string): string {
-  // Test name cannot contain #
-  // Test name cannot start with number
-  return str.replace(/#/g, '?').replace(/^[0-9]+/, '?')
+  return str
+    .replace(/\\/g, '\\\\') // escape slashes
+    .replace(/#/g, '\\#') // escape #
+    .replace(/\n/g, ' ') // remove newlines
 }
 
 export class TapReporter implements Reporter {


### PR DESCRIPTION
Fixing comment from @imcotton  https://github.com/vitest-dev/vitest/pull/445#discussion_r880760817