### PR TITLE
chore: fix rollup watch mode

### DIFF
--- a/packages/coverage-c8/package.json
+++ b/packages/coverage-c8/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch --watch.include=src",
+    "dev": "rollup -c --watch --watch.include 'src/**'",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch --watch.include=src",
+    "dev": "rollup -c --watch --watch.include 'src/**'",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch --watch.include=src",
+    "dev": "rollup -c --watch --watch.include 'src/**'",
     "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
-    "dev": "rollup -c --watch --watch.include=src",
+    "dev": "rollup -c --watch --watch.include 'src/**'",
     "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Rollup's watch mode doesn't seem to work on packages which explicitly set the included source. I think this has been working fine before but noticed that the packages were not reloading any more.

```
  System:
    OS: macOS 12.5
    CPU: (8) arm64 Apple M2
    Memory: 3.52 GB / 16.00 GB
    Shell: 5.8.1 - /bin/zsh
  Binaries:
    Node: 19.1.0 - /opt/homebrew/bin/node
    Yarn: 1.22.19 - /opt/homebrew/bin/yarn
    npm: 8.19.3 - /opt/homebrew/bin/npm
  Browsers:
    Brave Browser: 107.1.45.133
    Safari: 15.6
  npmPackages:
    vite: ^3.2.3 => 3.2.3
    vitest: workspace:* => 0.25.3
```