### PR TITLE
fix: mock properties of classes/functions (fix #1523)

### DIFF
--- a/test/core/src/mockedC.ts
+++ b/test/core/src/mockedC.ts
@@ -1,0 +1,24 @@
+import { mockedA } from './mockedA'
+
+export class MockedC {
+  public value: number
+
+  constructor() {
+    this.value = 42
+  }
+
+  public doSomething() {
+    return mockedA()
+  }
+
+  get getSetProp(): number {
+    return 123
+  }
+
+  set getSetProp(_val: number) {}
+}
+
+export async function asyncFunc(): Promise<string> {
+  await new Promise<void>(resolve => resolve())
+  return '1234'
+}

--- a/test/core/test/mocked.test.ts
+++ b/test/core/test/mocked.test.ts
@@ -1,21 +1,22 @@
-import { assert, expect, test, vi, vitest } from 'vitest'
+import { assert, describe, expect, test, vi, vitest } from 'vitest'
 // @ts-expect-error not typed module
 import { value as virtualValue } from 'virtual-module'
 import { two } from '../src/submodule'
 import * as mocked from '../src/mockedA'
 import { mockedB } from '../src/mockedB'
+import { MockedC, asyncFunc } from '../src/mockedC'
 import * as globalMock from '../src/global-mock'
 
 vitest.mock('../src/submodule')
-vitest.mock('virtual-module', () => {
-  return { value: 'mock' }
-})
+vitest.mock('virtual-module', () => ({ value: 'mock' }))
+vitest.mock('../src/mockedC')
 
 test('submodule is mocked to return "two" as 3', () => {
   assert.equal(3, two)
 })
 
 test('globally mocked files are mocked', () => {
+  // Mocked in setup.ts
   expect(globalMock.mocked).toBe(true)
 })
 
@@ -30,4 +31,35 @@ test('can mock esm', () => {
 
 test('mocked exports should override original exports', () => {
   expect(virtualValue).toBe('mock')
+})
+
+describe('mocked classes', () => {
+  test('should not delete the prototype', () => {
+    expect(MockedC).toBeTypeOf('function')
+    expect(MockedC.prototype.doSomething).toBeTypeOf('function')
+  })
+
+  test('should mock the constructor', () => {
+    const instance = new MockedC()
+
+    expect(instance.value).not.toBe(42)
+    expect(MockedC).toHaveBeenCalledOnce()
+  })
+
+  test('should mock functions in the prototype', () => {
+    const instance = new MockedC()
+
+    expect(instance.doSomething).toBeTypeOf('function')
+    expect(instance.doSomething()).not.toBe('A')
+
+    expect(MockedC.prototype.doSomething).toHaveBeenCalledOnce()
+    expect(MockedC.prototype.doSomething).not.toHaveReturnedWith('A')
+  })
+})
+
+test('async functions should be mocked', () => {
+  expect(asyncFunc()).toBeUndefined()
+  expect(vi.mocked(asyncFunc).mockResolvedValue).toBeDefined()
+  vi.mocked(asyncFunc).mockResolvedValue('foo')
+  expect(asyncFunc()).resolves.toBe('foo')
 })


### PR DESCRIPTION
Previously classes weren't mocked properly because their prototypes were not being copied, so they lost all their methods. This PR rewrites the automocker to properly handle:

- Functions with properties (namely classes)
- Circular objects (also to handle classes, thanks JavaScript)

With these changes classes can now be properly automocked!

This fixes #1523.