### PR TITLE
docs: fix contrast between lang name and code block

### DIFF
--- a/docs/.vitepress/style/vars.css
+++ b/docs/.vitepress/style/vars.css
@@ -17,6 +17,8 @@
   --vp-custom-block-tip-bg: rgba(18, 181, 157, 0.1);
   /* fix contrast on gray cards: used by --vp-c-text-2 */
   --vp-c-text-light-2: rgba(56 56 56 / 70%);
+  /* fix contrast: lang name on gray code block */
+  --vp-c-text-dark-3: rgba(180, 180, 180, 0.7);
 }
 
 .dark {
@@ -28,6 +30,8 @@
   --vp-custom-block-tip-bg: rgba(18, 181, 157, 0.1);
   /* fix contrast on gray cards: check the same above (this is the default) */
   --vp-c-text-dark-2: rgba(235, 235, 235, 0.60);
+  /* fix lang name: check the same above (this is the default) */
+  --vp-c-text-dark-3: rgba(235, 235, 235, 0.38);
 }
 
 /**


### PR DESCRIPTION
fix #1994 by darkening `--vp-c-text-dark-3`

It seems that only lang name and code line number (which does not exist in vitest docs) are affected by `--vp-c-text-dark-3` in light mode.

https://github.com/vuejs/vitepress/blob/b1511cf7b702a72b8fc79ff8190f9ae3c8fae2de/src/client/theme-default/styles/vars.css#L209

https://github.com/vuejs/vitepress/blob/b1511cf7b702a72b8fc79ff8190f9ae3c8fae2de/src/client/theme-default/styles/components/vp-doc.css#L415

Now in light mode:
![image](https://user-images.githubusercontent.com/40021217/188909568-e10cdc8d-3112-41fe-b71a-6ee124d88436.png)
