### PR TITLE
fix(coverage): istanbul crashes when no tests were run

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -105,7 +105,7 @@ export class IstanbulCoverageProvider implements CoverageProvider {
       const map = libCoverage.createCoverageMap(coverage)
       map.merge(previousCoverageMap)
       return map
-    }, {})
+    }, libCoverage.createCoverageMap({}))
 
     if (this.options.all && allTestsRun)
       await this.includeUntestedFiles(mergedCoverage)


### PR DESCRIPTION
While looking into other watch mode related issue I noticed that istanbul provider may crash when Vitest has run no tests. These cases may come up for example when filename pattern doesn't match any files.

```
TypeError: coverageMap.files is not a function or its return value is not iterable
```

I can't find a clear place where to add test case for this. I think we need to setup some watch mode tests next. 