### PR TITLE
fix: reload changed configuration file on watch mode

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -62,6 +62,8 @@ export class Vitest {
     this.restartsCount += 1
     this.pool?.close()
     this.pool = undefined
+    this.coverageProvider = undefined
+    this.runningPromise = undefined
 
     const resolved = resolveConfig(this.mode, options, server.config)
 
@@ -109,8 +111,6 @@ export class Vitest {
     this.reporters = resolved.mode === 'benchmark'
       ? await createBenchmarkReporters(toArray(resolved.benchmark?.reporters), this.runner)
       : await createReporters(resolved.reporters, this.runner)
-
-    this.runningPromise = undefined
 
     this.cache.results.setConfig(resolved.root, resolved.cache)
     try {

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -14,6 +14,8 @@ import { CSSEnablerPlugin } from './cssEnabler'
 import { CoverageTransform } from './coverageTransform'
 
 export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('test')): Promise<VitePlugin[]> {
+  const userConfig = deepMerge({}, options) as UserConfig
+
   const getRoot = () => ctx.config?.root || options.root || process.cwd()
 
   async function UIPlugin() {
@@ -34,6 +36,12 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
         this.meta.watchMode = false
       },
       async config(viteConfig: any) {
+        if (options.watch) {
+          // Earlier runs have overwritten values of the `options`.
+          // Reset it back to initial user config before setting up the server again.
+          options = deepMerge({}, userConfig) as UserConfig
+        }
+
         // preliminary merge of options to be able to create server options for vite
         // however to allow vitest plugins to modify vitest config values
         // this is repeated in configResolved where the config is final


### PR DESCRIPTION
- Fixes issues where configuration file changes were not reloaded in watch mode, https://github.com/vitest-dev/vitest/pull/2886#issuecomment-1436519446

The `options` here is mutated by multiple Vite hooks.

https://github.com/vitest-dev/vitest/blob/b67a5fbdf9940191573c5f90d94be7a2ecb26a36/packages/vitest/src/node/plugins/index.ts#L155-L161

Once it has been initialized by first server setup, the `deepMerge` will take previous values of `options` instead of using the fresh `viteConfig`. This PR will restore the `options` back to initial values when in watch mode.

Tested watch mode locally in linked project by changing `test.reporters` and `test.coverage.provider`. I don't think Vitest has any watch mode related tests set so just manual testing for now.