### PR TITLE
fix: crash with odd cpu counts

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -23,7 +23,7 @@ const workerPath = pathToFileURL(resolve(distDir, './worker.mjs')).href
 
 export function createPool(ctx: Vitest): WorkerPool {
   const threadsCount = ctx.config.watch
-    ? Math.max(cpus().length / 2, 1)
+    ? Math.max(Math.floor(cpus().length / 2), 1)
     : Math.max(cpus().length - 1, 1)
 
   const maxThreads = ctx.config.maxThreads ?? threadsCount


### PR DESCRIPTION
if `os.cpu().length` returns odd number, vitest crashes like this:

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
RangeError: Invalid array length
 ❯ new ThreadPool node_modules/tinypool/dist/esm/index.js:467:30
 ❯ new Tinypool node_modules/tinypool/dist/esm/index.js:739:31
 ❯ createPool node_modules/vitest/dist/chunk-vite-node-externalize.1efbe319.mjs:7057:16
 ❯ node_modules/vitest/dist/chunk-vite-node-externalize.1efbe319.mjs:10406:21
 ❯ Vitest.runFiles node_modules/vitest/dist/chunk-vite-node-externalize.1efbe319.mjs:10422:7
 ❯ Vitest.start node_modules/vitest/dist/chunk-vite-node-externalize.1efbe319.mjs:10349:5
 ❯ startVitest node_modules/vitest/dist/chunk-vite-node-externalize.1efbe319.mjs:11095:5
 ❯ CAC.start node_modules/vitest/dist/cli.mjs:667:9
```

This PR fixes this error.