### PR TITLE
feat: Add --no-color to cli

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -75,6 +75,7 @@ vitest related /src/index.ts /src/hello-world.js
 | `--changed [since]` | Run tests that are affected by the changed files (default: false). See [docs](#changed) |
 | `--shard <shard>` | Execute tests in a specified shard |
 | `--sequence` | Define in what order to run tests. Use [cac's dot notation] to specify options (for example, use `--sequence.shuffle` to run tests in random order) |
+| `--no-color` | Removes colors from the console output |
 | `-h, --help` | Display available CLI options |
 
 ### changed

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -38,6 +38,7 @@ cli
   .option('--shard <shard>', 'Test suite shard to execute in a format of <index>/<count>')
   .option('--changed [since]', 'Run tests that are affected by the changed files (default: false)')
   .option('--sequence <options>', 'Define in what order to run tests (use --sequence.shuffle to run tests in random order)')
+  .option('--no-color', 'Removes colors from the console output')
   .help()
 
 cli


### PR DESCRIPTION
There was no mention in the documentation that you could turn off colors in the console output. I then dug into what libraries the cli was using and discovered picocolor was adding the colors and that it could be turned off by either assigning the `NO_COLOR` environment variable, or by passing a `--no-color` cli option. 

It made sense to expose the `--no-color` cli option so that users aren't forced into the environment variable route. This also adds an entry into the cli documentation to help users discover the feature.