### PR TITLE
fix(bench): rank sorting, fix #2006

### DIFF
--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -347,7 +347,7 @@ async function runBenchmarkSuit(suite: Suite) {
       suite.result!.state = 'pass'
 
       benchmarkInstance.tasks
-        .sort((a, b) => b.result!.mean - a.result!.mean)
+        .sort((a, b) => a.result!.mean - b.result!.mean)
         .forEach((cycle, idx) => {
           const benchmark = benchmarkMap[cycle.name || '']
           benchmark.result!.state = 'pass'


### PR DESCRIPTION
Since the fastest benchmark has a rank of 1, we should be sorting in ascending, not descending, order.