### PR TITLE
Allow assigning new hotContext

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -323,6 +323,9 @@ export class ViteNodeRunner {
           hotContext ||= this.options.createHotContext?.(this, `/@fs/${fsPath}`)
           return hotContext
         },
+        set: (value) => {
+          hotContext = value;
+        },
       })
     }
 

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -324,7 +324,7 @@ export class ViteNodeRunner {
           return hotContext
         },
         set: (value) => {
-          hotContext = value;
+          hotContext = value
         },
       })
     }

--- a/test/vite-node/src/deps.css
+++ b/test/vite-node/src/deps.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/test/vite-node/src/deps.ts
+++ b/test/vite-node/src/deps.ts
@@ -1,3 +1,5 @@
+import './deps.css'
+
 // eslint-disable-next-line no-console
 console.log('deps')
 


### PR DESCRIPTION
When I try to use TailwindCSS with SSR on vite-node, I got this error

```
/src/client/base.css:2
__vite_ssr_import_meta__.hot = __vite_ssr_import_0__.createHotContext("/src/client/base.css");const __vite_ssr_import_1__ = await __vite_ssr_import__("/@vite/client");
                             ^

TypeError: Cannot set property hot of #<Object> which has only a getter
    at /src/client/base.css:1:94
    at ViteNodeRunner.directRequest
   ...
```

This patch fixed it