### PR TITLE
fix: bench had options

### DIFF
--- a/packages/vitest/src/runtime/map.ts
+++ b/packages/vitest/src/runtime/map.ts
@@ -1,8 +1,9 @@
-import type { Awaitable, BenchFunction, Benchmark, Suite, SuiteHooks, Test } from '../types'
+import type { Awaitable, BenchFunction, BenchOptions, Benchmark, Suite, SuiteHooks, Test } from '../types'
 
 // use WeakMap here to make the Test and Suite object serializable
 const fnMap = new WeakMap()
 const hooksMap = new WeakMap()
+const benchOptsMap = new WeakMap()
 
 export function setFn(key: Test | Benchmark, fn: (() => Awaitable<void>) | BenchFunction) {
   fnMap.set(key, fn)
@@ -22,4 +23,12 @@ export function getHooks(key: Suite): SuiteHooks {
 
 export function isTest(task: Test | Benchmark): task is Test {
   return task.type === 'test'
+}
+
+export function setBenchOptions(key: Benchmark, val: BenchOptions) {
+  benchOptsMap.set(key, val)
+}
+
+export function getBenchOptions(key: Benchmark): BenchOptions {
+  return benchOptsMap.get(key)
 }

--- a/packages/vitest/src/runtime/run.ts
+++ b/packages/vitest/src/runtime/run.ts
@@ -6,7 +6,7 @@ import { assertTypes, clearTimeout, createDefer, getFullName, getWorkerState, ha
 import { getState, setState } from '../integrations/chai/jest-expect'
 import { GLOBAL_EXPECT } from '../integrations/chai/constants'
 import { takeCoverageInsideWorker } from '../integrations/coverage'
-import { getFn, getHooks } from './map'
+import { getBenchOptions, getFn, getHooks } from './map'
 import { rpc } from './rpc'
 import { collectTests } from './collect'
 import { processError } from './error'
@@ -348,7 +348,8 @@ async function runBenchmarkSuite(suite: Suite) {
     }
     updateTask(suite)
     benchmarkGroup.forEach((benchmark, idx) => {
-      const benchmarkInstance = new Bench(benchmark.options)
+      const options = getBenchOptions(benchmark)
+      const benchmarkInstance = new Bench(options)
 
       const benchmarkFn = getFn(benchmark)
 

--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -3,7 +3,7 @@ import type { BenchFunction, BenchOptions, Benchmark, BenchmarkAPI, File, RunMod
 import { getWorkerState, isObject, isRunningInBenchmark, isRunningInTest, noop } from '../utils'
 import { createChainable } from './chain'
 import { collectTask, collectorContext, createTestContext, runWithSuite, withTimeout } from './context'
-import { getHooks, setFn, setHooks } from './map'
+import { getHooks, setBenchOptions, setFn, setHooks } from './map'
 
 // apis
 export const suite = createSuite()
@@ -106,11 +106,11 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
       id: '',
       name,
       mode,
-      options,
       suite: undefined!,
     }
 
     setFn(benchmark, fn)
+    setBenchOptions(benchmark, options)
     tasks.push(benchmark)
   })
 

--- a/packages/vitest/src/types/benchmark.ts
+++ b/packages/vitest/src/types/benchmark.ts
@@ -43,7 +43,6 @@ export interface Benchmark extends TaskBase {
   result?: TaskResult
   fails?: boolean
   task?: BenchTask
-  options: BenchOptions
 }
 
 export interface BenchmarkResult extends TinybenchResult {

--- a/test/benchmark/test/base.bench.ts
+++ b/test/benchmark/test/base.bench.ts
@@ -31,6 +31,13 @@ function timeout(time: number) {
 describe('timeout', () => {
   bench('timeout100', async () => {
     await timeout(100)
+  }, {
+    setup() {
+
+    },
+    teardown() {
+
+    },
   })
 
   bench('timeout75', async () => {


### PR DESCRIPTION
fix: #2284

`benchmark` will send by the worker. make sure `benchmark` should be a jsonify object