### PR TITLE
chore: update vite as peerDeps

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -20,15 +20,15 @@ You can try Vitest online on [StackBlitz](https://vitest.new). It runs Vitest di
 
 With npm
 ```bash
-npm install -D vitest
+npm install -D vitest vite
 ```
 or with yarn
 ```bash
-yarn add -D vitest
+yarn add -D vitest vite
 ```
 or with pnpm
 ```bash
-pnpm add -D vitest
+pnpm add -D vitest vite
 ```
 
 :::tip

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ts-node": "^10.9.1",
     "tsup": "^6.5.0",
     "typescript": "^4.9.4",
-    "vite": "^3.2.3",
+    "vite": "^4.0.0",
     "vitest": "workspace:*"
   },
   "pnpm": {

--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -82,13 +82,16 @@
     "pathe": "^0.2.0",
     "picocolors": "^1.0.0",
     "source-map": "^0.6.1",
-    "source-map-support": "^0.5.21",
-    "vite": "^3.0.0 || ^4.0.0"
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/source-map": "^0.5.7",
     "@types/source-map-support": "^0.5.6",
-    "rollup": "^2.79.1"
+    "rollup": "^2.79.1",
+    "vite": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0"
   }
 }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -86,7 +86,8 @@
     "@vitest/browser": "*",
     "@vitest/ui": "*",
     "happy-dom": "*",
-    "jsdom": "*"
+    "jsdom": "*",
+    "vite": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@vitest/ui": {
@@ -121,7 +122,6 @@
     "tinybench": "^2.3.1",
     "tinypool": "^0.3.0",
     "tinyspy": "^1.0.2",
-    "vite": "^3.0.0 || ^4.0.0",
     "vite-node": "workspace:*",
     "why-is-node-running": "^2.2.2"
   },
@@ -165,6 +165,7 @@
     "rollup": "^2.79.1",
     "strip-ansi": "^7.0.1",
     "typescript": "^4.9.4",
-    "ws": "^8.12.0"
+    "ws": "^8.12.0",
+    "vite": "^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
Considering Vite as peerDeps?

These modifications may cause people who have not explicitly installed vite to be prompted that **vite** cannot be found