### PR TITLE
feat: add an option to enable Vite optimizer

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -91,6 +91,28 @@ Files to exclude from the test run, using glob pattern.
 
 Handling for dependencies resolution.
 
+#### deps.experimentalOptimizer
+
+- **Type:** `DepOptimizationConfig & { enabled: boolean }`
+- **Version:** Vitets 0.29.0
+- **See also:** [Dep Optimization Options](https://vitejs.dev/config/dep-optimization-options.html)
+
+Enable dependency optimization. This can improve the performance of your tests.
+
+For `jsdom` and `happy-dom` environments, when Vitest will encounter the external library, it will be bundled into a single file using esbuild and imported as a whole module. This is good for several reasons:
+
+- Importing packages with a lot of imports is expensive. By bundling them into one file we can save a lot of time
+- Importing UI libraries is expensive because they are not meant to run inside Node.js
+- Your `alias` configuration is now respected inside bundled packages
+
+You can opt-out of this behavior for certain packages with `exclude` option. You can read more about available options in [Vite](https://vitejs.dev/config/dep-optimization-options.html) docs.
+
+This options also inherits your `optimizeDeps` configuration. If you redefine `include`/`exclude`/`entries` option in `deps.experimentalOptimizer` it will overwrite your `optimizeDeps` when running tests.
+
+:::note
+You will not be able to edit your `node_modules` code for debugging, since the code is actually located in your `cacheDir` or `test.cache.dir` directory. If you want to debug with `console.log` statements, edit it directly or force rebundling with `deps.experimentalOptimizer.force` option.
+:::
+
 #### deps.external
 
 - **Type:** `(string | RegExp)[]`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -97,7 +97,7 @@ Handling for dependencies resolution.
 - **Version:** Vitets 0.29.0
 - **See also:** [Dep Optimization Options](https://vitejs.dev/config/dep-optimization-options.html)
 
-Enable dependency optimization. This can improve the performance of your tests.
+Enable dependency optimization. If you have a lot of tests, this might improve their performance.
 
 For `jsdom` and `happy-dom` environments, when Vitest will encounter the external library, it will be bundled into a single file using esbuild and imported as a whole module. This is good for several reasons:
 

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -208,18 +208,18 @@ export class ViteNodeRunner {
     return !isInternalRequest(id) && !isNodeBuiltin(id)
   }
 
-  private async _resolveUrl(id: string, importee?: string): Promise<[url: string, fsPath: string]> {
+  private async _resolveUrl(id: string, importer?: string): Promise<[url: string, fsPath: string]> {
     // we don't pass down importee here, because otherwise Vite doesn't resolve it correctly
     // should be checked before normalization, because it removes this prefix
-    if (importee && id.startsWith(VALID_ID_PREFIX))
-      importee = undefined
+    if (importer && id.startsWith(VALID_ID_PREFIX))
+      importer = undefined
     id = normalizeRequestId(id, this.options.base)
     if (!this.shouldResolveId(id))
       return [id, id]
     const { path, exists } = toFilePath(id, this.root)
     if (!this.options.resolveId || exists)
       return [id, path]
-    const resolved = await this.options.resolveId(id, importee)
+    const resolved = await this.options.resolveId(id, importer)
     const resolvedId = resolved
       ? normalizeRequestId(resolved.id, this.options.base)
       : id

--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -106,7 +106,7 @@ async function _shouldExternalize(
   id = patchWindowsImportPath(id)
 
   // always externalize Vite deps, they are too big to inline
-  if (id.includes('.vite/deps'))
+  if (options?.cacheDir && id.includes(options.cacheDir))
     return id
 
   if (matchExternalizePattern(id, options?.inline))

--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -105,6 +105,10 @@ async function _shouldExternalize(
 
   id = patchWindowsImportPath(id)
 
+  // always externalize Vite deps, they are too big to inline
+  if (id.includes('.vite/deps'))
+    return id
+
   if (matchExternalizePattern(id, options?.inline))
     return false
   if (matchExternalizePattern(id, options?.external))

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -86,10 +86,10 @@ export class ViteNodeServer {
     })
   }
 
-  async resolveId(id: string, importer?: string): Promise<ViteNodeResolveId | null> {
+  async resolveId(id: string, importer?: string, transformMode?: 'web' | 'ssr'): Promise<ViteNodeResolveId | null> {
     if (importer && !importer.startsWith(this.server.config.root))
       importer = resolve(this.server.config.root, importer)
-    const mode = (importer && this.getTransformMode(importer)) || 'ssr'
+    const mode = transformMode ?? ((importer && this.getTransformMode(importer)) || 'ssr')
     return this.server.pluginContainer.resolveId(id, importer, { ssr: mode === 'ssr' })
   }
 

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -1,5 +1,6 @@
 import { performance } from 'node:perf_hooks'
-import { resolve } from 'pathe'
+import { existsSync } from 'node:fs'
+import { join, resolve } from 'pathe'
 import type { TransformResult, ViteDevServer } from 'vite'
 import createDebug from 'debug'
 import type { DebuggerOptions, FetchResult, RawSourceMap, ViteNodeResolveId, ViteNodeServerOptions } from './types'
@@ -15,6 +16,8 @@ const debugRequest = createDebug('vite-node:server:request')
 export class ViteNodeServer {
   private fetchPromiseMap = new Map<string, Promise<FetchResult>>()
   private transformPromiseMap = new Map<string, Promise<TransformResult | null | undefined>>()
+
+  private existingOptimizedDeps = new Set<string>()
 
   fetchCache = new Map<string, {
     duration?: number
@@ -64,7 +67,31 @@ export class ViteNodeServer {
     return shouldExternalize(id, this.options.deps, this.externalizeCache)
   }
 
+  private async ensureExists(id: string): Promise<boolean> {
+    if (this.existingOptimizedDeps.has(id))
+      return true
+    if (existsSync(id))
+      return true
+    return new Promise<boolean>((resolve) => {
+      setTimeout(() => {
+        this.ensureExists(id).then(() => {
+          this.existingOptimizedDeps.add(id)
+          resolve(true)
+        })
+      })
+    })
+  }
+
   async resolveId(id: string, importer?: string): Promise<ViteNodeResolveId | null> {
+    if (id.includes('.vite/deps')) {
+      id = join(this.server.config.root, id)
+      const timeout = setTimeout(() => {
+        throw new Error(`ViteNodeServer: ${id} not found. This is a bug, please report it.`)
+      }, 5000) // CI can be quite slow
+      await this.ensureExists(id)
+      clearTimeout(timeout)
+      return { id }
+    }
     if (importer && !importer.startsWith(this.server.config.root))
       importer = resolve(this.server.config.root, importer)
     const mode = (importer && this.getTransformMode(importer)) || 'ssr'
@@ -79,12 +106,12 @@ export class ViteNodeServer {
     return (ssrTransformResult?.map || null) as unknown as RawSourceMap | null
   }
 
-  async fetchModule(id: string): Promise<FetchResult> {
+  async fetchModule(id: string, transformMode?: 'web' | 'ssr'): Promise<FetchResult> {
     id = normalizeModuleId(id)
     // reuse transform for concurrent requests
     if (!this.fetchPromiseMap.has(id)) {
       this.fetchPromiseMap.set(id,
-        this._fetchModule(id)
+        this._fetchModule(id, transformMode)
           .then((r) => {
             return this.options.sourcemap !== true ? { ...r, map: undefined } : r
           })
@@ -122,7 +149,7 @@ export class ViteNodeServer {
     return 'web'
   }
 
-  private async _fetchModule(id: string): Promise<FetchResult> {
+  private async _fetchModule(id: string, transformMode?: 'web' | 'ssr'): Promise<FetchResult> {
     let result: FetchResult
 
     const { path: filePath } = toFilePath(id, this.server.config.root)
@@ -142,7 +169,7 @@ export class ViteNodeServer {
     }
     else {
       const start = performance.now()
-      const r = await this._transformRequest(id)
+      const r = await this._transformRequest(id, transformMode)
       duration = performance.now() - start
       result = { code: r?.code, map: r?.map as unknown as RawSourceMap }
     }
@@ -156,7 +183,7 @@ export class ViteNodeServer {
     return result
   }
 
-  private async _transformRequest(id: string) {
+  private async _transformRequest(id: string, customTransformMode?: 'web' | 'ssr') {
     debugRequest(id)
 
     let result: TransformResult | null = null
@@ -167,7 +194,9 @@ export class ViteNodeServer {
         return result
     }
 
-    if (this.getTransformMode(id) === 'web') {
+    const transformMode = customTransformMode ?? this.getTransformMode(id)
+
+    if (transformMode === 'web') {
       // for components like Vue, we want to use the client side
       // plugins but then convert the code to be consumed by the server
       result = await this.server.transformRequest(id)

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -7,6 +7,7 @@ export type Arrayable<T> = T | Array<T>
 export interface DepsHandlingOptions {
   external?: (string | RegExp)[]
   inline?: (string | RegExp)[] | true
+  cacheDir?: string
   /**
    * Try to guess the CJS version of a package when it's invalid ESM
    * @default false

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -155,8 +155,9 @@ export class Vitest {
   }
 
   async typecheck(filters: string[] = []) {
+    const { dir, root } = this.config
     const { include, exclude } = this.config.typecheck
-    const testsFilesList = await this.globFiles(filters, include, exclude)
+    const testsFilesList = await this.globFiles(filters, include, exclude, dir || root)
     const checker = new Typechecker(this, testsFilesList)
     this.typechecker = checker
     checker.onParseEnd(async ({ files, sourceErrors }) => {
@@ -606,11 +607,11 @@ export class Vitest {
     )))
   }
 
-  async globFiles(filters: string[], include: string[], exclude: string[]) {
+  async globFiles(filters: string[], include: string[], exclude: string[], cwd: string) {
     const globOptions: fg.Options = {
       absolute: true,
       dot: true,
-      cwd: this.config.dir || this.config.root,
+      cwd,
       ignore: exclude,
     }
 
@@ -626,12 +627,12 @@ export class Vitest {
   }
 
   async globTestFiles(filters: string[] = []) {
-    const { include, exclude, includeSource } = this.config
+    const { include, exclude, includeSource, dir, root } = this.config
 
-    const testFiles = await this.globFiles(filters, include, exclude)
+    const testFiles = await this.globFiles(filters, include, exclude, dir || root)
 
     if (includeSource) {
-      const files = await this.globFiles(filters, includeSource, exclude)
+      const files = await this.globFiles(filters, includeSource, exclude, dir || root)
 
       await Promise.all(files.map(async (file) => {
         try {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -618,7 +618,7 @@ export class Vitest {
     return fg(include, globOptions)
   }
 
-  private _allTestsCache: string[] | null = []
+  private _allTestsCache: string[] | null = null
 
   async globAllTestFiles(config: ResolvedConfig, cwd: string) {
     const { include, exclude, includeSource } = config

--- a/packages/vitest/src/node/create.ts
+++ b/packages/vitest/src/node/create.ts
@@ -28,7 +28,7 @@ export async function createVitest(mode: VitestRunMode, options: UserConfig, vit
   const server = await createServer(mergeConfig(config, mergeConfig(viteOverrides, { root: options.root })))
 
   // optimizer needs .listen() to be called
-  if (ctx.config.api?.port || ctx.config.deps?.experimentalOptimizer)
+  if (ctx.config.api?.port || ctx.config.deps?.experimentalOptimizer?.enabled)
     await server.listen()
   else
     await server.pluginContainer.buildStart({})

--- a/packages/vitest/src/node/create.ts
+++ b/packages/vitest/src/node/create.ts
@@ -27,7 +27,8 @@ export async function createVitest(mode: VitestRunMode, options: UserConfig, vit
 
   const server = await createServer(mergeConfig(config, mergeConfig(viteOverrides, { root: options.root })))
 
-  if (ctx.config.api?.port)
+  // optimizer needs .listen() to be called
+  if (ctx.config.api?.port || ctx.config.deps?.experimentalOptimizer)
     await server.listen()
   else
     await server.pluginContainer.buildStart({})

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -142,19 +142,21 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             }
           }
           else {
-            const entries = await ctx.globFiles([], preOptions.include || [], preOptions.exclude || [], preOptions.dir || getRoot())
+            const entries = await ctx.globTestFiles()
+            optimizeConfig.cacheDir = preOptions.cache?.dir ?? 'node_modules/.vitest'
             optimizeConfig.optimizeDeps = {
-              disabled: false,
+              ...viteConfig.optimizeDeps,
               ...optimizer,
-              entries: [...(optimizer.entries || []), ...entries],
-              exclude: ['vitest', ...(optimizer.exclude || [])],
-              include: (optimizer.include || []).filter((n: string) => n !== 'vitest'),
+              disabled: false,
+              entries: [...(optimizer.entries || viteConfig.optimizeDeps?.entries || []), ...entries],
+              exclude: ['vitest', ...(optimizer.exclude || viteConfig.optimizeDeps?.exclude || [])],
+              include: (optimizer.include || viteConfig.optimizeDeps?.include || []).filter((n: string) => n !== 'vitest'),
             }
             // Vite throws an error that it cannot rename "deps_temp", but optimization still works
             // let's not show this error to users
             const { error: logError } = console
             console.error = (...args) => {
-              if (typeof args[0] === 'string' && args[0].includes('.vite/deps_temp'))
+              if (typeof args[0] === 'string' && args[0].includes('/deps_temp'))
                 return
               return logError(...args)
             }

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -142,7 +142,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             }
           }
           else {
-            const entries = await ctx.globTestFiles()
+            const entries = await ctx.globAllTestFiles(preOptions as ResolvedConfig, preOptions.dir || getRoot())
             optimizeConfig.cacheDir = preOptions.cache?.dir ?? 'node_modules/.vitest'
             optimizeConfig.optimizeDeps = {
               ...viteConfig.optimizeDeps,

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -131,15 +131,22 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
         }
 
         if (!options.browser) {
-          // disable deps optimization
-          Object.assign(config, {
-            cacheDir: undefined,
-            optimizeDeps: {
+          const optimizeConfig: Partial<ViteConfig> = {}
+          if (!preOptions.deps?.experimentalOptimizer) {
+            optimizeConfig.cacheDir = undefined
+            optimizeConfig.optimizeDeps = {
               // experimental in Vite >2.9.2, entries remains to help with older versions
               disabled: true,
               entries: [],
-            },
-          })
+            }
+          }
+          else {
+            optimizeConfig.optimizeDeps = {
+              disabled: false,
+              exclude: ['vitest'],
+            }
+          }
+          Object.assign(config, optimizeConfig)
         }
 
         return config

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -199,8 +199,9 @@ function createChannel(ctx: Vitest) {
         const transformMode = environment === 'happy-dom' || environment === 'jsdom' ? 'web' : 'ssr'
         return ctx.vitenode.fetchModule(id, ctx.config.deps?.experimentalOptimizer ? transformMode : undefined)
       },
-      resolveId(id, importer) {
-        return ctx.vitenode.resolveId(id, importer)
+      resolveId(id, importer, environment) {
+        const transformMode = environment === 'happy-dom' || environment === 'jsdom' ? 'web' : 'ssr'
+        return ctx.vitenode.resolveId(id, importer, ctx.config.deps?.experimentalOptimizer ? transformMode : undefined)
       },
       onPathsCollected(paths) {
         ctx.state.collectPaths(paths)

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -195,8 +195,9 @@ function createChannel(ctx: Vitest) {
         const r = await ctx.vitenode.transformRequest(id)
         return r?.map as RawSourceMap | undefined
       },
-      fetch(id) {
-        return ctx.vitenode.fetchModule(id)
+      fetch(id, environment) {
+        const transformMode = environment === 'happy-dom' || environment === 'jsdom' ? 'web' : 'ssr'
+        return ctx.vitenode.fetchModule(id, ctx.config.deps?.experimentalOptimizer ? transformMode : undefined)
       },
       resolveId(id, importer) {
         return ctx.vitenode.resolveId(id, importer)

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -8,7 +8,7 @@ import { createBirpc } from 'birpc'
 import type { RawSourceMap } from 'vite-node'
 import type { ResolvedConfig, WorkerContext, WorkerRPC, WorkerTestEnvironment } from '../types'
 import { distDir, rootDir } from '../constants'
-import { AggregateError, groupBy } from '../utils'
+import { AggregateError, getEnvironmentTransformMode, groupBy } from '../utils'
 import { envsOrder, groupFilesByEnv } from '../utils/test-helpers'
 import type { Vitest } from './core'
 
@@ -196,12 +196,12 @@ function createChannel(ctx: Vitest) {
         return r?.map as RawSourceMap | undefined
       },
       fetch(id, environment) {
-        const transformMode = environment === 'happy-dom' || environment === 'jsdom' ? 'web' : 'ssr'
-        return ctx.vitenode.fetchModule(id, ctx.config.deps?.experimentalOptimizer ? transformMode : undefined)
+        const transformMode = getEnvironmentTransformMode(ctx.config, environment)
+        return ctx.vitenode.fetchModule(id, transformMode)
       },
       resolveId(id, importer, environment) {
-        const transformMode = environment === 'happy-dom' || environment === 'jsdom' ? 'web' : 'ssr'
-        return ctx.vitenode.resolveId(id, importer, ctx.config.deps?.experimentalOptimizer ? transformMode : undefined)
+        const transformMode = getEnvironmentTransformMode(ctx.config, environment)
+        return ctx.vitenode.resolveId(id, importer, transformMode)
       },
       onPathsCollected(paths) {
         ctx.state.collectPaths(paths)

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -43,10 +43,10 @@ export class VitestExecutor extends ViteNodeRunner {
     return environment === 'node' ? !isNodeBuiltin(id) : !id.startsWith('node:')
   }
 
-  async resolveUrl(id: string, importee?: string) {
-    if (importee && importee.startsWith('mock:'))
-      importee = importee.slice(5)
-    return super.resolveUrl(id, importee)
+  async resolveUrl(id: string, importer?: string) {
+    if (importer && importer.startsWith('mock:'))
+      importer = importer.slice(5)
+    return super.resolveUrl(id, importer)
   }
 
   async dependencyRequest(id: string, fsPath: string, callstack: string[]): Promise<any> {

--- a/packages/vitest/src/runtime/loader.ts
+++ b/packages/vitest/src/runtime/loader.ts
@@ -50,7 +50,7 @@ export const resolve: Resolver = async (url, context, next) => {
 
   const id = normalizeModuleId(url)
   const importer = normalizeModuleId(parentURL)
-  const resolved = await resolver(id, importer)
+  const resolved = await resolver(id, importer, state.ctx.environment.name)
 
   let result: ResolveResult
   let filepath: string

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -50,7 +50,7 @@ async function startViteNode(ctx: WorkerContext) {
 
   const executor = await createVitestExecutor({
     fetchModule(id) {
-      return rpc().fetch(id)
+      return rpc().fetch(id, ctx.environment.name)
     },
     resolveId(id, importer) {
       return rpc().resolveId(id, importer)

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -53,7 +53,7 @@ async function startViteNode(ctx: WorkerContext) {
       return rpc().fetch(id, ctx.environment.name)
     },
     resolveId(id, importer) {
-      return rpc().resolveId(id, importer)
+      return rpc().resolveId(id, importer, ctx.environment.name)
     },
     moduleCache,
     mockMap,

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -68,6 +68,10 @@ export interface InlineConfig {
    */
   deps?: {
     /**
+     * Enable dependency optimization. This can improve the performance of your tests.
+     */
+    experimentalOptimizer?: boolean
+    /**
      * Externalize means that Vite will bypass the package to native Node.
      *
      * Externalized dependencies will not be applied Vite's transformers and resolvers.

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -1,4 +1,4 @@
-import type { AliasOptions, CommonServerOptions } from 'vite'
+import type { AliasOptions, CommonServerOptions, DepOptimizationConfig } from 'vite'
 import type { PrettyFormatOptions } from 'pretty-format'
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
 import type { BuiltinReporters } from '../node/reporters'
@@ -70,7 +70,9 @@ export interface InlineConfig {
     /**
      * Enable dependency optimization. This can improve the performance of your tests.
      */
-    experimentalOptimizer?: boolean
+    experimentalOptimizer?: Omit<DepOptimizationConfig, 'disabled'> & {
+      enabled: boolean
+    }
     /**
      * Externalize means that Vite will bypass the package to native Node.
      *

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -29,7 +29,7 @@ export interface AfterSuiteRunMeta {
 
 export interface WorkerRPC {
   fetch: (id: string, environment: VitestEnvironment) => Promise<FetchResult>
-  resolveId: ResolveIdFunction
+  resolveId: (id: string, importer: string | undefined, environment: VitestEnvironment) => Promise<ViteNodeResolveId | null>
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>
 
   onFinished: (files: File[], errors?: unknown[]) => void

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -1,6 +1,6 @@
 import type { MessagePort } from 'node:worker_threads'
 import type { File, TaskResultPack, Test } from '@vitest/runner'
-import type { FetchFunction, ModuleCacheMap, RawSourceMap, ViteNodeResolveId } from 'vite-node'
+import type { FetchResult, ModuleCacheMap, RawSourceMap, ViteNodeResolveId } from 'vite-node'
 import type { BirpcReturn } from 'birpc'
 import type { MockMap } from './mocker'
 import type { EnvironmentOptions, ResolvedConfig, VitestEnvironment } from './config'
@@ -28,7 +28,7 @@ export interface AfterSuiteRunMeta {
 }
 
 export interface WorkerRPC {
-  fetch: FetchFunction
+  fetch: (id: string, environment: VitestEnvironment) => Promise<FetchResult>
   resolveId: ResolveIdFunction
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>
 

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -1,4 +1,4 @@
-import type { Arrayable, DeepMerge, Nullable } from '../types'
+import type { Arrayable, DeepMerge, Nullable, ResolvedConfig, VitestEnvironment } from '../types'
 
 function isFinalObj(obj: any) {
   return obj === Object.prototype || obj === Function.prototype || obj === RegExp.prototype
@@ -122,4 +122,10 @@ export function stdout(): NodeJS.WriteStream {
   // @ts-expect-error Node.js maps process.stdout to console._stdout
   // eslint-disable-next-line no-console
   return console._stdout || process.stdout
+}
+
+export function getEnvironmentTransformMode(config: ResolvedConfig, environment: VitestEnvironment) {
+  if (!config.deps?.experimentalOptimizer?.enabled)
+    return undefined
+  return environment === 'happy-dom' || environment === 'jsdom' ? 'web' : 'ssr'
 }

--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -62,11 +62,11 @@ export function createMessageEvent(data: any, transferOrOptions: StructuredSeria
 }
 
 export function getRunnerOptions() {
-  const { config, rpc, mockMap, moduleCache } = getWorkerState()
+  const { config, ctx, rpc, mockMap, moduleCache } = getWorkerState()
 
   return {
     fetchModule(id: string) {
-      return rpc.fetch(id)
+      return rpc.fetch(id, ctx.environment.name)
     },
     resolveId(id: string, importer?: string) {
       return rpc.resolveId(id, importer)

--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -69,7 +69,7 @@ export function getRunnerOptions() {
       return rpc.fetch(id, ctx.environment.name)
     },
     resolveId(id: string, importer?: string) {
-      return rpc.resolveId(id, importer)
+      return rpc.resolveId(id, importer, ctx.environment.name)
     },
     moduleCache,
     mockMap,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "vitest/node": ["./packages/vitest/src/node/index.ts"],
       "vitest/config": ["./packages/vitest/src/config.ts"],
       "vitest/browser": ["./packages/vitest/src/browser.ts"],
+      "vitest/runners": ["./packages/vitest/src/runners.ts"],
       "vite-node": ["./packages/vite-node/src/index.ts"],
       "vite-node/client": ["./packages/vite-node/src/client.ts"],
       "vite-node/server": ["./packages/vite-node/src/server.ts"],
@@ -43,8 +44,8 @@
   "exclude": [
     "**/dist/**",
     "./packages/vitest/dist/**",
-    "./packages/vitest/*.d.ts",
-    "./packages/vitest/*.d.cts",
+    "./packages/*/*.d.ts",
+    "./packages/*/*.d.cts",
     "./packages/ui/client/**",
     "./examples/**/*.*",
     "./bench/**",


### PR DESCRIPTION
This PR adds `deps.experimentalOptimizer` option to enable Vite optimizer. It bundles dependencies which makes them faster to import.

Benchmarks on M1 Macbook Air from #579:
Before:
<img width="586" alt="Screenshot 2023-02-24 at 10 38 39" src="https://user-images.githubusercontent.com/16173870/221148580-908f2d73-fe00-47f9-9d52-41f846f8f052.png">
After (notice "collect"):
> First run:
<img width="588" alt="Screenshot 2023-02-24 at 14 19 49" src="https://user-images.githubusercontent.com/16173870/221188575-10b766a7-4fd0-42ce-b40e-04df9d292bea.png">

> Second run:
<img width="587" alt="Screenshot 2023-02-24 at 10 39 05" src="https://user-images.githubusercontent.com/16173870/221148585-8050ba80-7dec-45df-9d75-e7a2c7282d91.png">

There are a few caveats though. The first run will be slower than subsequent runs because we need to wait until dependencies are bundled (it's still faster than without the optimizer). So it's strongly recommended to have a shared cache for `node_modules/.vitest` folder (or the one you specify in `config.cacheDir`) in your CI environment. This optimization works only in `jsdom`/`happy-dom` environments. `node` and `edge` environments use Vite's SSR optimizer.
