### PR TITLE
fix(reporter): load custom reporter using `executeFile`

### DIFF
--- a/packages/vitest/src/node/reporters/utils.ts
+++ b/packages/vitest/src/node/reporters/utils.ts
@@ -1,4 +1,5 @@
 import type { ViteNodeRunner } from 'vite-node/client'
+import { normalize } from 'pathe'
 import type { Reporter } from '../../types'
 import { BenchmarkReportsMap, ReportersMap } from './index'
 import type { BenchmarkBuiltinReporters, BuiltinReporters } from './index'
@@ -6,7 +7,7 @@ import type { BenchmarkBuiltinReporters, BuiltinReporters } from './index'
 async function loadCustomReporterModule<C extends Reporter>(path: string, runner: ViteNodeRunner): Promise<new () => C> {
   let customReporterModule: { default: new () => C }
   try {
-    customReporterModule = await runner.executeId(`/@fs/${path}`)
+    customReporterModule = await runner.executeId(normalize(`/@fs/${path}`))
   }
   catch (customReporterModuleError) {
     throw new Error(`Failed to load custom Reporter from ${path}`, { cause: customReporterModuleError as Error })

--- a/packages/vitest/src/node/reporters/utils.ts
+++ b/packages/vitest/src/node/reporters/utils.ts
@@ -6,7 +6,7 @@ import type { BenchmarkBuiltinReporters, BuiltinReporters } from './index'
 async function loadCustomReporterModule<C extends Reporter>(path: string, runner: ViteNodeRunner): Promise<new () => C> {
   let customReporterModule: { default: new () => C }
   try {
-    customReporterModule = await runner.executeId(path)
+    customReporterModule = await runner.executeId(`/@fs/${path}`)
   }
   catch (customReporterModuleError) {
     throw new Error(`Failed to load custom Reporter from ${path}`, { cause: customReporterModuleError as Error })

--- a/packages/vitest/src/node/reporters/utils.ts
+++ b/packages/vitest/src/node/reporters/utils.ts
@@ -1,5 +1,4 @@
 import type { ViteNodeRunner } from 'vite-node/client'
-import { normalize } from 'pathe'
 import type { Reporter } from '../../types'
 import { BenchmarkReportsMap, ReportersMap } from './index'
 import type { BenchmarkBuiltinReporters, BuiltinReporters } from './index'

--- a/packages/vitest/src/node/reporters/utils.ts
+++ b/packages/vitest/src/node/reporters/utils.ts
@@ -7,7 +7,7 @@ import type { BenchmarkBuiltinReporters, BuiltinReporters } from './index'
 async function loadCustomReporterModule<C extends Reporter>(path: string, runner: ViteNodeRunner): Promise<new () => C> {
   let customReporterModule: { default: new () => C }
   try {
-    customReporterModule = await runner.executeId(normalize(`/@fs/${path}`))
+    customReporterModule = await runner.executeFile(path)
   }
   catch (customReporterModuleError) {
     throw new Error(`Failed to load custom Reporter from ${path}`, { cause: customReporterModuleError as Error })

--- a/test/reporters/tests/utils.test.ts
+++ b/test/reporters/tests/utils.test.ts
@@ -10,7 +10,7 @@ import TestReporter from '../src/custom-reporter'
 
 const customReporterPath = resolve(__dirname, '../src/custom-reporter.js')
 const fetchModule = {
-  executeId: (id: string) => import(id),
+  executeFile: (id: string) => import(id),
 } as ViteNodeRunner
 
 describe('Reporter Utils', () => {


### PR DESCRIPTION
fix: #2176
load the reporter file base on file system
