### PR TITLE
fix(web-worker): ensure event listener functions are bound correctly

### DIFF
--- a/packages/web-worker/src/pure.ts
+++ b/packages/web-worker/src/pure.ts
@@ -102,8 +102,8 @@ export function defineWebWorker() {
           this.inside.emit(event.type, event)
           return true
         },
-        addEventListener: this.inside.on,
-        removeEventListener: this.inside.off,
+        addEventListener: this.inside.on.bind(this.inside),
+        removeEventListener: this.inside.off.bind(this.inside),
         postMessage: (data) => {
           this.outside.emit('message', { data })
         },

--- a/test/web-worker/src/eventListenerWorker.ts
+++ b/test/web-worker/src/eventListenerWorker.ts
@@ -1,0 +1,3 @@
+self.addEventListener('message', (e) => {
+  self.postMessage(`${e.data} world`)
+})

--- a/test/web-worker/test/init.test.ts
+++ b/test/web-worker/test/init.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from 'vitest'
 
 import MyWorker from '../src/worker?worker'
+import MyEventListenerWorker from '../src/eventListenerWorker?worker'
 
 const testWorker = (worker: Worker) => {
   return new Promise<void>((resolve) => {
@@ -21,6 +22,12 @@ it('simple worker', async () => {
   expect.assertions(1)
 
   await testWorker(new MyWorker())
+})
+
+it('event listener worker', async () => {
+  expect.assertions(1)
+
+  await testWorker(new MyEventListenerWorker())
 })
 
 it('can test workers several times', async () => {


### PR DESCRIPTION
Previously `.addEventListener` would throw an error in the worker context:

```
TypeError: Cannot read properties of undefined (reading 'message')
```

Seems this was due to the unbound method assignment. Added a test to prove it