### PR TITLE
fix(coverage-istanbul): clear coverage map after use

### DIFF
--- a/packages/coverage-istanbul/src/index.ts
+++ b/packages/coverage-istanbul/src/index.ts
@@ -7,5 +7,11 @@ export async function getProvider() {
 
 export function takeCoverage() {
   // @ts-expect-error -- untyped global
-  return globalThis[COVERAGE_STORE_KEY]
+  const coverage = globalThis[COVERAGE_STORE_KEY]
+
+  // Reset coverage map to prevent duplicate results if this is called twice in row
+  // @ts-expect-error -- untyped global
+  globalThis[COVERAGE_STORE_KEY] = {}
+
+  return coverage
 }

--- a/test/coverage-test/coverage-test/__snapshots__/coverage.istanbul.test.ts.snap
+++ b/test/coverage-test/coverage-test/__snapshots__/coverage.istanbul.test.ts.snap
@@ -1,0 +1,1577 @@
+// Vitest Snapshot v1
+
+exports[`istanbul json report 1`] = `
+{
+  "<root>/src/Counter/Counter.component.ts": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 1,
+      "1": 0,
+      "2": 2,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 10,
+            "line": 6,
+          },
+          "start": {
+            "column": 2,
+            "line": 6,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 9,
+          },
+          "start": {
+            "column": 10,
+            "line": 6,
+          },
+        },
+        "name": "(anonymous_0)",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 22,
+            "line": 12,
+          },
+          "start": {
+            "column": 4,
+            "line": 12,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 14,
+          },
+          "start": {
+            "column": 22,
+            "line": 12,
+          },
+        },
+        "name": "(anonymous_1)",
+      },
+      "2": {
+        "decl": {
+          "end": {
+            "column": 20,
+            "line": 16,
+          },
+          "start": {
+            "column": 4,
+            "line": 16,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 18,
+          },
+          "start": {
+            "column": 20,
+            "line": 16,
+          },
+        },
+        "name": "(anonymous_2)",
+      },
+    },
+    "path": "<root>/src/Counter/Counter.component.ts",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 0,
+      "3": 2,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 7,
+        },
+        "start": {
+          "column": 18,
+          "line": 7,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 8,
+        },
+        "start": {
+          "column": 4,
+          "line": 8,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 13,
+        },
+        "start": {
+          "column": 6,
+          "line": 13,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 17,
+        },
+        "start": {
+          "column": 6,
+          "line": 17,
+        },
+      },
+    },
+  },
+  "<root>/src/Counter/Counter.vue": {
+    "b": {
+      "0": [
+        2,
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 8,
+          },
+          "start": {
+            "column": 18,
+            "line": 8,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 8,
+            },
+            "start": {
+              "column": 18,
+              "line": 8,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 8,
+            },
+            "start": {
+              "column": 18,
+              "line": 8,
+            },
+          },
+        ],
+        "type": "binary-expr",
+      },
+    },
+    "f": {
+      "0": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": null,
+            "line": 8,
+          },
+          "start": {
+            "column": 18,
+            "line": 8,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 8,
+          },
+          "start": {
+            "column": 18,
+            "line": 8,
+          },
+        },
+        "name": "(anonymous_1)",
+      },
+    },
+    "path": "<root>/src/Counter/Counter.vue",
+    "s": {
+      "0": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 8,
+        },
+        "start": {
+          "column": 18,
+          "line": 8,
+        },
+      },
+    },
+  },
+  "<root>/src/Defined.vue": {
+    "b": {},
+    "branchMap": {},
+    "f": {},
+    "fnMap": {},
+    "path": "<root>/src/Defined.vue",
+    "s": {
+      "0": 1,
+      "1": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+    },
+  },
+  "<root>/src/Hello.vue": {
+    "b": {
+      "0": [
+        3,
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": 30,
+            "line": 14,
+          },
+          "start": {
+            "column": 16,
+            "line": 14,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 18,
+              "line": 14,
+            },
+            "start": {
+              "column": 16,
+              "line": 14,
+            },
+          },
+          {
+            "end": {
+              "column": 30,
+              "line": 14,
+            },
+            "start": {
+              "column": 16,
+              "line": 14,
+            },
+          },
+        ],
+        "type": "binary-expr",
+      },
+    },
+    "f": {
+      "0": 3,
+      "1": 2,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 30,
+            "line": 7,
+          },
+          "start": {
+            "column": 24,
+            "line": 7,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": 55,
+            "line": 7,
+          },
+          "start": {
+            "column": 30,
+            "line": 7,
+          },
+        },
+        "name": "(anonymous_1)",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 18,
+            "line": 14,
+          },
+          "start": {
+            "column": 16,
+            "line": 14,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": 30,
+            "line": 14,
+          },
+          "start": {
+            "column": 18,
+            "line": 14,
+          },
+        },
+        "name": "(anonymous_3)",
+      },
+    },
+    "path": "<root>/src/Hello.vue",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 3,
+      "3": 1,
+      "4": 2,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 14,
+          "line": 6,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 7,
+        },
+        "start": {
+          "column": 15,
+          "line": 7,
+        },
+      },
+      "2": {
+        "end": {
+          "column": 55,
+          "line": 7,
+        },
+        "start": {
+          "column": 30,
+          "line": 7,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 9,
+        },
+        "start": {
+          "column": 0,
+          "line": 9,
+        },
+      },
+      "4": {
+        "end": {
+          "column": 30,
+          "line": 14,
+        },
+        "start": {
+          "column": 18,
+          "line": 14,
+        },
+      },
+    },
+  },
+  "<root>/src/coverage-report/SFC.vue": {
+    "b": {
+      "0": [
+        0,
+        0,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 14,
+          },
+          "start": {
+            "column": 16,
+            "line": 14,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 18,
+              "line": 14,
+            },
+            "start": {
+              "column": 16,
+              "line": 14,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 14,
+            },
+            "start": {
+              "column": 16,
+              "line": 14,
+            },
+          },
+        ],
+        "type": "binary-expr",
+      },
+    },
+    "f": {
+      "0": 0,
+      "1": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 10,
+            "line": 5,
+          },
+          "start": {
+            "column": 2,
+            "line": 5,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 9,
+          },
+          "start": {
+            "column": 10,
+            "line": 5,
+          },
+        },
+        "name": "(anonymous_0)",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 18,
+            "line": 14,
+          },
+          "start": {
+            "column": 16,
+            "line": 14,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 14,
+          },
+          "start": {
+            "column": 18,
+            "line": 14,
+          },
+        },
+        "name": "(anonymous_2)",
+      },
+    },
+    "path": "<root>/src/coverage-report/SFC.vue",
+    "s": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 10,
+        },
+        "start": {
+          "column": 18,
+          "line": 4,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 18,
+          "line": 6,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 8,
+        },
+        "start": {
+          "column": 4,
+          "line": 8,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 15,
+        },
+        "start": {
+          "column": 2,
+          "line": 14,
+        },
+      },
+      "4": {
+        "end": {
+          "column": null,
+          "line": 14,
+        },
+        "start": {
+          "column": 18,
+          "line": 14,
+        },
+      },
+    },
+  },
+  "<root>/src/coverage-report/math.ts": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 20,
+            "line": 1,
+          },
+          "start": {
+            "column": 16,
+            "line": 1,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 3,
+          },
+          "start": {
+            "column": 42,
+            "line": 1,
+          },
+        },
+        "name": "add",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 25,
+            "line": 5,
+          },
+          "start": {
+            "column": 16,
+            "line": 5,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 7,
+          },
+          "start": {
+            "column": 47,
+            "line": 5,
+          },
+        },
+        "name": "multiply",
+      },
+      "2": {
+        "decl": {
+          "end": {
+            "column": 27,
+            "line": 9,
+          },
+          "start": {
+            "column": 16,
+            "line": 9,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 11,
+          },
+          "start": {
+            "column": 49,
+            "line": 9,
+          },
+        },
+        "name": "untestedFn",
+      },
+      "3": {
+        "decl": {
+          "end": {
+            "column": 28,
+            "line": 13,
+          },
+          "start": {
+            "column": 16,
+            "line": 13,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 15,
+          },
+          "start": {
+            "column": 50,
+            "line": 13,
+          },
+        },
+        "name": "untestedFn2",
+      },
+    },
+    "path": "<root>/src/coverage-report/math.ts",
+    "s": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 2,
+          "line": 6,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 10,
+        },
+        "start": {
+          "column": 2,
+          "line": 10,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 14,
+        },
+        "start": {
+          "column": 2,
+          "line": 14,
+        },
+      },
+    },
+  },
+  "<root>/src/coverage-report/not-SFC/not-SFC.ts": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 10,
+            "line": 4,
+          },
+          "start": {
+            "column": 2,
+            "line": 4,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 8,
+          },
+          "start": {
+            "column": 10,
+            "line": 4,
+          },
+        },
+        "name": "(anonymous_0)",
+      },
+    },
+    "path": "<root>/src/coverage-report/not-SFC/not-SFC.ts",
+    "s": {
+      "0": 0,
+      "1": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 5,
+        },
+        "start": {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 7,
+        },
+        "start": {
+          "column": 4,
+          "line": 7,
+        },
+      },
+    },
+  },
+  "<root>/src/coverage-report/utils.js": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 19,
+            "line": 1,
+          },
+          "start": {
+            "column": 16,
+            "line": 1,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 3,
+          },
+          "start": {
+            "column": 26,
+            "line": 1,
+          },
+        },
+        "name": "add",
+      },
+    },
+    "path": "<root>/src/coverage-report/utils.js",
+    "s": {
+      "0": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+    },
+  },
+  "<root>/src/implicitElse.ts": {
+    "b": {
+      "0": [
+        1,
+        0,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 5,
+          },
+          "start": {
+            "column": 2,
+            "line": 4,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 5,
+            },
+            "start": {
+              "column": 2,
+              "line": 4,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 5,
+            },
+            "start": {
+              "column": 2,
+              "line": 4,
+            },
+          },
+        ],
+        "type": "if",
+      },
+    },
+    "f": {
+      "0": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 29,
+            "line": 1,
+          },
+          "start": {
+            "column": 16,
+            "line": 1,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 8,
+          },
+          "start": {
+            "column": 49,
+            "line": 1,
+          },
+        },
+        "name": "implicitElse",
+      },
+    },
+    "path": "<root>/src/implicitElse.ts",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 5,
+        },
+        "start": {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 5,
+        },
+        "start": {
+          "column": 4,
+          "line": 5,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 7,
+        },
+        "start": {
+          "column": 2,
+          "line": 7,
+        },
+      },
+    },
+  },
+  "<root>/src/importEnv.ts": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 31,
+            "line": 1,
+          },
+          "start": {
+            "column": 16,
+            "line": 1,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 3,
+          },
+          "start": {
+            "column": 31,
+            "line": 1,
+          },
+        },
+        "name": "useImportEnv",
+      },
+    },
+    "path": "<root>/src/importEnv.ts",
+    "s": {
+      "0": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+    },
+  },
+  "<root>/src/index.ts": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 27,
+            "line": 5,
+          },
+          "start": {
+            "column": 16,
+            "line": 5,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 7,
+          },
+          "start": {
+            "column": 49,
+            "line": 5,
+          },
+        },
+        "name": "pythagoras",
+      },
+    },
+    "path": "<root>/src/index.ts",
+    "s": {
+      "0": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 2,
+          "line": 6,
+        },
+      },
+    },
+  },
+  "<root>/src/untested-file.ts": {
+    "b": {
+      "0": [
+        0,
+        0,
+      ],
+      "1": [
+        0,
+        0,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 24,
+          },
+          "start": {
+            "column": 2,
+            "line": 21,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 24,
+            },
+            "start": {
+              "column": 2,
+              "line": 21,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 24,
+            },
+            "start": {
+              "column": 2,
+              "line": 21,
+            },
+          },
+        ],
+        "type": "if",
+      },
+      "1": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 29,
+          },
+          "start": {
+            "column": 2,
+            "line": 26,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 29,
+            },
+            "start": {
+              "column": 2,
+              "line": 26,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 29,
+            },
+            "start": {
+              "column": 2,
+              "line": 26,
+            },
+          },
+        ],
+        "type": "if",
+      },
+    },
+    "f": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 39,
+            "line": 6,
+          },
+          "start": {
+            "column": 24,
+            "line": 6,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 8,
+          },
+          "start": {
+            "column": 39,
+            "line": 6,
+          },
+        },
+        "name": "untestedFile",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 13,
+            "line": 10,
+          },
+          "start": {
+            "column": 9,
+            "line": 10,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 13,
+          },
+          "start": {
+            "column": 35,
+            "line": 10,
+          },
+        },
+        "name": "add",
+      },
+      "2": {
+        "decl": {
+          "end": {
+            "column": 18,
+            "line": 15,
+          },
+          "start": {
+            "column": 9,
+            "line": 15,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 18,
+          },
+          "start": {
+            "column": 40,
+            "line": 15,
+          },
+        },
+        "name": "multiply",
+      },
+      "3": {
+        "decl": {
+          "end": {
+            "column": 21,
+            "line": 20,
+          },
+          "start": {
+            "column": 16,
+            "line": 20,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 33,
+          },
+          "start": {
+            "column": 64,
+            "line": 20,
+          },
+        },
+        "name": "math",
+      },
+    },
+    "path": "<root>/src/untested-file.ts",
+    "s": {
+      "0": 0,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "5": 0,
+      "6": 0,
+      "7": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 7,
+        },
+        "start": {
+          "column": 2,
+          "line": 7,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 12,
+        },
+        "start": {
+          "column": 2,
+          "line": 12,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 17,
+        },
+        "start": {
+          "column": 2,
+          "line": 17,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 24,
+        },
+        "start": {
+          "column": 2,
+          "line": 21,
+        },
+      },
+      "4": {
+        "end": {
+          "column": null,
+          "line": 23,
+        },
+        "start": {
+          "column": 4,
+          "line": 23,
+        },
+      },
+      "5": {
+        "end": {
+          "column": null,
+          "line": 29,
+        },
+        "start": {
+          "column": 2,
+          "line": 26,
+        },
+      },
+      "6": {
+        "end": {
+          "column": null,
+          "line": 28,
+        },
+        "start": {
+          "column": 4,
+          "line": 28,
+        },
+      },
+      "7": {
+        "end": {
+          "column": null,
+          "line": 32,
+        },
+        "start": {
+          "column": 2,
+          "line": 32,
+        },
+      },
+    },
+  },
+  "<root>/src/utils.ts": {
+    "b": {
+      "0": [
+        0,
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 16,
+          },
+          "start": {
+            "column": 2,
+            "line": 15,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 16,
+            },
+            "start": {
+              "column": 2,
+              "line": 15,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 16,
+            },
+            "start": {
+              "column": 2,
+              "line": 15,
+            },
+          },
+        ],
+        "type": "if",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 1,
+      "4": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 20,
+            "line": 1,
+          },
+          "start": {
+            "column": 16,
+            "line": 1,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 3,
+          },
+          "start": {
+            "column": 42,
+            "line": 1,
+          },
+        },
+        "name": "add",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 25,
+            "line": 5,
+          },
+          "start": {
+            "column": 16,
+            "line": 5,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 7,
+          },
+          "start": {
+            "column": 47,
+            "line": 5,
+          },
+        },
+        "name": "multiply",
+      },
+      "2": {
+        "decl": {
+          "end": {
+            "column": 23,
+            "line": 9,
+          },
+          "start": {
+            "column": 16,
+            "line": 9,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 12,
+          },
+          "start": {
+            "column": 45,
+            "line": 9,
+          },
+        },
+        "name": "divide",
+      },
+      "3": {
+        "decl": {
+          "end": {
+            "column": 21,
+            "line": 14,
+          },
+          "start": {
+            "column": 16,
+            "line": 14,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 19,
+          },
+          "start": {
+            "column": 32,
+            "line": 14,
+          },
+        },
+        "name": "sqrt",
+      },
+      "4": {
+        "decl": {
+          "end": {
+            "column": 22,
+            "line": 21,
+          },
+          "start": {
+            "column": 16,
+            "line": 21,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 24,
+          },
+          "start": {
+            "column": 22,
+            "line": 21,
+          },
+        },
+        "name": "run",
+      },
+    },
+    "path": "<root>/src/utils.ts",
+    "s": {
+      "0": 1,
+      "1": 2,
+      "2": 0,
+      "3": 1,
+      "4": 0,
+      "5": 1,
+      "6": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 2,
+          "line": 6,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 11,
+        },
+        "start": {
+          "column": 2,
+          "line": 11,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 16,
+        },
+        "start": {
+          "column": 2,
+          "line": 15,
+        },
+      },
+      "4": {
+        "end": {
+          "column": null,
+          "line": 16,
+        },
+        "start": {
+          "column": 4,
+          "line": 16,
+        },
+      },
+      "5": {
+        "end": {
+          "column": null,
+          "line": 18,
+        },
+        "start": {
+          "column": 2,
+          "line": 18,
+        },
+      },
+      "6": {
+        "end": {
+          "column": null,
+          "line": 23,
+        },
+        "start": {
+          "column": 2,
+          "line": 23,
+        },
+      },
+    },
+  },
+}
+`;


### PR DESCRIPTION
Adds snapshot test for `istanbul` provider's coverage result. This should provide confidence for future changes. I'll do same for `c8` some day.

While building the test case I encountered a bug:
When coverage is run with `threads: false`, it is possible that statement counts of coverage report are duplicated. The `coverageProvider.takeCoverage()` (Vitest's internal API, not V8) is called twice without resetting it in between. This can be reproduced in Vitest repository - revert the fix and run `test/coverage-test` tests. 