### PR TITLE
fix(browser): wrong path on dev:node script

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -28,7 +28,7 @@
     "build:client": "vite build src/client",
     "build:node": "rollup -c",
     "dev:client": "vite build src/client --watch",
-    "dev:node": "rollup -c --watch --watch.include=node",
+    "dev:node": "rollup -c --watch --watch.include src/node/index.ts",
     "dev": "rimraf dist && run-p dev:node dev:client",
     "copy": "esno scripts/copy-ui-to-browser.ts",
     "prepublishOnly": "pnpm build"


### PR DESCRIPTION
Running `pnpm rollup --help`: `--watch.include <files>     Limit watching to specified files`