### PR TITLE
feat(vite-node): cli option for vite mode

### DIFF
--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -15,6 +15,7 @@ cli
   .version(version)
   .option('-r, --root <path>', 'Use specified root directory')
   .option('-c, --config <path>', 'Use specified config file')
+  .option('-m, --mode <mode>', 'Set env mode')
   .option('-w, --watch', 'Restart on file changes, similar to "nodemon"')
   .option('--script', 'Use vite-node as a script runner')
   .option('--options <options>', 'Use specified Vite server options')
@@ -31,6 +32,7 @@ export interface CliOptions {
   root?: string
   script?: boolean
   config?: string
+  mode?: string
   watch?: boolean
   options?: ViteNodeServerOptionsCLI
   '--'?: string[]
@@ -60,6 +62,7 @@ async function run(files: string[], options: CliOptions = {}) {
     logLevel: 'error',
     configFile: options.config,
     root: options.root,
+    mode: options.mode,
     plugins: [
       options.watch && viteNodeHmrPlugin(),
     ],
@@ -115,13 +118,13 @@ function parseServerOptions(serverOptions: ViteNodeServerOptionsCLI): ViteNodeSe
       ...serverOptions.deps,
       inline: inlineOptions !== true
         ? inlineOptions.map((dep) => {
-          return dep.startsWith('/') && dep.endsWith('/')
+          return (dep.startsWith('/') && dep.endsWith('/'))
             ? new RegExp(dep)
             : dep
         })
         : true,
       external: toArray(serverOptions.deps?.external).map((dep) => {
-        return dep.startsWith('/') && dep.endsWith('/')
+        return (dep.startsWith('/') && dep.endsWith('/'))
           ? new RegExp(dep)
           : dep
       }),


### PR DESCRIPTION
Add CLI support for setting the vite mode e.g.

```bash
vite-node -m bar foo.ts
```

Tested using:

```bash
echo "console.log('mode', import.meta.env.MODE)" > foo.ts && node dist/cli.mjs -m bar foo.ts && rm foo.ts
echo "console.log('mode', import.meta.env.MODE)" > foo.ts && node dist/cli.mjs --mode bar foo.ts && rm foo.ts
```

Side-catch: I couldn't commit without resolving the eslint errors so I fixed those too:

```bash
121:38  error  Unexpected mix of '&&' and '?:'. Use parentheses to clarify the intended order of operations  no-mixed-operators
122:13  error  Unexpected mix of '&&' and '?:'. Use parentheses to clarify the intended order of operations  no-mixed-operators
127:36  error  Unexpected mix of '&&' and '?:'. Use parentheses to clarify the intended order of operations  no-mixed-operators
128:11  error  Unexpected mix of '&&' and '?:'. Use parentheses to clarify the intended order of operations  no-mixed-operators
```