### PR TITLE
fix(coverage): trim URL parameters from file paths in `istanbul` coverage

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -79,6 +79,8 @@ export class IstanbulCoverageProvider implements CoverageProvider {
       return
 
     const sourceMap = pluginCtx.getCombinedSourcemap()
+    sourceMap.sources = sourceMap.sources.map(removeQueryParameters)
+
     const code = this.instrumenter.instrumentSync(sourceCode, id, sourceMap as any)
     const map = this.instrumenter.lastSourceMap() as any
 
@@ -226,4 +228,13 @@ function resolveIstanbulOptions(options: CoverageIstanbulOptions, root: string) 
   }
 
   return resolved as ResolvedCoverageOptions & { provider: 'istanbul' }
+}
+
+/**
+ * Remove possible query parameters from filenames
+ * - From `/src/components/Header.component.ts?vue&type=script&src=true&lang.ts`
+ * - To `/src/components/Header.component.ts`
+ */
+function removeQueryParameters(filename: string) {
+  return filename.split('?')[0]
 }

--- a/test/coverage-test/coverage-test/coverage.istanbul.test.ts
+++ b/test/coverage-test/coverage-test/coverage.istanbul.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 
 test('istanbul html report', async () => {
-  const coveragePath = resolve('./coverage')
+  const coveragePath = resolve('./coverage/src')
   const files = fs.readdirSync(coveragePath)
 
   expect(files).toContain('index.html')
@@ -24,8 +24,18 @@ test('istanbul lcov report', async () => {
 })
 
 test('all includes untested files', () => {
-  const coveragePath = resolve('./coverage')
+  const coveragePath = resolve('./coverage/src')
   const files = fs.readdirSync(coveragePath)
 
   expect(files).toContain('untested-file.ts.html')
+})
+
+test('files should not contain query parameters', () => {
+  const coveragePath = resolve('./coverage/src/Counter')
+  const files = fs.readdirSync(coveragePath)
+
+  expect(files).toContain('index.html')
+  expect(files).toContain('Counter.vue.html')
+  expect(files).toContain('Counter.component.ts.html')
+  expect(files).not.toContain('Counter.component.ts?vue&type=script&src=true&lang.ts.html')
 })

--- a/test/coverage-test/src/Counter/Counter.component.ts
+++ b/test/coverage-test/src/Counter/Counter.component.ts
@@ -1,0 +1,21 @@
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  name: 'Counter',
+
+  setup() {
+    const count = ref(0)
+    return { count }
+  },
+
+  methods: {
+    uncoveredMethod() {
+      return 'This line should not be covered'
+    },
+
+    coveredMethod() {
+      return 'This line should be covered'
+    },
+  },
+})
+

--- a/test/coverage-test/src/Counter/Counter.vue
+++ b/test/coverage-test/src/Counter/Counter.vue
@@ -1,0 +1,15 @@
+<script lang="ts" src="./Counter.component.ts"></script>
+
+<template>
+  <button @click="count++">
+    {{ count }}
+  </button>
+
+  <div v-if="count > 10">
+    {{ uncoveredMethod() }}
+  </div>
+  <div v-else>
+    {{ coveredMethod() }}
+  </div>
+</template>
+

--- a/test/coverage-test/src/Counter/index.ts
+++ b/test/coverage-test/src/Counter/index.ts
@@ -1,0 +1,4 @@
+import CounterComponent from './Counter.component'
+import CounterVue from './Counter.vue'
+
+export { CounterComponent, CounterVue }

--- a/test/coverage-test/test/vue.test.ts
+++ b/test/coverage-test/test/vue.test.ts
@@ -6,6 +6,7 @@ import { expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 import Hello from '../src/Hello.vue'
 import Defined from '../src/Defined.vue'
+import { CounterVue } from '../src/Counter'
 
 test('vue 3 coverage', async () => {
   expect(Hello).toBeTruthy()
@@ -34,4 +35,11 @@ test('define package in vm', () => {
   const wrapper = mount(Defined)
 
   expect(wrapper.text()).toContain(MY_CONSTANT)
+})
+
+test('vue non-SFC, uses query parameters in file imports', async () => {
+  const wrapper = mount(CounterVue)
+
+  await wrapper.find('button').trigger('click')
+  expect(wrapper.text()).contain(1)
 })


### PR DESCRIPTION
- Fixes #2155

Vitest transforms files on-demand. Only files that are loaded are instrumented. `nyc`, `c8` and I think also `jest` instruments files before the test runner is even run. This introduces new issue for `istanbul`, where we may give it filenames that contain query parameters, e.g. `Counter.component.ts?vue&type=script&src=true&lang.ts`. These filenames end up as is in the coverage summaries and are used as filenames when writing reports in the file system. The HTML reporter of `istanbul-reports` generates links such as `<a href="Counter.component.ts?vue&type=script&src=true&lang.ts.html">` which cannot be opened on browser.


I added a test case where this issue can be reproduced, but as I have no experience in Vue, please check it thoroughly.

Before:

```
--------------------------------------------------------|---------|----------|---------|---------|-------------------
File                                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                               |      50 |    57.14 |   47.36 |   48.38 |                   
 src                                                    |   52.17 |       40 |      50 |      50 |                   
  Defined.vue                                           |     100 |      100 |     100 |     100 |                   
  Hello.vue                                             |     100 |      100 |     100 |     100 |                   
  index.ts                                              |     100 |      100 |     100 |     100 |                   
  untested-file.ts                                      |       0 |        0 |       0 |       0 | 7-32              
  utils.ts                                              |   57.14 |        0 |      60 |   57.14 | 11,16,23          
 src/Counter                                            |   44.44 |      100 |   42.85 |   44.44 |                   
  Counter.component.ts                                  |       0 |      100 |       0 |       0 | 7-17              
  Counter.component.ts?vue&type=script&src=true&lang.ts |      75 |      100 |   66.66 |      75 | 13                
  Counter.vue                                           |     100 |      100 |     100 |     100 |                   
--------------------------------------------------------|---------|----------|---------|---------|-------------------
```

After:

```
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |   57.14 |    57.14 |   56.25 |   55.55 |                   
 src                   |   52.17 |       40 |      50 |      50 |                   
  Defined.vue          |     100 |      100 |     100 |     100 |                   
  Hello.vue            |     100 |      100 |     100 |     100 |                   
  index.ts             |     100 |      100 |     100 |     100 |                   
  untested-file.ts     |       0 |        0 |       0 |       0 | 7-32              
  utils.ts             |   57.14 |        0 |      60 |   57.14 | 11,16,23          
 src/Counter           |      80 |      100 |      75 |      80 |                   
  Counter.component.ts |      75 |      100 |   66.66 |      75 | 13                
  Counter.vue          |     100 |      100 |     100 |     100 |                   
-----------------------|---------|----------|---------|---------|-------------------
```

<details>
   <summary>HTML coverage report</summary>

![image](https://user-images.githubusercontent.com/14806298/198824237-fa138c4c-e38f-4bea-9bdf-25ec8af41236.png)

![image](https://user-images.githubusercontent.com/14806298/198824254-4dd6124c-6c01-4eae-bfaf-914e0ab63cb3.png)

![image](https://user-images.githubusercontent.com/14806298/198824266-dbfd8f66-913f-44ac-8c2b-cb967981655d.png)

</details>

Coverage report from the reproduction repository (@Gnuk 👋)

<details>
   <summary>Coverage report jhipster</summary>

```
---------------------------------------|---------|----------|---------|---------|-------------------
File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------------------------------|---------|----------|---------|---------|-------------------
All files                              |    99.6 |      100 |   99.17 |   99.56 |                   
 common/domain                         |     100 |      100 |     100 |     100 |                   
  Memoizer.ts                          |     100 |      100 |     100 |     100 |                   
  Optional.ts                          |     100 |      100 |     100 |     100 |                   
 common/primary/app                    |     100 |      100 |     100 |     100 |                   
  App.vue                              |     100 |      100 |     100 |     100 |                   
 common/primary/header                 |     100 |      100 |     100 |     100 |                   
  Header.component.ts                  |     100 |      100 |     100 |     100 |                   
  Header.vue                           |     100 |      100 |     100 |     100 |                   
 common/primary/timeout                |     100 |      100 |     100 |     100 |                   
  Timeout.ts                           |     100 |      100 |     100 |     100 |                   
 common/primary/toast                  |     100 |      100 |     100 |     100 |                   
  Toast.component.ts                   |     100 |      100 |     100 |     100 |                   
  Toast.vue                            |     100 |      100 |     100 |     100 |                   
  ToastType.ts                         |     100 |      100 |     100 |     100 |                   
 common/secondary                      |     100 |      100 |     100 |     100 |                   
  ConsoleLogger.ts                     |     100 |      100 |     100 |     100 |                   
 common/secondary/alert                |     100 |      100 |     100 |     100 |                   
  AlertType.ts                         |     100 |      100 |     100 |     100 |                   
  MittAlertBus.ts                      |     100 |      100 |     100 |     100 |                   
  MittAlertListener.ts                 |     100 |      100 |     100 |     100 |                   
 http                                  |     100 |      100 |     100 |     100 |                   
  AxiosHttp.ts                         |     100 |      100 |     100 |     100 |                   
 loader/primary                        |     100 |      100 |     100 |     100 |                   
  Loader.ts                            |     100 |      100 |     100 |     100 |                   
 module/domain                         |     100 |      100 |     100 |     100 |                   
  ModuleSlug.ts                        |     100 |      100 |     100 |     100 |                   
  Modules.ts                           |     100 |      100 |     100 |     100 |                   
 module/domain/landscape               |     100 |      100 |     100 |     100 |                   
  Landscape.ts                         |     100 |      100 |     100 |     100 |                   
  LandscapeFeature.ts                  |     100 |      100 |     100 |     100 |                   
  LandscapeFeatureSlug.ts              |     100 |      100 |     100 |     100 |                   
  LandscapeModule.ts                   |     100 |      100 |     100 |     100 |                   
  LandscapeSelectionTree.ts            |     100 |      100 |     100 |     100 |                   
  LandscapeUnselectionTree.ts          |     100 |      100 |     100 |     100 |                   
 module/primary                        |     100 |      100 |     100 |     100 |                   
  PropertyValue.ts                     |     100 |      100 |     100 |     100 |                   
 module/primary/landscape              |   99.54 |      100 |   98.78 |   99.53 |                   
  Landscape.component.ts               |     100 |      100 |     100 |     100 |                   
  Landscape.vue                        |   96.55 |      100 |    92.3 |   96.55 | 57                
  LandscapeConnector.ts                |     100 |      100 |     100 |     100 |                   
  LandscapeConnectorsSize.ts           |     100 |      100 |     100 |     100 |                   
 module/primary/landscape-module       |     100 |      100 |     100 |     100 |                   
  LandscapeModule.component.ts         |     100 |      100 |     100 |     100 |                   
  LandscapeModule.vue                  |     100 |      100 |     100 |     100 |                   
 module/primary/module-parameters      |     100 |      100 |     100 |     100 |                   
  ModuleParameters.component.ts        |     100 |      100 |     100 |     100 |                   
  ModuleParameters.vue                 |     100 |      100 |     100 |     100 |                   
 module/primary/module-properties-form |     100 |      100 |     100 |     100 |                   
  ModulePropertiesForm.component.ts    |     100 |      100 |     100 |     100 |                   
  ModulePropertiesForm.vue             |     100 |      100 |     100 |     100 |                   
 module/primary/modules-patch          |   98.29 |      100 |      96 |   98.17 |                   
  ComponentModulePatch.ts              |     100 |      100 |     100 |     100 |                   
  ComponentModulePatchCategory.ts      |     100 |      100 |     100 |     100 |                   
  ComponentModulesPatch.ts             |     100 |      100 |     100 |     100 |                   
  ModulesPatch.component.ts            |     100 |      100 |     100 |     100 |                   
  ModulesPatch.vue                     |   86.36 |      100 |   66.66 |   85.71 | 8,10,37           
 module/primary/project-actions        |     100 |      100 |     100 |     100 |                   
  ProjectActions.component.ts          |     100 |      100 |     100 |     100 |                   
  ProjectActions.vue                   |     100 |      100 |     100 |     100 |                   
 module/primary/tag-filter             |     100 |      100 |     100 |     100 |                   
  TagFilter.component.ts               |     100 |      100 |     100 |     100 |                   
  TagFilter.vue                        |     100 |      100 |     100 |     100 |                   
 module/secondary                      |     100 |      100 |     100 |     100 |                   
  RestAppliedModule.ts                 |     100 |      100 |     100 |     100 |                   
  RestLandscape.ts                     |     100 |      100 |     100 |     100 |                   
  RestLandscapeElement.ts              |     100 |      100 |     100 |     100 |                   
  RestLandscapeFeature.ts              |     100 |      100 |     100 |     100 |                   
  RestLandscapeLevel.ts                |     100 |      100 |     100 |     100 |                   
  RestLandscapeModule.ts               |     100 |      100 |     100 |     100 |                   
  RestModule.ts                        |     100 |      100 |     100 |     100 |                   
  RestModulePropertiesDefinitions.ts   |     100 |      100 |     100 |     100 |                   
  RestModulePropertyDefinition.ts      |     100 |      100 |     100 |     100 |                   
  RestModuleToApply.ts                 |     100 |      100 |     100 |     100 |                   
  RestModules.ts                       |     100 |      100 |     100 |     100 |                   
  RestModulesRepository.ts             |     100 |      100 |     100 |     100 |                   
  RestModulesToApply.ts                |     100 |      100 |     100 |     100 |                   
  RestProjectFoldersRepository.ts      |     100 |      100 |     100 |     100 |                   
  RestProjectHistory.ts                |     100 |      100 |     100 |     100 |                   
---------------------------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 99.6% ( 996/1000 )
Branches     : 100% ( 175/175 )
Functions    : 99.17% ( 483/487 )
Lines        : 99.56% ( 920/924 )
================================================================================
```

</details>