### PR TITLE
fix: exclude dist directory from default coverage

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -8,6 +8,7 @@ export const defaultExclude = ['**/node_modules/**', '**/dist/**', '**/cypress/*
 
 const defaultCoverageExcludes = [
   'coverage/**',
+  'dist/**',
   'packages/*/test{,s}/**',
   '**/*.d.ts',
   'cypress/**',


### PR DESCRIPTION
`create-vue` for example generates projects with a `dist` folder that stores the built assets. By default, the coverage does not exclude this directory until now.