### PR TITLE
chore: don't bundle cac and picocolors

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@types/ws": "^8.5.3",
     "@vitest/ws-client": "workspace:*",
-    "picocolors": "^1.0.0",
     "rollup": "^2.79.1",
     "vitest": "workspace:*"
   }

--- a/packages/ui/client/components.d.ts
+++ b/packages/ui/client/components.d.ts
@@ -33,5 +33,6 @@ declare module '@vue/runtime-core' {
     ViewEditor: typeof import('./components/views/ViewEditor.vue')['default']
     ViewModuleGraph: typeof import('./components/views/ViewModuleGraph.vue')['default']
     ViewReport: typeof import('./components/views/ViewReport.vue')['default']
+    ViewReportError: typeof import('./components/views/ViewReportError.vue')['default']
   }
 }

--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -14,6 +14,7 @@
   "bugs": {
     "url": "https://github.com/vitest-dev/vitest/issues"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -75,9 +76,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "cac": "^6.7.14",
     "debug": "^4.3.4",
     "mlly": "^1.0.0",
     "pathe": "^0.2.0",
+    "picocolors": "^1.0.0",
     "source-map": "^0.6.1",
     "source-map-support": "^0.5.21",
     "vite": "^3.0.0 || ^4.0.0"
@@ -86,8 +89,6 @@
     "@types/debug": "^4.1.7",
     "@types/source-map": "^0.5.7",
     "@types/source-map-support": "^0.5.6",
-    "cac": "^6.7.14",
-    "picocolors": "^1.0.0",
     "rollup": "^2.79.1"
   }
 }

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -335,35 +335,6 @@ Repository: micromatch/braces
 
 ---------------------------------------
 
-## cac
-License: MIT
-By: egoist
-Repository: egoist/cac
-
-> The MIT License (MIT)
-> 
-> Copyright (c) EGOIST <0x142857@gmail.com> (https://github.com/egoist)
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
 ## chai-subset
 License: MIT
 By: Andrii Shumada, Robert Herhold

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1664,29 +1664,6 @@ Repository: unjs/pathe
 
 ---------------------------------------
 
-## picocolors
-License: ISC
-By: Alexey Raspopov
-Repository: alexeyraspopov/picocolors
-
-> ISC License
-> 
-> Copyright (c) 2021 Alexey Raspopov, Kostiantyn Denysov, Anton Verinov
-> 
-> Permission to use, copy, modify, and/or distribute this software for any
-> purpose with or without fee is hereby granted, provided that the above
-> copyright notice and this permission notice appear in all copies.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-> MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-> ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-> WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-> ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-> OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----------------------------------------
-
 ## picomatch
 License: MIT
 By: Jon Schlinkert

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -22,6 +22,7 @@
     "test",
     "jest"
   ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "require": {
@@ -110,9 +111,11 @@
     "@types/node": "*",
     "acorn": "^8.8.1",
     "acorn-walk": "^8.2.0",
+    "cac": "^6.7.14",
     "chai": "^4.3.7",
     "debug": "^4.3.4",
     "local-pkg": "^0.4.2",
+    "picocolors": "^1.0.0",
     "source-map": "^0.6.1",
     "strip-literal": "^1.0.0",
     "tinybench": "^2.3.1",
@@ -136,7 +139,6 @@
     "@vitest/ui": "workspace:*",
     "@vitest/utils": "workspace:*",
     "birpc": "^0.2.3",
-    "cac": "^6.7.14",
     "chai-subset": "^1.6.0",
     "cli-truncate": "^3.1.0",
     "diff": "^5.1.0",
@@ -156,7 +158,6 @@
     "natural-compare": "^1.4.0",
     "p-limit": "^4.0.0",
     "pathe": "^0.2.0",
-    "picocolors": "^1.0.0",
     "pkg-types": "^1.0.1",
     "pretty-format": "^27.5.1",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,7 +624,6 @@ importers:
       local-pkg: ^0.4.2
       mlly: ^1.0.0
       modern-node-polyfills: 0.0.9
-      picocolors: ^1.0.0
       rollup: ^2.79.1
       rollup-plugin-node-polyfills: ^0.2.1
       sirv: ^2.0.2
@@ -638,7 +637,6 @@ importers:
     devDependencies:
       '@types/ws': 8.5.3
       '@vitest/ws-client': link:../ws-client
-      picocolors: 1.0.0
       rollup: 2.79.1
       vitest: link:../vitest
 
@@ -884,6 +882,7 @@ importers:
       chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.2
+      picocolors: 1.0.0
       source-map: 0.6.1
       strip-literal: 1.0.0
       tinybench: 2.3.1
@@ -925,7 +924,6 @@ importers:
       natural-compare: 1.4.0
       p-limit: 4.0.0
       pathe: 0.2.0
-      picocolors: 1.0.0
       pkg-types: 1.0.1
       pretty-format: 27.5.1
       prompts: 2.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,9 +801,11 @@ importers:
       source-map-support: ^0.5.21
       vite: ^4.0.0
     dependencies:
+      cac: 6.7.14
       debug: 4.3.4
       mlly: 1.0.0
       pathe: 0.2.0
+      picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
       vite: 4.0.0
@@ -811,8 +813,6 @@ importers:
       '@types/debug': 4.1.7
       '@types/source-map': 0.5.7
       '@types/source-map-support': 0.5.6
-      cac: 6.7.14
-      picocolors: 1.0.0
       rollup: 2.79.1
 
   packages/vitest:
@@ -880,6 +880,7 @@ importers:
       '@types/node': 18.7.13
       acorn: 8.8.1
       acorn-walk: 8.2.0
+      cac: 6.7.14
       chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.2
@@ -905,7 +906,6 @@ importers:
       '@vitest/ui': link:../ui
       '@vitest/utils': link:../utils
       birpc: 0.2.3
-      cac: 6.7.14
       chai-subset: 1.6.0
       cli-truncate: 3.1.0
       diff: 5.1.0
@@ -9928,7 +9928,6 @@ packages:
   /cac/6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /cacache/12.0.4:
     resolution: {integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==}


### PR DESCRIPTION
Do not bundle cac and picocolors, because they are used between our different packages and increase the overall size.