### PR TITLE
fix: don't show extra properties for test context

### DIFF
--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -205,11 +205,6 @@ export interface RuntimeContext {
 
 export interface TestContext {
   /**
-   * @deprecated Use promise instead
-   */
-  (error?: any): void
-
-  /**
    * Metadata of the current test
    */
   meta: Readonly<Test>

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -55,5 +55,6 @@ test.skip('async with timeout', async () => {
 it('timeout', () => new Promise(resolve => setTimeout(resolve, timeout)))
 
 it.fails('deprecated done callback', (done) => {
+  // @ts-expect-error deprecated done callback is not typed
   done()
 })


### PR DESCRIPTION
This is still a function at runtime. But right now it shows a lot of function properties, like "arguments", "apply" and such, which bloats actual context.