### PR TITLE
fix: propagate `describe` options

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -268,7 +268,7 @@ When you use `test` in the top level of file, they are collected as part of the 
 
 ### describe.skip
 
-- **Type:** `(name: string, fn: TestFunction) => void`
+- **Type:** `(name: string, fn: TestFunction, options?: number | TestOptions) => void`
 
   Use `describe.skip` in a suite to avoid running a particular describe block.
 
@@ -285,7 +285,7 @@ When you use `test` in the top level of file, they are collected as part of the 
 
 ### describe.only
 
-- **Type:** `(name: string, fn: TestFunction) => void`
+- **Type:** `(name: string, fn: TestFunction, options?: number | TestOptions) => void`
 
   Use `describe.only` to only run certain suites
 
@@ -311,7 +311,7 @@ When you use `test` in the top level of file, they are collected as part of the 
 
 ### describe.concurrent
 
-- **Type:** `(name: string, fn: TestFunction, timeout?: number) => void`
+- **Type:** `(name: string, fn: TestFunction, options?: number | TestOptions) => void`
 
   `describe.concurrent` in a suite marks every tests as concurrent
 
@@ -335,7 +335,7 @@ When you use `test` in the top level of file, they are collected as part of the 
 
 ### describe.shuffle
 
-- **Type:** `(name: string, fn: TestFunction, timeout?: number | TestOptions) => void`
+- **Type:** `(name: string, fn: TestFunction, options?: number | TestOptions) => void`
 
   Vitest provides a way to run all tests in random order via CLI flag [`--sequence.shuffle`](/guide/cli) or config option [`sequence.shuffle`](/config/#sequence-shuffle), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
 
@@ -362,7 +362,7 @@ When you use `test` in the top level of file, they are collected as part of the 
   ```
 ### describe.each
 
-- **Type:** `(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => void) => void`
+- **Type:** `(cases: ReadonlyArray<T>): (name: string, fn: (...args: T[]) => void, options?: number | TestOptions) => void`
 
   Use `describe.each` if you have more than one test that depends on the same data.
 

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -159,7 +159,7 @@ export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & {
 
 type ChainableSuiteAPI<ExtraContext = {}> = ChainableFunction<
   'concurrent' | 'only' | 'skip' | 'todo' | 'shuffle',
-  [name: string, factory?: SuiteFactory<ExtraContext>],
+  [name: string, factory?: SuiteFactory<ExtraContext>, options?: number | TestOptions],
   SuiteCollector<ExtraContext>,
   {
     each: TestEachFunction

--- a/test/core/test/retry-only.test.ts
+++ b/test/core/test/retry-only.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+describe.only('description.only retry', () => {
+  let count4 = 0
+  let count5 = 0
+  it('test should inherit options from the description block if missing', () => {
+    count4 += 1
+    expect(count4).toBe(2)
+  })
+
+  it('test should not inherit options from the description block if exists', () => {
+    count5 += 1
+    expect(count5).toBe(5)
+  }, { retry: 5 })
+}, { retry: 2 })

--- a/test/core/test/retry.test.ts
+++ b/test/core/test/retry.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 let count1 = 0
 it('retry test', () => {
@@ -23,3 +23,44 @@ it('result', () => {
   expect(count2).toEqual(2)
   expect(count3).toEqual(3)
 })
+
+describe('description retry', () => {
+  let count4 = 0
+  let count5 = 0
+  it('test should inherit options from the description block if missing', () => {
+    count4 += 1
+    expect(count4).toBe(2)
+  })
+
+  it('test should not inherit options from the description block if exists', () => {
+    count5 += 1
+    expect(count5).toBe(5)
+  }, { retry: 5 })
+}, { retry: 2 })
+
+describe.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('describe object add($a, $b)', ({ a, b, expected }) => {
+  let flag1 = false
+  let flag2 = false
+  let flag3 = false
+  it(`returns ${expected}`, () => {
+    flag1 = !flag1
+    expect(a + b).toBe(expected)
+    expect(flag1).toBe(false)
+  })
+
+  it(`returned value not be greater than ${expected}`, () => {
+    flag2 = !flag2
+    expect(a + b).not.toBeGreaterThan(expected)
+    expect(flag2).toBe(false)
+  })
+
+  it(`returned value not be less than ${expected}`, () => {
+    flag3 = !flag3
+    expect(a + b).not.toBeLessThan(expected)
+    expect(flag3).toBe(false)
+  })
+}, { retry: 2 })


### PR DESCRIPTION
...to all tests inside

close: #1998