### PR TITLE
docs: fix the example for `test.fails` function

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -162,8 +162,8 @@ In Jest, `TestFunction` can also be of type `(done: DoneCallback) => void`. If t
   ```ts
   import { expect, test } from 'vitest'
   const myAsyncFunc = () => new Promise(resolve => resolve(1))
-  test.fails('fail test', () => {
-    expect(myAsyncFunc()).rejects.toBe(1)
+  test.fails('fail test', async () => {
+    await expect(myAsyncFunc()).rejects.toBe(1)
   })
   ```
 


### PR DESCRIPTION
[Link to the docs](https://vitest.dev/api/#test-fails).

1. The original example produces the following output to the console:
![image](https://user-images.githubusercontent.com/10310491/172014327-3df0e832-18ae-47ff-813e-679fcd5df850.png)
2. After changing the example according to the [rejects](https://vitest.dev/api/#rejects) assertion's description (adding `await` before `expect` and making the whole test asynchronous), the output to the console changes to this:
![image](https://user-images.githubusercontent.com/10310491/172014487-e0faedcb-cbe5-4c91-945c-ffbd1ae46c0f.png)
3. When changing `test.fails` to `test`, the output is the following:
![image](https://user-images.githubusercontent.com/10310491/172015307-ef1d6123-7275-40a4-bdc9-a0fe374096e5.png)

If I understand correctly, in the example the assertion throws an error, that a promise is resolved instead of being rejected, but since we use `.fails` function, vitest will mark the test as passed. If so, it seems the output of the fixed example (2) is correct.

If I understand the idea of `test.fails` **incorrectly**, I think it will be useful to leave a note in the [dedicated discussion](https://github.com/vitest-dev/vitest/discussions/1427) and/or in this pull request's comments.