### PR TITLE
fix: make globalThis more compatible with jest

### DIFF
--- a/packages/vitest/src/integrations/chai/constants.ts
+++ b/packages/vitest/src/integrations/chai/constants.ts
@@ -1,2 +1,3 @@
 export const GLOBAL_EXPECT = Symbol.for('expect-global')
 export const MATCHERS_OBJECT = Symbol.for('matchers-object')
+export const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object')

--- a/packages/vitest/src/integrations/chai/jest-asymmetric-matchers.ts
+++ b/packages/vitest/src/integrations/chai/jest-asymmetric-matchers.ts
@@ -16,6 +16,7 @@ export abstract class AsymmetricMatcher<
   T,
   State extends MatcherState = MatcherState,
 > implements AsymmetricMatcherInterface {
+  // should have "jest" to be compatible with its ecosystem
   $$typeof = Symbol.for('jest.asymmetricMatcher')
 
   constructor(protected sample: T, protected inverse = false) {}

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -10,11 +10,20 @@ import type { ChaiPlugin, MatcherState } from '../../types/chai'
 import { arrayBufferEquality, generateToBeMessage, iterableEquality, equals as jestEquals, sparseArrayEquality, subsetEquality, typeEquality } from './jest-utils'
 import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import { stringify } from './jest-matcher-utils'
-import { MATCHERS_OBJECT } from './constants'
+import { GLOBAL_EXPECT, JEST_MATCHERS_OBJECT, MATCHERS_OBJECT } from './constants'
 
 if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {
+  const matchers = new WeakMap<Vi.ExpectStatic, MatcherState>()
   Object.defineProperty(globalThis, MATCHERS_OBJECT, {
-    value: new WeakMap<Vi.ExpectStatic, MatcherState>(),
+    get: () => matchers,
+  })
+  Object.defineProperty(globalThis, JEST_MATCHERS_OBJECT, {
+    configurable: true,
+    writable: true,
+    get: () => ({
+      state: matchers.get((globalThis as any)[GLOBAL_EXPECT]),
+      matchers: Object.create(null),
+    }),
   })
 }
 

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -19,7 +19,6 @@ if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {
   })
   Object.defineProperty(globalThis, JEST_MATCHERS_OBJECT, {
     configurable: true,
-    writable: true,
     get: () => ({
       state: matchers.get((globalThis as any)[GLOBAL_EXPECT]),
       matchers: Object.create(null),

--- a/packages/vitest/src/integrations/chai/jest-extend.ts
+++ b/packages/vitest/src/integrations/chai/jest-extend.ts
@@ -6,7 +6,7 @@ import type {
   SyncExpectationResult,
 } from '../../types/chai'
 import { getSnapshotClient } from '../snapshot/chai'
-import { GLOBAL_EXPECT } from './constants'
+import { JEST_MATCHERS_OBJECT } from './constants'
 import { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import { getState } from './jest-expect'
 
@@ -80,7 +80,7 @@ function JestExtendPlugin(expect: Vi.ExpectStatic, matchers: MatchersObject): Ch
 
       const expectAssertionWrapper = isAsyncFunction(expectAssertion) ? expectAsyncWrapper : expectSyncWrapper
 
-      utils.addMethod((globalThis as any)[GLOBAL_EXPECT].matchers, expectAssertionName, expectAssertionWrapper)
+      utils.addMethod((globalThis as any)[JEST_MATCHERS_OBJECT].matchers, expectAssertionName, expectAssertionWrapper)
       utils.addMethod(c.Assertion.prototype, expectAssertionName, expectAssertionWrapper)
 
       class CustomMatcher extends AsymmetricMatcher<[unknown, ...unknown[]]> {

--- a/packages/vitest/src/integrations/chai/jest-extend.ts
+++ b/packages/vitest/src/integrations/chai/jest-extend.ts
@@ -6,6 +6,7 @@ import type {
   SyncExpectationResult,
 } from '../../types/chai'
 import { getSnapshotClient } from '../snapshot/chai'
+import { GLOBAL_EXPECT } from './constants'
 import { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import { getState } from './jest-expect'
 
@@ -79,6 +80,7 @@ function JestExtendPlugin(expect: Vi.ExpectStatic, matchers: MatchersObject): Ch
 
       const expectAssertionWrapper = isAsyncFunction(expectAssertion) ? expectAsyncWrapper : expectSyncWrapper
 
+      utils.addMethod((globalThis as any)[GLOBAL_EXPECT].matchers, expectAssertionName, expectAssertionWrapper)
       utils.addMethod(c.Assertion.prototype, expectAssertionName, expectAssertionWrapper)
 
       class CustomMatcher extends AsymmetricMatcher<[unknown, ...unknown[]]> {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -603,4 +603,16 @@ describe('async expect', () => {
   })
 })
 
+it('compatible with jest', () => {
+  expect.extend({
+    someObject() {
+      return { pass: true, message: () => '' }
+    },
+  })
+  const { matchers, state } = (globalThis as any)[Symbol.for('$$jest-matchers-object')]
+  expect(matchers).toHaveProperty('someObject')
+  expect(matchers).toHaveProperty('toBe')
+  expect(state).toHaveProperty('assertionCalls', 1)
+})
+
 it('timeout', () => new Promise(resolve => setTimeout(resolve, 500)))

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -612,7 +612,7 @@ it('compatible with jest', () => {
   const { matchers, state } = (globalThis as any)[Symbol.for('$$jest-matchers-object')]
   expect(matchers).toHaveProperty('someObject')
   expect(matchers).toHaveProperty('toBe')
-  expect(state).toHaveProperty('assertionCalls', 1)
+  expect(state.assertionCalls).toBe(2)
 })
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, 500)))


### PR DESCRIPTION
While investigating #756 I noticed we put our global state using another symbol. Our state is also incompatible with jest, because we have local expects.