### PR TITLE
fix: exit with code 1, when type tests fail

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -160,10 +160,14 @@ export class Vitest {
     checker.onParseEnd(async ({ files, sourceErrors }) => {
       this.state.collectFiles(checker.getTestFiles())
       await this.report('onCollected')
-      if (!files.length)
+      if (!files.length) {
         this.logger.printNoTestFound()
-      else
+      }
+      else {
+        if (hasFailed(files))
+          process.exitCode = 1
         await this.report('onFinished', files)
+      }
       if (sourceErrors.length && !this.config.typecheck.ignoreSourceErrors) {
         process.exitCode = 1
         await this.logger.printSourceTypeErrors(sourceErrors)


### PR DESCRIPTION
Fixes #2377