### PR TITLE
fix(dev) fix issue with decoding URI for import expression

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -15,12 +15,12 @@ export const DEFAULT_REQUEST_STUBS = {
     injectQuery: (id: string) => id,
     createHotContext() {
       return {
-        accept: () => {},
-        prune: () => {},
-        dispose: () => {},
-        decline: () => {},
-        invalidate: () => {},
-        on: () => {},
+        accept: () => { },
+        prune: () => { },
+        dispose: () => { },
+        decline: () => { },
+        invalidate: () => { },
+        on: () => { },
       }
     },
     updateStyle(id: string, css: string) {
@@ -102,7 +102,7 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
         continue
       invalidated.add(id)
       const subIds = Array.from(super.entries())
-        .filter(([,mod]) => mod.importers?.has(id))
+        .filter(([, mod]) => mod.importers?.has(id))
         .map(([key]) => key)
       subIds.length && this.invalidateSubDepTree(subIds, invalidated)
       super.delete(id)
@@ -221,7 +221,7 @@ export class ViteNodeRunner {
       return requestStubs[id]
 
     // eslint-disable-next-line prefer-const
-    let { code: transformed, externalize } = await this.options.fetchModule(id)
+    let { code: transformed, externalize } = await this.options.fetchModule(decodeURI(id))
     if (externalize) {
       debugNative(externalize)
       const exports = await this.interopedImport(externalize)

--- a/test/core/test/import-with-space.test.ts
+++ b/test/core/test/import-with-space.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+
+describe('should import default import from file within folder with space', async () => {
+  const util = await import('file:///test/test%20util/helper') // Error: [vite-node] Failed to load /test/test%20dir/util.mjs
+  it('should be triggered', () => {
+    expect(util.default).toBe('test helper')
+  })
+})

--- a/test/core/test/test util/helper.ts
+++ b/test/core/test/test util/helper.ts
@@ -1,0 +1,1 @@
+export default 'test helper'


### PR DESCRIPTION
close #1937

I just add `decodeURI` on the argument for the method responsible for resolving import expression.

I create a directory `test utils`+ one ts file with default export.
My unit test is importing this ts file via import expression and assert default export.
The import expression argument is encoded 
`const util = await import('file:///test/test%20util/helper')`