### PR TITLE
docs: guide of extending vite config

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -51,7 +51,7 @@ export default defineConfig({
 })
 ```
 
-You can also extend Vite's options if needed:
+When using a separate `vitest.config.js`, you can also extend Vite's options from another config file if needed:
 
 ```ts
 import { mergeConfig } from 'vite'

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -51,6 +51,20 @@ export default defineConfig({
 })
 ```
 
+You can also extend Vite's options if needed:
+
+```ts
+import { mergeConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: {
+    exclude: ['packages/template/*'],
+  },
+}))
+```
+
 ## Options
 
 :::tip


### PR DESCRIPTION
I hit error:
```
Error: Failed to parse source for import analysis because the content contains invalid JS syntax. Install @vitejs/plugin-vue to handle .vue files.
```
Because vitest.config.ts literally replaces vite config, it is not obvious from docs. And usually you want only augment vite config I suppose.