### PR TITLE
chore: not inject UIPlugin if disable watch mode

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -62,7 +62,7 @@ export default {
 | `-w, --watch` | Smart & instant watch mode |
 | `-t, --testNamePattern <pattern>` | Run tests with full names matching the pattern |
 | `--dir <path>`| Base directory to scan for the test files |
-| `--ui` | Enable UI |
+| `--ui` | Enable UI, you can use it in watch mode. |
 | `--open` | Open the UI automatically if enabled (default: `true`) |
 | `--api [api]` | Serve API, available options: `--api.port <port>`, `--api.host [host]` and `--api.strictPort` |
 | `--threads` | Enable Threads (default: `true`) |

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -17,7 +17,7 @@ cli
   .option('-w, --watch', 'Enable watch mode')
   .option('-t, --testNamePattern <pattern>', 'Run tests with full names matching the specified regexp pattern')
   .option('--dir <path>', 'Base directory to scan for the test files')
-  .option('--ui', 'Enable UI')
+  .option('--ui', 'Enable UI, you can use it in watch mode')
   .option('--open', 'Open UI automatically (default: !process.env.CI))')
   .option('--api [api]', 'Serve API, available options: --api.port <port>, --api.host [host] and --api.strictPort')
   .option('--threads', 'Enabled threads (default: true)')

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -17,6 +17,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
   const getRoot = () => ctx.config?.root || options.root || process.cwd()
 
   async function UIPlugin() {
+    console.log(options.watch)
     await ensurePackageInstalled('@vitest/ui', getRoot())
     return (await import('@vitest/ui')).default(options.uiBase)
   }
@@ -207,7 +208,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
       : []),
     ...CSSEnablerPlugin(ctx),
     CoverageTransform(ctx),
-    options.ui
+    (options.ui && options.watch !== false)
       ? await UIPlugin()
       : null,
   ]

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -17,7 +17,6 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
   const getRoot = () => ctx.config?.root || options.root || process.cwd()
 
   async function UIPlugin() {
-    console.log(options.watch)
     await ensurePackageInstalled('@vitest/ui', getRoot())
     return (await import('@vitest/ui')).default(options.uiBase)
   }


### PR DESCRIPTION
close: #2897

I run the [reproduction](https://stackblitz.com/edit/vitest-dev-vitest-shyza9?file=package.json) in my local, and found it maybe a little annoying about opening a discounted window when run `vitest run --ui`, so I disable the `UIPlugin` injection in run mode.

I am sorry for I don't really know add which kind of test suits for this.