### PR TITLE
fix: return types for vi.mocked are now equal to MaybeMocked

### DIFF
--- a/packages/vitest/src/integrations/spy.ts
+++ b/packages/vitest/src/integrations/spy.ts
@@ -67,10 +67,10 @@ export type MaybeMockedConstructor<T> = T extends new (
 ) => infer R
   ? SpyInstanceFn<ConstructorParameters<T>, R>
   : T
-export type MockedFunction<T extends Procedure> = MockWithArgs<T> & {
+export type MockedFunction<T extends Procedure> = SpyInstanceFn<Parameters<T>, ReturnType<T>> & {
   [K in keyof T]: T[K];
 }
-export type MockedFunctionDeep<T extends Procedure> = MockWithArgs<T> & MockedObjectDeep<T>
+export type MockedFunctionDeep<T extends Procedure> = SpyInstanceFn<Parameters<T>, ReturnType<T>> & MockedObjectDeep<T>
 export type MockedObject<T> = MaybeMockedConstructor<T> & {
   [K in Methods<T>]: T[K] extends Procedure
     ? MockedFunction<T[K]>
@@ -95,12 +95,6 @@ export type MaybeMocked<T> = T extends Procedure
     : T
 
 export type EnhancedSpy<TArgs extends any[] = any[], TReturns = any> = SpyInstance<TArgs, TReturns> & SpyImpl<TArgs, TReturns>
-
-export interface MockWithArgs<T extends Procedure>
-  extends SpyInstanceFn<Parameters<T>, ReturnType<T>> {
-  new (...args: T extends new (...args: any) => any ? ConstructorParameters<T> : never): T
-  (...args: Parameters<T>): ReturnType<T>
-}
 
 export const spies = new Set<SpyInstance>()
 

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -2,7 +2,10 @@
  * @vitest-environment jsdom
  */
 
+import type { MockedFunction, MockedObject } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
+
+const expectType = <T>(obj: T) => obj
 
 describe('testing vi utils', () => {
   test('global scope has variable', () => {
@@ -29,7 +32,14 @@ describe('testing vi utils', () => {
     expect(v1).toBe(v2)
   })
 
-  // TODO: it's unstable in CI, skip until resolved
+  test('vi mocked', () => {
+    expectType<MockedObject<{ bar: () => boolean }>>({
+      bar: vi.fn(() => true),
+    })
+    expectType<MockedFunction<() => boolean>>(vi.fn(() => true))
+    expectType<MockedFunction<() => boolean>>(vi.fn())
+  })
+
   test.skip('loads unloaded module', async () => {
     let mod: any
     import('../src/timeout').then(m => mod = m)


### PR DESCRIPTION
Fixes #1509