### PR TITLE
fix: apply Vite resolving algorithm to node_modules libraries

### DIFF
--- a/examples/solid/vite.config.mjs
+++ b/examples/solid/vite.config.mjs
@@ -10,9 +10,6 @@ export default defineConfig({
     transformMode: {
       web: [/.[jt]sx?/],
     },
-    deps: {
-      inline: [/solid-js/],
-    },
     threads: false,
     isolate: false,
   },

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch -m inline",
+    "dev": "NODE_OPTIONS=\"--max-old-space-size=8192\" rollup -c --watch -m inline",
     "prepublishOnly": "nr build"
   },
   "peerDependencies": {

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -20,6 +20,7 @@ const entries = [
   'src/node/cli.ts',
   'src/node.ts',
   'src/runtime/worker.ts',
+  'src/runtime/loader.ts',
   'src/runtime/entry.ts',
   'src/runtime/suite.ts',
   'src/integrations/spy.ts',

--- a/packages/vitest/src/constants.ts
+++ b/packages/vitest/src/constants.ts
@@ -1,6 +1,7 @@
 import url from 'url'
 import { resolve } from 'pathe'
 
+export const rootDir = resolve(url.fileURLToPath(import.meta.url), '../../')
 export const distDir = resolve(url.fileURLToPath(import.meta.url), '../../dist')
 
 // if changed, update also jsdocs and docs

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -7,7 +7,7 @@ import { Tinypool } from 'tinypool'
 import { createBirpc } from 'birpc'
 import type { RawSourceMap } from 'vite-node'
 import type { ResolvedConfig, WorkerContext, WorkerRPC } from '../types'
-import { distDir } from '../constants'
+import { distDir, rootDir } from '../constants'
 import { AggregateError } from '../utils'
 import type { Vitest } from './core'
 
@@ -20,6 +20,8 @@ export interface WorkerPool {
 
 const workerPath = _url.pathToFileURL(resolve(distDir, './worker.mjs')).href
 const loaderPath = _url.pathToFileURL(resolve(distDir, './loader.mjs')).href
+
+const suppressLoaderWarningsPath = resolve(rootDir, './suppress-warnings.cjs')
 
 export function createPool(ctx: Vitest): WorkerPool {
   const threadsCount = ctx.config.watch
@@ -41,10 +43,11 @@ export function createPool(ctx: Vitest): WorkerPool {
     minThreads,
 
     execArgv: [
+      '--require',
+      suppressLoaderWarningsPath,
       '--experimental-loader',
       loaderPath,
       ...conditions || [],
-      '--no-warnings',
     ],
   }
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -19,6 +19,7 @@ export interface WorkerPool {
 }
 
 const workerPath = _url.pathToFileURL(resolve(distDir, './worker.mjs')).href
+const loaderPath = _url.pathToFileURL(resolve(distDir, './loader.mjs')).href
 
 export function createPool(ctx: Vitest): WorkerPool {
   const threadsCount = ctx.config.watch
@@ -36,6 +37,13 @@ export function createPool(ctx: Vitest): WorkerPool {
 
     maxThreads,
     minThreads,
+
+    execArgv: [
+      '--experimental-loader',
+      loaderPath,
+      ...ctx.server.config.resolve.conditions?.flatMap(c => ['-C', c]) ?? [],
+      '--no-warnings',
+    ],
   }
 
   if (ctx.config.isolate) {

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -29,6 +29,8 @@ export function createPool(ctx: Vitest): WorkerPool {
   const maxThreads = ctx.config.maxThreads ?? threadsCount
   const minThreads = ctx.config.minThreads ?? threadsCount
 
+  const conditions = ctx.server.config.resolve.conditions?.flatMap(c => ['-C', c])
+
   const options: TinypoolOptions = {
     filename: workerPath,
     // TODO: investigate further
@@ -41,7 +43,7 @@ export function createPool(ctx: Vitest): WorkerPool {
     execArgv: [
       '--experimental-loader',
       loaderPath,
-      ...ctx.server.config.resolve.conditions?.flatMap(c => ['-C', c]) ?? [],
+      ...conditions || [],
       '--no-warnings',
     ],
   }

--- a/packages/vitest/src/runtime/loader.ts
+++ b/packages/vitest/src/runtime/loader.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL } from 'url'
+import { isNodeBuiltin } from 'mlly'
 import { normalizeModuleId } from 'vite-node/utils'
 import type { Awaitable } from '../types'
 import { getWorkerState } from '../utils'
@@ -39,9 +40,11 @@ interface Loader {
   (url: string, context: LoaderContext, next: Loader): Awaitable<LoaderResult>
 }
 
+// apply transformations only to libraries
+// inline code preccessed by vite-node
 export const resolve: Resolver = async (url, context, next) => {
   const { parentURL } = context
-  if (!parentURL || !parentURL.includes('node_modules'))
+  if (!parentURL || !parentURL.includes('node_modules') || isNodeBuiltin(url))
     return next(url, context, next)
 
   const id = normalizeModuleId(url)

--- a/packages/vitest/src/runtime/loader.ts
+++ b/packages/vitest/src/runtime/loader.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from 'url'
+import { normalizeModuleId } from 'vite-node/utils'
+import type { Awaitable } from '../types'
+import { getWorkerState } from '../utils'
+
+interface ModuleContext {
+  conditions: string[]
+  parentURL?: string
+}
+
+enum ModuleFormat {
+  Builtin = 'builtin',
+  Commonjs = 'commonjs',
+  Json = 'json',
+  Module = 'module',
+  Wasm = 'wasm',
+}
+
+interface ResolveResult {
+  url: string
+  format?: ModuleFormat
+}
+
+interface Resolver {
+  (url: string, context: ModuleContext, next: Resolver): Awaitable<ResolveResult>
+}
+
+interface LoaderContext {
+  format: ModuleFormat
+  importAssertions: Record<string, string>
+}
+
+interface LoaderResult {
+  format: ModuleFormat
+  source: string | ArrayBuffer | SharedArrayBuffer | Uint8Array
+}
+
+interface Loader {
+  (url: string, context: LoaderContext, next: Loader): Awaitable<LoaderResult>
+}
+
+export const resolve: Resolver = async (url, context, next) => {
+  const { parentURL } = context
+  if (!parentURL || !parentURL.includes('node_modules'))
+    return next(url, context, next)
+
+  const id = normalizeModuleId(url)
+  const importer = normalizeModuleId(parentURL)
+  const state = getWorkerState()
+  const resolver = state?.rpc.resolveId
+  if (resolver) {
+    const resolved = await resolver(id, importer)
+    if (resolved) {
+      return {
+        url: pathToFileURL(resolved.id).toString(),
+      }
+    }
+  }
+  return next(url, context, next)
+}
+
+export const load: Loader = (url, context, next) => {
+  return next(url, context, next)
+}

--- a/packages/vitest/src/runtime/loader.ts
+++ b/packages/vitest/src/runtime/loader.ts
@@ -1,44 +1,8 @@
 import { pathToFileURL } from 'url'
 import { isNodeBuiltin } from 'mlly'
 import { normalizeModuleId } from 'vite-node/utils'
-import type { Awaitable } from '../types'
 import { getWorkerState } from '../utils'
-
-interface ModuleContext {
-  conditions: string[]
-  parentURL?: string
-}
-
-enum ModuleFormat {
-  Builtin = 'builtin',
-  Commonjs = 'commonjs',
-  Json = 'json',
-  Module = 'module',
-  Wasm = 'wasm',
-}
-
-interface ResolveResult {
-  url: string
-  format?: ModuleFormat
-}
-
-interface Resolver {
-  (url: string, context: ModuleContext, next: Resolver): Awaitable<ResolveResult>
-}
-
-interface LoaderContext {
-  format: ModuleFormat
-  importAssertions: Record<string, string>
-}
-
-interface LoaderResult {
-  format: ModuleFormat
-  source: string | ArrayBuffer | SharedArrayBuffer | Uint8Array
-}
-
-interface Loader {
-  (url: string, context: LoaderContext, next: Loader): Awaitable<LoaderResult>
-}
+import type { Loader, Resolver } from '../types/loader'
 
 // apply transformations only to libraries
 // inline code preccessed by vite-node

--- a/packages/vitest/src/types/loader.ts
+++ b/packages/vitest/src/types/loader.ts
@@ -1,0 +1,37 @@
+import type { Awaitable } from './general'
+
+interface ModuleContext {
+  conditions: string[]
+  parentURL?: string
+}
+
+enum ModuleFormat {
+  Builtin = 'builtin',
+  Commonjs = 'commonjs',
+  Json = 'json',
+  Module = 'module',
+  Wasm = 'wasm',
+}
+
+interface ResolveResult {
+  url: string
+  format?: ModuleFormat
+}
+
+export interface Resolver {
+  (url: string, context: ModuleContext, next: Resolver): Awaitable<ResolveResult>
+}
+
+interface LoaderContext {
+  format: ModuleFormat
+  importAssertions: Record<string, string>
+}
+
+interface LoaderResult {
+  format: ModuleFormat
+  source: string | ArrayBuffer | SharedArrayBuffer | Uint8Array
+}
+
+export interface Loader {
+  (url: string, context: LoaderContext, next: Loader): Awaitable<LoaderResult>
+}

--- a/packages/vitest/suppress-warnings.cjs
+++ b/packages/vitest/suppress-warnings.cjs
@@ -1,0 +1,20 @@
+// borrowed from tsx implementation:
+// https://github.com/esbuild-kit/tsx
+
+const ignoreWarnings = new Set([
+  '--experimental-loader is an experimental feature. This feature could change at any time',
+  'Custom ESM Loaders is an experimental feature. This feature could change at any time',
+])
+
+const { emit } = process
+
+process.emit = function (event, warning) {
+  if (
+    event === 'warning'
+    && ignoreWarnings.has(warning.message)
+  )
+    return
+
+  // eslint-disable-next-line prefer-rest-params
+  return Reflect.apply(emit, this, arguments)
+}


### PR DESCRIPTION
This PR adds experimental loader and conditions, so native Node resolving algorithm knows about Vite's resolving algorithm.

This is a giant breaking change, but still should not affect a lot of people. This fixes issues when people applied custom conditions and they were working in Vite, but didn't work in Vitest, because it was imported from another library. This PR also allows applying `alias` to external libraries - this is useful for `preact`, for example.

We still don't allow mocking external libraries within another external library!

Closes #1638