### PR TITLE
fix: console log not visible

### DIFF
--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -41,7 +41,11 @@ function withSafeTimers(fn: () => void) {
 
 const promises = new Set<Promise<unknown>>()
 
-export const rpcDone = () => {
+export const rpcDone = async () => {
+  // Run possible setTimeouts, e.g. the onces used by ConsoleLogSpy
+  const { setTimeout } = getSafeTimers()
+  await new Promise(resolve => setTimeout(resolve))
+
   if (!promises.size)
     return
   const awaitable = Array.from(promises)


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/2938

I can reproduce the reported issue 99% of the times when running a local project. The changes of this PR fix the bug completely.

I was chasing this bug with debugger for long time but I think I finally got it. It's some kind of race condition caused by `setTimeout` and `worker_threads` exiting.

ConsoleLogSpy uses `setTimeout` to group users' test cases' `console.log` calls. The `rpcDone` does not flush setTimeout's. It simply exits before `schedule` gets to run the logging. 

https://github.com/vitest-dev/vitest/blob/bce5a9f8a8572805317ec336bb4289d18606679c/packages/vitest/src/runtime/setup.node.ts#L59-L74

https://github.com/vitest-dev/vitest/blob/bce5a9f8a8572805317ec336bb4289d18606679c/packages/vitest/src/runtime/rpc.ts#L44-L49