### PR TITLE
feat: allow hooks to be executed in a stack or list

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -821,7 +821,7 @@ Path to cache directory.
 
 ### sequence
 
-- **Type**: `{ sequencer?, shuffle?, seed? }`
+- **Type**: `{ sequencer?, shuffle?, seed?, hooks? }`
 
 Options for how tests should be sorted.
 
@@ -849,6 +849,17 @@ Vitest usually uses cache to sort tests, so long running tests start earlier - t
 - **Default**: `Date.now()`
 
 Sets the randomization seed, if tests are running in random order.
+
+#### sequence.hooks
+
+- **Type**: `'stack' | 'list' | 'parallel'`
+- **Default**: `'parallel'`
+
+Changes the order in which hooks are executed.
+
+- `stack` will order "after" hooks in reverse order, "before" hooks will run in the order they were defined
+- `list` will order all hooks in the order they are defined
+- `parallel` will run hooks in a single group in parallel (hooks in parent suites will still run before the current suite's hooks)
 
 ### typecheck
 

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -221,13 +221,14 @@ export function resolveConfig(
   if (resolved.cache)
     resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir)
 
+  resolved.sequence ??= {} as any
   if (!resolved.sequence?.sequencer) {
-    resolved.sequence ??= {} as any
     // CLI flag has higher priority
     resolved.sequence.sequencer = resolved.sequence.shuffle
       ? RandomSequencer
       : BaseSequencer
   }
+  resolved.sequence.hooks ??= 'parallel'
 
   resolved.typecheck = {
     ...configDefaults.typecheck,

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -14,6 +14,7 @@ export type BuiltinEnvironment = 'node' | 'jsdom' | 'happy-dom' | 'edge-runtime'
 // Record is used, so user can get intellisense for builtin environments, but still allow custom environments
 export type VitestEnvironment = BuiltinEnvironment | (string & Record<never, never>)
 export type CSSModuleScopeStrategy = 'stable' | 'scoped' | 'non-scoped'
+export type SequenceHooks = 'stack' | 'list' | 'parallel'
 
 export type ApiConfig = Pick<CommonServerOptions, 'port' | 'strictPort' | 'host'>
 
@@ -430,6 +431,14 @@ export interface InlineConfig {
      * @default Date.now()
      */
     seed?: number
+    /**
+     * Defines how hooks should be ordered
+     * - `stack` will order "after" hooks in reverse order, "before" hooks will run sequentially
+     * - `list` will order hooks in the order they are defined
+     * - `parallel` will run hooks in a single group in parallel
+     * @default 'parallel'
+     */
+    hooks?: SequenceHooks
   }
 
   /**
@@ -552,6 +561,7 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
 
   sequence: {
     sequencer: TestSequencerConstructor
+    hooks: SequenceHooks
     shuffle?: boolean
     seed?: number
   }
@@ -569,4 +579,4 @@ export type RuntimeConfig = Pick<
   | 'restoreMocks'
   | 'fakeTimers'
   | 'maxConcurrency'
->
+> & { sequence?: { hooks?: SequenceHooks } }

--- a/test/core/test/hooks-list.test.ts
+++ b/test/core/test/hooks-list.test.ts
@@ -1,0 +1,47 @@
+import * as vitest from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.setConfig({
+  sequence: {
+    hooks: 'list',
+  },
+})
+
+const hookOrder: number[] = []
+function callHook(hook: 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach', order: number) {
+  vitest[hook](() => {
+    hookOrder.push(order)
+  })
+}
+
+describe('hooks are called as list', () => {
+  callHook('beforeAll', 1)
+  callHook('beforeAll', 2)
+  callHook('beforeAll', 3)
+
+  callHook('afterAll', 4)
+  // will wait for it
+  vitest.afterAll(async () => {
+    await Promise.resolve()
+    hookOrder.push(5)
+  })
+  callHook('afterAll', 6)
+
+  callHook('beforeEach', 7)
+  callHook('beforeEach', 8)
+  callHook('beforeEach', 9)
+
+  callHook('afterEach', 10)
+  callHook('afterEach', 11)
+  callHook('afterEach', 12)
+
+  test('before hooks pushed in order', () => {
+    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9])
+  })
+})
+
+describe('previous suite run all hooks', () => {
+  test('after all hooks run in defined order', () => {
+    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9, 10, 11, 12, 4, 5, 6])
+  })
+})

--- a/test/core/test/hooks-parallel.test.ts
+++ b/test/core/test/hooks-parallel.test.ts
@@ -1,0 +1,47 @@
+import * as vitest from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.setConfig({
+  sequence: {
+    hooks: 'parallel',
+  },
+})
+
+const hookOrder: number[] = []
+function callHook(hook: 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach', order: number) {
+  vitest[hook](() => {
+    hookOrder.push(order)
+  })
+}
+
+describe('hooks are called in parallel', () => {
+  callHook('beforeAll', 1)
+  callHook('beforeAll', 2)
+  callHook('beforeAll', 3)
+
+  callHook('afterAll', 4)
+  // will always be last
+  vitest.afterAll(async () => {
+    await Promise.resolve()
+    hookOrder.push(5)
+  })
+  callHook('afterAll', 6)
+
+  callHook('beforeEach', 7)
+  callHook('beforeEach', 8)
+  callHook('beforeEach', 9)
+
+  callHook('afterEach', 10)
+  callHook('afterEach', 11)
+  callHook('afterEach', 12)
+
+  test('before hooks pushed in order', () => {
+    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9])
+  })
+})
+
+describe('previous suite run all hooks', () => {
+  test('after all hooks run in defined order', () => {
+    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9, 10, 11, 12, 4, 6, 5])
+  })
+})

--- a/test/core/test/hooks-stack.test.ts
+++ b/test/core/test/hooks-stack.test.ts
@@ -1,0 +1,47 @@
+import * as vitest from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.setConfig({
+  sequence: {
+    hooks: 'stack',
+  },
+})
+
+const hookOrder: number[] = []
+function callHook(hook: 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach', order: number) {
+  vitest[hook](() => {
+    hookOrder.push(order)
+  })
+}
+
+describe('hooks are called sequentially', () => {
+  callHook('beforeAll', 1)
+  callHook('beforeAll', 2)
+  callHook('beforeAll', 3)
+
+  callHook('afterAll', 4)
+  // will wait for it
+  vitest.afterAll(async () => {
+    await Promise.resolve()
+    hookOrder.push(5)
+  })
+  callHook('afterAll', 6)
+
+  callHook('beforeEach', 7)
+  callHook('beforeEach', 8)
+  callHook('beforeEach', 9)
+
+  callHook('afterEach', 10)
+  callHook('afterEach', 11)
+  callHook('afterEach', 12)
+
+  test('before hooks pushed in order', () => {
+    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9])
+  })
+})
+
+describe('previous suite run all hooks', () => {
+  test('after all hooks run in reverse order', () => {
+    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9, 12, 11, 10, 6, 5, 4])
+  })
+})

--- a/test/core/test/hooks-stack.test.ts
+++ b/test/core/test/hooks-stack.test.ts
@@ -16,32 +16,28 @@ function callHook(hook: 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach', o
 
 describe('hooks are called sequentially', () => {
   callHook('beforeAll', 1)
-  callHook('beforeAll', 2)
-  callHook('beforeAll', 3)
-
   callHook('afterAll', 4)
+
+  callHook('beforeAll', 2)
   // will wait for it
   vitest.afterAll(async () => {
     await Promise.resolve()
     hookOrder.push(5)
   })
-  callHook('afterAll', 6)
 
   callHook('beforeEach', 7)
-  callHook('beforeEach', 8)
-  callHook('beforeEach', 9)
-
   callHook('afterEach', 10)
+
+  callHook('beforeEach', 8)
   callHook('afterEach', 11)
-  callHook('afterEach', 12)
 
   test('before hooks pushed in order', () => {
-    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9])
+    expect(hookOrder).toEqual([1, 2, 7, 8])
   })
 })
 
 describe('previous suite run all hooks', () => {
   test('after all hooks run in reverse order', () => {
-    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9, 12, 11, 10, 6, 5, 4])
+    expect(hookOrder).toEqual([1, 2, 7, 8, 11, 10, 5, 4])
   })
 })


### PR DESCRIPTION
Closes #2279

This PR adds an option `sequence.hooks` with possible values:

- `stack` will order "after" hooks in reverse order, "before" hooks will run in the order they were defined
- `list` will order all hooks in the order they are defined
- `parallel` will run hooks in a single group in parallel (hooks in parent suites will still run before the current suite's hooks)

I want to release this in 0.25.1 or 0.25.2, so we don't change the default behaviour, since it would be a breaking change.

@kristiandupont can you review this? It's possible that I misunderstood the idea
