### PR TITLE
Add options to resolveSnapshotPath

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -503,7 +503,7 @@ Format options for snapshot testing. These options are passed down to [`pretty-f
 
 ### resolveSnapshotPath
 
-- **Type**: `(testPath: string, snapExtension: string) => string`
+- **Type**: `(testPath: string, snapExtension: string, options: { context: any }) => string`
 - **Default**: stores snapshot files in `__snapshots__` directory
 
 Overrides default snapshot path. For example, to store snapshots next to test files:

--- a/packages/vitest/src/integrations/snapshot/client.ts
+++ b/packages/vitest/src/integrations/snapshot/client.ts
@@ -40,7 +40,7 @@ export class SnapshotClient {
           filePath,
           new SnapshotState(
             filePath,
-            await rpc().resolveSnapshotPath(filePath),
+            await rpc().resolveSnapshotPath(filePath, undefined, { context: this.test.context }),
             getWorkerState().config.snapshotOptions,
           ),
         )

--- a/packages/vitest/src/integrations/snapshot/manager.ts
+++ b/packages/vitest/src/integrations/snapshot/manager.ts
@@ -17,7 +17,7 @@ export class SnapshotManager {
     addSnapshotResult(this.summary, result)
   }
 
-  resolvePath(testPath: string) {
+  resolvePath(testPath: string, options: { context: any }) {
     const resolver = this.options.resolveSnapshotPath || (() => {
       return join(
         join(
@@ -26,7 +26,7 @@ export class SnapshotManager {
       )
     })
 
-    return resolver(testPath, this.extension)
+    return resolver(testPath, this.extension, options)
   }
 }
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -129,8 +129,8 @@ function createChannel(ctx: Vitest) {
       snapshotSaved(snapshot) {
         ctx.snapshot.add(snapshot)
       },
-      resolveSnapshotPath(testPath: string) {
-        return ctx.snapshot.resolvePath(testPath)
+      resolveSnapshotPath(testPath: string, options: { context: any }) {
+        return ctx.snapshot.resolvePath(testPath, options)
       },
       async getSourceMap(id, force) {
         if (force) {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -312,7 +312,7 @@ export interface InlineConfig {
   /**
    * Resolve custom snapshot path
    */
-  resolveSnapshotPath?: (path: string, extension: string) => string
+  resolveSnapshotPath?: (path: string, extension: string, options: { context: any }) => string
 
   /**
    * Pass with no tests

--- a/packages/vitest/src/types/snapshot.ts
+++ b/packages/vitest/src/types/snapshot.ts
@@ -8,7 +8,7 @@ export interface SnapshotStateOptions {
   updateSnapshot: SnapshotUpdateState
   expand?: boolean
   snapshotFormat?: PrettyFormatOptions
-  resolveSnapshotPath?: (path: string, extension: string) => string
+  resolveSnapshotPath?: (path: string, extension: string, options: { context: any }) => string
 }
 
 export interface SnapshotMatchOptions {

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -30,7 +30,7 @@ export interface WorkerRPC {
   onTaskUpdate: (pack: TaskResultPack[]) => void
 
   snapshotSaved: (snapshot: SnapshotResult) => void
-  resolveSnapshotPath: (testPath: string) => string
+  resolveSnapshotPath: (testPath: string, options: { context: any }) => string
 }
 
 export interface WorkerGlobalState {


### PR DESCRIPTION
My team wants to save our snapshots in different files, depending on some variables that are defined by a table (`describe.each`). Specifically we want to run the same test for various versions of clients. Storing all of these snapshots in the same file has some very annoying downsides, because the diff tools will confuse the addition and deletion of versions and display generally unhelpful outputs for human review.

Today the snapshot path depends only on the test file and the extension (`.snap`) and given that it runs in a different thread (using some RPC protocol) we can't pass down variables using AsyncLocalStorage or other mechanisms with global state.

This PR adds the easily customizable Test.Context object to the snapshot resolver, allowing users to conveniently specify a different path per context.

I'm not sure this works due to the nature of the RPC: can it send other parameters than strings? Does it fall apart if the object isn't JSON serialisable? I'm not sure. But I wanted to create this PR already, to make the proposal and gather some opinions.