### PR TITLE
fix(mocker): clear automocked modules on unmock

### DIFF
--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -291,7 +291,7 @@ export class VitestMocker {
     const id = this.normalizePath(path)
 
     const mock = this.mockMap.get(suitefile)
-    if (mock?.[id])
+    if (mock && id in mock)
       delete mock[id]
 
     const mockId = this.getMockPath(id)

--- a/test/core/test/fixtures/mocked-dependency.ts
+++ b/test/core/test/fixtures/mocked-dependency.ts
@@ -1,0 +1,3 @@
+export function helloWorld(): void {
+  throw new Error('not implemented')
+}

--- a/test/core/test/unmock-import.test.ts
+++ b/test/core/test/unmock-import.test.ts
@@ -8,6 +8,7 @@ beforeEach(() => {
     },
   }))
 })
+
 afterEach(() => {
   vi.doUnmock('/data')
 })
@@ -23,4 +24,14 @@ test('second import should had been re-mock', async () => {
   // @ts-expect-error I know this
   const { data } = await import('/data')
   expect(data.state).toBe('STARTED')
+})
+
+test('unmock should clear modules replaced with imitation', async () => {
+  vi.doMock('./fixtures/mocked-dependency')
+  const { helloWorld } = await import('./fixtures/mocked-dependency')
+  expect(vi.isMockFunction(helloWorld)).toBe(true)
+
+  vi.doUnmock('./fixtures/mocked-dependency')
+  const { helloWorld: unmocked } = await import('./fixtures/mocked-dependency')
+  expect(vi.isMockFunction(unmocked)).toBe(false)
 })


### PR DESCRIPTION
This PR implements the fix for #2351 suggested in https://github.com/vitest-dev/vitest/issues/2351#issuecomment-1320974209.

I've added a test to the existing `test/core/test/unmock-import.test.ts` suite, which involved adding a little fixture file. Let me know if you'd like any changes or adjustments to the tests for this fix!