### PR TITLE
feat(coverage-istanbul): add "all" option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -532,6 +532,13 @@ Set to array of class method names to ignore for coverage.
 
 Watermarks for statements, lines, branches and functions.
 
+##### all
+
+- **Type:** `boolean`
+- **Default:** false
+
+Whether to include all files, including the untested ones into report.
+
 ### testNamePattern
 
 - **Type** `string | RegExp`

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -137,6 +137,11 @@ export interface BaseCoverageOptions {
    * Extensions for files to be included in coverage
    */
   extension?: string | string[]
+
+  /**
+   * Whether to include all files, including the untested ones into report
+   */
+  all?: boolean
 }
 
 export interface CoverageIstanbulOptions extends BaseCoverageOptions {
@@ -166,7 +171,6 @@ export interface CoverageC8Options extends BaseCoverageOptions {
    */
   excludeNodeModules?: boolean
 
-  all?: boolean
   src?: string[]
 
   100?: boolean

--- a/test/coverage-test/coverage-test/coverage.istanbul.test.ts
+++ b/test/coverage-test/coverage-test/coverage.istanbul.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 
 test('istanbul html report', async () => {
-  const coveragePath = resolve('./coverage')
+  const coveragePath = resolve('./coverage/coverage-test/src')
   const files = fs.readdirSync(coveragePath)
 
   expect(files).toContain('index.html')
@@ -21,4 +21,11 @@ test('istanbul lcov report', async () => {
   const lcovReportFiles = fs.readdirSync(lcovReport)
 
   expect(lcovReportFiles).toContain('index.html')
+})
+
+test('all includes untested files', () => {
+  const coveragePath = resolve('./coverage/coverage-test/src')
+  const files = fs.readdirSync(coveragePath)
+
+  expect(files).toContain('untested-file.ts.html')
 })

--- a/test/coverage-test/src/untested-file.ts
+++ b/test/coverage-test/src/untested-file.ts
@@ -1,0 +1,3 @@
+export default function untestedFile() {
+  return 'This file should end up in report when {"all": true} is given'
+}

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     coverage: {
       enabled: true,
       clean: true,
+      all: true,
       reporter: ['html', 'text', 'lcov'],
     },
   },


### PR DESCRIPTION
Adds similar `all` option as [`c8`](https://github.com/bcoe/c8#checking-for-full-source-coverage-using---all) and [`nyc`](https://github.com/istanbuljs/nyc#common-configuration-options) have.

References from other projects:
- `c8`: https://github.com/bcoe/c8/blob/v7.12.0/lib/report.js#L187-L222
- `nyc`: https://github.com/istanbuljs/nyc/blob/v15.1.0/index.js#L186-L217
- `jest`https://github.com/facebook/jest/blob/v28.1.3/packages/jest-reporters/src/CoverageReporter.ts#L107-L222
