### PR TITLE
ci: cache cypress, playwright, puppeteer

### DIFF
--- a/.github/actions/setup-and-cache/action.yml
+++ b/.github/actions/setup-and-cache/action.yml
@@ -1,0 +1,63 @@
+name: Setup and cache
+description: Setup for node, pnpm and cache for browser testing binaries
+inputs:
+  node-version:
+    required: false
+    description: Node version for setup-node
+    default: 18.x
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+
+    - name: Set node version to ${{ inputs.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Resolve package versions
+      id: resolve-package-versions
+      shell: bash
+      run: >
+        echo "$(
+          node -e "
+            const fs = require('fs');
+            const lockfile = fs.readFileSync('./pnpm-lock.yaml', 'utf8');
+            const cypressVersion = lockfile.match(/cypress: (\d+\.\d+\.\d+)/)[1];
+            const playwrightVersion = lockfile.match(/playwright: (\d+\.\d+\.\d+)/)[1];
+            const puppeteerVersion = lockfile.match(/puppeteer: (\d+\.\d+\.\d+)/)[1];
+            console.log('CYPRESS_VERSION=' + cypressVersion);
+            console.log('PLAYWRIGHT_VERSION=' + playwrightVersion);
+            console.log('PUPPETEER_VERSION=' + puppeteerVersion);
+          "
+        )" >> $GITHUB_OUTPUT
+
+    - name: Cache Cypress v${{ steps.resolve-package-versions.outputs.CYPRESS_VERSION }}
+      uses: actions/cache@v3
+      id: cypress-cache
+      with:
+        path: ${{ env.CYPRESS_CACHE_FOLDER }}
+        key: ${{ runner.os }}-cypress-${{ steps.resolve-package-versions.outputs.CYPRESS_VERSION }}
+        restore-keys: |
+          ${{ runner.os }}-cypress-
+
+    - name: Cache Playwright v${{ steps.resolve-package-versions.outputs.PLAYWRIGHT_VERSION }}
+      uses: actions/cache@v3
+      id: playwright-cache
+      with:
+        path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+        key: ${{ runner.os }}-playwright-${{ steps.resolve-package-versions.outputs.PLAYWRIGHT_VERSION }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
+    - name: Cache Puppeteer v${{ steps.resolve-package-versions.outputs.PUPPETEER_VERSION }}
+      uses: actions/cache@v3
+      id: puppeteer-cache
+      with:
+        path: ${{ env.PUPPETEER_DOWNLOAD_PATH }}
+        key: ${{ runner.os }}-puppeteer-${{ steps.resolve-package-versions.outputs.PUPPETEER_VERSION }}
+        restore-keys: |
+          ${{ runner.os }}-puppeteer-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 
 env:
   VITEST_SEGFAULT_RETRY: 3
+  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
+  CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/Cypress
+  PUPPETEER_DOWNLOAD_PATH: ${{ github.workspace }}/.cache/Puppeteer
 
 jobs:
   lint:
@@ -18,13 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
-      - name: Set node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
+      - uses: ./.github/actions/setup-and-cache
 
       - name: Install
         run: pnpm i
@@ -37,13 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
-      - name: Set node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
+      - uses: ./.github/actions/setup-and-cache
 
       - name: Install
         run: pnpm i
@@ -73,11 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
-      - name: Set node version to ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+      - uses: ./.github/actions/setup-and-cache
         with:
           node-version: ${{ matrix.node_version }}
 
@@ -101,11 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
-      - name: Set node
-        uses: actions/setup-node@v3
+      - uses: ./.github/actions/setup-and-cache
         with:
           node-version: 16.16
 


### PR DESCRIPTION
Adds caching for browser testing libraries binaries. 

Vite has a bit similar setup for Playwright but I think using Node for resolving the version number is more readable. https://github.com/vitejs/vite/blob/f2ee219e2f4d1a6ac09221dfb7807a684847c595/.github/workflows/ci.yml#L85-L106

Each binary is in their own caches, using OS and library version number as cache keys.

![image](https://user-images.githubusercontent.com/14806298/212606459-f625bb12-9d66-4e14-918a-90a2fbaefe74.png)
