### PR TITLE
fix(cli): Don't override config by setting cli options to undefined

### DIFF
--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -103,9 +103,15 @@ async function typecheck(cliFilters: string[] = [], options: CliOptions = {}) {
 }
 
 function normalizeOptions(argv: CliOptions): CliOptions {
-  argv.root = argv.root && normalize(argv.root)
-  argv.config = argv.config && normalize(argv.config)
-  argv.dir = argv.dir && normalize(argv.dir)
+  if (argv.root)
+    argv.root = normalize(argv.root)
+
+  if (argv.config)
+    argv.config = normalize(argv.config)
+
+  if (argv.dir)
+    argv.dir = normalize(argv.dir)
+
   return argv
 }
 


### PR DESCRIPTION
This has been introduced by #2180. The change there will *always* set argv.dir, no matter if it's been there before or not. When it's not there, it will set it to undefined, which then will lead to vitest using the root as fallback instead of the config set in the config file, since CLI options override config options.

In our case, this config was essentially ignored since 0.24.4.

```js
import { defineConfig } from "vite"

export default defineConfig({
  root: "app/javascript",
  test: {
    dir: "spec/javascript"
  }
})
```

with the only workaround of providing `dir` via CLI option.

Btw. I'd love to add tests, but I haven't found existing tests for this and didn't have too much time on my hands. Happy to take pointers and add them.