### PR TITLE
fix(coverage): istanbul provider to use `coverage.extension`

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -66,7 +66,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
       include: typeof this.options.include === 'undefined' ? undefined : [...this.options.include],
       exclude: [...defaultExclude, ...defaultInclude, ...this.options.exclude],
       excludeNodeModules: true,
-      extension: configDefaults.coverage.extension,
+      extension: this.options.extension,
     })
   }
 


### PR DESCRIPTION
Documentation already states this option is exposed by API. 

https://github.com/vitest-dev/vitest/blob/09d6222669433423a916d086022972761415d245/docs/config/index.md?plain=1#L610-L615

Defaults come from
https://github.com/vitest-dev/vitest/blob/09d6222669433423a916d086022972761415d245/packages/vitest/src/defaults.ts#L38-L40