### PR TITLE
feat: improve deep equality check failing message for toBe

### DIFF
--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -131,7 +131,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const actual = this._obj
     const pass = Object.is(actual, expected)
 
-    let deepEqualityName = '';
+    let deepEqualityName = ''
 
     if (!pass) {
       const toStrictEqualPass = jestEquals(

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -7,7 +7,7 @@ import type { Constructable, Test } from '../../types'
 import { assertTypes } from '../../utils'
 import { unifiedDiff } from '../../node/diff'
 import type { ChaiPlugin, MatcherState } from '../../types/chai'
-import { arrayBufferEquality, iterableEquality, equals as jestEquals, sparseArrayEquality, subsetEquality, typeEquality, generateToBeMessage } from './jest-utils'
+import { arrayBufferEquality, generateToBeMessage, iterableEquality, equals as jestEquals, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
 import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import { stringify } from './jest-matcher-utils'
 

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -132,9 +132,8 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const pass = Object.is(actual, expected)
 
     let toBeMessage = 'expected #{this} to be #{exp} // Object.is equality'
-    let notToBeMessage = 'expected #{this} not to be #{exp} // Object.is equality'
     if (!pass) {
-      let deepEqualityName = 'toStrictEqual'
+      let reminderMessage = 'If it should pass with deep equality, replace "toBe" with "toStrictEqual"\n\n'
       const toStrictEqualPass = jestEquals(
         actual,
         expected,
@@ -148,10 +147,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       )
 
       if (toStrictEqualPass) {
-        const reminderMessage = `If it should pass with deep equality, replace "toBe" with "${deepEqualityName}"\n\n`
-
         toBeMessage = `${reminderMessage}expected #{this} to be [serializes to the same string] // Object.is equality`
-        notToBeMessage = `${reminderMessage}expected #{this} not to be [serializes to the same string] // Object.is equality`
       }
       else {
         const toEqualPass = jestEquals(
@@ -161,11 +157,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         )
 
         if (toEqualPass) {
-          deepEqualityName = 'toEqual'
-          const reminderMessage = `If it should pass with deep equality, replace "toBe" with "${deepEqualityName}"\n\n`
+          reminderMessage = 'If it should pass with deep equality, replace "toBe" with "toEqual"\n\n'
 
           toBeMessage = `${reminderMessage}expected #{this} to be [serializes to the same string] // Object.is equality`
-          notToBeMessage = `${reminderMessage}expected #{this} not to be [serializes to the same string] // Object.is equality`
         }
       }
     }
@@ -173,7 +167,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     return this.assert(
       pass,
       toBeMessage,
-      notToBeMessage,
+      'expected #{this} not to be #{exp} // Object.is equality',
       expected,
       actual,
     )

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -129,16 +129,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
   def('toBe', function (expected) {
     const actual = this._obj
-    const equal = Object.is(actual, expected)
+    const pass = Object.is(actual, expected)
 
     let toBeMessage = 'expected #{this} to be #{exp} // Object.is equality'
     let notToBeMessage = 'expected #{this} not to be #{exp} // Object.is equality'
-    if (!equal) {
-      const objectEqual = jestEquals(
-        actual,
-        expected,
-        [iterableEquality],
-      ) || jestEquals(
+    if (!pass) {
+      let deepEqualityName = 'toStrictEqual'
+      const toStrictEqualPass = jestEquals(
         actual,
         expected,
         [
@@ -150,14 +147,31 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         true,
       )
 
-      if (objectEqual) {
-        toBeMessage = 'expected #{this} to be [serializes to the same string] // Object.is equality'
-        notToBeMessage = 'expected #{this} to not be #{exp} // Object.is equality'
+      if (toStrictEqualPass) {
+        const reminderMessage = `If it should pass with deep equality, replace "toBe" with "${deepEqualityName}"\n\n`
+
+        toBeMessage = `${reminderMessage}expected #{this} to be [serializes to the same string] // Object.is equality`
+        notToBeMessage = `${reminderMessage}expected #{this} not to be [serializes to the same string] // Object.is equality`
+      }
+      else {
+        const toEqualPass = jestEquals(
+          actual,
+          expected,
+          [iterableEquality],
+        )
+
+        if (toEqualPass) {
+          deepEqualityName = 'toEqual'
+          const reminderMessage = `If it should pass with deep equality, replace "toBe" with "${deepEqualityName}"\n\n`
+
+          toBeMessage = `${reminderMessage}expected #{this} to be [serializes to the same string] // Object.is equality`
+          notToBeMessage = `${reminderMessage}expected #{this} not to be [serializes to the same string] // Object.is equality`
+        }
       }
     }
 
     return this.assert(
-      equal,
+      pass,
       toBeMessage,
       notToBeMessage,
       expected,

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -129,10 +129,37 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
   def('toBe', function (expected) {
     const actual = this._obj
+    const equal = Object.is(actual, expected)
+
+    let toBeMessage = 'expected #{this} to be #{exp} // Object.is equality'
+    let notToBeMessage = 'expected #{this} not to be #{exp} // Object.is equality'
+    if (!equal) {
+      const objectEqual = jestEquals(
+        actual,
+        expected,
+        [iterableEquality],
+      ) || jestEquals(
+        actual,
+        expected,
+        [
+          iterableEquality,
+          typeEquality,
+          sparseArrayEquality,
+          arrayBufferEquality,
+        ],
+        true,
+      )
+
+      if (objectEqual) {
+        toBeMessage = 'expected #{this} to be [serializes to the same string] // Object.is equality'
+        notToBeMessage = 'expected #{this} to not be #{exp} // Object.is equality'
+      }
+    }
+
     return this.assert(
-      Object.is(actual, expected),
-      'expected #{this} to be #{exp} // Object.is equality',
-      'expected #{this} not to be #{exp} // Object.is equality',
+      equal,
+      toBeMessage,
+      notToBeMessage,
       expected,
       actual,
     )

--- a/packages/vitest/src/integrations/chai/jest-utils.ts
+++ b/packages/vitest/src/integrations/chai/jest-utils.ts
@@ -508,3 +508,16 @@ export const sparseArrayEquality = (
     equals(a, b, [iterableEquality, typeEquality], true) && equals(aKeys, bKeys)
   )
 }
+
+export const generateToBeMessage = (
+  deepEqualityName: string,
+  expected = '#{this}',
+  actual = '#{exp}',
+) => {
+  const toBeMessage = `expected ${expected} to be ${actual} // Object.is equality`
+
+  if (['toStrictEqual', 'toEqual'].includes(deepEqualityName))
+    return `${toBeMessage}\n\nIf it should pass with deep equality, replace "toBe" with "${deepEqualityName}"\n\nExpected: ${expected}\nReceived: serializes to the same string\n`
+
+  return toBeMessage
+}

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -551,17 +551,49 @@ describe('async expect', () => {
     }
   })
 
-  it('show users message `[serializes to the same string]` if they are comparing objects', () => {
-    const actual = { key: 'value' }
-    const expectedError = new AssertionError({
-      message: 'expected { key: \'value\' } to be [serializes to the same string] // Object.is equality',
+  it('reminds users to use deep equality checks if they are comparing objects', () => {
+    const createAssertionError = (
+      deepEqualityName: string,
+      expected: string,
+    ) => new AssertionError({
+      message: 'If it should pass with deep equality, '
+        + `replace "toBe" with "${deepEqualityName}"\n\nexpected ${expected} `
+        + 'to be [serializes to the same string] // Object.is equality',
     })
 
+    const actual = { key: 'value' }
+    class FakeClass {}
+
+    const toStrictEqualError1 = createAssertionError('toStrictEqual', '{ key: \'value\' }')
     try {
       expect(actual).toBe({ ...actual })
     }
     catch (error) {
-      expect(error).toEqual(expectedError)
+      expect(error).toEqual(toStrictEqualError1)
+    }
+
+    const toStrictEqualError2 = createAssertionError('toStrictEqual', 'FakeClass{}')
+    try {
+      expect(new FakeClass()).toBe(new FakeClass())
+    }
+    catch (error) {
+      expect(error).toEqual(toStrictEqualError2)
+    }
+
+    const toEqualError1 = createAssertionError('toEqual', '{}')
+    try {
+      expect({}).toBe(new FakeClass())
+    }
+    catch (error) {
+      expect(error).toEqual(toEqualError1)
+    }
+
+    const toEqualError2 = createAssertionError('toEqual', 'FakeClass{}')
+    try {
+      expect(new FakeClass()).toBe({})
+    }
+    catch (error) {
+      expect(error).toEqual(toEqualError2)
     }
   })
 })

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable comma-spacing */
 /* eslint-disable no-sparse-arrays */
+import { AssertionError } from 'assert'
 import { describe, expect, it, vi } from 'vitest'
 
 class TestError extends Error {}
@@ -544,6 +545,20 @@ describe('async expect', () => {
 
     try {
       expect(() => 1).rejects.toEqual(2)
+    }
+    catch (error) {
+      expect(error).toEqual(expectedError)
+    }
+  })
+
+  it('show users message `[serializes to the same string]` if they are comparing objects', () => {
+    const actual = { key: 'value' }
+    const expectedError = new AssertionError({
+      message: 'expected { key: \'value\' } to be [serializes to the same string] // Object.is equality',
+    })
+
+    try {
+      expect(actual).toBe({ ...actual })
     }
     catch (error) {
       expect(error).toEqual(expectedError)

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-sparse-arrays */
 import { AssertionError } from 'assert'
 import { describe, expect, it, vi } from 'vitest'
+import { generateToBeMessage } from 'vitest/src/integrations/chai/jest-utils'
 
 class TestError extends Error {}
 
@@ -552,19 +553,18 @@ describe('async expect', () => {
   })
 
   it('reminds users to use deep equality checks if they are comparing objects', () => {
-    const createAssertionError = (
+    const generatedToBeMessage = (
       deepEqualityName: string,
       expected: string,
+      actual: string,
     ) => new AssertionError({
-      message: 'If it should pass with deep equality, '
-        + `replace "toBe" with "${deepEqualityName}"\n\nexpected ${expected} `
-        + 'to be [serializes to the same string] // Object.is equality',
+      message: generateToBeMessage(deepEqualityName, expected, actual),
     })
 
     const actual = { key: 'value' }
     class FakeClass {}
 
-    const toStrictEqualError1 = createAssertionError('toStrictEqual', '{ key: \'value\' }')
+    const toStrictEqualError1 = generatedToBeMessage('toStrictEqual', '{ key: \'value\' }', '{ key: \'value\' }')
     try {
       expect(actual).toBe({ ...actual })
     }
@@ -572,7 +572,7 @@ describe('async expect', () => {
       expect(error).toEqual(toStrictEqualError1)
     }
 
-    const toStrictEqualError2 = createAssertionError('toStrictEqual', 'FakeClass{}')
+    const toStrictEqualError2 = generatedToBeMessage('toStrictEqual', 'FakeClass{}', 'FakeClass{}')
     try {
       expect(new FakeClass()).toBe(new FakeClass())
     }
@@ -580,15 +580,16 @@ describe('async expect', () => {
       expect(error).toEqual(toStrictEqualError2)
     }
 
-    const toEqualError1 = createAssertionError('toEqual', '{}')
+    const toEqualError1 = generatedToBeMessage('toEqual', '{}', 'FakeClass{}')
     try {
       expect({}).toBe(new FakeClass())
     }
     catch (error) {
       expect(error).toEqual(toEqualError1)
+      // expect(error).toEqual('1234')
     }
 
-    const toEqualError2 = createAssertionError('toEqual', 'FakeClass{}')
+    const toEqualError2 = generatedToBeMessage('toEqual', 'FakeClass{}', '{}')
     try {
       expect(new FakeClass()).toBe({})
     }


### PR DESCRIPTION
## What does this PR do?

A PR for issue #1290.

We would like to have a message to remind users they should use deep equality checks, when object comparison fails with `toBe`. The error message would look like this now:
![Screenshot 2022-05-27 at 12 12 49 PM](https://user-images.githubusercontent.com/46992350/170627832-d2cd2b6d-b143-437d-8d15-c49213846a91.png)

The implementation is similar to how [jest](https://github.com/facebook/jest/blob/main/packages/expect/src/matchers.ts#L85-L124) does it.

## How the change is tested?
Unit tests
