### PR TITLE
fix(coverage): c8 to log warning when run in Stackblitz

### DIFF
--- a/packages/coverage-c8/package.json
+++ b/packages/coverage-c8/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "c8": "^7.12.0",
+    "picocolors": "^1.0.0",
+    "std-env": "^3.3.1",
     "vitest": "workspace:*"
   },
   "devDependencies": {

--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -3,6 +3,8 @@ import _url from 'url'
 import type { Profiler } from 'inspector'
 import { takeCoverage } from 'v8'
 import { extname, resolve } from 'pathe'
+import c from 'picocolors'
+import { provider } from 'std-env'
 import type { RawSourceMap } from 'vite-node'
 import { coverageConfigDefaults } from 'vitest/config'
 // eslint-disable-next-line no-restricted-imports
@@ -51,6 +53,9 @@ export class C8CoverageProvider implements CoverageProvider {
 
   async reportCoverage({ allTestsRun }: ReportContext = {}) {
     takeCoverage()
+
+    if (provider === 'stackblitz')
+      this.ctx.logger.log(c.blue(' % ') + c.yellow('@vitest/coverage-c8 does not work on Stackblitz. Report will be empty.'))
 
     const options: ConstructorParameters<typeof Report>[0] = {
       ...this.options,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,10 +652,14 @@ importers:
     specifiers:
       c8: ^7.12.0
       pathe: ^1.1.0
+      picocolors: ^1.0.0
+      std-env: ^3.3.1
       vite-node: workspace:*
       vitest: workspace:*
     dependencies:
       c8: 7.12.0
+      picocolors: 1.0.0
+      std-env: 3.3.1
       vitest: link:../vitest
     devDependencies:
       pathe: 1.1.0


### PR DESCRIPTION
Log warning message when `@vitest/coverage-c8` is used in Stackblitz environment. For some time users have been reporting that coverage reports are empty when using `c8`. Stackblitz's web containers do not implement every NodeJS API, e.g. [`v8`'s `takeCoverage`](https://nodejs.org/api/v8.html#v8takecoverage).

Uses same versions of `std-env` and `picocolors` as `vitest` package does so that dependencies are shared. 

![image](https://user-images.githubusercontent.com/14806298/213989080-0dc8c3e9-df95-42a1-bc41-3a67df263f52.png)
