### PR TITLE
feat: add --script option to vite-node

### DIFF
--- a/packages/vite-node/README.md
+++ b/packages/vite-node/README.md
@@ -72,7 +72,7 @@ $ ./file.ts hello
 argv: [ 'hello' ]
 ```
 
-Note that when using the `--script` option, Vite Node forwards every arguments and options to the script to execute, even the one supported by Vite Node itself.
+Note that when using the `--script` option, Vite Node forwards every argument and option to the script to execute, even the one supported by Vite Node itself.
 
 ## Programmatic Usage
 

--- a/packages/vite-node/README.md
+++ b/packages/vite-node/README.md
@@ -50,7 +50,7 @@ Note that for options supporting RegExps, strings passed to the CLI must start _
 
 ### Hashbang
 
-If you prefer to write scripts that doesn't need to be passed into tsx, you can declare it in the [hashbang](https://bash.cyberciti.biz/guide/Shebang).
+If you prefer to write scripts that doesn't need to be passed into Vite Node, you can declare it in the [hashbang](https://bash.cyberciti.biz/guide/Shebang).
 
 Simply add `#!/usr/bin/env vite-node --script` at the top of your file:
 
@@ -66,13 +66,13 @@ And make the file executable:
 chmod +x ./file.ts
 ```
 
-Now, you can run the file without passing it into vite-node:
+Now, you can run the file without passing it into Vite Node:
 ```sh
 $ ./file.ts hello
 argv: [ 'hello' ]
 ```
 
-Note that when using the `--script` option, `vite-node` forwards every arguments and options to the script to execute, even the one supported by `vite-node` itself.
+Note that when using the `--script` option, Vite Node forwards every arguments and options to the script to execute, even the one supported by Vite Node itself.
 
 ## Programmatic Usage
 

--- a/packages/vite-node/README.md
+++ b/packages/vite-node/README.md
@@ -48,6 +48,32 @@ npx vite-node --options.deps.inline="module-name" --options.deps.external="/modu
 
 Note that for options supporting RegExps, strings passed to the CLI must start _and_ end with a `/`;
 
+### Hashbang
+
+If you prefer to write scripts that doesn't need to be passed into tsx, you can declare it in the [hashbang](https://bash.cyberciti.biz/guide/Shebang).
+
+Simply add `#!/usr/bin/env vite-node --script` at the top of your file:
+
+_file.ts_
+```ts
+#!/usr/bin/env vite-node --script
+
+console.log('argv:', process.argv.slice(2))
+```
+
+And make the file executable:
+```sh
+chmod +x ./file.ts
+```
+
+Now, you can run the file without passing it into vite-node:
+```sh
+$ ./file.ts hello
+argv: [ 'hello' ]
+```
+
+Note that when using the `--script` option, `vite-node` forwards every arguments and options to the script to execute, even the one supported by `vite-node` itself.
+
 ## Programmatic Usage
 
 In Vite Node, the server and runner (client) are separated, so you can integrate them in different contexts (workers, cross-process, or remote) if needed. The demo below shows a simple example of having both (server and runner) running in the same context

--- a/packages/vite-node/README.md
+++ b/packages/vite-node/README.md
@@ -50,7 +50,7 @@ Note that for options supporting RegExps, strings passed to the CLI must start _
 
 ### Hashbang
 
-If you prefer to write scripts that doesn't need to be passed into Vite Node, you can declare it in the [hashbang](https://bash.cyberciti.biz/guide/Shebang).
+If you prefer to write scripts that don't need to be passed into Vite Node, you can declare it in the [hashbang](https://bash.cyberciti.biz/guide/Shebang).
 
 Simply add `#!/usr/bin/env vite-node --script` at the top of your file:
 

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -16,8 +16,8 @@ cli
   .option('-r, --root <path>', 'Use specified root directory')
   .option('-c, --config <path>', 'Use specified config file')
   .option('-w, --watch', 'Restart on file changes, similar to "nodemon"')
+  .option('--script', 'Use vite-node as a script runner')
   .option('--options <options>', 'Use specified Vite server options')
-  .option('--script-mode', 'Use vite-node as a script runner')
   .help()
 
 cli
@@ -29,7 +29,7 @@ cli.parse()
 
 export interface CliOptions {
   root?: string
-  scriptMode?: string
+  script?: boolean
   config?: string
   watch?: boolean
   options?: ViteNodeServerOptionsCLI
@@ -37,20 +37,20 @@ export interface CliOptions {
 }
 
 async function run(files: string[], options: CliOptions = {}) {
-  if (options.scriptMode)
-    files = [options.scriptMode]
+  if (options.script) {
+    files = [files[0]]
+    options = {}
+    process.argv = [process.argv[0], files[0], ...process.argv.slice(2).filter(arg => arg !== '--script' && arg !== files[0])]
+  }
+  else {
+    process.argv = [...process.argv.slice(0, 2), ...(options['--'] || [])]
+  }
 
   if (!files.length) {
     console.error(c.red('No files specified.'))
     cli.outputHelp()
     process.exit(1)
   }
-
-  // forward argv
-  if (options.scriptMode)
-    process.argv = [process.argv[0], options.scriptMode, ...process.argv.slice(4)]
-  else
-    process.argv = [...process.argv.slice(0, 2), ...(options['--'] || [])]
 
   const serverOptions = options.options
     ? parseServerOptions(options.options)

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -17,16 +17,19 @@ cli
   .option('-c, --config <path>', 'Use specified config file')
   .option('-w, --watch', 'Restart on file changes, similar to "nodemon"')
   .option('--options <options>', 'Use specified Vite server options')
+  .option('--script-mode', 'Use vite-node as a script runner')
   .help()
 
 cli
   .command('[...files]')
+  .allowUnknownOptions()
   .action(run)
 
 cli.parse()
 
 export interface CliOptions {
   root?: string
+  scriptMode?: string
   config?: string
   watch?: boolean
   options?: ViteNodeServerOptionsCLI
@@ -34,6 +37,9 @@ export interface CliOptions {
 }
 
 async function run(files: string[], options: CliOptions = {}) {
+  if (options.scriptMode)
+    files = [options.scriptMode]
+
   if (!files.length) {
     console.error(c.red('No files specified.'))
     cli.outputHelp()
@@ -41,7 +47,10 @@ async function run(files: string[], options: CliOptions = {}) {
   }
 
   // forward argv
-  process.argv = [...process.argv.slice(0, 2), ...(options['--'] || [])]
+  if (options.scriptMode)
+    process.argv = [process.argv[0], options.scriptMode, ...process.argv.slice(4)]
+  else
+    process.argv = [...process.argv.slice(0, 2), ...(options['--'] || [])]
 
   const serverOptions = options.options
     ? parseServerOptions(options.options)


### PR DESCRIPTION
In order to fix https://github.com/vitest-dev/vitest/issues/2554, I added a `--script` option to `vite-node` so it can be used in shebang! 🎊 

The code is a bit weird because `cac` does not interpret options passed before positional arguments correctly (see [here](https://github.com/cacjs/cac/issues/25)) so I had to play with this and `process.argv` ordering to have it right.

Another limitation in this implementation is that passing other options in the shebang to `vite-node` won't work, as I expect exact indexes in order to figure out what are the arguments to forward.

It's not perfect but I think it's good enough to unblock people like me as a start. 👍 