### PR TITLE
fix(mocker): set cache before mocking to allow circular dependencies

### DIFF
--- a/test/core/test/mocked-circular.test.ts
+++ b/test/core/test/mocked-circular.test.ts
@@ -1,0 +1,12 @@
+import { expect, it, vi } from 'vitest'
+// The order of the two imports here matters: B before A
+import { circularB } from '../src/circularB'
+import { circularA } from '../src/circularA'
+
+vi.mock('../src/circularB')
+
+it('circular', () => {
+  circularA()
+
+  expect(circularB).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
Fixes #2381

This is an attempt to fix the issue described in #2381.

As suggested by @sheremet-va I removed the `moduleCache` Handling and only used `this.request`
```diff
-const mod = this.moduleCache.get(cacheKey)?.exports || await this.request(dep)
+const mod = await this.request(dep)
```

This alone did not fix the problem, as [this block](https://github.com/vitest-dev/vitest/blob/main/packages/vite-node/src/client.ts#L204-L209) kicks in for the second request to the module and at that point we already have the Module-Symbol set on exports.

In order to fix this, it is necessary to already assign an empty exports object in the module cache for the mocked module. This way the second call to `requestWithMock()` would return this empty object, which later gets filled once the first call resolves.

This also mimics [what Node.js does](https://nodejs.org/api/modules.html#modules_cycles) for circular dependencies and as long as the imported value isn't directly used in the module scope everything is fine.
