### PR TITLE
feat(vite-node): respect ssr field, allow inlining everything

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -82,10 +82,12 @@ Externalize means that Vite will bypass the package to native Node. Externalized
 
 #### deps.inline
 
-- **Type:** `(string | RegExp)[]`
+- **Type:** `(string | RegExp)[] | true`
 - **Default:** `[]`
 
 Vite will process inlined modules. This could be helpful to handle packages that ship `.js` in ESM format (that Node can't handle).
+
+If `true`, every dependency will be inlined.
 
 #### deps.fallbackCJS
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -87,7 +87,7 @@ Externalize means that Vite will bypass the package to native Node. Externalized
 
 Vite will process inlined modules. This could be helpful to handle packages that ship `.js` in ESM format (that Node can't handle).
 
-If `true`, every dependency will be inlined.
+If `true`, every dependency will be inlined. All dependencies, specified in [`ssr.noExternal`](https://vitejs.dev/guide/ssr.html#ssr-externals) will be inlined by default.
 
 #### deps.fallbackCJS
 

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -90,15 +90,19 @@ async function run(files: string[], options: CliOptions = {}) {
 }
 
 function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeServerOptions {
+  const inlineOptions = serverOptions.deps?.inline === true ? true : toArray(serverOptions.deps?.inline)
+
   return {
     ...serverOptions,
     deps: {
       ...serverOptions.deps,
-      inline: toArray(serverOptions.deps?.inline).map((dep) => {
-        return dep.startsWith('/') && dep.endsWith('/')
-          ? new RegExp(dep)
-          : dep
-      }),
+      inline: inlineOptions !== true
+        ? inlineOptions.map((dep) => {
+          return dep.startsWith('/') && dep.endsWith('/')
+            ? new RegExp(dep)
+            : dep
+        })
+        : true,
       external: toArray(serverOptions.deps?.external).map((dep) => {
         return dep.startsWith('/') && dep.endsWith('/')
           ? new RegExp(dep)
@@ -121,9 +125,11 @@ type ComputeViteNodeServerOptionsCLI<T extends Record<string, any>> = {
     ? string | string[]
     : T[K] extends Optional<(string | RegExp)[]>
       ? string | string[]
-      : T[K] extends Optional<Record<string, any>>
-        ? ComputeViteNodeServerOptionsCLI<T[K]>
-        : T[K]
+      : T[K] extends Optional<(string | RegExp)[] | true>
+        ? string | string[] | true
+        : T[K] extends Optional<Record<string, any>>
+          ? ComputeViteNodeServerOptionsCLI<T[K]>
+          : T[K]
 }
 
 export type ViteNodeServerOptionsCLI = ComputeViteNodeServerOptionsCLI<ViteNodeServerOptions>

--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -85,9 +85,11 @@ async function _shouldExternalize(
   return false
 }
 
-function matchExternalizePattern(id: string, patterns?: (string | RegExp)[]) {
-  if (!patterns)
+function matchExternalizePattern(id: string, patterns?: (string | RegExp)[] | true) {
+  if (patterns == null)
     return false
+  if (patterns === true)
+    return true
   for (const ex of patterns) {
     if (typeof ex === 'string') {
       if (id.includes(`/node_modules/${ex}/`))

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -37,7 +37,7 @@ export class ViteNodeServer {
       // }
 
       if (ssrOptions.noExternal === true) {
-        options.deps.inline = true
+        options.deps.inline ??= true
       }
       else if (options.deps.inline !== true) {
         options.deps.inline ??= []

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -31,7 +31,6 @@ export class ViteNodeServer {
       options.deps ??= {}
 
       // we don't externalize ssr, because it has different semantics in Vite
-      // Vite prefers using `require`, but we try to import ESM with async `import`
       // if (ssrOptions.external) {
       //   options.deps.external ??= []
       //   options.deps.external.push(...ssrOptions.external)

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -5,7 +5,7 @@ export type Arrayable<T> = T | Array<T>
 
 export interface DepsHandlingOptions {
   external?: (string | RegExp)[]
-  inline?: (string | RegExp)[]
+  inline?: (string | RegExp)[] | true
   /**
    * Try to guess the CJS version of a package when it's invalid ESM
    * @default false

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -94,8 +94,16 @@ export function resolveConfig(
   // vitenode will try to import such file with native node,
   // but then our mocker will not work properly
   if (resolved.deps.inline !== true) {
-    resolved.deps.inline ??= []
-    resolved.deps.inline.push(...extraInlineDeps)
+    // @ts-expect-error ssr is not typed
+    const ssrOptions = viteConfig.ssr
+
+    if (ssrOptions.noExternal === true && resolved.deps.inline == null) {
+      resolved.deps.inline = true
+    }
+    else {
+      resolved.deps.inline ??= []
+      resolved.deps.inline.push(...extraInlineDeps)
+    }
   }
 
   resolved.testNamePattern = resolved.testNamePattern

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -95,7 +95,7 @@ export function resolveConfig(
   // but then our mocker will not work properly
   if (resolved.deps.inline !== true) {
     // @ts-expect-error ssr is not typed
-    const ssrOptions = viteConfig.ssr
+    const ssrOptions = viteConfig.ssr || {}
 
     if (ssrOptions.noExternal === true && resolved.deps.inline == null) {
       resolved.deps.inline = true

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -93,8 +93,10 @@ export function resolveConfig(
   resolved.deps = resolved.deps || {}
   // vitenode will try to import such file with native node,
   // but then our mocker will not work properly
-  resolved.deps.inline ??= []
-  resolved.deps.inline.push(...extraInlineDeps)
+  if (resolved.deps.inline !== true) {
+    resolved.deps.inline ??= []
+    resolved.deps.inline.push(...extraInlineDeps)
+  }
 
   resolved.testNamePattern = resolved.testNamePattern
     ? resolved.testNamePattern instanceof RegExp

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -59,8 +59,10 @@ export interface InlineConfig {
      * Vite will process inlined modules.
      *
      * This could be helpful to handle packages that ship `.js` in ESM format (that Node can't handle).
+     *
+     * If `true`, every dependency will be inlined
      */
-    inline?: (string | RegExp)[]
+    inline?: (string | RegExp)[] | true
 
     /**
      * Interpret CJS module's default as named exports


### PR DESCRIPTION
Vite allows `true` for `noExternal`, so I added support to us

I am adding this logic to `ViteNode`, because it can be used outside of Vitest, and I think it can help Histoire in the future.