### PR TITLE
test: add typing tests for coverage

### DIFF
--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { builtinModules } from 'module'
-import { dirname, join, relative, resolve } from 'pathe'
+import { dirname, join, normalize, relative, resolve } from 'pathe'
 import esbuild from 'rollup-plugin-esbuild'
 import dts from 'rollup-plugin-dts'
 import nodeResolve from '@rollup/plugin-node-resolve'
@@ -106,7 +106,7 @@ export default ({ watch }) => defineConfig([
     input: dtsEntries,
     output: {
       dir: 'dist',
-      entryFileNames: chunk => `${chunk.name.replace('src/', '')}.d.ts`,
+      entryFileNames: chunk => `${normalize(chunk.name).replace('src/', '')}.d.ts`,
       format: 'esm',
     },
     external,

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -2,9 +2,10 @@
   "name": "@vitest/test-coverage",
   "private": true,
   "scripts": {
-    "test": "pnpm run test:c8 && pnpm run test:istanbul",
+    "test": "pnpm run test:c8 && pnpm run test:istanbul && pnpm run test:types",
     "test:c8": "node ./testing.mjs --provider c8",
-    "test:istanbul": "node ./testing.mjs --provider istanbul"
+    "test:istanbul": "node ./testing.mjs --provider istanbul",
+    "test:types": "vitest typecheck --run"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "latest",

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -1,0 +1,133 @@
+import { assertType, test } from 'vitest'
+import type { ResolvedCoverageOptions, Vitest } from 'vitest'
+import type { defineConfig } from 'vitest/config'
+
+type NarrowToTestConfig<T> = T extends { test?: any } ? NonNullable<T['test']> : never
+type Configuration = NarrowToTestConfig<(Parameters<typeof defineConfig>[0])>
+type Coverage = NonNullable<Configuration['coverage']>
+
+test('providers, built-in', () => {
+  assertType<Coverage>({ provider: 'c8' })
+  assertType<Coverage>({ provider: 'istanbul' })
+
+  // @ts-expect-error -- String options must be known built-in's
+  assertType<Coverage>({ provider: 'unknown-reporter' })
+})
+
+test('providers, custom', () => {
+  assertType<Coverage>({
+    provider: {
+      getProvider() {
+        return {
+          name: 'custom-provider',
+          initialize(_: Vitest) {},
+          resolveOptions() {
+            return {} as ResolvedCoverageOptions
+          },
+          clean(_: boolean) {},
+          onBeforeFilesRun() {},
+          onAfterSuiteRun({ coverage: _coverage }) {},
+          reportCoverage() {},
+          onFileTransform(_code: string, _id: string, ctx) {
+            ctx.getCombinedSourcemap()
+          },
+        }
+      },
+      takeCoverage() {},
+    },
+  })
+})
+
+test('provider options, generic', () => {
+  assertType<Coverage>({
+    provider: 'c8',
+    enabled: true,
+    include: ['string'],
+  })
+
+  assertType<Coverage>({
+    provider: 'istanbul',
+    enabled: true,
+    include: ['string'],
+  })
+})
+
+test('provider specific options, c8', () => {
+  assertType<Coverage>({
+    provider: 'c8',
+    src: ['string'],
+    100: true,
+    excludeNodeModules: false,
+    allowExternal: true,
+  })
+
+  assertType<Coverage>({
+    provider: 'c8',
+    // @ts-expect-error -- Istanbul-only option is not allowed
+    ignoreClassMethods: ['string'],
+  })
+})
+
+test('provider specific options, istanbul', () => {
+  assertType<Coverage>({
+    provider: 'istanbul',
+    ignoreClassMethods: ['string'],
+    watermarks: {
+      statements: [80, 95],
+      functions: [80, 95],
+      branches: [80, 95],
+      lines: [80, 95],
+    },
+  })
+
+  assertType<Coverage>({
+    provider: 'istanbul',
+    // @ts-expect-error -- C8-only option is not allowed
+    src: ['string'],
+  })
+})
+
+test('reporters, single', () => {
+  assertType<Coverage>({ reporter: 'clover' })
+  assertType<Coverage>({ reporter: 'cobertura' })
+  assertType<Coverage>({ reporter: 'html-spa' })
+  assertType<Coverage>({ reporter: 'html' })
+  assertType<Coverage>({ reporter: 'json-summary' })
+  assertType<Coverage>({ reporter: 'json' })
+  assertType<Coverage>({ reporter: 'lcov' })
+  assertType<Coverage>({ reporter: 'lcovonly' })
+  assertType<Coverage>({ reporter: 'none' })
+  assertType<Coverage>({ reporter: 'teamcity' })
+  assertType<Coverage>({ reporter: 'text-lcov' })
+  assertType<Coverage>({ reporter: 'text-summary' })
+  assertType<Coverage>({ reporter: 'text' })
+
+  // @ts-expect-error -- String reporters must be known built-in's
+  assertType<Coverage>({ reporter: 'unknown-reporter' })
+})
+
+test('reporters, multiple', () => {
+  assertType<Coverage>({
+    reporter: [
+      'clover',
+      'cobertura',
+      'html-spa',
+      'html',
+      'json-summary',
+      'json',
+      'lcov',
+      'lcovonly',
+      'none',
+      'teamcity',
+      'text-lcov',
+      'text-summary',
+      'text',
+    ],
+  })
+
+  // @ts-expect-error -- List of string reporters must be known built-in's
+  assertType<Coverage>({ reporter: ['unknown-reporter'] })
+
+  // @ts-expect-error -- ... and all reporters must be known
+  assertType<Coverage>({ reporter: ['html', 'json', 'unknown-reporter'] })
+})


### PR DESCRIPTION
Adds typings tests for coverage options. I'm building another coverage related feature, and run into so many internal typing errors that I decided to refactor internal typings quite much. Before refactoring the typings, some tests should be in place.