### PR TITLE
fix: spyOn default export of module

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -205,6 +205,12 @@ export class ViteNodeRunner {
     if (transformed[0] === '#')
       transformed = transformed.replace(/^\#\!.*/, s => ' '.repeat(s.length))
 
+    // #855 make `default` property configurable
+    if (/Object\.defineProperty\(\_\_vite\_ssr\_exports\_\_\,\s\"default\"\,\s\{.*value/.test(transformed)) {
+      const exportsPropertyDefinition = 'Object.defineProperty(__vite_ssr_exports__, "default", { configurable: true, writable: true, enumerable: true, value'
+      transformed = transformed.replace(/Object\.defineProperty\(\_\_vite\_ssr\_exports\_\_\,\s\"default\"\,\s\{.*value/, exportsPropertyDefinition)
+    }
+
     // add 'use strict' since ESM enables it by default
     const fn = vm.runInThisContext(`'use strict';async (${Object.keys(context).join(',')})=>{{${transformed}\n}}`, {
       filename: fsPath,

--- a/test/core/src/default-import.ts
+++ b/test/core/src/default-import.ts
@@ -1,0 +1,5 @@
+import c from './module-esm'
+
+export function defaultImport() {
+  return c()
+}

--- a/test/core/src/module-esm.ts
+++ b/test/core/src/module-esm.ts
@@ -1,3 +1,5 @@
 const c = 1
-export default c
+export default function getC() {
+  return c
+}
 export const d = 2

--- a/test/core/test/module.test.ts
+++ b/test/core/test/module.test.ts
@@ -10,6 +10,6 @@ it('should work when using cjs module', () => {
 })
 
 it('should work when using esm module', () => {
-  expect(c).toBe(1)
+  expect(c()).toBe(1)
   expect(d).toBe(2)
 })

--- a/test/core/test/spy.test.ts
+++ b/test/core/test/spy.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
+import * as c from '../src/module-esm'
+import { defaultImport } from '../src/default-import'
 
 /**
  * @vitest-environment happy-dom
@@ -8,5 +10,11 @@ describe('spyOn', () => {
   test('correctly infers method types', async () => {
     vi.spyOn(localStorage, 'getItem').mockReturnValue('world')
     expect(window.localStorage.getItem('hello')).toEqual('world')
+  })
+
+  test('spyOn default export of module', async () => {
+    const mySpy = vi.spyOn(c, 'default')
+    expect(defaultImport()).equals(1)
+    expect(mySpy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes #855 .

I changed the result of source-map transformation, which made the `default` property configurable so that it can create spy on default exports.