### PR TITLE
docs(coverage): c8 ignore hints actually work

### DIFF
--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -124,4 +124,10 @@ Beware that these ignore hints may now be included in final production build as 
 if (condition) {
 ```
 
-Unfortunately this does not work for `c8` at the moment.
+For `c8` this does not cause any issues. You can use `c8 ignore` comments with Typescript as usual:
+
+<!-- eslint-skip -->
+```ts
+/* c8 ignore next 3 */
+if (condition) {
+```

--- a/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
@@ -2515,8 +2515,8 @@ exports[`c8 json report 1`] = `
     "f": {
       "0": 1,
       "1": 1,
-      "10": 0,
-      "11": 0,
+      "10": 1,
+      "11": 1,
       "2": 2,
       "3": 2,
       "4": 0,
@@ -2579,22 +2579,22 @@ exports[`c8 json report 1`] = `
         "decl": {
           "end": {
             "column": 1,
-            "line": 29,
+            "line": 30,
           },
           "start": {
             "column": 7,
-            "line": 27,
+            "line": 28,
           },
         },
-        "line": 27,
+        "line": 28,
         "loc": {
           "end": {
             "column": 1,
-            "line": 29,
+            "line": 30,
           },
           "start": {
             "column": 7,
-            "line": 27,
+            "line": 28,
           },
         },
         "name": "ignoredFunction",
@@ -2603,22 +2603,22 @@ exports[`c8 json report 1`] = `
         "decl": {
           "end": {
             "column": 1,
-            "line": 29,
+            "line": 30,
           },
           "start": {
             "column": 0,
-            "line": 29,
+            "line": 30,
           },
         },
-        "line": 29,
+        "line": 30,
         "loc": {
           "end": {
             "column": 1,
-            "line": 29,
+            "line": 30,
           },
           "start": {
             "column": 0,
-            "line": 29,
+            "line": 30,
           },
         },
         "name": "get",
@@ -2838,8 +2838,9 @@ exports[`c8 json report 1`] = `
       "24": 1,
       "25": 1,
       "26": 1,
-      "27": 0,
-      "28": 0,
+      "27": 1,
+      "28": 1,
+      "29": 1,
       "3": 1,
       "4": 1,
       "5": 2,
@@ -3031,7 +3032,7 @@ exports[`c8 json report 1`] = `
       },
       "25": {
         "end": {
-          "column": 39,
+          "column": 22,
           "line": 26,
         },
         "start": {
@@ -3041,7 +3042,7 @@ exports[`c8 json report 1`] = `
       },
       "26": {
         "end": {
-          "column": 35,
+          "column": 39,
           "line": 27,
         },
         "start": {
@@ -3051,7 +3052,7 @@ exports[`c8 json report 1`] = `
       },
       "27": {
         "end": {
-          "column": 59,
+          "column": 35,
           "line": 28,
         },
         "start": {
@@ -3061,12 +3062,22 @@ exports[`c8 json report 1`] = `
       },
       "28": {
         "end": {
-          "column": 1,
+          "column": 62,
           "line": 29,
         },
         "start": {
           "column": 0,
           "line": 29,
+        },
+      },
+      "29": {
+        "end": {
+          "column": 1,
+          "line": 30,
+        },
+        "start": {
+          "column": 0,
+          "line": 30,
         },
       },
       "3": {

--- a/test/coverage-test/coverage-report-tests/c8.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/c8.report.test.ts
@@ -11,3 +11,21 @@ test('c8 json report', async () => {
   // If this fails, you can use "npx live-server@1.2.1 ./coverage" to see coverage report
   expect(jsonReport).toMatchSnapshot()
 })
+
+test('ignored code is marked as covered in the report', async () => {
+  const functionName = 'ignoredFunction'
+  const filename = '<process-cwd>/src/utils.ts'
+
+  const coverageMap = await readCoverageJson()
+  const fileCoverage = coverageMap[filename]
+
+  const [functionKey] = Object.entries(fileCoverage.fnMap).find(([, fn]) => fn.name === functionName)!
+  const functionCallCount = fileCoverage.f[functionKey]
+
+  // C8 marks excluded lines as covered, instead of removing them from report completely
+  expect(functionCallCount).toBe(1)
+
+  // Function should still be found from the actual sources
+  const utils = await import('../src/utils')
+  expect(utils[functionName]).toBeTypeOf('function')
+})

--- a/test/coverage-test/coverage-report-tests/utils.ts
+++ b/test/coverage-test/coverage-report-tests/utils.ts
@@ -5,6 +5,7 @@ interface CoverageFinalJson {
     [filename: string]: {
       path: string
       b: Record<string, number[]>
+      f: Record<string, number>
       fnMap: Record<string, { name: string }>
       // ... and more unrelated keys
     }

--- a/test/coverage-test/src/utils.ts
+++ b/test/coverage-test/src/utils.ts
@@ -23,7 +23,8 @@ export function run() {
   divide(1, 1)
 }
 
+/* c8 ignore next 4 */
 /* istanbul ignore next -- @preserve */
 export function ignoredFunction() {
-  return 'This function is excluded from istanbul coverage'
+  throw new Error('Test files should not call this function!')
 }


### PR DESCRIPTION
When writing this part of the guide initially I thought c8's ignore hints would not work, as their regexp is very strict and does not allow additional content such as `@preseve` keywords.

The ignore hints don't work with `@vitest/coverage-istanbul` since esbuild strips the comments before code is instrumented. Istanbul uses ignore hints to check whether coverage counters should be placed in given code block.

With `@vitest/coverage-c8` the coverage filtering is done after the coverage report has been collected. The exclusion is done by comparing results to the actual sources where original comments are in place. `v8-to-istanbul` used by `c8` uses ignore hints to see whether uncovered lines should be marked as covered. 
