### PR TITLE
fix: better bundling of types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:ci": "cross-env CI=true pnpm -r --stream --filter !test-fails --filter !test-browser run test --allowOnly",
     "test:ci:single-thread": "cross-env CI=true pnpm -r --stream --filter !test-fails run test --allowOnly --no-threads",
     "typecheck": "tsc --noEmit",
+    "typecheck:why": "tsc --noEmit --explainFiles > explainTypes.txt",
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui",
     "ui:test": "npm -C packages/ui run test:run"

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -60,7 +60,7 @@ const plugins = [
   }),
 ]
 
-export default ({ watch }) => [
+export default ({ watch }) => defineConfig([
   {
     input: entries,
     output: {
@@ -107,25 +107,19 @@ export default ({ watch }) => [
     external,
     plugins,
   },
-  ...dtsEntries.map((input) => {
-    const _external = external
-    // index is vitest default types export
-    if (!input.includes('index'))
-      _external.push('vitest')
-
-    return defineConfig({
-      input,
-      output: {
-        file: input.replace('src/', 'dist/').replace('.ts', '.d.ts'),
-        format: 'esm',
-      },
-      external: _external,
-      plugins: [
-        dts({ respectExternal: true }),
-      ],
-    })
-  }),
-]
+  {
+    input: dtsEntries,
+    output: {
+      dir: 'dist',
+      entryFileNames: chunk => `${chunk.name.replace('src/', '')}.d.ts`,
+      format: 'esm',
+    },
+    external,
+    plugins: [
+      dts({ respectExternal: true }),
+    ],
+  },
+])
 
 function licensePlugin() {
   return license({

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -1,7 +1,4 @@
-// rollup dts building will external vitest
-// so output dts entry using vitest to import internal types
-// eslint-disable-next-line no-restricted-imports
-import type { ResolvedC8Options, UserConfig } from 'vitest'
+import type { ResolvedC8Options, UserConfig } from './types'
 
 export const defaultInclude = ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
 export const defaultExclude = ['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**']

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "exclude": ["./dist"]
-}

--- a/shims.d.ts
+++ b/shims.d.ts
@@ -1,3 +1,2 @@
-/// <reference path="./packages/vitest/config.d.ts" />
 /// <reference path="./packages/vitest/globals.d.ts" />
 /// <reference path="./packages/vitest/importMeta.d.ts" />

--- a/test/core/vitest.config.ts
+++ b/test/core/vitest.config.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join, resolve } from 'pathe'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [

--- a/test/global-setup-fail/fixtures/vitest.config.ts
+++ b/test/global-setup-fail/fixtures/vitest.config.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { defineConfig } from 'vite'
 
 export default defineConfig({

--- a/test/global-setup-fail/vitest.config.ts
+++ b/test/global-setup-fail/vitest.config.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { defineConfig } from 'vite'
 
 export default defineConfig({

--- a/test/global-setup/vitest.config.ts
+++ b/test/global-setup/vitest.config.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { defineConfig } from 'vite'
 
 export default defineConfig({

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -1,6 +1,5 @@
 import { AssertionError } from 'assert'
-import type { ErrorWithDiff } from '../../../packages/vitest/dist'
-import type { File, Suite, Task } from '../../../packages/vitest/src/types'
+import type { ErrorWithDiff, File, Suite, Task } from 'vitest'
 
 const file: File = {
   id: '1223128da3',

--- a/test/vite-config/vite.config.ts
+++ b/test/vite-config/vite.config.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import assert from 'assert'
 import { join } from 'pathe'
 import { defineConfig } from 'vite'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
   "exclude": [
     "**/dist/**",
     "./packages/vitest/dist/**",
+    "./packages/vitest/*.d.ts",
     "./packages/ui/client/**",
     "./examples/**/*.*",
     "./bench/**"


### PR DESCRIPTION
Reduces the bundle size (and time for `build`), since we no longer bundle the same `Vitest` type (and its dependencies).

Before:
```
➜ du -sh dist/                                              
1.5Mb    dist/
```
After:
```
➜ du -sh dist/
1.4Mb    dist/
```

Possible fix for #1619?