### PR TITLE
feat!: if not processed, CSS Modules return a proxy, scope class names by filename

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -706,14 +706,12 @@ Show heap usage after each test. Useful for debugging memory leaks.
 
 - **Type**: `boolean | { include?, exclude? }`
 
-Configure if CSS should be processed. When excluded, CSS files will be replaced with empty strings to bypass the subsequent processing.
-
-By default, processes only CSS Modules, because it affects runtime. JSDOM and Happy DOM don't fully support injecting CSS, so disabling this setting might help with performance.
+Configure if CSS should be processed. When excluded, CSS files will be replaced with empty strings to bypass the subsequent processing. CSS Modules will return a proxy to not affect runtime.
 
 #### css.include
 
 - **Type**: `RegExp | RegExp[]`
-- **Default**: `[/\.module\./]`
+- **Default**: `[]`
 
 RegExp pattern for files that should return actual CSS and will be processed by Vite pipeline.
 
@@ -723,6 +721,33 @@ RegExp pattern for files that should return actual CSS and will be processed by 
 - **Default**: `[]`
 
 RegExp pattern for files that will return an empty CSS file.
+
+#### css.modules
+
+- **Type**: `{ scopeClassNames? }`
+- **Default**: `{}`
+
+#### css.modules.scopeClassNames
+
+- **Type**: `boolean`
+- **Default**: false
+
+If you decide to process CSS files, you can configure if class names inside CSS modules should be scoped. By default, Vitest exports a proxy, bypassing CSS Modules processing.
+
+You might want to enable this, if your CSS classes are conflicting with each other, when CSS is inlined. For example, when you are accessing computed styles:
+
+```tsx
+// global.module.css
+// .error { width: 600px }
+
+// element.module.css
+// .error { width: 100px }
+
+// test
+const styles = window.getComputedStyles(<div className={error}></div>)
+// it's possible to have two different classes with conflicting styles
+expect(styles).toMatchObject({ with: '100px' })
+```
 
 ### maxConcurrency
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -745,7 +745,7 @@ You might want to enable this, if your CSS classes are conflicting with each oth
 
 // test
 const styles = window.getComputedStyles(<div className={error}></div>)
-// it's possible to have two different classes with conflicting styles
+// this will fail, if global css is loaded after element
 expect(styles).toMatchObject({ with: '100px' })
 ```
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -724,30 +724,19 @@ RegExp pattern for files that will return an empty CSS file.
 
 #### css.modules
 
-- **Type**: `{ scopeClassNames? }`
+- **Type**: `{ classNamesStrategy? }`
 - **Default**: `{}`
 
-#### css.modules.scopeClassNames
+#### css.modules.classNamesStrategy
 
-- **Type**: `boolean`
-- **Default**: false
+- **Type**: `'stable' | 'scoped' | 'non-scoped'`
+- **Default**: `'stable'`
 
-If you decide to process CSS files, you can configure if class names inside CSS modules should be scoped. By default, Vitest exports a proxy, bypassing CSS Modules processing.
+If you decide to process CSS files, you can configure if class names inside CSS modules should be scoped. By default, Vitest exports a proxy, bypassing CSS Modules processing. You can choose one of the options:
 
-You might want to enable this, if your CSS classes are conflicting with each other, when CSS is inlined. For example, when you are accessing computed styles:
-
-```tsx
-// global.module.css
-// .error { width: 600px }
-
-// element.module.css
-// .error { width: 100px }
-
-// test
-const styles = window.getComputedStyles(<div className={error}></div>)
-// this will fail, if global css is loaded after element
-expect(styles).toMatchObject({ with: '100px' })
-```
+- `stable`: class names will be generated as `_${name}_${hashedFilename}`, which means that generated class will stay the same, if CSS content is changed, but will change, if the name of the file is modified, or file is moved to another folder. This setting is useful, if you use snapshot feature.
+- `scoped`: class names will be generated as usual, respecting `css.modules.generateScopeName` method, if you have one. By default, filename will be generated as `_${name}_${hash}`, where hash includes filename and content of the file.
+- `non-scoped`: class names will stay as they are defined in CSS.
 
 ### maxConcurrency
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -724,10 +724,10 @@ RegExp pattern for files that will return an empty CSS file.
 
 #### css.modules
 
-- **Type**: `{ classNamesStrategy? }`
+- **Type**: `{ classNameStrategy? }`
 - **Default**: `{}`
 
-#### css.modules.classNamesStrategy
+#### css.modules.classNameStrategy
 
 - **Type**: `'stable' | 'scoped' | 'non-scoped'`
 - **Default**: `'stable'`

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -76,7 +76,7 @@ const config = {
   uiBase: '/__vitest__/',
   open: true,
   css: {
-    include: [/\.module\./],
+    include: [],
   },
   coverage: coverageConfigDefaults,
   fakeTimers: fakeTimersDefaults,

--- a/packages/vitest/src/integrations/css/css-modules.ts
+++ b/packages/vitest/src/integrations/css/css-modules.ts
@@ -1,7 +1,8 @@
+import { createHash } from 'node:crypto'
 import type { CSSModuleScopeStrategy } from '../../types'
 
-export function generateCssFilenameHash(filename: string) {
-  return Buffer.from(filename).toString('base64').substring(0, 6)
+export function generateCssFilenameHash(filepath: string) {
+  return createHash('md5').update(filepath).digest('hex').slice(0, 6)
 }
 
 export function generateScopedClassName(

--- a/packages/vitest/src/integrations/css/css-modules.ts
+++ b/packages/vitest/src/integrations/css/css-modules.ts
@@ -1,0 +1,19 @@
+import type { CSSModuleScopeStrategy } from '../../types'
+
+export function generateCssFilenameHash(filename: string) {
+  return Buffer.from(filename).toString('base64').substring(0, 6)
+}
+
+export function generateScopedClassName(
+  strategy: CSSModuleScopeStrategy,
+  name: string,
+  filename: string,
+) {
+  // should be configured by Vite defaults
+  if (strategy === 'scoped')
+    return null
+  if (strategy === 'non-scoped')
+    return name
+  const hash = generateCssFilenameHash(filename)
+  return `_${name}_${hash}`
+}

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -184,7 +184,7 @@ export function resolveConfig(
   resolved.css ??= {}
   if (typeof resolved.css === 'object') {
     resolved.css.modules ??= {}
-    resolved.css.modules.classNamesStrategy ??= 'stable'
+    resolved.css.modules.classNameStrategy ??= 'stable'
   }
 
   resolved.cache ??= { dir: '' }

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -182,8 +182,11 @@ export function resolveConfig(
     resolved.passWithNoTests ??= true
 
   resolved.css ??= {}
-  if (typeof resolved.css === 'object')
+  if (typeof resolved.css === 'object') {
     resolved.css.include ??= [/\.module\./]
+    resolved.css.modules ??= {}
+    resolved.css.modules.mangleClassName ??= false
+  }
 
   resolved.cache ??= { dir: '' }
   if (resolved.cache)

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -184,7 +184,7 @@ export function resolveConfig(
   resolved.css ??= {}
   if (typeof resolved.css === 'object') {
     resolved.css.modules ??= {}
-    resolved.css.modules.scopeClassNames ??= false
+    resolved.css.modules.classNamesStrategy ??= 'stable'
   }
 
   resolved.cache ??= { dir: '' }

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -183,9 +183,8 @@ export function resolveConfig(
 
   resolved.css ??= {}
   if (typeof resolved.css === 'object') {
-    resolved.css.include ??= [/\.module\./]
     resolved.css.modules ??= {}
-    resolved.css.modules.mangleClassName ??= false
+    resolved.css.modules.scopeClassNames ??= false
   }
 
   resolved.cache ??= { dir: '' }

--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -56,6 +56,8 @@ export function CSSEnablerPlugin(ctx: Vitest): VitePlugin[] {
           })`
           return { code }
         }
+
+        return { code: '' }
       },
     },
   ]

--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -60,7 +60,7 @@ export function CSSEnablerPlugin(ctx: Vitest): VitePlugin[] {
           // return proxy for css modules, so that imported module has names:
           // styles.foo returns a "foo" instead of "undefined"
           // we don't use code content to generate hash for "scoped", because it's empty
-          const scopeStrategy = (typeof ctx.config.css !== 'boolean' && ctx.config.css.modules?.classNamesStrategy) || 'stable'
+          const scopeStrategy = (typeof ctx.config.css !== 'boolean' && ctx.config.css.modules?.classNameStrategy) || 'stable'
           const proxyReturn = getCSSModuleProxyReturn(scopeStrategy, relative(ctx.config.root, id))
           const code = `export default new Proxy(Object.create(null), {
             get(_, style) {

--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -4,9 +4,14 @@ import type { Vitest } from '../core'
 
 const cssLangs = '\\.(css|less|sass|scss|styl|stylus|pcss|postcss)($|\\?)'
 const cssLangRE = new RegExp(cssLangs)
+const cssModuleRE = new RegExp(`\\.module${cssLangs}`)
 
 const isCSS = (id: string) => {
   return cssLangRE.test(id)
+}
+
+const isCSSModule = (id: string) => {
+  return cssModuleRE.test(id)
 }
 
 export function CSSEnablerPlugin(ctx: Vitest): VitePlugin {
@@ -21,14 +26,33 @@ export function CSSEnablerPlugin(ctx: Vitest): VitePlugin {
     return false
   }
 
+  const shouldReturnProxy = (id: string) => {
+    const { css } = ctx.config
+    if (typeof css === 'boolean')
+      return css
+    if (!isCSSModule(id))
+      return false
+    return !css.modules?.mangleClassName
+  }
+
   return {
     name: 'vitest:css-enabler',
     enforce: 'pre',
     transform(code, id) {
       if (!isCSS(id))
         return
-      if (!shouldProcessCSS(id))
+      if (!shouldProcessCSS(id)) {
         return { code: '' }
+      }
+      else if (shouldReturnProxy(id)) {
+        // TODO parse and check if object actually exists
+        const code = `export default new Proxy(Object.create(null), {
+          get(_, style) {
+            return style;
+          },
+        })`
+        return { code }
+      }
     },
   }
 }

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -98,6 +98,12 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
           },
         }
 
+        if (!preOptions?.css?.modules?.scopeClassNames) {
+          config.css ??= {}
+          config.css.modules ??= {}
+          config.css.modules.generateScopedName = (name: string) => name
+        }
+
         if (!options.browser) {
           // disable deps optimization
           Object.assign(config, {

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -170,7 +170,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
     ...(options.browser
       ? await BrowserPlugin()
       : []),
-    CSSEnablerPlugin(ctx),
+    ...CSSEnablerPlugin(ctx),
     CoverageTransform(ctx),
     options.ui
       ? await UIPlugin()

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -102,14 +102,14 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
           },
         }
 
-        const classNamesStrategy = preOptions.css && preOptions.css?.modules?.classNamesStrategy
+        const classNameStrategy = preOptions.css && preOptions.css?.modules?.classNameStrategy
 
-        if (classNamesStrategy !== 'scoped') {
+        if (classNameStrategy !== 'scoped') {
           config.css ??= {}
           config.css.modules ??= {}
           config.css.modules.generateScopedName = (name: string, filename: string) => {
             const root = getRoot()
-            return generateScopedClassName(classNamesStrategy, name, relative(root, filename))!
+            return generateScopedClassName(classNameStrategy, name, relative(root, filename))!
           }
         }
 

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -1,9 +1,11 @@
 import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
+import { relative } from 'pathe'
 import { configDefaults } from '../../defaults'
 import type { ResolvedConfig, UserConfig } from '../../types'
 import { deepMerge, ensurePackageInstalled, notNullish } from '../../utils'
 import { resolveApiConfig } from '../config'
 import { Vitest } from '../core'
+import { generateScopedClassName } from '../../integrations/css/css-modules'
 import { EnvReplacerPlugin } from './envReplacer'
 import { GlobalSetupPlugin } from './globalSetup'
 import { MocksPlugin } from './mock'
@@ -11,13 +13,15 @@ import { CSSEnablerPlugin } from './cssEnabler'
 import { CoverageTransform } from './coverageTransform'
 
 export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest()): Promise<VitePlugin[]> {
+  const getRoot = () => ctx.config?.root || options.root || process.cwd()
+
   async function UIPlugin() {
-    await ensurePackageInstalled('@vitest/ui', ctx.config?.root || options.root || process.cwd())
+    await ensurePackageInstalled('@vitest/ui', getRoot())
     return (await import('@vitest/ui')).default(options.uiBase)
   }
 
   async function BrowserPlugin() {
-    await ensurePackageInstalled('@vitest/browser', ctx.config?.root || options.root || process.cwd())
+    await ensurePackageInstalled('@vitest/browser', getRoot())
     return (await import('@vitest/browser')).default('/')
   }
 
@@ -98,10 +102,15 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest())
           },
         }
 
-        if (!preOptions?.css?.modules?.scopeClassNames) {
+        const classNamesStrategy = preOptions.css && preOptions.css?.modules?.classNamesStrategy
+
+        if (classNamesStrategy !== 'scoped') {
           config.css ??= {}
           config.css.modules ??= {}
-          config.css.modules.generateScopedName = (name: string) => name
+          config.css.modules.generateScopedName = (name: string, filename: string) => {
+            const root = getRoot()
+            return generateScopedClassName(classNamesStrategy, name, relative(root, filename))!
+          }
         }
 
         if (!options.browser) {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -375,11 +375,14 @@ export interface InlineConfig {
    *
    * When excluded, the CSS files will be replaced with empty strings to bypass the subsequent processing.
    *
-   * @default { include: [/\.module\./] }
+   * @default { include: [/\.module\./], modules: { mangleClassName: false } }
    */
   css?: boolean | {
     include?: RegExp | RegExp[]
     exclude?: RegExp | RegExp[]
+    modules?: {
+      mangleClassName?: boolean
+    }
   }
   /**
    * A number of tests that are allowed to run at the same time marked with `test.concurrent`.

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -375,13 +375,13 @@ export interface InlineConfig {
    *
    * When excluded, the CSS files will be replaced with empty strings to bypass the subsequent processing.
    *
-   * @default { include: [/\.module\./], modules: { mangleClassName: false } }
+   * @default { include: [], modules: { scopeClassNames: false } }
    */
   css?: boolean | {
     include?: RegExp | RegExp[]
     exclude?: RegExp | RegExp[]
     modules?: {
-      mangleClassName?: boolean
+      scopeClassNames?: boolean
     }
   }
   /**

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -376,13 +376,13 @@ export interface InlineConfig {
    *
    * When excluded, the CSS files will be replaced with empty strings to bypass the subsequent processing.
    *
-   * @default { include: [], modules: { classNamesStrategy: false } }
+   * @default { include: [], modules: { classNameStrategy: false } }
    */
   css?: boolean | {
     include?: RegExp | RegExp[]
     exclude?: RegExp | RegExp[]
     modules?: {
-      classNamesStrategy?: CSSModuleScopeStrategy
+      classNameStrategy?: CSSModuleScopeStrategy
     }
   }
   /**

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -12,6 +12,7 @@ import type { Arrayable } from './general'
 export type BuiltinEnvironment = 'node' | 'jsdom' | 'happy-dom' | 'edge-runtime'
 // Record is used, so user can get intellisense for builtin environments, but still allow custom environments
 export type VitestEnvironment = BuiltinEnvironment | (string & Record<never, never>)
+export type CSSModuleScopeStrategy = 'stable' | 'scoped' | 'non-scoped'
 
 export type ApiConfig = Pick<CommonServerOptions, 'port' | 'strictPort' | 'host'>
 
@@ -375,13 +376,13 @@ export interface InlineConfig {
    *
    * When excluded, the CSS files will be replaced with empty strings to bypass the subsequent processing.
    *
-   * @default { include: [], modules: { scopeClassNames: false } }
+   * @default { include: [], modules: { classNamesStrategy: false } }
    */
   css?: boolean | {
     include?: RegExp | RegExp[]
     exclude?: RegExp | RegExp[]
     modules?: {
-      scopeClassNames?: boolean
+      classNamesStrategy?: CSSModuleScopeStrategy
     }
   }
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,7 +126,7 @@ importers:
       unocss: 0.45.13_vite@3.0.9
       unplugin-vue-components: 0.22.4_vite@3.0.9+vue@3.2.38
       vite: 3.0.9
-      vite-plugin-pwa: 0.12.3_vite@3.0.9
+      vite-plugin-pwa: 0.12.3_f7se6o6eqkwcix4u3svh6mkvda
       vitepress: 1.0.0-alpha.13
       workbox-window: 6.5.4
 
@@ -931,6 +931,14 @@ importers:
       vite: 3.0.9
       vitest: link:../../packages/vitest
       vue: 3.2.38
+
+  test/css:
+    specifiers:
+      jsdom: ^20.0.0
+      vitest: workspace:*
+    devDependencies:
+      jsdom: 20.0.0
+      vitest: link:../../packages/vitest
 
   test/edge-runtime:
     specifiers:
@@ -17836,6 +17844,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -18387,10 +18396,11 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.12.3_vite@3.0.9:
+  /vite-plugin-pwa/0.12.3_f7se6o6eqkwcix4u3svh6mkvda:
     resolution: {integrity: sha512-gmYdIVXpmBuNjzbJFPZFzxWYrX4lHqwMAlOtjmXBbxApiHjx9QPXKQPJjSpeTeosLKvVbNcKSAAhfxMda0QVNQ==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0-0
+      workbox-window: ^6.4.0
     dependencies:
       debug: 4.3.4
       fast-glob: 3.2.11

--- a/test/css/package.json
+++ b/test/css/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-css",
+  "private": true,
+  "scripts": {
+    "test": "node testing.mjs",
+    "coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "jsdom": "^20.0.0",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/css/src/App.css
+++ b/test/css/src/App.css
@@ -1,0 +1,4 @@
+.main {
+  display: flex;
+  width: 100px;
+}

--- a/test/css/src/App.module.css
+++ b/test/css/src/App.module.css
@@ -1,0 +1,7 @@
+.main {
+  display: flex;
+}
+
+.module {
+  width: 100px;
+}

--- a/test/css/test/default-css.spec.ts
+++ b/test/css/test/default-css.spec.ts
@@ -11,17 +11,28 @@ describe('don\'t process css by default', () => {
     element.className = 'main'
     const computed = window.getComputedStyle(element)
     expect(computed.display).toBe('block')
+    expect(element).toMatchInlineSnapshot(`
+      <div
+        class="main"
+      />
+    `)
   })
 
   test('module is not processed', async () => {
     const { default: styles } = await import('../src/App.module.css')
 
-    expect(styles.module).toBe('module')
-    expect(styles.someRandomValue).toBe('someRandomValue')
+    // HASH is static, based on the filepath to root
+    expect(styles.module).toBe('_module_c3JjL0')
+    expect(styles.someRandomValue).toBe('_someRandomValue_c3JjL0')
     const element = document.createElement('div')
-    element.className = 'module'
+    element.className = '_module_c3JjL0'
     const computed = window.getComputedStyle(element)
     expect(computed.display).toBe('block')
     expect(computed.width).toBe('')
+    expect(element).toMatchInlineSnapshot(`
+      <div
+        class="_module_c3JjL0"
+      />
+    `)
   })
 })

--- a/test/css/test/default-css.spec.ts
+++ b/test/css/test/default-css.spec.ts
@@ -22,16 +22,16 @@ describe('don\'t process css by default', () => {
     const { default: styles } = await import('../src/App.module.css')
 
     // HASH is static, based on the filepath to root
-    expect(styles.module).toBe('_module_c3JjL0')
-    expect(styles.someRandomValue).toBe('_someRandomValue_c3JjL0')
+    expect(styles.module).toBe('_module_6dc87e')
+    expect(styles.someRandomValue).toBe('_someRandomValue_6dc87e')
     const element = document.createElement('div')
-    element.className = '_module_c3JjL0'
+    element.className = '_module_6dc87e'
     const computed = window.getComputedStyle(element)
     expect(computed.display).toBe('block')
     expect(computed.width).toBe('')
     expect(element).toMatchInlineSnapshot(`
       <div
-        class="_module_c3JjL0"
+        class="_module_6dc87e"
       />
     `)
   })

--- a/test/css/test/default-css.spec.ts
+++ b/test/css/test/default-css.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { useRemoveStyles } from './utils'
+
+describe('don\'t process css by default', () => {
+  useRemoveStyles()
+
+  test('doesn\'t apply css', async () => {
+    await import('../src/App.css')
+
+    const element = document.createElement('div')
+    element.className = 'main'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display).toBe('block')
+  })
+
+  test('module is not processed', async () => {
+    const { default: styles } = await import('../src/App.module.css')
+
+    expect(styles.module).toBe('module')
+    expect(styles.someRandomValue).toBe('someRandomValue')
+    const element = document.createElement('div')
+    element.className = 'module'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display).toBe('block')
+    expect(computed.width).toBe('')
+  })
+})

--- a/test/css/test/non-scope-module.spec.ts
+++ b/test/css/test/non-scope-module.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'vitest'
+
+test('module is processed', async () => {
+  const { default: styles } = await import('../src/App.module.css')
+
+  expect(styles.module).toBe('module')
+  expect(styles.someRandomValue).toBeUndefined()
+  const element = document.createElement('div')
+  element.className = `${styles.main} ${styles.module}`
+  const computed = window.getComputedStyle(element)
+  expect(computed.display).toBe('flex')
+  expect(computed.width).toBe('100px')
+  expect(element).toMatchInlineSnapshot(`
+    <div
+      class="main module"
+    />
+  `)
+})

--- a/test/css/test/process-css.spec.ts
+++ b/test/css/test/process-css.spec.ts
@@ -21,16 +21,16 @@ describe('process only css, not module css', () => {
   test('module is not processed', async () => {
     const { default: styles } = await import('../src/App.module.css')
 
-    expect(styles.module).toBe('_module_c3JjL0')
-    expect(styles.someRandomValue).toBe('_someRandomValue_c3JjL0')
+    expect(styles.module).toBe('_module_6dc87e')
+    expect(styles.someRandomValue).toBe('_someRandomValue_6dc87e')
     const element = document.createElement('div')
-    element.className = '_module_c3JjL0'
+    element.className = '_module_6dc87e'
     const computed = window.getComputedStyle(element)
     expect(computed.display).toBe('block')
     expect(computed.width).toBe('')
     expect(element).toMatchInlineSnapshot(`
       <div
-        class="_module_c3JjL0"
+        class="_module_6dc87e"
       />
     `)
   })

--- a/test/css/test/process-css.spec.ts
+++ b/test/css/test/process-css.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { useRemoveStyles } from './utils'
+
+describe('don\'t process css by default', () => {
+  useRemoveStyles()
+
+  test('apply css', async () => {
+    await import('../src/App.css')
+
+    const element = document.createElement('div')
+    element.className = 'main'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display).toBe('flex')
+  })
+
+  test('module is not processed', async () => {
+    const { default: styles } = await import('../src/App.module.css')
+
+    expect(styles.module).toBe('module')
+    expect(styles.someRandomValue).toBe('someRandomValue')
+    const element = document.createElement('div')
+    element.className = 'module'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display).toBe('block')
+    expect(computed.width).toBe('')
+  })
+})

--- a/test/css/test/process-css.spec.ts
+++ b/test/css/test/process-css.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { useRemoveStyles } from './utils'
 
-describe('don\'t process css by default', () => {
+describe('process only css, not module css', () => {
   useRemoveStyles()
 
   test('apply css', async () => {
@@ -11,17 +11,27 @@ describe('don\'t process css by default', () => {
     element.className = 'main'
     const computed = window.getComputedStyle(element)
     expect(computed.display).toBe('flex')
+    expect(element).toMatchInlineSnapshot(`
+      <div
+        class="main"
+      />
+    `)
   })
 
   test('module is not processed', async () => {
     const { default: styles } = await import('../src/App.module.css')
 
-    expect(styles.module).toBe('module')
-    expect(styles.someRandomValue).toBe('someRandomValue')
+    expect(styles.module).toBe('_module_c3JjL0')
+    expect(styles.someRandomValue).toBe('_someRandomValue_c3JjL0')
     const element = document.createElement('div')
-    element.className = 'module'
+    element.className = '_module_c3JjL0'
     const computed = window.getComputedStyle(element)
     expect(computed.display).toBe('block')
     expect(computed.width).toBe('')
+    expect(element).toMatchInlineSnapshot(`
+      <div
+        class="_module_c3JjL0"
+      />
+    `)
   })
 })

--- a/test/css/test/process-module.spec.ts
+++ b/test/css/test/process-module.spec.ts
@@ -16,16 +16,16 @@ describe('processing module css', () => {
   test('module is processed', async () => {
     const { default: styles } = await import('../src/App.module.css')
 
-    expect(styles.module).toBe('_module_c3JjL0')
+    expect(styles.module).toBe('_module_6dc87e')
     expect(styles.someRandomValue).toBeUndefined()
     const element = document.createElement('div')
-    element.className = '_main_c3JjL0 _module_c3JjL0'
+    element.className = '_main_6dc87e _module_6dc87e'
     const computed = window.getComputedStyle(element)
     expect(computed.display, 'css is processed').toBe('flex')
     expect(computed.width).toBe('100px')
     expect(element).toMatchInlineSnapshot(`
       <div
-        class="_main_c3JjL0 _module_c3JjL0"
+        class="_main_6dc87e _module_6dc87e"
       />
     `)
   })

--- a/test/css/test/process-module.spec.ts
+++ b/test/css/test/process-module.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { useRemoveStyles } from './utils'
+
+describe('don\'t process css by default', () => {
+  useRemoveStyles()
+
+  test('doesn\'t apply css', async () => {
+    await import('../src/App.css')
+
+    const element = document.createElement('div')
+    element.className = 'main'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display).toBe('block')
+  })
+
+  test('module is processed', async () => {
+    const { default: styles } = await import('../src/App.module.css')
+
+    expect(styles.module).toBe('module')
+    expect(styles.someRandomValue).toBeUndefined()
+    const element = document.createElement('div')
+    element.className = 'main module'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display).toBe('flex')
+    expect(computed.width).toBe('100px')
+  })
+})

--- a/test/css/test/process-module.spec.ts
+++ b/test/css/test/process-module.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { useRemoveStyles } from './utils'
 
-describe('don\'t process css by default', () => {
+describe('processing module css', () => {
   useRemoveStyles()
 
   test('doesn\'t apply css', async () => {
@@ -10,18 +10,23 @@ describe('don\'t process css by default', () => {
     const element = document.createElement('div')
     element.className = 'main'
     const computed = window.getComputedStyle(element)
-    expect(computed.display).toBe('block')
+    expect(computed.display, 'css is not processed').toBe('block')
   })
 
   test('module is processed', async () => {
     const { default: styles } = await import('../src/App.module.css')
 
-    expect(styles.module).toBe('module')
+    expect(styles.module).toBe('_module_c3JjL0')
     expect(styles.someRandomValue).toBeUndefined()
     const element = document.createElement('div')
-    element.className = 'main module'
+    element.className = '_main_c3JjL0 _module_c3JjL0'
     const computed = window.getComputedStyle(element)
-    expect(computed.display).toBe('flex')
+    expect(computed.display, 'css is processed').toBe('flex')
     expect(computed.width).toBe('100px')
+    expect(element).toMatchInlineSnapshot(`
+      <div
+        class="_main_c3JjL0 _module_c3JjL0"
+      />
+    `)
   })
 })

--- a/test/css/test/scope-module.spec.ts
+++ b/test/css/test/scope-module.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest'
+
+describe('don\'t process css by default', () => {
+  test('module is processed and scoped', async () => {
+    const { default: styles } = await import('../src/App.module.css')
+
+    expect(styles.module).toMatch(/_module/)
+    expect(styles.someRandomValue).toBeUndefined()
+    const element = document.createElement('div')
+    element.className = 'module main'
+    const computedStatic = window.getComputedStyle(element)
+    expect(computedStatic.display).toBe('block')
+    expect(computedStatic.width).toBe('')
+
+    element.className = `${styles.module} ${styles.main}`
+    const computedModules = window.getComputedStyle(element)
+    expect(computedModules.display).toBe('flex')
+    expect(computedModules.width).toBe('100px')
+  })
+})

--- a/test/css/test/scope-module.spec.ts
+++ b/test/css/test/scope-module.spec.ts
@@ -1,20 +1,28 @@
-import { describe, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
-describe('don\'t process css by default', () => {
-  test('module is processed and scoped', async () => {
-    const { default: styles } = await import('../src/App.module.css')
+test('module is processed and scoped', async () => {
+  const { default: styles } = await import('../src/App.module.css')
 
-    expect(styles.module).toMatch(/_module/)
-    expect(styles.someRandomValue).toBeUndefined()
-    const element = document.createElement('div')
-    element.className = 'module main'
-    const computedStatic = window.getComputedStyle(element)
-    expect(computedStatic.display).toBe('block')
-    expect(computedStatic.width).toBe('')
+  expect(styles.module).toMatch(/_module_\w+_\w/)
+  expect(styles.someRandomValue).toBeUndefined()
+  const element = document.createElement('div')
+  element.className = 'module main'
+  const computedStatic = window.getComputedStyle(element)
+  expect(computedStatic.display).toBe('block')
+  expect(computedStatic.width).toBe('')
+  expect(element).toMatchInlineSnapshot(`
+    <div
+      class="module main"
+    />
+  `)
 
-    element.className = `${styles.module} ${styles.main}`
-    const computedModules = window.getComputedStyle(element)
-    expect(computedModules.display).toBe('flex')
-    expect(computedModules.width).toBe('100px')
-  })
+  element.className = `${styles.module} ${styles.main}`
+  const computedModules = window.getComputedStyle(element)
+  expect(computedModules.display).toBe('flex')
+  expect(computedModules.width).toBe('100px')
+  expect(element).toMatchInlineSnapshot(`
+    <div
+      class="_module_19cso_5 _main_19cso_1"
+    />
+  `)
 })

--- a/test/css/test/utils.ts
+++ b/test/css/test/utils.ts
@@ -1,0 +1,13 @@
+import { afterEach, beforeEach } from 'vitest'
+
+const removeStyles = () => {
+  document.head.querySelectorAll('style').forEach(style => style.remove())
+}
+export function useRemoveStyles() {
+  beforeEach(() => removeStyles())
+  afterEach(() => removeStyles())
+
+  return {
+    removeStyles,
+  }
+}

--- a/test/css/testing.mjs
+++ b/test/css/testing.mjs
@@ -4,8 +4,8 @@ const configs = [
   ['test/default-css', {}],
   ['test/process-css', { include: [/App\.css/] }],
   ['test/process-module', { include: [/App\.module\.css/] }],
-  ['test/scope-module', { include: [/App\.module\.css/], modules: { classNamesStrategy: 'scoped' } }],
-  ['test/non-scope-module', { include: [/App\.module\.css/], modules: { classNamesStrategy: 'non-scoped' } }],
+  ['test/scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'scoped' } }],
+  ['test/non-scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'non-scoped' } }],
 ]
 
 async function runTests() {

--- a/test/css/testing.mjs
+++ b/test/css/testing.mjs
@@ -1,10 +1,11 @@
 import { startVitest } from 'vitest/node'
 
 const configs = [
-  ['default-css', {}],
-  ['process-css', { include: [/App\.css/] }],
-  ['process-module', { include: [/App\.module\.css/] }],
-  ['scope-module', { include: [/App\.module\.css/], modules: { scopeClassNames: true } }],
+  ['test/default-css', {}],
+  ['test/process-css', { include: [/App\.css/] }],
+  ['test/process-module', { include: [/App\.module\.css/] }],
+  ['test/scope-module', { include: [/App\.module\.css/], modules: { classNamesStrategy: 'scoped' } }],
+  ['test/non-scope-module', { include: [/App\.module\.css/], modules: { classNamesStrategy: 'non-scoped' } }],
 ]
 
 async function runTests() {
@@ -12,6 +13,7 @@ async function runTests() {
     const success = await startVitest([name], {
       run: true,
       css: config,
+      update: false,
       teardownTimeout: 1000_000_000,
     })
 

--- a/test/css/testing.mjs
+++ b/test/css/testing.mjs
@@ -1,0 +1,25 @@
+import { startVitest } from 'vitest/node'
+
+const configs = [
+  ['default-css', {}],
+  ['process-css', { include: [/App\.css/] }],
+  ['process-module', { include: [/App\.module\.css/] }],
+  ['scope-module', { include: [/App\.module\.css/], modules: { scopeClassNames: true } }],
+]
+
+async function runTests() {
+  for (const [name, config] of configs) {
+    const success = await startVitest([name], {
+      run: true,
+      css: config,
+      teardownTimeout: 1000_000_000,
+    })
+
+    if (!success)
+      process.exit(1)
+  }
+
+  process.exit(0)
+}
+
+runTests()

--- a/test/css/vitest.config.ts
+++ b/test/css/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
Closes #1512

This PR implements the following logic:

- By default, CSS processing is disabled for every css file
  - `module.*` exports a proxy in that case to not affect runtime (meaning, `styles.{value}` will always return a key with filename hash)
- If processing is enabled (`css.include`), css is processed and injected into DOM
  - By default, `module.*` returns pseudo-scoped class names (`styles.module` always returns `_module_${filenameHash}`, `styles.someRandomValue` will return `undefined`)
  - If you want to enable original scoped names (so production and tests generate the same names), use `css.modules.classNameStrategy: 'scoped'`
- Added `css.modules.classNameStrategy` option:
  - `scoped` - use `css.modules.generateScopeName` from user config or fallback to default behaviour, this is how it works in dev and prod
  - `non-scoped` - returns just the name
  - `stable` - returns the nama and hash, based on filepath, relative to root