### PR TITLE
fix: do not include source files in `onWatcherStart` when `typecheck.ignoreSourceErrors` is true

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -183,7 +183,7 @@ export class Vitest {
       }
       if (this.config.watch) {
         await this.report('onWatcherStart', files, [
-          ...sourceErrors,
+          ...(this.config.typecheck.ignoreSourceErrors ? [] : sourceErrors),
           ...this.state.getUnhandledErrors(),
         ])
       }


### PR DESCRIPTION
All tests appear to pass, but "FAIL" is displayed by the file watcher.

```
$ npx vitest typecheck --config ./config/vitest.ts
Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow semver, please pin Vitest's version when using it.

 DEV  v0.28.3 /Users/mascii/repoName

 ✓ __tests__/testName.types.spec.ts (1)

 Test Files  1 passed (1)
      Tests  1 passed (1)
Type Errors  no errors
   Start at  03:20:47
   Duration  2.49s



 FAIL  Tests failed. Watching for file changes...
       press q to quit
```

```typescript
// ./config/vitest.ts
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    globals: true,
    typecheck: {
      include: ["__tests__/**/*.types.spec.ts"],
      ignoreSourceErrors: true,
    },
  },
});
```