### PR TITLE
fix: don't hang on mocking module with circular dependency

### DIFF
--- a/examples/mocks/src/export-default-circle-b.ts
+++ b/examples/mocks/src/export-default-circle-b.ts
@@ -1,0 +1,5 @@
+import b from './export-default-circle-index'
+
+export default function () {
+  return b()
+}

--- a/examples/mocks/src/export-default-circle-index.ts
+++ b/examples/mocks/src/export-default-circle-index.ts
@@ -1,0 +1,5 @@
+import b from './export-default-circle-b'
+
+export default function () {
+  return b()
+}

--- a/examples/mocks/test/circular.spec.ts
+++ b/examples/mocks/test/circular.spec.ts
@@ -1,11 +1,18 @@
 import { expect, test, vi } from 'vitest'
 import { main } from '../src/main.js'
+import x from '../src/export-default-circle-index'
 
 vi.mock('../src/A', async () => ({
   ...(await vi.importActual<any>('../src/A')),
   funcA: () => 'mockedA',
 }))
 
-test('main', () => {
+vi.mock('../src/export-default-circle-b')
+
+test('can import actual inside mock factory', () => {
   expect(main()).toBe('mockedA')
+})
+
+test('can mock a circular dependency', () => {
+  expect(x()).toBe(undefined)
 })

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -359,13 +359,13 @@ export class VitestMocker {
 
     if (mock === null) {
       const cache = this.moduleCache.get(mockPath)
-      if (cache?.exports)
+      if (cache.exports)
         return cache.exports
 
       const exports = {}
       // Assign the empty exports object early to allow for cycles to work. The object will be filled by mockObject()
       this.moduleCache.set(mockPath, { exports })
-      const mod = await this.runner.directRequest(url, url, [])
+      const mod = await this.runner.directRequest(url, url, callstack)
       this.mockObject(mod, exports)
       return exports
     }


### PR DESCRIPTION
Fixes #2567