### PR TITLE
fix: normalize `moduleCache` path

### DIFF
--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -103,6 +103,7 @@ export class VitestMocker {
   }
 
   private async callFunctionMock(dep: string, mock: () => any) {
+    dep = toFilePath(dep, this.root)
     const cached = this.moduleCache.get(dep)?.exports
     if (cached)
       return cached


### PR DESCRIPTION
fix: #1714

This problem is caused by the `moduleCache` key is not same in setup file and the vue component.
In setup file, the key is `/@fs/user/../node_modules/vue-meta/dist/vue-meta.cjs.js`, but in the component, is `/node_modules/vue-meta/dist/vue-meta.cjs.js`.

I'm not sure if this solution is the best, if not, modifications or rewrites are welcome~
