### PR TITLE
fix: ignore benchmark.reporters in getSerializableConfig

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -142,6 +142,10 @@ export class Vitest {
         ...this.config.sequence,
         sequencer: undefined!,
       },
+      benchmark: {
+        ...this.config.benchmark,
+        reporters: [],
+      } as ResolvedConfig['benchmark'],
     },
     this.configOverride || {} as any,
     ) as ResolvedConfig

--- a/test/benchmark/vitest.config.ts
+++ b/test/benchmark/vitest.config.ts
@@ -1,12 +1,25 @@
 import { defineConfig } from 'vitest/config'
 
+const noop = () => {}
+
 export default defineConfig({
   test: {
     update: false,
     allowOnly: true,
     benchmark: {
       outputFile: './bench.json',
-      reporters: ['json'],
+      reporters: ['json', {
+        onInit: noop,
+        onPathsCollected: noop,
+        onCollected: noop,
+        onFinished: noop,
+        onTaskUpdate: noop,
+        onTestRemoved: noop,
+        onWatcherStart: noop,
+        onWatcherRerun: noop,
+        onServerRestart: noop,
+        onUserConsoleLog: noop,
+      }],
     },
   },
 })


### PR DESCRIPTION
- overwrite `benchmark.reporters` to empty array in `getSerializableConfig`, it makes custom reporter not throw `DataCloneError`
- add custom reporter test case in `@vitest/benchmark`