### PR TITLE
fix(coverage): watch mode to use `coverage.all` only when all tests are run

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -2,7 +2,7 @@
 import { existsSync, promises as fs } from 'fs'
 import { relative, resolve } from 'pathe'
 import type { TransformPluginContext } from 'rollup'
-import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, ResolvedCoverageOptions, Vitest } from 'vitest'
+import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, ReportContext, ResolvedCoverageOptions, Vitest } from 'vitest'
 import { configDefaults, defaultExclude, defaultInclude } from 'vitest/config'
 import libReport from 'istanbul-lib-report'
 import reports from 'istanbul-reports'
@@ -98,14 +98,14 @@ export class IstanbulCoverageProvider implements CoverageProvider {
     this.coverages = []
   }
 
-  async reportCoverage() {
+  async reportCoverage({ allTestsRun }: ReportContext) {
     const mergedCoverage: CoverageMap = this.coverages.reduce((coverage, previousCoverageMap) => {
       const map = libCoverage.createCoverageMap(coverage)
       map.merge(previousCoverageMap)
       return map
     }, {})
 
-    if (this.options.all)
+    if (this.options.all && allTestsRun)
       await this.includeUntestedFiles(mergedCoverage)
 
     includeImplicitElseBranches(mergedCoverage)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -354,8 +354,14 @@ export class Vitest {
   }
 
   async rerunFiles(files: string[] = this.state.getFilepaths(), trigger?: string) {
+    if (this.coverageProvider && this.config.coverage.cleanOnRerun)
+      await this.coverageProvider.clean()
+
     await this.report('onWatcherRerun', files, trigger)
     await this.runFiles(files)
+
+    await this.reportCoverage()
+
     if (!this.config.browser)
       await this.report('onWatcherStart')
   }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -238,10 +238,7 @@ export class Vitest {
 
     await this.runFiles(files)
 
-    if (this.coverageProvider) {
-      this.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.coverageProvider.name))
-      await this.coverageProvider.reportCoverage()
-    }
+    await this.reportCoverage()
 
     if (this.config.watch && !this.config.browser)
       await this.report('onWatcherStart')
@@ -435,7 +432,7 @@ export class Vitest {
 
       await this.runFiles(files)
 
-      await this.coverageProvider?.reportCoverage()
+      await this.reportCoverage()
 
       if (!this.config.browser)
         await this.report('onWatcherStart')
@@ -531,6 +528,13 @@ export class Vitest {
     })
 
     return rerun
+  }
+
+  private async reportCoverage() {
+    if (this.coverageProvider) {
+      this.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.coverageProvider.name))
+      await this.coverageProvider.reportCoverage()
+    }
   }
 
   async close() {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -238,7 +238,7 @@ export class Vitest {
 
     await this.runFiles(files)
 
-    await this.reportCoverage()
+    await this.reportCoverage(true)
 
     if (this.config.watch && !this.config.browser)
       await this.report('onWatcherStart')
@@ -360,7 +360,7 @@ export class Vitest {
     await this.report('onWatcherRerun', files, trigger)
     await this.runFiles(files)
 
-    await this.reportCoverage()
+    await this.reportCoverage(!trigger)
 
     if (!this.config.browser)
       await this.report('onWatcherStart')
@@ -438,7 +438,7 @@ export class Vitest {
 
       await this.runFiles(files)
 
-      await this.reportCoverage()
+      await this.reportCoverage(false)
 
       if (!this.config.browser)
         await this.report('onWatcherStart')
@@ -536,10 +536,10 @@ export class Vitest {
     return rerun
   }
 
-  private async reportCoverage() {
+  private async reportCoverage(allTestsRun: boolean) {
     if (this.coverageProvider) {
       this.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.coverageProvider.name))
-      await this.coverageProvider.reportCoverage()
+      await this.coverageProvider.reportCoverage({ allTestsRun })
     }
   }
 

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -13,13 +13,18 @@ export interface CoverageProvider {
   onBeforeFilesRun?(): void | Promise<void>
   onAfterSuiteRun(meta: AfterSuiteRunMeta): void | Promise<void>
 
-  reportCoverage(): void | Promise<void>
+  reportCoverage(reportContext: ReportContext): void | Promise<void>
 
   onFileTransform?(
     sourceCode: string,
     id: string,
     pluginCtx: TransformPluginContext
   ): TransformResult | Promise<TransformResult>
+}
+
+export interface ReportContext {
+  /** Indicates whether all tests were run. False when only specific tests were run. */
+  allTestsRun?: boolean
 }
 
 export interface CoverageProviderModule {


### PR DESCRIPTION
- Fixes #2628

Description of the changes: https://github.com/vitest-dev/vitest/issues/2628#issuecomment-1378365261

Three watch mode related coverage fixes:
- fix(coverage): always print reporter name
- fix(coverage): report on watch mode manually triggered re-runs
- fix(coverage): watch mode to use `coverage.all` only when all tests are run

There are no test cases for watch mode and I'm not sure how those could be implemented at the moment so here's screen capture of manual testing:

https://user-images.githubusercontent.com/14806298/212475460-47fec4d6-1fdd-4f0f-969b-b6f06eb7f10d.mov

