### PR TITLE
feat: support relative path in html report

### DIFF
--- a/packages/ui/client/global-setup.ts
+++ b/packages/ui/client/global-setup.ts
@@ -3,6 +3,7 @@
 import { createRouter as _createRouter, createWebHistory } from 'vue-router'
 import FloatingVue, { VTooltip } from 'floating-vue'
 import routes from 'virtual:generated-pages'
+import { isReport } from '~/composables/client'
 import 'd3-graph-controller/default.css'
 import 'splitpanes/dist/splitpanes.css'
 import '@unocss/reset/tailwind.css'
@@ -20,7 +21,7 @@ FloatingVue.options.instantMove = true
 FloatingVue.options.distance = 10
 
 export const createRouter = () => _createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(isReport ? import.meta.env.BASE_URL : __BASE_PATH__),
   routes,
 })
 

--- a/packages/ui/client/shim.d.ts
+++ b/packages/ui/client/shim.d.ts
@@ -8,7 +8,7 @@ declare module '*.vue' {
   export default component
 }
 
-const __REPORT__: boolean
+const __BASE_PATH__: string
 
 declare interface Window {
   METADATA_PATH?: string

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -15,7 +15,7 @@ const debugLink = 'http://127.0.0.1:4173'
 
 export const config: UserConfig = {
   root: __dirname,
-  base: '/__vitest__/',
+  base: './',
   resolve: {
     dedupe: ['vue'],
     alias: {
@@ -24,7 +24,7 @@ export const config: UserConfig = {
     },
   },
   define: {
-    __REPORT__: false,
+    __BASE_PATH__: '"/__vitest__/"',
   },
   plugins: [
     Vue(),


### PR DESCRIPTION
fix: #2651

setting the `vue-router` base on `/__vitest__/` when is not the report mode.
setting the `vue-router` base on `./` when is not the report mode.

I test this in test/reporter and `vitest --ui` is ok.
