### PR TITLE
fix(browser): wait for files scanning in browser

### DIFF
--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -50,8 +50,8 @@ export function setup(ctx: Vitest) {
         getFiles() {
           return ctx.state.getFiles()
         },
-        getPaths() {
-          return ctx.state.getPaths()
+        async getPaths() {
+          return await ctx.state.getPaths()
         },
         readFile(id) {
           return fs.readFile(id, 'utf-8')

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -11,7 +11,7 @@ export interface WebSocketHandlers {
   onCollected(files?: File[]): Promise<void>
   onTaskUpdate(packs: TaskResultPack[]): void
   getFiles(): File[]
-  getPaths(): string[]
+  getPaths(): Promise<string[]>
   getConfig(): ResolvedConfig
   getModuleGraph(id: string): Promise<ModuleGraphData>
   getTransformResult(id: string): Promise<TransformResultWithSource | undefined>

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -244,8 +244,7 @@ export class Vitest {
     })()
       .finally(() => {
         this.runningPromise = undefined
-        if (this.config.browser)
-          this.state.finishCollectingPaths()
+        this.state.finishCollectingPaths()
       })
 
     return await this.runningPromise

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -214,6 +214,7 @@ export class Vitest {
   async runFiles(paths: string[]) {
     // previous run
     await this.runningPromise
+    this.state.startCollectingPaths()
 
     // schedule the new run
     this.runningPromise = (async () => {
@@ -243,6 +244,8 @@ export class Vitest {
     })()
       .finally(() => {
         this.runningPromise = undefined
+        if (this.config.browser)
+          this.state.finishCollectingPaths()
       })
 
     return await this.runningPromise

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
       vite: ^2.9.12
       vitest: workspace:*
     dependencies:
-      '@rollup/plugin-graphql': 1.1.0_nhmex7luzljoezdhc6xbg5ot4a
+      '@rollup/plugin-graphql': 1.1.0_43ql3v2t6o4ybgpyc3nievjubi
       graphql: 16.5.0
     devDependencies:
       '@vitest/ui': link:../../packages/ui
@@ -168,7 +168,7 @@ importers:
       lit: 2.2.5
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 6.0.3
+      happy-dom: 6.0.4
       vite: 2.9.14
       vitest: link:../../packages/vitest
 
@@ -4233,7 +4233,7 @@ packages:
       rollup: 2.77.0
     dev: true
 
-  /@rollup/plugin-graphql/1.1.0_nhmex7luzljoezdhc6xbg5ot4a:
+  /@rollup/plugin-graphql/1.1.0_43ql3v2t6o4ybgpyc3nievjubi:
     resolution: {integrity: sha512-X+H6oFlprDlnO3D0UiEytdW97AMphPXO0C7KunS7i/rBXIGQRQVDU5WKTXnBu2tfyYbjCTtfhXMSGI0i885PNg==}
     peerDependencies:
       graphql: '>=0.9.0'
@@ -4242,7 +4242,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       graphql: 16.5.0
       graphql-tag: 2.12.6_graphql@16.5.0
-      rollup: 2.76.0
+      rollup: 2.77.0
     dev: false
 
   /@rollup/plugin-inject/4.0.4_rollup@2.77.0:
@@ -12750,6 +12750,20 @@ packages:
 
   /happy-dom/6.0.3:
     resolution: {integrity: sha512-1P1l2ynhs9lkO2M8X+fJzMbGUBzKZX8CSqjYrMw5LInqwdURvwj1veYD+br13jtNCwbjzZrYNuQXjj1vqENK4w==}
+    dependencies:
+      css.escape: 1.5.1
+      he: 1.2.0
+      node-fetch: 2.6.7
+      sync-request: 6.1.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /happy-dom/6.0.4:
+    resolution: {integrity: sha512-b+ID23Ms0BY08UNLymsOMG7EI2jSlwEt4cbJs938GZfeNAg+fqgkSO3TokQMgSOFoHznpjWmpVjBUL5boJ9PWw==}
     dependencies:
       css.escape: 1.5.1
       he: 1.2.0


### PR DESCRIPTION
This PR tries to create an empty promise when vitest starts and then finishes it when vitest node (runningPromise) gets done! so when the client calls getPaths, it waits for files to be scanned. This also fixes some inconsistencies between the client and vitest node.

So `vitest --browser` should work (when It opens the browser automatically)!