### PR TITLE
fix: disable node loader for Yarn PnP

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -129,7 +129,9 @@ export function resolveConfig(
     }
   }
 
-  resolved.deps.registerNodeLoader ??= true
+  // disable loader for Yarn PnP until Node implements chain loader
+  // https://github.com/nodejs/node/pull/43772
+  resolved.deps.registerNodeLoader ??= typeof process.versions.pnp === 'undefined'
 
   resolved.testNamePattern = resolved.testNamePattern
     ? resolved.testNamePattern instanceof RegExp


### PR DESCRIPTION
Related #1758

Yarn recommends using `process.versions.pnp` to detect Yarn PnP: https://yarnpkg.com/advanced/pnpapi#processversionspnp