### PR TITLE
feat: make sequencer public, add option to run tests in random order

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -316,7 +316,7 @@ When you use `test` in the top level of file, they are collected as part of the 
 
 - **Type:** `(name: string, fn: TestFunction, timeout?: number) => void`
 
-  Vitest provides a way to run all tests in random order via CLI flag [`--random`](/guide/cli) or config option [`sequence.shuffle`](/config/#sequence-shuffle), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
+  Vitest provides a way to run all tests in random order via CLI flag [`--sequence.shuffle`](/guide/cli) or config option [`sequence.shuffle`](/config/#sequence-shuffle), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
 
   ```ts
   describe.shuffle('suite', () => {

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -320,9 +320,9 @@ When you use `test` in the top level of file, they are collected as part of the 
 
   ```ts
   describe.random('suite', () => {
-    test('concurrent test 1', async () => { /* ... */ })
-    test('concurrent test 2', async () => { /* ... */ })
-    test('concurrent test 3', async () => { /* ... */ })
+    test('random test 1', async () => { /* ... */ })
+    test('random test 2', async () => { /* ... */ })
+    test('random test 3', async () => { /* ... */ })
   })
   // order depends on sequence.seed option in config (Date.now() by default)
   ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -312,6 +312,23 @@ When you use `test` in the top level of file, they are collected as part of the 
   describe.todo.concurrent(/* ... */) // or describe.concurrent.todo(/* ... */)
   ```
 
+### describe.random
+
+- **Type:** `(name: string, fn: TestFunction, timeout?: number) => void`
+
+  Vitest provides a way to run all tests in random order via CLI flag [`--random`](/guide/cli) or config option [`sequence.random`](/config/#sequence-random), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
+
+  ```ts
+  describe.random('suite', () => {
+    test('concurrent test 1', async () => { /* ... */ })
+    test('concurrent test 2', async () => { /* ... */ })
+    test('concurrent test 3', async () => { /* ... */ })
+  })
+  // order depends on sequence.seed option in config (Date.now() by default)
+  ```
+
+`.skip`, `.only`, and `.todo` works with random suites.
+
 ### describe.todo
 
 - **Type:** `(name: string) => void`

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -312,14 +312,14 @@ When you use `test` in the top level of file, they are collected as part of the 
   describe.todo.concurrent(/* ... */) // or describe.concurrent.todo(/* ... */)
   ```
 
-### describe.random
+### describe.shuffle
 
 - **Type:** `(name: string, fn: TestFunction, timeout?: number) => void`
 
-  Vitest provides a way to run all tests in random order via CLI flag [`--random`](/guide/cli) or config option [`sequence.random`](/config/#sequence-random), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
+  Vitest provides a way to run all tests in random order via CLI flag [`--random`](/guide/cli) or config option [`sequence.shuffle`](/config/#sequence-shuffle), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
 
   ```ts
-  describe.random('suite', () => {
+  describe.shuffle('suite', () => {
     test('random test 1', async () => { /* ... */ })
     test('random test 2', async () => { /* ... */ })
     test('random test 3', async () => { /* ... */ })

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -603,7 +603,7 @@ Sharding is happening before sorting, and only if `--shard` option is provided.
 - **Type**: `boolean`
 - **Default**: `false`
 
-If you want tests to run randomly, you can enable it with this option, or CLI argument [`--shuffle`](/guide/cli).
+If you want tests to run randomly, you can enable it with this option, or CLI argument [`--sequence.shuffle`](/guide/cli).
 
 Vitest usually uses cache to sort tests, so long running tests start earlier - this makes tests run faster. If your tests will run in random order you will lose this performance improvement, but it may be useful to track tests that accidentally depend on another run previously.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -582,3 +582,34 @@ Options to configure Vitest cache policy. At the moment Vitest stores cache for 
 - **Default**: `node_modules/.vitest`
 
 Path to cache directory.
+
+### sequence
+
+- **Type**: `{ sequencer?, random?, seed? }`
+
+Options for how tests should be sorted.
+
+#### sequence.sequencer
+
+- **Type**: `TestSequencerConstructor`
+- **Default**: `BaseSequencer`
+
+A custom class that defines methods for sharding and sorting. You can extend `BaseSequencer` from `vitest/node`, if you only need to redefine one of the `sort` and `shard` methods, but both should exist.
+
+Sharding is happening before sorting, and only if `--shard` option is provided.
+
+#### sequence.random
+
+- **Type**: `boolean`
+- **Default**: `false`
+
+If you want tests to run randomly, you can enable it with this option, or CLI argument [`--random`](/guide/cli).
+
+Vitest usually uses cache to sort tests, so long running tests start earlier - this makes tests run faster. If your tests will run in random order you will lose this performance improvement, but it may be useful to track tests that accidentally depend on another run previously.
+
+#### sequence.seed
+
+- **Type**: `number`
+- **Default**: `Date.now()`
+
+Sets the randomization seed, if tests are running in random order.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -585,7 +585,7 @@ Path to cache directory.
 
 ### sequence
 
-- **Type**: `{ sequencer?, random?, seed? }`
+- **Type**: `{ sequencer?, shuffle?, seed? }`
 
 Options for how tests should be sorted.
 
@@ -598,12 +598,12 @@ A custom class that defines methods for sharding and sorting. You can extend `Ba
 
 Sharding is happening before sorting, and only if `--shard` option is provided.
 
-#### sequence.random
+#### sequence.shuffle
 
 - **Type**: `boolean`
 - **Default**: `false`
 
-If you want tests to run randomly, you can enable it with this option, or CLI argument [`--random`](/guide/cli).
+If you want tests to run randomly, you can enable it with this option, or CLI argument [`--shuffle`](/guide/cli).
 
 Vitest usually uses cache to sort tests, so long running tests start earlier - this makes tests run faster. If your tests will run in random order you will lose this performance improvement, but it may be useful to track tests that accidentally depend on another run previously.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -68,7 +68,7 @@ vitest related /src/index.ts /src/hello-world.js
 | `--allowOnly` | Allow tests and suites that are marked as `only` (default: false in CI, true otherwise) |
 | `--changed [since]` | Run tests that are affected by the changed files (default: false). See [docs](#changed) |
 | `--shard <shard>` | Execute tests in a specified shard |
-| `--random` | Execute tests in random order |
+| `--sequence` | Define in what order to run tests. Use [cac's dot notation] to specify options (for example, use `--sequence.suffle` to run tests in random order) |
 | `-h, --help` | Display available CLI options |
 
 ### changed

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -36,10 +36,6 @@ Useful to run with [`lint-staged`](https://github.com/okonet/lint-staged) or wit
 vitest related /src/index.ts /src/hello-world.js
 ```
 
-### `vitest clean cache`
-
-Clears cache folder.
-
 ## Options
 
 | Options       |               |
@@ -72,6 +68,7 @@ Clears cache folder.
 | `--allowOnly` | Allow tests and suites that are marked as `only` (default: false in CI, true otherwise) |
 | `--changed [since]` | Run tests that are affected by the changed files (default: false). See [docs](#changed) |
 | `--shard <shard>` | Execute tests in a specified shard |
+| `--random` | Execute tests in random order |
 | `-h, --help` | Display available CLI options |
 
 ### changed

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -35,7 +35,7 @@ cli
   .option('--allowOnly', 'Allow tests and suites that are marked as only (default: !process.env.CI)')
   .option('--shard <shard>', 'Test suite shard to execute in a format of <index>/<count>')
   .option('--changed [since]', 'Run tests that are affected by the changed files (default: false)')
-  .option('--random', 'Run tests in random order (default: false)')
+  .option('--sequence <options>', 'Define in what order to run tests (use --sequence.shuffle to run tests in random order)')
   .help()
 
 cli

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -35,6 +35,7 @@ cli
   .option('--allowOnly', 'Allow tests and suites that are marked as only (default: !process.env.CI)')
   .option('--shard <shard>', 'Test suite shard to execute in a format of <index>/<count>')
   .option('--changed [since]', 'Run tests that are affected by the changed files (default: false)')
+  .option('--random', 'Run tests in random order (default: false)')
   .help()
 
 cli

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -191,6 +191,7 @@ export function resolveConfig(
   // random should have the priority over config, because it is a CLI flag
   if (!resolved.sequence?.sequencer || resolved.random) {
     resolved.sequence ??= {} as any
+    resolved.sequence.random ??= resolved.random
     resolved.sequence.sequencer = resolved.sequence.random || resolved.random
       ? RandomSequencer
       : BaseSequencer

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -9,6 +9,8 @@ import { configDefaults } from '../defaults'
 import { resolveC8Options } from '../integrations/coverage'
 import { toArray } from '../utils'
 import { VitestCache } from './cache'
+import { BaseSequencer } from './sequencers/BaseSequencer'
+import { RandomSequencer } from './sequencers/RandomSequencer'
 
 const extraInlineDeps = [
   /^(?!.*(?:node_modules)).*\.mjs$/,
@@ -185,6 +187,14 @@ export function resolveConfig(
   resolved.cache ??= { dir: '' }
   if (resolved.cache)
     resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir)
+
+  // random should have the priority over config, because it is a CLI flag
+  if (!resolved.sequence?.sequencer || resolved.random) {
+    resolved.sequence ??= {} as any
+    resolved.sequence.sequencer = resolved.sequence.random || resolved.random
+      ? RandomSequencer
+      : BaseSequencer
+  }
 
   return resolved
 }

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -188,13 +188,10 @@ export function resolveConfig(
   if (resolved.cache)
     resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir)
 
-  // random should have the priority over config, because it is a CLI flag
-  if (!resolved.sequence?.sequencer || resolved.random) {
+  if (!resolved.sequence?.sequencer) {
     resolved.sequence ??= {} as any
     // CLI flag has higher priority
-    if (resolved.random)
-      resolved.sequence.random = true
-    resolved.sequence.sequencer = resolved.sequence.random
+    resolved.sequence.sequencer = resolved.sequence.shuffle
       ? RandomSequencer
       : BaseSequencer
   }

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -191,8 +191,10 @@ export function resolveConfig(
   // random should have the priority over config, because it is a CLI flag
   if (!resolved.sequence?.sequencer || resolved.random) {
     resolved.sequence ??= {} as any
-    resolved.sequence.random ??= resolved.random
-    resolved.sequence.sequencer = resolved.sequence.random || resolved.random
+    // CLI flag has higher priority
+    if (resolved.random)
+      resolved.sequence.random = true
+    resolved.sequence.sequencer = resolved.sequence.random
       ? RandomSequencer
       : BaseSequencer
   }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -105,6 +105,7 @@ export class Vitest {
         resolveSnapshotPath: undefined,
       },
       onConsoleLog: undefined!,
+      sequence: undefined!,
     },
     this.configOverride || {} as any,
     ) as ResolvedConfig

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -105,7 +105,10 @@ export class Vitest {
         resolveSnapshotPath: undefined,
       },
       onConsoleLog: undefined!,
-      sequence: undefined!,
+      sequence: {
+        ...this.config.sequence,
+        sequencer: undefined!,
+      },
     },
     this.configOverride || {} as any,
     ) as ResolvedConfig

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -5,3 +5,6 @@ export { startVitest } from './cli-api'
 
 export { VitestRunner } from '../runtime/execute'
 export type { ExecuteOptions } from '../runtime/execute'
+
+export type { TestSequencer, TestSequencerContructor } from './sequencers/types'
+export { BaseSequencer } from './sequencers/BaseSequencer'

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -10,7 +10,6 @@ import type { ResolvedConfig, WorkerContext, WorkerRPC } from '../types'
 import { distDir } from '../constants'
 import { AggregateError } from '../utils'
 import type { Vitest } from './core'
-import { BaseSequelizer } from './sequelizers/BaseSequelizer'
 
 export type RunWithFiles = (files: string[], invalidates?: string[]) => Promise<void>
 
@@ -86,15 +85,16 @@ export function createPool(ctx: Vitest): WorkerPool {
       }
     }
 
-    const sequelizer = new BaseSequelizer(ctx)
+    const Sequencer = ctx.config.sequence.sequencer
+    const sequencer = new Sequencer(ctx)
 
     return async (files, invalidates) => {
       const config = ctx.getSerializableConfig()
 
       if (config.shard)
-        files = await sequelizer.shard(files)
+        files = await sequencer.shard(files)
 
-      files = await sequelizer.sort(files)
+      files = await sequencer.sort(files)
 
       if (!ctx.config.threads) {
         await runFiles(config, files)

--- a/packages/vitest/src/node/sequencers/BaseSequencer.ts
+++ b/packages/vitest/src/node/sequencers/BaseSequencer.ts
@@ -2,9 +2,9 @@ import { createHash } from 'crypto'
 import { resolve } from 'pathe'
 import { slash } from 'vite-node/utils'
 import type { Vitest } from '../core'
-import type { TestSequelizer } from './types'
+import type { TestSequencer } from './types'
 
-export class BaseSequelizer implements TestSequelizer {
+export class BaseSequencer implements TestSequencer {
   protected ctx: Vitest
 
   constructor(ctx: Vitest) {

--- a/packages/vitest/src/node/sequencers/RandomSequencer.ts
+++ b/packages/vitest/src/node/sequencers/RandomSequencer.ts
@@ -1,4 +1,4 @@
-import { randomize } from '../../utils'
+import { shuffle } from '../../utils'
 import { BaseSequencer } from './BaseSequencer'
 
 export class RandomSequencer extends BaseSequencer {
@@ -7,6 +7,6 @@ export class RandomSequencer extends BaseSequencer {
 
     const seed = sequence?.seed ?? Date.now()
 
-    return randomize(files, seed)
+    return shuffle(files, seed)
   }
 }

--- a/packages/vitest/src/node/sequencers/RandomSequencer.ts
+++ b/packages/vitest/src/node/sequencers/RandomSequencer.ts
@@ -1,0 +1,26 @@
+import { BaseSequencer } from './BaseSequencer'
+
+export class RandomSequencer extends BaseSequencer {
+  private random(seed: number) {
+    const x = Math.sin(seed++) * 10000
+    return x - Math.floor(x)
+  }
+
+  public async sort(files: string[]) {
+    const { sequence } = this.ctx.config
+
+    let seed = sequence?.seed ?? Date.now()
+    let length = files.length
+
+    while (length) {
+      const index = Math.floor(this.random(seed) * length--)
+
+      const previous = files[length]
+      files[length] = files[index]
+      files[index] = previous
+      ++seed
+    }
+
+    return files
+  }
+}

--- a/packages/vitest/src/node/sequencers/RandomSequencer.ts
+++ b/packages/vitest/src/node/sequencers/RandomSequencer.ts
@@ -1,26 +1,12 @@
+import { randomize } from '../../utils'
 import { BaseSequencer } from './BaseSequencer'
 
 export class RandomSequencer extends BaseSequencer {
-  private random(seed: number) {
-    const x = Math.sin(seed++) * 10000
-    return x - Math.floor(x)
-  }
-
   public async sort(files: string[]) {
     const { sequence } = this.ctx.config
 
-    let seed = sequence?.seed ?? Date.now()
-    let length = files.length
+    const seed = sequence?.seed ?? Date.now()
 
-    while (length) {
-      const index = Math.floor(this.random(seed) * length--)
-
-      const previous = files[length]
-      files[length] = files[index]
-      files[index] = previous
-      ++seed
-    }
-
-    return files
+    return randomize(files, seed)
   }
 }

--- a/packages/vitest/src/node/sequencers/types.ts
+++ b/packages/vitest/src/node/sequencers/types.ts
@@ -1,7 +1,7 @@
 import type { Awaitable } from '../../types'
 import type { Vitest } from '../core'
 
-export interface TestSequelizer {
+export interface TestSequencer {
   /**
    * Slicing tests into shards. Will be run before `sort`.
    * Only run, if `shard` is defined.
@@ -10,6 +10,6 @@ export interface TestSequelizer {
   sort(files: string[]): Awaitable<string[]>
 }
 
-export interface TestSequelizerContructor {
-  new (ctx: Vitest): TestSequelizer
+export interface TestSequencerContructor {
+  new (ctx: Vitest): TestSequencer
 }

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -2,7 +2,7 @@ import limit from 'p-limit'
 import type { File, HookCleanupCallback, HookListener, ResolvedConfig, Suite, SuiteHooks, Task, TaskResult, TaskState, Test } from '../types'
 import { vi } from '../integrations/vi'
 import { getSnapshotClient } from '../integrations/snapshot/chai'
-import { clearTimeout, getFullName, getWorkerState, hasFailed, hasTests, partitionSuiteChildren, randomize, setTimeout } from '../utils'
+import { clearTimeout, getFullName, getWorkerState, hasFailed, hasTests, partitionSuiteChildren, setTimeout, shuffle } from '../utils'
 import { takeCoverage } from '../integrations/coverage'
 import { getState, setState } from '../integrations/chai/jest-expect'
 import { GLOBAL_EXPECT } from '../integrations/chai/constants'
@@ -217,12 +217,12 @@ export async function runSuite(suite: Suite) {
         }
         else {
           const { sequence } = workerState.config
-          if (sequence.random || suite.random) {
+          if (sequence.shuffle || suite.shuffle) {
             // run describe block independently from tests
             const suites = tasksGroup.filter(group => group.type === 'suite')
             const tests = tasksGroup.filter(group => group.type === 'test')
-            const groups = randomize([suites, tests], sequence.seed)
-            tasksGroup = groups.flatMap(group => randomize(group, sequence.seed))
+            const groups = shuffle([suites, tests], sequence.seed)
+            tasksGroup = groups.flatMap(group => shuffle(group, sequence.seed))
           }
           for (const c of tasksGroup)
             await runSuiteChild(c)

--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -40,8 +40,8 @@ export const it = test
 const workerState = getWorkerState()
 
 // implementations
-export const defaultSuite = workerState.config.sequence.random
-  ? suite.random('')
+export const defaultSuite = workerState.config.sequence.shuffle
+  ? suite.shuffle('')
   : suite('')
 
 export function clearCollectorContext() {
@@ -63,7 +63,7 @@ export function createSuiteHooks() {
   }
 }
 
-function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, mode: RunMode, concurrent?: boolean, random?: boolean) {
+function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, mode: RunMode, concurrent?: boolean, shuffle?: boolean) {
   const tasks: (Test | Suite | SuiteCollector)[] = []
   const factoryQueue: (Test | Suite | SuiteCollector)[] = []
 
@@ -84,8 +84,8 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
     } as Omit<Test, 'context'> as Test
     if (this.concurrent || concurrent)
       test.concurrent = true
-    if (random)
-      test.random = true
+    if (shuffle)
+      test.shuffle = true
 
     const context = createTestContext(test)
     // create test context
@@ -123,7 +123,7 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
       type: 'suite',
       name,
       mode,
-      random,
+      shuffle,
       tasks: [],
     }
     setHooks(suite, createSuiteHooks())
@@ -164,10 +164,10 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
 
 function createSuite() {
   const suite = createChainable(
-    ['concurrent', 'random', 'skip', 'only', 'todo'],
+    ['concurrent', 'shuffle', 'skip', 'only', 'todo'],
     function (name: string, factory?: SuiteFactory) {
       const mode = this.only ? 'only' : this.skip ? 'skip' : this.todo ? 'todo' : 'run'
-      return createSuiteCollector(name, factory, mode, this.concurrent, this.random)
+      return createSuiteCollector(name, factory, mode, this.concurrent, this.shuffle)
     },
   ) as SuiteAPI
 

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -2,6 +2,7 @@ import type { CommonServerOptions } from 'vite'
 import type { PrettyFormatOptions } from 'pretty-format'
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
 import type { BuiltinReporters } from '../node/reporters'
+import type { TestSequencerContructor } from '../node/sequencers/types'
 import type { C8Options, ResolvedC8Options } from './coverage'
 import type { JSDOMOptions } from './jsdom-options'
 import type { Reporter } from './reporter'
@@ -369,6 +370,29 @@ export interface InlineConfig {
   cache?: false | {
     dir?: string
   }
+
+  /**
+   * Options for configuring the order of running tests.
+   */
+  sequence?: {
+    /**
+     * Class that handles sorting and sharding algorithm.
+     * If you only need to change sorting, you can extend
+     * your custom sequencer from `BaseSequencer` from `vitest/node`.
+     * @default BaseSequencer
+     */
+    sequencer?: TestSequencerContructor
+    /**
+     * Should tests run in random order.
+     * @default false
+     */
+    random?: boolean
+    /**
+     * Seed for the random number generator.
+     * @default Date.now()
+     */
+    seed?: number
+  }
 }
 
 export interface UserConfig extends InlineConfig {
@@ -413,9 +437,15 @@ export interface UserConfig extends InlineConfig {
    * @example --shard=2/3
    */
   shard?: string
+
+  /**
+   * If tests should be run in random.
+   * @default false
+   */
+  random?: string
 }
 
-export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'shard' | 'cache'> {
+export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'shard' | 'cache' | 'sequence'> {
   base?: string
 
   config?: string
@@ -439,4 +469,10 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
   cache: {
     dir: string
   } | false
+
+  sequence: {
+    sequencer: TestSequencerContructor
+    random?: boolean
+    seed?: number
+  }
 }

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -386,7 +386,7 @@ export interface InlineConfig {
      * Should tests run in random order.
      * @default false
      */
-    random?: boolean
+    shuffle?: boolean
     /**
      * Seed for the random number generator.
      * @default Date.now()
@@ -437,12 +437,6 @@ export interface UserConfig extends InlineConfig {
    * @example --shard=2/3
    */
   shard?: string
-
-  /**
-   * If tests should be run in random.
-   * @default false
-   */
-  random?: boolean
 }
 
 export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'shard' | 'cache' | 'sequence'> {
@@ -472,7 +466,7 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
 
   sequence: {
     sequencer: TestSequencerContructor
-    random?: boolean
+    shuffle?: boolean
     seed?: number
   }
 }

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -442,7 +442,7 @@ export interface UserConfig extends InlineConfig {
    * If tests should be run in random.
    * @default false
    */
-  random?: string
+  random?: boolean
 }
 
 export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'shard' | 'cache' | 'sequence'> {

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -10,6 +10,7 @@ export interface TaskBase {
   name: string
   mode: RunMode
   concurrent?: boolean
+  random?: boolean
   suite?: Suite
   file?: File
   result?: TaskResult
@@ -113,7 +114,7 @@ void
 }
 
 export type SuiteAPI<ExtraContext = {}> = ChainableFunction<
-'concurrent' | 'only' | 'skip' | 'todo',
+'concurrent' | 'only' | 'skip' | 'todo' | 'random',
 [name: string, factory?: SuiteFactory],
 SuiteCollector<ExtraContext>
 > & {

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -10,7 +10,7 @@ export interface TaskBase {
   name: string
   mode: RunMode
   concurrent?: boolean
-  random?: boolean
+  shuffle?: boolean
   suite?: Suite
   file?: File
   result?: TaskResult
@@ -114,7 +114,7 @@ void
 }
 
 export type SuiteAPI<ExtraContext = {}> = ChainableFunction<
-'concurrent' | 'only' | 'skip' | 'todo' | 'random',
+'concurrent' | 'only' | 'skip' | 'todo' | 'shuffle',
 [name: string, factory?: SuiteFactory],
 SuiteCollector<ExtraContext>
 > & {

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -1,3 +1,4 @@
+import { RealDate } from '../integrations/mock/date'
 import type { Arrayable, DeepMerge, Nullable } from '../types'
 
 function isFinalObj(obj: any) {
@@ -161,7 +162,7 @@ function random(seed: number) {
 
 export function randomize<T>(array: T[], seed?: number): T[] {
   let length = array.length
-  seed ??= Date.now()
+  seed ??= RealDate.now()
 
   while (length) {
     const index = Math.floor(random(seed) * length--)

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -153,3 +153,24 @@ export function stdout(): NodeJS.WriteStream {
   // eslint-disable-next-line no-console
   return console._stdout || process.stdout
 }
+
+function random(seed: number) {
+  const x = Math.sin(seed++) * 10000
+  return x - Math.floor(x)
+}
+
+export function randomize<T>(array: T[], seed?: number): T[] {
+  let length = array.length
+  seed ??= Date.now()
+
+  while (length) {
+    const index = Math.floor(random(seed) * length--)
+
+    const previous = array[length]
+    array[length] = array[index]
+    array[index] = previous
+    ++seed
+  }
+
+  return array
+}

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -160,9 +160,8 @@ function random(seed: number) {
   return x - Math.floor(x)
 }
 
-export function randomize<T>(array: T[], seed?: number): T[] {
+export function randomize<T>(array: T[], seed = RealDate.now()): T[] {
   let length = array.length
-  seed ??= RealDate.now()
 
   while (length) {
     const index = Math.floor(random(seed) * length--)

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -160,7 +160,7 @@ function random(seed: number) {
   return x - Math.floor(x)
 }
 
-export function randomize<T>(array: T[], seed = RealDate.now()): T[] {
+export function shuffle<T>(array: T[], seed = RealDate.now()): T[] {
   let length = array.length
 
   while (length) {

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -2,7 +2,7 @@
   "name": "@vitest/test-core",
   "private": true,
   "scripts": {
-    "test": "vitest test/core/test/random.test.ts",
+    "test": "vitest",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -2,7 +2,7 @@
   "name": "@vitest/test-core",
   "private": true,
   "scripts": {
-    "test": "vitest",
+    "test": "vitest test/core/test/random.test.ts",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/test/core/test/random.test.ts
+++ b/test/core/test/random.test.ts
@@ -3,9 +3,9 @@ import { afterAll, describe, expect, test } from 'vitest'
 // tests use seed of 101, so they have deterministic random order
 const numbers: number[] = []
 
-describe.random('random tests', () => {
+describe.shuffle('random tests', () => {
   describe('inside', () => {
-    // random is not inhereted from parent
+    // shuffle is not inhereted from parent
 
     test('inside 1', () => {
       numbers.push(1)

--- a/test/core/test/random.test.ts
+++ b/test/core/test/random.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, describe, expect, test } from 'vitest'
+
+// tests use seed of 101, so they have deterministic random order
+const numbers: number[] = []
+
+describe.random('random tests', () => {
+  describe('inside', () => {
+    // random is not inhereted from parent
+
+    test('inside 1', () => {
+      numbers.push(1)
+    })
+    test('inside 2', () => {
+      numbers.push(2)
+    })
+  })
+
+  test('test 1', () => {
+    numbers.push(3)
+  })
+  test('test 2', () => {
+    numbers.push(4)
+  })
+  test('test 3', () => {
+    numbers.push(5)
+  })
+
+  afterAll(() => {
+    expect(numbers).toStrictEqual([4, 5, 3, 1, 2])
+  })
+})

--- a/test/core/test/sequencers.test.ts
+++ b/test/core/test/sequencers.test.ts
@@ -1,9 +1,13 @@
 import type { Vitest } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
-import { BaseSequencer } from '../../../packages/vitest/src/node/sequencers/BaseSequencer'
+import { RandomSequencer } from 'vitest/src/node/sequencers/RandomSequencer'
+import { BaseSequencer } from 'vitest/src/node/sequencers/BaseSequencer'
 
 const buildCtx = () => {
   return {
+    config: {
+      sequence: {},
+    },
     state: {
       getFileTestResults: vi.fn(),
       getFileStats: vi.fn(),
@@ -11,11 +15,11 @@ const buildCtx = () => {
   } as unknown as Vitest
 }
 
-describe('test sequelizers', () => {
+describe('base sequencer', () => {
   test('sorting when no info is available', async () => {
-    const sequelizer = new BaseSequencer(buildCtx())
+    const sequencer = new BaseSequencer(buildCtx())
     const files = ['a', 'b', 'c']
-    const sorted = await sequelizer.sort(files)
+    const sorted = await sequencer.sort(files)
     expect(sorted).toStrictEqual(files)
   })
 
@@ -25,9 +29,9 @@ describe('test sequelizers', () => {
       if (file === 'b')
         return { size: 2 }
     })
-    const sequelizer = new BaseSequencer(ctx)
+    const sequencer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
-    const sorted = await sequelizer.sort(files)
+    const sorted = await sequencer.sort(files)
     expect(sorted).toStrictEqual(['a', 'c', 'b'])
   })
 
@@ -41,9 +45,9 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { size: 3 }
     })
-    const sequelizer = new BaseSequencer(ctx)
+    const sequencer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
-    const sorted = await sequelizer.sort(files)
+    const sorted = await sequencer.sort(files)
     expect(sorted).toStrictEqual(['c', 'b', 'a'])
   })
 
@@ -57,9 +61,9 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { failed: true, duration: 1 }
     })
-    const sequelizer = new BaseSequencer(ctx)
+    const sequencer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
-    const sorted = await sequelizer.sort(files)
+    const sorted = await sequencer.sort(files)
     expect(sorted).toStrictEqual(['b', 'c', 'a'])
   })
 
@@ -73,9 +77,9 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { failed: true, duration: 3 }
     })
-    const sequelizer = new BaseSequencer(ctx)
+    const sequencer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
-    const sorted = await sequelizer.sort(files)
+    const sorted = await sequencer.sort(files)
     expect(sorted).toStrictEqual(['c', 'b', 'a'])
   })
 
@@ -89,9 +93,20 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { failed: true, duration: 3 }
     })
-    const sequelizer = new BaseSequencer(ctx)
+    const sequencer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
-    const sorted = await sequelizer.sort(files)
+    const sorted = await sequencer.sort(files)
     expect(sorted).toStrictEqual(['c', 'b', 'a'])
+  })
+})
+
+describe('random sequencer', () => {
+  test('sorting is the same when seed is defined', async () => {
+    const ctx = buildCtx()
+    ctx.config.sequence.seed = 101
+    const sequencer = new RandomSequencer(ctx)
+    const files = ['b', 'a', 'c']
+    const sorted = await sequencer.sort(files)
+    expect(sorted).toStrictEqual(['a', 'c', 'b'])
   })
 })

--- a/test/core/test/sequencers.test.ts
+++ b/test/core/test/sequencers.test.ts
@@ -1,6 +1,6 @@
 import type { Vitest } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
-import { BaseSequelizer } from '../../../packages/vitest/src/node/sequelizers/BaseSequelizer'
+import { BaseSequencer } from '../../../packages/vitest/src/node/sequencers/BaseSequencer'
 
 const buildCtx = () => {
   return {
@@ -13,7 +13,7 @@ const buildCtx = () => {
 
 describe('test sequelizers', () => {
   test('sorting when no info is available', async () => {
-    const sequelizer = new BaseSequelizer(buildCtx())
+    const sequelizer = new BaseSequencer(buildCtx())
     const files = ['a', 'b', 'c']
     const sorted = await sequelizer.sort(files)
     expect(sorted).toStrictEqual(files)
@@ -25,7 +25,7 @@ describe('test sequelizers', () => {
       if (file === 'b')
         return { size: 2 }
     })
-    const sequelizer = new BaseSequelizer(ctx)
+    const sequelizer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
     const sorted = await sequelizer.sort(files)
     expect(sorted).toStrictEqual(['a', 'c', 'b'])
@@ -41,7 +41,7 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { size: 3 }
     })
-    const sequelizer = new BaseSequelizer(ctx)
+    const sequelizer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
     const sorted = await sequelizer.sort(files)
     expect(sorted).toStrictEqual(['c', 'b', 'a'])
@@ -57,7 +57,7 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { failed: true, duration: 1 }
     })
-    const sequelizer = new BaseSequelizer(ctx)
+    const sequelizer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
     const sorted = await sequelizer.sort(files)
     expect(sorted).toStrictEqual(['b', 'c', 'a'])
@@ -73,7 +73,7 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { failed: true, duration: 3 }
     })
-    const sequelizer = new BaseSequelizer(ctx)
+    const sequelizer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
     const sorted = await sequelizer.sort(files)
     expect(sorted).toStrictEqual(['c', 'b', 'a'])
@@ -89,7 +89,7 @@ describe('test sequelizers', () => {
       if (file === 'c')
         return { failed: true, duration: 3 }
     })
-    const sequelizer = new BaseSequelizer(ctx)
+    const sequelizer = new BaseSequencer(ctx)
     const files = ['b', 'a', 'c']
     const sorted = await sequelizer.sort(files)
     expect(sorted).toStrictEqual(['c', 'b', 'a'])

--- a/test/core/vitest.config.ts
+++ b/test/core/vitest.config.ts
@@ -53,5 +53,8 @@ export default defineConfig({
         return path + extension
       return join(dirname(path), '__snapshots__', `${basename(path)}${extension}`)
     },
+    sequence: {
+      seed: 101,
+    },
   },
 })


### PR DESCRIPTION
Closes #1570

TODO
- [x] Docs
- [x] Tests

This PR adds a few new options to config:
1. `--shuffle` to CLI flags
2. `sequence` to options
  - `sequencer` allows users to overwrite builtin logic for sharding and sorting 
  - `shuffle` allows tests to be run in random order
  - `seed` makes random order more deterministic

Also added `shuffle` flag to `describe` block to make only part of suite random. I've noticed we have some tests rely on running in the same order, so I though this option might be helpful.