### PR TITLE
fix(expect): accept array index as number in toHaveProperty

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -474,6 +474,10 @@ type Awaitable<T> = T | PromiseLike<T>
     expect(invoice).toHaveProperty('items[0].type', 'apples')
     expect(invoice).toHaveProperty('items.0.type', 'apples') // dot notation also works
 
+    // Deep referencing using an array containing the keyPath
+    expect(invoice).toHaveProperty(['items', 0, 'type'], 'apples')
+    expect(invoice).toHaveProperty(['items', '0', 'type'], 'apples') // string notation also works
+
     // Wrap your key in an array to avoid the key from being parsed as a deep reference
     expect(invoice).toHaveProperty(['P.O'], '12345')
   })

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -280,7 +280,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   // destructuring, because it checks `arguments` inside, and value is passing as `undefined`
   def('toHaveProperty', function (...args: [property: string | string[], value?: any]) {
     if (Array.isArray(args[0]))
-      args[0] = args[0].map(key => key.replace(/([.[\]])/g, '\\$1')).join('.')
+      args[0] = args[0].map(key => String(key).replace(/([.[\]])/g, '\\$1')).join('.')
 
     const actual = this._obj
     const [propertyName, expected] = args

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -278,7 +278,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     return this.have.length(length)
   })
   // destructuring, because it checks `arguments` inside, and value is passing as `undefined`
-  def('toHaveProperty', function (...args: [property: string | string[], value?: any]) {
+  def('toHaveProperty', function (...args: [property: string | (string | number)[], value?: any]) {
     if (Array.isArray(args[0]))
       args[0] = args[0].map(key => String(key).replace(/([.[\]])/g, '\\$1')).join('.')
 

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -97,7 +97,7 @@ declare global {
       toBeInstanceOf<E>(expected: E): void
       toBeCalledTimes(times: number): void
       toHaveLength(length: number): void
-      toHaveProperty<E>(property: string | string[], value?: E): void
+      toHaveProperty<E>(property: string | (string | number)[], value?: E): void
       toBeCloseTo(number: number, numDigits?: number): void
       toHaveBeenCalledTimes(times: number): void
       toHaveBeenCalledOnce(): void

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -259,7 +259,7 @@ describe('jest-expect', () => {
 
     expect(() => {
       expect(complex).toHaveProperty('a-b', false)
-    }).toThrowErrorMatchingInlineSnapshot('"expected { foo: 1, \'foo.bar[0]\': \'baz\', …(3) } to have property \\"a-b\\" with value false"')
+    }).toThrowErrorMatchingInlineSnapshot('"expected { \'0\': \'zero\', foo: 1, …(4) } to have property \\"a-b\\" with value false"')
   })
 
   it('assertions', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -235,9 +235,7 @@ describe('jest-expect', () => {
     expect(complex).toHaveProperty('bar.arr.0')
     expect(complex).toHaveProperty(['bar', 'arr', '0'])
     expect(complex).toHaveProperty(['bar', 'arr', '0'], 'first')
-    // @ts-expect-error - passes number inside the array
     expect(complex).toHaveProperty(['bar', 'arr', 0])
-    // @ts-expect-error - passes number inside the array
     expect(complex).toHaveProperty(['bar', 'arr', 0], 'first')
     expect(complex).toHaveProperty('bar.arr.1.zoo', 'monkey')
     expect(complex).toHaveProperty(['bar', 'arr', '1', 'zoo'], 'monkey')

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -235,6 +235,10 @@ describe('jest-expect', () => {
     expect(complex).toHaveProperty('bar.arr.0')
     expect(complex).toHaveProperty(['bar', 'arr', '0'])
     expect(complex).toHaveProperty(['bar', 'arr', '0'], 'first')
+    // @ts-expect-error - passes number inside the array
+    expect(complex).toHaveProperty(['bar', 'arr', 0])
+    // @ts-expect-error - passes number inside the array
+    expect(complex).toHaveProperty(['bar', 'arr', 0], 'first')
     expect(complex).toHaveProperty('bar.arr.1.zoo', 'monkey')
     expect(complex).toHaveProperty(['bar', 'arr', '1', 'zoo'], 'monkey')
     expect(complex).toHaveProperty(['foo.bar[0]'], 'baz')

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -233,6 +233,8 @@ describe('jest-expect', () => {
     expect(complex).toHaveProperty('bar.arr[0]')
     expect(complex).toHaveProperty('bar.arr[1].zoo', 'monkey')
     expect(complex).toHaveProperty('bar.arr.0')
+    expect(complex).toHaveProperty(['bar', 'arr', '0'])
+    expect(complex).toHaveProperty(['bar', 'arr', '0'], 'first')
     expect(complex).toHaveProperty('bar.arr.1.zoo', 'monkey')
     expect(complex).toHaveProperty(['bar', 'arr', '1', 'zoo'], 'monkey')
     expect(complex).toHaveProperty(['foo.bar[0]'], 'baz')

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -205,6 +205,7 @@ describe('jest-expect', () => {
 
     const foo = {}
     const complex = {
+      '0': 'zero',
       'foo': 1,
       'foo.bar[0]': 'baz',
       'a-b': true,
@@ -227,6 +228,12 @@ describe('jest-expect', () => {
 
     expect(complex).toHaveProperty('a-b')
     expect(complex).toHaveProperty('a-b-1.0.0')
+    expect(complex).toHaveProperty('0')
+    expect(complex).toHaveProperty('0', 'zero')
+    expect(complex).toHaveProperty(['0'])
+    expect(complex).toHaveProperty(['0'], 'zero')
+    expect(complex).toHaveProperty([0])
+    expect(complex).toHaveProperty([0], 'zero')
     expect(complex).toHaveProperty('foo')
     expect(complex).toHaveProperty('foo', 1)
     expect(complex).toHaveProperty('bar.foo', 'foo')


### PR DESCRIPTION
Fixes https://github.com/vitest-dev/vitest/issues/2804