### PR TITLE
refactor: internal coverage typings

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -3,7 +3,7 @@ import { existsSync, promises as fs } from 'fs'
 import { relative, resolve } from 'pathe'
 import type { TransformPluginContext } from 'rollup'
 import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, ReportContext, ResolvedCoverageOptions, Vitest } from 'vitest'
-import { configDefaults, defaultExclude, defaultInclude } from 'vitest/config'
+import { coverageConfigDefaults, defaultExclude, defaultInclude } from 'vitest/config'
 import libReport from 'istanbul-lib-report'
 import reports from 'istanbul-reports'
 import type { CoverageMap } from 'istanbul-lib-coverage'
@@ -13,6 +13,8 @@ import { type Instrumenter, createInstrumenter } from 'istanbul-lib-instrument'
 // @ts-expect-error missing types
 import _TestExclude from 'test-exclude'
 import { COVERAGE_STORE_KEY } from './constants'
+
+type Options = ResolvedCoverageOptions<'istanbul'>
 
 type Threshold = 'lines' | 'functions' | 'statements' | 'branches'
 
@@ -33,7 +35,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
   name = 'istanbul'
 
   ctx!: Vitest
-  options!: ResolvedCoverageOptions & CoverageIstanbulOptions & { provider: 'istanbul' }
+  options!: Options
   instrumenter!: Instrumenter
   testExclude!: InstanceType<TestExclude>
 
@@ -70,7 +72,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
     })
   }
 
-  resolveOptions(): ResolvedCoverageOptions {
+  resolveOptions() {
     return this.options
   }
 
@@ -121,7 +123,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
     })
 
     for (const reporter of this.options.reporter) {
-      reports.create(reporter as any, {
+      reports.create(reporter, {
         skipFull: this.options.skipFull,
         projectRoot: this.ctx.config.root,
       }).execute(context)
@@ -217,19 +219,23 @@ export class IstanbulCoverageProvider implements CoverageProvider {
   }
 }
 
-function resolveIstanbulOptions(options: CoverageIstanbulOptions, root: string) {
-  const reportsDirectory = resolve(root, options.reportsDirectory || configDefaults.coverage.reportsDirectory!)
+function resolveIstanbulOptions(options: CoverageIstanbulOptions, root: string): Options {
+  const reportsDirectory = resolve(root, options.reportsDirectory || coverageConfigDefaults.reportsDirectory)
+  const reporter = options.reporter || coverageConfigDefaults.reporter
 
-  const resolved = {
-    ...configDefaults.coverage,
+  const resolved: Options = {
+    ...coverageConfigDefaults,
+
+    // User's options
     ...options,
+
+    // Resolved fields
     provider: 'istanbul',
     reportsDirectory,
-    tempDirectory: resolve(reportsDirectory, 'tmp'),
-    reporter: Array.isArray(options.reporter) ? options.reporter : [options.reporter],
+    reporter: Array.isArray(reporter) ? reporter : [reporter],
   }
 
-  return resolved as ResolvedCoverageOptions & { provider: 'istanbul' }
+  return resolved
 }
 
 /**

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -5,7 +5,7 @@ export interface UserConfig extends ViteUserConfig {
 }
 
 // will import vitest declare test in module 'vite'
-export { configDefaults, defaultInclude, defaultExclude } from './defaults'
+export { configDefaults, defaultInclude, defaultExclude, coverageConfigDefaults } from './defaults'
 
 export type { ConfigEnv }
 export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -24,21 +24,19 @@ const defaultCoverageExcludes = [
   '**/.{eslint,mocha,prettier}rc.{js,cjs,yml}',
 ]
 
-const coverageConfigDefaults = {
-  all: false,
+// These are the generic defaults for coverage. Providers may also set some provider speficic defaults.
+export const coverageConfigDefaults: ResolvedCoverageOptions = {
   provider: 'c8',
   enabled: false,
   clean: true,
   cleanOnRerun: true,
   reportsDirectory: './coverage',
-  excludeNodeModules: true,
   exclude: defaultCoverageExcludes,
   reporter: ['text', 'html', 'clover', 'json'],
-  allowExternal: false,
   // default extensions used by c8, plus '.vue' and '.svelte'
   // see https://github.com/istanbuljs/schema/blob/master/default-extension.js
   extension: ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.vue', '.svelte'],
-} as ResolvedCoverageOptions
+}
 
 export const fakeTimersDefaults = {
   loopLimit: 10_000,

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -53,14 +53,30 @@ export type CoverageReporter =
   | 'text-summary'
   | 'text'
 
-export type CoverageOptions =
-  | BaseCoverageOptions & { provider?: null | CoverageProviderModule }
-  | CoverageC8Options & { provider?: 'c8' }
-  | CoverageIstanbulOptions & { provider?: 'istanbul' }
+type Provider = 'c8' | 'istanbul' | CoverageProviderModule | undefined
 
-export type ResolvedCoverageOptions =
-  & { tempDirectory: string }
-  & Required<CoverageOptions>
+export type CoverageOptions<T extends Provider = Provider> =
+  T extends CoverageProviderModule ? ({ provider: T } & BaseCoverageOptions) :
+    T extends 'istanbul' ? ({ provider: T } & CoverageIstanbulOptions) :
+        ({ provider?: T } & CoverageC8Options)
+
+/** Fields that have default values. Internally these will always be defined. */
+type FieldsWithDefaultValues =
+  | 'enabled'
+  | 'clean'
+  | 'cleanOnRerun'
+  | 'reportsDirectory'
+  | 'exclude'
+  | 'extension'
+  | 'reporter'
+
+export type ResolvedCoverageOptions<T extends Provider = Provider> =
+  & CoverageOptions<T>
+  & Required<Pick<CoverageOptions<T>, FieldsWithDefaultValues>>
+  // Resolved fields which may have different typings as public configuration API has
+  & {
+    reporter: CoverageReporter[]
+  }
 
 export interface BaseCoverageOptions {
   /**

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -21,8 +21,16 @@ test('providers, custom', () => {
         return {
           name: 'custom-provider',
           initialize(_: Vitest) {},
-          resolveOptions() {
-            return {} as ResolvedCoverageOptions
+          resolveOptions(): ResolvedCoverageOptions {
+            return {
+              clean: true,
+              cleanOnRerun: true,
+              enabled: true,
+              exclude: ['string'],
+              extension: ['string'],
+              reporter: ['html', 'json'],
+              reportsDirectory: 'string',
+            }
           },
           clean(_: boolean) {},
           onBeforeFilesRun() {},


### PR DESCRIPTION
- Split from #2690. This one will be blocked by `c8` for a while so let's merge this separately.

Fixes multiple internal typing violations of coverage typings. Reduces the amount of `as` type assertions used to trick `tsc`. Typings are now actually correct and respond the runtime values.

- Tested intellisense manually on locally linked project
- `test/coverage-test/test/configuration-options.test-d.ts` is passing

