### PR TITLE
fix(vite-node): don't cache modules with `timestamp: 0`

### DIFF
--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -130,7 +130,7 @@ export class ViteNodeServer {
     const module = this.server.moduleGraph.getModuleById(id)
     const timestamp = module ? module.lastHMRTimestamp : null
     const cache = this.fetchCache.get(filePath)
-    if (timestamp !== null && cache && cache.timestamp >= timestamp)
+    if (timestamp && cache && cache.timestamp >= timestamp)
       return cache.result
 
     const time = Date.now()


### PR DESCRIPTION
**Resolves**:

https://github.com/nuxt/nuxt/issues/15651
https://github.com/nuxt/nuxt/pull/18447

There may be a legitimate reason to use cache for `timestamp: 0`; if so, please feel free to resolve differently.