### PR TITLE
fix: document.defaultView references the same window as the global one

### DIFF
--- a/packages/vitest/src/integrations/env/utils.ts
+++ b/packages/vitest/src/integrations/env/utils.ts
@@ -72,11 +72,14 @@ export function populateGlobal(global: any, win: any, options: PopulateOptions =
   if (global.global)
     global.global = global
 
-  Object.defineProperty(global.document, 'defaultView', {
-    get: () => global,
-    enumerable: true,
-    configurable: true,
-  })
+  // rewrite defaultView to reference the same global context
+  if (global.document && global.document.defaultView) {
+    Object.defineProperty(global.document, 'defaultView', {
+      get: () => global,
+      enumerable: true,
+      configurable: true,
+    })
+  }
 
   skipKeys.forEach(k => keys.add(k))
 

--- a/packages/vitest/src/integrations/env/utils.ts
+++ b/packages/vitest/src/integrations/env/utils.ts
@@ -72,6 +72,12 @@ export function populateGlobal(global: any, win: any, options: PopulateOptions =
   if (global.global)
     global.global = global
 
+  Object.defineProperty(global.document, 'defaultView', {
+    get: () => global,
+    enumerable: true,
+    configurable: true,
+  })
+
   skipKeys.forEach(k => keys.add(k))
 
   return {

--- a/test/core/test/dom.test.ts
+++ b/test/core/test/dom.test.ts
@@ -130,10 +130,15 @@ it('can call global functions without window works as expected', async () => {
 })
 
 it('globals are the same', () => {
+  expect(window).toBe(globalThis)
+  expect(window).toBe(global)
   expect(window.globalThis).toBe(globalThis)
   expect(window.Blob).toBe(globalThis.Blob)
   expect(window.globalThis.Blob).toBe(globalThis.Blob)
   expect(Blob).toBe(globalThis.Blob)
+  expect(document.defaultView).toBe(window)
+  const el = document.createElement('div')
+  expect(el.ownerDocument.defaultView).toBe(globalThis)
 })
 
 it('can extend global class', () => {

--- a/test/core/test/happy-dom.test.ts
+++ b/test/core/test/happy-dom.test.ts
@@ -102,8 +102,14 @@ it('can call global functions without window works as expected', async () => {
 })
 
 it('globals are the same', () => {
+  expect(window).toBe(globalThis)
+  expect(window).toBe(global)
   expect(window.globalThis).toBe(globalThis)
   expect(window.Blob).toBe(globalThis.Blob)
   expect(window.globalThis.Blob).toBe(globalThis.Blob)
   expect(Blob).toBe(globalThis.Blob)
+  expect(document.defaultView).toBe(window)
+  expect(document.defaultView).toBe(globalThis)
+  const el = document.createElement('div')
+  expect(el.ownerDocument.defaultView).toBe(globalThis)
 })


### PR DESCRIPTION
Fixes #2648