### PR TITLE
fix: Detect tests in folders starting with `.` (fix #2344)

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -553,8 +553,9 @@ export class Vitest {
   async globTestFiles(filters: string[] = []) {
     const { include, exclude, includeSource } = this.config
 
-    const globOptions = {
+    const globOptions: fg.Options = {
       absolute: true,
+      dot: true,
       cwd: this.config.dir || this.config.root,
       ignore: exclude,
     }

--- a/test/core/test/.dot-folder/dot-test.test.ts
+++ b/test/core/test/.dot-folder/dot-test.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('check that tests inside folder with . is run', () => {
+  expect(true).toBe(true)
+})

--- a/test/fails/fixtures/.dot-folder/dot-test.test.ts
+++ b/test/fails/fixtures/.dot-folder/dot-test.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
 
 test('check that tests inside folder with . is run', () => {
-  expect(true).toBe(true)
+  expect(true).toBe(false)
 })

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1
 
+exports[`should fails > .dot-folder/dot-test.test.ts > .dot-folder/dot-test.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
+
 exports[`should fails > each-timeout.test.ts > each-timeout.test.ts 1`] = `"Error: Test timed out in 10ms."`;
 
 exports[`should fails > empty.test.ts > empty.test.ts 1`] = `"Error: No test suite found in file <rootDir>/empty.test.ts"`;

--- a/test/fails/test/runner.test.ts
+++ b/test/fails/test/runner.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('should fails', async () => {
   const root = resolve(__dirname, '../fixtures')
-  const files = await fg('*.test.ts', { cwd: root })
+  const files = await fg('**/*.test.ts', { cwd: root, dot: true })
 
   for (const file of files) {
     it(file, async () => {


### PR DESCRIPTION
I have added a test in a folder starting with `.` and manually verified that it's picked up. 
<img width="379" alt="image" src="https://user-images.githubusercontent.com/10703445/203096473-4d7efdab-53b0-42cb-ae46-94e9a71c095a.png">


But it's not the right test as it won't fail even if `dot` is `false`. 

Is there an example test I can refer to ensure the path is picked up? Or somehow verify that that exact test was run?

fixes #2344