### PR TITLE
fix(cli): set inputNamePattern to RegExp source instead of string

### DIFF
--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -69,7 +69,7 @@ export function registerConsoleShortcuts(ctx: Vitest) {
       name: 'filter',
       type: 'text',
       message: 'Input test name pattern (RegExp)',
-      initial: String(ctx.config.testNamePattern || ''),
+      initial: ctx.config.testNamePattern?.source || '',
     }])
     await ctx.changeNamePattern(filter, undefined, 'change pattern')
     on()


### PR DESCRIPTION
Goal: set inputNamePattern to RegExp source instead of string so the `testNamePattern` can be easily reused

Impact: when running the vitest in watch mode with --testNamePattern, when pressing t to re-run the filtered test, the suggested value is wrong and value cannot be reused because it has / /

1. actual filter: `role admin`
2. 1st t press, it suggest `/role admin/`
3. 2nd t press, it suggest `/\/role admin\//`

version: 0.24.3
cause:
using RegExp.toString() returns a valid regex string (with / at the beginning and the end of the string), but when this value is reused as RegExp constructor, it tries to covert the string value in to regex, causing the those / to be escaped.

simplified code to reproduce this issue
```typescript
// Actual
const reg1: RegExp|undefined = new RegExp("foo");
const reg2 = new RegExp(String(reg1||''));
const reg3 = new RegExp(String(reg2||''));

console.log(reg1, reg2, reg3);


// Expected
const eReg1: RegExp|undefined = new RegExp("bar");
const eReg2 = new RegExp(eReg1?.source||'');
const eReg3 = new RegExp(eReg2?.source||'');
console.log(eReg1, eReg2, eReg3);
```
output
```
/foo/ /\/foo\// /\/\/foo\/\//
/bar/ /bar/ /bar/
```
