### PR TITLE
feat: check related against `forceRerunTriggers`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -374,7 +374,7 @@ Glob pattern of file paths to be ignored from triggering watch rerun.
 - **Type**: `string[]`
 - **Default:** `[]`
 
-Glob patter of file paths that will trigger the whole suite rerun.
+Glob patter of file paths that will trigger the whole suite rerun. This paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
 
 Useful if you are testing calling CLI commands, because Vite cannot construct a module graph:
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -372,7 +372,7 @@ Glob pattern of file paths to be ignored from triggering watch rerun.
 ### forceRerunTriggers
 
 - **Type**: `string[]`
-- **Default:** `[]`
+- **Default:** `['**/package.json/**', '**/vitest.config.*/**', '**/vite.config.*/**', '**/dist/**']`
 
 Glob pattern of file paths that will trigger the whole suite rerun. This paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -374,7 +374,7 @@ Glob pattern of file paths to be ignored from triggering watch rerun.
 - **Type**: `string[]`
 - **Default:** `[]`
 
-Glob patter of file paths that will trigger the whole suite rerun. This paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
+Glob pattern of file paths that will trigger the whole suite rerun. This paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
 
 Useful if you are testing calling CLI commands, because Vite cannot construct a module graph:
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -372,7 +372,7 @@ Glob pattern of file paths to be ignored from triggering watch rerun.
 ### forceRerunTriggers
 
 - **Type**: `string[]`
-- **Default:** `['**/package.json/**', '**/vitest.config.*/**', '**/vite.config.*/**', '**/dist/**']`
+- **Default:** `['**/package.json/**', '**/vitest.config.*/**', '**/vite.config.*/**']`
 
 Glob pattern of file paths that will trigger the whole suite rerun. This paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -374,7 +374,7 @@ Glob pattern of file paths to be ignored from triggering watch rerun.
 - **Type**: `string[]`
 - **Default:** `['**/package.json/**', '**/vitest.config.*/**', '**/vite.config.*/**']`
 
-Glob pattern of file paths that will trigger the whole suite rerun. This paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
+Glob pattern of file paths that will trigger the whole suite rerun. When paired with the `--changed` argument will run the whole test suite if the trigger is found in the git diff.
 
 Useful if you are testing calling CLI commands, because Vite cannot construct a module graph:
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -83,6 +83,8 @@ Clears cache folder.
 
   To run tests against changes made in the last commit, you can use `--changed HEAD~1`. You can also pass commit hash or branch name.
 
+  If paired with the `forceRerunTriggers` config option it will run the whole test suite if a match is found.
+
 ### shard
 
 - **Type**: `string`

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -66,7 +66,6 @@ const config = {
     '**/package.json/**',
     '**/vitest.config.*/**',
     '**/vite.config.*/**',
-    '**/dist/**',
   ],
   update: false,
   reporters: [],

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -62,7 +62,12 @@ const config = {
   hookTimeout: 10000,
   isolate: true,
   watchExclude: ['**/node_modules/**', '**/dist/**'],
-  forceRerunTriggers: [],
+  forceRerunTriggers: [
+    '**/package.json/**',
+    '**/vitest.config.*/**',
+    '**/vite.config.*/**',
+    '**/dist/**',
+  ],
   update: false,
   reporters: [],
   silent: false,

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -189,6 +189,10 @@ export class Vitest {
     if (!related)
       return tests
 
+    const forceRerunTriggers = this.config.forceRerunTriggers
+    if (forceRerunTriggers.length && mm(related, forceRerunTriggers))
+      return tests
+
     // don't run anything if no related sources are found
     if (!related.length)
       return []

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -190,7 +190,7 @@ export class Vitest {
       return tests
 
     const forceRerunTriggers = this.config.forceRerunTriggers
-    if (forceRerunTriggers.length && mm(related, forceRerunTriggers))
+    if (forceRerunTriggers.length && mm(related, forceRerunTriggers).length)
       return tests
 
     // don't run anything if no related sources are found

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,8 +848,10 @@ importers:
 
   test/related:
     specifiers:
+      execa: ^6.1.0
       vitest: workspace:*
     devDependencies:
+      execa: 6.1.0
       vitest: link:../../packages/vitest
 
   test/reporters:
@@ -6335,7 +6337,7 @@ packages:
     dev: true
 
   /@types/form-data/0.0.33:
-    resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
+    resolution: {integrity: sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=}
     dependencies:
       '@types/node': 17.0.40
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15235,7 +15235,7 @@ packages:
     dev: true
 
   /lz-string/1.4.4:
-    resolution: {integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=}
+    resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
     hasBin: true
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15235,7 +15235,7 @@ packages:
     dev: true
 
   /lz-string/1.4.4:
-    resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
+    resolution: {integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=}
     hasBin: true
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6337,7 +6337,7 @@ packages:
     dev: true
 
   /@types/form-data/0.0.33:
-    resolution: {integrity: sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=}
+    resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
       '@types/node': 17.0.40
     dev: true

--- a/test/related/force-rerun.vitest.config.ts
+++ b/test/related/force-rerun.vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/related.test.ts'],
+    forceRerunTriggers: ['**/rerun.temp/**'],
+  },
+})

--- a/test/related/package.json
+++ b/test/related/package.json
@@ -3,9 +3,10 @@
   "private": true,
   "scripts": {
     "test": "nr test:related && nr test:rerun",
-    "test:related": "vitest run related src/sourceA.ts --globals",
+    "test:related": "vitest related src/sourceA.ts --globals --watch=false",
     "test:rerun": "vitest run rerun"
   },
+  
   "devDependencies": {
     "execa": "^6.1.0",
     "vitest": "workspace:*"

--- a/test/related/package.json
+++ b/test/related/package.json
@@ -6,7 +6,6 @@
     "test:related": "vitest related src/sourceA.ts --globals --watch=false",
     "test:rerun": "vitest run rerun"
   },
-  
   "devDependencies": {
     "execa": "^6.1.0",
     "vitest": "workspace:*"

--- a/test/related/package.json
+++ b/test/related/package.json
@@ -2,9 +2,12 @@
   "name": "@vitest/test-related",
   "private": true,
   "scripts": {
-    "test": "vitest related src/sourceA.ts --globals"
+    "test": "nr test:related && nr test:rerun",
+    "test:related": "vitest run related src/sourceA.ts --globals",
+    "test:rerun": "vitest run rerun"
   },
   "devDependencies": {
+    "execa": "^6.1.0",
     "vitest": "workspace:*"
   }
 }

--- a/test/related/tests/force-rerun.test.ts
+++ b/test/related/tests/force-rerun.test.ts
@@ -1,0 +1,24 @@
+import { unlink, writeFile } from 'fs'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { execa } from 'execa'
+
+const run = async () => await execa('vitest', ['run', '--changed', '--config', 'force-rerun.vitest.config.ts'])
+
+const fileName = 'rerun.temp'
+
+describe('forceRerunTrigger', () => {
+  beforeEach(async () => {
+    unlink(fileName, () => {})
+  })
+
+  it('should run the whole test suite if file exists', async () => {
+    writeFile(fileName, '', error => console.error(error))
+    const { stdout } = await run()
+    expect(stdout).toContain('1 passed')
+  })
+
+  it('should run no tests if file does not exist', async () => {
+    const { stdout } = await run()
+    expect(stdout).toContain('No test files found, exiting with code 0')
+  })
+})

--- a/test/related/tests/force-rerun.test.ts
+++ b/test/related/tests/force-rerun.test.ts
@@ -12,7 +12,7 @@ describe('forceRerunTrigger', () => {
   })
 
   it('should run the whole test suite if file exists', async () => {
-    writeFile(fileName, '', error => console.error(error))
+    writeFile(fileName, '', () => {})
     const { stdout } = await run()
     expect(stdout).toContain('1 passed')
   }, 60_000)

--- a/test/related/tests/force-rerun.test.ts
+++ b/test/related/tests/force-rerun.test.ts
@@ -15,10 +15,10 @@ describe('forceRerunTrigger', () => {
     writeFile(fileName, '', error => console.error(error))
     const { stdout } = await run()
     expect(stdout).toContain('1 passed')
-  })
+  }, 60_000)
 
   it('should run no tests if file does not exist', async () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
-  })
+  }, 60_000)
 })


### PR DESCRIPTION
If forceRerunTriggers has globs in it then we use `micromatch` to see if there's a file in `related` that should trigger the whole test suite

Was going to write some tests for this, but not sure where they should go

Resolves: #1592