### PR TITLE
fix: start tracking module resolution as soon as possible for easier tracking

### DIFF
--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -45,6 +45,7 @@ export interface ModuleCache {
   promise?: Promise<any>
   exports?: any
   evaluated?: boolean
+  resolving?: boolean
   code?: string
   map?: RawSourceMap
   /**


### PR DESCRIPTION
Fixes #2552

I am not sure, if we should reuse `moduleCache` here, @antfu what do you think? I initially wanted to use original ID and update mod path to `fsPath`, but it complicates things too much, I think.