### PR TITLE
fix: auto-mock based on descriptor list, not property keys (fix #1671)

### DIFF
--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -1,7 +1,7 @@
 import { RealDate } from '../integrations/mock/date'
 import type { Arrayable, DeepMerge, Nullable } from '../types'
 
-function isFinalObj(obj: any) {
+export function isFinalObj(obj: any) {
   return obj === Object.prototype || obj === Function.prototype || obj === RegExp.prototype
 }
 
@@ -11,19 +11,6 @@ function collectOwnProperties(obj: any, collector: Set<string | symbol>) {
 
   props.forEach(prop => collector.add(prop))
   symbols.forEach(symbol => collector.add(symbol))
-}
-
-export function getAllProperties(obj: any) {
-  const allProps = new Set<string | symbol>()
-  let curr = obj
-  do {
-    // we don't need propterties from these
-    if (isFinalObj(curr))
-      break
-    collectOwnProperties(curr, allProps)
-    // eslint-disable-next-line no-cond-assign
-  } while (curr = Object.getPrototypeOf(curr))
-  return Array.from(allProps)
 }
 
 export function notNullish<T>(v: T | null | undefined): v is NonNullable<T> {

--- a/test/core/src/mockedC.ts
+++ b/test/core/src/mockedC.ts
@@ -22,3 +22,6 @@ export async function asyncFunc(): Promise<string> {
   await new Promise<void>(resolve => resolve())
   return '1234'
 }
+
+// This is here because mocking streams previously caused some problems (#1671).
+export const exportedStream = process.stderr

--- a/test/core/test/mocked.test.ts
+++ b/test/core/test/mocked.test.ts
@@ -4,7 +4,7 @@ import { value as virtualValue } from 'virtual-module'
 import { two } from '../src/submodule'
 import * as mocked from '../src/mockedA'
 import { mockedB } from '../src/mockedB'
-import { MockedC, asyncFunc } from '../src/mockedC'
+import { MockedC, asyncFunc, exportedStream } from '../src/mockedC'
 import * as globalMock from '../src/global-mock'
 
 vitest.mock('../src/submodule')
@@ -62,4 +62,9 @@ test('async functions should be mocked', () => {
   expect(vi.mocked(asyncFunc).mockResolvedValue).toBeDefined()
   vi.mocked(asyncFunc).mockResolvedValue('foo')
   expect(asyncFunc()).resolves.toBe('foo')
+})
+
+// This is here because mocking streams previously caused some problems (#1671).
+test('streams', () => {
+  expect(exportedStream).toBeDefined()
 })


### PR DESCRIPTION
These two methods seem like they should be the same, but they're not. Some objects, especially native Node exports, behave strangely; they have properties that are enumerated by `Object.getOwnPropertyNames()` and/or `Object.getOwnPropertySymbols()`, but when you try to get the descriptor for that property using `Object.getOwnPropertyDescriptor()` it returns `undefined`. To combat this, instead of getting the property names / symbols manually, we instead offload that work to the JS engine itself via `Object.getOwnPropertyDescriptors`, and just iterate through the result.

Fixes #1671