### PR TITLE
fix(coverage): env-replacer to add filenames into sourcemaps

### DIFF
--- a/packages/vitest/src/node/plugins/envReplacer.ts
+++ b/packages/vitest/src/node/plugins/envReplacer.ts
@@ -8,7 +8,7 @@ export const EnvReplacerPlugin = (): Plugin => {
   return {
     name: 'vitest:env-replacer',
     enforce: 'pre',
-    transform(code) {
+    transform(code, id) {
       if (!/\bimport\.meta\.env\b/g.test(code))
         return null
 
@@ -27,7 +27,7 @@ export const EnvReplacerPlugin = (): Plugin => {
       if (s) {
         return {
           code: s.toString(),
-          map: s.generateMap({ hires: true }),
+          map: s.generateMap({ hires: true, source: id }),
         }
       }
     },

--- a/test/coverage-test/coverage-test/coverage.istanbul.test.ts
+++ b/test/coverage-test/coverage-test/coverage.istanbul.test.ts
@@ -50,3 +50,10 @@ test('implicit else is included in branch count', async () => {
   expect(fileCoverage.b).toHaveProperty('0')
   expect(fileCoverage.b['0']).toHaveLength(2)
 })
+
+test('file using import.meta.env is included in report', async () => {
+  const coveragePath = resolve('./coverage/src')
+  const files = fs.readdirSync(coveragePath)
+
+  expect(files).toContain('importEnv.ts.html')
+})

--- a/test/coverage-test/src/importEnv.ts
+++ b/test/coverage-test/src/importEnv.ts
@@ -1,0 +1,3 @@
+export function useImportEnv() {
+  return import.meta.env.SOME_VARIABLE == null
+}

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { pythagoras } from '../src'
 import { implicitElse } from '../src/implicitElse'
+import { useImportEnv } from '../src/importEnv'
 
 test('Math.sqrt()', async () => {
   expect(pythagoras(3, 4)).toBe(5)
@@ -8,4 +9,8 @@ test('Math.sqrt()', async () => {
 
 test('implicit else', () => {
   expect(implicitElse(true)).toBe(2)
+})
+
+test('import meta env', () => {
+  expect(useImportEnv()).toBe(true)
 })


### PR DESCRIPTION
Fixes #2332.
Possibly fixes #2214.

![image](https://user-images.githubusercontent.com/14806298/202242080-db15257d-9bd4-4f16-94b5-2f2cb73b15a1.png)