### PR TITLE
fix: `TestSequencerConstructor` typo

### DIFF
--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -6,5 +6,5 @@ export { startVitest } from './cli-api'
 export { VitestRunner } from '../runtime/execute'
 export type { ExecuteOptions } from '../runtime/execute'
 
-export type { TestSequencer, TestSequencerContructor } from './sequencers/types'
+export type { TestSequencer, TestSequencerConstructor } from './sequencers/types'
 export { BaseSequencer } from './sequencers/BaseSequencer'

--- a/packages/vitest/src/node/sequencers/types.ts
+++ b/packages/vitest/src/node/sequencers/types.ts
@@ -10,6 +10,6 @@ export interface TestSequencer {
   sort(files: string[]): Awaitable<string[]>
 }
 
-export interface TestSequencerContructor {
+export interface TestSequencerConstructor {
   new (ctx: Vitest): TestSequencer
 }

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -2,7 +2,7 @@ import type { CommonServerOptions } from 'vite'
 import type { PrettyFormatOptions } from 'pretty-format'
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
 import type { BuiltinReporters } from '../node/reporters'
-import type { TestSequencerContructor } from '../node/sequencers/types'
+import type { TestSequencerConstructor } from '../node/sequencers/types'
 import type { C8Options, ResolvedC8Options } from './coverage'
 import type { JSDOMOptions } from './jsdom-options'
 import type { Reporter } from './reporter'
@@ -381,7 +381,7 @@ export interface InlineConfig {
      * your custom sequencer from `BaseSequencer` from `vitest/node`.
      * @default BaseSequencer
      */
-    sequencer?: TestSequencerContructor
+    sequencer?: TestSequencerConstructor
     /**
      * Should tests run in random order.
      * @default false
@@ -465,7 +465,7 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
   } | false
 
   sequence: {
-    sequencer: TestSequencerContructor
+    sequencer: TestSequencerConstructor
     shuffle?: boolean
     seed?: number
   }


### PR DESCRIPTION
Fixed typo on Typescript interface.

Attempting to create custom sequencer by following docs, https://vitest.dev/config/#sequence. Docs are correct but codebase has a typo.

> - Type: `TestSequencerConstructor`

```diff
-TestSequencerContructor
+TestSequencerConstructor
```