### PR TITLE
fix(expect): check for no 'throw' type in toHaveReturned

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -549,7 +549,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def(['toHaveReturned', 'toReturn'], function () {
     const spy = getSpy(this)
     const spyName = spy.getMockName()
-    const calledAndNotThrew = spy.mock.calls.length > 0 && !spy.mock.results.some(({ type }) => type === 'throw')
+    const calledAndNotThrew = spy.mock.calls.length > 0 && spy.mock.results.some(({ type }) => type !== 'throw')
     this.assert(
       calledAndNotThrew,
       `expected "${spyName}" to be successfully called at least once`,

--- a/test/core/test/fn.test.ts
+++ b/test/core/test/fn.test.ts
@@ -80,13 +80,13 @@ describe('mock', () => {
     fn()
 
     try {
-      expect(fn).toHaveNthReturnedWith(2, '2')
+      expect(fn).toHaveNthReturnedWith(2, '1')
       assert.fail('expect should throw, since 2nd call is thrown')
     }
     catch {}
 
     // not throws
-    expect(fn).not.toHaveNthReturnedWith(2, '2')
+    expect(fn).not.toHaveNthReturnedWith(2, '1')
 
     expect(fn).toHaveReturnedTimes(2)
     expect(fn).toHaveNthReturnedWith(3, '3')

--- a/test/core/test/fn.test.ts
+++ b/test/core/test/fn.test.ts
@@ -60,7 +60,7 @@ describe('mock', () => {
     let i = 0
 
     const fn = vitest.fn(() => {
-      if (i === 1) {
+      if (i === 0) {
         ++i
         throw new Error('error')
       }
@@ -68,11 +68,15 @@ describe('mock', () => {
       return String(++i)
     })
 
-    fn()
     try {
       fn()
     }
     catch {}
+    expect(fn).not.toHaveReturned()
+
+    fn()
+    expect(fn).toHaveReturned()
+
     fn()
 
     try {

--- a/test/core/test/fn.test.ts
+++ b/test/core/test/fn.test.ts
@@ -80,13 +80,13 @@ describe('mock', () => {
     fn()
 
     try {
-      expect(fn).toHaveNthReturnedWith(2, '1')
-      assert.fail('expect should throw, since 2nd call is thrown')
+      expect(fn).toHaveNthReturnedWith(1, '1')
+      assert.fail('expect should throw, since 1st call is thrown')
     }
     catch {}
 
     // not throws
-    expect(fn).not.toHaveNthReturnedWith(2, '1')
+    expect(fn).not.toHaveNthReturnedWith(1, '1')
 
     expect(fn).toHaveReturnedTimes(2)
     expect(fn).toHaveNthReturnedWith(3, '3')


### PR DESCRIPTION
Fixes: https://github.com/vitest-dev/vitest/issues/2849