### PR TITLE
fix(api): make api parse error stacks and return sourcePos in onTaskUpdate

### DIFF
--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -79,12 +79,12 @@ watch([cm, failed], ([cmValue]) => {
       const e = i.result?.error
       const stacks = (e?.stacks || []).filter(i => i.file && i.file === props.file?.filepath)
       if (stacks.length) {
-        const pos = stacks[0].sourcePos || stacks[0]
+        const stack = stacks[0]
         const div = document.createElement('div')
         div.className = 'op80 flex gap-x-2 items-center'
         const pre = document.createElement('pre')
         pre.className = 'c-red-600 dark:c-red-400'
-        pre.textContent = `${' '.repeat(pos.column)}^ ${e?.nameStr}: ${e?.message}`
+        pre.textContent = `${' '.repeat(stack.column)}^ ${e?.nameStr}: ${e?.message}`
         div.appendChild(pre)
         const span = document.createElement('span')
         span.className = 'i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer min-w-1em min-h-1em'
@@ -95,12 +95,12 @@ watch([cm, failed], ([cmValue]) => {
           placement: 'bottom',
         }, false)
         const el: EventListener = async () => {
-          await openInEditor(stacks[0].file, pos.line, pos.column)
+          await openInEditor(stacks[0].file, stack.line, stack.column)
         }
         div.appendChild(span)
         listeners.push([span, el, () => destroyTooltip(span)])
-        handles.push(cm.value!.addLineClass(pos.line - 1, 'wrap', 'bg-red-500/10'))
-        widgets.push(cm.value!.addLineWidget(pos.line - 1, div))
+        handles.push(cm.value!.addLineClass(stack.line - 1, 'wrap', 'bg-red-500/10'))
+        widgets.push(cm.value!.addLineWidget(stack.line - 1, div))
       }
     })
     if (!hasBeenEdited.value)

--- a/packages/ui/client/components/views/ViewReport.cy.tsx
+++ b/packages/ui/client/components/views/ViewReport.cy.tsx
@@ -9,10 +9,6 @@ const stackRowSelector = '[data-testid=stack]'
 const makeTextStack = () => ({
   line: faker.datatype.number({ min: 0, max: 120 }),
   column: faker.datatype.number({ min: 0, max: 5000 }),
-  sourcePos: {
-    line: faker.datatype.number({ min: 121, max: 240 }),
-    column: faker.datatype.number({ min: 5001, max: 10000 }),
-  },
   // Absolute file paths
   file: faker.system.filePath(),
   method: faker.hacker.verb(),
@@ -49,9 +45,8 @@ describe('ViewReport', () => {
       cy.get(stackRowSelector).should('have.length', stacks.length)
         .get(stackRowSelector)
         .each(($stack, idx) => {
-          const { column, line, file: fileName, sourcePos } = stacks[idx]
-          expect($stack).not.to.contain.text(`${line}:${column}`)
-          expect($stack).to.contain.text(`${sourcePos.line}:${sourcePos.column}`)
+          const { column, line, file: fileName } = stacks[idx]
+          expect($stack).to.contain.text(`${line}:${column}`)
           expect($stack).to.contain.text(`- ${fileName}`)
         })
     })

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -88,14 +88,6 @@ function relative(p: string) {
   return p
 }
 
-function line(stack: ParsedStack) {
-  return stack.sourcePos?.line ?? stack.line
-}
-
-function column(stack: ParsedStack) {
-  return stack.sourcePos?.column ?? stack.column
-}
-
 interface Diff { error: NonNullable<Pick<ErrorWithDiff, 'expected' | 'actual'>> }
 type ResultWithDiff = Task['result'] & Diff
 function isDiffShowable(result?: Task['result']): result is ResultWithDiff {
@@ -128,14 +120,14 @@ function diff(result: ResultWithDiff): string {
           <div v-else-if="task.result?.error" class="scrolls scrolls-rounded task-error">
             <pre><b>{{ task.result.error.name || task.result.error.nameStr }}</b>: {{ task.result.error.message }}</pre>
             <div v-for="(stack, i) of task.result.error.stacks" :key="i" class="op80 flex gap-x-2 items-center" data-testid="stack">
-              <pre> - {{ relative(stack.file) }}:{{ line(stack) }}:{{ column(stack) }}</pre>
+              <pre> - {{ relative(stack.file) }}:{{ stack.line }}:{{ stack.column }}</pre>
               <div
                 v-if="shouldOpenInEditor(stack.file, props.file?.name)"
                 v-tooltip.bottom="'Open in Editor'"
                 class="i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer min-w-1em min-h-1em"
                 tabindex="0"
                 aria-label="Open in Editor"
-                @click.passive="openInEditor(stack.file, line(stack), column(stack))"
+                @click.passive="openInEditor(stack.file, stack.line, stack.column)"
               />
             </div>
             <pre v-if="isDiffShowable(task.result)">

--- a/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
+++ b/packages/vitest/src/integrations/snapshot/port/inlineSnapshot.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs'
 import type MagicString from 'magic-string'
-import { lineSplitRE, numberToPos, posToNumber } from '../../../utils/source-map'
+import { lineSplitRE, offsetToLineNumber, positionToOffset } from '../../../utils/source-map'
 import { getCallLastIndex } from '../../../utils'
 
 export interface InlineSnapshot {
@@ -21,7 +21,7 @@ export async function saveInlineSnapshots(
     const s = new MagicString(code)
 
     for (const snap of snaps) {
-      const index = posToNumber(code, snap)
+      const index = positionToOffset(code, snap.line, snap.column)
       replaceInlineSnap(code, s, index, snap.snapshot)
     }
 
@@ -50,8 +50,8 @@ function replaceObjectSnap(code: string, s: MagicString, index: number, newSnap:
 }
 
 function prepareSnapString(snap: string, source: string, index: number) {
-  const lineIndex = numberToPos(source, index).line
-  const line = source.split(lineSplitRE)[lineIndex - 1]
+  const lineNumber = offsetToLineNumber(source, index)
+  const line = source.split(lineSplitRE)[lineNumber - 1]
   const indent = line.match(/^\s*/)![0] || ''
   const indentNext = indent.includes('\t') ? `${indent}\t` : `${indent}  `
 

--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -188,7 +188,6 @@ export class JsonReporter implements Reporter {
     if (!frame)
       return
 
-    const pos = frame.sourcePos || frame
-    return { line: pos.line, column: pos.column }
+    return { line: frame.line, column: frame.column }
   }
 }

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -127,10 +127,9 @@ export class JUnitReporter implements Reporter {
 
     // TODO: This is same as printStack but without colors. Find a way to reuse code.
     for (const frame of stack) {
-      const pos = frame.sourcePos ?? frame
       const path = relative(this.ctx.config.root, frame.file)
 
-      await this.baseLog(` ${F_POINTER} ${[frame.method, `${path}:${pos.line}:${pos.column}`].filter(Boolean).join(' ')}`)
+      await this.baseLog(` ${F_POINTER} ${[frame.method, `${path}:${frame.line}:${frame.column}`].filter(Boolean).join(' ')}`)
 
       // reached at test file, skip the follow stack
       if (frame.file in this.ctx.state.filesMap)

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -149,10 +149,6 @@ export class Typechecker {
             line: info.line,
             column: info.column,
             method: '',
-            sourcePos: {
-              line: info.line,
-              column: info.column,
-            },
           },
         ])
         Error.stackTraceLimit = limit

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -58,7 +58,6 @@ export interface ParsedStack {
   file: string
   line: number
   column: number
-  sourcePos?: Position
 }
 
 export interface ErrorWithDiff extends Error {

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -47,12 +47,6 @@ export interface UserConsoleLog {
   size: number
 }
 
-export interface Position {
-  source?: string
-  line: number
-  column: number
-}
-
 export interface ParsedStack {
   method: string
   file: string

--- a/packages/vitest/src/utils/source-map.ts
+++ b/packages/vitest/src/utils/source-map.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import type { ErrorWithDiff, ParsedStack, Position } from '../types'
+import type { ErrorWithDiff, ParsedStack } from '../types'
 import { notNullish } from './base'
 
 export const lineSplitRE = /\r?\n/
@@ -91,29 +91,27 @@ export function parseStacktrace(e: ErrorWithDiff, full = false): ParsedStack[] {
   return stackFrames
 }
 
-export function posToNumber(
+export function positionToOffset(
   source: string,
-  pos: Position,
+  lineNumber: number,
+  columnNumber: number,
 ): number {
   const lines = source.split(lineSplitRE)
-  const { line, column } = pos
   let start = 0
 
-  if (line > lines.length)
+  if (lineNumber > lines.length)
     return source.length
 
-  for (let i = 0; i < line - 1; i++)
+  for (let i = 0; i < lineNumber - 1; i++)
     start += lines[i].length + 1
 
-  return start + column
+  return start + columnNumber
 }
 
-export function numberToPos(
+export function offsetToLineNumber(
   source: string,
-  offset: number | Position,
-): Position {
-  if (typeof offset !== 'number')
-    return offset
+  offset: number,
+): number {
   if (offset > source.length) {
     throw new Error(
       `offset is longer than source length! offset ${offset} > length ${source.length}`,
@@ -122,14 +120,12 @@ export function numberToPos(
   const lines = source.split(lineSplitRE)
   let counted = 0
   let line = 0
-  let column = 0
   for (; line < lines.length; line++) {
     const lineLength = lines[line].length + 1
-    if (counted + lineLength >= offset) {
-      column = offset - counted + 1
+    if (counted + lineLength >= offset)
       break
-    }
+
     counted += lineLength
   }
-  return { line: line + 1, column }
+  return line + 1
 }

--- a/packages/vitest/src/utils/source-map.ts
+++ b/packages/vitest/src/utils/source-map.ts
@@ -93,10 +93,8 @@ export function parseStacktrace(e: ErrorWithDiff, full = false): ParsedStack[] {
 
 export function posToNumber(
   source: string,
-  pos: number | Position,
+  pos: Position,
 ): number {
-  if (typeof pos === 'number')
-    return pos
   const lines = source.split(lineSplitRE)
   const { line, column } = pos
   let start = 0


### PR DESCRIPTION
Starting with [this PR](https://github.com/vitest-dev/vitest/pull/2248) included in [Vitest 0.25.0](https://github.com/vitest-dev/vitest/releases/tag/v0.25.0), Vitest api hasn't been parsing and returning the stacks when a test fails.

This is due to the removal of [this piece of code](https://github.com/vitest-dev/vitest/pull/2248/files#diff-d6bd07e0f22c35d34b1ed42ab42349ba26e7a1a063d3880961b4317ccd3c0b93L157).

A side effect of this is that the VSCode extension for Vitest doesn't show the error at the line where the assertion failure occurs, but rather on the failing test itself.

**Here is the bug in action:**

https://user-images.githubusercontent.com/4410247/209474578-402a6b6a-05d6-4dac-aa0f-d2e98f4a6df3.mov

As you can see, the error displays on the `it` block itself rather than on the the expect.

With this fix, we reintroduce parsing the error stack before sending it out. We also add the `sourcePos` attribute in the stack,  which is simply the position of the error as the position is now always the correct one (as sourcemaps are loaded in the Node environment).

**This is what it looks like with the fix:**

https://user-images.githubusercontent.com/4410247/209474618-900d57ae-64e5-48ae-aa1a-d4147967c056.mov
