### PR TITLE
fix: duplicate callbacks in vite-node HMR

### DIFF
--- a/packages/vite-node/src/hmr/hmr.ts
+++ b/packages/vite-node/src/hmr/hmr.ts
@@ -292,6 +292,9 @@ export function createHotContext(
     ): void {
       const addToMap = (map: Map<string, any[]>) => {
         const existing = map.get(event) || []
+        const existingCbIndex = existing.findIndex(_cb => _cb.toString() === cb.toString())
+        if (existingCbIndex > -1)
+          existing.splice(existingCbIndex, 1)
         existing.push(cb)
         map.set(event, existing)
       }

--- a/packages/vite-node/src/hmr/hmr.ts
+++ b/packages/vite-node/src/hmr/hmr.ts
@@ -283,7 +283,6 @@ export function createHotContext(
     },
 
     invalidate() {
-      console.log('invalidated')
       notifyListeners(runner, 'vite:invalidate', { path: ownerPath, message: undefined })
       return reload(runner, files)
     },

--- a/packages/vite-node/src/hmr/hmr.ts
+++ b/packages/vite-node/src/hmr/hmr.ts
@@ -196,6 +196,7 @@ export async function handleMessage(runner: ViteNodeRunner, emitter: HMREmitter,
       break
     case 'full-reload':
       notifyListeners(runner, 'vite:beforeFullReload', payload)
+      maps.customListenersMap.delete('vite:beforeFullReload')
       reload(runner, files)
       break
     case 'prune':
@@ -282,6 +283,7 @@ export function createHotContext(
     },
 
     invalidate() {
+      console.log('invalidated')
       notifyListeners(runner, 'vite:invalidate', { path: ownerPath, message: undefined })
       return reload(runner, files)
     },
@@ -292,9 +294,6 @@ export function createHotContext(
     ): void {
       const addToMap = (map: Map<string, any[]>) => {
         const existing = map.get(event) || []
-        const existingCbIndex = existing.findIndex(_cb => _cb.toString() === cb.toString())
-        if (existingCbIndex > -1)
-          existing.splice(existingCbIndex, 1)
         existing.push(cb)
         map.set(event, existing)
       }


### PR DESCRIPTION
When using vite-node HMR, the callbacks registered with:

```ts
if (import.meta.hot) {
  import.meta.hot.on("vite:beforeFullReload", () => {
    console.log("full reload");
    server.close();
  });
}
```

are duplicated/accumulated on each reload (logs below after 4 saves):

```bash
> vite-node --watch src/index.ts

listening on port 4000
full reload
listening on port 4000
full reload
full reload
listening on port 4000
full reload
full reload
full reload
listening on port 4000
full reload
full reload
full reload
full reload
listening on port 4000
```

This change ensures that if for the same event, two callbacks are identical, the old one is replaced with the new one.

We can't use reference identity check unfortunately as the identity of the callback change between reloads, hence the usage of `.toString()`.