### PR TITLE
fix: invalidate new worker and its dependencies (fix #1873)

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -91,6 +91,24 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     }
     return invalidated
   }
+
+  /**
+   * Invalidate dependency modules of the given modules, down to the bottom-level dependencies
+   */
+  invalidateSubDepTree(ids: string[] | Set<string>, invalidated = new Set<string>()) {
+    for (const _id of ids) {
+      const id = this.normalizePath(_id)
+      if (invalidated.has(id))
+        continue
+      invalidated.add(id)
+      const subIds = Array.from(super.entries())
+        .filter(([,mod]) => mod.importers?.has(id))
+        .map(([key]) => key)
+      subIds.length && this.invalidateSubDepTree(subIds, invalidated)
+      super.delete(id)
+    }
+    return invalidated
+  }
 }
 
 export class ViteNodeRunner {

--- a/packages/web-worker/src/pure.ts
+++ b/packages/web-worker/src/pure.ts
@@ -133,11 +133,11 @@ export function defineWebWorker() {
 
       runner.executeFile(fsPath)
         .then(() => {
-          invalidates.forEach((fsPath) => {
-            // worker should be new every time
-            moduleCache.delete(fsPath)
-            moduleCache.delete(`mock:${fsPath}`)
-          })
+          // worker should be new every time, invalidate its sub dependency
+          moduleCache.invalidateSubDepTree(
+            invalidates.reduce(
+              (acc, fsPath) => acc.concat([fsPath, `mock:${fsPath}`]), [] as string[]
+          ))
           const q = this.messageQueue
           this.messageQueue = null
           if (q)

--- a/packages/web-worker/src/pure.ts
+++ b/packages/web-worker/src/pure.ts
@@ -136,8 +136,8 @@ export function defineWebWorker() {
           // worker should be new every time, invalidate its sub dependency
           moduleCache.invalidateSubDepTree(
             invalidates.reduce(
-              (acc, fsPath) => acc.concat([fsPath, `mock:${fsPath}`]), [] as string[]
-          ))
+              (acc, fsPath) => acc.concat([fsPath, `mock:${fsPath}`]), [] as string[],
+            ))
           const q = this.messageQueue
           this.messageQueue = null
           if (q)

--- a/test/web-worker/src/selfWorker.ts
+++ b/test/web-worker/src/selfWorker.ts
@@ -1,0 +1,3 @@
+import subSelf from './selfWorkerDep'
+
+self.postMessage(subSelf === self)

--- a/test/web-worker/src/selfWorkerDep.ts
+++ b/test/web-worker/src/selfWorkerDep.ts
@@ -1,0 +1,1 @@
+export default self


### PR DESCRIPTION
Worker and its dependencies should be invalidated every time it is created so that Worker module and its dependencies will be injected into a new `context` on the next creation.

fix #1873

Before PR:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/102238922/185831297-4aafbd0f-b3f0-4a0d-89c6-ad8278349149.png">


After PR:

<img width="619" alt="image" src="https://user-images.githubusercontent.com/102238922/185831243-08639713-90b6-4cc6-9a9b-6f87ee7354f8.png">

