### PR TITLE
docs: replace invalid example for `toBeString` in `expectTypeOf` API …

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2218,10 +2218,9 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
   ```ts
   import { expectTypeOf } from 'vitest'
 
-  expectTypeOf(42).not.toBeArray()
-  expectTypeOf([]).toBeArray()
-  expectTypeOf([1, 2]).toBeArray()
-  expectTypeOf<number[]>().toBeArray()
+  expectTypeOf(42).not.toBeString()
+  expectTypeOf('').toBeString()
+  expectTypeOf('a').toBeString()
   ```
 
 ### toBeBoolean


### PR DESCRIPTION
…documentation

[toBeString](https://vitest.dev/api/#tobestring) example in [expectTypeOf](https://vitest.dev/api/#expecttypeof) API docs is using `toBeArray` instead of `toBeString`