### PR TITLE
docs: exclude algolia `searchParameters`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -57,9 +57,9 @@ export default defineConfig({
       appId: 'ZTF29HGJ69',
       apiKey: '9c3ced6fed60d2670bb36ab7e8bed8bc',
       indexName: 'vitest',
-      searchParameters: {
-        facetFilters: ['tags:en'],
-      },
+      // searchParameters: {
+      //   facetFilters: ['tags:en'],
+      // },
     },
 
     localeLinks: {


### PR DESCRIPTION
it seems we need to review algolia, `searchParameters` prevents search working...

fix #1420