### PR TITLE
chore: set githooks using simple-git-hooks in the prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "typecheck": "tsc --noEmit",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui",
-    "ui:test": "npm -C packages/ui run test:run"
+    "ui:test": "npm -C packages/ui run test:run",
+    "prepare": "simple-git-hooks"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.25.1",


### PR DESCRIPTION
It needs to run `npx simple-git-hooks` to update the git hooks.

[simple-git-hooks#update-git-hooks-command](https://github.com/toplenboren/simple-git-hooks#update-git-hooks-command)