### PR TITLE
The Chinese code template lacks the three slash command

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -44,6 +44,8 @@ One of the main advantages of Vitest is its unified configuration with Vite. If 
 To configure `vitest` itself, add `test` property in your Vite config. You'll also need to add a reference to Vitest types using a [triple slash command](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) at the top of your config file, if you are importing `defineConfig` from `vite` itself.
 
 ```ts
+/// <reference types="vitest" />
+
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
The Chinese document code template lacks the three slash command

<img width="691" alt="image" src="https://user-images.githubusercontent.com/48111694/191261128-321c2d3a-702b-4b3b-acb5-4f24023e8af8.png">
