### PR TITLE
docs: add instructions for debugging tests via terminal

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -6,7 +6,7 @@ title: Debugging | Guide
 
 ## Terminal
 
-To debug a test file in your shell, add a `debugger` statement anywhere in your code, and then run `ndb`:
+To debug a test file without an IDE, you can use [`ndb`](https://github.com/GoogleChromeLabs/ndb). Just add a `debugger` statement anywhere in your code, and then run `ndb`:
 
 ```sh
 # install ndb globally

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -4,6 +4,18 @@ title: Debugging | Guide
 
 # Debugging
 
+## Terminal
+
+To debug a test file in you shell, add a `debugger` statement anywhere in your code, and then run `ndb`:
+
+```sh
+# install ndb globally
+npm install -g ndb
+
+# run tests with debugger enabled
+ndb npm run test
+```
+
 ## VSCode
 
 To debug a test file in VSCode, create the following launch configuration.

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -12,6 +12,9 @@ To debug a test file in your shell, add a `debugger` statement anywhere in your 
 # install ndb globally
 npm install -g ndb
 
+# alternatively, with yarn
+yarn global add ndb
+
 # run tests with debugger enabled
 ndb npm run test
 ```

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -6,7 +6,7 @@ title: Debugging | Guide
 
 ## Terminal
 
-To debug a test file in you shell, add a `debugger` statement anywhere in your code, and then run `ndb`:
+To debug a test file in your shell, add a `debugger` statement anywhere in your code, and then run `ndb`:
 
 ```sh
 # install ndb globally


### PR DESCRIPTION
Adds example of running `vitest` with debugger in the shell (without an IDE) 