### PR TITLE
fix: always display serialized error, even if it doesn't have stack

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -188,9 +188,6 @@ function printStack(
   errorProperties: Record<string, unknown>,
   onStack?: ((stack: ParsedStack) => void),
 ) {
-  if (!stack.length)
-    return
-
   const logger = ctx.logger
 
   for (const frame of stack) {
@@ -200,7 +197,8 @@ function printStack(
     logger.error(color(` ${c.dim(F_POINTER)} ${[frame.method, c.dim(`${path}:${frame.line}:${frame.column}`)].filter(Boolean).join(' ')}`))
     onStack?.(frame)
   }
-  logger.error()
+  if (stack.length)
+    logger.error()
   const hasProperties = Object.keys(errorProperties).length > 0
   if (hasProperties) {
     logger.error(c.red(c.dim(divider())))

--- a/packages/vitest/src/utils/tasks.ts
+++ b/packages/vitest/src/utils/tasks.ts
@@ -10,7 +10,7 @@ export function hasBenchmark(suite: Arrayable<Suite>): boolean {
 
 export function hasFailedSnapshot(suite: Arrayable<Task>): boolean {
   return getTests(suite).some((s) => {
-    return s.result?.errors?.some(e => e.message.match(/Snapshot .* mismatched/))
+    return s.result?.errors?.some(e => e && e.message && e.message.match(/Snapshot .* mismatched/))
   })
 }
 


### PR DESCRIPTION
Fixes #2779