### PR TITLE
fix: add throat when running spec files

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -119,6 +119,7 @@
     "micromatch": "^4.0.5",
     "mlly": "^0.5.2",
     "natural-compare": "^1.4.0",
+    "p-limit": "^4.0.0",
     "pathe": "^0.2.0",
     "picocolors": "^1.0.0",
     "pkg-types": "^0.3.2",

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -75,7 +75,7 @@ export function createPool(ctx: Vitest): WorkerPool {
     async function runFiles(files: string[], invalidates: string[] = []) {
       const { workerPort, port } = createChannel(ctx)
       const workerId = ++id
-      const poolId = !ctx.config.threads ? 1 : freePoolId.values().next().value
+      const poolId = !ctx.config.threads ? 0 : freePoolId.values().next().value
       const data: WorkerContext = {
         port: workerPort,
         config,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,6 +676,7 @@ importers:
       micromatch: ^4.0.5
       mlly: ^0.5.2
       natural-compare: ^1.4.0
+      p-limit: ^4.0.0
       pathe: ^0.2.0
       picocolors: ^1.0.0
       pkg-types: ^0.3.2
@@ -727,6 +728,7 @@ importers:
       micromatch: 4.0.5
       mlly: 0.5.2
       natural-compare: 1.4.0
+      p-limit: 4.0.0
       pathe: 0.2.0
       picocolors: 1.0.0
       pkg-types: 0.3.2


### PR DESCRIPTION
Fixes `VITETS_POOL_ID` logic.

I noticed no performance differences with this.

I _think_ this might also help with segfalts and Node errors? I have a feeling that running them all might cause it, but I don't have anything to back up that claim.