### PR TITLE
fix(coverage): `istanbul` provider to preserve implicit else

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -108,6 +108,8 @@ export class IstanbulCoverageProvider implements CoverageProvider {
     if (this.options.all)
       await this.includeUntestedFiles(mergedCoverage)
 
+    includeImplicitElseBranches(mergedCoverage)
+
     const sourceMapStore = libSourceMaps.createSourceMapStore()
     const coverageMap: CoverageMap = await sourceMapStore.transformCoverage(mergedCoverage)
 
@@ -237,4 +239,45 @@ function resolveIstanbulOptions(options: CoverageIstanbulOptions, root: string) 
  */
 function removeQueryParameters(filename: string) {
   return filename.split('?')[0]
+}
+
+/**
+ * Work-around for #1887 and #2239 while waiting for https://github.com/istanbuljs/istanbuljs/pull/706
+ *
+ * Goes through all files in the coverage map and checks if branchMap's have
+ * if-statements with implicit else. When finds one, copies source location of
+ * the if-statement into the else statement.
+ */
+function includeImplicitElseBranches(coverageMap: CoverageMap) {
+  for (const file of coverageMap.files()) {
+    const fileCoverage = coverageMap.fileCoverageFor(file)
+
+    for (const branchMap of Object.values(fileCoverage.branchMap)) {
+      if (branchMap.type === 'if') {
+        const lastIndex = branchMap.locations.length - 1
+
+        if (lastIndex > 0) {
+          const elseLocation = branchMap.locations[lastIndex]
+
+          if (elseLocation && isEmptyCoverageRange(elseLocation)) {
+            const ifLocation = branchMap.locations[0]
+
+            elseLocation.start = { ...ifLocation.start }
+            elseLocation.end = { ...ifLocation.end }
+          }
+        }
+      }
+    }
+  }
+}
+
+function isEmptyCoverageRange(range: libCoverage.Range) {
+  return (
+    range.start === undefined
+    || range.start.line === undefined
+    || range.start.column === undefined
+    || range.end === undefined
+    || range.end.line === undefined
+    || range.end.column === undefined
+  )
 }

--- a/test/coverage-test/coverage-test/coverage.istanbul.test.ts
+++ b/test/coverage-test/coverage-test/coverage.istanbul.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { resolve } from 'pathe'
+import { normalize, resolve } from 'pathe'
 import { expect, test } from 'vitest'
 
 test('istanbul html report', async () => {
@@ -38,4 +38,15 @@ test('files should not contain query parameters', () => {
   expect(files).toContain('Counter.vue.html')
   expect(files).toContain('Counter.component.ts.html')
   expect(files).not.toContain('Counter.component.ts?vue&type=script&src=true&lang.ts.html')
+})
+
+test('implicit else is included in branch count', async () => {
+  // @ts-expect-error -- generated file
+  const { default: coverageMap } = await import('./coverage/coverage-final.json')
+
+  const filename = normalize(resolve('./src/implicitElse.ts'))
+  const fileCoverage = coverageMap[filename]
+
+  expect(fileCoverage.b).toHaveProperty('0')
+  expect(fileCoverage.b['0']).toHaveLength(2)
 })

--- a/test/coverage-test/src/implicitElse.ts
+++ b/test/coverage-test/src/implicitElse.ts
@@ -1,0 +1,8 @@
+export function implicitElse(condition: boolean) {
+  let a = 1
+
+  if (condition)
+    a = 2
+
+  return a
+}

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'vitest'
 import { pythagoras } from '../src'
+import { implicitElse } from '../src/implicitElse'
 
 test('Math.sqrt()', async () => {
   expect(pythagoras(3, 4)).toBe(5)
+})
+
+test('implicit else', () => {
+  expect(implicitElse(true)).toBe(2)
 })

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
       enabled: true,
       clean: true,
       all: true,
-      reporter: ['html', 'text', 'lcov'],
+      reporter: ['html', 'text', 'lcov', 'json'],
     },
   },
 })


### PR DESCRIPTION
- Fixes #1887.
- Fixes #2239.
- Upstream issue https://github.com/istanbuljs/istanbuljs/issues/705.
- Upstream fix https://github.com/istanbuljs/istanbuljs/issues/706.

Adds a work-around for implicit else's branch coverages. There is a PR for the upstream issue but as `istanbul` packages do not update that often it might be worth to apply this work-around for now. This work-around is compatible with the upstream patch but should be removed once it is merged and released. 

The upstream issue has minimal reproduction setup which mimics vitest (esbuild, TS, istanbul packages).
