### PR TITLE
fix(coverage): c8 provider to work when isolate:false

### DIFF
--- a/packages/coverage-c8/src/takeCoverage.ts
+++ b/packages/coverage-c8/src/takeCoverage.ts
@@ -33,6 +33,7 @@ export async function takeCoverage() {
 export function stopCoverage() {
   session.post('Profiler.stopPreciseCoverage')
   session.post('Profiler.disable')
+  session.disconnect()
 }
 
 function filterResult(coverage: Profiler.ScriptCoverage): boolean {

--- a/test/coverage-test/testing.mjs
+++ b/test/coverage-test/testing.mjs
@@ -23,15 +23,19 @@ const configs = [
   }],
 ]
 
-for (const threads of [true, false]) {
-  for (const [directory, config] of configs) {
-    await startVitest('test', [directory], {
-      ...config,
-      update: UPDATE_SNAPSHOTS,
-      threads,
-    })
+for (const threads of [{ threads: true }, { threads: false }, { singleThread: true }]) {
+  for (const isolate of [true, false]) {
+    for (const [directory, config] of configs) {
+      await startVitest('test', [directory], {
+        name: `With settings: ${JSON.stringify({ ...threads, isolate, directory })}`,
+        ...config,
+        update: UPDATE_SNAPSHOTS,
+        ...threads,
+        isolate,
+      })
 
-    if (process.exitCode)
-      process.exit()
+      if (process.exitCode)
+        process.exit()
+    }
   }
 }


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/2928

Added a failing test case by introducing `isolate` into the coverage test configurations. The `{ isolate: false, singleThread: true }` triggers the reported error message.

- [x] Manual regression test with `vuejs/core`. Coverage summary matches 100% between `main` and PR branch.
