### PR TITLE
fix: test.each() in vitest differs from jest

### DIFF
--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -232,9 +232,10 @@ function createTest(fn: (
   testFn.each = function<T>(this: { withContext: () => TestAPI }, cases: ReadonlyArray<T>) {
     const test = this.withContext()
 
+    const isTable = cases.every(Array.isArray)
     return (name: string, fn: (...args: T[]) => void, options?: number | TestOptions) => {
       cases.forEach((i, idx) => {
-        const items = Array.isArray(i) ? i : [i]
+        const items = isTable ? i as T[] : [i]
         test(formatTitle(name, items, idx), () => fn(...items), options)
       })
     }

--- a/test/core/test/each.test.ts
+++ b/test/core/test/each.test.ts
@@ -19,7 +19,7 @@ let index = 0
 test.each([
   null,
   [null],
-])('[null] is [null] then cases are not a table', (value) => {
+])('[null] is [null] when cases are not a table', (value) => {
   expect(value).toStrictEqual(expected[index])
   index++
 })

--- a/test/core/test/each.test.ts
+++ b/test/core/test/each.test.ts
@@ -9,10 +9,19 @@ test.each([
 })
 
 test.each([
+  [null],
+])('[null] is null when cases form a table', (value) => {
+  expect(value).toBe(null)
+})
+
+const expected = [null, [null]]
+let index = 0
+test.each([
   null,
   [null],
-])('null is null', (value) => {
-  expect(value).toBe(null)
+])('[null] is [null] then cases are not a table', (value) => {
+  expect(value).toStrictEqual(expected[index])
+  index++
 })
 
 test.each([


### PR DESCRIPTION
- Fixes #2278 

Previously:
- every test case was tested individually to see if it's an array,
- if so, the test case was spread as test parameters  (in the test callback function).

This PR makes `test.each()` follow the same algorithm as `jest-each`:
- the array of test cases is first evaluated to see it's a table (an array of arrays),
- if so, then all test cases are spread as test parameters, otherwise not.

This means for example that a single array in a series of test cases is not spread as test parameters.

Note that Jest pre-normalize the table, which we can still can avoid here, and process each row on the fly.
https://github.com/facebook/jest/blob/main/packages/jest-each/src/table/array.ts#L49