### PR TITLE
docs: fix `vi.fn` signature

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1794,7 +1794,7 @@ Vitest provides utility functions to help you out through it's **vi** helper. Yo
 
 ### vi.fn
 
-- **Type:** `(fn: Function) => CallableMockInstance`
+- **Type:** `(fn?: Function) => CallableMockInstance`
 
   Creates a spy on a function, though can be initiated without one. Every time a function is invoked, it stores its call arguments, returns and instances. Also, you can manipulate its behavior with [methods](#mockinstance-methods).
   If no function is given, mock will return `undefined`, when invoked.


### PR DESCRIPTION
Make the argument optional as described:

> Creates a spy on a function, though can be initiated without one.