### PR TITLE
feat!: vitest as peer dependency for coverage packages

### DIFF
--- a/packages/coverage-c8/package.json
+++ b/packages/coverage-c8/package.json
@@ -41,14 +41,17 @@
     "dev": "rollup -c --watch --watch.include 'src/**'",
     "prepublishOnly": "pnpm build"
   },
+  "peerDependencies": {
+    "vitest": ">=0.28.0 <1"
+  },
   "dependencies": {
     "c8": "^7.12.0",
     "picocolors": "^1.0.0",
-    "std-env": "^3.3.1",
-    "vitest": "workspace:*"
+    "std-env": "^3.3.1"
   },
   "devDependencies": {
     "pathe": "^1.1.0",
-    "vite-node": "workspace:*"
+    "vite-node": "workspace:*",
+    "vitest": "workspace:*"
   }
 }

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -41,14 +41,16 @@
     "dev": "rollup -c --watch --watch.include 'src/**'",
     "prepublishOnly": "pnpm build"
   },
+  "peerDependencies": {
+    "vitest": ">=0.28.0 <1"
+  },
   "dependencies": {
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-instrument": "^5.2.1",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.1",
     "istanbul-reports": "^3.1.5",
-    "test-exclude": "^6.0.0",
-    "vitest": "workspace:*"
+    "test-exclude": "^6.0.0"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.4",
@@ -56,6 +58,7 @@
     "@types/istanbul-lib-report": "^3.0.0",
     "@types/istanbul-lib-source-maps": "^4.0.1",
     "@types/istanbul-reports": "^3.0.1",
-    "pathe": "^1.1.0"
+    "pathe": "^1.1.0",
+    "vitest": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,10 +660,10 @@ importers:
       c8: 7.12.0
       picocolors: 1.0.0
       std-env: 3.3.1
-      vitest: link:../vitest
     devDependencies:
       pathe: 1.1.0
       vite-node: link:../vite-node
+      vitest: link:../vitest
 
   packages/coverage-istanbul:
     specifiers:
@@ -687,7 +687,6 @@ importers:
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.5
       test-exclude: 6.0.0
-      vitest: link:../vitest
     devDependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-lib-instrument': 1.7.4
@@ -695,6 +694,7 @@ importers:
       '@types/istanbul-lib-source-maps': 4.0.1
       '@types/istanbul-reports': 3.0.1
       pathe: 1.1.0
+      vitest: link:../vitest
 
   packages/expect:
     specifiers:


### PR DESCRIPTION
Breaking changes:
- `@vitest/coverage-c8` and `@vitest/coverage-istanbul` require `vitest` as peer dependency. End users may need to update their `vitest` when updating latest coverage packages.

Some related earlier discussion at #2725.

Currently the coverage packages declare `vitest` as depedency. If user installs `vitest@0.28.0` and `@vitest/coverage-c8@0.28.0`, they'll end up with two copies of `vitest` in `node_modules`, https://github.com/vitest-dev/vitest/pull/2725#issuecomment-1399838852. Note that now that Vitest is in version `0.x.y`, the semver follows some special rules. For example `0.21.0` does not match `^0.20.0`.

>
> ```sh
> $ npm i -D -E vitest@0.26.0
> $ npm i -D -E @vitest/coverage-istanbul@0.27.2
> $ npm ls vitest
> repro@1.0.0 /Users/x/y/repro
> ├─┬ @vitest/coverage-istanbul@0.27.2
> │ └── vitest@0.27.2
> └── vitest@0.26.0
> ```
>

Also when we intentionally introduce breaking changes to the packages, users may run into errors when mixing two incompatible versions. Using `peerDependencies` solves the issue by failing fast when package managers detect incompatibility issues.
