### PR TITLE
fix(ui): update vue dependency conflict

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,7 @@
     "unplugin-auto-import": "^0.8.6",
     "unplugin-vue-components": "^0.19.6",
     "vite-plugin-pages": "^0.23.0",
-    "vue": "^3.2.36",
+    "vue": "^3.2.37",
     "vue-router": "^4.0.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
       lit: 2.2.5
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 5.0.0
+      happy-dom: 5.2.0
       vite: 2.9.10
       vitest: link:../../packages/vitest
 
@@ -258,15 +258,15 @@ importers:
       vite: ^2.9.10
       vitest: workspace:*
     dependencies:
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
+      react: 17.0.2
+      react-dom: 16.14.0_react@17.0.2
     devDependencies:
       '@types/react': 17.0.45
       '@types/react-dom': 17.0.17
       '@vitejs/plugin-react': 1.3.1
       '@vitest/ui': link:../../packages/ui
       enzyme: 3.11.0
-      enzyme-adapter-react-16: 1.15.6_j6bpv5pizkyfppcg2tmva6pmii
+      enzyme-adapter-react-16: 1.15.6_nzetpuaj6rwcpymp3an2fxuqfy
       vite: 2.9.10
       vitest: link:../../packages/vitest
 
@@ -294,7 +294,7 @@ importers:
     dependencies:
       '@emotion/react': 11.9.0_3dj5wppwohj5ocihzt4m54mr2a
       '@emotion/styled': 11.8.1_3zgpe2oef7sbs566rsy6a7qm7i
-      '@mui/lab': 5.0.0-alpha.84_r7a7s2hz762ox6q4ctdyql64vq
+      '@mui/lab': 5.0.0-alpha.85_r7a7s2hz762ox6q4ctdyql64vq
       '@mui/material': 5.6.4_rikzftoujo3cmwul4lespwcm6i
       history: 5.3.0
       notistack: 2.0.5_udzxwwnbdmb3fntj5kb5hemvo4
@@ -459,7 +459,7 @@ importers:
       solid-js: 1.4.3
     devDependencies:
       jsdom: 19.0.0
-      solid-start: 0.1.0-alpha.87_rr56xi33h37vhc4tv5jhq4mlhy
+      solid-start: 0.1.0-alpha.88_rr56xi33h37vhc4tv5jhq4mlhy
       solid-testing-library: 0.3.0_solid-js@1.4.3
       vitest: link:../../packages/vitest
 
@@ -585,13 +585,13 @@ importers:
       unplugin-auto-import: ^0.8.6
       unplugin-vue-components: ^0.19.6
       vite-plugin-pages: ^0.23.0
-      vue: ^3.2.36
+      vue: ^3.2.37
       vue-router: ^4.0.15
     dependencies:
       sirv: 2.0.2
     devDependencies:
       '@cypress/vite-dev-server': 2.2.3_vite@2.9.10
-      '@cypress/vue': 3.1.2_cypress@9.7.0+vue@3.2.33
+      '@cypress/vue': 3.1.2_cypress@9.7.0+vue@3.2.37
       '@faker-js/faker': 7.1.0
       '@testing-library/cypress': 8.0.2_cypress@9.7.0
       '@types/codemirror': 5.60.5
@@ -599,10 +599,10 @@ importers:
       '@types/d3-selection': 3.0.2
       '@types/ws': 8.5.3
       '@unocss/reset': 0.36.0
-      '@vitejs/plugin-vue': 2.3.3_vite@2.9.10+vue@3.2.33
+      '@vitejs/plugin-vue': 2.3.3_vite@2.9.10+vue@3.2.37
       '@vitejs/plugin-vue-jsx': 1.3.10
       '@vitest/ws-client': link:../ws-client
-      '@vueuse/core': 8.5.0_vue@3.2.33
+      '@vueuse/core': 8.5.0_vue@3.2.37
       ansi-to-html: 0.7.2
       birpc: 0.2.3
       codemirror: 5.65.5
@@ -610,16 +610,16 @@ importers:
       cypress: 9.7.0
       d3-graph-controller: 2.2.37
       flatted: 3.2.5
-      floating-vue: 2.0.0-y.0_vue@3.2.33
+      floating-vue: 2.0.0-y.0_vue@3.2.37
       picocolors: 1.0.0
       rollup: 2.75.3
       splitpanes: 3.1.1
       unocss: 0.36.0_vite@2.9.10
       unplugin-auto-import: 0.8.6_fpqoeqsojee4r52i7tfxfpxikm
-      unplugin-vue-components: 0.19.6_xryfcjbhcaugpvo4tb4hnngsvu
+      unplugin-vue-components: 0.19.6_nvesjkuk74o2t3vn4mt5blmpe4
       vite-plugin-pages: 0.23.0_vite@2.9.10
-      vue: 3.2.33
-      vue-router: 4.0.15_vue@3.2.33
+      vue: 3.2.37
+      vue-router: 4.0.15_vue@3.2.37
 
   packages/vite-node:
     specifiers:
@@ -3874,7 +3874,7 @@ packages:
       - supports-color
     dev: true
 
-  /@cypress/vue/3.1.2_cypress@9.7.0+vue@3.2.33:
+  /@cypress/vue/3.1.2_cypress@9.7.0+vue@3.2.37:
     resolution: {integrity: sha512-CqIBupPW6EhXJ7lXE64MBKh3VfdShHnuC3HBV/euHBt9tsgSo7RZHBTZUsKc8aM745VzVnuNiax+JV4CplrtLQ==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -3889,9 +3889,9 @@ packages:
         optional: true
     dependencies:
       '@cypress/mount-utils': 1.0.2
-      '@vue/test-utils': 2.0.0-rc.21_vue@3.2.33
+      '@vue/test-utils': 2.0.0-rc.21_vue@3.2.37
       cypress: 9.7.0
-      vue: 3.2.33
+      vue: 3.2.37
     dev: true
 
   /@cypress/xvfb/1.2.4_supports-color@8.1.1:
@@ -4688,8 +4688,8 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /@mui/base/5.0.0-alpha.83_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-/bFcjiI36R2Epf2Y3BkZOIdxrz5uMLqOU4cRai4igJ8DHTRMZDeKbOff0SdvwJNwg8r6oPUyoeOpsWkaOOX9/g==}
+  /@mui/base/5.0.0-alpha.84_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-uDx+wGVytS+ZHiWHyzUyijY83GSIXJpzSJ0PGc/8/s+8nBzeHvaPKrAyJz15ASLr52hYRA6PQGqn0eRAsB7syQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -4711,8 +4711,8 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /@mui/lab/5.0.0-alpha.84_r7a7s2hz762ox6q4ctdyql64vq:
-    resolution: {integrity: sha512-HLYD6E3PAlzKMGZkkpiPI7trHP3WYDvrjQstEsFwdaGy9AMWPmyTxhwUyfB4VVHOx3zcj4p/a36kECDtEOAJ+g==}
+  /@mui/lab/5.0.0-alpha.85_r7a7s2hz762ox6q4ctdyql64vq:
+    resolution: {integrity: sha512-GaPl5azVXr9dbwZe1DiKr3GO9Bg3nbZ48oRTDZoMxWYMB8dm4f73GrY2Sv1Sf03z19YzlD7Ixskr6rGcKGPWlw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -4744,11 +4744,11 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/react': 11.9.0_3dj5wppwohj5ocihzt4m54mr2a
       '@emotion/styled': 11.8.1_3zgpe2oef7sbs566rsy6a7qm7i
-      '@mui/base': 5.0.0-alpha.83_sfoxds7t5ydpegc3knd667wn6m
+      '@mui/base': 5.0.0-alpha.84_sfoxds7t5ydpegc3knd667wn6m
       '@mui/material': 5.6.4_rikzftoujo3cmwul4lespwcm6i
-      '@mui/system': 5.8.2_bgqmsvm4hz6izcmpcwescmz73y
+      '@mui/system': 5.8.3_bgqmsvm4hz6izcmpcwescmz73y
       '@mui/utils': 5.8.0_react@17.0.2
-      '@mui/x-date-pickers': 5.0.0-alpha.1_c2ezohbeeu4t7xc7xz3ud3dbca
+      '@mui/x-date-pickers': 5.0.0-alpha.1_lh4hitfw5hvjrz4q2uyrogte5m
       clsx: 1.1.1
       date-fns: 2.28.0
       prop-types: 15.8.1
@@ -4860,8 +4860,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@mui/system/5.8.2_bgqmsvm4hz6izcmpcwescmz73y:
-    resolution: {integrity: sha512-N74gDNKM+MnWvKTMmCPvCVLH4f0ZzakP1bcMDaPctrHwcyxNcEmtTGNpIiVk0Iu7vtThZAFL3DjHpINPGF7+cg==}
+  /@mui/system/5.8.3_bgqmsvm4hz6izcmpcwescmz73y:
+    resolution: {integrity: sha512-/tyGQcYqZT0nl98qV9XnGiedTO+V7VHc28k4POfhMJNedB1CRrwWRm767DeEdc5f/8CU2See3WD16ikP6pYiOA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -4912,7 +4912,7 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /@mui/x-date-pickers/5.0.0-alpha.1_c2ezohbeeu4t7xc7xz3ud3dbca:
+  /@mui/x-date-pickers/5.0.0-alpha.1_lh4hitfw5hvjrz4q2uyrogte5m:
     resolution: {integrity: sha512-dLPkRiIn2Gr0momblxiOnIwrxn4SijVix+8e08mwAGWhiWcmWep1O9XTRDpZsjB0kjHYCf+kZjlRX4dxnj2acg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -4939,7 +4939,7 @@ packages:
       '@date-io/luxon': 2.13.1
       '@date-io/moment': 2.13.1
       '@mui/material': 5.6.4_rikzftoujo3cmwul4lespwcm6i
-      '@mui/system': 5.8.2_bgqmsvm4hz6izcmpcwescmz73y
+      '@mui/system': 5.8.3_bgqmsvm4hz6izcmpcwescmz73y
       '@mui/utils': 5.8.0_react@17.0.2
       clsx: 1.1.1
       date-fns: 2.28.0
@@ -7275,7 +7275,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 17.0.35
+      '@types/node': 17.0.40
     dev: true
 
   /@types/graceful-fs/4.1.5:
@@ -8418,12 +8418,12 @@ packages:
       vue-template-compiler: 2.6.14
     dev: true
 
-  /@vue/test-utils/2.0.0-rc.21_vue@3.2.33:
+  /@vue/test-utils/2.0.0-rc.21_vue@3.2.37:
     resolution: {integrity: sha512-wIJR4e/jISBKVKfiod3DV32BlDsoD744WVCuCaGtaSKvhvTL9gI5vl2AYSy00V51YaM8dCOFi3zcpCON8G1WqA==}
     peerDependencies:
       vue: ^3.0.1
     dependencies:
-      vue: 3.2.33
+      vue: 3.2.37
     dev: true
 
   /@vue/test-utils/2.0.0_vue@3.2.36:
@@ -8457,6 +8457,7 @@ packages:
       '@vueuse/shared': 8.5.0_vue@3.2.33
       vue: 3.2.33
       vue-demi: 0.12.5_vue@3.2.33
+    dev: false
 
   /@vueuse/core/8.5.0_vue@3.2.37:
     resolution: {integrity: sha512-VEJ6sGNsPlUp0o9BGda2YISvDZbhWJSOJu5zlp2TufRGVrLcYUKr31jyFEOj6RXzG3k/H4aCYeZyjpItfU8glw==}
@@ -8532,6 +8533,7 @@ packages:
     dependencies:
       vue: 3.2.33
       vue-demi: 0.12.5_vue@3.2.33
+    dev: false
 
   /@vueuse/shared/8.5.0_vue@3.2.37:
     resolution: {integrity: sha512-qKG+SZb44VvGD4dU5cQ63z4JE2Yk39hQUecR0a9sEdJA01cx+XrxAvFKJfPooxwoiqalAVw/ktWK6xbyc/jS3g==}
@@ -8811,7 +8813,7 @@ packages:
       symbol.prototype.description: 1.0.5
     dev: true
 
-  /airbnb-prop-types/2.16.0_react@16.14.0:
+  /airbnb-prop-types/2.16.0_react@17.0.2:
     resolution: {integrity: sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==}
     peerDependencies:
       react: ^0.14 || ^15.0.0 || ^16.0.0-alpha
@@ -8824,7 +8826,7 @@ packages:
       object.entries: 1.1.5
       prop-types: 15.8.1
       prop-types-exact: 1.2.0
-      react: 16.14.0
+      react: 17.0.2
       react-is: 16.13.1
     dev: true
 
@@ -11978,7 +11980,7 @@ packages:
     engines: {node: '>=0.12'}
     dev: true
 
-  /enzyme-adapter-react-16/1.15.6_j6bpv5pizkyfppcg2tmva6pmii:
+  /enzyme-adapter-react-16/1.15.6_nzetpuaj6rwcpymp3an2fxuqfy:
     resolution: {integrity: sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==}
     peerDependencies:
       enzyme: ^3.0.0
@@ -11986,31 +11988,31 @@ packages:
       react-dom: ^16.0.0-0
     dependencies:
       enzyme: 3.11.0
-      enzyme-adapter-utils: 1.14.0_react@16.14.0
+      enzyme-adapter-utils: 1.14.0_react@17.0.2
       enzyme-shallow-equal: 1.0.4
       has: 1.0.3
       object.assign: 4.1.2
       object.values: 1.1.5
       prop-types: 15.8.1
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
+      react: 17.0.2
+      react-dom: 16.14.0_react@17.0.2
       react-is: 16.13.1
-      react-test-renderer: 16.14.0_react@16.14.0
+      react-test-renderer: 16.14.0_react@17.0.2
       semver: 5.7.1
     dev: true
 
-  /enzyme-adapter-utils/1.14.0_react@16.14.0:
+  /enzyme-adapter-utils/1.14.0_react@17.0.2:
     resolution: {integrity: sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==}
     peerDependencies:
       react: 0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0
     dependencies:
-      airbnb-prop-types: 2.16.0_react@16.14.0
+      airbnb-prop-types: 2.16.0_react@17.0.2
       function.prototype.name: 1.1.5
       has: 1.0.3
       object.assign: 4.1.2
       object.fromentries: 2.0.5
       prop-types: 15.8.1
-      react: 16.14.0
+      react: 17.0.2
       semver: 5.7.1
     dev: true
 
@@ -13264,14 +13266,14 @@ packages:
   /flatted/3.2.5:
     resolution: {integrity: sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==}
 
-  /floating-vue/2.0.0-y.0_vue@3.2.33:
+  /floating-vue/2.0.0-y.0_vue@3.2.37:
     resolution: {integrity: sha512-UpJquQIlP0Z5978RYwGN3qsE6jhxxCt7ltzE1mV2m9GwsZ6y7IaIOAszWqALC+OqWhdPad/0GYxoQYGLC0y+Ow==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
       '@floating-ui/dom': 0.1.10
-      vue: 3.2.33
-      vue-resize: 2.0.0-alpha.1_vue@3.2.33
+      vue: 3.2.37
+      vue-resize: 2.0.0-alpha.1_vue@3.2.37
     dev: true
 
   /flush-write-stream/1.1.1:
@@ -13846,8 +13848,8 @@ packages:
       - encoding
     dev: true
 
-  /happy-dom/5.0.0:
-    resolution: {integrity: sha512-n47uxVRW2prLQ1mYEfwc5JPeMmiQGHpUsM0edtqlKIWJlAvpZJmq0ZAKdeDuZ/f1Gu8kXumy9jyWsJ1zRT7VEw==}
+  /happy-dom/5.2.0:
+    resolution: {integrity: sha512-WbMaOZjadH7/c15U1I1GheswXX12g/QxTPjs9gYHZQGl+Xx9X5eQEj84BQ5ivjFLFR6oJ56lL5+jcesXP0FLjg==}
     dependencies:
       css.escape: 1.5.1
       he: 1.2.0
@@ -18162,7 +18164,7 @@ packages:
       - supports-color
     dev: true
 
-  /react-dom/16.14.0_react@16.14.0:
+  /react-dom/16.14.0_react@17.0.2:
     resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==}
     peerDependencies:
       react: ^16.14.0
@@ -18170,7 +18172,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-      react: 16.14.0
+      react: 17.0.2
       scheduler: 0.19.1
 
   /react-dom/17.0.2_react@17.0.2:
@@ -18410,14 +18412,14 @@ packages:
       refractor: 3.6.0
     dev: true
 
-  /react-test-renderer/16.14.0_react@16.14.0:
+  /react-test-renderer/16.14.0_react@17.0.2:
     resolution: {integrity: sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==}
     peerDependencies:
       react: ^16.14.0
     dependencies:
       object-assign: 4.1.1
       prop-types: 15.8.1
-      react: 16.14.0
+      react: 17.0.2
       react-is: 16.13.1
       scheduler: 0.19.1
     dev: true
@@ -18475,14 +18477,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
-
-  /react/16.14.0:
-    resolution: {integrity: sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.8.1
 
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -18778,7 +18772,7 @@ packages:
     dev: false
 
   /remove-trailing-separator/1.1.0:
-    resolution: {integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=}
+    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
     dev: true
 
   /renderkid/2.0.7:
@@ -18838,7 +18832,7 @@ packages:
     dev: true
 
   /resolve-url/0.2.1:
-    resolution: {integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=}
+    resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
     dev: true
 
@@ -19052,7 +19046,7 @@ packages:
     dev: true
 
   /run-queue/1.0.3:
-    resolution: {integrity: sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=}
+    resolution: {integrity: sha512-ntymy489o0/QQplUDnpYAYUsO50K9SBrIVaKCWDOJzYJts0f9WH9RFJkyagebkw5+y1oi00R7ynNW/d12GBumg==}
     dependencies:
       aproba: 1.2.0
     dev: true
@@ -19082,7 +19076,7 @@ packages:
     dev: true
 
   /safe-regex/1.1.0:
-    resolution: {integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4=}
+    resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
     dependencies:
       ret: 0.1.15
     dev: true
@@ -19269,7 +19263,7 @@ packages:
     dev: true
 
   /set-blocking/2.0.0:
-    resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
 
   /set-cookie-parser/2.4.8:
@@ -19287,7 +19281,7 @@ packages:
     dev: true
 
   /setimmediate/1.0.5:
-    resolution: {integrity: sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=}
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
     dev: true
 
   /setprototypeof/1.2.0:
@@ -19490,7 +19484,7 @@ packages:
       solid-js: 1.4.3
     dev: true
 
-  /solid-start-node/0.1.0-alpha.82_6qelsoyn4rkn4vbtejet25lfru:
+  /solid-start-node/0.1.0-alpha.82_rg23sq3othatmmcq7gaspvqd4y:
     resolution: {integrity: sha512-v0S/y260wcFBNSZ9gShJvZjw6MWD8OfHHruPqDWgzquD0izCXtYfAoU6+YpkejF482Nt/ZfPWXB5LKR+3GdxrQ==}
     requiresBuild: true
     peerDependencies:
@@ -19505,7 +19499,7 @@ packages:
       polka: 1.0.0-next.22
       rollup: 2.75.5
       sirv: 1.0.19
-      solid-start: 0.1.0-alpha.87_rr56xi33h37vhc4tv5jhq4mlhy
+      solid-start: 0.1.0-alpha.88_rr56xi33h37vhc4tv5jhq4mlhy
       undici: 4.16.0
       vite: 2.9.10
     transitivePeerDependencies:
@@ -19513,8 +19507,8 @@ packages:
     dev: true
     optional: true
 
-  /solid-start/0.1.0-alpha.87_rr56xi33h37vhc4tv5jhq4mlhy:
-    resolution: {integrity: sha512-iKO715lLf/040N1up7hfs4Gicmjtiueb1NM/mQ5dCP6neguuweb8+MrLvKhvLcbyQXlGZaXaHPxXJ6clDhKdaw==}
+  /solid-start/0.1.0-alpha.88_rr56xi33h37vhc4tv5jhq4mlhy:
+    resolution: {integrity: sha512-sML6krhbYg0oW+UVnVA0XIJjiXifP7GWKMwAKMyx9Ut9mYPiLhGTq61NEzSMr34F2z3SUq2PK9XmvvSCqMt+AA==}
     hasBin: true
     peerDependencies:
       solid-app-router: ^0.3.1
@@ -19550,7 +19544,7 @@ packages:
       vite-plugin-inspect: 0.3.15_vite@2.9.10
       vite-plugin-solid: 2.2.6
     optionalDependencies:
-      solid-start-node: 0.1.0-alpha.82_6qelsoyn4rkn4vbtejet25lfru
+      solid-start-node: 0.1.0-alpha.82_rg23sq3othatmmcq7gaspvqd4y
     transitivePeerDependencies:
       - less
       - sass
@@ -19777,7 +19771,7 @@ packages:
     dev: true
 
   /static-extend/0.1.2:
-    resolution: {integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=}
+    resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
     engines: {node: '>=0.10.0'}
     dependencies:
       define-property: 0.2.5
@@ -20984,7 +20978,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
-      '@vueuse/core': 8.5.0_vue@3.2.33
+      '@vueuse/core': 8.5.0_vue@3.2.37
       local-pkg: 0.4.1
       magic-string: 0.26.2
       unimport: 0.2.5_rollup@2.75.3+vite@2.9.10
@@ -20992,6 +20986,38 @@ packages:
     transitivePeerDependencies:
       - esbuild
       - rollup
+      - vite
+      - webpack
+    dev: true
+
+  /unplugin-vue-components/0.19.6_nvesjkuk74o2t3vn4mt5blmpe4:
+    resolution: {integrity: sha512-APvrJ9Hpid1MLT0G4PWerMJgARhNw6dzz0pcCwCxaO2DR7VyvDacMqjOQNC6ukq7FSw3wzD8VH+9i3EFXwkGmw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/parser': ^7.15.8
+      '@babel/traverse': ^7.15.4
+      vue: 2 || 3
+    peerDependenciesMeta:
+      '@babel/parser':
+        optional: true
+      '@babel/traverse':
+        optional: true
+    dependencies:
+      '@antfu/utils': 0.5.2
+      '@rollup/pluginutils': 4.2.1
+      chokidar: 3.5.3
+      debug: 4.3.4
+      fast-glob: 3.2.11
+      local-pkg: 0.4.1
+      magic-string: 0.26.2
+      minimatch: 5.0.1
+      resolve: 1.22.0
+      unplugin: 0.6.3_rollup@2.75.3+vite@2.9.10
+      vue: 3.2.37
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - supports-color
       - vite
       - webpack
     dev: true
@@ -21052,38 +21078,6 @@ packages:
       resolve: 1.22.0
       unplugin: 0.6.3_vite@2.9.10
       vue: 3.2.36
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - supports-color
-      - vite
-      - webpack
-    dev: true
-
-  /unplugin-vue-components/0.19.6_xryfcjbhcaugpvo4tb4hnngsvu:
-    resolution: {integrity: sha512-APvrJ9Hpid1MLT0G4PWerMJgARhNw6dzz0pcCwCxaO2DR7VyvDacMqjOQNC6ukq7FSw3wzD8VH+9i3EFXwkGmw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/parser': ^7.15.8
-      '@babel/traverse': ^7.15.4
-      vue: 2 || 3
-    peerDependenciesMeta:
-      '@babel/parser':
-        optional: true
-      '@babel/traverse':
-        optional: true
-    dependencies:
-      '@antfu/utils': 0.5.2
-      '@rollup/pluginutils': 4.2.1
-      chokidar: 3.5.3
-      debug: 4.3.4
-      fast-glob: 3.2.11
-      local-pkg: 0.4.1
-      magic-string: 0.26.2
-      minimatch: 5.0.1
-      resolve: 1.22.0
-      unplugin: 0.6.3_rollup@2.75.3+vite@2.9.10
-      vue: 3.2.33
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -21660,6 +21654,7 @@ packages:
         optional: true
     dependencies:
       vue: 3.2.33
+    dev: false
 
   /vue-demi/0.12.5_vue@3.2.37:
     resolution: {integrity: sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==}
@@ -21694,21 +21689,21 @@ packages:
       - supports-color
     dev: true
 
-  /vue-resize/2.0.0-alpha.1_vue@3.2.33:
+  /vue-resize/2.0.0-alpha.1_vue@3.2.37:
     resolution: {integrity: sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:
-      vue: 3.2.33
+      vue: 3.2.37
     dev: true
 
-  /vue-router/4.0.15_vue@3.2.33:
+  /vue-router/4.0.15_vue@3.2.37:
     resolution: {integrity: sha512-xa+pIN9ZqORdIW1MkN2+d9Ui2pCM1b/UMgwYUCZOiFYHAvz/slKKBDha8DLrh5aCG/RibtrpyhKjKOZ85tYyWg==}
     peerDependencies:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.1.4
-      vue: 3.2.33
+      vue: 3.2.37
     dev: true
 
   /vue-template-compiler/2.6.14:


### PR DESCRIPTION
The test I made on local to reproduce the problem result on multiple versions of vue: 3.2.33 and 3.2.37.

There is something weird with vite plugin vue 2.3.3 and the current version of vue on ui package: it is using 3.2.36 and I don't know why the vue dev dep is using 3.2.33, just updating to latest vue 3.2.37 the ui on local works via `vitest --ui` once run build script finish.

![imagen](https://user-images.githubusercontent.com/6311119/172950312-78417708-5111-4fa2-964d-38bfc280a8d5.png)

![imagen](https://user-images.githubusercontent.com/6311119/172950364-e2a338e7-ba5f-424a-9811-c5139e46b49f.png)


fix #1418