### PR TITLE
fix(coverage): esbuild to preserve legal comments for ignore hints

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -92,6 +92,9 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
         const config: ViteConfig = {
           esbuild: {
             sourcemap: 'external',
+
+            // Enables using ignore hint for coverage providers with @preserve keyword
+            legalComments: 'inline',
           },
           resolve: {
             // by default Vite resolves `module` field, which not always a native ESM module

--- a/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
@@ -2272,6 +2272,8 @@ exports[`c8 json report 1`] = `
     "f": {
       "0": 1,
       "1": 1,
+      "10": 0,
+      "11": 0,
       "2": 2,
       "3": 2,
       "4": 0,
@@ -2326,6 +2328,54 @@ exports[`c8 json report 1`] = `
           "start": {
             "column": 0,
             "line": 3,
+          },
+        },
+        "name": "get",
+      },
+      "10": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 29,
+          },
+          "start": {
+            "column": 7,
+            "line": 27,
+          },
+        },
+        "line": 27,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 29,
+          },
+          "start": {
+            "column": 7,
+            "line": 27,
+          },
+        },
+        "name": "ignoredFunction",
+      },
+      "11": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 29,
+          },
+          "start": {
+            "column": 0,
+            "line": 29,
+          },
+        },
+        "line": 29,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 29,
+          },
+          "start": {
+            "column": 0,
+            "line": 29,
           },
         },
         "name": "get",
@@ -2542,6 +2592,11 @@ exports[`c8 json report 1`] = `
       "21": 0,
       "22": 0,
       "23": 0,
+      "24": 1,
+      "25": 1,
+      "26": 1,
+      "27": 0,
+      "28": 0,
       "3": 1,
       "4": 1,
       "5": 2,
@@ -2719,6 +2774,56 @@ exports[`c8 json report 1`] = `
         "start": {
           "column": 0,
           "line": 24,
+        },
+      },
+      "24": {
+        "end": {
+          "column": 0,
+          "line": 25,
+        },
+        "start": {
+          "column": 0,
+          "line": 25,
+        },
+      },
+      "25": {
+        "end": {
+          "column": 39,
+          "line": 26,
+        },
+        "start": {
+          "column": 0,
+          "line": 26,
+        },
+      },
+      "26": {
+        "end": {
+          "column": 35,
+          "line": 27,
+        },
+        "start": {
+          "column": 0,
+          "line": 27,
+        },
+      },
+      "27": {
+        "end": {
+          "column": 59,
+          "line": 28,
+        },
+        "start": {
+          "column": 0,
+          "line": 28,
+        },
+      },
+      "28": {
+        "end": {
+          "column": 1,
+          "line": 29,
+        },
+        "start": {
+          "column": 0,
+          "line": 29,
         },
       },
       "3": {

--- a/test/coverage-test/coverage-report-tests/istanbul.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/istanbul.report.test.ts
@@ -21,3 +21,19 @@ test('implicit else is included in branch count', async () => {
   expect(fileCoverage.b).toHaveProperty('0')
   expect(fileCoverage.b['0']).toHaveLength(2)
 })
+
+test('ignored code is excluded from the report', async () => {
+  const functionName = 'ignoredFunction'
+  const filename = '<process-cwd>/src/utils.ts'
+
+  const coverageMap = await readCoverageJson()
+  const fileCoverage = coverageMap[filename]
+
+  // Function should not be included in report
+  const functionCoverage = Object.values(fileCoverage.fnMap).find(fn => fn.name === functionName)
+  expect(functionCoverage).toBe(undefined)
+
+  // Function should still be found from the actual sources
+  const utils = await import('../src/utils')
+  expect(utils[functionName]).toBeTypeOf('function')
+})

--- a/test/coverage-test/coverage-report-tests/utils.ts
+++ b/test/coverage-test/coverage-report-tests/utils.ts
@@ -5,6 +5,7 @@ interface CoverageFinalJson {
     [filename: string]: {
       path: string
       b: Record<string, number[]>
+      fnMap: Record<string, { name: string }>
       // ... and more unrelated keys
     }
   }

--- a/test/coverage-test/src/utils.ts
+++ b/test/coverage-test/src/utils.ts
@@ -22,3 +22,8 @@ export function run() {
   // this should not be covered
   divide(1, 1)
 }
+
+/* istanbul ignore next -- @preserve */
+export function ignoredFunction() {
+  return 'This function is excluded from istanbul coverage'
+}


### PR DESCRIPTION
Fixes #2491.
