### PR TITLE
chore: bug reports to include `@vitest/*` packages versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     id: system-info
     attributes:
       label: System Info
-      description: Output of `npx envinfo --system --npmPackages '{vitest,vite,@vitejs/*}' --binaries --browsers`
+      description: Output of `npx envinfo --system --npmPackages '{vitest,@vitest/*,vite,@vitejs/*}' --binaries --browsers`
       render: shell
       placeholder: System, Binaries, Browsers
     validations:


### PR DESCRIPTION
Include `@vitest/*` packages in `envinfo`. Helps narrowing down issues like https://github.com/vitest-dev/vitest/issues/2716 where users have different versions of `vitest` and other `@vitest/*` packages running. 