### PR TITLE
feat: introduce `VITEST_POOL_ID`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -315,7 +315,7 @@ Silent console output from tests
 
 Path to setup files. They will be run before each test file.
 
-You can use `process.env.VITEST_WORKER_ID` (integer-like string) inside to distinguish between threads (will always be `'1'`, if run with `threads: false`).
+You can use `process.env.VITEST_POOL_ID` (integer-like string) inside to distinguish between threads (will always be `'1'`, if run with `threads: false`).
 
 :::tip
 Note, that if you are running [`--no-threads`](#threads), this file will be run in the same global scope. Meaning, that you are accessing the same global object before each test, so make sure you are not doing the same thing more than you need.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -20,7 +20,7 @@ Jest exports various [`jasmine`](https://jasmine.github.io/) globals (such as `j
 
 **Envs**
 
-Just like Jest, Vitest sets `NODE_ENV` to `test`, if it wasn't set before. Vitest also has a counterpart for `JEST_WORKER_ID` called `VITEST_WORKER_ID`, so if you rely on it, don't forget to rename it.
+Just like Jest, Vitest sets `NODE_ENV` to `test`, if it wasn't set before. Vitest also has a counterpart for `JEST_WORKER_ID` called `VITEST_POOL_ID` (always less than or equal to `maxThreads`), so if you rely on it, don't forget to rename it. Vitest also exposes `VITEST_WORKER_ID` which is a unique ID of a running worker - this number is not affected by `maxThreads`, and will increase with each created worker.
 
 **Done Callback**
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -69,14 +69,14 @@ export function createPool(ctx: Vitest): WorkerPool {
 
     async function runFiles(files: string[], invalidates: string[] = []) {
       const { workerPort, port } = createChannel(ctx)
-      const workerId = ctx.config.threads ? 1 : ++id
+      const workerId = ++id
       const data: WorkerContext = {
         port: workerPort,
         config,
         files,
         invalidates,
         workerId,
-        poolId: ((workerId - 1) % maxThreads) + 1,
+        poolId: !ctx.config.threads ? 1 : ((workerId - 1) % maxThreads) + 1,
       }
       try {
         await pool.run(data, { transferList: [workerPort], name })

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -63,9 +63,10 @@ function init(ctx: WorkerContext) {
   if (typeof __vitest_worker__ !== 'undefined' && ctx.config.threads && ctx.config.isolate)
     throw new Error(`worker for ${ctx.files.join(',')} already initialized by ${getWorkerState().ctx.files.join(',')}. This is probably an internal bug of Vitest.`)
 
-  const { config, port, id } = ctx
+  const { config, port, workerId, poolId } = ctx
 
-  process.env.VITEST_WORKER_ID = String(id)
+  process.env.VITEST_WORKER_ID = String(workerId)
+  process.env.VITEST_POOL_ID = String(poolId)
 
   // @ts-expect-error I know what I am doing :P
   globalThis.__vitest_worker__ = {

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -8,7 +8,8 @@ import type { SnapshotResult } from './snapshot'
 import type { UserConsoleLog } from './general'
 
 export interface WorkerContext {
-  id: number
+  workerId: number
+  poolId: number
   port: MessagePort
   config: ResolvedConfig
   files: string[]

--- a/test/core/test/env.test.ts
+++ b/test/core/test/env.test.ts
@@ -36,6 +36,7 @@ test('can see env in "define"', () => {
 
 test('has worker env', () => {
   expect(process.env.VITEST_WORKER_ID).toBeDefined()
+  expect(process.env.VITEST_POOL_ID).toBeDefined()
 })
 
 test('custom env', () => {


### PR DESCRIPTION
`VITEST_POOL_ID` behaves more like jets's `JEST_WORKER_ID`. 

`VITEST_WORKER_ID` is still working like it worked before.

Closes #1469