### PR TITLE
feat: use child_process for --no-threads

### DIFF
--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -21,6 +21,7 @@ const entries = [
   'src/node.ts',
   'src/runtime/worker.ts',
   'src/runtime/loader.ts',
+  'src/runtime/child.ts',
   'src/runtime/entry.ts',
   'src/runtime/suite.ts',
   'src/integrations/spy.ts',

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -95,6 +95,8 @@ export function resolveConfig(
 
   resolved.coverage = resolveC8Options(options.coverage || {}, resolved.root)
 
+  resolved.parallel ??= true
+
   if (options.shard) {
     if (resolved.watch)
       throw new Error('You cannot use --shard option with enabled watch')

--- a/packages/vitest/src/runtime/child.ts
+++ b/packages/vitest/src/runtime/child.ts
@@ -1,0 +1,26 @@
+import type { MessagePort } from 'worker_threads'
+import process from 'process'
+import v8 from 'v8'
+import { run } from './worker'
+
+async function initialize(data: any) {
+  if (typeof data === 'object' && data && data.action === 'run') {
+    process.off('message', initialize)
+    await run({
+      ...data.data,
+      port: {
+        postMessage: (data: any) => process.send!(v8.serialize(data)),
+        addListener: (event: string, fn: (data: any) => void) => process.on(event, (data) => {
+          if (data.type === 'Buffer')
+            return fn(v8.deserialize(Buffer.from(data.data)))
+
+          return fn(data)
+        }),
+      } as unknown as MessagePort,
+    }).finally(() => {
+      process.send!({ action: 'finished' })
+    })
+  }
+}
+
+process.on('message', initialize)

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -22,12 +22,13 @@ async function startViteNode(ctx: WorkerContext) {
 
   const processExit = process.exit
 
-  process.on('beforeExit', (code) => {
-    rpc().onWorkerExit(code)
+  // TODO
+  process.on('beforeExit', () => {
+    // rpc().onWorkerExit(code)
   })
 
   process.exit = (code = process.exitCode || 0): never => {
-    rpc().onWorkerExit(code)
+    // rpc().onWorkerExit(code)
     return processExit(code)
   }
 
@@ -79,8 +80,12 @@ function init(ctx: WorkerContext) {
       {},
       {
         eventNames: ['onUserConsoleLog', 'onFinished', 'onCollected', 'onWorkerExit'],
-        post(v) { port.postMessage(v) },
-        on(fn) { port.addListener('message', fn) },
+        post(v) {
+          port.postMessage(v)
+        },
+        on(fn) {
+          port.addListener('message', fn)
+        },
       },
     ),
   }
@@ -97,5 +102,6 @@ function init(ctx: WorkerContext) {
 export async function run(ctx: WorkerContext) {
   init(ctx)
   const { run } = await startViteNode(ctx)
+  // console.log('vite node started')
   return run(ctx.files, ctx.config)
 }

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -167,6 +167,13 @@ export interface InlineConfig {
   threads?: boolean
 
   /**
+   * Run tests in parallel
+   *
+   * @default true
+   */
+  parallel?: boolean
+
+  /**
    * Maximum number of threads
    *
    * @default available CPUs


### PR DESCRIPTION
Possible solution for running tests in child_process, if your tests are failing with v8 segfault.