### PR TITLE
docs: fix the example for in-source testing unbuild config

### DIFF
--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -75,9 +75,9 @@ export default defineConfig({
 
 ```diff
 // build.config.ts
-import { defineConfig } from 'unbuild'
+import { defineBuildConfig } from 'unbuild'
 
-export default defineConfig({
+export default defineBuildConfig({
 + replace: {
 +   'import.meta.vitest': 'undefined',
 + },


### PR DESCRIPTION
[link to vitest docs](https://vitest.dev/guide/in-source.html#production-build)  
[link to unbuild docs](https://github.com/unjs/unbuild#Configuration)