### PR TITLE
feat: add option for ignoring unhandled errors

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -538,6 +538,13 @@ export default defineConfig({
 
 Allow tests and suites that are marked as only.
 
+### dangerouslyIgnoreUnhandledErrors
+
+- **Type**: `boolean`
+- **Default**: `false`
+
+Ignore any unhandled errors that occur.
+
 ### passWithNoTests
 
 - **Type**: `boolean`

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -71,6 +71,7 @@ vitest related /src/index.ts /src/hello-world.js
 | `--environment <env>` | Runner environment (default: `node`) |
 | `--passWithNoTests` | Pass when no tests found |
 | `--allowOnly` | Allow tests and suites that are marked as `only` (default: false in CI, true otherwise) |
+| `--dangerouslyIgnoreUnhandledErrors` | Ignore any unhandled errors that occur |
 | `--changed [since]` | Run tests that are affected by the changed files (default: false). See [docs](#changed) |
 | `--shard <shard>` | Execute tests in a specified shard |
 | `--sequence` | Define in what order to run tests. Use [cac's dot notation] to specify options (for example, use `--sequence.shuffle` to run tests in random order) |

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -83,6 +83,7 @@ const config = {
   coverage: coverageConfigDefaults,
   fakeTimers: fakeTimersDefaults,
   maxConcurrency: 5,
+  dangerouslyIgnoreUnhandledErrors: false,
 }
 
 export const configDefaults: Required<Pick<UserConfig, keyof typeof config>> = Object.freeze(config)

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -34,6 +34,7 @@ cli
   .option('--environment <env>', 'runner environment (default: node)')
   .option('--passWithNoTests', 'pass when no tests found')
   .option('--allowOnly', 'Allow tests and suites that are marked as only (default: !process.env.CI)')
+  .option('--dangerouslyIgnoreUnhandledErrors', 'Ignore any unhandled errors that occur')
   .option('--shard <shard>', 'Test suite shard to execute in a format of <index>/<count>')
   .option('--changed [since]', 'Run tests that are affected by the changed files (default: false)')
   .option('--sequence <options>', 'Define in what order to run tests (use --sequence.shuffle to run tests in random order)')

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -48,7 +48,8 @@ export abstract class BaseReporter implements Reporter {
     this.end = performance.now()
     await this.reportSummary(files)
     if (errors.length) {
-      process.exitCode = 1
+      if (!this.ctx.config.dangerouslyIgnoreUnhandledErrors)
+        process.exitCode = 1
       this.ctx.logger.printUnhandledErrors(errors)
     }
   }

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -413,6 +413,11 @@ export interface InlineConfig {
    * Will be merged with the default aliases inside `resolve.alias`.
    */
   alias?: AliasOptions
+
+  /**
+   * Ignore any unhandled errors that occur
+   */
+  dangerouslyIgnoreUnhandledErrors?: boolean
 }
 
 export interface UserConfig extends InlineConfig {


### PR DESCRIPTION
I recently migrated a large project from Jest to Vitest.
During the migration, I encountered issues with unhandled errors due to race conditions (caused by poor tests that don't clean up their async React hooks).

Since there's a huge number of tests, without any way of knowing which tests cause these issues, I had to use `patch-package` to prevent Vitest from failing due to unhandled errors.

I am aware that this isn't the proper way, but there was no other way of getting around this issue.

With this PR, I propose a new config option for ignoring unhandled errors.
It's fittingly labelled `dangerouslyIgnoreUnhandledErrors`.