### PR TITLE
fix: Don't generate coverage folder when coverage is not enabled

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -46,7 +46,7 @@ export function createPool(ctx: Vitest): WorkerPool {
     options.minThreads = 1
   }
 
-  if (ctx.config.coverage)
+  if (ctx.config.coverage.enabled)
     process.env.NODE_V8_COVERAGE ||= ctx.config.coverage.tempDirectory
 
   options.env = {


### PR DESCRIPTION
After upgrading to 0.13.0 a coverage folder was generated although i didn't configure any code coverage.