### PR TITLE
types(SpyOn): Add callable typing

### DIFF
--- a/packages/vitest/src/integrations/spy.ts
+++ b/packages/vitest/src/integrations/spy.ts
@@ -37,6 +37,8 @@ type Classes<T> = {
 }[keyof T] & (string | symbol)
 
 export interface SpyInstance<TArgs extends any[] = any[], TReturns = any> {
+  (...args: TArgs): TReturns
+
   getMockName(): string
   mockName(n: string): this
   mock: SpyContext<TArgs, TReturns>


### PR DESCRIPTION
Just allowing the correct typing to `spyOn` 
```ts
const a = {
  call(a: 1) {
    return a
  }
}

a.call(1)

const ss = spyOn(a, 'call')
ss(1)
// @ts-expect-error invalid type
ss('2')
```