### PR TITLE
fix: ENOENT assets when htmldir exists

### DIFF
--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs } from 'node:fs'
+import { promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { basename, dirname, relative, resolve } from 'pathe'
 import c from 'picocolors'
@@ -50,8 +50,7 @@ export default class HTMLReporter implements Reporter {
 
     const metaFile = resolve(htmlDir, 'html.meta.json')
 
-    if (!existsSync(htmlDir))
-      await fs.mkdir(resolve(htmlDir, 'assets'), { recursive: true })
+    await fs.mkdir(resolve(htmlDir, 'assets'), { recursive: true })
 
     await fs.writeFile(metaFile, report, 'utf-8')
     const ui = resolve(distDir, 'client')


### PR DESCRIPTION
if htmlDir already exists the previous code would not create the assets dir, this can cause ENOENT errors whenever htmlDir exists, but assets does not - for instance when outputing junit and html to the same parent folder

```
vitest --reporter junit html --outputFile.html tests/ --outputFile.junit tests/junit.xml
```

I don't understand why the previous code was checking existsSync before mkdir -p. My best guess is performance, but it's not going to have a significant effect.