### PR TITLE
feat: json report skip bench mark

### DIFF
--- a/packages/vitest/src/node/reporters/benchmark/json.ts
+++ b/packages/vitest/src/node/reporters/benchmark/json.ts
@@ -29,12 +29,16 @@ export class JsonReporter implements Reporter {
     for (const file of files) {
       const tests = getTests([file])
       for (const test of tests) {
-        const res = test.result?.benchmark
-        if (!res || test.mode === 'skip') // TODO mark as skipped
-          continue
+        let res = test.result?.benchmark
+        if (!res || test.mode === 'skip') {
+          res = {
+            name: test.name,
+          } as any
+        }
+
         if (!outputFile)
-          res.samples = 'ignore on terminal' as any
-        testResults[test.suite.name] = (testResults[test.suite.name] || []).concat(res)
+          res!.samples = 'ignore on terminal' as any
+        testResults[test.suite.name] = (testResults[test.suite.name] || []).concat(res!)
       }
 
       if (tests.some(t => t.result?.state === 'run')) {

--- a/test/benchmark/test/mode.bench.ts
+++ b/test/benchmark/test/mode.bench.ts
@@ -3,13 +3,13 @@ import { bench, describe } from 'vitest'
 describe.todo('unimplemented suite')
 
 describe.skip('skipped', () => {
-  bench('skipped', () => {
+  bench('skipped-1', () => {
     throw new Error('should be skipped')
   })
 
   bench.todo('unimplemented test')
 })
 
-bench.skip('skipped', () => {
+bench.skip('skipped-2', () => {
   throw new Error('should be skipped')
 })


### PR DESCRIPTION
#2005

keep json output if `benck.skip`