### PR TITLE
fix(docs): use `type: node` in launch configuration to debug (fix #2080)

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -14,7 +14,7 @@ To debug a test file in VSCode, create the following launch configuration.
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "name": "Debug Current Test File",
       "autoAttachChildProcesses": true,


### PR DESCRIPTION
fix #2080 