### PR TITLE
docs(coverage): overall improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
   "[json]": {
     "editor.formatOnSave": false
   },
+  "[markdown]": {
+    "editor.formatOnSave": false
+  },
   "prettier.enable": false
 }

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -506,9 +506,6 @@ Isolate environment for each test file. Does not work if you disable [`--threads
 
 ### coverage
 
-- **Type:** `CoverageC8Options | CoverageIstanbulOptions`
-- **Default:** `undefined`
-
 You can use [`c8`](https://github.com/bcoe/c8) or [`istanbul`](https://istanbul.js.org/) for coverage collection.
 
 #### provider
@@ -518,74 +515,185 @@ You can use [`c8`](https://github.com/bcoe/c8) or [`istanbul`](https://istanbul.
 
 Use `provider` to select the tool for coverage collection.
 
-#### CoverageC8Options
+#### enabled
 
-Used when `provider: 'c8'` is set. Coverage options are passed to [`c8`](https://github.com/bcoe/c8).
+- **Type:** `boolean`
+- **Default:** `false`
+- **Available for providers:** `'c8' | 'istanbul'`
 
-#### CoverageIstanbulOptions
+Enables coverage collection. Can be overriden using `--coverage` CLI option.
 
-Used when `provider: 'istanbul'` is set.
-
-##### include
+#### include
 
 - **Type:** `string[]`
 - **Default:** `['**']`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 List of files included in coverage as glob patterns
 
-##### exclude
+#### extension
+
+- **Type:** `string | string[]`
+- **Default:** `['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.vue', '.svelte']`
+- **Available for providers:** `'c8' | 'istanbul'`
+
+#### exclude
 
 - **Type:** `string[]`
-- **Default:** `['coverage/**', 'dist/**', 'packages/*/test{,s}/**', '**/*.d.ts', 'cypress/**', 'test{,s}/**', 'test{,-*}.{js,cjs,mjs,ts,tsx,jsx}', '**/*{.,-}test.{js,cjs,mjs,ts,tsx,jsx}', '**/*{.,-}spec.{js,cjs,mjs,ts,tsx,jsx}', '**/__tests__/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress}.config.{js,cjs,mjs,ts}', '**/.{eslint,mocha,prettier}rc.{js,cjs,yml}']`
+- **Default:**
+```js
+[
+  'coverage/**',
+  'dist/**',
+  'packages/*/test{,s}/**',
+  '**/*.d.ts',
+  'cypress/**',
+  'test{,s}/**',
+  'test{,-*}.{js,cjs,mjs,ts,tsx,jsx}',
+  '**/*{.,-}test.{js,cjs,mjs,ts,tsx,jsx}',
+  '**/*{.,-}spec.{js,cjs,mjs,ts,tsx,jsx}',
+  '**/__tests__/**',
+  '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress}.config.*',
+  '**/.{eslint,mocha,prettier}rc.{js,cjs,yml}',
+]
+```
+- **Available for providers:** `'c8' | 'istanbul'`
 
 List of files excluded from coverage as glob patterns.
 
-##### skipFull
+#### all
 
 - **Type:** `boolean`
 - **Default:** `false`
+- **Available for providers:** `'c8' | 'istanbul'`
+
+Whether to include all files, including the untested ones into report.
+
+#### clean
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Available for providers:** `'c8' | 'istanbul'`
+
+Clean coverage results before running tests
+
+#### cleanOnRerun
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Available for providers:** `'c8' | 'istanbul'`
+
+Clean coverage report on watch rerun
+
+#### reportsDirectory
+
+- **Type:** `string`
+- **Default:** `'./coverage'`
+- **Available for providers:** `'c8' | 'istanbul'`
+
+Directory to write coverage report to.
+When using `c8` provider a temporary `/tmp` directory is created for [V8 coverage results](https://nodejs.org/api/cli.html#coverage-output).
+
+#### reporter
+
+- **Type:** `string | string[]`
+- **Default:** `['text', 'html', 'clover', 'json']`
+- **Available for providers:** `'c8' | 'istanbul'`
+
+Coverage reporters to use. See [istanbul documentation](https://istanbul.js.org/docs/advanced/alternative-reporters/) for detailed list of all reporters.
+
+
+#### skipFull
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Do not show files with 100% statement, branch, and function coverage.
 
-##### perFile
+#### perFile
 
 - **Type:** `boolean`
 - **Default:** `false`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Check thresholds per file.
+See `lines`, `functions`, `branches` and `statements` for the actual thresholds.
 
-##### lines
+#### lines
 
 - **Type:** `number`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Threshold for lines.
+See [istanbul documentation](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information.
 
-##### functions
+#### functions
 
 - **Type:** `number`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Threshold for functions.
+See [istanbul documentation](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information.
 
-##### branches
+#### branches
 
 - **Type:** `number`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Threshold for branches.
+See [istanbul documentation](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information.
 
-##### statements
+#### statements
 
 - **Type:** `number`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Threshold for statements.
+See [istanbul documentation](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information.
 
-##### ignoreClassMethods
+#### allowExternal
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Available for providers:** `'c8'`
+
+Allow files from outside of your cwd.
+
+#### excludeNodeModules
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Available for providers:** `'c8'`
+
+Exclude coverage under `/node_modules/`.
+
+#### src
 
 - **Type:** `string[]`
-- **Default:** []
+- **Default:** `process.cwd()`
+- **Available for providers:** `'c8'`
+
+Specifies the directories that are used when `--all` is enabled.
+
+#### 100
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Available for providers:** `'c8'`
+
+Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`.
+
+#### ignoreClassMethods
+
+- **Type:** `string[]`
+- **Default:** `[]`
+- **Available for providers:** `'istanbul'`
 
 Set to array of class method names to ignore for coverage.
+See [istanbul documentation](https://github.com/istanbuljs/nyc#high-and-low-watermarks) for more information.
 
-##### watermarks
+#### watermarks
 
 - **Type:**
 <!-- eslint-skip -->
@@ -610,13 +718,6 @@ Set to array of class method names to ignore for coverage.
 ```
 
 Watermarks for statements, lines, branches and functions.
-
-##### all
-
-- **Type:** `boolean`
-- **Default:** false
-
-Whether to include all files, including the untested ones into report.
 
 ### testNamePattern
 

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -88,3 +88,24 @@ export default defineConfig({
 ```
 
 Please refer to the type definition for more details.
+
+## Ignoring code
+
+Both coverage providers have their own ways how to ignore code from coverage reports.
+
+- `c8`: https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks
+- `ìstanbul` https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines
+
+When using Typescript the source codes are transpiled using `esbuild`, which strips all comments from the source codes ([esbuild#516](https://github.com/evanw/esbuild/issues/516)).
+Comments which are considered as [legal comments](https://esbuild.github.io/api/#legal-comments) are preserved.
+
+For `istanbul` provider you can include a `@preserve` keyword in the ignore hint.
+Beware that these ignore hints may now be included in final production build as well.
+
+```diff
+-/* istanbul ignore if */
++/* istanbul ignore if -- @preserve */
+if (condition) {
+```
+
+Unfortunately this does not work for `c8` at the moment.

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -59,14 +59,40 @@ export type ResolvedCoverageOptions =
 
 export interface BaseCoverageOptions {
   /**
-   * Enable coverage, pass `--coverage` to enable
+   * Enables coverage collection. Can be overriden using `--coverage` CLI option.
    *
    * @default false
    */
   enabled?: boolean
 
   /**
-   * Clean coverage before running tests
+   * List of files included in coverage as glob patterns
+   *
+   * @default ['**']
+   */
+  include?: string[]
+
+  /**
+    * Extensions for files to be included in coverage
+    *
+    * @default ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.vue', '.svelte']
+    */
+  extension?: string | string[]
+
+  /**
+    * List of files excluded from coverage as glob patterns
+    */
+  exclude?: string[]
+
+  /**
+   * Whether to include all files, including the untested ones into report
+   *
+   * @default false
+   */
+  all?: boolean
+
+  /**
+   * Clean coverage results before running tests
    *
    * @default true
    */
@@ -85,29 +111,23 @@ export interface BaseCoverageOptions {
   reportsDirectory?: string
 
   /**
-   * Reporters
+   * Coverage reporters to use.
+   * See [istanbul documentation](https://istanbul.js.org/docs/advanced/alternative-reporters/) for detailed list of all reporters.
    *
-   * @default 'text'
+   * @default ['text', 'html', 'clover', 'json']
    */
   reporter?: Arrayable<CoverageReporter>
 
   /**
-   * List of files included in coverage as glob patterns
-   */
-  include?: string[]
-
-  /**
-   * List of files excluded from coverage as glob patterns
-   */
-  exclude?: string[]
-
-  /**
    * Do not show files with 100% statement, branch, and function coverage
+   *
+   * @default false
    */
   skipFull?: boolean
 
   /**
-   * Check thresholds per file
+   * Check thresholds per file.
+   * See `lines`, `functions`, `branches` and `statements` for the actual thresholds.
    *
    * @default false
    */
@@ -115,40 +135,46 @@ export interface BaseCoverageOptions {
 
   /**
    * Threshold for lines
+   *
+   * @default undefined
    */
   lines?: number
 
   /**
    * Threshold for functions
+   *
+   * @default undefined
    */
   functions?: number
 
   /**
    * Threshold for branches
+   *
+   * @default undefined
    */
   branches?: number
 
   /**
    * Threshold for statements
+   *
+   * @default undefined
    */
   statements?: number
-
-  /**
-   * Extensions for files to be included in coverage
-   */
-  extension?: string | string[]
-
-  /**
-   * Whether to include all files, including the untested ones into report
-   */
-  all?: boolean
 }
 
 export interface CoverageIstanbulOptions extends BaseCoverageOptions {
-  /* Set to array of class method names to ignore for coverage */
+  /**
+   * Set to array of class method names to ignore for coverage
+   *
+   * @default []
+   */
   ignoreClassMethods?: string[]
 
-  /* Watermarks for statements, lines, branches and functions */
+  /**
+   * Watermarks for statements, lines, branches and functions.
+   *
+   * Default value is `[50,80]` for each property.
+   */
   watermarks?: {
     statements?: [number, number]
     functions?: [number, number]
@@ -163,15 +189,26 @@ export interface CoverageC8Options extends BaseCoverageOptions {
    *
    * @default false
    */
-  allowExternal?: any
+  allowExternal?: boolean
+
   /**
-   * Exclude coverage under /node_modules/
+   * Exclude coverage under `/node_modules/`
    *
    * @default true
    */
   excludeNodeModules?: boolean
 
+  /**
+   * Specifies the directories that are used when `--all` is enabled.
+   *
+   * @default cwd
+  */
   src?: string[]
 
+  /**
+   * Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`
+   *
+   * @default false
+   */
   100?: boolean
 }


### PR DESCRIPTION
- adds **Ignoring code** section to guides
- adds clear descriptions for each coverage option
- ordered coverage options in a logical order

There have been many questions related to coverage options on Vitest Discrod and here on Github issues. Currently the available options are unclear as some options of both providers are not included in documentation. Instead of stating `C8Options`, the documentation should describe all `c8` options that are supported. 