### PR TITLE
fix(ui): don't show "connecting" screen in html reporter

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -66,7 +66,7 @@ export function runCurrent() {
 watch(
   () => client.ws,
   (ws) => {
-    status.value = 'CONNECTING'
+    status.value = isReport ? 'OPEN' : 'CONNECTING'
 
     ws.addEventListener('open', async () => {
       status.value = 'OPEN'

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -11,7 +11,7 @@ import { presetAttributify, presetIcons, presetUno } from 'unocss'
 // for debug:
 // open a static file serve to share the report json
 // and ui using the link to load the report json data
-const debugLink = 'http://127.0.0.1:4173'
+const debugLink = 'http://127.0.0.1:4173/__vitest__'
 
 export const config: UserConfig = {
   root: __dirname,


### PR DESCRIPTION
fix: #2675

I always send the 'open' signal, but the status also error. 
now force setting status 'OPEN'