### PR TITLE
fix: don't clear default suite's hooks

### DIFF
--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -42,6 +42,7 @@ export const defaultSuite = suite('')
 
 export function clearCollectorContext() {
   collectorContext.tasks.length = 0
+  defaultSuite.clear(false)
   collectorContext.currentSuite = defaultSuite
 }
 
@@ -121,10 +122,12 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
     setHooks(suite, createSuiteHooks())
   }
 
-  function clear() {
+  function clear(recreate = true) {
     tasks.length = 0
     factoryQueue.length = 0
-    initSuite()
+
+    if (recreate)
+      initSuite()
   }
 
   async function collect(file?: File) {

--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -42,7 +42,6 @@ export const defaultSuite = suite('')
 
 export function clearCollectorContext() {
   collectorContext.tasks.length = 0
-  defaultSuite.clear()
   collectorContext.currentSuite = defaultSuite
 }
 

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -140,7 +140,7 @@ export interface SuiteCollector<ExtraContext = {}> {
   test: TestAPI<ExtraContext>
   tasks: (Suite | Test | SuiteCollector<ExtraContext>)[]
   collect: (file?: File) => Promise<Suite>
-  clear: () => void
+  clear: (clearHooks?: boolean) => void
   on: <T extends keyof SuiteHooks>(name: T, ...fn: SuiteHooks[T]) => void
 }
 


### PR DESCRIPTION
Fixes #1430

`@testing-library/react` puts `afterEach`, `beforeAll`, `afterAll` hooks when initialized. In `--threads` clearing doesn't matter, since `[paths]` is always initialized once, but with `--no-threads` we need to remember previously initialized global hooks.