### PR TITLE
fix: show error in the terminal, if "only" flag is used

### DIFF
--- a/packages/vitest/src/utils/collect.ts
+++ b/packages/vitest/src/utils/collect.ts
@@ -65,9 +65,11 @@ function skipAllTasks(suite: Suite) {
 function checkAllowOnly(task: TaskBase, allowOnly?: boolean) {
   if (allowOnly)
     return
+  const error = new Error('[Vitest] Unexpected .only modifier. Remove it or pass --allowOnly argument to bypass this error')
   task.result = {
     state: 'fail',
-    error: new Error('[Vitest] Unexpected .only modifier. Remove it or pass --allowOnly argument to bypass this error'),
+    error,
+    errors: [error],
   }
 }
 


### PR DESCRIPTION
Currently it fails, but doesn't show the error