### PR TITLE
docs: more resources

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -129,6 +129,10 @@ pnpm link --global # you can use your preferred package manager for this step
 
 Then go to the project where you are using Vitest and run `pnpm link --global vitest` (or the package manager that you used to link `vitest` globally).
 
+## More Resources 
+
+- [Vitest + React Testing Library](https://www.robinwieruch.de/vitest-react-testing-library/)
+
 ## Community
 
 If you have questions or need help, reach out to the community at [Discord](https://chat.vitest.dev) and [GitHub Discussions](https://github.com/vitest-dev/vitest/discussions).


### PR DESCRIPTION
Not sure whether this is wanted in the documentation, however, when I set up Vitest with React Testing Library, I didn't find any resources about it.

Context: [The Road to React](https://www.amazon.com/dp/B077HJFCQX) is using Vite/Vitest instead of CRA/Jest now 🎆 Hence I needed to come up with a short guide which helps readers to install React Testing Library in Vitest.