### PR TITLE
fix: clean coverage-c8 tmp before reporting (fix #1917)

### DIFF
--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs } from 'fs'
+import { existsSync, promises as fs, mkdirSync, rmSync } from 'fs'
 import _url from 'url'
 import type { Profiler } from 'inspector'
 import { takeCoverage } from 'v8'
@@ -29,6 +29,18 @@ export class C8CoverageProvider implements CoverageProvider {
   }
 
   onBeforeFilesRun() {
+    let tmpExist = existsSync(this.options.tempDirectory)
+
+    // clean tmp dir before run
+    if (tmpExist) {
+      rmSync(this.options.tempDirectory, { recursive: true, force: true })
+      tmpExist = false
+    }
+
+    // make sure tmp dir exist before run
+    if (!tmpExist)
+      mkdirSync(this.options.tempDirectory, { recursive: true })
+
     process.env.NODE_V8_COVERAGE ||= this.options.tempDirectory
   }
 

--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs, mkdirSync, rmSync } from 'fs'
+import { existsSync, promises as fs } from 'fs'
 import _url from 'url'
 import type { Profiler } from 'inspector'
 import { takeCoverage } from 'v8'
@@ -29,18 +29,6 @@ export class C8CoverageProvider implements CoverageProvider {
   }
 
   onBeforeFilesRun() {
-    let tmpExist = existsSync(this.options.tempDirectory)
-
-    // clean tmp dir before run
-    if (tmpExist) {
-      rmSync(this.options.tempDirectory, { recursive: true, force: true })
-      tmpExist = false
-    }
-
-    // make sure tmp dir exist before run
-    if (!tmpExist)
-      mkdirSync(this.options.tempDirectory, { recursive: true })
-
     process.env.NODE_V8_COVERAGE ||= this.options.tempDirectory
   }
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -105,8 +105,6 @@ export class Vitest {
 
     this.runningPromise = undefined
 
-    await this.coverageProvider?.clean(this.config.coverage.clean)
-
     this.cache.results.setConfig(resolved.root, resolved.cache)
     try {
       await this.cache.results.readFromCache()
@@ -148,6 +146,7 @@ export class Vitest {
   async start(filters?: string[]) {
     try {
       await this.initCoverageProvider()
+      await this.coverageProvider?.clean(this.config.coverage.clean)
     }
     catch (e) {
       this.logger.error(e)


### PR DESCRIPTION
fix #1917 

Clean tmp dir before coverage-c8 report each time.

Same as:


https://github.com/bcoe/c8/blob/7f1069dcce6821a6794557b39d6a13f620c64bad/bin/c8.js#L31-L35