### PR TITLE
fix(vite-node): Prevent crash when passing single module as options

### DIFF
--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -89,16 +89,32 @@ async function run(files: string[], options: CliOptions = {}) {
 }
 
 function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeServerOptions {
+  const serverOptionsDepsInline = typeof serverOptions.deps?.inline === 'string'
+    ? [serverOptions.deps?.inline]
+    : serverOptions.deps?.inline
+
+  const serverOptionsDepsExternal = typeof serverOptions.deps?.external === 'string'
+    ? [serverOptions.deps?.external]
+    : serverOptions.deps?.external
+
+  const serverOptionsTransformModeSsr = typeof serverOptions.transformMode?.ssr === 'string'
+    ? [serverOptions.transformMode?.ssr]
+    : serverOptions.transformMode?.ssr
+
+  const serverOptionsTransformModeWeb = typeof serverOptions.transformMode?.web === 'string'
+    ? [serverOptions.transformMode?.web]
+    : serverOptions.transformMode?.web
+
   return {
     ...serverOptions,
     deps: {
       ...serverOptions.deps,
-      inline: serverOptions.deps?.inline?.map((dep) => {
+      inline: serverOptionsDepsInline?.map((dep) => {
         return dep.startsWith('/') && dep.endsWith('/')
           ? new RegExp(dep)
           : dep
       }),
-      external: serverOptions.deps?.external?.map((dep) => {
+      external: serverOptionsDepsExternal?.map((dep) => {
         return dep.startsWith('/') && dep.endsWith('/')
           ? new RegExp(dep)
           : dep
@@ -108,8 +124,8 @@ function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeSe
     transformMode: {
       ...serverOptions.transformMode,
 
-      ssr: serverOptions.transformMode?.ssr?.map(dep => new RegExp(dep)),
-      web: serverOptions.transformMode?.ssr?.map(dep => new RegExp(dep)),
+      ssr: serverOptionsTransformModeSsr?.map(dep => new RegExp(dep)),
+      web: serverOptionsTransformModeWeb?.map(dep => new RegExp(dep)),
     },
   }
 }
@@ -117,9 +133,9 @@ function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeSe
 type Optional<T> = T | undefined
 type ComputeViteNodeServerOptionsCLI<T extends Record<string, any>> = {
   [K in keyof T]: T[K] extends Optional<RegExp[]>
-    ? string[]
+    ? string | string[]
     : T[K] extends Optional<(string | RegExp)[]>
-      ? string[]
+      ? string | string[]
       : T[K] extends Optional<Record<string, any>>
         ? ComputeViteNodeServerOptionsCLI<T[K]>
         : T[K]

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -5,6 +5,7 @@ import { version } from '../package.json'
 import { ViteNodeServer } from './server'
 import { ViteNodeRunner } from './client'
 import type { ViteNodeServerOptions } from './types'
+import { toArray } from './utils'
 
 const cli = cac('vite-node')
 
@@ -89,32 +90,16 @@ async function run(files: string[], options: CliOptions = {}) {
 }
 
 function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeServerOptions {
-  const serverOptionsDepsInline = typeof serverOptions.deps?.inline === 'string'
-    ? [serverOptions.deps?.inline]
-    : serverOptions.deps?.inline
-
-  const serverOptionsDepsExternal = typeof serverOptions.deps?.external === 'string'
-    ? [serverOptions.deps?.external]
-    : serverOptions.deps?.external
-
-  const serverOptionsTransformModeSsr = typeof serverOptions.transformMode?.ssr === 'string'
-    ? [serverOptions.transformMode?.ssr]
-    : serverOptions.transformMode?.ssr
-
-  const serverOptionsTransformModeWeb = typeof serverOptions.transformMode?.web === 'string'
-    ? [serverOptions.transformMode?.web]
-    : serverOptions.transformMode?.web
-
   return {
     ...serverOptions,
     deps: {
       ...serverOptions.deps,
-      inline: serverOptionsDepsInline?.map((dep) => {
+      inline: toArray(serverOptions.deps?.inline).map((dep) => {
         return dep.startsWith('/') && dep.endsWith('/')
           ? new RegExp(dep)
           : dep
       }),
-      external: serverOptionsDepsExternal?.map((dep) => {
+      external: toArray(serverOptions.deps?.external).map((dep) => {
         return dep.startsWith('/') && dep.endsWith('/')
           ? new RegExp(dep)
           : dep
@@ -124,8 +109,8 @@ function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeSe
     transformMode: {
       ...serverOptions.transformMode,
 
-      ssr: serverOptionsTransformModeSsr?.map(dep => new RegExp(dep)),
-      web: serverOptionsTransformModeWeb?.map(dep => new RegExp(dep)),
+      ssr: toArray(serverOptions.transformMode?.ssr).map(dep => new RegExp(dep)),
+      web: toArray(serverOptions.transformMode?.web).map(dep => new RegExp(dep)),
     },
   }
 }

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -1,5 +1,8 @@
 import type { ModuleCacheMap } from './client'
 
+export type Nullable<T> = T | null | undefined
+export type Arrayable<T> = T | Array<T>
+
 export interface DepsHandlingOptions {
   external?: (string | RegExp)[]
   inline?: (string | RegExp)[]

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath, pathToFileURL } from 'url'
 import { dirname, resolve } from 'pathe'
 import type { TransformResult } from 'vite'
+import type { Arrayable, Nullable } from './types'
 
 export const isWindows = process.platform === 'win32'
 
@@ -73,4 +74,19 @@ export async function withInlineSourcemap(result: TransformResult) {
     result.code = `${code}\n\n//# ${SOURCEMAPPING_URL}=data:application/json;charset=utf-8;base64,${Buffer.from(JSON.stringify(map), 'utf-8').toString('base64')}\n`
 
   return result
+}
+
+/**
+ * Convert `Arrayable<T>` to `Array<T>`
+ *
+ * @category Array
+ */
+export function toArray<T>(array?: Nullable<Arrayable<T>>): Array<T> {
+  if (array === null || array === undefined)
+    array = []
+
+  if (Array.isArray(array))
+    return array
+
+  return [array]
 }


### PR DESCRIPTION
Right now, when passing a single module with the new `--options` CLI flag, `cac` returns a string instead of an array. This causes a crash, trying to call `map` on it.

```
❯ ./packages/vite-node/vite-node.mjs --options.deps.inline="module" hello.js
file:///Users/antoine/Code/vitest/packages/vite-node/dist/cli.js:697
      inline: (_b = (_a = serverOptions.deps) == null ? void 0 : _a.inline) == null ? void 0 : _b.map((dep) => {
                                                                                                  ^

TypeError: _b.map is not a function
    at parseServerOptions (file:///Users/antoine/Code/vitest/packages/vite-node/dist/cli.js:697:99)
    at CAC.run (file:///Users/antoine/Code/vitest/packages/vite-node/dist/cli.js:660:49)
    at CAC.runMatchedCommand (file:///Users/antoine/Code/vitest/packages/vite-node/dist/cli.js:622:34)
    at CAC.parse (file:///Users/antoine/Code/vitest/packages/vite-node/dist/cli.js:549:12)
    at file:///Users/antoine/Code/vitest/packages/vite-node/dist/cli.js:652:5
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
```

This PR updates the typings to reflect that, and makes sure that both `string` and `string[]` are properly handled.
