### PR TITLE
fix: correct export extension

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -41,8 +41,8 @@
       "import": "./dist/config.mjs"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "bin": {
     "vitest": "./vitest.mjs"


### PR DESCRIPTION
Missing updates from https://github.com/vitest-dev/vitest/pull/1411

Caused runtime issue in https://github.com/vitejs/vite/pull/8474