### PR TITLE
docs: add different package managers installations

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -16,14 +16,16 @@ You can try Vitest online on [StackBlitz](https://vitest.new). It runs Vitest di
 
 ## Adding Vitest to your Project
 
+With npm
 ```bash
-# with npm
 npm install -D vitest
-
-# or with yarn
+```
+or with yarn
+```bash
 yarn add -D vitest
-
-# or with pnpm
+```
+or with pnpm
+```bash
 pnpm add -D vitest
 ```
 


### PR DESCRIPTION
Allow users to copy the corresponding bash command depending on which package manager they are using. Accomplished this by separating the bash commands from the descriptive texts "with npm" "or with yarn" or "with pnpm"