### PR TITLE
fix(cli): forward node wasm flags

### DIFF
--- a/packages/vitest/src/node/cli-wrapper.ts
+++ b/packages/vitest/src/node/cli-wrapper.ts
@@ -15,7 +15,7 @@ const NODE_ARGS = [
   '--inspect-brk',
   '--trace-deprecation',
   '--experimental-wasm-threads',
-  '--wasm-atomics-on-non-shared-memory'
+  '--wasm-atomics-on-non-shared-memory',
 ]
 
 interface ErrorDef {

--- a/packages/vitest/src/node/cli-wrapper.ts
+++ b/packages/vitest/src/node/cli-wrapper.ts
@@ -14,6 +14,8 @@ const NODE_ARGS = [
   '--inspect',
   '--inspect-brk',
   '--trace-deprecation',
+  '--experimental-wasm-threads',
+  '--wasm-atomics-on-non-shared-memory'
 ]
 
 interface ErrorDef {


### PR DESCRIPTION
`--experimental-wasm-threads --wasm-atomics-on-non-shared-memory`
These node options cannot be enabled via the `NODE_OPTIONS` environment variable, only via cli flags. But using `node --experimental-wasm-threads --wasm-atomics-on-non-shared-memory vitest` only applies them to `cli-wrapper`, not to any subsequently spawned processes. The proposed change adds them to the list of flags that Vitest forwards to spawned processes.