### PR TITLE
fix: clear mocks between tests

### DIFF
--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -144,6 +144,8 @@ export async function run(files: string[], config: ResolvedConfig, executor: Vit
 
           // reset after tests, because user might call `vi.setConfig` in setupFile
           vi.resetConfig()
+          // mocks should not affect different files
+          vi.restoreAllMocks()
         }
       })
     }

--- a/test/single-thread/package.json
+++ b/test/single-thread/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vitest/test-single-thread",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "vitest",
     "coverage": "vitest run --coverage"

--- a/test/single-thread/package.json
+++ b/test/single-thread/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vitest/test-single-thread",
-  "private": true,
   "type": "module",
+  "private": true,
   "scripts": {
     "test": "vitest",
     "coverage": "vitest run --coverage"

--- a/test/single-thread/test/a.test.ts
+++ b/test/single-thread/test/a.test.ts
@@ -1,4 +1,11 @@
-import { it } from 'vitest'
+import fs from 'node:fs'
+import { expect, it, vi } from 'vitest'
 import { timeout } from './timeout'
+
+// this file is running first, it should not affect file "b.test.ts"
+it('mock is mocked', () => {
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('mocked')
+  expect(fs.readFileSync('')).toBe('mocked')
+})
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, timeout)))

--- a/test/single-thread/test/b.test.ts
+++ b/test/single-thread/test/b.test.ts
@@ -1,4 +1,18 @@
-import { it } from 'vitest'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'pathe'
+import { expect, it } from 'vitest'
 import { timeout } from './timeout'
+
+// this file is running second, it should not be affected by mock in "a.test.ts"
+it('mock is mocked', () => {
+  expect(fs.readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), './timeout.ts'), 'utf-8')).toMatchInlineSnapshot(`
+    "export const timeout = 200
+    export const mockedFn = function () {
+      return 'original'
+    }
+    "
+  `)
+})
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, timeout)))

--- a/test/single-thread/test/timeout.ts
+++ b/test/single-thread/test/timeout.ts
@@ -1,1 +1,4 @@
 export const timeout = 200
+export const mockedFn = function () {
+  return 'original'
+}

--- a/test/single-thread/vitest.config.ts
+++ b/test/single-thread/vitest.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
+import { BaseSequencer } from 'vitest/node'
 
 export default defineConfig({
   test: {
     threads: false,
+    sequence: {
+      sequencer: class Sequences extends BaseSequencer {
+        public async sort(files: string[]): Promise<string[]> {
+          return files.sort()
+        }
+      },
+    },
   },
 })


### PR DESCRIPTION
Fixes #2845

When `--no-threads` is enabled, we always need to restore mocks that were defined in a test file.
