### PR TITLE
Changed `toThrow` to `toThrowError`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -393,7 +393,7 @@ When you use `test` or `bench` in the top level of file, they are collected as p
   describe('numberToCurrency', () => {
     describe('given an invalid number', () => {
       test('composed of non-numbers to throw error', () => {
-        expect(() => numberToCurrency('abc')).toThrow()
+        expect(() => numberToCurrency('abc')).toThrowError()
       })
     })
 
@@ -868,7 +868,7 @@ When you use `test` or `bench` in the top level of file, they are collected as p
   ```
 
   :::warning
-  A _deep equality_ will not be performed for `Error` objects. To test if something was thrown, use [`toThrow`](#tothrow) assertion.
+  A _deep equality_ will not be performed for `Error` objects. To test if something was thrown, use [`toThrowError`](#tothrowerror) assertion.
   :::
 
 ### toStrictEqual


### PR DESCRIPTION
Changed `toThrow` to `toThrowError` and corrected link from `#tothrow` to `#tothrowerror`.

Line 1497 might also need to be updated but I haven't tested if `rejects` returns an object with `toThrow` or `toThrowError`.