### PR TITLE
chore: rename variable for clarity

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -178,9 +178,9 @@ export abstract class BaseReporter implements Reporter {
   shouldLog(log: UserConsoleLog) {
     if (this.ctx.config.silent)
       return false
-    const shouldIgnore = this.ctx.config.onConsoleLog?.(log.content, log.type)
-    if (shouldIgnore === false)
-      return shouldIgnore
+    const shouldLog = this.ctx.config.onConsoleLog?.(log.content, log.type)
+    if (shouldLog === false)
+      return shouldLog
     return true
   }
 


### PR DESCRIPTION
This renames the variable `shouldIgnore` to `shouldLog` as this is what the value of the variable is actually saying.

