### PR TITLE
docs(api): fix the explanation for 'mockRestore'

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1943,7 +1943,7 @@ Vitest provides utility functions to help you out through it's **vi** helper. Yo
 
 - **Type:** `() => MockInstance`
 
-  Does what `mockRestore` does and restores inner implementation to the original function.
+  Does what `mockReset` does and restores inner implementation to the original function.
 
   Note that restoring mock from `vi.fn()` will set implementation to an empty function that returns `undefined`. Restoring a `vi.fn(impl)` will restore implementation to `impl`.
 


### PR DESCRIPTION
Hi maintainers 👋 
I found a tiny typo in the docs. I'd be happy to merge them!

The explanation for 'mockRestore' says "Does what `mockRestore` does", but this should be "Does what `mockReset` does" based on the code.

https://github.com/vitest-dev/vitest/blob/17dfd39e51b33a02458aaab8bf75d42dd680e72b/packages/vitest/src/integrations/spy.ts#L200-L201