### PR TITLE
fix(ui): do not load graph if never displayed (fix #1602)

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -93,7 +93,7 @@ function onDraft(value: boolean) {
     </div>
 
     <div flex flex-col flex-1 overflow="hidden">
-      <div v-if="hasGraphBeenDisplayed">
+      <div v-if="hasGraphBeenDisplayed" flex-1>
         <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" />
       </div>
       <ViewEditor v-if="viewMode === 'editor'" :key="current.filepath" :file="current" @draft="onDraft" />

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -9,6 +9,7 @@ import type { ModuleGraphData } from '#types'
 const data = ref<ModuleGraphData>({ externalized: [], graph: {}, inlined: [] })
 const graph = ref<ModuleGraph>({ nodes: [], links: [] })
 const draft = ref(false)
+const hasGraphBeenDisplayed = ref(false)
 
 debouncedWatch(
   current,
@@ -28,6 +29,9 @@ const open = () => {
 }
 
 const changeViewMode = (view: Params['view']) => {
+  if (view === 'graph')
+    hasGraphBeenDisplayed.value = true
+
   viewMode.value = view
 }
 const consoleCount = computed(() => {
@@ -89,7 +93,9 @@ function onDraft(value: boolean) {
     </div>
 
     <div flex flex-col flex-1 overflow="hidden">
-      <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" />
+      <div v-if="hasGraphBeenDisplayed">
+        <ViewModuleGraph v-show="viewMode === 'graph'" :graph="graph" />
+      </div>
       <ViewEditor v-if="viewMode === 'editor'" :key="current.filepath" :file="current" @draft="onDraft" />
       <ViewConsoleOutput v-else-if="viewMode === 'console'" :file="current" />
       <ViewReport v-else-if="!viewMode" :file="current" />


### PR DESCRIPTION
Add small UI optimization for large module graph 

If the user never clicks on the graph tab, do not load the graph. 

Once they click on it once, we keep the graph loaded so the next time they load the tab it is at the same place.

## ⛰️  Screenshots

### Before
Ui lags


https://user-images.githubusercontent.com/755469/180872288-e6812506-88a6-46b5-963e-9b3f529a8407.mp4

### After
UI doesn't lag


https://user-images.githubusercontent.com/755469/180872305-f731ece1-a355-49e2-bb3e-18c333a0b499.mp4


Graph works as before

https://user-images.githubusercontent.com/755469/180876969-02939645-a5f1-43e8-911c-a04f7fd78e04.mp4




Fixes https://github.com/vitest-dev/vitest/issues/1602