### PR TITLE
fix: exclude cypress config from default coverage

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -16,7 +16,7 @@ const defaultCoverageExcludes = [
   '**/*{.,-}test.{js,cjs,mjs,ts,tsx,jsx}',
   '**/*{.,-}spec.{js,cjs,mjs,ts,tsx,jsx}',
   '**/__tests__/**',
-  '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc}.config.{js,cjs,mjs,ts}',
+  '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress}.config.{js,cjs,mjs,ts}',
   '**/.{eslint,mocha,prettier}rc.{js,cjs,yml}',
 ]
 


### PR DESCRIPTION
Cypress v10 now has a dedicated file `cypress.config.js/ts` at the root of the project.