### PR TITLE
fix: toFilePath with abs path in root

### DIFF
--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, pathToFileURL } from 'url'
-import { dirname, resolve } from 'pathe'
+import { resolve } from 'pathe'
 import type { TransformResult } from 'vite'
 import type { Arrayable, Nullable } from './types'
 
@@ -48,7 +48,7 @@ export function isPrimitive(v: any) {
 export function toFilePath(id: string, root: string): string {
   let absolute = slash(id).startsWith('/@fs/')
     ? id.slice(4)
-    : id.startsWith(dirname(root)) && dirname(root) !== '/'
+    : id.startsWith(root)
       ? id
       : id.startsWith('/')
         ? slash(resolve(root, id.slice(1)))

--- a/test/core/test/file-path.test.ts
+++ b/test/core/test/file-path.test.ts
@@ -77,5 +77,17 @@ describe('toFilePath', () => {
 
       expect(slash(filePath)).toEqual(expected)
     })
+
+    it('unix with absolute path in first level catalog', () => {
+      const root = '/root'
+      const id = '/root/path/to/file.js'
+      const expected = '/root/path/to/file.js'
+
+      const processSpy = vi.spyOn(process, 'cwd').mockReturnValue(root)
+      const filePath = toFilePath(id, root)
+      processSpy.mockRestore()
+
+      expect(slash(filePath)).toEqual(expected)
+    })
   }
 })


### PR DESCRIPTION
I'm working on a devcontainer where the workspace path is `/workspace`. (which is default when configured from vscode)

When I run vitest spec including `expect(doc).toMatchInlineSnapshot()`, the test is passed successfully but it fails to update snapshots. The error log is like below.

```
$ /workspace/node_modules/.bin/vitest run src/ui/consultationEditorV2/utils/convert.test.ts
Debugger attached.

 RUN  v0.15.2 /workspace

 ✓ src/ui/consultationEditorV2/utils/convert.test.ts (1)

Test Files  1 passed (1)
     Tests  1 passed (1)
      Time  6.03s (in thread 13ms, 46366.64%)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run. This might cause false positive tests.
Please, resolve all the errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: Errors occurred while running tests. For more information, see serialized error.
 ❯ Object.runTests node_modules/vitest/dist/chunk-vite-node-externalize.0ec89ad1.mjs:7089:17
 ❯ processTicksAndRejections node:internal/process/task_queues:96:5
 ❯ async file:/workspace/node_modules/vitest/dist/chunk-vite-node-externalize.0ec89ad1.mjs:10369:9
 ❯ Vitest.runFiles node_modules/vitest/dist/chunk-vite-node-externalize.0ec89ad1.mjs:10379:12
 ❯ Vitest.start node_modules/vitest/dist/chunk-vite-node-externalize.0ec89ad1.mjs:10306:5
 ❯ startVitest node_modules/vitest/dist/chunk-vite-node-externalize.0ec89ad1.mjs:11074:5
 ❯ start node_modules/vitest/dist/cli.mjs:666:9
 ❯ CAC.run node_modules/vitest/dist/cli.mjs:662:3

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: {
  "errors": [
    [Error: ENOENT: no such file or directory, open '/workspace/workspace/src/ui/consultationEditorV2/utils/convert.test.ts'],
  ],
}
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

`/workspace/workspace/src/` is a wrong path. the correct is `/workspace/src/`.
After debugging, I've found a bug in `toFilePath` function when given absolute path as id and root directry as base. And this will solve this problem.


