### PR TITLE
fix: convert string coverage reporters to array

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -184,6 +184,7 @@ function resolveIstanbulOptions(options: CoverageIstanbulOptions, root: string) 
     provider: 'istanbul',
     reportsDirectory,
     tempDirectory: resolve(reportsDirectory, 'tmp'),
+    reporter: Array.isArray(options.reporter) ? options.reporter : [options.reporter],
   }
 
   return resolved as ResolvedCoverageOptions & { provider: 'istanbul' }


### PR DESCRIPTION
Fixes issue where `coverage: { reporters: 'text' }` crashes coverage report generation. String reporter is converted into array of characters and looped here:

https://github.com/vitest-dev/vitest/blob/14279d53e8b5b431a6b6c49dccd3b03696c5a489/packages/coverage-istanbul/src/provider.ts#L112

C8 is already converting string reporters into an array before looping them. Applied the same logic to istanbul.

https://github.com/vitest-dev/vitest/blob/14279d53e8b5b431a6b6c49dccd3b03696c5a489/packages/coverage-c8/src/provider.ts#L121

Error seen with string reporters:
```ts
export default defineConfig({
    test: {
        coverage: {
            provider: 'istanbul',
            enabled: true,
            reporter: 'text'
        }
    },
})
```

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 ❯ Function.Module._resolveFilename node:internal/modules/cjs/loader:933:15
Error: Cannot find module 't'
Require stack:
- /workspaces/vitest/node_modules/.pnpm/istanbul-reports@3.1.5/node_modules/istanbul-reports/index.js
 ❯ Function.Module._load node:internal/modules/cjs/loader:778:27
 ❯ Module.require node:internal/modules/cjs/loader:1005:19
 ❯ require node:internal/modules/cjs/helpers:102:18
 ❯ Object.create ../vitest/node_modules/.pnpm/istanbul-reports@3.1.5/node_modules/istanbul-reports/index.js:19:20
 ❯ IstanbulCoverageProvider.reportCoverage ../vitest/packages/coverage-istanbul/dist/provider-c0b24cef.js:253:15
 ❯ Vitest.start ../vitest/packages/vitest/dist/chunk-vite-node-externalize.1a5aabf5.mjs:9553:7
 ❯ startVitest ../vitest/packages/vitest/dist/chunk-vite-node-externalize.1a5aabf5.mjs:10322:5
 ❯ start ../vitest/packages/vitest/dist/cli.mjs:668:9
 ❯ CAC.run ../vitest/packages/vitest/dist/cli.mjs:664:3

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: {
  "code": "MODULE_NOT_FOUND",
  "requireStack": [
    "/workspaces/vitest/node_modules/.pnpm/istanbul-reports@3.1.5/node_modules/istanbul-reports/index.js",
  ],
}
```