### PR TITLE
chore: add/update `repository` properties in `package.json`

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/vitest-dev/vitest#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitest-dev/vitest.git"
+    "url": "git+https://github.com/vitest-dev/vitest.git",
+    "directory": "packages/vitest"
   },
   "bugs": {
     "url": "https://github.com/vitest-dev/vitest/issues"

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -3,6 +3,11 @@
   "type": "module",
   "version": "0.24.3",
   "description": "Web Worker support for testing in Vitest",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vitest-dev/vitest.git",
+    "directory": "packages/web-worker"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/vitest-dev/vitest#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitest-dev/vitest.git"
+    "url": "git+https://github.com/vitest-dev/vitest.git",
+    "directory": "packages/ws-client"
   },
   "bugs": {
     "url": "https://github.com/vitest-dev/vitest/issues"


### PR DESCRIPTION
Ensure all packages specify both `repository` and `repository.directory`, which helps package tooling to find the correct source files based on the npm package metadata.