### PR TITLE
fix: run related test, even if test doesn't have dependencies

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -235,7 +235,7 @@ export class Vitest {
     if (!related.length)
       return []
 
-    const testDeps = await Promise.all(
+    const testGraphs = await Promise.all(
       tests.map(async (filepath) => {
         const deps = await this.getTestDependencies(filepath)
         return [filepath, deps] as const
@@ -244,9 +244,9 @@ export class Vitest {
 
     const runningTests = []
 
-    for (const [filepath, deps] of testDeps) {
+    for (const [filepath, deps] of testGraphs) {
       // if deps or the test itself were changed
-      if (deps.size && related.some(path => path === filepath || deps.has(path)))
+      if (related.some(path => path === filepath || deps.has(path)))
         runningTests.push(filepath)
     }
 


### PR DESCRIPTION
Currently if test doesn't have any dependencies, but was changed, `vitest related` will not run it.