### PR TITLE
refactor: make ids in typecheck suites more reliable, store errors in array

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -71,7 +71,7 @@ export class Vitest {
     this.cache = new VitestCache()
     this.snapshot = new SnapshotManager({ ...resolved.snapshotOptions })
 
-    if (this.config.watch)
+    if (this.config.watch && this.mode !== 'typecheck')
       this.registerWatcher()
 
     this.vitenode = new ViteNodeServer(server, this.config)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -154,8 +154,9 @@ export class Vitest {
     ) as ResolvedConfig
   }
 
-  async typecheck(filters?: string[]) {
-    const testsFilesList = await this.globTestFiles(filters)
+  async typecheck(filters: string[] = []) {
+    const { include, exclude } = this.config.typecheck
+    const testsFilesList = await this.globFiles(filters, include, exclude)
     const checker = new Typechecker(this, testsFilesList)
     this.typechecker = checker
     checker.onParseEnd(async ({ files, sourceErrors }) => {
@@ -198,6 +199,7 @@ export class Vitest {
       await this.report('onTaskUpdate', checker.getTestPacks())
       await this.report('onCollected')
     })
+    await checker.prepare()
     await checker.collectTests()
     await checker.start()
   }
@@ -562,9 +564,7 @@ export class Vitest {
     )))
   }
 
-  async globTestFiles(filters: string[] = []) {
-    const { include, exclude, includeSource } = this.config
-
+  async globFiles(filters: string[], include: string[], exclude: string[]) {
     const globOptions: fg.Options = {
       absolute: true,
       dot: true,
@@ -580,10 +580,16 @@ export class Vitest {
     if (filters.length)
       testFiles = testFiles.filter(i => filters.some(f => i.includes(f)))
 
+    return testFiles
+  }
+
+  async globTestFiles(filters: string[] = []) {
+    const { include, exclude, includeSource } = this.config
+
+    const testFiles = await this.globFiles(filters, include, exclude)
+
     if (includeSource) {
-      let files = await fg(includeSource, globOptions)
-      if (filters.length)
-        files = files.filter(i => filters.some(f => i.includes(f)))
+      const files = await this.globFiles(filters, includeSource, exclude)
 
       await Promise.all(files.map(async (file) => {
         try {

--- a/packages/vitest/src/node/reporters/renderers/listRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/listRenderer.ts
@@ -2,7 +2,7 @@ import c from 'picocolors'
 import cliTruncate from 'cli-truncate'
 import stripAnsi from 'strip-ansi'
 import type { Benchmark, BenchmarkResult, SuiteHooks, Task, VitestRunMode } from '../../../types'
-import { clearInterval, getTests, getTypecheckTests, isTypecheckTest, notNullish, setInterval } from '../../../utils'
+import { clearInterval, getTests, notNullish, setInterval } from '../../../utils'
 import { F_RIGHT } from '../../../utils/figures'
 import type { Logger } from '../../logger'
 import { formatProjectName, getCols, getHookStateSymbol, getStateSymbol } from './utils'
@@ -99,8 +99,8 @@ export function renderTree(tasks: Task[], options: ListRendererOptions, level = 
     if (task.type === 'test' && task.result?.retryCount && task.result.retryCount > 1)
       suffix += c.yellow(` (retry x${task.result.retryCount})`)
 
-    if (task.type === 'suite' && !isTypecheckTest(task)) {
-      const tests = options.mode === 'typecheck' ? getTypecheckTests(task) : getTests(task)
+    if (task.type === 'suite' && !task.meta?.typecheck) {
+      const tests = getTests(task)
       suffix += c.dim(` (${tests.length})`)
     }
 

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -91,6 +91,10 @@ export function renderSnapshotSummary(rootDir: string, snapshots: SnapshotSummar
   return summary
 }
 
+export function countTestErrors(tasks: Task[]) {
+  return tasks.reduce((c, i) => c + (i.result?.errors?.length || 0), 0)
+}
+
 export function getStateString(tasks: Task[], name = 'tests', showTotal = true) {
   if (tasks.length === 0)
     return c.dim(`no ${name}`)

--- a/packages/vitest/src/typecheck/collect.ts
+++ b/packages/vitest/src/typecheck/collect.ts
@@ -3,11 +3,15 @@ import { parse as parseAst } from 'acorn'
 import { ancestor as walkAst } from 'acorn-walk'
 import type { RawSourceMap } from 'vite-node'
 
-import type { File, Suite, Vitest } from '../types'
-import { interpretTaskModes, someTasksAreOnly } from '../utils/collect'
-import { TYPECHECK_SUITE } from './constants'
+import type { File, Suite, Test, Vitest } from '../types'
+import { calculateSuiteHash, generateHash, interpretTaskModes, someTasksAreOnly } from '../utils/collect'
 
 interface ParsedFile extends File {
+  start: number
+  end: number
+}
+
+interface ParsedTest extends Test {
   start: number
   end: number
 }
@@ -21,9 +25,9 @@ interface LocalCallDefinition {
   start: number
   end: number
   name: string
-  type: string
+  type: 'suite' | 'test'
   mode: 'run' | 'skip' | 'only' | 'todo'
-  task: ParsedSuite | ParsedFile
+  task: ParsedSuite | ParsedFile | ParsedTest
 }
 
 export interface FileInformation {
@@ -42,18 +46,16 @@ export async function collectTests(ctx: Vitest, filepath: string): Promise<null 
     ecmaVersion: 'latest',
     allowAwaitOutsideFunction: true,
   })
+  const testFilepath = relative(ctx.config.root, filepath)
   const file: ParsedFile = {
     filepath,
     type: 'suite',
-    id: filepath,
-    name: relative(ctx.config.root, filepath),
+    id: generateHash(testFilepath),
+    name: testFilepath,
     mode: 'run',
     tasks: [],
     start: ast.start,
     end: ast.end,
-    result: {
-      state: 'pass',
-    },
   }
   const definitions: LocalCallDefinition[] = []
   const getName = (callee: any): string | null => {
@@ -80,14 +82,17 @@ export async function collectTests(ctx: Vitest, filepath: string): Promise<null 
         return
       const { arguments: [{ value: message }] } = node as any
       const property = callee?.property?.name
-      const mode = !property || property === name ? 'run' : property
-      if (!['run', 'skip', 'todo', 'only'].includes(mode))
+      let mode = !property || property === name ? 'run' : property
+      if (!['run', 'skip', 'todo', 'only', 'skipIf', 'runIf'].includes(mode))
         throw new Error(`${name}.${mode} syntax is not supported when testing types`)
+      // cannot statically analyze, so we always skip it
+      if (mode === 'skipIf' || mode === 'runIf')
+        mode = 'skip'
       definitions.push({
         start: node.start,
         end: node.end,
         name: message,
-        type: name,
+        type: name === 'it' || name === 'test' ? 'test' : 'suite',
         mode,
       } as LocalCallDefinition)
     },
@@ -99,37 +104,49 @@ export async function collectTests(ctx: Vitest, filepath: string): Promise<null 
       lastSuite = suite.suite as ParsedSuite
     return lastSuite
   }
-  definitions.sort((a, b) => a.start - b.start).forEach((definition, idx) => {
+  definitions.sort((a, b) => a.start - b.start).forEach((definition) => {
     const latestSuite = updateLatestSuite(definition.start)
     let mode = definition.mode
     if (latestSuite.mode !== 'run') // inherit suite mode, if it's set
       mode = latestSuite.mode
-    const state = mode === 'run' ? 'pass' : mode
-    // expectTypeOf and any type error is actually a "test" ("typecheck"),
-    // and all "test"s should be inside a "suite", so semantics inside typecheck for "test" changes
-    // if we ever allow having multiple errors in a test, we can change type to "test"
-    const task: ParsedSuite = {
-      type: 'suite',
-      id: idx.toString(),
+    if (definition.type === 'suite') {
+      const task: ParsedSuite = {
+        type: definition.type,
+        id: '',
+        suite: latestSuite,
+        file,
+        tasks: [],
+        mode,
+        name: definition.name,
+        end: definition.end,
+        start: definition.start,
+        meta: {
+          typecheck: true,
+        },
+      }
+      definition.task = task
+      latestSuite.tasks.push(task)
+      lastSuite = task
+      return
+    }
+    const task: ParsedTest = {
+      type: definition.type,
+      id: '',
       suite: latestSuite,
       file,
-      tasks: [],
       mode,
+      context: {} as any, // not used in typecheck
       name: definition.name,
       end: definition.end,
       start: definition.start,
-      result: {
-        state,
+      meta: {
+        typecheck: true,
       },
     }
     definition.task = task
     latestSuite.tasks.push(task)
-    if (definition.type === 'describe' || definition.type === 'suite')
-      lastSuite = task
-    else
-      // to show correct amount of "tests" in summary, we mark this with a special symbol
-      Object.defineProperty(task, TYPECHECK_SUITE, { value: true })
   })
+  calculateSuiteHash(file)
   const hasOnly = someTasksAreOnly(file)
   interpretTaskModes(file, ctx.config.testNamePattern, hasOnly, false, ctx.config.allowOnly)
   return {

--- a/packages/vitest/src/typecheck/constants.ts
+++ b/packages/vitest/src/typecheck/constants.ts
@@ -1,2 +1,0 @@
-export const EXPECT_TYPEOF_MATCHERS = Symbol('vitest:expect-typeof-matchers')
-export const TYPECHECK_SUITE = Symbol('vitest:typecheck-suite')

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -187,7 +187,7 @@ export class Typechecker {
     const { config, path } = await getTsconfig(root, typecheck)
 
     this.tempConfigPath = path
-    this.allowJs = config.allowJs || typecheck.allowJs || false
+    this.allowJs = typecheck.allowJs || config.allowJs || false
   }
 
   public async start() {

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -1,11 +1,11 @@
 import { rm } from 'node:fs/promises'
 import type { ExecaChildProcess } from 'execa'
 import { execa } from 'execa'
-import { resolve } from 'pathe'
+import { extname, resolve } from 'pathe'
 import { SourceMapConsumer } from 'source-map'
 import { ensurePackageInstalled } from '../utils'
 import type { Awaitable, File, ParsedStack, Task, TaskResultPack, TaskState, TscErrorInfo, Vitest } from '../types'
-import { getRawErrsMapFromTsCompile, getTsconfigPath } from './parse'
+import { getRawErrsMapFromTsCompile, getTsconfig } from './parse'
 import { createIndexMap } from './utils'
 import type { FileInformation } from './collect'
 import { collectTests } from './collect'
@@ -36,6 +36,7 @@ export class Typechecker {
 
   private _tests: Record<string, FileInformation> | null = {}
   private tempConfigPath?: string
+  private allowJs?: boolean
   private process!: ExecaChildProcess
 
   constructor(protected ctx: Vitest, protected files: string[]) {}
@@ -56,9 +57,16 @@ export class Typechecker {
     return collectTests(this.ctx, filepath)
   }
 
+  protected getFiles() {
+    return this.files.filter((filename) => {
+      const extension = extname(filename)
+      return extension !== '.js' || this.allowJs
+    })
+  }
+
   public async collectTests() {
     const tests = (await Promise.all(
-      this.files.map(filepath => this.collectFileTests(filepath)),
+      this.getFiles().map(filepath => this.collectFileTests(filepath)),
     )).reduce((acc, data) => {
       if (!data)
         return acc
@@ -71,7 +79,7 @@ export class Typechecker {
 
   protected async prepareResults(output: string) {
     const typeErrors = await this.parseTscLikeOutput(output)
-    const testFiles = new Set(this.files)
+    const testFiles = new Set(this.getFiles())
 
     if (!this._tests)
       this._tests = await this.collectTests()
@@ -96,31 +104,24 @@ export class Typechecker {
         if (task.suite)
           markFailed(task.suite)
       }
-      errors.forEach(({ error, originalError }, idx) => {
+      errors.forEach(({ error, originalError }) => {
         const originalPos = mapConsumer?.generatedPositionFor({
           line: originalError.line,
           column: originalError.column,
           source: path,
         }) || originalError
         const index = indexMap.get(`${originalPos.line}:${originalPos.column}`)
-        const definition = (index != null && sortedDefinitions.find(def => def.start <= index && def.end >= index)) || file
-        const suite = 'task' in definition ? definition.task : definition
+        const definition = (index != null && sortedDefinitions.find(def => def.start <= index && def.end >= index))
+        const suite = definition ? definition.task : file
         const state: TaskState = suite.mode === 'run' || suite.mode === 'only' ? 'fail' : suite.mode
-        const task: Task = {
-          type: 'typecheck',
-          id: `${path}${idx.toString()}`,
-          name: `error expect ${idx + 1}`, // TODO naming
-          mode: suite.mode,
-          file,
-          suite,
-          result: {
-            state,
-            error: state === 'fail' ? error : undefined,
-          },
+        const errors = suite.result?.errors || []
+        suite.result = {
+          state,
+          errors,
         }
-        if (state === 'fail')
-          markFailed(suite)
-        suite.tasks.push(task)
+        errors.push(error)
+        if (state === 'fail' && suite.suite)
+          markFailed(suite.suite)
       })
     })
 
@@ -179,11 +180,22 @@ export class Typechecker {
     await ensurePackageInstalled(packageName, root)
   }
 
-  public async start() {
-    const { root, watch, typecheck } = this.ctx.config
+  public async prepare() {
+    const { root, typecheck } = this.ctx.config
     await this.ensurePackageInstalled(root, typecheck.checker)
 
-    this.tempConfigPath = await getTsconfigPath(root, typecheck)
+    const { config, path } = await getTsconfig(root, typecheck)
+
+    this.tempConfigPath = path
+    this.allowJs = config.allowJs || typecheck.allowJs || false
+  }
+
+  public async start() {
+    if (!this.tempConfigPath)
+      throw new Error('tsconfig was not initialized')
+
+    const { root, watch, typecheck } = this.ctx.config
+
     const args = ['--noEmit', '--pretty', 'false', '-p', this.tempConfigPath]
     // use builtin watcher, because it's faster
     if (watch)
@@ -223,7 +235,6 @@ export class Typechecker {
       await child
       this._result = await this.prepareResults(output)
       await this._onParseEnd?.(this._result)
-      await this.clear()
     }
   }
 

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -16,6 +16,7 @@ export interface TaskBase {
   result?: TaskResult
   retry?: number
   logs?: UserConsoleLog[]
+  meta?: any
 }
 
 export interface TaskResult {
@@ -59,11 +60,7 @@ export interface Test<ExtraContext = {}> extends TaskBase {
   onFailed?: OnTestFailedHandler[]
 }
 
-export interface TypeCheck extends TaskBase {
-  type: 'typecheck'
-}
-
-export type Task = Test | Suite | File | Benchmark | TypeCheck
+export type Task = Test | Suite | File | Benchmark
 
 export type DoneCallback = (error?: any) => void
 export type TestFunction<ExtraContext = {}> = (context: TestContext & ExtraContext) => Awaitable<any> | void

--- a/packages/vitest/src/utils/collect.ts
+++ b/packages/vitest/src/utils/collect.ts
@@ -70,3 +70,23 @@ function checkAllowOnly(task: TaskBase, allowOnly?: boolean) {
     error: new Error('[Vitest] Unexpected .only modifier. Remove it or pass --allowOnly argument to bypass this error'),
   }
 }
+
+export function generateHash(str: string): string {
+  let hash = 0
+  if (str.length === 0)
+    return `${hash}`
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    hash = (hash << 5) - hash + char
+    hash = hash & hash // Convert to 32bit integer
+  }
+  return `${hash}`
+}
+
+export function calculateSuiteHash(parent: Suite) {
+  parent.tasks.forEach((t, idx) => {
+    t.id = `${parent.id}_${idx}`
+    if (t.type === 'suite')
+      calculateSuiteHash(t)
+  })
+}

--- a/packages/vitest/src/utils/tasks.ts
+++ b/packages/vitest/src/utils/tasks.ts
@@ -1,25 +1,12 @@
-import type { Arrayable, Benchmark, Suite, Task, Test, TypeCheck } from '../types'
-import { TYPECHECK_SUITE } from '../typecheck/constants'
+import type { Arrayable, Benchmark, Suite, Task, Test } from '../types'
 import { toArray } from './base'
 
-function isAtomTest(s: Task): s is Test | Benchmark | TypeCheck {
-  return (s.type === 'test' || s.type === 'benchmark' || s.type === 'typecheck')
+function isAtomTest(s: Task): s is Test | Benchmark {
+  return (s.type === 'test' || s.type === 'benchmark')
 }
 
-export function getTests(suite: Arrayable<Task>): (Test | Benchmark | TypeCheck)[] {
+export function getTests(suite: Arrayable<Task>): (Test | Benchmark)[] {
   return toArray(suite).flatMap(s => isAtomTest(s) ? [s] : s.tasks.flatMap(c => isAtomTest(c) ? [c] : getTests(c)))
-}
-
-export function isTypecheckTest(suite: Task): suite is Suite {
-  return TYPECHECK_SUITE in suite
-}
-
-export function getTypecheckTests(suite: Arrayable<Task>): Suite[] {
-  return toArray(suite).flatMap((s) => {
-    if (s.type !== 'suite')
-      return []
-    return TYPECHECK_SUITE in s ? [s, ...getTypecheckTests(s.tasks)] : getTypecheckTests(s.tasks)
-  })
 }
 
 export function getTasks(tasks: Arrayable<Task> = []): Task[] {

--- a/test/typescript/failing/fail.test-d.ts
+++ b/test/typescript/failing/fail.test-d.ts
@@ -8,6 +8,7 @@ describe('nested suite', () => {
   describe('nested 2', () => {
     test('failing test 2', () => {
       expectTypeOf(1).toBeVoid()
+      expectTypeOf(1).toBeUndefined()
     })
   })
 

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -1,54 +1,88 @@
 // Vitest Snapshot v1
 
-exports[`should fails > typecheck files > expect-error.test-d.ts 1`] = `
-" ❯ expect-error.test-d.ts:4:3
-      2| 
-      3| test('failing test with expect-error', () => {
-      4|   // @ts-expect-error expect nothing
-       |   ^
-      5|   expectTypeOf(1).toEqualTypeOf<number>()
-      6| })
-"
-`;
-
-exports[`should fails > typecheck files > fail.test-d.ts 1`] = `
-" ❯ fail.test-d.ts:4:19
-      2| 
-      3| test('failing test', () => {
-      4|   expectTypeOf(1).toEqualTypeOf<string>()
-       |                   ^
-      5| })
-      6| 
-"
-`;
-
-exports[`should fails > typecheck files > js-fail.test-d.js 1`] = `
-" ❯ js-fail.test-d.js:6:19
-      4| 
-      5| test('js test fails', () => {
-      6|   expectTypeOf(1).toBeArray()
-       |                   ^
-      7| })
-      8| 
-"
-`;
-
-exports[`should fails > typecheck files > only.test-d.ts 1`] = `
-" ❯ only.test-d.ts:4:19
-      2| 
-      3| test.only('failing test', () => {
-      4|   expectTypeOf(1).toEqualTypeOf<string>()
-       |                   ^
-      5| })
-      6| 
-"
-`;
-
 exports[`should fails > typecheck files 1`] = `
 "TypeCheckError: Expected 1 arguments, but got 0.
 TypeCheckError: Expected 1 arguments, but got 0.
 TypeCheckError: Expected 1 arguments, but got 0.
 TypeCheckError: Expected 1 arguments, but got 0.
 TypeCheckError: Expected 1 arguments, but got 0.
-TypeCheckError: Unused '@ts-expect-error' directive."
+TypeCheckError: Unused '@ts-expect-error' directive.
+TypeCheckError: Expected 1 arguments, but got 0."
+`;
+
+exports[`should fails > typecheck files 2`] = `
+" FAIL  fail.test-d.ts > nested suite
+TypeCheckError: Expected 1 arguments, but got 0.
+ ❯ fail.test-d.ts:15:19
+     13|   })
+     14| 
+     15|   expectTypeOf(1).toBeVoid()
+       |                   ^
+     16| })"
+`;
+
+exports[`should fails > typecheck files 3`] = `
+" FAIL  expect-error.test-d.ts > failing test with expect-error
+TypeCheckError: Unused '@ts-expect-error' directive.
+ ❯ expect-error.test-d.ts:4:3
+      2| 
+      3| test('failing test with expect-error', () => {
+      4|   // @ts-expect-error expect nothing
+       |   ^
+      5|   expectTypeOf(1).toEqualTypeOf<number>()"
+`;
+
+exports[`should fails > typecheck files 4`] = `
+" FAIL  fail.test-d.ts > failing test
+TypeCheckError: Expected 1 arguments, but got 0.
+ ❯ fail.test-d.ts:4:19
+      2| 
+      3| test('failing test', () => {
+      4|   expectTypeOf(1).toEqualTypeOf<string>()
+       |                   ^
+      5| })"
+`;
+
+exports[`should fails > typecheck files 5`] = `
+" FAIL  fail.test-d.ts > nested suite > nested 2 > failing test 2
+TypeCheckError: Expected 1 arguments, but got 0.
+ ❯ fail.test-d.ts:10:23
+      8|   describe('nested 2', () => {
+      9|     test('failing test 2', () => {
+     10|       expectTypeOf(1).toBeVoid()
+       |                       ^
+     11|       expectTypeOf(1).toBeUndefined()"
+`;
+
+exports[`should fails > typecheck files 6`] = `
+" FAIL  fail.test-d.ts > nested suite > nested 2 > failing test 2
+TypeCheckError: Expected 1 arguments, but got 0.
+ ❯ fail.test-d.ts:11:23
+      9|     test('failing test 2', () => {
+     10|       expectTypeOf(1).toBeVoid()
+     11|       expectTypeOf(1).toBeUndefined()
+       |                       ^
+     12|     })"
+`;
+
+exports[`should fails > typecheck files 7`] = `
+" FAIL  js-fail.test-d.js > js test fails
+TypeCheckError: Expected 1 arguments, but got 0.
+ ❯ js-fail.test-d.js:6:19
+      4| 
+      5| test('js test fails', () => {
+      6|   expectTypeOf(1).toBeArray()
+       |                   ^
+      7| })"
+`;
+
+exports[`should fails > typecheck files 8`] = `
+" FAIL  only.test-d.ts > failing test
+TypeCheckError: Expected 1 arguments, but got 0.
+ ❯ only.test-d.ts:4:19
+      2| 
+      3| test.only('failing test', () => {
+      4|   expectTypeOf(1).toEqualTypeOf<string>()
+       |                   ^
+      5| })"
 `;

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -16,7 +16,7 @@ describe('should fails', async () => {
       'vitest',
       'typecheck',
       '--dir',
-      'failing',
+      resolve(__dirname, '..', './failing'),
       '--config',
       resolve(__dirname, './vitest.config.ts'),
     ], {
@@ -37,12 +37,18 @@ describe('should fails', async () => {
       .join('\n')
       .trim()
       .replace(root, '<rootDir>')
+    expect(stderr).not.toMatch('files found, exiting with code')
     expect(msg).toMatchSnapshot()
 
     files.forEach((file) => {
-      const index = lines.findIndex(val => val.includes(`${file}:`))
-      const msg = lines.slice(index, index + 8).join('\n')
-      expect(msg).toMatchSnapshot(file)
+      expect(String(stderr)).toMatch(`${file}:`)
+    })
+
+    lines.forEach((line, idx) => {
+      if (line.includes('TypeCheckError')) {
+        const msg = lines.slice(idx - 1, idx + 7).join('\n')
+        expect(msg).toMatchSnapshot()
+      }
     })
   }, 30_000)
 })


### PR DESCRIPTION
In preparation for #2299