### PR TITLE
fix: don't escape $ in snapshots, when not needed

### DIFF
--- a/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
+++ b/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
@@ -61,7 +61,6 @@ function prepareSnapString(snap: string, source: string, index: number) {
   const lines = snap
     .trim()
     .replace(/\\/g, '\\\\')
-    .replace(/\$/g, '\\$')
     .split(/\n/g)
 
   const isOneline = lines.length <= 1
@@ -69,7 +68,7 @@ function prepareSnapString(snap: string, source: string, index: number) {
   if (isOneline)
     return `'${lines.join('\n').replace(/'/g, '\\\'')}'`
   else
-    return `${quote}\n${lines.map(i => i ? indentNext + i : '').join('\n').replace(/`/g, '\\`')}\n${indent}${quote}`
+    return `${quote}\n${lines.map(i => i ? indentNext + i : '').join('\n').replace(/`/g, '\\`').replace(/\${/g, '\\${')}\n${indent}${quote}`
 }
 
 const startRegex = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*[\w_$]*(['"`\)])/m

--- a/test/core/test/snapshot-inline.test.ts
+++ b/test/core/test/snapshot-inline.test.ts
@@ -19,6 +19,16 @@ test('object', () => {
 
 test('single line', () => {
   expect('inline string').toMatchInlineSnapshot('"inline string"')
+  expect('inline $ string').toMatchInlineSnapshot('"inline $ string"')
+  expect('inline multiline\n $string').toMatchInlineSnapshot(`
+    "inline multiline
+     $string"
+  `)
+  // eslint-disable-next-line no-template-curly-in-string
+  expect('inline multiline\n \${string}').toMatchInlineSnapshot(`
+    "inline multiline
+     \${string}"
+  `)
 })
 
 test('multiline', () => {

--- a/test/core/test/snapshot-inline.test.ts
+++ b/test/core/test/snapshot-inline.test.ts
@@ -25,7 +25,7 @@ test('single line', () => {
      $string"
   `)
   // eslint-disable-next-line no-template-curly-in-string
-  expect('inline multiline\n \${string}').toMatchInlineSnapshot(`
+  expect('inline multiline\n ${string}').toMatchInlineSnapshot(`
     "inline multiline
      \${string}"
   `)


### PR DESCRIPTION
Fixes #1389