### PR TITLE
feat: disable Vite hmr in tests

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -78,6 +78,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
           server: {
             ...preOptions.api,
             open,
+            hmr: false,
             preTransformRequests: false,
           },
           // disable deps optimization


### PR DESCRIPTION
Vitest has it's own hrm implementation

Fixes #1363