### PR TITLE
feat: use custom source-map-support implementation

### DIFF
--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -4,7 +4,7 @@ import type { Profiler } from 'inspector'
 import { extname, resolve } from 'pathe'
 import c from 'picocolors'
 import { provider } from 'std-env'
-import type { RawSourceMap } from 'vite-node'
+import type { EncodedSourceMap } from 'vite-node'
 import { coverageConfigDefaults } from 'vitest/config'
 // eslint-disable-next-line no-restricted-imports
 import type { AfterSuiteRunMeta, CoverageC8Options, CoverageProvider, ReportContext, ResolvedCoverageOptions } from 'vitest'
@@ -67,7 +67,7 @@ export class C8CoverageProvider implements CoverageProvider {
     // Overwrite C8's loader as results are in memory instead of file system
     report._loadReports = () => this.coverages
 
-    interface MapAndSource { map: RawSourceMap; source: string | undefined }
+    interface MapAndSource { map: EncodedSourceMap; source: string | undefined }
     type SourceMapMeta = { url: string; filepath: string } & MapAndSource
 
     // add source maps

--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -81,14 +81,11 @@
     "mlly": "^1.1.0",
     "pathe": "^1.1.0",
     "picocolors": "^1.0.0",
-    "source-map": "^0.6.1",
-    "source-map-support": "^0.5.21",
     "vite": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
+    "@jridgewell/trace-mapping": "^0.3.17",
     "@types/debug": "^4.1.7",
-    "@types/source-map": "^0.5.7",
-    "@types/source-map-support": "^0.5.6",
     "rollup": "^2.79.1"
   }
 }

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -170,10 +170,6 @@ export class ViteNodeRunner {
     return await this.cachedRequest(id, url, [])
   }
 
-  getSourceMap(id: string) {
-    return this.moduleCache.getSourceMap(id)
-  }
-
   /** @internal */
   async cachedRequest(id: string, fsPath: string, callstack: string[]) {
     const importee = callstack[callstack.length - 1]

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -2,7 +2,8 @@ import { performance } from 'node:perf_hooks'
 import { resolve } from 'pathe'
 import type { TransformResult, ViteDevServer } from 'vite'
 import createDebug from 'debug'
-import type { DebuggerOptions, FetchResult, RawSourceMap, ViteNodeResolveId, ViteNodeServerOptions } from './types'
+import type { EncodedSourceMap } from '@jridgewell/trace-mapping'
+import type { DebuggerOptions, FetchResult, ViteNodeResolveId, ViteNodeServerOptions } from './types'
 import { shouldExternalize } from './externalize'
 import { normalizeModuleId, toArray, toFilePath } from './utils'
 import { Debugger } from './debug'
@@ -76,7 +77,7 @@ export class ViteNodeServer {
     if (fetchResult?.map)
       return fetchResult.map
     const ssrTransformResult = this.server.moduleGraph.getModuleById(source)?.ssrTransformResult
-    return (ssrTransformResult?.map || null) as unknown as RawSourceMap | null
+    return (ssrTransformResult?.map || null) as unknown as EncodedSourceMap | null
   }
 
   async fetchModule(id: string): Promise<FetchResult> {
@@ -144,7 +145,7 @@ export class ViteNodeServer {
       const start = performance.now()
       const r = await this._transformRequest(id)
       duration = performance.now() - start
-      result = { code: r?.code, map: r?.map as unknown as RawSourceMap }
+      result = { code: r?.code, map: r?.map as any }
     }
 
     this.fetchCache.set(filePath, {

--- a/packages/vite-node/src/source-map-handler.ts
+++ b/packages/vite-node/src/source-map-handler.ts
@@ -1,0 +1,474 @@
+// adapted from https://github.com/evanw/node-source-map-support/blob/master/source-map-support.js
+// we need this because "--enable-source-maps" flag doesn't support VM
+// we make a custom implementatin because we don't need some feature from source-map-support,
+// like polyfilled Buffer, browser support, etc.
+
+import path from 'node:path'
+import fs from 'node:fs'
+import type { OriginalMapping, SourceMapInput } from '@jridgewell/trace-mapping'
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
+
+// Only install once if called multiple times
+let errorFormatterInstalled = false
+
+// If true, the caches are reset before a stack trace formatting operation
+const emptyCacheBetweenOperations = false
+
+// Maps a file path to a string containing the file contents
+let fileContentsCache: Record<string, string> = {}
+
+// Maps a file path to a source map for that file
+let sourceMapCache: Record<string, { url: string | null; map: TraceMap | null }> = {}
+
+// Regex for detecting source maps
+const reSourceMap = /^data:application\/json[^,]+base64,/
+
+type RetrieveFileHandler = (path: string) => string | null | undefined
+type RetrieveMapHandler = (source: string) => { url: string; map?: string | SourceMapInput | null } | null | undefined
+
+// Priority list of retrieve handlers
+let retrieveFileHandlers: RetrieveFileHandler[] = []
+let retrieveMapHandlers: RetrieveMapHandler[] = []
+
+function globalProcessVersion() {
+  if ((typeof process === 'object') && (process !== null))
+    return process.version
+
+  else
+    return ''
+}
+
+function handlerExec<T>(list: ((arg: string) => T)[]) {
+  return function (arg: string) {
+    for (let i = 0; i < list.length; i++) {
+      const ret = list[i](arg)
+      if (ret)
+        return ret
+    }
+    return null
+  }
+}
+
+let retrieveFile = handlerExec(retrieveFileHandlers)
+
+retrieveFileHandlers.push((path) => {
+  // Trim the path to make sure there is no extra whitespace.
+  path = path.trim()
+  if (path.startsWith('file:')) {
+    // existsSync/readFileSync can't handle file protocol, but once stripped, it works
+    path = path.replace(/file:\/\/\/(\w:)?/, (protocol, drive) => {
+      return drive
+        ? '' // file:///C:/dir/file -> C:/dir/file
+        : '/' // file:///root-dir/file -> /root-dir/file
+    })
+  }
+  if (path in fileContentsCache)
+    return fileContentsCache[path]
+
+  let contents = ''
+  try {
+    if (fs.existsSync(path))
+      contents = fs.readFileSync(path, 'utf8')
+  }
+  catch (er) {
+    /* ignore any errors */
+  }
+
+  return fileContentsCache[path] = contents
+})
+
+// Support URLs relative to a directory, but be careful about a protocol prefix
+function supportRelativeURL(file: string, url: string) {
+  if (!file)
+    return url
+  const dir = path.dirname(file)
+  const match = /^\w+:\/\/[^\/]*/.exec(dir)
+  let protocol = match ? match[0] : ''
+  const startPath = dir.slice(protocol.length)
+  if (protocol && /^\/\w\:/.test(startPath)) {
+    // handle file:///C:/ paths
+    protocol += '/'
+    return protocol + path.resolve(dir.slice(protocol.length), url).replace(/\\/g, '/')
+  }
+  return protocol + path.resolve(dir.slice(protocol.length), url)
+}
+
+function retrieveSourceMapURL(source: string) {
+  // Get the URL of the source map
+  const fileData = retrieveFile(source)
+  if (!fileData)
+    return null
+  const re = /(?:\/\/[@#][\s]*sourceMappingURL=([^\s'"]+)[\s]*$)|(?:\/\*[@#][\s]*sourceMappingURL=([^\s*'"]+)[\s]*(?:\*\/)[\s]*$)/mg
+  // Keep executing the search to find the *last* sourceMappingURL to avoid
+  // picking up sourceMappingURLs from comments, strings, etc.
+  let lastMatch, match
+  // eslint-disable-next-line no-cond-assign
+  while (match = re.exec(fileData)) lastMatch = match
+  if (!lastMatch)
+    return null
+  return lastMatch[1]
+}
+
+// Can be overridden by the retrieveSourceMap option to install. Takes a
+// generated source filename; returns a {map, optional url} object, or null if
+// there is no source map.  The map field may be either a string or the parsed
+// JSON object (ie, it must be a valid argument to the SourceMapConsumer
+// constructor).
+let retrieveSourceMap = handlerExec(retrieveMapHandlers)
+retrieveMapHandlers.push((source) => {
+  let sourceMappingURL = retrieveSourceMapURL(source)
+  if (!sourceMappingURL)
+    return null
+
+  // Read the contents of the source map
+  let sourceMapData
+  if (reSourceMap.test(sourceMappingURL)) {
+    // Support source map URL as a data url
+    const rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1)
+    sourceMapData = Buffer.from(rawData, 'base64').toString()
+    sourceMappingURL = source
+  }
+  else {
+    // Support source map URLs relative to the source URL
+    sourceMappingURL = supportRelativeURL(source, sourceMappingURL)
+    sourceMapData = retrieveFile(sourceMappingURL)
+  }
+
+  if (!sourceMapData)
+    return null
+
+  return {
+    url: sourceMappingURL,
+    map: sourceMapData,
+  }
+})
+
+// interface Position {
+//   source: string
+//   line: number
+//   column: number
+// }
+
+function mapSourcePosition(position: OriginalMapping) {
+  if (!position.source)
+    return position
+  let sourceMap = sourceMapCache[position.source]
+  if (!sourceMap) {
+    // Call the (overrideable) retrieveSourceMap function to get the source map.
+    const urlAndMap = retrieveSourceMap(position.source)
+    if (urlAndMap && urlAndMap.map) {
+      sourceMap = sourceMapCache[position.source] = {
+        url: urlAndMap.url,
+        map: new TraceMap(urlAndMap.map),
+      }
+
+      // Load all sources stored inline with the source map into the file cache
+      // to pretend like they are already loaded. They may not exist on disk.
+      if (sourceMap.map?.sourcesContent) {
+        sourceMap.map.sources.forEach((source, i) => {
+          const contents = sourceMap.map?.sourcesContent?.[i]
+          if (contents && source && sourceMap.url) {
+            const url = supportRelativeURL(sourceMap.url, source)
+            fileContentsCache[url] = contents
+          }
+        })
+      }
+    }
+    else {
+      sourceMap = sourceMapCache[position.source] = {
+        url: null,
+        map: null,
+      }
+    }
+  }
+
+  // Resolve the source URL relative to the URL of the source map
+  if (sourceMap && sourceMap.map && sourceMap.url) {
+    const originalPosition = originalPositionFor(sourceMap.map, position)
+
+    // Only return the original position if a matching line was found. If no
+    // matching line is found then we return position instead, which will cause
+    // the stack trace to print the path and line for the compiled file. It is
+    // better to give a precise location in the compiled file than a vague
+    // location in the original file.
+    if (originalPosition.source !== null) {
+      originalPosition.source = supportRelativeURL(
+        sourceMap.url, originalPosition.source)
+      return originalPosition
+    }
+  }
+
+  return position
+}
+
+// Parses code generated by FormatEvalOrigin(), a function inside V8:
+// https://code.google.com/p/v8/source/browse/trunk/src/messages.js
+function mapEvalOrigin(origin: string): string {
+  // Most eval() calls are in this format
+  let match = /^eval at ([^(]+) \((.+):(\d+):(\d+)\)$/.exec(origin)
+  if (match) {
+    const position = mapSourcePosition({
+      name: null,
+      source: match[2],
+      line: +match[3],
+      column: +match[4] - 1,
+    })
+    return `eval at ${match[1]} (${position.source}:${
+      position.line}:${position.column + 1})`
+  }
+
+  // Parse nested eval() calls using recursion
+  match = /^eval at ([^(]+) \((.+)\)$/.exec(origin)
+  if (match)
+    return `eval at ${match[1]} (${mapEvalOrigin(match[2])})`
+
+  // Make sure we still return useful information if we didn't find anything
+  return origin
+}
+
+interface CallSite extends NodeJS.CallSite {
+  getScriptNameOrSourceURL(): string
+}
+
+// This is copied almost verbatim from the V8 source code at
+// https://code.google.com/p/v8/source/browse/trunk/src/messages.js. The
+// implementation of wrapCallSite() used to just forward to the actual source
+// code of CallSite.prototype.toString but unfortunately a new release of V8
+// did something to the prototype chain and broke the shim. The only fix I
+// could find was copy/paste.
+function CallSiteToString(this: CallSite) {
+  let fileName
+  let fileLocation = ''
+  if (this.isNative()) {
+    fileLocation = 'native'
+  }
+  else {
+    fileName = this.getScriptNameOrSourceURL()
+    if (!fileName && this.isEval()) {
+      fileLocation = this.getEvalOrigin() as string
+      fileLocation += ', ' // Expecting source position to follow.
+    }
+
+    if (fileName) {
+      fileLocation += fileName
+    }
+    else {
+      // Source code does not originate from a file and is not native, but we
+      // can still get the source position inside the source string, e.g. in
+      // an eval string.
+      fileLocation += '<anonymous>'
+    }
+    const lineNumber = this.getLineNumber()
+    if (lineNumber != null) {
+      fileLocation += `:${lineNumber}`
+      const columnNumber = this.getColumnNumber()
+      if (columnNumber)
+        fileLocation += `:${columnNumber}`
+    }
+  }
+
+  let line = ''
+  const functionName = this.getFunctionName()
+  let addSuffix = true
+  const isConstructor = this.isConstructor()
+  const isMethodCall = !(this.isToplevel() || isConstructor)
+  if (isMethodCall) {
+    let typeName = this.getTypeName()
+    // Fixes shim to be backward compatable with Node v0 to v4
+    if (typeName === '[object Object]')
+      typeName = 'null'
+
+    const methodName = this.getMethodName()
+    if (functionName) {
+      if (typeName && functionName.indexOf(typeName) !== 0)
+        line += `${typeName}.`
+
+      line += functionName
+      if (methodName && functionName.indexOf(`.${methodName}`) !== functionName.length - methodName.length - 1)
+        line += ` [as ${methodName}]`
+    }
+    else {
+      line += `${typeName}.${methodName || '<anonymous>'}`
+    }
+  }
+  else if (isConstructor) {
+    line += `new ${functionName || '<anonymous>'}`
+  }
+  else if (functionName) {
+    line += functionName
+  }
+  else {
+    line += fileLocation
+    addSuffix = false
+  }
+  if (addSuffix)
+    line += ` (${fileLocation})`
+
+  return line
+}
+
+function cloneCallSite(frame: CallSite) {
+  const object = {} as CallSite
+  Object.getOwnPropertyNames(Object.getPrototypeOf(frame)).forEach((name) => {
+    const key = name as keyof CallSite
+    // @ts-expect-error difficult to type
+    object[key] = /^(?:is|get)/.test(name)
+      ? function () {
+        // eslint-disable-next-line no-useless-call
+        return frame[key].call(frame)
+      }
+      : frame[key]
+  })
+  object.toString = CallSiteToString
+  return object
+}
+
+interface State {
+  nextPosition: null | OriginalMapping
+  curPosition: null | OriginalMapping
+}
+
+function wrapCallSite(frame: CallSite, state: State) {
+  // provides interface backward compatibility
+  if (state === undefined)
+    state = { nextPosition: null, curPosition: null }
+
+  if (frame.isNative()) {
+    state.curPosition = null
+    return frame
+  }
+
+  // Most call sites will return the source file from getFileName(), but code
+  // passed to eval() ending in "//# sourceURL=..." will return the source file
+  // from getScriptNameOrSourceURL() instead
+  const source = frame.getFileName() || frame.getScriptNameOrSourceURL()
+  if (source) {
+    const line = frame.getLineNumber() as number
+    let column = (frame.getColumnNumber() as number) - 1
+
+    // Fix position in Node where some (internal) code is prepended.
+    // See https://github.com/evanw/node-source-map-support/issues/36
+    // Header removed in node at ^10.16 || >=11.11.0
+    // v11 is not an LTS candidate, we can just test the one version with it.
+    // Test node versions for: 10.16-19, 10.20+, 12-19, 20-99, 100+, or 11.11
+    const noHeader = /^v(10\.1[6-9]|10\.[2-9][0-9]|10\.[0-9]{3,}|1[2-9]\d*|[2-9]\d|\d{3,}|11\.11)/
+    const headerLength = noHeader.test(globalProcessVersion()) ? 0 : 62
+    if (line === 1 && column > headerLength && !frame.isEval())
+      column -= headerLength
+
+    const position = mapSourcePosition({
+      name: null,
+      source,
+      line,
+      column,
+    })
+    state.curPosition = position
+    frame = cloneCallSite(frame)
+    const originalFunctionName = frame.getFunctionName
+    frame.getFunctionName = function () {
+      if (state.nextPosition == null)
+        return originalFunctionName()
+
+      return state.nextPosition.name || originalFunctionName()
+    }
+    frame.getFileName = function () {
+      return position.source
+    }
+    frame.getLineNumber = function () {
+      return position.line
+    }
+    frame.getColumnNumber = function () {
+      return position.column + 1
+    }
+    frame.getScriptNameOrSourceURL = function () {
+      return position.source as string
+    }
+    return frame
+  }
+
+  // Code called using eval() needs special handling
+  let origin = frame.isEval() && frame.getEvalOrigin()
+  if (origin) {
+    origin = mapEvalOrigin(origin)
+    frame = cloneCallSite(frame)
+    frame.getEvalOrigin = function () {
+      return origin || undefined
+    }
+    return frame
+  }
+
+  // If we get here then we were unable to change the source position
+  return frame
+}
+
+// This function is part of the V8 stack trace API, for more info see:
+// https://v8.dev/docs/stack-trace-api
+function prepareStackTrace(error: Error, stack: CallSite[]) {
+  if (emptyCacheBetweenOperations) {
+    fileContentsCache = {}
+    sourceMapCache = {}
+  }
+
+  const name = error.name || 'Error'
+  const message = error.message || ''
+  const errorString = `${name}: ${message}`
+
+  const state = { nextPosition: null, curPosition: null }
+  const processedStack = []
+  for (let i = stack.length - 1; i >= 0; i--) {
+    processedStack.push(`\n    at ${wrapCallSite(stack[i], state)}`)
+    state.nextPosition = state.curPosition
+  }
+  state.curPosition = state.nextPosition = null
+  return errorString + processedStack.reverse().join('')
+}
+
+const originalRetrieveFileHandlers = retrieveFileHandlers.slice(0)
+const originalRetrieveMapHandlers = retrieveMapHandlers.slice(0)
+
+interface Options {
+  hookRequire?: boolean
+  overrideRetrieveFile?: boolean
+  overrideRetrieveSourceMap?: boolean
+  retrieveFile?: RetrieveFileHandler
+  retrieveSourceMap?: RetrieveMapHandler
+}
+
+export const install = function (options: Options) {
+  options = options || {}
+
+  // Allow sources to be found by methods other than reading the files
+  // directly from disk.
+  if (options.retrieveFile) {
+    if (options.overrideRetrieveFile)
+      retrieveFileHandlers.length = 0
+
+    retrieveFileHandlers.unshift(options.retrieveFile)
+  }
+
+  // Allow source maps to be found by methods other than reading the files
+  // directly from disk.
+  if (options.retrieveSourceMap) {
+    if (options.overrideRetrieveSourceMap)
+      retrieveMapHandlers.length = 0
+
+    retrieveMapHandlers.unshift(options.retrieveSourceMap)
+  }
+
+  // Install the error reformatter
+  if (!errorFormatterInstalled) {
+    errorFormatterInstalled = true
+    Error.prepareStackTrace = prepareStackTrace as ErrorConstructor['prepareStackTrace']
+  }
+}
+
+export const resetRetrieveHandlers = function () {
+  retrieveFileHandlers.length = 0
+  retrieveMapHandlers.length = 0
+
+  retrieveFileHandlers = originalRetrieveFileHandlers.slice(0)
+  retrieveMapHandlers = originalRetrieveMapHandlers.slice(0)
+
+  retrieveSourceMap = handlerExec(retrieveMapHandlers)
+  retrieveFile = handlerExec(retrieveFileHandlers)
+}

--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -1,9 +1,9 @@
-import { install } from 'source-map-support'
 import type { TransformResult } from 'vite'
-import type { RawSourceMap } from './types'
+import type { EncodedSourceMap } from '@jridgewell/trace-mapping'
+import { install } from './source-map-handler'
 
 interface InstallSourceMapSupportOptions {
-  getSourceMap: (source: string) => RawSourceMap | null | undefined
+  getSourceMap: (source: string) => EncodedSourceMap | null | undefined
 }
 
 let SOURCEMAPPING_URL = 'sourceMa'
@@ -31,7 +31,7 @@ export async function withInlineSourcemap(result: TransformResult) {
   return result
 }
 
-export function extractSourceMap(code: string): RawSourceMap | null {
+export function extractSourceMap(code: string): EncodedSourceMap | null {
   const mapString = code.match(VITE_NODE_SOURCEMAPPING_REGEXP)?.[1]
   if (mapString)
     return JSON.parse(Buffer.from(mapString, 'base64').toString('utf-8'))
@@ -40,8 +40,6 @@ export function extractSourceMap(code: string): RawSourceMap | null {
 
 export function installSourcemapsSupport(options: InstallSourceMapSupportOptions) {
   install({
-    environment: 'node',
-    handleUncaughtExceptions: false,
     retrieveSourceMap(source) {
       const map = options.getSourceMap(source)
       if (map) {

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -1,4 +1,5 @@
 import type { ViteHotContext } from 'vite/types/hot'
+import type { EncodedSourceMap } from '@jridgewell/trace-mapping'
 import type { ModuleCacheMap, ViteNodeRunner } from './client'
 
 export type Nullable<T> = T | null | undefined
@@ -19,6 +20,8 @@ export interface StartOfSourceMap {
   sourceRoot?: string
 }
 
+export type { EncodedSourceMap, DecodedSourceMap } from '@jridgewell/trace-mapping'
+
 export interface RawSourceMap extends StartOfSourceMap {
   version: string
   sources: string[]
@@ -30,7 +33,7 @@ export interface RawSourceMap extends StartOfSourceMap {
 export interface FetchResult {
   code?: string
   externalize?: string
-  map?: RawSourceMap
+  map?: EncodedSourceMap | null
 }
 
 export type HotContext = Omit<ViteHotContext, 'acceptDeps' | 'decline'>
@@ -47,7 +50,7 @@ export interface ModuleCache {
   evaluated?: boolean
   resolving?: boolean
   code?: string
-  map?: RawSourceMap
+  map?: EncodedSourceMap
   /**
    * Module ids that imports this module
    */

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1097,7 +1097,7 @@ Repository: ehmicky/human-signals
 >       same "printed page" as the copyright notice for easier
 >       identification within third-party archives.
 > 
->    Copyright 2021 ehmicky <ehmicky@gmail.com>
+>    Copyright 2022 ehmicky <ehmicky@gmail.com>
 > 
 >    Licensed under the Apache License, Version 2.0 (the "License");
 >    you may not use this file except in compliance with the License.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,7 +240,7 @@ importers:
       react-dom: 18.0.0_react@18.0.0
     devDependencies:
       '@testing-library/react': 13.3.0_zpnidt7m3osuk7shl3s4oenomq
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       '@types/react': 18.0.28
       '@vitejs/plugin-react': 3.1.0
       jsdom: 21.1.0
@@ -292,7 +292,7 @@ importers:
       '@types/react-test-renderer': 17.0.2
       '@vitejs/plugin-react': 3.1.0_vite@4.0.0
       '@vitest/ui': link:../../packages/ui
-      happy-dom: 8.3.2
+      happy-dom: 8.7.1
       jsdom: 21.1.0
       react-test-renderer: 17.0.2_react@17.0.2
       vite: 4.0.0
@@ -502,7 +502,7 @@ importers:
       vue: latest
     devDependencies:
       '@vitejs/plugin-vue': 4.0.0_vite@4.0.0+vue@3.2.47
-      '@vue/test-utils': 2.2.10_vue@3.2.47
+      '@vue/test-utils': 2.3.0_vue@3.2.47
       jsdom: 21.1.0
       vite: 4.0.0
       vite-plugin-ruby: 3.1.2_vite@4.0.0
@@ -596,7 +596,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue': 4.0.0_vite@4.0.0+vue@3.2.47
       '@vitejs/plugin-vue-jsx': 3.0.0_vite@4.0.0+vue@3.2.47
-      '@vue/test-utils': 2.2.10_vue@3.2.47
+      '@vue/test-utils': 2.3.0_vue@3.2.47
       jsdom: 21.1.0
       vite: 4.0.0
       vitest: link:../../packages/vitest
@@ -815,17 +815,14 @@ importers:
 
   packages/vite-node:
     specifiers:
+      '@jridgewell/trace-mapping': ^0.3.17
       '@types/debug': ^4.1.7
-      '@types/source-map': ^0.5.7
-      '@types/source-map-support': ^0.5.6
       cac: ^6.7.14
       debug: ^4.3.4
       mlly: ^1.1.0
       pathe: ^1.1.0
       picocolors: ^1.0.0
       rollup: ^2.79.1
-      source-map: ^0.6.1
-      source-map-support: ^0.5.21
       vite: ^4.0.0
     dependencies:
       cac: 6.7.14
@@ -833,13 +830,10 @@ importers:
       mlly: 1.1.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      source-map: 0.6.1
-      source-map-support: 0.5.21
       vite: 4.0.0
     devDependencies:
+      '@jridgewell/trace-mapping': 0.3.17
       '@types/debug': 4.1.7
-      '@types/source-map': 0.5.7
-      '@types/source-map-support': 0.5.6
       rollup: 2.79.1
 
   packages/vitest:
@@ -1073,8 +1067,8 @@ importers:
       vue: latest
     devDependencies:
       '@vitejs/plugin-vue': 4.0.0_vite@4.0.0+vue@3.2.47
-      '@vue/test-utils': 2.2.10_vue@3.2.47
-      happy-dom: 8.3.2
+      '@vue/test-utils': 2.3.0_vue@3.2.47
+      happy-dom: 8.7.1
       vite: 4.0.0
       vitest: link:../../packages/vitest
       vue: 3.2.47
@@ -4286,24 +4280,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/traverse/7.20.5:
-    resolution: {integrity: sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/types/7.18.13:
     resolution: {integrity: sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==}
     engines: {node: '>=6.9.0'}
@@ -5031,7 +5007,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: true
@@ -5043,7 +5019,7 @@ packages:
       '@jest/schemas': 29.0.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       '@types/yargs': 17.0.12
       chalk: 4.1.2
     dev: true
@@ -7381,7 +7357,7 @@ packages:
   /@types/cheerio/0.22.31:
     resolution: {integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/codemirror/5.60.6:
@@ -7448,33 +7424,33 @@ packages:
     resolution: {integrity: sha512-zdV5odfHf95B4qr6bdpshG4VMm/3xgnPhSJLa3xh75CYr35e34k+4FQli82Q48sPqwHazJGy+6+jl4T+Vw1AMg==}
     dependencies:
       '@types/jsonfile': 6.1.1
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.1
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/glob/8.0.0:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.1
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/hast/2.3.4:
@@ -7535,7 +7511,7 @@ packages:
   /@types/jsdom/21.1.0:
     resolution: {integrity: sha512-leWreJOdnuIxq9Y70tBVm/bvTuh31DSlF/r4l7Cfi4uhVQqLHD0Q4v301GMisEMwwbMgF7ZKxuZ+Jbd4NcdmRw==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.1
     dev: true
@@ -7551,7 +7527,7 @@ packages:
   /@types/jsonfile/6.1.1:
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/lodash/4.14.191:
@@ -7585,7 +7561,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       form-data: 3.0.1
     dev: true
 
@@ -7603,6 +7579,10 @@ packages:
 
   /@types/node/18.13.0:
     resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
+    dev: true
+
+  /@types/node/18.14.0:
+    resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
     dev: true
 
   /@types/node/18.7.13:
@@ -7635,7 +7615,7 @@ packages:
   /@types/prompts/2.4.2:
     resolution: {integrity: sha512-TwNx7qsjvRIUv/BCx583tqF5IINEVjCNqg9ofKHRlSoUHE62WBHrem4B1HGXcIrG511v29d1kJ9a/t2Esz7MIg==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       kleur: 3.0.3
     dev: true
 
@@ -7708,7 +7688,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/resolve/1.20.2:
@@ -7725,7 +7705,7 @@ packages:
   /@types/set-cookie-parser/2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/sinonjs__fake-timers/8.1.1:
@@ -7742,19 +7722,6 @@ packages:
 
   /@types/source-list-map/0.1.2:
     resolution: {integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==}
-    dev: true
-
-  /@types/source-map-support/0.5.6:
-    resolution: {integrity: sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==}
-    dependencies:
-      source-map: 0.6.1
-    dev: true
-
-  /@types/source-map/0.5.7:
-    resolution: {integrity: sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==}
-    deprecated: This is a stub types definition for source-map (https://github.com/mozilla/source-map). source-map provides its own type definitions, so you don't need @types/source-map installed!
-    dependencies:
-      source-map: 0.7.4
     dev: true
 
   /@types/stack-utils/2.0.1:
@@ -7812,7 +7779,7 @@ packages:
   /@types/webpack-sources/3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: true
@@ -7820,7 +7787,7 @@ packages:
   /@types/webpack/4.41.32:
     resolution: {integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.17.0
       '@types/webpack-sources': 3.2.0
@@ -7831,7 +7798,7 @@ packages:
   /@types/ws/8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
 
   /@types/yargs-parser/21.0.0:
@@ -7854,7 +7821,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
     dev: true
     optional: true
 
@@ -8376,7 +8343,7 @@ packages:
       '@vue/compiler-core': 3.2.47
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-sfc': 3.2.47
-      '@vue/reactivity': 3.2.45
+      '@vue/reactivity': 3.2.47
       '@vue/shared': 3.2.47
     dev: true
 
@@ -8397,9 +8364,9 @@ packages:
     dependencies:
       '@babel/helper-module-imports': 7.18.6
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.5
-      '@babel/template': 7.18.10
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.12
+      '@babel/types': 7.20.7
       '@vue/babel-helper-vue-transform-on': 1.0.2
       camelcase: 6.3.0
       html-tags: 3.2.0
@@ -8688,8 +8655,8 @@ packages:
       vue: 3.2.47
     dev: true
 
-  /@vue/test-utils/2.2.10_vue@3.2.47:
-    resolution: {integrity: sha512-UPY+VdWST5vYZ/Qhl+sLuJAv596e6kTbrOPgdGY82qd9kGN/MfjzLT5KXlmpChkiCbPP3abZ8XT25u1n5h+mRg==}
+  /@vue/test-utils/2.3.0_vue@3.2.47:
+    resolution: {integrity: sha512-S8/9Z+B4VSsTUNtZtzS7J1TfxJbf10n+gcH9X8cASbG0Tp7qD6vqs/sUNlmpzk6i7+pP00ptauJp9rygyW89Ww==}
     peerDependencies:
       vue: ^3.0.1
     dependencies:
@@ -8697,6 +8664,7 @@ packages:
       vue: 3.2.47
     optionalDependencies:
       '@vue/compiler-dom': 3.2.47
+      '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
   /@vueuse/core/8.9.4_vue@3.2.39:
@@ -10208,6 +10176,7 @@ packages:
 
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
 
   /buffer-xor/1.0.3:
     resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
@@ -13820,6 +13789,19 @@ packages:
       - encoding
     dev: true
 
+  /happy-dom/8.7.1:
+    resolution: {integrity: sha512-/z+B/LUEETO9qGbUw80TTCjyhibmczB7OF1XxJ+UU1LlFOBkqO+GCVM+lDaQKVH62HxvX4sbu/EL2KlUtmyyZw==}
+    dependencies:
+      css.escape: 1.5.1
+      he: 1.2.0
+      node-fetch: 2.6.7
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /has-ansi/2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
     engines: {node: '>=0.10.0'}
@@ -14946,7 +14928,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -15014,7 +14996,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       graceful-fs: 4.2.10
     dev: true
 
@@ -15023,7 +15005,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       chalk: 4.1.2
       graceful-fs: 4.2.10
       is-ci: 2.0.0
@@ -15035,7 +15017,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.0.1
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       chalk: 4.1.2
       ci-info: 3.7.0
       graceful-fs: 4.2.10
@@ -15046,7 +15028,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -15055,7 +15037,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -19179,6 +19161,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    dev: true
 
   /source-map-url/0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}


### PR DESCRIPTION
Replacing `source-map-support` package with our custom implementation. Also replacing `source-map` package with `@jridgewell/trace-mapping`. This should reduce the size of the package considerably and make `new Error().stack` a bit faster.