### PR TITLE
fix(tests): cut duplicate error in negated toHaveBeenCalled

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -418,7 +418,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       ],
     )
     if (called && isNot)
-      msg += formatCalls(spy, msg)
+      msg = formatCalls(spy, msg)
 
     if ((called && isNot) || (!called && !isNot)) {
       const err = new Error(msg)
@@ -443,7 +443,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     )
 
     if ((pass && isNot) || (!pass && !isNot)) {
-      msg += formatCalls(spy, msg, args)
+      msg = formatCalls(spy, msg, args)
       const err = new Error(msg)
       err.name = 'AssertionError'
       throw err

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -463,6 +463,32 @@ describe('toSatisfy()', () => {
   })
 })
 
+describe('toHaveBeenCalled', () => {
+  describe('negated', () => {
+    it('fails if called', () => {
+      const mock = vi.fn()
+      mock()
+
+      expect(() => {
+        expect(mock).not.toHaveBeenCalled()
+      }).toThrow(/^expected "spy" to not be called at all[^e]/)
+    })
+  })
+})
+
+describe('toHaveBeenCalledWith', () => {
+  describe('negated', () => {
+    it('fails if called', () => {
+      const mock = vi.fn()
+      mock(3)
+
+      expect(() => {
+        expect(mock).not.toHaveBeenCalledWith(3)
+      }).toThrow(/^expected "spy" to not be called with arguments: \[ 3 \][^e]/)
+    })
+  })
+})
+
 describe('async expect', () => {
   it('resolves', async () => {
     await expect((async () => 'true')()).resolves.toBe('true')


### PR DESCRIPTION
Previously the error message when failing a negated `toHaveBeenCalled` or `toHaveBeenCalledWith` expectation was duplicated. This commit removes the duplication.

The error occurs because `formatCalls` already appends to the message, so appending the result of `formatCalls` to the message results in the original message being duplicated.

Please let me know if the tests are not sufficient enough. I tried matching the complete error message but I was not able to match against the newline character. Also the error message contains some color codes which are a bit hard to test.