### PR TITLE
doc: fix option for updating snapshots

### DIFF
--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -63,7 +63,7 @@ When the received value doesn't match the snapshot, the test fails and shows you
 
 In watch mode, you can press the `u` key in the terminal to update the failed snapshot directly.
 
-Or you can use the `--updateSnapshot` or `-u` flag in the CLI to make Vitest update snapshots.
+Or you can use the `--update` or `-u` flag in the CLI to make Vitest update snapshots.
 
 ```bash
 vitest -u


### PR DESCRIPTION
Documentation suggests using `vitest --updateSnapshot` to update snapshots. When doing so, `vitest` throws an error.

```node
file:///usr/local/share/.config/yarn/global/node_modules/vitest/dist/cli.mjs:432
          throw new CACError(`Unknown option \`${name.length > 1 ? `--${name}` : `-${name}`}\``);
                ^

CACError: Unknown option `--updateSnapshot`
    at Command.checkUnknownOptions (file:///usr/local/share/.config/yarn/global/node_modules/vitest/dist/cli.mjs:432:17)
    at CAC.runMatchedCommand (file:///usr/local/share/.config/yarn/global/node_modules/vitest/dist/cli.mjs:630:13)
    at CAC.parse (file:///usr/local/share/.config/yarn/global/node_modules/vitest/dist/cli.mjs:569:12)
    at file:///usr/local/share/.config/yarn/global/node_modules/vitest/dist/cli.mjs:655:5
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12)
```

The correct way how to update snapshots based on `--help` is to use `vitest --update`.