### PR TITLE
fix!: drop support for Vite 2

### DIFF
--- a/.tazerc.json
+++ b/.tazerc.json
@@ -1,6 +1,6 @@
 {
   "exclude": [
-    "vite",
+    "vue",
     "puppeteer",
     "pretty-format",
     "pathe"

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@vitest/ui": "latest",
-    "happy-dom": "latest",
+    "jsdom": "latest",
     "vite": "latest",
     "vitest": "latest"
   },

--- a/examples/lit/test/basic.test.ts
+++ b/examples/lit/test/basic.test.ts
@@ -1,26 +1,23 @@
-import type { IWindow } from 'happy-dom'
-import { beforeEach, describe, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '../src/my-button'
 
-declare global {
-  interface Window extends IWindow {}
-}
-
 describe('Button with increment', async () => {
-  beforeEach(async () => {
-    document.body.innerHTML = '<my-button name="World"></my-button>'
-    await window.happyDOM.whenAsyncComplete()
-    await new Promise(resolve => setTimeout(resolve, 0))
-  })
-
   function getInsideButton(): HTMLElement | null | undefined {
     return document.body.querySelector('my-button')?.shadowRoot?.querySelector('button')
   }
 
+  beforeEach(async () => {
+    document.body.innerHTML = '<my-button name="World"></my-button>'
+    await new Promise<void>(resolve => setInterval(() => {
+      if (getInsideButton())
+        resolve()
+    }))
+  })
+
   it('should increment the count on each click', () => {
     getInsideButton()?.click()
-    expect(getInsideButton()?.innerText).toContain('1')
+    expect(getInsideButton()?.textContent).toContain('1')
   })
 
   it('should show name props', () => {

--- a/examples/lit/test/basic.test.ts
+++ b/examples/lit/test/basic.test.ts
@@ -9,10 +9,14 @@ describe('Button with increment', async () => {
 
   beforeEach(async () => {
     document.body.innerHTML = '<my-button name="World"></my-button>'
-    await new Promise<void>(resolve => setInterval(() => {
-      if (getInsideButton())
-        resolve()
-    }))
+    await new Promise<void>((resolve) => {
+      const interval = setInterval(() => {
+        if (getInsideButton()) {
+          clearInterval(interval)
+          resolve()
+        }
+      })
+    })
   })
 
   it('should increment the count on each click', () => {

--- a/examples/lit/vite.config.ts
+++ b/examples/lit/vite.config.ts
@@ -6,6 +6,6 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'happy-dom',
+    environment: 'jsdom',
   },
 })

--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -73,7 +73,7 @@
     "debug": "^4.3.4",
     "mlly": "^0.5.16",
     "pathe": "^0.2.0",
-    "vite": "^2.9.12 || ^3.0.0-0"
+    "vite": "^3.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -106,7 +106,7 @@
     "tinybench": "^2.2.1",
     "tinypool": "^0.3.0",
     "tinyspy": "^1.0.2",
-    "vite": "^2.9.12 || ^3.0.0-0"
+    "vite": "^3.0.0"
   },
   "devDependencies": {
     "@antfu/install-pkg": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ importers:
   examples/lit:
     specifiers:
       '@vitest/ui': latest
-      happy-dom: latest
+      jsdom: latest
       lit: ^2.2.5
       vite: ^3.1.0
       vitest: workspace:*
@@ -193,7 +193,7 @@ importers:
       lit: 2.3.1
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 7.3.0
+      jsdom: 20.0.1
       vite: 3.1.0
       vitest: link:../../packages/vitest
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
       lit: 2.3.1
     devDependencies:
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 6.0.4
+      happy-dom: 7.3.0
       vite: 3.1.0
       vitest: link:../../packages/vitest
 
@@ -238,7 +238,7 @@ importers:
       react-dom: 18.0.0_react@18.0.0
     devDependencies:
       '@testing-library/react': 13.3.0_zpnidt7m3osuk7shl3s4oenomq
-      '@types/node': 18.8.0
+      '@types/node': 18.8.3
       '@types/react': 18.0.21
       '@vitejs/plugin-react': 2.1.0
       jsdom: 20.0.1
@@ -290,7 +290,7 @@ importers:
       '@types/react-test-renderer': 17.0.2
       '@vitejs/plugin-react': 2.1.0_vite@3.1.0
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 6.0.4
+      happy-dom: 7.3.0
       jsdom: 20.0.1
       react-test-renderer: 17.0.2_react@17.0.2
       vite: 3.1.0
@@ -958,7 +958,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue': 3.1.2_vite@3.1.0+vue@3.2.40
       '@vue/test-utils': 2.1.0_vue@3.2.40
-      happy-dom: 6.0.4
+      happy-dom: 7.3.0
       vite: 3.1.0
       vitest: link:../../packages/vitest
       vue: 3.2.40
@@ -5635,7 +5635,7 @@ packages:
   /@types/concat-stream/1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
-      '@types/node': 18.8.0
+      '@types/node': 18.8.3
     dev: true
 
   /@types/cookie/0.4.1:
@@ -5693,9 +5693,9 @@ packages:
     dev: true
 
   /@types/form-data/0.0.33:
-    resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
+    resolution: {integrity: sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=}
     dependencies:
-      '@types/node': 18.8.0
+      '@types/node': 18.8.3
     dev: true
 
   /@types/fs-extra/9.0.13:
@@ -5852,6 +5852,10 @@ packages:
 
   /@types/node/18.8.0:
     resolution: {integrity: sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==}
+    dev: true
+
+  /@types/node/18.8.3:
+    resolution: {integrity: sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==}
     dev: true
 
   /@types/node/8.10.66:
@@ -11810,6 +11814,20 @@ packages:
 
   /happy-dom/6.0.4:
     resolution: {integrity: sha512-b+ID23Ms0BY08UNLymsOMG7EI2jSlwEt4cbJs938GZfeNAg+fqgkSO3TokQMgSOFoHznpjWmpVjBUL5boJ9PWw==}
+    dependencies:
+      css.escape: 1.5.1
+      he: 1.2.0
+      node-fetch: 2.6.7
+      sync-request: 6.1.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /happy-dom/7.3.0:
+    resolution: {integrity: sha512-KJDR6CJ2S9MeOznLUU4iF98sh2yBmwEOTFcJHHZvNCYo8PsmgeeECZqUOr33VmNdSYBO+X9hSOTjeT533hwSXA==}
     dependencies:
       css.escape: 1.5.1
       he: 1.2.0


### PR DESCRIPTION
Given the fact that Vite 3 is out for about two months and most of the ecosystem is finished upgrading, we could drop the compact range for Vite to allow non-vite usage always to install Vite 3 as the dependency.