### PR TITLE
fix: repair TestFunction return type.

### DIFF
--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -50,7 +50,7 @@ export interface Test<ExtraContext = {}> extends TaskBase {
 export type Task = Test | Suite | File
 
 export type DoneCallback = (error?: any) => void
-export type TestFunction<ExtraContext = {}> = (context: TestContext & ExtraContext) => Awaitable<unknown>
+export type TestFunction<ExtraContext = {}> = (context: TestContext & ExtraContext) => Awaitable<any>
 
 // jest's ExtractEachCallbackArgs
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -50,7 +50,7 @@ export interface Test<ExtraContext = {}> extends TaskBase {
 export type Task = Test | Suite | File
 
 export type DoneCallback = (error?: any) => void
-export type TestFunction<ExtraContext = {}> = (context: TestContext & ExtraContext) => Awaitable<void>
+export type TestFunction<ExtraContext = {}> = (context: TestContext & ExtraContext) => Awaitable<unknown>
 
 // jest's ExtractEachCallbackArgs
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {


### PR DESCRIPTION
Is they any need to force void. This stops doing inline source testing
![image](https://user-images.githubusercontent.com/2092344/171270981-5ca85fea-8e7a-495e-bad3-ba12834637ae.png)

Currently having to cast the type