### PR TITLE
fix(types): add explicit extension for ESM compatibility

### DIFF
--- a/packages/vitest/config.d.ts
+++ b/packages/vitest/config.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/config'
+export * from './dist/config.js'

--- a/packages/vitest/node.d.ts
+++ b/packages/vitest/node.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/node'
+export * from './dist/node.js'


### PR DESCRIPTION
Hello 👋

When consuming `vitest/config` from my own project which is using ESM (`"type": "module"`), `defineConfig` is seen as `any`.

I think this is because `vitest` is itself using ESM, so the types definition files have to use explicit paths when importing/exporting local files.

I think the issue was never detected before because the types definition files outside of `config.d.ts` and `node.d.ts` are all flattened and don't import/export local files.

I already encountered this issue here: https://github.com/tinyhttp/tinyhttp/pull/359

What's a bit strange in your case is that TypeScript seems to see the types, but `@typescript-eslint` can't (it relies in TypeScript itself for types resolution 🤔):

<img width="769" alt="image" src="https://user-images.githubusercontent.com/1443499/171836990-40f85eb0-a4c7-4a16-a769-b1f0c00416cf.png">

Anyway, I think if you are declaring your module as ESM and you are writing it in TypeScript, it's a best practice (or even a requirement?) to use explicit paths in the import/export statements for local files.