### PR TITLE
fix: watch mode's filename pattern to persist on unrelated file changes

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -374,7 +374,7 @@ export class Vitest {
     await this.reportCoverage(!trigger)
 
     if (!this.config.browser)
-      await this.report('onWatcherStart')
+      await this.report('onWatcherStart', this.state.getFiles(files))
   }
 
   async changeNamePattern(pattern: string, files: string[] = this.state.getFilepaths(), trigger?: string) {
@@ -467,7 +467,7 @@ export class Vitest {
       await this.reportCoverage(false)
 
       if (!this.config.browser)
-        await this.report('onWatcherStart')
+        await this.report('onWatcherStart', this.state.getFiles(files))
     }, WATCHER_DEBOUNCE)
   }
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -360,6 +360,11 @@ export class Vitest {
   }
 
   async rerunFiles(files: string[] = this.state.getFilepaths(), trigger?: string) {
+    if (this.filenamePattern) {
+      const filteredFiles = await this.globTestFiles([this.filenamePattern])
+      files = files.filter(file => filteredFiles.includes(file))
+    }
+
     if (this.coverageProvider && this.config.coverage.cleanOnRerun)
       await this.coverageProvider.clean()
 
@@ -385,10 +390,9 @@ export class Vitest {
     this.filenamePattern = pattern
 
     const files = this.state.getFilepaths()
-    if (!this.filenamePattern)
-      return await this.rerunFiles(files, 'reset filename pattern')
-    const filteredFiles = await this.globTestFiles([this.filenamePattern])
-    await this.rerunFiles(filteredFiles, 'change filename pattern')
+    const trigger = this.filenamePattern ? 'change filename pattern' : 'reset filename pattern'
+
+    await this.rerunFiles(files, trigger)
   }
 
   async rerunFailed() {

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -155,15 +155,17 @@ export abstract class BaseReporter implements Reporter {
 
     const BADGE = c.inverse(c.bold(c.blue(' RERUN ')))
     const TRIGGER = trigger ? c.dim(` ${this.relative(trigger)}`) : ''
+    const FILENAME_PATTERN = this.ctx.filenamePattern ? `${BADGE_PADDING} ${c.dim('Filename pattern: ')}${c.blue(this.ctx.filenamePattern)}\n` : ''
+
     if (files.length > 1) {
       // we need to figure out how to handle rerun all from stdin
-      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER}\n`)
+      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER}\n${FILENAME_PATTERN}`)
       this._lastRunCount = 0
     }
     else if (files.length === 1) {
       const rerun = this._filesInWatchMode.get(files[0]) ?? 1
       this._lastRunCount = rerun
-      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER} ${c.blue(`x${rerun}`)}\n`)
+      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER} ${c.blue(`x${rerun}`)}\n${FILENAME_PATTERN}`)
     }
 
     this._timeStart = new Date()

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -156,16 +156,17 @@ export abstract class BaseReporter implements Reporter {
     const BADGE = c.inverse(c.bold(c.blue(' RERUN ')))
     const TRIGGER = trigger ? c.dim(` ${this.relative(trigger)}`) : ''
     const FILENAME_PATTERN = this.ctx.filenamePattern ? `${BADGE_PADDING} ${c.dim('Filename pattern: ')}${c.blue(this.ctx.filenamePattern)}\n` : ''
+    const TESTNAME_PATTERN = this.ctx.config.testNamePattern ? `${BADGE_PADDING} ${c.dim('Test name pattern: ')}${c.blue(String(this.ctx.config.testNamePattern))}\n` : ''
 
     if (files.length > 1) {
       // we need to figure out how to handle rerun all from stdin
-      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER}\n${FILENAME_PATTERN}`)
+      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER}\n${FILENAME_PATTERN}${TESTNAME_PATTERN}`)
       this._lastRunCount = 0
     }
     else if (files.length === 1) {
       const rerun = this._filesInWatchMode.get(files[0]) ?? 1
       this._lastRunCount = rerun
-      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER} ${c.blue(`x${rerun}`)}\n${FILENAME_PATTERN}`)
+      this.ctx.logger.clearFullScreen(`\n${BADGE}${TRIGGER} ${c.blue(`x${rerun}`)}\n${FILENAME_PATTERN}${TESTNAME_PATTERN}`)
     }
 
     this._timeStart = new Date()


### PR DESCRIPTION
This PR contains couple of fixes and features related to watch mode and filename+testname pattern filters. As each fix/feat builds on top of the other one, here is a single PR containing all. Commits are ready for rebasing (instead of squashing) as well. 

- `fix: watch mode's filename pattern to persist on unrelated file changes`
  - Fixes #2728

- `fix: watch mode's filename pattern to persist re-run of failed tests, snapshot updates and testname filter changes`
  - Fixes cases where filename pattern was ignored when:
    - user pressed `f` to run failed test cases only
    - user pressed `u` to update failed snapshots
    - user pressed `t` to apply new testname filter
  - In all of the cases above the action was also performed against files that did not match the filename pattern

- `fix: dont incorrectly mark a run failed if filename pattern excludes previously failed tests`
  - Fixes case where a test run was marked failed if previous run contained file changes, and new run contained filename pattern
  - Here is example where `math.test.ts` failed on earlier run, but now we are using `/animal/` as test name filter
  - ![image](https://user-images.githubusercontent.com/14806298/214827769-f44e0841-0346-4c5b-9033-aa015210f0d2.png)


- `feat: show active filename pattern on CLI`
  - Adds filename pattern to the terminal
  - See line 2 below:
  - ![image](https://user-images.githubusercontent.com/14806298/214828039-d86ab59d-0d7b-411e-81ae-537e4cc179d5.png)


- `feat: show active test name pattern on CLI`
  - Adds test name pattern to the terminal
  - See line 2 below:
  - ![image](https://user-images.githubusercontent.com/14806298/214828180-b63168f4-5fc9-4ea6-8e36-ad96e5a82684.png)


