### PR TITLE
docs: add mising `async` to `resolves` and `rejects` example

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1253,7 +1253,7 @@ When you use `test` in the top level of file, they are collected as part of the 
   ```ts
   import { expect, test } from 'vitest'
 
-  function buyApples() {
+  async function buyApples() {
     return fetch('/buy/apples').then(r => r.json())
   }
 
@@ -1281,7 +1281,7 @@ When you use `test` in the top level of file, they are collected as part of the 
   ```ts
   import { expect, test } from 'vitest'
 
-  function buyApples(id) {
+  async function buyApples(id) {
     if (!id)
       throw new Error('no id')
   }


### PR DESCRIPTION
These examples were fixed.
Otherwise, the call of `buyApples` "bleeds" the error thrown in the stack of the test.