### PR TITLE
fix: show diff for errors that contain actual/expected without showDiff

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -69,7 +69,8 @@ export async function printError(error: unknown, ctx: Vitest, options: PrintErro
 
   handleImportOutsideModuleError(e.stack || e.stackStr || '', ctx)
 
-  if (e.showDiff) {
+  // Eg. AssertionError from assert does not set showDiff but has both actual and expected properties
+  if (e.showDiff || (e.showDiff === undefined && e.actual && e.expected)) {
     displayDiff(stringify(e.actual), stringify(e.expected), ctx.logger.console, {
       outputTruncateLength: ctx.config.outputTruncateLength,
       outputDiffLines: ctx.config.outputDiffLines,


### PR DESCRIPTION
Display a diff of `actual`/`expected` when `showDiff` is undefined (as is the case for the AssertionError of node's assert).

Resolves https://github.com/vitest-dev/vitest/issues/1965

Ping @sheremet-va 