### PR TITLE
fix: use correct word when printing "long-running" warning

### DIFF
--- a/packages/vitest/src/runtime/context.ts
+++ b/packages/vitest/src/runtime/context.ts
@@ -75,5 +75,5 @@ export function createTestContext(test: Test): TestContext {
 }
 
 function makeTimeoutMsg(isHook: boolean, timeout: number) {
-  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nIf this is a long-running test, pass a timeout value as the last argument or configure it globally with "${isHook ? 'hookTimeout' : 'testTimeout'}".`
+  return `${isHook ? 'Hook' : 'Test'} timed out in ${timeout}ms.\nIf this is a long-running ${isHook ? 'hook' : 'test'}, pass a timeout value as the last argument or configure it globally with "${isHook ? 'hookTimeout' : 'testTimeout'}".`
 }


### PR DESCRIPTION
There were are 3 places the word 'test' can appear in the 'long-running' warning. Only 2 of them were being replaced with 'hook'. Now all 3 of them are.