### PR TITLE
fix: don't clear mocks with vi.resetModules, cache normalised mock paths

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -231,7 +231,8 @@ class VitestUtils {
   }
 
   public resetModules() {
-    resetModules()
+    const state = getWorkerState()
+    resetModules(state.moduleCache)
     return this
   }
 

--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -46,7 +46,7 @@ export async function run(files: string[], config: ResolvedConfig): Promise<void
     await withEnv(environment, config.environmentOptions || {}, async () => {
       for (const file of files) {
         workerState.mockMap.clear()
-        resetModules(workerState.moduleCache)
+        resetModules(workerState.moduleCache, true)
 
         workerState.filepath = file
 

--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -46,7 +46,7 @@ export async function run(files: string[], config: ResolvedConfig): Promise<void
     await withEnv(environment, config.environmentOptions || {}, async () => {
       for (const file of files) {
         workerState.mockMap.clear()
-        resetModules()
+        resetModules(workerState.moduleCache)
 
         workerState.filepath = file
 

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -88,7 +88,7 @@ function init(ctx: WorkerContext) {
   if (ctx.invalidates) {
     ctx.invalidates.forEach((fsPath) => {
       moduleCache.delete(fsPath)
-      moduleCache.delete(`${fsPath}__mock`)
+      moduleCache.delete(`mock:${fsPath}`)
     })
   }
   ctx.files.forEach(i => moduleCache.delete(i))

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -3,8 +3,8 @@ import { relative as relativeBrowser } from 'path'
 import c from 'picocolors'
 import { isPackageExists } from 'local-pkg'
 import { relative as relativeNode } from 'pathe'
+import type { ModuleCacheMap } from 'vite-node'
 import type { Suite, Task } from '../types'
-import { getWorkerState } from '../utils/global'
 import { getNames } from './tasks'
 
 export * from './tasks'
@@ -40,8 +40,7 @@ export function partitionSuiteChildren(suite: Suite) {
   return tasksGroups
 }
 
-export function resetModules() {
-  const modules = getWorkerState().moduleCache
+export function resetModules(modules: ModuleCacheMap) {
   const vitestPaths = [
     // Vitest
     /\/vitest\/dist\//,
@@ -49,6 +48,8 @@ export function resetModules() {
     /vitest-virtual-\w+\/dist/,
     // cnpm
     /@vitest\/dist/,
+    // don't clear mocks
+    /^mock:/,
   ]
   modules.forEach((_, path) => {
     if (vitestPaths.some(re => re.test(path)))

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -40,8 +40,8 @@ export function partitionSuiteChildren(suite: Suite) {
   return tasksGroups
 }
 
-export function resetModules(modules: ModuleCacheMap) {
-  const vitestPaths = [
+export function resetModules(modules: ModuleCacheMap, resetMocks = false) {
+  const skipPaths = [
     // Vitest
     /\/vitest\/dist\//,
     // yarn's .store folder
@@ -49,10 +49,10 @@ export function resetModules(modules: ModuleCacheMap) {
     // cnpm
     /@vitest\/dist/,
     // don't clear mocks
-    /^mock:/,
+    ...(!resetMocks ? [/^mock:/] : []),
   ]
   modules.forEach((_, path) => {
-    if (vitestPaths.some(re => re.test(path)))
+    if (skipPaths.some(re => re.test(path)))
       return
     modules.delete(path)
   })

--- a/packages/web-worker/src/pure.ts
+++ b/packages/web-worker/src/pure.ts
@@ -136,7 +136,7 @@ export function defineWebWorker() {
           invalidates.forEach((fsPath) => {
             // worker should be new every time
             moduleCache.delete(fsPath)
-            moduleCache.delete(`${fsPath}__mock`)
+            moduleCache.delete(`mock:${fsPath}`)
           })
           const q = this.messageQueue
           this.messageQueue = null


### PR DESCRIPTION
Fixes #1645
Fixes #1563