### PR TITLE
fix: change Vite root, if test.root is used

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -90,6 +90,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
           open = '/'
 
         const config: ViteConfig = {
+          root: options.root,
           esbuild: {
             sourcemap: 'external',
 

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -90,7 +90,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
           open = '/'
 
         const config: ViteConfig = {
-          root: options.root,
+          root: viteConfig.test?.root || options.root,
           esbuild: {
             sourcemap: 'external',
 


### PR DESCRIPTION
Fixes #2050