### PR TITLE
fix: avoid random ENOTEMPTY errors

### DIFF
--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -34,7 +34,7 @@ export class C8CoverageProvider implements CoverageProvider {
 
   async clean(clean = true) {
     if (clean && existsSync(this.options.reportsDirectory))
-      await fs.rm(this.options.reportsDirectory, { recursive: true, force: true })
+      await fs.rm(this.options.reportsDirectory, { recursive: true, force: true, maxRetries: 10 })
 
     if (!existsSync(this.options.tempDirectory))
       await fs.mkdir(this.options.tempDirectory, { recursive: true })
@@ -109,7 +109,7 @@ export class C8CoverageProvider implements CoverageProvider {
     // There will still be a temp directory with some reports when vitest exists,
     // but at least it will only contain reports of vitest's internal functions.
     if (existsSync(this.options.tempDirectory))
-      await fs.rm(this.options.tempDirectory, { recursive: true, force: true })
+      await fs.rm(this.options.tempDirectory, { recursive: true, force: true, maxRetries: 10 })
   }
 }
 function resolveC8Options(options: CoverageC8Options, root: string) {

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -93,7 +93,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
 
   async clean(clean = true) {
     if (clean && existsSync(this.options.reportsDirectory))
-      await fs.rm(this.options.reportsDirectory, { recursive: true, force: true })
+      await fs.rm(this.options.reportsDirectory, { recursive: true, force: true, maxRetries: 10 })
 
     this.coverages = []
   }


### PR DESCRIPTION
- Helps preventing crashes where C8 provider causes `ENOTEMPTY` crashes. Mostly seen on Vitest's CI.

I think the root cause is that `require("v8").takeCoverage()` keeps writing the results to file system, and at the same time Vitest is trying to clean the directory. The directory may contain results from earlier run, or it is just being cleaned (#2144). Running `require("v8").stopCoverage()` before removing the directory does not help. To be honest I've never seen `stopCoverage` working correctly. 

I can reproduce the CI failures locally by running `test/coverage-tests` in loop. After ~5-7 `pnpm test` runs the process crashes exactly as it does on CI.

https://github.com/vitest-dev/vitest/blob/6b3e36d4e9fd029984ce0f6a723ddb3fdce92379/test/coverage-test/testing.mjs#L27-L28

```diff
 async function runTests() {
+  for (const [index] of Array(1000).fill(null).entries()) {
+    console.log('Round', index)
    for (const threads of [true, false]) {
```

After these changes I can run the `pnpm test` ~50 times in row, and then Node crashes with some random OOM error:

<details>
  <summary>Crash log</summary>


```
$ node -v
v19.1.0
```

```
<--- Last few GCs --->

[1494:0x118040000]   280602 ms: Mark-sweep 4065.1 (4142.6) -> 4055.8 (4142.2) MB, 82.3 / 0.0 ms  (average mu = 0.271, current mu = 0.112) allocation failure; scavenge might not succeed
[1494:0x118040000]   280705 ms: Mark-sweep 4073.5 (4144.2) -> 4065.2 (4151.7) MB, 98.4 / 0.0 ms  (average mu = 0.156, current mu = 0.047) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0x1011a6c88 node::Abort() [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 2: 0x1011a7f54 node::ModifyCodeGenerationFromStrings(v8::Local<v8::Context>, v8::Local<v8::Value>, bool) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 3: 0x101301648 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 4: 0x1013015f4 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 5: 0x101499678 v8::internal::Heap::GarbageCollectionReasonToString(v8::internal::GarbageCollectionReason) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 6: 0x101498ff0 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 7: 0x10148ea4c v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 8: 0x10148f1ac v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
 9: 0x1014740bc v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
10: 0x1017c46b8 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
11: 0x10100324c Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_NoBuiltinExit [/opt/homebrew/Cellar/node/19.1.0/bin/node]
12: 0x1302e57a4 
13: 0x130b75ff8 
14: 0x130293fe8 
15: 0x13024c4a4 
16: 0x130d28618 
17: 0x130349f94 
18: 0x100fbb7b4 Builtins_AsyncFunctionAwaitResolveClosure [/opt/homebrew/Cellar/node/19.1.0/bin/node]
19: 0x101055a98 Builtins_PromiseFulfillReactionJob [/opt/homebrew/Cellar/node/19.1.0/bin/node]
20: 0x100facc54 Builtins_RunMicrotasks [/opt/homebrew/Cellar/node/19.1.0/bin/node]
21: 0x100f863c4 Builtins_JSRunMicrotasksEntry [/opt/homebrew/Cellar/node/19.1.0/bin/node]
22: 0x1014207e4 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
23: 0x101420da0 v8::internal::(anonymous namespace)::InvokeWithTryCatch(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
24: 0x1014434b0 v8::internal::MicrotaskQueue::RunMicrotasks(v8::internal::Isolate*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
25: 0x1014432e0 v8::internal::MicrotaskQueue::PerformCheckpointInternal(v8::Isolate*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
26: 0x1010e0af4 node::InternalCallbackScope::Close() [/opt/homebrew/Cellar/node/19.1.0/bin/node]
27: 0x1011ae01c node::fs::FileHandle::CloseReq::Resolve() [/opt/homebrew/Cellar/node/19.1.0/bin/node]
28: 0x1011aeabc node::fs::FileHandle::ClosePromise()::$_0::__invoke(uv_fs_s*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
29: 0x1011a0e1c node::MakeLibuvRequestCallback<uv_fs_s, void (*)(uv_fs_s*)>::Wrapper(uv_fs_s*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
30: 0x10396aff0 uv__work_done [/opt/homebrew/Cellar/libuv/1.44.2/lib/libuv.1.dylib]
31: 0x10396e3c4 uv__async_io [/opt/homebrew/Cellar/libuv/1.44.2/lib/libuv.1.dylib]
32: 0x10397e1e0 uv__io_poll [/opt/homebrew/Cellar/libuv/1.44.2/lib/libuv.1.dylib]
33: 0x10396e7bc uv_run [/opt/homebrew/Cellar/libuv/1.44.2/lib/libuv.1.dylib]
34: 0x1010e18b8 node::SpinEventLoopInternal(node::Environment*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
35: 0x1011e8348 node::NodeMainInstance::Run(node::ExitCode*, node::Environment*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
36: 0x1011e7fac node::NodeMainInstance::Run() [/opt/homebrew/Cellar/node/19.1.0/bin/node]
37: 0x10116fcd0 node::LoadSnapshotDataAndRun(node::SnapshotData const**, node::InitializationResultImpl const*) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
38: 0x10116fe30 node::Start(int, char**) [/opt/homebrew/Cellar/node/19.1.0/bin/node]
```

</details>

Improvement can be seen on this CI run which runs coverage tests in loop: https://github.com/AriPerkkio/vitest/actions/runs/3855214382