### PR TITLE
fix: don't escape quotes for objects in difference view

### DIFF
--- a/packages/vitest/src/node/diff.ts
+++ b/packages/vitest/src/node/diff.ts
@@ -60,6 +60,7 @@ export function unifiedDiff(actual: string, expected: string, options: DiffOptio
   const isCompact = counts['+'] === 1 && counts['-'] === 1 && lines.length === 2
 
   let formatted = lines.map((line: string) => {
+    line = line.replace(/\\"/g, '"')
     if (line[0] === '-') {
       line = formatLine(line.slice(1), outputTruncateLength)
       if (isCompact)
@@ -86,6 +87,13 @@ export function unifiedDiff(actual: string, expected: string, options: DiffOptio
       ]
     }
     else {
+      if (formatted[0].includes('"'))
+        formatted[0] = formatted[0].replace('"', '')
+
+      const last = formatted.length - 1
+      if (formatted[last].endsWith('"'))
+        formatted[last] = formatted[last].slice(0, formatted[last].length - 1)
+
       formatted.unshift(
         c.green(`- Expected  - ${counts['-']}`),
         c.red(`+ Received  + ${counts['+']}`),


### PR DESCRIPTION
Before:
<img width="239" alt="Screenshot 2022-06-05 at 14 15 47" src="https://user-images.githubusercontent.com/16173870/172047947-c27dec05-d74e-46ac-9efd-3966441d0522.png">

After:
<img width="267" alt="Screenshot 2022-06-05 at 14 15 20" src="https://user-images.githubusercontent.com/16173870/172047937-b0a7c27d-71e6-4df3-a9e5-148f45dfa57f.png">

Vue/html-like snapshots are still escaped