### PR TITLE
fix(coverage): `istanbul-reports` to support `projectRoot`

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -120,6 +120,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
     for (const reporter of this.options.reporter) {
       reports.create(reporter as any, {
         skipFull: this.options.skipFull,
+        projectRoot: this.ctx.config.root,
       }).execute(context)
     }
 


### PR DESCRIPTION
Adds support for configuring `projectRoot` of `istanbul-reports`. This is something that `nyc` does as well: https://github.com/istanbuljs/nyc/blob/v15.1.0/index.js#L465. `c8` has similar PR open.

The `istanbul-reports` uses this internally for reporters `['clover', 'cobertura', 'lcovonly']`. Many third party tooling use the pure `lcov.info` when creating their own reports, e.g. SonarQube.

#### Example

```
/workspaces/__vitest-monorepo-coverage
├── package.json
└── packages
   ├── a
   |  ├── package.json
   |  └── src
   |     └── index.js
   └── b
      ├── package.json
      ├── src
      |  ├── add-and-double.js
      |  └── add-and-double.test.js
      └── vitest.config.js
```

```js
// packages/b/vitest.config.js
export default defineConfig({
  test: { coverage: { provider: "istanbul", reporter: 'lcovonly' } }
});

```

```sh
# Run in project root
$ vitest run --coverage -r packages/b
```
`coverage/lcov.info`:
Before: `SF:packages/b/src/add-and-double.js`
After: `SF:src/add-and-double.js`