### PR TITLE
perf: don't inline Vitest entry

### DIFF
--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -76,8 +76,6 @@ export default ({ watch }) => defineConfig([
         let id = chunkInfo.facadeModuleId || Object.keys(chunkInfo.modules).find(i => !i.includes('node_modules') && (i.includes('src/') || i.includes('src\\')))
         if (id) {
           id = normalize(id)
-          if (id.includes('runtime/runners'))
-            return 'runners-chunk.js'
           const parts = Array.from(
             new Set(relative(process.cwd(), id).split(/\//g)
               .map(i => i.replace(/\..*$/, ''))

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -18,11 +18,11 @@ const extraInlineDeps = [
   // Vite client
   /vite\w*\/dist\/client\/env.mjs/,
   // Vitest
-  /\/vitest\/dist\/(runners-chunk|entry)\.js/,
+  /\/vitest\/dist\/runners\.js/,
   // yarn's .store folder
-  /vitest-virtual-\w+\/dist\/(runners-chunk|entry)\.js/,
+  /vitest-virtual-\w+\/dist\/runners\.js/,
   // cnpm
-  /@vitest\/dist\/(runners-chunk|entry)\.js/,
+  /@vitest\/dist\/runners\.js/,
   // Nuxt
   '@nuxt/test-utils',
 ]

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -3,7 +3,7 @@ export { createVitest } from './create'
 export { VitestPlugin } from './plugins'
 export { startVitest } from './cli-api'
 
-export { VitestRunner } from '../runtime/execute'
+export { VitestExecutor } from '../runtime/execute'
 export type { ExecuteOptions } from '../runtime/execute'
 
 export type { TestSequencer, TestSequencerConstructor } from './sequencers/types'

--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -126,7 +126,7 @@ export async function run(files: string[], config: ResolvedConfig, executor: Vit
       if (!files || !files.length)
         continue
 
-      await withEnv(environment, files[0].envOptions || config.environmentOptions || {}, async () => {
+      await withEnv(environment, files[0].envOptions || config.environmentOptions || {}, executor, async () => {
         for (const { file } of files) {
           // it doesn't matter if running with --threads
           // if running with --no-threads, we usually want to reset everything before running a test

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -15,7 +15,6 @@ export async function createVitestExecutor(options: ExecuteOptions) {
   const runner = new VitestExecutor(options)
 
   await runner.executeId('/@vite/env')
-  await runner.mocker.initializeSpyModule()
 
   return runner
 }

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -11,20 +11,16 @@ export interface ExecuteOptions extends ViteNodeRunnerOptions {
   mockMap: MockMap
 }
 
-export async function executeInViteNode(options: ExecuteOptions & { files: string[] }) {
-  const runner = new VitestRunner(options)
+export async function createVitestExecutor(options: ExecuteOptions) {
+  const runner = new VitestExecutor(options)
 
   await runner.executeId('/@vite/env')
   await runner.mocker.initializeSpyModule()
 
-  const result: any[] = []
-  for (const file of options.files)
-    result.push(await runner.executeFile(file))
-
-  return result
+  return runner
 }
 
-export class VitestRunner extends ViteNodeRunner {
+export class VitestExecutor extends ViteNodeRunner {
   public mocker: VitestMocker
 
   constructor(public options: ExecuteOptions) {

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -8,11 +8,13 @@ import type { ResolvedConfig, WorkerContext, WorkerRPC } from '../types'
 import { distDir } from '../constants'
 import { getWorkerState } from '../utils/global'
 import type { MockMap } from '../types/mocker'
-import { executeInViteNode } from './execute'
+import type { VitestExecutor } from './execute'
+import { createVitestExecutor } from './execute'
 import { rpc } from './rpc'
 
 let _viteNode: {
-  run: (files: string[], config: ResolvedConfig) => Promise<void>
+  run: (files: string[], config: ResolvedConfig, executor: VitestExecutor) => Promise<void>
+  executor: VitestExecutor
 }
 
 const moduleCache = new ModuleCacheMap()
@@ -45,10 +47,7 @@ async function startViteNode(ctx: WorkerContext) {
   process.on('uncaughtException', e => catchError(e, 'Uncaught Exception'))
   process.on('unhandledRejection', e => catchError(e, 'Unhandled Rejection'))
 
-  const { run } = (await executeInViteNode({
-    files: [
-      resolve(distDir, 'entry.js'),
-    ],
+  const executor = await createVitestExecutor({
     fetchModule(id) {
       return rpc().fetch(id)
     },
@@ -60,9 +59,11 @@ async function startViteNode(ctx: WorkerContext) {
     interopDefault: config.deps.interopDefault,
     root: config.root,
     base: config.base,
-  }))[0]
+  })
 
-  _viteNode = { run }
+  const { run } = await import(resolve(distDir, 'entry.js'))
+
+  _viteNode = { run, executor }
 
   return _viteNode
 }
@@ -106,6 +107,6 @@ function init(ctx: WorkerContext) {
 
 export async function run(ctx: WorkerContext) {
   init(ctx)
-  const { run } = await startViteNode(ctx)
-  return run(ctx.files, ctx.config)
+  const { run, executor } = await startViteNode(ctx)
+  return run(ctx.files, ctx.config, executor)
 }

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import { relative, resolve } from 'pathe'
 import { createBirpc } from 'birpc'
 import { workerId as poolId } from 'tinypool'
@@ -61,7 +62,7 @@ async function startViteNode(ctx: WorkerContext) {
     base: config.base,
   })
 
-  const { run } = await import(resolve(distDir, 'entry.js'))
+  const { run } = await import(pathToFileURL(resolve(distDir, 'entry.js')).href)
 
   _viteNode = { run, executor }
 

--- a/packages/web-worker/src/runner.ts
+++ b/packages/web-worker/src/runner.ts
@@ -1,6 +1,6 @@
-import { VitestRunner } from 'vitest/node'
+import { VitestExecutor } from 'vitest/node'
 
-export class InlineWorkerRunner extends VitestRunner {
+export class InlineWorkerRunner extends VitestExecutor {
   constructor(options: any, private context: any) {
     super(options)
   }


### PR DESCRIPTION
This gives a small boost to performance, because we only inline a small portion of the codebase. (it was quite small since 0.27.0, but now it's even smaller!)