### PR TITLE
fix: include spy directory export in runtime barrel

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -6,6 +6,7 @@ export { runOnce, isFirstRun } from './integrations/run-once'
 export * from './integrations/chai'
 export * from './integrations/vi'
 export * from './integrations/utils'
+export * from './integrations/spy'
 
 export * from './types'
 export * from './api/types'

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -6,7 +6,7 @@ export { runOnce, isFirstRun } from './integrations/run-once'
 export * from './integrations/chai'
 export * from './integrations/vi'
 export * from './integrations/utils'
-export * from './integrations/spy'
+export { spyOn } from './integrations/spy'
 
 export * from './types'
 export * from './api/types'

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -6,7 +6,7 @@ export { runOnce, isFirstRun } from './integrations/run-once'
 export * from './integrations/chai'
 export * from './integrations/vi'
 export * from './integrations/utils'
-export { spyOn } from './integrations/spy'
+export { spyOn, fn } from './integrations/spy'
 
 export * from './types'
 export * from './api/types'


### PR DESCRIPTION
This PR simply exports the spy module from the integrations directory so that its exports are available as expected

Fixes [#1850]