### PR TITLE
fix(reporter-junit): escape XML when in error message (fix: #1823)

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -112,7 +112,10 @@ export class JUnitReporter implements Reporter {
 
   async writeErrorDetails(error: ErrorWithDiff): Promise<void> {
     const errorName = error.name ?? error.nameStr ?? 'Unknown Error'
-    await this.baseLog(`${errorName}: ${error.message}`)
+    const errorDetails = `${errorName}: ${error.message}`
+
+    // Be sure to escape any XML in the error Details
+    await this.baseLog(escapeXML(errorDetails))
 
     const stack = parseStacktrace(error)
 

--- a/test/reporters/src/data-for-junit.ts
+++ b/test/reporters/src/data-for-junit.ts
@@ -1,0 +1,58 @@
+import { AssertionError } from 'assert'
+import type { File, Suite, Task } from 'vitest'
+
+function createSuiteHavingFailedTestWithXmlInError(): File[] {
+  const file: File = {
+    id: '1223128da3',
+    name: 'test/core/test/basic.test.ts',
+    type: 'suite',
+    mode: 'run',
+    filepath: '/vitest/test/core/test/basic.test.ts',
+    result: { state: 'fail', duration: 145.99284195899963 },
+    tasks: [],
+  }
+
+  const suite: Suite = {
+    id: '',
+    type: 'suite',
+    name: 'suite',
+    mode: 'run',
+    file,
+    result: { state: 'pass', duration: 1.90183687210083 },
+    tasks: [],
+  }
+
+  const errorWithXml = new AssertionError({
+    message: 'error message that has XML in it <tag>',
+  })
+
+  errorWithXml.stack = 'Error: error message that has XML in it <tag>\n'
+    + '    at /vitest/test/core/test/basic.test.ts:8:32\n'
+    + '    at etc....'
+
+  const tasks: Task[] = [
+    {
+      id: '123_0',
+      type: 'test',
+      name: 'test with xml in error',
+      mode: 'run',
+      suite,
+      fails: undefined,
+      file,
+      result: {
+        state: 'fail',
+        error: errorWithXml,
+        duration: 2.123123123,
+      },
+      context: null as any,
+    },
+  ]
+
+  file.tasks = [suite]
+  suite.tasks = tasks
+
+  return [file]
+}
+
+export { createSuiteHavingFailedTestWithXmlInError }
+

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -176,58 +176,5 @@ suite.tasks = tasks
 
 const files = [file]
 
-function createSuiteHavingFailedTestWithXmlInError(): File[] {
-  const file: File = {
-    id: '1223128da3',
-    name: 'test/core/test/basic.test.ts',
-    type: 'suite',
-    mode: 'run',
-    filepath: '/vitest/test/core/test/basic.test.ts',
-    result: { state: 'fail', duration: 145.99284195899963 },
-    tasks: [],
-  }
-
-  const suite: Suite = {
-    id: '',
-    type: 'suite',
-    name: 'suite',
-    mode: 'run',
-    file,
-    result: { state: 'pass', duration: 1.90183687210083 },
-    tasks: [],
-  }
-
-  const errorWithXml = new AssertionError({
-    message: 'error message that has XML in it <tag>',
-  })
-
-  errorWithXml.stack = 'Error: error message that has XML in it <tag>\n'
-    + '    at /vitest/test/core/test/basic.test.ts:8:32\n'
-    + '    at etc....'
-
-  const tasks: Task[] = [
-    {
-      id: '123_0',
-      type: 'test',
-      name: 'test with xml in error',
-      mode: 'run',
-      suite,
-      fails: undefined,
-      file,
-      result: {
-        state: 'fail',
-        error: errorWithXml,
-        duration: 2.123123123,
-      },
-      context: null as any,
-    },
-  ]
-
-  file.tasks = [suite]
-  suite.tasks = tasks
-
-  return [file]
-}
-
-export { files, createSuiteHavingFailedTestWithXmlInError }
+export { files }
 

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -174,4 +174,60 @@ const tasks: Task[] = [
 file.tasks = [suite]
 suite.tasks = tasks
 
-export const files = [file]
+const files = [file]
+
+function createSuiteHavingFailedTestWithXmlInError(): File[] {
+  const file: File = {
+    id: '1223128da3',
+    name: 'test/core/test/basic.test.ts',
+    type: 'suite',
+    mode: 'run',
+    filepath: '/vitest/test/core/test/basic.test.ts',
+    result: { state: 'fail', duration: 145.99284195899963 },
+    tasks: [],
+  }
+
+  const suite: Suite = {
+    id: '',
+    type: 'suite',
+    name: 'suite',
+    mode: 'run',
+    file,
+    result: { state: 'pass', duration: 1.90183687210083 },
+    tasks: [],
+  }
+
+  const errorWithXml = new AssertionError({
+    message: 'error message that has XML in it <tag>',
+  })
+
+  errorWithXml.stack = 'Error: error message that has XML in it <tag>\n'
+    + '    at /vitest/test/core/test/basic.test.ts:8:32\n'
+    + '    at etc....'
+
+  const tasks: Task[] = [
+    {
+      id: '123_0',
+      type: 'test',
+      name: 'test with xml in error',
+      mode: 'run',
+      suite,
+      fails: undefined,
+      file,
+      result: {
+        state: 'fail',
+        error: errorWithXml,
+        duration: 2.123123123,
+      },
+      context: null as any,
+    },
+  ]
+
+  file.tasks = [suite]
+  suite.tasks = tasks
+
+  return [file]
+}
+
+export { files, createSuiteHavingFailedTestWithXmlInError }
+

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -236,6 +236,26 @@ AssertionError: expected 2.23606797749979 to equal 2
 "
 `;
 
+exports[`JUnit reporter with outputFile with XML in error details 1`] = `
+"JUNIT report written to <process-cwd>/report.xml
+"
+`;
+
+exports[`JUnit reporter with outputFile with XML in error details 2`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<testsuites>
+    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"1\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"0\\" time=\\"0.145992842\\">
+        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; test with xml in error\\" time=\\"0.0021231231\\">
+            <failure message=\\"error message that has XML in it &lt;tag&gt;\\" type=\\"AssertionError\\">
+AssertionError: error message that has XML in it &lt;tag&gt;
+ ❯ vitest/test/core/test/basic.test.ts:8:32
+            </failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
 exports[`json reporter (no outputFile entry) 1`] = `
 {
   "numFailedTestSuites": 0,

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -236,12 +236,12 @@ AssertionError: expected 2.23606797749979 to equal 2
 "
 `;
 
-exports[`JUnit reporter with outputFile with XML in error details 1`] = `
-"JUNIT report written to <process-cwd>/report.xml
+exports[`JUnit reporter with outputFile with XML in error message 1`] = `
+"JUNIT report written to <process-cwd>/report_escape_msg_xml.xml
 "
 `;
 
-exports[`JUnit reporter with outputFile with XML in error details 2`] = `
+exports[`JUnit reporter with outputFile with XML in error message 2`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
 <testsuites>
     <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"1\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"0\\" time=\\"0.145992842\\">

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -103,10 +103,10 @@ test('JUnit reporter with outputFile', async () => {
   rmSync(outputFile)
 })
 
-test('JUnit reporter with outputFile with XML in error details', async () => {
+test('JUnit reporter with outputFile with XML in error message', async () => {
   // Arrange
   const reporter = new JUnitReporter()
-  const outputFile = resolve('report.xml')
+  const outputFile = resolve('report_escape_msg_xml.xml')
   const context = getContext()
   context.vitest.config.outputFile = outputFile
 

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -6,7 +6,8 @@ import { JUnitReporter } from '../../../packages/vitest/src/node/reporters/junit
 import { TapReporter } from '../../../packages/vitest/src/node/reporters/tap'
 import { TapFlatReporter } from '../../../packages/vitest/src/node/reporters/tap-flat'
 import { getContext } from '../src/context'
-import { createSuiteHavingFailedTestWithXmlInError, files } from '../src/data'
+import { files } from '../src/data'
+import { createSuiteHavingFailedTestWithXmlInError } from '../src/data-for-junit'
 
 afterEach(() => {
   vi.useRealTimers()
@@ -116,7 +117,7 @@ test('JUnit reporter with outputFile with XML in error message', async () => {
 
   vi.setSystemTime(1642587001759)
 
-  // setup test with failed test with xml
+  // setup suite with failed test with xml
   const filesWithTestHavingXmlInError = createSuiteHavingFailedTestWithXmlInError()
 
   // Act


### PR DESCRIPTION
When a error message has XML it made the junit reporter wasn't escaping when writing it to the log. 

This should fix #1823 

I don't love how i created `createSuiteHavingFailedTestWithXmlInError` to have an test case and welcome feedback.




