### PR TITLE
fix: allow referring to first seen value while automocking

### DIFF
--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -224,7 +224,7 @@ export class VitestMocker {
         // Special handling of references we've seen before to prevent infinite
         // recursion in circular objects.
         const refId = refs.getId(value)
-        if (refId) {
+        if (refId !== undefined) {
           finalizers.push(() => define(newContainer, property, refs.getMockedValue(refId)))
           continue
         }

--- a/test/core/src/mockedD.ts
+++ b/test/core/src/mockedD.ts
@@ -1,0 +1,4 @@
+import { MockedC } from './mockedC'
+
+export default MockedC
+export * from './mockedC'

--- a/test/core/test/mocked.test.ts
+++ b/test/core/test/mocked.test.ts
@@ -5,11 +5,13 @@ import { two } from '../src/submodule'
 import * as mocked from '../src/mockedA'
 import { mockedB } from '../src/mockedB'
 import { MockedC, asyncFunc, exportedStream } from '../src/mockedC'
+import MockedDefault, { MockedC as MockedD } from '../src/mockedD'
 import * as globalMock from '../src/global-mock'
 
 vitest.mock('../src/submodule')
 vitest.mock('virtual-module', () => ({ value: 'mock' }))
 vitest.mock('../src/mockedC')
+vitest.mock('../src/mockedD')
 
 test('submodule is mocked to return "two" as 3', () => {
   assert.equal(3, two)
@@ -37,6 +39,7 @@ describe('mocked classes', () => {
   test('should not delete the prototype', () => {
     expect(MockedC).toBeTypeOf('function')
     expect(MockedC.prototype.doSomething).toBeTypeOf('function')
+    expect(MockedC.prototype.constructor).toBe(MockedC)
   })
 
   test('should mock the constructor', () => {
@@ -54,6 +57,17 @@ describe('mocked classes', () => {
 
     expect(MockedC.prototype.doSomething).toHaveBeenCalledOnce()
     expect(MockedC.prototype.doSomething).not.toHaveReturnedWith('A')
+  })
+})
+
+describe('default exported classes', () => {
+  test('should preserve equality for re-exports', () => {
+    expect(MockedDefault).toEqual(MockedD)
+  })
+
+  test('should preserve prototype', () => {
+    expect(MockedDefault.prototype.constructor).toBe(MockedDefault)
+    expect(MockedD.prototype.constructor).toBe(MockedD)
   })
 })
 


### PR DESCRIPTION
The ref ids start at 0. This was a problem because doing `if (refId)` would behave incorrectly if `refId === 0`, which is a valid state.