### PR TITLE
build: include *.d.cts files in npm package

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -67,6 +67,7 @@
     "dist",
     "bin",
     "*.d.ts",
+    "*.d.cts",
     "*.mjs",
     "*.cjs"
   ],


### PR DESCRIPTION
In the [package.json](https://github.com/vitest-dev/vitest/blob/af3ad61791bd6c04838270d274417bc5001aefed/packages/vitest/package.json#L27) there is a `index.d.cts` declaration file defined for all packages that use CommonJS (`require`)

```json
"exports": {
  ".": {
    "require": {
      "types": "./index.d.cts",
      "default": "./index.cjs"
    },
    "import": {
      "types": "./dist/index.d.ts",
      "default": "./dist/index.js"
    }
  },
```

Unfortunately this file is missing in the npm package:

<img width="197" alt="Screenshot 2022-10-09 at 09 11 13" src="https://user-images.githubusercontent.com/149248/194743627-3e8e8ec9-5204-4922-8388-bbe68115b61a.png">

