### PR TITLE
fix: don't terminate workers on Node 14 to not trigger fatal error

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -128,7 +128,10 @@ export function createPool(ctx: Vitest): WorkerPool {
   return {
     runTests: runWithFiles('run'),
     close: async () => {
-      await Promise.all(pool.threads.map(w => w.terminate()))
+      // node before 16.17 has a bug that causes FATAL ERROR because of the race condition
+      const nodeVersion = Number(process.version.match(/v(\d+)\.(\d+)/)?.[0].slice(1))
+      if (nodeVersion >= 16.17)
+        await Promise.all(pool.threads.map(w => w.terminate()))
     },
   }
 }


### PR DESCRIPTION
Fixes #2657