### PR TITLE
fix(coverage): prevent c8 from crashing on invalid sourcemaps

### DIFF
--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -86,6 +86,7 @@ export class C8CoverageProvider implements CoverageProvider {
           entry.map.mappings.length > 0
           && entry.map.sourcesContent
           && entry.map.sourcesContent.length > 0
+          && entry.map.sourcesContent[0]
           && entry.map.sourcesContent[0].length > 0
         )
       }) as SourceMapMeta[]

--- a/test/coverage-test/test/no-esbuild-transform.test.js
+++ b/test/coverage-test/test/no-esbuild-transform.test.js
@@ -1,0 +1,10 @@
+import { expect, test, vi } from 'vitest'
+import { add } from '../src/utils'
+
+vi.mock('../src/utils', async () => ({
+  add: vi.fn().mockReturnValue('mocked'),
+}))
+
+test('mocking in Javascript test should not break sourcemaps', () => {
+  expect(add(1, 2)).toBe('mocked')
+})

--- a/test/coverage-test/testing.mjs
+++ b/test/coverage-test/testing.mjs
@@ -8,7 +8,7 @@ const provider = getArgument('--provider')
 const configs = [
   // Run test cases. Generates coverage report.
   ['test/', {
-    include: ['test/*.test.ts'],
+    include: ['test/*.test.*'],
     exclude: ['coverage-report-tests/**/*'],
   }],
 


### PR DESCRIPTION
- Fixes #2627

The source map may be missing `sourcesContent` when
- it is run through Vitest's mock plugin, which uses `magic-string`
- it is written in Javascript and not processed with `esbuild`, so that `esbuild` is not there the one adding `sourcesContent`

In practice this means that test files written in Javascript that use `vi.mock` are currently crashing c8 provider. 

This seems to be a bug in `magic-string`. I'll open a PR there next.
- https://github.com/Rich-Harris/magic-string/blob/69b13c7a09af742e4f31cf419e8f96e6db32ab5a/src/MagicString.js#L168
- https://github.com/Rich-Harris/magic-string/blob/69b13c7a09af742e4f31cf419e8f96e6db32ab5a/index.d.ts#L38

We could use `includeContent: true` here, but as these are test files we don't really need the sources. With that flag we can prevent `magic-string` from passing `[null]` in `string[]` typed property.

https://github.com/vitest-dev/vitest/blob/532cc11b0c6f482dfde927c0ea25d62b0cb36706/packages/vitest/src/node/plugins/mock.ts#L71