### PR TITLE
Update docs on mocking

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -7,7 +7,7 @@ title: Mocking | Guide
 When writing tests it's only a matter of time before you need to create a "fake" version of an internal — or external — service. This is commonly referred to as **mocking**. Vitest provides utility functions to help you out through its **vi** helper. You can `import { vi } from 'vitest'` or access it **globally** (when [global configuration](/config/#globals) is **enabled**).
 
 ::: warning
-Always remember to clear or restore mocks before or after each test run to undo mock state changes between runs! See [`mockReset`](/api/#mockreset) docs for more info.
+Always remember to clear or restore mocks before or after each test run to undo mock state changes between runs! See [`mockRestore`](/api/#mockrestore) docs for more info.
 :::
 
 If you wanna dive in head first, check out the [API section](/api/#vi) otherwise keep reading to take a deeper dive into the world of mocking.


### PR DESCRIPTION
This really threw me off. `mockReset` didn't do the trick, and let mock data bleed between tests. However, setting `restoreMocks: true` in my vitest config solved the issue, so the docs should mention `mockRestore` instead of `mockReset`.