### PR TITLE
feat: show error, when process.exit is called

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -138,6 +138,10 @@ function createChannel(ctx: Vitest) {
 
   createBirpc<{}, WorkerRPC>(
     {
+      async onWorkerExit(error, code) {
+        await ctx.logger.printError(error, false, 'Unexpected Exit')
+        process.exit(code || 1)
+      },
       snapshotSaved(snapshot) {
         ctx.snapshot.add(snapshot)
       },

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -138,9 +138,6 @@ function createChannel(ctx: Vitest) {
 
   createBirpc<{}, WorkerRPC>(
     {
-      onWorkerExit(code) {
-        process.exit(code || 1)
-      },
       snapshotSaved(snapshot) {
         ctx.snapshot.add(snapshot)
       },

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -21,15 +21,8 @@ async function startViteNode(ctx: WorkerContext) {
   if (_viteNode)
     return _viteNode
 
-  const processExit = process.exit
-
-  process.on('beforeExit', (code) => {
-    rpc().onWorkerExit(code)
-  })
-
   process.exit = (code = process.exitCode || 0): never => {
-    rpc().onWorkerExit(code)
-    return processExit(code)
+    throw new Error(`process.exit called with "${code}"`)
   }
 
   process.on('unhandledRejection', (err) => {
@@ -81,7 +74,7 @@ function init(ctx: WorkerContext) {
     rpc: createBirpc<WorkerRPC>(
       {},
       {
-        eventNames: ['onUserConsoleLog', 'onFinished', 'onCollected', 'onWorkerExit'],
+        eventNames: ['onUserConsoleLog', 'onFinished', 'onCollected'],
         post(v) { port.postMessage(v) },
         on(fn) { port.addListener('message', fn) },
       },

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -27,7 +27,6 @@ export interface WorkerRPC {
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>
 
   onFinished: (files: File[], errors?: unknown[]) => void
-  onWorkerExit: (code?: number) => void
   onPathsCollected: (paths: string[]) => void
   onUserConsoleLog: (log: UserConsoleLog) => void
   onUnhandledRejection: (err: unknown) => void

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -27,6 +27,7 @@ export interface WorkerRPC {
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>
 
   onFinished: (files: File[], errors?: unknown[]) => void
+  onWorkerExit: (error: unknown, code?: number) => void
   onPathsCollected: (paths: string[]) => void
   onUserConsoleLog: (log: UserConsoleLog) => void
   onUnhandledRejection: (err: unknown) => void

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -63,8 +63,3 @@ test('escaping', () => {
   expect(['\\123']).toEqual(['\\123'])
   expect('\\123').toEqual('\\123')
 })
-
-test('don\'t exit', () => {
-  expect(() => process.exit()).toThrowError('process.exit called with "0"')
-  expect(() => process.exit(1)).toThrowError('process.exit called with "1"')
-})

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -63,3 +63,8 @@ test('escaping', () => {
   expect(['\\123']).toEqual(['\\123'])
   expect('\\123').toEqual('\\123')
 })
+
+test('don\'t exit', () => {
+  expect(() => process.exit()).toThrowError('process.exit called with "0"')
+  expect(() => process.exit(1)).toThrowError('process.exit called with "1"')
+})


### PR DESCRIPTION
Closes #2615

Users should not rely on "process.exit" in their test code, because it will exit Vitest process. It should be mocked in the best case scenario.