### PR TITLE
Fix: Using Vite cacheDir key unless user define.

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -182,7 +182,7 @@ export function resolveConfig(
   if (typeof resolved.css === 'object')
     resolved.css.include ??= [/\.module\./]
 
-  resolved.cache ??= { dir: '' }
+  resolved.cache ??= "cacheDir" in resolved ? {dir: (resolved.cacheDir ?? '') as string } :  { dir: '' }
   if (resolved.cache)
     resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir)
 


### PR DESCRIPTION
Quick try to see if any tests fail.

Related: https://github.com/vitest-dev/vitest/issues/1603