### PR TITLE
fix: align `.each` behavior with jest

### DIFF
--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -200,12 +200,15 @@ function createSuite() {
     return createSuiteCollector(name, factory, mode, this.concurrent, this.shuffle, options)
   }
 
-  suiteFn.each = function<T>(this: { withContext: () => SuiteAPI }, cases: ReadonlyArray<T>) {
+  suiteFn.each = function <T>(this: { withContext: () => SuiteAPI }, cases: ReadonlyArray<T>) {
     const suite = this.withContext()
     return (name: string, fn: (...args: T[]) => void, options?: number | TestOptions) => {
+      const arrayOnlyCases = cases.every(Array.isArray)
       cases.forEach((i, idx) => {
         const items = Array.isArray(i) ? i : [i]
-        suite(formatTitle(name, items, idx), () => fn(...items), options)
+        arrayOnlyCases
+          ? suite(formatTitle(name, items, idx), () => fn(...items), options)
+          : suite(formatTitle(name, items, idx), () => fn(i), options)
       })
     }
   }
@@ -233,9 +236,12 @@ function createTest(fn: (
     const test = this.withContext()
 
     return (name: string, fn: (...args: T[]) => void, options?: number | TestOptions) => {
+      const arrayOnlyCases = cases.every(Array.isArray)
       cases.forEach((i, idx) => {
         const items = Array.isArray(i) ? i : [i]
-        test(formatTitle(name, items, idx), () => fn(...items), options)
+        arrayOnlyCases
+          ? test(formatTitle(name, items, idx), () => fn(...items), options)
+          : test(formatTitle(name, items, idx), () => fn(i), options)
       })
     }
   }

--- a/test/core/test/each.test.ts
+++ b/test/core/test/each.test.ts
@@ -9,13 +9,6 @@ test.each([
 })
 
 test.each([
-  null,
-  [null],
-])('null is null', (value) => {
-  expect(value).toBe(null)
-})
-
-test.each([
   ['string', true],
   ['string', false],
 ])('can be parsed', (a, b) => {
@@ -135,4 +128,37 @@ describe('context with each - concurrent', () => {
       expect(number1 + number2).toBe(number3)
     })
   })
+})
+
+describe('not all arguments are array describe.each', () => {
+  const results = [null, [null]]
+  let i = 0
+
+  describe.each([null, [null]])('null is null', (value) => {
+    test('null is null', () => {
+      expect(value).toEqual(results[i++])
+    })
+  })
+})
+
+describe('not all arguments are array test.each', () => {
+  const results = [null, [null]]
+  let i = 0
+
+  test.each([null, [null]])('null is null', (value) => {
+    expect(value).toEqual(results[i++])
+  })
+})
+
+test.each([
+  null,
+])('value is null', (value) => {
+  expect(value).toBeNull()
+})
+
+test.each([
+  [null, null],
+  [null, null],
+])('if all cases are arrays of equal length, treats array elements as arguments', (value) => {
+  expect(value).toBeNull()
 })

--- a/test/core/test/each.test.ts
+++ b/test/core/test/each.test.ts
@@ -142,10 +142,16 @@ describe('not all arguments are array describe.each', () => {
 })
 
 describe('not all arguments are array test.each', () => {
-  const results = [null, [null]]
+  const results = [
+    null,
+    [null],
+  ]
   let i = 0
 
-  test.each([null, [null]])('null is null', (value) => {
+  test.each([
+    null,
+    [null],
+  ])('matches results', (value) => {
     expect(value).toEqual(results[i++])
   })
 })
@@ -159,6 +165,7 @@ test.each([
 test.each([
   [null, null],
   [null, null],
-])('if all cases are arrays of equal length, treats array elements as arguments', (value) => {
-  expect(value).toBeNull()
+])('if all cases are arrays of equal length, treats array elements as arguments', (value1, value2) => {
+  expect(value1).toBeNull()
+  expect(value2).toBeNull()
 })


### PR DESCRIPTION
close #1858