### PR TITLE
feat(mock): expose a `importOriginal` helper to the factory

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2594,11 +2594,36 @@ Vitest provides utility functions to help you out through it's **vi** helper. Yo
 
   Makes all `imports` to passed module to be mocked. Inside a path you _can_ use configured Vite aliases. The call to `vi.mock` is hoisted, so it doesn't matter where you call it. It will always be executed before all imports.
 
-  - If `factory` is defined, will return its result. Factory function can be asynchronous. You may call [`vi.importActual`](#vi-importactual) inside to get the original module. Since the call to `vi.mock` is hoisted, you don't have access to variables declared in the global file scope!
+  - If `factory` is defined, will return its result. The factory function can be asynchronous. A helper to import the original module is passed to the factory function, or you call [`vi.importActual`](#vi-importactual) inside to get other modules. Since the call to `vi.mock` is hoisted, you don't have access to variables declared in the global file scope!
+  
+  ```ts
+  vi.mock('./path/to/module', async (importOriginal) => {
+    const mod = await importOriginal()
+    return {
+      ...mod,
+      // replace some exports
+      namedExport: vi.fn(),
+    }
+  })
+  ```
+
+  or
+
+  ```ts
+  vi.mock('./path/to/module', async () => {
+    const mod = await vi.importActual('./path/to/module')
+    return {
+      ...mod,
+      // replace some exports
+      namedExport: vi.fn(),
+    }
+  })
+  ```
+
   - If mocking a module with a default export, you'll need to provide a `default` key within the returned factory function object. This is an ES modules specific caveat, therefore `jest` documentation may differ as `jest` uses commonJS modules. *Example:*
 
   ```ts
-  vi.mock('path', () => {
+  vi.mock('./path/to/module', () => {
     return {
       default: { myDefaultKey: vi.fn() },
       namedExport: vi.fn(),

--- a/examples/mocks/src/moduleB.ts
+++ b/examples/mocks/src/moduleB.ts
@@ -1,0 +1,2 @@
+export const A = 'A'
+export const B = 'B'

--- a/examples/mocks/test/factory.test.ts
+++ b/examples/mocks/test/factory.test.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import * as example from '../src/example'
 import * as moduleA from '../src/moduleA'
+import * as moduleB from '../src/moduleB'
 import logger from '../src/log'
 
 vi
@@ -22,6 +23,15 @@ vi.mock('../src/moduleA', async () => {
   return {
     B: 'B',
     ...actual,
+  }
+})
+
+vi.mock('../src/moduleB', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    B: 'mockedB',
+    C: 'addedC',
   }
 })
 
@@ -71,6 +81,12 @@ describe('mocking with factory', () => {
   test('successfully with actual', () => {
     expect(moduleA.A).toBe('A')
     expect((moduleA as any).B).toBe('B')
+  })
+
+  test('successfully with factory helper', () => {
+    expect(moduleB.A).toBe('A')
+    expect(moduleB.B).toBe('mockedB')
+    expect((moduleB as any).C).toBe('addedC')
   })
 
   test('mocks node_modules', () => {

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -35,19 +35,19 @@ By: Anthony Fu
 Repository: git+https://github.com/antfu/install-pkg.git
 
 > MIT License
->
+> 
 > Copyright (c) 2021 Anthony Fu <https://github.com/antfu>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -64,19 +64,19 @@ By: Rich Harris
 Repository: git+https://github.com/jridgewell/sourcemap-codec.git
 
 > The MIT License
->
+> 
 > Copyright (c) 2015 Rich Harris
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -92,19 +92,19 @@ License: MIT
 Repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Denis Malinochkin
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -120,19 +120,19 @@ License: MIT
 Repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Denis Malinochkin
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -148,19 +148,19 @@ License: MIT
 Repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Denis Malinochkin
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -176,24 +176,24 @@ License: BSD-3-Clause
 Repository: git+https://github.com/sinonjs/commons.git
 
 > BSD 3-Clause License
->
+> 
 > Copyright (c) 2018, Sinon.JS
 > All rights reserved.
->
+> 
 > Redistribution and use in source and binary forms, with or without
 > modification, are permitted provided that the following conditions are met:
->
+> 
 > * Redistributions of source code must retain the above copyright notice, this
 >   list of conditions and the following disclaimer.
->
+> 
 > * Redistributions in binary form must reproduce the above copyright notice,
 >   this list of conditions and the following disclaimer in the documentation
 >   and/or other materials provided with the distribution.
->
+> 
 > * Neither the name of the copyright holder nor the names of its
 >   contributors may be used to endorse or promote products derived from
 >   this software without specific prior written permission.
->
+> 
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 > AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 > IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -213,15 +213,15 @@ By: Christian Johansen
 Repository: https://github.com/sinonjs/fake-timers.git
 
 > Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no. All rights reserved.
->
+> 
 > Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
+> 
 > 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
->
+> 
 > 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
->
+> 
 > 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
->
+> 
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---------------------------------------
@@ -232,13 +232,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/ansi-escapes
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -249,13 +249,13 @@ By: Sindre Sorhus
 Repository: chalk/ansi-regex
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -266,13 +266,13 @@ By: Sindre Sorhus
 Repository: chalk/ansi-styles
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -283,19 +283,19 @@ By: Anthony Fu
 Repository: git+https://github.com/antfu/birpc.git
 
 > MIT License
->
+> 
 > Copyright (c) 2021 Anthony Fu <https://github.com/antfu>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -312,19 +312,19 @@ By: Jon Schlinkert, Brian Woodward, Elan Shanker, Eugene Sharygin, hemanth.hm
 Repository: micromatch/braces
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-2018, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -341,19 +341,19 @@ By: egoist
 Repository: egoist/cac
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) EGOIST <0x142857@gmail.com> (https://github.com/egoist)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -370,19 +370,19 @@ By: Andrii Shumada, Robert Herhold
 Repository: https://github.com/debitoor/chai-subset.git
 
 > The MIT License (MIT)
->
-> Copyright (c) 2014
->
+> 
+> Copyright (c) 2014 
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -399,13 +399,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/cli-cursor
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -416,13 +416,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/cli-truncate
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -433,19 +433,19 @@ By: André Cruz
 Repository: git@github.com:moxystudio/node-cross-spawn.git
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2018 Made With MOXY Lda <hello@moxy.studio>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -461,28 +461,28 @@ License: BSD-3-Clause
 Repository: git://github.com/kpdecker/jsdiff.git
 
 > Software License Agreement (BSD License)
->
+> 
 > Copyright (c) 2009-2015, Kevin Decker <kpdecker@gmail.com>
->
+> 
 > All rights reserved.
->
+> 
 > Redistribution and use of this software in source and binary forms, with or without modification,
 > are permitted provided that the following conditions are met:
->
+> 
 > * Redistributions of source code must retain the above
 >   copyright notice, this list of conditions and the
 >   following disclaimer.
->
+> 
 > * Redistributions in binary form must reproduce the above
 >   copyright notice, this list of conditions and the
 >   following disclaimer in the documentation and/or other
 >   materials provided with the distribution.
->
+> 
 > * Neither the name of Kevin Decker nor the names of its
 >   contributors may be used to endorse or promote products
 >   derived from this software without specific prior
 >   written permission.
->
+> 
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 > IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 > FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
@@ -507,7 +507,7 @@ By: Mathias Bynens
 Repository: https://github.com/mathiasbynens/emoji-regex.git
 
 > Copyright Mathias Bynens <https://mathiasbynens.be/>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > "Software"), to deal in the Software without restriction, including
@@ -515,10 +515,10 @@ Repository: https://github.com/mathiasbynens/emoji-regex.git
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -535,19 +535,19 @@ By: Ben Lesh
 Repository: git+https://github.com/benlesh/event-target-polyfill.git
 
 > MIT License
->
+> 
 > Copyright (c) 2020 Ben Lesh
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -564,13 +564,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/execa
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -582,17 +582,17 @@ Repository: https://github.com/mmkal/expect-type.git
 > Apache License
 >                            Version 2.0, January 2004
 >                         http://www.apache.org/licenses/
->
+> 
 >    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
->
+> 
 >    1. Definitions.
->
+> 
 >       "License" shall mean the terms and conditions for use, reproduction,
 >       and distribution as defined by Sections 1 through 9 of this document.
->
+> 
 >       "Licensor" shall mean the copyright owner or entity authorized by
 >       the copyright owner that is granting the License.
->
+> 
 >       "Legal Entity" shall mean the union of the acting entity and all
 >       other entities that control, are controlled by, or are under common
 >       control with that entity. For the purposes of this definition,
@@ -600,24 +600,24 @@ Repository: https://github.com/mmkal/expect-type.git
 >       direction or management of such entity, whether by contract or
 >       otherwise, or (ii) ownership of fifty percent (50%) or more of the
 >       outstanding shares, or (iii) beneficial ownership of such entity.
->
+> 
 >       "You" (or "Your") shall mean an individual or Legal Entity
 >       exercising permissions granted by this License.
->
+> 
 >       "Source" form shall mean the preferred form for making modifications,
 >       including but not limited to software source code, documentation
 >       source, and configuration files.
->
+> 
 >       "Object" form shall mean any form resulting from mechanical
 >       transformation or translation of a Source form, including but
 >       not limited to compiled object code, generated documentation,
 >       and conversions to other media types.
->
+> 
 >       "Work" shall mean the work of authorship, whether in Source or
 >       Object form, made available under the License, as indicated by a
 >       copyright notice that is included in or attached to the work
 >       (an example is provided in the Appendix below).
->
+> 
 >       "Derivative Works" shall mean any work, whether in Source or Object
 >       form, that is based on (or derived from) the Work and for which the
 >       editorial revisions, annotations, elaborations, or other modifications
@@ -625,7 +625,7 @@ Repository: https://github.com/mmkal/expect-type.git
 >       of this License, Derivative Works shall not include works that remain
 >       separable from, or merely link (or bind by name) to the interfaces of,
 >       the Work and Derivative Works thereof.
->
+> 
 >       "Contribution" shall mean any work of authorship, including
 >       the original version of the Work and any modifications or additions
 >       to that Work or Derivative Works thereof, that is intentionally
@@ -639,18 +639,18 @@ Repository: https://github.com/mmkal/expect-type.git
 >       Licensor for the purpose of discussing and improving the Work, but
 >       excluding communication that is conspicuously marked or otherwise
 >       designated in writing by the copyright owner as "Not a Contribution."
->
+> 
 >       "Contributor" shall mean Licensor and any individual or Legal Entity
 >       on behalf of whom a Contribution has been received by Licensor and
 >       subsequently incorporated within the Work.
->
+> 
 >    2. Grant of Copyright License. Subject to the terms and conditions of
 >       this License, each Contributor hereby grants to You a perpetual,
 >       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
 >       copyright license to reproduce, prepare Derivative Works of,
 >       publicly display, publicly perform, sublicense, and distribute the
 >       Work and such Derivative Works in Source or Object form.
->
+> 
 >    3. Grant of Patent License. Subject to the terms and conditions of
 >       this License, each Contributor hereby grants to You a perpetual,
 >       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -666,24 +666,24 @@ Repository: https://github.com/mmkal/expect-type.git
 >       or contributory patent infringement, then any patent licenses
 >       granted to You under this License for that Work shall terminate
 >       as of the date such litigation is filed.
->
+> 
 >    4. Redistribution. You may reproduce and distribute copies of the
 >       Work or Derivative Works thereof in any medium, with or without
 >       modifications, and in Source or Object form, provided that You
 >       meet the following conditions:
->
+> 
 >       (a) You must give any other recipients of the Work or
 >           Derivative Works a copy of this License; and
->
+> 
 >       (b) You must cause any modified files to carry prominent notices
 >           stating that You changed the files; and
->
+> 
 >       (c) You must retain, in the Source form of any Derivative Works
 >           that You distribute, all copyright, patent, trademark, and
 >           attribution notices from the Source form of the Work,
 >           excluding those notices that do not pertain to any part of
 >           the Derivative Works; and
->
+> 
 >       (d) If the Work includes a "NOTICE" text file as part of its
 >           distribution, then any Derivative Works that You distribute must
 >           include a readable copy of the attribution notices contained
@@ -700,14 +700,14 @@ Repository: https://github.com/mmkal/expect-type.git
 >           or as an addendum to the NOTICE text from the Work, provided
 >           that such additional attribution notices cannot be construed
 >           as modifying the License.
->
+> 
 >       You may add Your own copyright statement to Your modifications and
 >       may provide additional or different license terms and conditions
 >       for use, reproduction, or distribution of Your modifications, or
 >       for any such Derivative Works as a whole, provided Your use,
 >       reproduction, and distribution of the Work otherwise complies with
 >       the conditions stated in this License.
->
+> 
 >    5. Submission of Contributions. Unless You explicitly state otherwise,
 >       any Contribution intentionally submitted for inclusion in the Work
 >       by You to the Licensor shall be under the terms and conditions of
@@ -715,12 +715,12 @@ Repository: https://github.com/mmkal/expect-type.git
 >       Notwithstanding the above, nothing herein shall supersede or modify
 >       the terms of any separate license agreement you may have executed
 >       with Licensor regarding such Contributions.
->
+> 
 >    6. Trademarks. This License does not grant permission to use the trade
 >       names, trademarks, service marks, or product names of the Licensor,
 >       except as required for reasonable and customary use in describing the
 >       origin of the Work and reproducing the content of the NOTICE file.
->
+> 
 >    7. Disclaimer of Warranty. Unless required by applicable law or
 >       agreed to in writing, Licensor provides the Work (and each
 >       Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -730,7 +730,7 @@ Repository: https://github.com/mmkal/expect-type.git
 >       PARTICULAR PURPOSE. You are solely responsible for determining the
 >       appropriateness of using or redistributing the Work and assume any
 >       risks associated with Your exercise of permissions under this License.
->
+> 
 >    8. Limitation of Liability. In no event and under no legal theory,
 >       whether in tort (including negligence), contract, or otherwise,
 >       unless required by applicable law (such as deliberate and grossly
@@ -742,7 +742,7 @@ Repository: https://github.com/mmkal/expect-type.git
 >       work stoppage, computer failure or malfunction, or any and all
 >       other commercial damages or losses), even if such Contributor
 >       has been advised of the possibility of such damages.
->
+> 
 >    9. Accepting Warranty or Additional Liability. While redistributing
 >       the Work or Derivative Works thereof, You may choose to offer,
 >       and charge a fee for, acceptance of support, warranty, indemnity,
@@ -753,11 +753,11 @@ Repository: https://github.com/mmkal/expect-type.git
 >       defend, and hold each Contributor harmless for any liability
 >       incurred by, or claims asserted against, such Contributor by reason
 >       of your accepting any such warranty or additional liability.
->
+> 
 >    END OF TERMS AND CONDITIONS
->
+> 
 >    APPENDIX: How to apply the Apache License to your work.
->
+> 
 >       To apply the Apache License to your work, attach the following
 >       boilerplate notice, with the fields enclosed by brackets "[]"
 >       replaced with your own identifying information. (Don't include
@@ -766,15 +766,15 @@ Repository: https://github.com/mmkal/expect-type.git
 >       file or class name and description of purpose be included on the
 >       same "printed page" as the copyright notice for easier
 >       identification within third-party archives.
->
+> 
 >    Copyright [yyyy] [name of copyright owner]
->
+> 
 >    Licensed under the Apache License, Version 2.0 (the "License");
 >    you may not use this file except in compliance with the License.
 >    You may obtain a copy of the License at
->
+> 
 >        http://www.apache.org/licenses/LICENSE-2.0
->
+> 
 >    Unless required by applicable law or agreed to in writing, software
 >    distributed under the License is distributed on an "AS IS" BASIS,
 >    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -789,19 +789,19 @@ By: Denis Malinochkin
 Repository: mrmlnc/fast-glob
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Denis Malinochkin
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -818,11 +818,11 @@ By: Matteo Collina
 Repository: git+https://github.com/mcollina/fastq.git
 
 > Copyright (c) 2015-2020, Matteo Collina <matteo.collina@gmail.com>
->
+> 
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -839,19 +839,19 @@ By: Jon Schlinkert, Edo Rivai, Paul Miller, Rouven Weßling
 Repository: jonschlinkert/fill-range
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-present, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -868,13 +868,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/find-up
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -885,13 +885,13 @@ By: Andrea Giammarchi
 Repository: git+https://github.com/WebReflection/flatted.git
 
 > ISC License
->
+> 
 > Copyright (c) 2018-2020, Andrea Giammarchi, @WebReflection
->
+> 
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
 > REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
 > AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
@@ -908,13 +908,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/get-stream
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -925,19 +925,19 @@ By: Hiroki Osame
 Repository: privatenumber/get-tsconfig
 
 > MIT License
->
+> 
 > Copyright (c) Hiroki Osame <hiroki.osame@gmail.com>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -954,13 +954,13 @@ By: Gulp Team, Elan Shanker, Blaine Bublitz
 Repository: gulpjs/glob-parent
 
 > The ISC License
->
+> 
 > Copyright (c) 2015, 2019 Elan Shanker
->
+> 
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -979,17 +979,17 @@ Repository: ehmicky/human-signals
 > Apache License
 >                            Version 2.0, January 2004
 >                         http://www.apache.org/licenses/
->
+> 
 >    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
->
+> 
 >    1. Definitions.
->
+> 
 >       "License" shall mean the terms and conditions for use, reproduction,
 >       and distribution as defined by Sections 1 through 9 of this document.
->
+> 
 >       "Licensor" shall mean the copyright owner or entity authorized by
 >       the copyright owner that is granting the License.
->
+> 
 >       "Legal Entity" shall mean the union of the acting entity and all
 >       other entities that control, are controlled by, or are under common
 >       control with that entity. For the purposes of this definition,
@@ -997,24 +997,24 @@ Repository: ehmicky/human-signals
 >       direction or management of such entity, whether by contract or
 >       otherwise, or (ii) ownership of fifty percent (50%) or more of the
 >       outstanding shares, or (iii) beneficial ownership of such entity.
->
+> 
 >       "You" (or "Your") shall mean an individual or Legal Entity
 >       exercising permissions granted by this License.
->
+> 
 >       "Source" form shall mean the preferred form for making modifications,
 >       including but not limited to software source code, documentation
 >       source, and configuration files.
->
+> 
 >       "Object" form shall mean any form resulting from mechanical
 >       transformation or translation of a Source form, including but
 >       not limited to compiled object code, generated documentation,
 >       and conversions to other media types.
->
+> 
 >       "Work" shall mean the work of authorship, whether in Source or
 >       Object form, made available under the License, as indicated by a
 >       copyright notice that is included in or attached to the work
 >       (an example is provided in the Appendix below).
->
+> 
 >       "Derivative Works" shall mean any work, whether in Source or Object
 >       form, that is based on (or derived from) the Work and for which the
 >       editorial revisions, annotations, elaborations, or other modifications
@@ -1022,7 +1022,7 @@ Repository: ehmicky/human-signals
 >       of this License, Derivative Works shall not include works that remain
 >       separable from, or merely link (or bind by name) to the interfaces of,
 >       the Work and Derivative Works thereof.
->
+> 
 >       "Contribution" shall mean any work of authorship, including
 >       the original version of the Work and any modifications or additions
 >       to that Work or Derivative Works thereof, that is intentionally
@@ -1036,18 +1036,18 @@ Repository: ehmicky/human-signals
 >       Licensor for the purpose of discussing and improving the Work, but
 >       excluding communication that is conspicuously marked or otherwise
 >       designated in writing by the copyright owner as "Not a Contribution."
->
+> 
 >       "Contributor" shall mean Licensor and any individual or Legal Entity
 >       on behalf of whom a Contribution has been received by Licensor and
 >       subsequently incorporated within the Work.
->
+> 
 >    2. Grant of Copyright License. Subject to the terms and conditions of
 >       this License, each Contributor hereby grants to You a perpetual,
 >       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
 >       copyright license to reproduce, prepare Derivative Works of,
 >       publicly display, publicly perform, sublicense, and distribute the
 >       Work and such Derivative Works in Source or Object form.
->
+> 
 >    3. Grant of Patent License. Subject to the terms and conditions of
 >       this License, each Contributor hereby grants to You a perpetual,
 >       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -1063,24 +1063,24 @@ Repository: ehmicky/human-signals
 >       or contributory patent infringement, then any patent licenses
 >       granted to You under this License for that Work shall terminate
 >       as of the date such litigation is filed.
->
+> 
 >    4. Redistribution. You may reproduce and distribute copies of the
 >       Work or Derivative Works thereof in any medium, with or without
 >       modifications, and in Source or Object form, provided that You
 >       meet the following conditions:
->
+> 
 >       (a) You must give any other recipients of the Work or
 >           Derivative Works a copy of this License; and
->
+> 
 >       (b) You must cause any modified files to carry prominent notices
 >           stating that You changed the files; and
->
+> 
 >       (c) You must retain, in the Source form of any Derivative Works
 >           that You distribute, all copyright, patent, trademark, and
 >           attribution notices from the Source form of the Work,
 >           excluding those notices that do not pertain to any part of
 >           the Derivative Works; and
->
+> 
 >       (d) If the Work includes a "NOTICE" text file as part of its
 >           distribution, then any Derivative Works that You distribute must
 >           include a readable copy of the attribution notices contained
@@ -1097,14 +1097,14 @@ Repository: ehmicky/human-signals
 >           or as an addendum to the NOTICE text from the Work, provided
 >           that such additional attribution notices cannot be construed
 >           as modifying the License.
->
+> 
 >       You may add Your own copyright statement to Your modifications and
 >       may provide additional or different license terms and conditions
 >       for use, reproduction, or distribution of Your modifications, or
 >       for any such Derivative Works as a whole, provided Your use,
 >       reproduction, and distribution of the Work otherwise complies with
 >       the conditions stated in this License.
->
+> 
 >    5. Submission of Contributions. Unless You explicitly state otherwise,
 >       any Contribution intentionally submitted for inclusion in the Work
 >       by You to the Licensor shall be under the terms and conditions of
@@ -1112,12 +1112,12 @@ Repository: ehmicky/human-signals
 >       Notwithstanding the above, nothing herein shall supersede or modify
 >       the terms of any separate license agreement you may have executed
 >       with Licensor regarding such Contributions.
->
+> 
 >    6. Trademarks. This License does not grant permission to use the trade
 >       names, trademarks, service marks, or product names of the Licensor,
 >       except as required for reasonable and customary use in describing the
 >       origin of the Work and reproducing the content of the NOTICE file.
->
+> 
 >    7. Disclaimer of Warranty. Unless required by applicable law or
 >       agreed to in writing, Licensor provides the Work (and each
 >       Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -1127,7 +1127,7 @@ Repository: ehmicky/human-signals
 >       PARTICULAR PURPOSE. You are solely responsible for determining the
 >       appropriateness of using or redistributing the Work and assume any
 >       risks associated with Your exercise of permissions under this License.
->
+> 
 >    8. Limitation of Liability. In no event and under no legal theory,
 >       whether in tort (including negligence), contract, or otherwise,
 >       unless required by applicable law (such as deliberate and grossly
@@ -1139,7 +1139,7 @@ Repository: ehmicky/human-signals
 >       work stoppage, computer failure or malfunction, or any and all
 >       other commercial damages or losses), even if such Contributor
 >       has been advised of the possibility of such damages.
->
+> 
 >    9. Accepting Warranty or Additional Liability. While redistributing
 >       the Work or Derivative Works thereof, You may choose to offer,
 >       and charge a fee for, acceptance of support, warranty, indemnity,
@@ -1150,11 +1150,11 @@ Repository: ehmicky/human-signals
 >       defend, and hold each Contributor harmless for any liability
 >       incurred by, or claims asserted against, such Contributor by reason
 >       of your accepting any such warranty or additional liability.
->
+> 
 >    END OF TERMS AND CONDITIONS
->
+> 
 >    APPENDIX: How to apply the Apache License to your work.
->
+> 
 >       To apply the Apache License to your work, attach the following
 >       boilerplate notice, with the fields enclosed by brackets "[]"
 >       replaced with your own identifying information. (Don't include
@@ -1163,15 +1163,15 @@ Repository: ehmicky/human-signals
 >       file or class name and description of purpose be included on the
 >       same "printed page" as the copyright notice for easier
 >       identification within third-party archives.
->
+> 
 >    Copyright 2021 ehmicky <ehmicky@gmail.com>
->
+> 
 >    Licensed under the Apache License, Version 2.0 (the "License");
 >    you may not use this file except in compliance with the License.
 >    You may obtain a copy of the License at
->
+> 
 >        http://www.apache.org/licenses/LICENSE-2.0
->
+> 
 >    Unless required by applicable law or agreed to in writing, software
 >    distributed under the License is distributed on an "AS IS" BASIS,
 >    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -1186,19 +1186,19 @@ By: Jon Schlinkert
 Repository: jonschlinkert/is-extglob
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-2016, Jon Schlinkert
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1215,13 +1215,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/is-fullwidth-code-point
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1232,19 +1232,19 @@ By: Jon Schlinkert, Brian Woodward, Daniel Perez
 Repository: micromatch/is-glob
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-2017, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1261,19 +1261,19 @@ By: Jon Schlinkert, Olsten Larck, Rouven Weßling
 Repository: jonschlinkert/is-number
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-present, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1290,13 +1290,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/is-stream
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1307,13 +1307,13 @@ By: Isaac Z. Schlueter
 Repository: git+https://github.com/isaacs/isexe.git
 
 > The ISC License
->
+> 
 > Copyright (c) Isaac Z. Schlueter and Contributors
->
+> 
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -1330,19 +1330,19 @@ By: Luke Edwards
 Repository: lukeed/kleur
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1359,13 +1359,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/locate-path
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1376,13 +1376,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/log-update
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1393,11 +1393,11 @@ By: Rich Harris
 Repository: https://github.com/rich-harris/magic-string
 
 > Copyright 2018 Rich Harris
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1408,19 +1408,19 @@ By: Stephen Sugden
 Repository: grncdr/merge-stream
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Stephen Sugden <me@stephensugden.com> (stephensugden.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1436,19 +1436,19 @@ License: MIT
 Repository: git@github.com:teambition/merge2.git
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-2020 Teambition
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1465,19 +1465,19 @@ By: Jon Schlinkert, Amila Welihinda, Bogdan Chadkin, Brian Woodward, Devon Govet
 Repository: micromatch/micromatch
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2014-present, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1494,13 +1494,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/mimic-fn
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1510,19 +1510,19 @@ License: MIT
 Repository: unjs/mlly
 
 > MIT License
->
+> 
 > Copyright (c) Pooya Parsa <pooya@pi0.io>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1546,13 +1546,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/npm-run-path
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1563,13 +1563,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/onetime
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1580,13 +1580,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/p-limit
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1597,13 +1597,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/p-locate
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1614,13 +1614,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/path-exists
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1631,13 +1631,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/path-key
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1647,19 +1647,19 @@ License: MIT
 Repository: unjs/pathe
 
 > MIT License
->
+> 
 > Copyright (c) 2021 UnJS
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1667,11 +1667,11 @@ Repository: unjs/pathe
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
->
+> 
 > --------------------------------------------------------------------------------
->
+> 
 > Copyright Joyent, Inc. and other Node contributors.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a
 > copy of this software and associated documentation files (the
 > "Software"), to deal in the Software without restriction, including
@@ -1679,10 +1679,10 @@ Repository: unjs/pathe
 > distribute, sublicense, and/or sell copies of the Software, and to permit
 > persons to whom the Software is furnished to do so, subject to the
 > following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included
 > in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 > OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
@@ -1699,13 +1699,13 @@ By: Alexey Raspopov
 Repository: alexeyraspopov/picocolors
 
 > ISC License
->
+> 
 > Copyright (c) 2021 Alexey Raspopov, Kostiantyn Denysov, Anton Verinov
->
+> 
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -1722,19 +1722,19 @@ By: Jon Schlinkert
 Repository: micromatch/picomatch
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2017-present, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1751,19 +1751,19 @@ By: James Kyle
 Repository: https://github.com/facebook/jest.git
 
 > MIT License
->
+> 
 > Copyright (c) Facebook, Inc. and its affiliates.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1780,19 +1780,19 @@ By: Terkel Gjervig
 Repository: terkelg/prompts
 
 > MIT License
->
+> 
 > Copyright (c) 2018 Terkel Gjervig Nielsen
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1809,19 +1809,19 @@ By: Feross Aboukhadijeh
 Repository: git://github.com/feross/queue-microtask.git
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Feross Aboukhadijeh
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -1836,19 +1836,19 @@ License: MIT
 Repository: https://github.com/facebook/react.git
 
 > MIT License
->
+> 
 > Copyright (c) Facebook, Inc. and its affiliates.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1865,13 +1865,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/restore-cursor
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1882,19 +1882,19 @@ By: Matteo Collina
 Repository: git+https://github.com/mcollina/reusify.git
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2015 Matteo Collina
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1911,19 +1911,19 @@ By: Feross Aboukhadijeh
 Repository: git://github.com/feross/run-parallel.git
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) Feross Aboukhadijeh
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -1939,13 +1939,13 @@ By: Kevin Mårtensson
 Repository: kevva/shebang-command
 
 > MIT License
->
+> 
 > Copyright (c) Kevin Mårtensson <kevinmartensson@gmail.com> (github.com/kevva)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1956,13 +1956,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/shebang-regex
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -1973,14 +1973,14 @@ By: Ben Coe
 Repository: https://github.com/tapjs/signal-exit.git
 
 > The ISC License
->
+> 
 > Copyright (c) 2015, Contributors
->
+> 
 > Permission to use, copy, modify, and/or distribute this software
 > for any purpose with or without fee is hereby granted, provided
 > that the above copyright notice and this permission notice
 > appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
 > OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
@@ -1997,19 +1997,19 @@ By: Terkel Gjervig
 Repository: https://github.com/terkelg/sisteransi
 
 > MIT License
->
+> 
 > Copyright (c) 2018 Terkel Gjervig Nielsen
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2025,14 +2025,14 @@ License: MIT
 Repository: chalk/slice-ansi
 
 > MIT License
->
+> 
 > Copyright (c) DC <threedeecee@gmail.com>
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -2043,13 +2043,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/string-width
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -2060,13 +2060,13 @@ By: Sindre Sorhus
 Repository: chalk/strip-ansi
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -2077,13 +2077,13 @@ By: Sindre Sorhus
 Repository: sindresorhus/strip-final-newline
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -2094,19 +2094,19 @@ By: Jon Schlinkert, Rouven Weßling
 Repository: micromatch/to-regex-range
 
 > The MIT License (MIT)
->
+> 
 > Copyright (c) 2015-present, Jon Schlinkert.
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2123,17 +2123,17 @@ By: Jake Luer, Keith Cirkel, David Losert, Aleksey Shvayka, Lucas Fernandes da C
 Repository: git+ssh://git@github.com/chaijs/type-detect.git
 
 > Copyright (c) 2013 Jake Luer <jake@alogicalparadox.com> (http://alogicalparadox.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2150,13 +2150,13 @@ By: Isaac Z. Schlueter
 Repository: git://github.com/isaacs/node-which.git
 
 > The ISC License
->
+> 
 > Copyright (c) Isaac Z. Schlueter and Contributors
->
+> 
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -2173,13 +2173,13 @@ By: Sindre Sorhus
 Repository: chalk/wrap-ansi
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -2190,17 +2190,17 @@ By: Einar Otto Stangvik
 Repository: websockets/ws
 
 > Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2217,11 +2217,11 @@ By: Sindre Sorhus
 Repository: sindresorhus/yocto-queue
 
 > MIT License
->
+> 
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
+> 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
+> 
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
+> 
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -4,7 +4,7 @@ import { basename, dirname, extname, isAbsolute, join, resolve } from 'pathe'
 import c from 'picocolors'
 import { getAllMockableProperties, getType, getWorkerState } from '../utils'
 import { distDir } from '../constants'
-import type { PendingSuiteMock } from '../types/mocker'
+import type { MockFactory, PendingSuiteMock } from '../types/mocker'
 import type { VitestRunner } from './execute'
 
 class RefTracker {
@@ -101,7 +101,7 @@ export class VitestMocker {
     VitestMocker.pendingIds = []
   }
 
-  private async callFunctionMock(dep: string, mock: () => any) {
+  private async callFunctionMock(dep: string, mock: MockFactory) {
     const cached = this.moduleCache.get(dep)?.exports
     if (cached)
       return cached
@@ -303,7 +303,7 @@ export class VitestMocker {
       this.moduleCache.delete(mockId)
   }
 
-  public mockPath(originalId: string, path: string, external: string | null, factory?: () => any) {
+  public mockPath(originalId: string, path: string, external: string | null, factory?: MockFactory) {
     const suitefile = this.getSuiteFilepath()
     const id = this.normalizePath(path)
 
@@ -381,7 +381,7 @@ export class VitestMocker {
     return url
   }
 
-  public queueMock(id: string, importer: string, factory?: () => unknown) {
+  public queueMock(id: string, importer: string, factory?: MockFactory) {
     VitestMocker.pendingIds.push({ type: 'mock', id, importer, factory })
   }
 

--- a/packages/vitest/src/types/mocker.ts
+++ b/packages/vitest/src/types/mocker.ts
@@ -1,8 +1,11 @@
-export type MockMap = Map<string, Record<string, string | null | (() => unknown)>>
+export type MockFactoryWithHelper = (importOriginal: <T = unknown>() => Promise<T>) => any
+export type MockFactory = () => any
+
+export type MockMap = Map<string, Record<string, string | null | MockFactory>>
 
 export interface PendingSuiteMock {
   id: string
   importer: string
   type: 'mock' | 'unmock'
-  factory?: () => unknown
+  factory?: MockFactory
 }


### PR DESCRIPTION
This could be helpful to avoid duplicating the path with `vi.importActual` to extend the existing imports.