### PR TITLE
fix: use --conditions instead of -C

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -31,7 +31,7 @@ export function createPool(ctx: Vitest): WorkerPool {
   const maxThreads = ctx.config.maxThreads ?? threadsCount
   const minThreads = ctx.config.minThreads ?? threadsCount
 
-  const conditions = ctx.server.config.resolve.conditions?.flatMap(c => ['-C', c]) || []
+  const conditions = ctx.server.config.resolve.conditions?.flatMap(c => ['--conditions', c]) || []
 
   const options: TinypoolOptions = {
     filename: workerPath,


### PR DESCRIPTION
Fixes #2251

`-C` flag was introduced in 14.9.0, but `--conditions` in 12.19.0