### PR TITLE
feat: try to serialize error as possible

### DIFF
--- a/packages/vitest/src/runtime/error.ts
+++ b/packages/vitest/src/runtime/error.ts
@@ -7,45 +7,50 @@ const OBJECT_PROTO = Object.getPrototypeOf({})
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 export function serializeError(val: any, seen = new WeakMap()): any {
-  if (!val || typeof val === 'string')
-    return val
-  if (typeof val === 'function')
-    return `Function<${val.name}>`
-  if (typeof val !== 'object')
-    return val
-  if (val instanceof Promise || 'then' in val || (val.constructor && val.constructor.prototype === 'AsyncFunction'))
-    return 'Promise'
-  if (typeof Element !== 'undefined' && val instanceof Element)
-    return val.tagName
-  if (typeof val.asymmetricMatch === 'function')
-    return `${val.toString()} ${util.format(val.sample)}`
+  try {
+    if (!val || typeof val === 'string')
+      return val
+    if (typeof val === 'function')
+      return `Function<${val.name}>`
+    if (typeof val !== 'object')
+      return val
+    if (val instanceof Promise || 'then' in val || (val.constructor && val.constructor.prototype === 'AsyncFunction'))
+      return 'Promise'
+    if (typeof Element !== 'undefined' && val instanceof Element)
+      return val.tagName
+    if (typeof val.asymmetricMatch === 'function')
+      return `${val.toString()} ${util.format(val.sample)}`
 
-  if (seen.has(val))
-    return seen.get(val)
+    if (seen.has(val))
+      return seen.get(val)
 
-  if (Array.isArray(val)) {
-    const clone: any[] = new Array(val.length)
-    seen.set(val, clone)
-    val.forEach((e, i) => {
-      clone[i] = serializeError(e, seen)
-    })
-    return clone
-  }
-  else {
-    // Objects with `Error` constructors appear to cause problems during worker communication
-    // using `MessagePort`, so the serialized error object is being recreated as plain object.
-    const clone = Object.create(null)
-    seen.set(val, clone)
-
-    let obj = val
-    while (obj && obj !== OBJECT_PROTO) {
-      Object.getOwnPropertyNames(obj).forEach((key) => {
-        if (!(key in clone))
-          clone[key] = serializeError(obj[key], seen)
+    if (Array.isArray(val)) {
+      const clone: any[] = new Array(val.length)
+      seen.set(val, clone)
+      val.forEach((e, i) => {
+        clone[i] = serializeError(e, seen)
       })
-      obj = Object.getPrototypeOf(obj)
+      return clone
     }
-    return clone
+    else {
+      // Objects with `Error` constructors appear to cause problems during worker communication
+      // using `MessagePort`, so the serialized error object is being recreated as plain object.
+      const clone = Object.create(null)
+      seen.set(val, clone)
+
+      let obj = val
+      while (obj && obj !== OBJECT_PROTO) {
+        Object.getOwnPropertyNames(obj).forEach((key) => {
+          if (!(key in clone))
+            clone[key] = serializeError(obj[key], seen)
+        })
+        obj = Object.getPrototypeOf(obj)
+      }
+      return clone
+    }
+  }
+  catch (e: any) {
+    return { UNSERIALIZABLE_VALUE: { error: e.message } }
   }
 }
 
@@ -86,12 +91,7 @@ export function processError(err: any) {
   }
   catch {}
 
-  try {
-    return serializeError(err)
-  }
-  catch (e: any) {
-    return serializeError(new Error(`Failed to fully serialize error: ${e?.message}\nInner error message: ${err?.message}`))
-  }
+  return serializeError(err)
 }
 
 function isAsymmetricMatcher(data: any) {

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream'
 import { describe, expect, it } from 'vitest'
 import { serializeError } from '../../../packages/vitest/src/runtime/error'
 
@@ -92,5 +93,14 @@ describe('error serialize', () => {
       stack: expect.any(String),
       toString: 'Function<toString>',
     })
+  })
+
+  it('Should try to serialize even if the object contains unserializable values', () => {
+    const unserializable = new Readable()
+    const error = Object.assign(new Error('test'), { unserializable })
+
+    const serialized = serializeError(error)
+    expect(serialized.unserializable).toHaveProperty('UNSERIALIZABLE_VALUE')
+    expect(serialized.unserializable.UNSERIALIZABLE_VALUE.error).toBeTypeOf('string')
   })
 })


### PR DESCRIPTION
This PR is based on issue #1882 and improves the error serialization.

As per an [test example](https://github.com/kaorukobo/vitest/commit/2a8abd9bb1c35ced983401e7d6dd397c3a169697#diff-bfdbab86fc478fa36ab4a47c11aeae9a5a1aaa0ce4b1ac8bf89495711654e867), it serializes an error object as possible even if the object contains unserializable values.

Therefore, vitest will not show `Failed to fully serialize` error anymore and the stacktrace/codeframe comes up as usual.

## Substitution of unserializable value

Values that failed to serialize are substituted with an special object as follows: 
`{ UNSERIALIZABLE_VALUE: { error: 'ErrorMessage' } }`.

## Note on axios

As for axios mentioned in #1822, the AxiosError object does not contain `stack` property in the first place. So the stacktrace does not appear even though this patch is applied.
