### PR TITLE
feat!: always run separate environments in isolation

### DIFF
--- a/packages/vitest/src/runtime/entry.ts
+++ b/packages/vitest/src/runtime/entry.ts
@@ -1,12 +1,9 @@
-import { promises as fs } from 'node:fs'
-import mm from 'micromatch'
 import type { VitestRunner, VitestRunnerConstructor } from '@vitest/runner'
 import { startTests } from '@vitest/runner'
 import { resolve } from 'pathe'
-import type { EnvironmentOptions, ResolvedConfig, VitestEnvironment } from '../types'
+import type { ResolvedConfig, WorkerTestEnvironment } from '../types'
 import { getWorkerState, resetModules } from '../utils'
 import { vi } from '../integrations/vi'
-import { envs } from '../integrations/env'
 import { distDir } from '../constants'
 import { startCoverageInsideWorker, stopCoverageInsideWorker, takeCoverageInsideWorker } from '../integrations/coverage'
 import { setupGlobalEnv, withEnv } from './setup.node'
@@ -14,15 +11,6 @@ import { rpc } from './rpc'
 import type { VitestExecutor } from './execute'
 
 const runnersFile = resolve(distDir, 'runners.js')
-
-function groupBy<T, K extends string | number | symbol>(collection: T[], iteratee: (item: T) => K) {
-  return collection.reduce((acc, item) => {
-    const key = iteratee(item)
-    acc[key] ||= []
-    acc[key].push(item)
-    return acc
-  }, {} as Record<K, T[]>)
-}
 
 async function getTestRunnerConstructor(config: ResolvedConfig, executor: VitestExecutor): Promise<VitestRunnerConstructor> {
   if (!config.runner) {
@@ -77,7 +65,7 @@ async function getTestRunner(config: ResolvedConfig, executor: VitestExecutor): 
 }
 
 // browser shouldn't call this!
-export async function run(files: string[], config: ResolvedConfig, executor: VitestExecutor): Promise<void> {
+export async function run(files: string[], config: ResolvedConfig, environment: WorkerTestEnvironment, executor: VitestExecutor): Promise<void> {
   await setupGlobalEnv(config)
   await startCoverageInsideWorker(config.coverage, executor)
 
@@ -85,81 +73,31 @@ export async function run(files: string[], config: ResolvedConfig, executor: Vit
 
   const runner = await getTestRunner(config, executor)
 
-  // if calling from a worker, there will always be one file
-  // if calling with no-threads, this will be the whole suite
-  const filesWithEnv = await Promise.all(files.map(async (file) => {
-    const code = await fs.readFile(file, 'utf-8')
+  // @ts-expect-error untyped global
+  globalThis.__vitest_environment__ = environment
 
-    // 1. Check for control comments in the file
-    let env = code.match(/@(?:vitest|jest)-environment\s+?([\w-]+)\b/)?.[1]
-    // 2. Check for globals
-    if (!env) {
-      for (const [glob, target] of config.environmentMatchGlobs || []) {
-        if (mm.isMatch(file, glob)) {
-          env = target
-          break
-        }
+  await withEnv(environment.name, environment.options || config.environmentOptions || {}, executor, async () => {
+    for (const file of files) {
+      // it doesn't matter if running with --threads
+      // if running with --no-threads, we usually want to reset everything before running a test
+      // but we have --isolate option to disable this
+      if (config.isolate) {
+        workerState.mockMap.clear()
+        resetModules(workerState.moduleCache, true)
       }
+
+      workerState.filepath = file
+
+      await startTests([file], runner)
+
+      workerState.filepath = undefined
+
+      // reset after tests, because user might call `vi.setConfig` in setupFile
+      vi.resetConfig()
+      // mocks should not affect different files
+      vi.restoreAllMocks()
     }
-    // 3. Fallback to global env
-    env ||= config.environment || 'node'
 
-    const envOptions = JSON.parse(code.match(/@(?:vitest|jest)-environment-options\s+?(.+)/)?.[1] || 'null')
-    return {
-      file,
-      env: env as VitestEnvironment,
-      envOptions: envOptions ? { [env]: envOptions } as EnvironmentOptions : null,
-    }
-  }))
-
-  const filesByEnv = groupBy(filesWithEnv, ({ env }) => env)
-
-  const orderedEnvs = envs.concat(
-    Object.keys(filesByEnv).filter(env => !envs.includes(env)),
-  )
-
-  for (const env of orderedEnvs) {
-    const environment = env as VitestEnvironment
-    const files = filesByEnv[environment]
-
-    if (!files || !files.length)
-      continue
-
-    // @ts-expect-error untyped global
-    globalThis.__vitest_environment__ = environment
-
-    const filesByOptions = groupBy(files, ({ envOptions }) => JSON.stringify(envOptions))
-
-    for (const options of Object.keys(filesByOptions)) {
-      const files = filesByOptions[options]
-
-      if (!files || !files.length)
-        continue
-
-      await withEnv(environment, files[0].envOptions || config.environmentOptions || {}, executor, async () => {
-        for (const { file } of files) {
-          // it doesn't matter if running with --threads
-          // if running with --no-threads, we usually want to reset everything before running a test
-          // but we have --isolate option to disable this
-          if (config.isolate) {
-            workerState.mockMap.clear()
-            resetModules(workerState.moduleCache, true)
-          }
-
-          workerState.filepath = file
-
-          await startTests([file], runner)
-
-          workerState.filepath = undefined
-
-          // reset after tests, because user might call `vi.setConfig` in setupFile
-          vi.resetConfig()
-          // mocks should not affect different files
-          vi.restoreAllMocks()
-        }
-      })
-    }
-  }
-
-  await stopCoverageInsideWorker(config.coverage, executor)
+    await stopCoverageInsideWorker(config.coverage, executor)
+  })
 }

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -5,7 +5,7 @@ import { workerId as poolId } from 'tinypool'
 import { processError } from '@vitest/runner/utils'
 import { ModuleCacheMap } from 'vite-node/client'
 import { isPrimitive } from 'vite-node/utils'
-import type { ResolvedConfig, WorkerContext, WorkerRPC } from '../types'
+import type { ResolvedConfig, WorkerContext, WorkerRPC, WorkerTestEnvironment } from '../types'
 import { distDir } from '../constants'
 import { getWorkerState } from '../utils/global'
 import type { MockMap } from '../types/mocker'
@@ -14,7 +14,7 @@ import { createVitestExecutor } from './execute'
 import { rpc, rpcDone } from './rpc'
 
 let _viteNode: {
-  run: (files: string[], config: ResolvedConfig, executor: VitestExecutor) => Promise<void>
+  run: (files: string[], config: ResolvedConfig, environment: WorkerTestEnvironment, executor: VitestExecutor) => Promise<void>
   executor: VitestExecutor
 }
 
@@ -109,6 +109,6 @@ function init(ctx: WorkerContext) {
 export async function run(ctx: WorkerContext) {
   init(ctx)
   const { run, executor } = await startViteNode(ctx)
-  await run(ctx.files, ctx.config, executor)
+  await run(ctx.files, ctx.config, ctx.environment, executor)
   await rpcDone()
 }

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -3,15 +3,21 @@ import type { File, TaskResultPack, Test } from '@vitest/runner'
 import type { FetchFunction, ModuleCacheMap, RawSourceMap, ViteNodeResolveId } from 'vite-node'
 import type { BirpcReturn } from 'birpc'
 import type { MockMap } from './mocker'
-import type { ResolvedConfig } from './config'
+import type { EnvironmentOptions, ResolvedConfig, VitestEnvironment } from './config'
 import type { SnapshotResult } from './snapshot'
 import type { UserConsoleLog } from './general'
+
+export interface WorkerTestEnvironment {
+  name: VitestEnvironment
+  options: EnvironmentOptions | null
+}
 
 export interface WorkerContext {
   workerId: number
   port: MessagePort
   config: ResolvedConfig
   files: string[]
+  environment: WorkerTestEnvironment
   invalidates?: string[]
 }
 

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -10,6 +10,15 @@ function collectOwnProperties(obj: any, collector: Set<string | symbol> | ((key:
   Object.getOwnPropertySymbols(obj).forEach(collect)
 }
 
+export function groupBy<T, K extends string | number | symbol>(collection: T[], iteratee: (item: T) => K) {
+  return collection.reduce((acc, item) => {
+    const key = iteratee(item)
+    acc[key] ||= []
+    acc[key].push(item)
+    return acc
+  }, {} as Record<K, T[]>)
+}
+
 export function getAllMockableProperties(obj: any, isModule: boolean) {
   const allProps = new Map<string | symbol, { key: string | symbol; descriptor: PropertyDescriptor }>()
   let curr = obj

--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -1,0 +1,48 @@
+import { promises as fs } from 'node:fs'
+import mm from 'micromatch'
+import type { EnvironmentOptions, ResolvedConfig, VitestEnvironment } from '../types'
+import { groupBy } from './base'
+
+export const envsOrder = [
+  'node',
+  'jsdom',
+  'happy-dom',
+  'edge-runtime',
+]
+
+export interface FileByEnv {
+  file: string
+  env: VitestEnvironment
+  envOptions: EnvironmentOptions | null
+}
+
+export async function groupFilesByEnv(files: string[], config: ResolvedConfig) {
+  const filesWithEnv = await Promise.all(files.map(async (file) => {
+    const code = await fs.readFile(file, 'utf-8')
+
+    // 1. Check for control comments in the file
+    let env = code.match(/@(?:vitest|jest)-environment\s+?([\w-]+)\b/)?.[1]
+    // 2. Check for globals
+    if (!env) {
+      for (const [glob, target] of config.environmentMatchGlobs || []) {
+        if (mm.isMatch(file, glob)) {
+          env = target
+          break
+        }
+      }
+    }
+    // 3. Fallback to global env
+    env ||= config.environment || 'node'
+
+    const envOptions = JSON.parse(code.match(/@(?:vitest|jest)-environment-options\s+?(.+)/)?.[1] || 'null')
+    return {
+      file,
+      environment: {
+        name: env as VitestEnvironment,
+        options: envOptions ? { [env]: envOptions } as EnvironmentOptions : null,
+      },
+    }
+  }))
+
+  return groupBy(filesWithEnv, ({ environment }) => environment.name)
+}


### PR DESCRIPTION
In preparation for #2854

Tests are no longer running in the same worker if they don't share the same environment. This means that they don't share the same module cache and global scope, which should help with isolation. After PR is merged, tests in some projects will take longer to run, but the difference should be insignificant.

This also allows us to add "browser"/"node" conditions based on the environment in the future (we can safely pass `--conditions` to "worker" option).