### PR TITLE
fix: don't throw on null error, hide JSON results warning

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -1,7 +1,7 @@
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
 import { parseStacktrace } from '../utils/source-map'
 import type { VitestMocker } from '../runtime/mocker'
-import { getWorkerState, resetModules, setTimeout } from '../utils'
+import { createSimpleError, getWorkerState, resetModules, setTimeout } from '../utils'
 import { FakeTimers } from './mock/timers'
 import type { EnhancedSpy, MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartiallyMockedDeep } from './spy'
 import { fn, isMockFunction, spies, spyOn } from './spy'
@@ -108,7 +108,7 @@ class VitestUtils {
   fn = fn
 
   private getImporter() {
-    const err = new Error('mock')
+    const err = createSimpleError('mock', 3)
     const [,, importer] = parseStacktrace(err, true)
     return importer.file
   }

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -1,7 +1,8 @@
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
 import { parseStacktrace } from '../utils/source-map'
 import type { VitestMocker } from '../runtime/mocker'
-import { createSimpleError, getWorkerState, resetModules, setTimeout } from '../utils'
+import { getWorkerState, resetModules, setTimeout } from '../utils'
+import { createErrorWithTraceLimit } from '../utils/base'
 import { FakeTimers } from './mock/timers'
 import type { EnhancedSpy, MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartiallyMockedDeep } from './spy'
 import { fn, isMockFunction, spies, spyOn } from './spy'
@@ -108,7 +109,7 @@ class VitestUtils {
   fn = fn
 
   private getImporter() {
-    const err = createSimpleError('mock', 3)
+    const err = createErrorWithTraceLimit('mock', 3)
     const [,, importer] = parseStacktrace(err, true)
     return importer.file
   }

--- a/packages/vitest/src/node/cache/results.ts
+++ b/packages/vitest/src/node/cache/results.ts
@@ -34,9 +34,12 @@ export class ResultsCache {
 
     if (fs.existsSync(this.cachePath)) {
       const resultsCache = await fs.promises.readFile(this.cachePath, 'utf8')
-      const { results, version } = JSON.parse(resultsCache)
-      this.cache = new Map(results)
-      this.version = version
+      try {
+        const { results, version } = JSON.parse(resultsCache)
+        this.cache = new Map(results)
+        this.version = version
+      }
+      catch {}
     }
   }
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -106,12 +106,7 @@ export class Vitest {
     this.runningPromise = undefined
 
     this.cache.results.setConfig(resolved.root, resolved.cache)
-    try {
-      await this.cache.results.readFromCache()
-    }
-    catch (err) {
-      this.logger.error(`[vitest] Error, while trying to parse cache in ${this.cache.results.getCachePath()}:`, err)
-    }
+    await this.cache.results.readFromCache()
   }
 
   async initCoverageProvider() {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -1,7 +1,7 @@
 import type { ErrorWithDiff, File, Task, TaskResultPack, UserConsoleLog } from '../types'
 // can't import actual functions from utils, because it's incompatible with @vitest/browsers
 import type { AggregateError as AggregateErrorPonyfill } from '../utils'
-import { createSimpleError } from '../utils'
+import { createErrorWithTraceLimit } from '../utils/base'
 
 interface CollectingPromise {
   promise: Promise<void>
@@ -26,7 +26,7 @@ export class StateManager {
 
   catchError(err: unknown, type: string): void {
     if (err == null)
-      err = createSimpleError('Unknown "null" error thrown')
+      err = createErrorWithTraceLimit('Unknown "null" error thrown')
 
     if (isAggregateError(err))
       return err.errors.forEach(error => this.catchError(error, type))

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -177,3 +177,21 @@ export function shuffle<T>(array: T[], seed = RealDate.now()): T[] {
 
   return array
 }
+
+// removes stack trace from error, when we don't really need it
+// by default stack trace limit is 100 in vitest, but we might
+// create errors just to get the last line of stack trace behind the scenes
+export function createSimpleError(message?: string, limit = 0) {
+  if (!('stackTraceLimit' in Error)) {
+    const err = new Error(message)
+    if (limit === 0)
+      err.stack = ''
+    return err
+  }
+
+  const oldLimit = Error.stackTraceLimit
+  Error.stackTraceLimit = limit
+  const err = new Error(message)
+  Error.stackTraceLimit = oldLimit
+  return err
+}

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -181,7 +181,7 @@ export function shuffle<T>(array: T[], seed = RealDate.now()): T[] {
 // removes stack trace from error, when we don't really need it
 // by default stack trace limit is 100 in vitest, but we might
 // create errors just to get the last line of stack trace behind the scenes
-export function createSimpleError(message?: string, limit = 0) {
+export function createErrorWithTraceLimit(message?: string, limit = 0) {
   if (!('stackTraceLimit' in Error)) {
     const err = new Error(message)
     if (limit === 0)


### PR DESCRIPTION
We might corrupt JSON somehow, if user ends the process, so I think we should just skip it.