### PR TITLE
feat: support edge runtime

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -153,13 +153,14 @@ export default defineConfig({
 
 ### environment
 
-- **Type:** `'node' | 'jsdom' | 'happy-dom'`
+- **Type:** `'node' | 'jsdom' | 'happy-dom' | 'edge-runtime'`
 - **Default:** `'node'`
 
 The environment that will be used for testing. The default environment in Vitest
 is a Node.js environment. If you are building a web application, you can use
 browser-like environment through either [`jsdom`](https://github.com/jsdom/jsdom)
 or [`happy-dom`](https://github.com/capricorn86/happy-dom) instead.
+If you are building edge functions, you can use [`edge-runtime`](https://edge-runtime.vercel.app/packages/vm) environment
 
 By adding a `@vitest-environment` docblock or comment at the top of the file,
 you can specify another environment to be used for all tests in that file:

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -465,6 +465,13 @@ Repository: git://github.com/kpdecker/jsdiff.git
 
 ---------------------------------------
 
+## eastasianwidth
+License: MIT
+By: Masaki Komagata
+Repository: git://github.com/komagata/eastasianwidth.git
+
+---------------------------------------
+
 ## emoji-regex
 License: MIT
 By: Mathias Bynens

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@antfu/install-pkg": "^0.1.0",
+    "@edge-runtime/vm": "1.1.0-beta.10",
     "@sinonjs/fake-timers": "^9.1.2",
     "@types/diff": "^5.0.2",
     "@types/jsdom": "^16.2.14",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -62,11 +62,11 @@
     "prepublishOnly": "nr build"
   },
   "peerDependencies": {
+    "@edge-runtime/vm": "*",
     "@vitest/ui": "*",
     "c8": "*",
     "happy-dom": "*",
-    "jsdom": "*",
-    "@edge-runtime/vm": "*"
+    "jsdom": "*"
   },
   "peerDependenciesMeta": {
     "@vitest/ui": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -65,7 +65,8 @@
     "@vitest/ui": "*",
     "c8": "*",
     "happy-dom": "*",
-    "jsdom": "*"
+    "jsdom": "*",
+    "@edge-runtime/vm": "*"
   },
   "peerDependenciesMeta": {
     "@vitest/ui": {
@@ -78,6 +79,9 @@
       "optional": true
     },
     "jsdom": {
+      "optional": true
+    },
+    "@edge-runtime/vm": {
       "optional": true
     }
   },

--- a/packages/vitest/src/integrations/env/edge-runtime.ts
+++ b/packages/vitest/src/integrations/env/edge-runtime.ts
@@ -1,0 +1,24 @@
+import { importModule } from 'local-pkg'
+import type { Environment } from '../../types'
+import { populateGlobal } from './utils'
+
+export default <Environment>({
+  name: 'edge-runtime',
+  async setup(global) {
+    const { EdgeVM } = await importModule('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
+    const vm = new EdgeVM({
+      extend: (context) => {
+        context.global = context
+        context.Buffer = Buffer
+        return context
+      },
+    })
+    const { keys, originals } = populateGlobal(global, vm.context, { bindFunctions: true })
+    return {
+      teardown(global) {
+        keys.forEach(key => delete global[key])
+        originals.forEach((v, k) => global[k] = v)
+      },
+    }
+  },
+})

--- a/packages/vitest/src/integrations/env/index.ts
+++ b/packages/vitest/src/integrations/env/index.ts
@@ -1,9 +1,19 @@
 import node from './node'
 import jsdom from './jsdom'
 import happy from './happy-dom'
+import edge from './edge-runtime'
 
 export const environments = {
   node,
   jsdom,
   'happy-dom': happy,
+  'edge-runtime': edge,
+}
+
+export const envs = Object.keys(environments)
+
+export const envNpm = {
+  'jsdom': 'jsdom',
+  'happy-dom': 'happy-dom',
+  'edge-runtime': '@edge-runtime/vm',
 }

--- a/packages/vitest/src/integrations/env/index.ts
+++ b/packages/vitest/src/integrations/env/index.ts
@@ -12,7 +12,7 @@ export const environments = {
 
 export const envs = Object.keys(environments)
 
-export const envNpm = {
+export const envPackageNames: Record<Exclude<keyof typeof environments, 'node'>, string> = {
   'jsdom': 'jsdom',
   'happy-dom': 'happy-dom',
   'edge-runtime': '@edge-runtime/vm',

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -1,5 +1,5 @@
 import type { UserConfig as ViteUserConfig } from 'vite'
-import { envNpm } from '../integrations/env'
+import { envPackageNames } from '../integrations/env'
 import type { UserConfig } from '../types'
 import { ensurePackageInstalled } from '../utils'
 import { createVitest } from './create'
@@ -38,8 +38,8 @@ export async function startVitest(cliFilters: string[], options: CliOptions, vit
   }
 
   if (ctx.config.environment && ctx.config.environment !== 'node') {
-    const packName = envNpm[ctx.config.environment]
-    if (!await ensurePackageInstalled(packName)) {
+    const packageName = envPackageNames[ctx.config.environment]
+    if (!await ensurePackageInstalled(packageName)) {
       process.exitCode = 1
       return false
     }

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -1,4 +1,5 @@
 import type { UserConfig as ViteUserConfig } from 'vite'
+import { envNpm } from '../integrations/env'
 import type { UserConfig } from '../types'
 import { ensurePackageInstalled } from '../utils'
 import { createVitest } from './create'
@@ -37,7 +38,8 @@ export async function startVitest(cliFilters: string[], options: CliOptions, vit
   }
 
   if (ctx.config.environment && ctx.config.environment !== 'node') {
-    if (!await ensurePackageInstalled(ctx.config.environment)) {
+    const packName = envNpm[ctx.config.environment]
+    if (!await ensurePackageInstalled(packName)) {
       process.exitCode = 1
       return false
     }

--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import type { BuiltinEnvironment, ResolvedConfig } from '../types'
 import { getWorkerState, resetModules } from '../utils'
+import { envs } from '../integrations/env'
 import { setupGlobalEnv, withEnv } from './setup'
 import { startTests } from './run'
 
@@ -8,8 +9,6 @@ export async function run(files: string[], config: ResolvedConfig): Promise<void
   await setupGlobalEnv(config)
 
   const workerState = getWorkerState()
-
-  const envs = ['node', 'jsdom', 'happy-dom']
 
   // if calling from a worker, there will always be one file
   // if calling with no-threads, this will be the whole suite

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -8,7 +8,7 @@ import type { Reporter } from './reporter'
 import type { SnapshotStateOptions } from './snapshot'
 import type { Arrayable } from './general'
 
-export type BuiltinEnvironment = 'node' | 'jsdom' | 'happy-dom'
+export type BuiltinEnvironment = 'node' | 'jsdom' | 'happy-dom' | 'edge-runtime'
 
 export type ApiConfig = Pick<CommonServerOptions, 'port' | 'strictPort' | 'host'>
 
@@ -98,7 +98,7 @@ export interface InlineConfig {
   /**
    * Running environment
    *
-   * Supports 'node', 'jsdom', 'happy-dom'
+   * Supports 'node', 'jsdom', 'happy-dom', 'edge-runtime'
    *
    * @default 'node'
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
       lit: 2.2.5
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 5.3.2
+      happy-dom: 5.3.4
       vite: 2.9.12
       vitest: link:../../packages/vitest
 
@@ -295,7 +295,7 @@ importers:
     dependencies:
       '@emotion/react': 11.9.0_3dj5wppwohj5ocihzt4m54mr2a
       '@emotion/styled': 11.8.1_3zgpe2oef7sbs566rsy6a7qm7i
-      '@mui/lab': 5.0.0-alpha.87_xjii3a7ufdwggkrf6imrcribfm
+      '@mui/lab': 5.0.0-alpha.88_xjii3a7ufdwggkrf6imrcribfm
       '@mui/material': 5.8.3_rikzftoujo3cmwul4lespwcm6i
       history: 5.3.0
       notistack: 2.0.5_ozyq7dscrvuimqma7xstouyo4e
@@ -648,6 +648,7 @@ importers:
   packages/vitest:
     specifiers:
       '@antfu/install-pkg': ^0.1.0
+      '@edge-runtime/vm': 1.1.0-beta.10
       '@sinonjs/fake-timers': ^9.1.2
       '@types/chai': ^4.3.1
       '@types/chai-subset': ^1.3.3
@@ -706,6 +707,7 @@ importers:
       vite: 3.0.0-beta.4
     devDependencies:
       '@antfu/install-pkg': 0.1.0
+      '@edge-runtime/vm': 1.1.0-beta.10
       '@sinonjs/fake-timers': 9.1.2
       '@types/diff': 5.0.2
       '@types/jsdom': 16.2.14
@@ -878,6 +880,16 @@ importers:
       vitest: workspace:*
     devDependencies:
       pathe: 0.2.0
+      vitest: link:../../packages/vitest
+
+  test/vite-edge:
+    specifiers:
+      '@edge-runtime/vm': 1.1.0-beta.10
+      '@vitest/web-worker': workspace:*
+      vitest: workspace:*
+    devDependencies:
+      '@edge-runtime/vm': 1.1.0-beta.10
+      '@vitest/web-worker': link:../../packages/web-worker
       vitest: link:../../packages/vitest
 
   test/vite-node:
@@ -3059,6 +3071,16 @@ packages:
       react-dom: 18.1.0_react@18.1.0
     dev: true
 
+  /@edge-runtime/primitives/1.1.0-beta.10:
+    resolution: {integrity: sha512-hv0i2ce35yspqlnmcSKV/GEKfk8WyB9aTSOk0ZMK6gOR6ZvBDCzDpdacIcGuktaTuDinwon2DLxXRhiAS2PjUg==}
+    dev: true
+
+  /@edge-runtime/vm/1.1.0-beta.10:
+    resolution: {integrity: sha512-AHeIdWp1OUf4kvA4to56shXZzM66bR84LMNTbYGY7G3+BBr+VkUcvU+hWr8JYCOj/iAHi/fuE9r1TyrMm2pQaw==}
+    dependencies:
+      '@edge-runtime/primitives': 1.1.0-beta.10
+    dev: true
+
   /@emotion/babel-plugin/11.9.2_@babel+core@7.18.2:
     resolution: {integrity: sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==}
     peerDependencies:
@@ -3736,8 +3758,8 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /@mui/base/5.0.0-alpha.86_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-0vi/Nni1mizrgrzKeyksEjw5JVSrgT8Vr2NhxzFtYxqpMgtdSrBvcmcuzBf9kE/ECMPbgpSIcqv0nLbLZUYkOQ==}
+  /@mui/base/5.0.0-alpha.87_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-PuxRYrvG63Yj/UTwf4hSwZ5ClMv88iXHK+5hUV1CrG3kNPo6FFQiIFNRaNpRt/3nsXj6+xygJByNFA8m4Leetg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -3750,7 +3772,7 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/is-prop-valid': 1.1.2
       '@mui/types': 7.1.4
-      '@mui/utils': 5.8.4_react@17.0.2
+      '@mui/utils': 5.8.6_react@17.0.2
       '@popperjs/core': 2.11.5
       clsx: 1.1.1
       prop-types: 15.8.1
@@ -3759,8 +3781,8 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /@mui/lab/5.0.0-alpha.87_xjii3a7ufdwggkrf6imrcribfm:
-    resolution: {integrity: sha512-Zuth3wdX5wSpn1aMJsnJqX1lRiNTUcUs7HaCQI1AufbuE+84Drl5c5kANLtb6VOEGoThqvbINpne+oGGoJuqwA==}
+  /@mui/lab/5.0.0-alpha.88_xjii3a7ufdwggkrf6imrcribfm:
+    resolution: {integrity: sha512-YS2NPw0D0CHG9z9Y6Wjocl3g2LNzdXdkvORPoyc05ea9Xm+m8buddvMeTuL/r/e3S7yLK8HOMN2uHE0rwD/oVQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -3792,11 +3814,11 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/react': 11.9.0_3dj5wppwohj5ocihzt4m54mr2a
       '@emotion/styled': 11.8.1_3zgpe2oef7sbs566rsy6a7qm7i
-      '@mui/base': 5.0.0-alpha.86_sfoxds7t5ydpegc3knd667wn6m
+      '@mui/base': 5.0.0-alpha.87_sfoxds7t5ydpegc3knd667wn6m
       '@mui/material': 5.8.3_rikzftoujo3cmwul4lespwcm6i
-      '@mui/system': 5.8.5_bgqmsvm4hz6izcmpcwescmz73y
-      '@mui/utils': 5.8.4_react@17.0.2
-      '@mui/x-date-pickers': 5.0.0-alpha.1_4app2jldh5bx4balclxn7wcw7i
+      '@mui/system': 5.8.6_bgqmsvm4hz6izcmpcwescmz73y
+      '@mui/utils': 5.8.6_react@17.0.2
+      '@mui/x-date-pickers': 5.0.0-alpha.1_a27cws6df4ygyi4adk5k5wbyme
       clsx: 1.1.1
       date-fns: 2.28.0
       prop-types: 15.8.1
@@ -3853,7 +3875,23 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.17.9
-      '@mui/utils': 5.8.4_react@17.0.2
+      '@mui/utils': 5.8.6_react@17.0.2
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
+
+  /@mui/private-theming/5.8.6_react@17.0.2:
+    resolution: {integrity: sha512-yHsJk1qU9r/q0DlnxGRJPHyM0Y/nUv8FTNgDTiI9I58GWuVuZqeTUr7JRvPh6ybeP/FLtW5eXEavRK9wxVk4uQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@mui/utils': 5.8.6_react@17.0.2
       prop-types: 15.8.1
       react: 17.0.2
     dev: false
@@ -3908,8 +3946,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@mui/system/5.8.5_bgqmsvm4hz6izcmpcwescmz73y:
-    resolution: {integrity: sha512-1bhITHp5sX/CVEf1QwtBWvW+kNnH+GU7lKz0CeAL1RyH9dWvoL9Yt/+i/L8hJ6jVZB/7Au2F6MsyDPt8V1jfdA==}
+  /@mui/system/5.8.6_bgqmsvm4hz6izcmpcwescmz73y:
+    resolution: {integrity: sha512-+a+rD58XltKQHDrrjcuCta2cUBqdnLDUDwnphSLCMFigRl8/uk+R+fdQRlMNRXAOgnMb8ioWIgfjxri5pmTH4A==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -3927,10 +3965,10 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/react': 11.9.0_3dj5wppwohj5ocihzt4m54mr2a
       '@emotion/styled': 11.8.1_3zgpe2oef7sbs566rsy6a7qm7i
-      '@mui/private-theming': 5.8.4_react@17.0.2
+      '@mui/private-theming': 5.8.6_react@17.0.2
       '@mui/styled-engine': 5.8.0_bgqmsvm4hz6izcmpcwescmz73y
       '@mui/types': 7.1.4
-      '@mui/utils': 5.8.4_react@17.0.2
+      '@mui/utils': 5.8.6_react@17.0.2
       clsx: 1.1.1
       csstype: 3.1.0
       prop-types: 15.8.1
@@ -3983,7 +4021,21 @@ packages:
       react-is: 17.0.2
     dev: false
 
-  /@mui/x-date-pickers/5.0.0-alpha.1_4app2jldh5bx4balclxn7wcw7i:
+  /@mui/utils/5.8.6_react@17.0.2:
+    resolution: {integrity: sha512-QM2Sd1xZo2jOt2Vz5Rmro+pi2FLJyiv4+OjxkUwXR3oUM65KSMAMLl/KNYU55s3W3DLRFP5MVwE4FhAbHseHAg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@types/prop-types': 15.7.5
+      '@types/react-is': 17.0.3
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-is: 17.0.2
+    dev: false
+
+  /@mui/x-date-pickers/5.0.0-alpha.1_a27cws6df4ygyi4adk5k5wbyme:
     resolution: {integrity: sha512-dLPkRiIn2Gr0momblxiOnIwrxn4SijVix+8e08mwAGWhiWcmWep1O9XTRDpZsjB0kjHYCf+kZjlRX4dxnj2acg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -4010,8 +4062,8 @@ packages:
       '@date-io/luxon': 2.13.1
       '@date-io/moment': 2.13.1
       '@mui/material': 5.8.3_rikzftoujo3cmwul4lespwcm6i
-      '@mui/system': 5.8.5_bgqmsvm4hz6izcmpcwescmz73y
-      '@mui/utils': 5.8.4_react@17.0.2
+      '@mui/system': 5.8.6_bgqmsvm4hz6izcmpcwescmz73y
+      '@mui/utils': 5.8.6_react@17.0.2
       clsx: 1.1.1
       date-fns: 2.28.0
       prop-types: 15.8.1
@@ -6303,7 +6355,7 @@ packages:
     dev: true
 
   /@types/form-data/0.0.33:
-    resolution: {integrity: sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=}
+    resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
       '@types/node': 17.0.40
     dev: true
@@ -12828,8 +12880,8 @@ packages:
       - encoding
     dev: true
 
-  /happy-dom/5.3.2:
-    resolution: {integrity: sha512-TVTS1wGeSi3oCi0gqBA97DvsvS5nOuB2GTSdQlvxQ/JgntDjXHbf/xj1VMXenLomGjm9Keu0IW5ExBXHhoE8zQ==}
+  /happy-dom/5.3.4:
+    resolution: {integrity: sha512-EGVX/03ZQcWWqjorPHbUNuVM47bc56K5QtUZUAwEjc1D3e3BzrZO4TtBt+FrM0DfrirBc/Fbtz4FzpD1ohIcqQ==}
     dependencies:
       css.escape: 1.5.1
       he: 1.2.0

--- a/test/vite-edge/package.json
+++ b/test/vite-edge/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vitest/test-edge-runtime",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "1.1.0-beta.10",
+    "@vitest/web-worker": "workspace:*",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/vite-edge/test/edge.test.ts
+++ b/test/vite-edge/test/edge.test.ts
@@ -1,0 +1,19 @@
+/**
+ *  @vitest-environment edge-runtime
+ */
+import { describe, expect, it } from 'vitest'
+describe('edge runtime api', () => {
+  it('TextEncoder references the same global Uint8Array constructor', () => {
+    expect(new TextEncoder().encode('abc')).toBeInstanceOf(Uint8Array)
+  })
+
+  it('allows to run fetch', async () => {
+    const response = await fetch('https://vitest.dev')
+    expect(response.status).toEqual(200)
+  })
+
+  it('allows to run crypto', async () => {
+    const array = new Uint32Array(10)
+    expect(crypto.getRandomValues(array)).toHaveLength(array.length)
+  })
+})

--- a/test/vite-edge/test/node.test.ts
+++ b/test/vite-edge/test/node.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('node env should not have crypto', () => {
+  expect(global).not.toHaveProperty('crypto')
+})

--- a/test/vite-edge/vitest.config.ts
+++ b/test/vite-edge/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
add environment support for https://github.com/vercel/edge-runtime

## limitations
`eval` and `new Function()` still works in vitest edge environment. 
#1470 might help to solve this problem
```js
// ❌ Fail
// Error name:    "EvalError"
// Error message: "Code generation from strings disallowed for this context"
it('should return the correct value', () => {
  let val = eval('2 + 2');
  expect(val).toBe(4);
});

```