### PR TITLE
docs: typo

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -127,7 +127,7 @@ export default defineConfig({
 })
 ```
 
-To get TypeScript working with the global APIs, add `vitest/globals` to the `types` filed in your `tsconfig.json`
+To get TypeScript working with the global APIs, add `vitest/globals` to the `types` field in your `tsconfig.json`
 
 ```json
 // tsconfig.json


### PR DESCRIPTION
Minor docs PR to fix a typo:

> To get TypeScript working with the global APIs, add vitest/globals to the types ~~filed~~ field in your tsconfig.json