### PR TITLE
Show example chai.use example

### DIFF
--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -6,7 +6,18 @@ title: Extending Matchers | Guide
 
 Since Vitest is compatible with both Chai and Jest, you can use either the `chai.use` API or `expect.extend`, whichever you prefer.
 
-This guide will explore extending matchers with `expect.extend`. If you are interested in Chai's API, check [their guide](https://www.chaijs.com/guide/plugins/).
+This guide will explore extending matchers with `expect.extend`, however, here is a little guide on how to extend Chai assertions in Vitest using an existing plugin. If you are interested in Chai's API on how to create Chai plugins check [their guide](https://www.chaijs.com/guide/plugins/). 
+
+To extend Vitest's chai assertions with an existing plugin or one you create, here is a quick example on how to `chai.use` [sinon-chai](https://www.chaijs.com/plugins/sinon-chai/) plugin with Vitest:
+
+```ts
+import { chai } from 'vitest'
+import SinonChai from 'sinon-chai'
+
+chai.use(SinonChai)
+
+// then use it in your tests as indicated in the plugin's documentation.
+```
 
 To extend default matchers, call `expect.extend` with an object containing your matchers.
 

--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -8,7 +8,7 @@ Since Vitest is compatible with both Chai and Jest, you can use either the `chai
 
 This guide will explore extending matchers with `expect.extend`, however, here is a little guide on how to extend Chai assertions in Vitest using an existing plugin. If you are interested in Chai's API on how to create Chai plugins check [their guide](https://www.chaijs.com/guide/plugins/). 
 
-To extend Vitest's chai assertions with an existing plugin or one you create, here is a quick example on how to `chai.use` [sinon-chai](https://www.chaijs.com/plugins/sinon-chai/) plugin with Vitest:
+To extend Vitest's chai assertions with an existing plugin or one you create, here is a quick example of how to `chai.use` [sinon-chai](https://www.chaijs.com/plugins/sinon-chai/) plugin with Vitest:
 
 ```ts
 import { chai } from 'vitest'


### PR DESCRIPTION
Show how to extend vitest.chai using `chai.use` for existing plugins or ones that the developer creates. It's not clear in the documentation how to do this and I believe this is the place to just briefly mention it.