### PR TITLE
 fix: .only annotation is ignored (fix #1811)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -545,7 +545,7 @@ export default defineConfig({
 - **Type**: `boolean`
 - **Default**: `false`
 
-Allow tests and suites that are marked as only.
+Allow tests and suites that are marked as only. This also requires to set `threads` to `false`.
 
 ### dangerouslyIgnoreUnhandledErrors
 

--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -22,6 +22,7 @@ function hash(str: string): string {
 
 export async function collectTests(paths: string[], config: ResolvedConfig) {
   const files: File[] = []
+  const filesWithOnlyTasks = []
 
   const browserHashMap = getWorkerState().browserHashMap!
 
@@ -91,9 +92,10 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
     interpretTaskModes(file, config.testNamePattern, hasOnlyTasks, false, config.allowOnly)
 
     files.push(file)
+    if (hasOnlyTasks) filesWithOnlyTasks.push(file);
   }
 
-  return files
+  return config.allowOnly ? filesWithOnlyTasks : files;
 }
 
 /**

--- a/packages/vitest/src/runtime/collect.ts
+++ b/packages/vitest/src/runtime/collect.ts
@@ -92,10 +92,11 @@ export async function collectTests(paths: string[], config: ResolvedConfig) {
     interpretTaskModes(file, config.testNamePattern, hasOnlyTasks, false, config.allowOnly)
 
     files.push(file)
-    if (hasOnlyTasks) filesWithOnlyTasks.push(file);
+    if (hasOnlyTasks)
+      filesWithOnlyTasks.push(file)
   }
 
-  return config.allowOnly ? filesWithOnlyTasks : files;
+  return config.allowOnly ? filesWithOnlyTasks : files
 }
 
 /**


### PR DESCRIPTION
Also add a hint to the API reference that `threat` needs to be `false` when `allowOnly` is used.