### PR TITLE
fix: restart on config file change crashes

### DIFF
--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -76,8 +76,10 @@ export async function startVitest(
     // if it's in a CLI wrapper, exit with a special code to request restart
     if (process.env.VITEST_CLI_WRAPPER)
       process.exit(EXIT_CODE_RESTART)
-    else
-      ctx.start(cliFilters)
+  })
+
+  ctx.onAfterSetServer(() => {
+    ctx.start(cliFilters)
   })
 
   try {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -54,6 +54,7 @@ export class Vitest {
   }
 
   private _onRestartListeners: OnServerRestartHandler[] = []
+  private _onSetServer: OnServerRestartHandler[] = []
 
   async setServer(options: UserConfig, server: ViteDevServer) {
     this.unregisterWatcher?.()
@@ -116,6 +117,8 @@ export class Vitest {
       await this.cache.results.readFromCache()
     }
     catch {}
+
+    await Promise.all(this._onSetServer.map(fn => fn()))
   }
 
   async initCoverageProvider() {
@@ -614,5 +617,9 @@ export class Vitest {
 
   onServerRestart(fn: OnServerRestartHandler) {
     this._onRestartListeners.push(fn)
+  }
+
+  onAfterSetServer(fn: OnServerRestartHandler) {
+    this._onSetServer.push(fn)
   }
 }


### PR DESCRIPTION
Fixes #2393.

Changes the order of `Vitest.start()` (`src/node/core.ts`) call when server restarts.

<details>
  <summary>Execution order before</summary>

- `cli::start`
https://github.com/vitest-dev/vitest/blob/b51cda3c4994c8e8168ec5b45aa9070b4c5905ff/packages/vitest/src/node/cli.ts#L118

- `plugins::setServer`
https://github.com/vitest-dev/vitest/blob/b51cda3c4994c8e8168ec5b45aa9070b4c5905ff/packages/vitest/src/node/plugins/index.ts#L172-L174

- `core::setServer`
https://github.com/vitest-dev/vitest/blob/b51cda3c4994c8e8168ec5b45aa9070b4c5905ff/packages/vitest/src/node/core.ts#L58

- `core::start`
https://github.com/vitest-dev/vitest/blob/b51cda3c4994c8e8168ec5b45aa9070b4c5905ff/packages/vitest/src/node/core.ts#L200

- Make change to configuration file
- `core::server.watcher-change`
https://github.com/vitest-dev/vitest/blob/b51cda3c4994c8e8168ec5b45aa9070b4c5905ff/packages/vitest/src/node/core.ts#L98-L103

> Restarting due to config changes...

- `core::start`

> DEV  v0.25.6 /Users/x/y/vitest-example-project

- `plugins::setServer`
- `core::setServer`

>⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
> TypeError: Cannot read properties of undefined (reading 'logger')
</details>

<details>
  <summary>Execution order after change</summary>

- `cli::start`
- `plugins::setServer`
- `core::setServer`
- `core::start`

- Make change to configuration file
- `core::server.watcher-change`

> Restarting due to config changes...

- `plugins::setServer`
- `core::setServer`
- `core::start`

> DEV  v0.25.6 /Users/x/y/vitest-example-project
>  ...tests run ok

</details>