### PR TITLE
docs: description for coverage `include` option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -526,6 +526,13 @@ Used when `provider: 'c8'` is set. Coverage options are passed to [`c8`](https:/
 
 Used when `provider: 'istanbul'` is set.
 
+##### include
+
+- **Type:** `string[]`
+- **Default:** `['**']`
+
+List of files included in coverage as glob patterns
+
 ##### exclude
 
 - **Type:** `string[]`


### PR DESCRIPTION
Adds missing documentation of #1883.

Default value comes from https://github.com/istanbuljs/test-exclude#optionsinclude.