### PR TITLE
docs: update react-testing-lib example

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -19,7 +19,7 @@
     "@types/react": "latest",
     "@vitejs/plugin-react": "latest",
     "jsdom": "latest",
-    "typescript": "4.6.3",
+    "typescript": "^4.8.4",
     "vitest": "latest"
   }
 }

--- a/examples/react-storybook/package.json
+++ b/examples/react-storybook/package.json
@@ -34,7 +34,7 @@
     "jsdom": "latest",
     "msw": "^0.39.2",
     "msw-storybook-addon": "^1.6.3",
-    "typescript": "^4.7.2",
+    "typescript": "^4.8.4",
     "vite": "latest",
     "vitest": "latest"
   },

--- a/examples/react-testing-lib/package.json
+++ b/examples/react-testing-lib/package.json
@@ -20,8 +20,10 @@
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
     "@vitejs/plugin-react": "^2.2.0",
+    "@vitest/coverage-c8": "^0.24.5",
     "@vitest/ui": "latest",
     "jsdom": "latest",
+    "typescript": "^4.8.4",
     "vite": "latest",
     "vitest": "latest"
   },

--- a/examples/react-testing-lib/package.json
+++ b/examples/react-testing-lib/package.json
@@ -10,17 +10,16 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^12.1.5",
-    "@testing-library/react-hooks": "^8.0.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/react": "^17.0.45",
-    "@types/react-dom": "^17.0.17",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/react": "^18.0.24",
+    "@types/react-dom": "^18.0.8",
+    "@vitejs/plugin-react": "^2.2.0",
     "@vitest/ui": "latest",
     "jsdom": "latest",
     "vite": "latest",

--- a/examples/react-testing-lib/src/App.test.tsx
+++ b/examples/react-testing-lib/src/App.test.tsx
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import App from './App'
 import { render, screen, userEvent } from './utils/test-utils'
 

--- a/examples/react-testing-lib/src/components/input.test.tsx
+++ b/examples/react-testing-lib/src/components/input.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom'
 import { render, screen, userEvent } from '../utils/test-utils'
 import { Input } from './Input'
 

--- a/examples/react-testing-lib/src/components/input.test.tsx
+++ b/examples/react-testing-lib/src/components/input.test.tsx
@@ -18,7 +18,7 @@ describe('Input', async () => {
       name: /email address/i,
     })).toBeInTheDocument()
   })
-  it('should change input value', () => {
+  it('should change input value', async () => {
     render(
       <Input
         name="email"
@@ -36,7 +36,7 @@ describe('Input', async () => {
       name: /email address/i,
     })
     expect(input).toBeInTheDocument()
-    userEvent.type(input, '1337')
+    await userEvent.type(input, '1337')
     expect(input).toHaveValue('1337')
   })
   it('should render the input with error', () => {

--- a/examples/react-testing-lib/src/hooks/useCounter.test.ts
+++ b/examples/react-testing-lib/src/hooks/useCounter.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react'
 import { useCounter } from './useCounter'
 
 describe('useCounter', () => {

--- a/examples/react-testing-lib/src/main.tsx
+++ b/examples/react-testing-lib/src/main.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
 

--- a/examples/react-testing-lib/src/main.tsx
+++ b/examples/react-testing-lib/src/main.tsx
@@ -1,11 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 
-ReactDOM.render(
-  <React.StrictMode>
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root'),
+  </StrictMode>
 )

--- a/examples/react-testing-lib/src/main.tsx
+++ b/examples/react-testing-lib/src/main.tsx
@@ -6,5 +6,5 @@ import App from './App'
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
       next: 12.1.5
       react: 18.0.0
       react-dom: 18.0.0
-      typescript: 4.6.3
+      typescript: ^4.8.4
       vitest: workspace:*
     dependencies:
       next: 12.1.5_zpnidt7m3osuk7shl3s4oenomq
@@ -239,10 +239,10 @@ importers:
     devDependencies:
       '@testing-library/react': 13.3.0_zpnidt7m3osuk7shl3s4oenomq
       '@types/node': 18.11.9
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
       '@vitejs/plugin-react': 2.2.0
       jsdom: 20.0.2
-      typescript: 4.6.3
+      typescript: 4.8.4
       vitest: link:../../packages/vitest
 
   examples/playwright:
@@ -390,7 +390,7 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       react-query: ^3.39.0
-      typescript: ^4.7.2
+      typescript: ^4.8.4
       vite: ^3.2.0
       vitest: workspace:*
     dependencies:
@@ -401,10 +401,10 @@ importers:
     devDependencies:
       '@babel/core': 7.18.13
       '@storybook/addon-actions': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/addon-essentials': 6.5.10_3dluw2xseh6veqm2kl5ixdlsse
+      '@storybook/addon-essentials': 6.5.10_woybfvsee2x6d3zh4gjoip7njy
       '@storybook/addon-links': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/builder-vite': 0.1.41_erk3pgs5guegcpaaqwmmovmymq
-      '@storybook/react': 6.5.10_3dluw2xseh6veqm2kl5ixdlsse
+      '@storybook/builder-vite': 0.1.41_be3jsoghr34mheek6rzfxmc5k4
+      '@storybook/react': 6.5.10_woybfvsee2x6d3zh4gjoip7njy
       '@storybook/testing-library': 0.0.11_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/testing-react': 1.3.0_35blmeidzgqisdr5wtpltokp2e
       '@testing-library/jest-dom': 5.16.5
@@ -417,38 +417,40 @@ importers:
       jsdom: 20.0.2
       msw: 0.39.2
       msw-storybook-addon: 1.6.3_ssm5z5kjlefxgbmyszjdm3lzke
-      typescript: 4.8.2
+      typescript: 4.8.4
       vite: 3.2.1
       vitest: link:../../packages/vitest
 
   examples/react-testing-lib:
     specifiers:
       '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^12.1.5
-      '@testing-library/react-hooks': ^8.0.0
-      '@testing-library/user-event': ^13.5.0
-      '@types/react': ^17.0.45
-      '@types/react-dom': ^17.0.17
-      '@vitejs/plugin-react': ^1.3.2
+      '@testing-library/react': ^13.4.0
+      '@testing-library/user-event': ^14.4.3
+      '@types/react': ^18.0.24
+      '@types/react-dom': ^18.0.8
+      '@vitejs/plugin-react': ^2.2.0
+      '@vitest/coverage-c8': ^0.24.5
       '@vitest/ui': latest
       jsdom: latest
-      react: ^17.0.2
-      react-dom: ^17.0.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      typescript: ^4.8.4
       vite: ^3.2.0
       vitest: workspace:*
     dependencies:
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@testing-library/jest-dom': 5.16.5
-      '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
-      '@testing-library/react-hooks': 8.0.1_j6sw2p2tdbh6crpcmkxtmmhma4
-      '@testing-library/user-event': 13.5.0
-      '@types/react': 17.0.49
-      '@types/react-dom': 17.0.17
-      '@vitejs/plugin-react': 1.3.2
+      '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
+      '@testing-library/user-event': 14.4.3
+      '@types/react': 18.0.24
+      '@types/react-dom': 18.0.8
+      '@vitejs/plugin-react': 2.2.0_vite@3.2.1
+      '@vitest/coverage-c8': link:../../packages/coverage-c8
       '@vitest/ui': link:../../packages/ui
       jsdom: 20.0.2
+      typescript: 4.8.4
       vite: 3.2.1
       vitest: link:../../packages/vitest
 
@@ -4513,7 +4515,7 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@joshwooding/vite-plugin-react-docgen-typescript/0.0.4_qpm4z4w26rmhhvml5zxgo5rbea:
+  /@joshwooding/vite-plugin-react-docgen-typescript/0.0.4_qpqpptm6doui2bjlmcwwgpgdpe:
     resolution: {integrity: sha512-ezL7SU//1OV4Oyt/zQ3CsX8uLujVEYUHuULkqgcW6wOuQfRnvgkn99HZtLWwS257GmZVwszGQzhL7VE3PbMAYw==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -4522,8 +4524,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2_glob@7.2.3
       magic-string: 0.26.7
-      react-docgen-typescript: 2.2.2_typescript@4.8.2
-      typescript: 4.8.2
+      react-docgen-typescript: 2.2.2_typescript@4.8.4
+      typescript: 4.8.4
       vite: 3.2.1
     dev: true
 
@@ -5315,7 +5317,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.10_rw34wyrummvuuuhgiylphbvpae:
+  /@storybook/addon-controls/6.5.10_56jbash75ng5psbctf36wqywr4:
     resolution: {integrity: sha512-lC2y3XcolmQAJwFurIyGrynAHPWmfNtTCdu3rQBTVGwyxCoNwdOOeC2jV0BRqX2+CW6OHzJr9frNWXPSaZ8c4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5330,7 +5332,7 @@ packages:
       '@storybook/api': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.10
       '@storybook/store': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
@@ -5349,7 +5351,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.10_3dluw2xseh6veqm2kl5ixdlsse:
+  /@storybook/addon-docs/6.5.10_woybfvsee2x6d3zh4gjoip7njy:
     resolution: {integrity: sha512-1kgjo3f0vL6GN8fTwLL05M/q/kDdzvuqwhxPY/v5hubFb3aQZGr2yk9pRBaLAbs4bez0yG0ASXcwhYnrEZUppg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -5370,7 +5372,7 @@ packages:
       '@storybook/addons': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/api': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/components': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
@@ -5404,7 +5406,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.10_3dluw2xseh6veqm2kl5ixdlsse:
+  /@storybook/addon-essentials/6.5.10_woybfvsee2x6d3zh4gjoip7njy:
     resolution: {integrity: sha512-PT2aiR4vgAyB0pl3HNBUa4/a7NDRxASxAazz7zt9ZDirkipDKfxwdcLeRoJzwSngVDWEhuz5/paN5x4eNp4Hww==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -5464,15 +5466,15 @@ packages:
       '@babel/core': 7.18.13
       '@storybook/addon-actions': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-backgrounds': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/addon-controls': 6.5.10_rw34wyrummvuuuhgiylphbvpae
-      '@storybook/addon-docs': 6.5.10_3dluw2xseh6veqm2kl5ixdlsse
+      '@storybook/addon-controls': 6.5.10_56jbash75ng5psbctf36wqywr4
+      '@storybook/addon-docs': 6.5.10_woybfvsee2x6d3zh4gjoip7njy
       '@storybook/addon-measure': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-outline': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-toolbars': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-viewport': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addons': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/api': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/node-logger': 6.5.10
       core-js: 3.25.0
       react: 17.0.2
@@ -5660,7 +5662,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-vite/0.1.41_erk3pgs5guegcpaaqwmmovmymq:
+  /@storybook/builder-vite/0.1.41_be3jsoghr34mheek6rzfxmc5k4:
     resolution: {integrity: sha512-h/7AgEUfSuVexTD6LuJ6BCNu+FSo/+IKYBQ1O3TyF2BEgcob5/BGrx9QcwM0LJCF44L1zNKaxkKpCZs9p+LRRA==}
     peerDependencies:
       '@storybook/core-common': '>=6.4.3 || >=6.5.0-alpha.0'
@@ -5671,7 +5673,7 @@ packages:
       '@storybook/mdx2-csf':
         optional: true
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.4_qpm4z4w26rmhhvml5zxgo5rbea
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.4_qpqpptm6doui2bjlmcwwgpgdpe
       '@storybook/mdx1-csf': 0.0.4_u2aypivye4tius5ftakppbroiy
       '@storybook/source-loader': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@vitejs/plugin-react': 1.3.2
@@ -5692,7 +5694,7 @@ packages:
       - typescript
     dev: true
 
-  /@storybook/builder-webpack4/6.5.10_rw34wyrummvuuuhgiylphbvpae:
+  /@storybook/builder-webpack4/6.5.10_56jbash75ng5psbctf36wqywr4:
     resolution: {integrity: sha512-AoKjsCNoQQoZXYwBDxO8s+yVEd5FjBJAaysEuUTHq2fb81jwLrGcEOo6hjw4jqfugZQIzYUEjPazlvubS78zpw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5710,7 +5712,7 @@ packages:
       '@storybook/client-api': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.10
       '@storybook/components': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/core-events': 6.5.10
       '@storybook/node-logger': 6.5.10
       '@storybook/preview-web': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
@@ -5728,12 +5730,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_52v4mnadlpsg7i2qs7mzsj75c4
+      fork-ts-checker-webpack-plugin: 4.1.6_lasgyenclx45ngbljrbo537mpe
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.8.2
+      pnp-webpack-plugin: 1.6.4_typescript@4.8.4
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -5744,7 +5746,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -5846,7 +5848,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.10_5bux6joajxjwtryfea6pxumd6u:
+  /@storybook/core-client/6.5.10_jrbh53wlplns5k3knei7sip5xu:
     resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5877,50 +5879,50 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      typescript: 4.8.2
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-    dev: true
-
-  /@storybook/core-client/6.5.10_5ysc5kprm2gqmrsxblravkdpgy:
-    resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/channel-postmessage': 6.5.10
-      '@storybook/channel-websocket': 6.5.10
-      '@storybook/client-api': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/client-logger': 6.5.10
-      '@storybook/core-events': 6.5.10
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/store': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/ui': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.25.0
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.11.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      regenerator-runtime: 0.13.9
-      ts-dedent: 2.2.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.74.0
     dev: true
 
-  /@storybook/core-common/6.5.10_rw34wyrummvuuuhgiylphbvpae:
+  /@storybook/core-client/6.5.10_lb6j7tllhltqtas2n635xqdotu:
+    resolution: {integrity: sha512-THsIjNrOrampTl0Lgfjvfjk1JnktKb4CQLOM80KpQb4cjDqorBjJmErzUkUQ2y3fXvrDmQ/kUREkShET4XEdtA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/channel-postmessage': 6.5.10
+      '@storybook/channel-websocket': 6.5.10
+      '@storybook/client-api': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/client-logger': 6.5.10
+      '@storybook/core-events': 6.5.10
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/preview-web': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/store': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/ui': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.25.0
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.11.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      regenerator-runtime: 0.13.9
+      ts-dedent: 2.2.0
+      typescript: 4.8.4
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+    dev: true
+
+  /@storybook/core-common/6.5.10_56jbash75ng5psbctf36wqywr4:
     resolution: {integrity: sha512-Bx+VKkfWdrAmD8T51Sjq/mMhRaiapBHcpG4cU5bc3DMbg+LF2/yrgqv/cjVu+m5gHAzYCac5D7gqzBgvG7Myww==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5964,7 +5966,7 @@ packages:
       express: 4.18.1
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_52v4mnadlpsg7i2qs7mzsj75c4
+      fork-ts-checker-webpack-plugin: 6.5.2_lasgyenclx45ngbljrbo537mpe
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -5980,7 +5982,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -5997,7 +5999,7 @@ packages:
       core-js: 3.25.0
     dev: true
 
-  /@storybook/core-server/6.5.10_rw34wyrummvuuuhgiylphbvpae:
+  /@storybook/core-server/6.5.10_56jbash75ng5psbctf36wqywr4:
     resolution: {integrity: sha512-jqwpA0ccA8X5ck4esWBid04+cEIVqirdAcqJeNb9IZAD+bRreO4Im8ilzr7jc5AmQ9fkqHs2NByFKh9TITp8NQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -6014,17 +6016,17 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.10_rw34wyrummvuuuhgiylphbvpae
-      '@storybook/core-client': 6.5.10_5bux6joajxjwtryfea6pxumd6u
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/builder-webpack4': 6.5.10_56jbash75ng5psbctf36wqywr4
+      '@storybook/core-client': 6.5.10_lb6j7tllhltqtas2n635xqdotu
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/core-events': 6.5.10
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.10
-      '@storybook/manager-webpack4': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/manager-webpack4': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/node-logger': 6.5.10
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/telemetry': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/telemetry': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@types/node': 16.11.56
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -6055,7 +6057,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.46.0
@@ -6074,7 +6076,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.10_5ysc5kprm2gqmrsxblravkdpgy:
+  /@storybook/core/6.5.10_jrbh53wlplns5k3knei7sip5xu:
     resolution: {integrity: sha512-K86yYa0tYlMxADlwQTculYvPROokQau09SCVqpsLg3wJCTvYFL4+SIqcYoyBSbFmHOdnYbJgPydjN33MYLiOZQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -6091,11 +6093,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.5.10_5ysc5kprm2gqmrsxblravkdpgy
-      '@storybook/core-server': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-client': 6.5.10_jrbh53wlplns5k3knei7sip5xu
+      '@storybook/core-server': 6.5.10_56jbash75ng5psbctf36wqywr4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      typescript: 4.8.2
+      typescript: 4.8.4
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -6177,7 +6179,7 @@ packages:
       - react-dom
     dev: true
 
-  /@storybook/manager-webpack4/6.5.10_rw34wyrummvuuuhgiylphbvpae:
+  /@storybook/manager-webpack4/6.5.10_56jbash75ng5psbctf36wqywr4:
     resolution: {integrity: sha512-N/TlNDhuhARuFipR/ZJ/xEVESz23iIbCsZ4VNehLHm8PpiGlQUehk+jMjWmz5XV0bJItwjRclY+CU3GjZKblfQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -6191,8 +6193,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.19.6
       '@babel/preset-react': 7.18.6_@babel+core@7.19.6
       '@storybook/addons': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
-      '@storybook/core-client': 6.5.10_5bux6joajxjwtryfea6pxumd6u
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-client': 6.5.10_lb6j7tllhltqtas2n635xqdotu
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/node-logger': 6.5.10
       '@storybook/theming': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/ui': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
@@ -6209,7 +6211,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.8.2
+      pnp-webpack-plugin: 1.6.4_typescript@4.8.4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       read-pkg-up: 7.0.1
@@ -6219,7 +6221,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -6336,7 +6338,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_frxmcuunqqqeqipt45cd6rjuvu:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_qqxisngxjbp7lstdk7boexbu3e:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -6347,15 +6349,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@4.8.2
+      react-docgen-typescript: 2.2.2_typescript@4.8.4
       tslib: 2.4.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       webpack: 5.74.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.10_3dluw2xseh6veqm2kl5ixdlsse:
+  /@storybook/react/6.5.10_woybfvsee2x6d3zh4gjoip7njy:
     resolution: {integrity: sha512-m8S1qQrwA7pDGwdKEvL6LV3YKvSzVUY297Fq+xcTU3irnAy4sHDuFoLqV6Mi1510mErK1r8+rf+0R5rEXB219g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -6389,12 +6391,12 @@ packages:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_metx475lqcp4j5c75za4zf7xbi
       '@storybook/addons': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.10
-      '@storybook/core': 6.5.10_5ysc5kprm2gqmrsxblravkdpgy
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core': 6.5.10_jrbh53wlplns5k3knei7sip5xu
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/node-logger': 6.5.10
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_frxmcuunqqqeqipt45cd6rjuvu
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_qqxisngxjbp7lstdk7boexbu3e
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.10_sfoxds7t5ydpegc3knd667wn6m
       '@types/estree': 0.0.51
@@ -6419,7 +6421,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      typescript: 4.8.2
+      typescript: 4.8.4
       util-deprecate: 1.0.2
       webpack: 5.74.0
     transitivePeerDependencies:
@@ -6513,11 +6515,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.10_rw34wyrummvuuuhgiylphbvpae:
+  /@storybook/telemetry/6.5.10_56jbash75ng5psbctf36wqywr4:
     resolution: {integrity: sha512-+M5HILDFS8nDumLxeSeAwi1MTzIuV6UWzV4yB2wcsEXOBTdplcl9oYqFKtlst78oOIdGtpPYxYfivDlqxC2K4g==}
     dependencies:
       '@storybook/client-logger': 6.5.10
-      '@storybook/core-common': 6.5.10_rw34wyrummvuuuhgiylphbvpae
+      '@storybook/core-common': 6.5.10_56jbash75ng5psbctf36wqywr4
       chalk: 4.1.2
       core-js: 3.25.0
       detect-package-manager: 2.0.1
@@ -6564,7 +6566,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/react': 6.5.10_3dluw2xseh6veqm2kl5ixdlsse
+      '@storybook/react': 6.5.10_woybfvsee2x6d3zh4gjoip7njy
       react: 17.0.2
     dev: true
 
@@ -6692,29 +6694,6 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react-hooks/8.0.1_j6sw2p2tdbh6crpcmkxtmmhma4:
-    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0
-      react: ^16.9.0 || ^17.0.0
-      react-dom: ^16.9.0 || ^17.0.0
-      react-test-renderer: ^16.9.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react-dom:
-        optional: true
-      react-test-renderer:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.18.9
-      '@types/react': 17.0.49
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-error-boundary: 3.1.4_react@17.0.2
-    dev: true
-
   /@testing-library/react/12.1.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==}
     engines: {node: '>=12'}
@@ -6755,6 +6734,20 @@ packages:
       '@types/react-dom': 18.0.6
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
+    dev: true
+
+  /@testing-library/react/13.4.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.18.9
+      '@testing-library/dom': 8.17.1
+      '@types/react-dom': 18.0.8
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: true
 
   /@testing-library/svelte/3.2.1_svelte@3.49.0:
@@ -6880,7 +6873,7 @@ packages:
     resolution: {integrity: sha512-xryQlOEIe1TduDWAOphR0ihfebKFSWOXpIsk+70JskCfRfW+xALdnJ0r1ZOTo85F9Qsjk6vtlU7edTYHbls9tA==}
     dependencies:
       '@types/cheerio': 0.22.31
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
     dev: true
 
   /@types/eslint-scope/3.7.4:
@@ -7119,13 +7112,19 @@ packages:
   /@types/react-dom/18.0.6:
     resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
     dependencies:
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
+    dev: true
+
+  /@types/react-dom/18.0.8:
+    resolution: {integrity: sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==}
+    dependencies:
+      '@types/react': 18.0.25
     dev: true
 
   /@types/react-is/17.0.3:
     resolution: {integrity: sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==}
     dependencies:
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
     dev: false
 
   /@types/react-test-renderer/17.0.2:
@@ -7137,7 +7136,7 @@ packages:
   /@types/react-transition-group/4.4.5:
     resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}
     dependencies:
-      '@types/react': 18.0.24
+      '@types/react': 18.0.25
     dev: false
 
   /@types/react/17.0.49:
@@ -7150,6 +7149,14 @@ packages:
 
   /@types/react/18.0.24:
     resolution: {integrity: sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.2
+      csstype: 3.1.0
+    dev: true
+
+  /@types/react/18.0.25:
+    resolution: {integrity: sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -12656,7 +12663,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6_52v4mnadlpsg7i2qs7mzsj75c4:
+  /fork-ts-checker-webpack-plugin/4.1.6_lasgyenclx45ngbljrbo537mpe:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -12676,14 +12683,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.8.2
+      typescript: 4.8.4
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.2_52v4mnadlpsg7i2qs7mzsj75c4:
+  /fork-ts-checker-webpack-plugin/6.5.2_lasgyenclx45ngbljrbo537mpe:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -12710,7 +12717,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.8.2
+      typescript: 4.8.4
       webpack: 4.46.0
     dev: true
 
@@ -16677,11 +16684,11 @@ packages:
     engines: {node: '>=12.13.0'}
     dev: true
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.8.2:
+  /pnp-webpack-plugin/1.6.4_typescript@4.8.4:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.8.2
+      ts-pnp: 1.2.0_typescript@4.8.4
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -17197,12 +17204,12 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /react-docgen-typescript/2.2.2_typescript@4.8.2:
+  /react-docgen-typescript/2.2.2_typescript@4.8.4:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.8.2
+      typescript: 4.8.4
     dev: true
 
   /react-docgen/5.4.3:
@@ -17282,16 +17289,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
-    dev: true
-
-  /react-error-boundary/3.1.4_react@17.0.2:
-    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
-    engines: {node: '>=10', npm: '>=6'}
-    peerDependencies:
-      react: '>=16.13.1'
-    dependencies:
-      '@babel/runtime': 7.18.9
-      react: 17.0.2
     dev: true
 
   /react-inspector/5.1.1_react@17.0.2:
@@ -19496,7 +19493,7 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-pnp/1.2.0_typescript@4.8.2:
+  /ts-pnp/1.2.0_typescript@4.8.4:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -19505,7 +19502,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.8.2
+      typescript: 4.8.4
     dev: true
 
   /ts-toolbelt/9.6.0:
@@ -19663,18 +19660,6 @@ packages:
 
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-    dev: true
-
-  /typescript/4.6.3:
-    resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.8.2:
-    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /typescript/4.8.4:


### PR DESCRIPTION
1. React 17 -> 18
2. `@testing-library/react` 12 -> 13
3. Remove `@testing-library/react-hooks`, its functions are now provided by `@testing-library/react`
4. Remove unnecessary `import ... from 'vitest'`, becaused globals are congfigured