### PR TITLE
perf: improve vi.mock performance

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -4,6 +4,7 @@ import type { VitestMocker } from '../runtime/mocker'
 import type { ResolvedConfig, RuntimeConfig } from '../types'
 import { getWorkerState, resetModules, waitForImportsToResolve } from '../utils'
 import type { MockFactoryWithHelper } from '../types/mocker'
+import { createSimpleStackTrace } from '../utils/error'
 import { FakeTimers } from './mock/timers'
 import type { EnhancedSpy, MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartiallyMockedDeep } from './spy'
 import { fn, isMockFunction, spies, spyOn } from './spy'
@@ -115,14 +116,7 @@ class VitestUtils {
    * - Rewrite prepareStackTrace to bypass support-stack-trace (usually takes ~250ms).
    */
   private getImporter() {
-    const limit = Error.stackTraceLimit
-    const prepareStackTrace = Error.prepareStackTrace
-    Error.stackTraceLimit = 3
-    Error.prepareStackTrace = e => e.stack
-    const err = new Error('mock')
-    const stackTrace = err.stack || ''
-    Error.prepareStackTrace = prepareStackTrace
-    Error.stackTraceLimit = limit
+    const stackTrace = createSimpleStackTrace({ stackTraceLimit: 3 })
     const importerStack = stackTrace.split('\n')[3]
     const stack = parseSingleStack(importerStack)
     return stack?.file || ''

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -111,8 +111,8 @@ class VitestUtils {
   fn = fn
 
   private getImporter() {
-    const stackTrace = createSimpleStackTrace({ stackTraceLimit: 3 })
-    const importerStack = stackTrace.split('\n')[3]
+    const stackTrace = createSimpleStackTrace({ stackTraceLimit: 4 })
+    const importerStack = stackTrace.split('\n')[4]
     const stack = parseSingleStack(importerStack)
     return stack?.file || ''
   }

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -110,11 +110,6 @@ class VitestUtils {
   spyOn = spyOn
   fn = fn
 
-  /**
-   * Get importer with the most performant way.
-   * - Create only 3 stack frames, because the last one is the importer.
-   * - Rewrite prepareStackTrace to bypass support-stack-trace (usually takes ~250ms).
-   */
   private getImporter() {
     const stackTrace = createSimpleStackTrace({ stackTraceLimit: 3 })
     const importerStack = stackTrace.split('\n')[3]

--- a/packages/vitest/src/utils/error.ts
+++ b/packages/vitest/src/utils/error.ts
@@ -3,6 +3,11 @@ interface ErrorOptions {
   stackTraceLimit?: number
 }
 
+/**
+ * Get original stacktrace without source map support the most performant way.
+ * - Create only 1 stack frame.
+ * - Rewrite prepareStackTrace to bypass "support-stack-trace" (usually takes ~250ms).
+ */
 export function createSimpleStackTrace(options?: ErrorOptions) {
   const { message = 'error', stackTraceLimit = 1 } = options || {}
   const limit = Error.stackTraceLimit

--- a/packages/vitest/src/utils/error.ts
+++ b/packages/vitest/src/utils/error.ts
@@ -1,0 +1,17 @@
+interface ErrorOptions {
+  message?: string
+  stackTraceLimit?: number
+}
+
+export function createSimpleStackTrace(options?: ErrorOptions) {
+  const { message = 'error', stackTraceLimit = 1 } = options || {}
+  const limit = Error.stackTraceLimit
+  const prepareStackTrace = Error.prepareStackTrace
+  Error.stackTraceLimit = stackTraceLimit
+  Error.prepareStackTrace = e => e.stack
+  const err = new Error(message)
+  const stackTrace = err.stack || ''
+  Error.prepareStackTrace = prepareStackTrace
+  Error.stackTraceLimit = limit
+  return stackTrace
+}

--- a/packages/vitest/src/utils/source-map.ts
+++ b/packages/vitest/src/utils/source-map.ts
@@ -27,6 +27,52 @@ function extractLocation(urlLike: string) {
   return [parts[1], parts[2] || undefined, parts[3] || undefined]
 }
 
+// Based on https://github.com/stacktracejs/error-stack-parser
+// Credit to stacktracejs
+export function parseSingleStack(raw: string): ParsedStack | null {
+  let line = raw.trim()
+
+  if (line.includes('(eval '))
+    line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(,.*$)/g, '')
+
+  let sanitizedLine = line
+    .replace(/^\s+/, '')
+    .replace(/\(eval code/g, '(')
+    .replace(/^.*?\s+/, '')
+
+  // capture and preserve the parenthesized location "(/foo/my bar.js:12:87)" in
+  // case it has spaces in it, as the string is split on \s+ later on
+  const location = sanitizedLine.match(/ (\(.+\)$)/)
+
+  // remove the parenthesized location from the line, if it was matched
+  sanitizedLine = location ? sanitizedLine.replace(location[0], '') : sanitizedLine
+
+  // if a location was matched, pass it to extractLocation() otherwise pass all sanitizedLine
+  // because this line doesn't have function name
+  const [url, lineNumber, columnNumber] = extractLocation(location ? location[1] : sanitizedLine)
+  let method = (location && sanitizedLine) || ''
+  let file = url && ['eval', '<anonymous>'].includes(url) ? undefined : url
+
+  if (!file || !lineNumber || !columnNumber)
+    return null
+
+  if (method.startsWith('async '))
+    method = method.slice(6)
+
+  if (file.startsWith('file://'))
+    file = file.slice(7)
+
+  // normalize Windows path (\ -> /)
+  file = resolve(file)
+
+  return {
+    method,
+    file,
+    line: parseInt(lineNumber),
+    column: parseInt(columnNumber),
+  }
+}
+
 export function parseStacktrace(e: ErrorWithDiff, full = false): ParsedStack[] {
   if (!e)
     return []
@@ -37,53 +83,13 @@ export function parseStacktrace(e: ErrorWithDiff, full = false): ParsedStack[] {
   const stackStr = e.stack || e.stackStr || ''
   const stackFrames = stackStr
     .split('\n')
-    // Based on https://github.com/stacktracejs/error-stack-parser
-    // Credit to stacktracejs
     .map((raw): ParsedStack | null => {
-      let line = raw.trim()
+      const stack = parseSingleStack(raw)
 
-      if (line.includes('(eval '))
-        line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(,.*$)/g, '')
-
-      let sanitizedLine = line
-        .replace(/^\s+/, '')
-        .replace(/\(eval code/g, '(')
-        .replace(/^.*?\s+/, '')
-
-      // capture and preserve the parenthesized location "(/foo/my bar.js:12:87)" in
-      // case it has spaces in it, as the string is split on \s+ later on
-      const location = sanitizedLine.match(/ (\(.+\)$)/)
-
-      // remove the parenthesized location from the line, if it was matched
-      sanitizedLine = location ? sanitizedLine.replace(location[0], '') : sanitizedLine
-
-      // if a location was matched, pass it to extractLocation() otherwise pass all sanitizedLine
-      // because this line doesn't have function name
-      const [url, lineNumber, columnNumber] = extractLocation(location ? location[1] : sanitizedLine)
-      let method = (location && sanitizedLine) || ''
-      let file = url && ['eval', '<anonymous>'].includes(url) ? undefined : url
-
-      if (!file || !lineNumber || !columnNumber)
+      if (!stack || (!full && stackIgnorePatterns.some(p => stack.file.includes(p))))
         return null
 
-      if (method.startsWith('async '))
-        method = method.slice(6)
-
-      if (file.startsWith('file://'))
-        file = file.slice(7)
-
-      // normalize Windows path (\ -> /)
-      file = resolve(file)
-
-      if (!full && stackIgnorePatterns.some(p => file && file.includes(p)))
-        return null
-
-      return {
-        method,
-        file,
-        line: parseInt(lineNumber),
-        column: parseInt(columnNumber),
-      }
+      return stack
     })
     .filter(notNullish)
 


### PR DESCRIPTION
With this change:

```
   Duration  8.67s (transform 1.68s, setup 580ms, collect 1.59s, tests 5.41s)
```

Before the change:

```
   Duration  16.21s (transform 1.70s, setup 29.17s, collect 1.64s, tests 5.34s)
```

We had a single `vi.mock` in `setupFiles`, that was called before each test, but was needed only in one test.

`this.getImporter` took 250-300ms, now it takes ~13ms. This fixes regression, when we added `support-source-map`.