### PR TITLE
support inline source map

### DIFF
--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -135,13 +135,13 @@ export class C8CoverageProvider implements CoverageProvider {
     // that we add in packages/vite-node/src/client.ts:114 (vm.runInThisContext)
     // TODO: Include our transformations in sourcemaps
     const offset = 185
-
+    const originalGetSourceMap = report._getSourceMap;
     report._getSourceMap = (coverage: Profiler.ScriptCoverage) => {
       const path = _url.pathToFileURL(coverage.url.split('?')[0]).href
       const data = sourceMapMeta[path]
 
       if (!data)
-        return {}
+        return originalGetSourceMap.call(report, coverage)
 
       return {
         sourceMap: {

--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -42,6 +42,7 @@ export function installSourcemapsSupport(options: InstallSourceMapSupportOptions
   install({
     environment: 'node',
     handleUncaughtExceptions: false,
+    hookRequire: true,
     retrieveSourceMap(source) {
       const map = options.getSourceMap(source)
       if (map) {


### PR DESCRIPTION
Some server side framework like egg.js relies on ts-node to handle TS files.

When using vitest to test such projects, I found the source map is completely missing, because the ts file is not loaded by vitest.

This PR fixes source map issue for such projects that rely on ts-node  runtime transpiler.
