### PR TITLE
feat: format test objects (fix #2420)

### DIFF
--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -281,7 +281,7 @@ function formatTitle(template: string, items: any[], idx: number) {
   return formatted
 }
 
-function formatObject(value: unknown, maxDepth = 4): string {
+function formatObject(value: unknown, maxDepth = 3, maxWidth = 2): string {
   const formatFunctions = {
     test: (val: unknown) => typeof val === 'function',
     serialize: (val: Function) => val.toString(),
@@ -291,6 +291,7 @@ function formatObject(value: unknown, maxDepth = 4): string {
     plugins: [formatFunctions],
     escapeRegex: true,
     maxDepth,
+    maxWidth,
     min: true,
   })
 }

--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -1,5 +1,4 @@
 import util from 'util'
-import { serialize } from 'v8'
 import { format as prettyFormat } from 'pretty-format'
 import type { BenchFunction, BenchOptions, Benchmark, BenchmarkAPI, File, RunMode, Suite, SuiteAPI, SuiteCollector, SuiteFactory, SuiteHooks, Task, Test, TestAPI, TestFunction, TestOptions } from '../types'
 import { getWorkerState, isObject, isRunningInBenchmark, isRunningInTest, noop, objectAttr } from '../utils'

--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -1,5 +1,5 @@
 import util from 'util'
-import { format as prettyFormat } from 'pretty-format'
+import { util as chaiUtil } from 'chai'
 import type { BenchFunction, BenchOptions, Benchmark, BenchmarkAPI, File, RunMode, Suite, SuiteAPI, SuiteCollector, SuiteFactory, SuiteHooks, Task, Test, TestAPI, TestFunction, TestOptions } from '../types'
 import { getWorkerState, isObject, isRunningInBenchmark, isRunningInTest, noop, objectAttr } from '../utils'
 import { createChainable } from './chain'
@@ -275,25 +275,11 @@ function formatTitle(template: string, items: any[], idx: number) {
   let formatted = util.format(template, ...items.slice(0, count))
   if (isObject(items[0])) {
     formatted = formatted.replace(/\$([$\w_.]+)/g,
-      (_, key) => formatObject(objectAttr(items[0], key)),
+      (_, key) => chaiUtil.objDisplay(objectAttr(items[0], key)) as unknown as string,
+    // https://github.com/chaijs/chai/pull/1490
     )
   }
   return formatted
-}
-
-function formatObject(value: unknown, maxDepth = 3, maxWidth = 2): string {
-  const formatFunctions = {
-    test: (val: unknown) => typeof val === 'function',
-    serialize: (val: Function) => val.toString(),
-  }
-
-  return prettyFormat(value, {
-    plugins: [formatFunctions],
-    escapeRegex: true,
-    maxDepth,
-    maxWidth,
-    min: true,
-  })
 }
 
 function formatTemplateString(cases: any[], args: any[]): any[] {

--- a/packages/vitest/src/runtime/suite.ts
+++ b/packages/vitest/src/runtime/suite.ts
@@ -281,7 +281,7 @@ function formatTitle(template: string, items: any[], idx: number) {
   return formatted
 }
 
-function formatObject(value: unknown, maxDepth = 4) {
+function formatObject(value: unknown, maxDepth = 4): string {
   const formatFunctions = {
     test: (val: unknown) => typeof val === 'function',
     serialize: (val: Function) => val.toString(),

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -190,18 +190,19 @@ describe('objectAttr', () => {
   }
 
   test.each`
-    value                        | path             | expected
-    ${{ foo: 'bar' }}            | ${'foo'}         | ${'bar'}
-    ${{ foo: { bar: 'baz' } }}   | ${'foo'}         | ${{ bar: 'baz' }}
-    ${{ foo: { bar: 'baz' } }}   | ${'foo.bar'}     | ${'baz'}
-    ${{ foo: [{ bar: 'baz' }] }} | ${'foo.0.bar'}   | ${'baz'}
-    ${{ foo: [1, 2, ['a']] }}    | ${'foo'}         | ${[1, 2, ['a']]}
-    ${{ foo: [1, 2, ['a']] }}    | ${'foo.2'}       | ${['a']}
-    ${{ foo: [1, 2, ['a']] }}    | ${'foo.2.0'}     | ${'a'}
-    ${{ foo: [[[1]]] }}          | ${'foo.0.0.0'}   | ${1}
-    ${{ foo: [[[[1]]]] }}        | ${'foo.0.0.0.0'} | ${1}
-    ${{ foo: arrow }}            | ${'foo'}         | ${arrow}
-    ${{ foo: func }}             | ${'foo'}         | ${func}
+    value                         | path            | expected
+    ${{ foo: 'bar' }}             | ${'foo'}        | ${'bar'}
+    ${{ foo: { bar: 'baz' } }}    | ${'foo'}        | ${{ bar: 'baz' }}
+    ${{ foo: { bar: 'baz' } }}    | ${'foo.bar'}    | ${'baz'}
+    ${{ foo: [{ bar: 'baz' }] }}  | ${'foo.0.bar'}  | ${'baz'}
+    ${{ foo: [1, 2, ['a']] }}     | ${'foo'}        | ${[1, 2, ['a']]}
+    ${{ foo: [1, 2, ['a']] }}     | ${'foo.2'}      | ${['a']}
+    ${{ foo: [1, 2, ['a']] }}     | ${'foo.2.0'}    | ${'a'}
+    ${{ foo: [[1]] }}             | ${'foo.0.0'}    | ${1}
+    ${{ deep: [[[1]]] }}          | ${'deep.0.0.0'} | ${1}
+    ${{ a: 1, b: 2, c: 3, d: 4 }} | ${'a'}          | ${1}
+    ${{ arrow }}                  | ${'arrow'}      | ${arrow}
+    ${{ func }}                   | ${'func'}       | ${func}
   `('objectAttr($value, $path) -> $expected', ({ value, path, expected }) => {
     expect(objectAttr(value, path)).toEqual(expected)
   })


### PR DESCRIPTION
Resolves #2420

![image](https://user-images.githubusercontent.com/54838975/205595255-3d3a3d42-93a6-4ede-a3ff-b743e0de857c.png)

this PR enhances `formatTitle` function by pretty-formatting individual objects.
also added test suite for `objectAttr` function.