### PR TITLE
fix(coverage): fix sourcemaps of uncovered lines

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -211,7 +211,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
 
         const lastCoverage = this.instrumenter.lastFileCoverage()
         if (lastCoverage)
-          coverageMap.data[lastCoverage.path] = lastCoverage
+          coverageMap.addFileCoverage(lastCoverage)
       }
     }
   }

--- a/test/coverage-test/coverage-test/coverage.istanbul.test.ts
+++ b/test/coverage-test/coverage-test/coverage.istanbul.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 
 test('istanbul html report', async () => {
-  const coveragePath = resolve('./coverage/coverage-test/src')
+  const coveragePath = resolve('./coverage')
   const files = fs.readdirSync(coveragePath)
 
   expect(files).toContain('index.html')
@@ -24,7 +24,7 @@ test('istanbul lcov report', async () => {
 })
 
 test('all includes untested files', () => {
-  const coveragePath = resolve('./coverage/coverage-test/src')
+  const coveragePath = resolve('./coverage')
   const files = fs.readdirSync(coveragePath)
 
   expect(files).toContain('untested-file.ts.html')

--- a/test/coverage-test/src/untested-file.ts
+++ b/test/coverage-test/src/untested-file.ts
@@ -1,3 +1,33 @@
+/*
+ * Some top level comment which adds some padding. This helps us see
+ * if sourcemaps are off.
+*/
+
 export default function untestedFile() {
   return 'This file should end up in report when {"all": true} is given'
+}
+
+function add(a: number, b: number) {
+  // This line should NOT be covered
+  return a + b
+}
+
+function multiply(a: number, b: number) {
+  // This line should NOT be covered
+  return a * b
+}
+
+export function math(a: number, b: number, operator: '*' | '+') {
+  if (operator === '*') {
+    // This line should NOT be covered
+    return multiply(a, b)
+  }
+
+  if (operator === '+') {
+    // This line should NOT be covered
+    return add(a, b)
+  }
+
+  // This line should NOT be covered
+  throw new Error('Unsupported operator')
 }


### PR DESCRIPTION
While looking into #2121 I noticed that sourcemaps of uncovered files' coverages are off. 

```bash
$ cd test/coverage-test
$ pnpm coverage:istanbul
$ npx live-server ./coverage
```

Before:
<img src="https://user-images.githubusercontent.com/14806298/194381350-ad1df2c3-1fe6-46fc-b118-9894b3997b60.png" width="320px" />

After:

<img src="https://user-images.githubusercontent.com/14806298/194381405-664542b8-a39c-4186-a465-5441d9b58df2.png" width="320px" />

