### PR TITLE
fix(types): use `any` as default value for TArgs in vi.fn()

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -315,7 +315,7 @@ function enhanceSpy<TArgs extends any[], TReturns>(
   return stub as any
 }
 
-export function fn<TArgs extends any[] = any[], R = any>(): Mock<TArgs, R>
+export function fn<TArgs extends any[] = any, R = any>(): Mock<TArgs, R>
 export function fn<TArgs extends any[] = any[], R = any>(
   implementation: (...args: TArgs) => R
 ): Mock<TArgs, R>


### PR DESCRIPTION
```ts
import { vi, type Mocked } from 'vitest';

type Subject = {
	doSomething(x: string): boolean;
};

const mockedSubject: Mocked<Subject> = {
	doSomething: vi.fn().mockReturnValue(true),
};
```

This snippet results in the following error when type checking:
```
error TS2322: Type 'Mock<any[], any>' is not assignable to type 'MockInstance<[x: string], boolean> & ((x: string) => boolean)'.
  Type 'Mock<any[], any>' is not assignable to type 'MockInstance<[x: string], boolean>'.
    The types of 'mockName(...).mock' are incompatible between these types.
      Type 'MockContext<any[], any>' is not assignable to type 'MockContext<[x: string], boolean>'.
        Type 'any[]' is not assignable to type '[x: string]'.
          Target requires 1 element(s) but source may have fewer.

10  doSomething: vi.fn().mockReturnValue(true),
    ~~~~~~~~~~~

  src/my.test.ts:4:2
    4  doSomething(x: string): boolean;
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from property 'doSomething' which is declared here on type 'MockedSubject'
```

This is because `MockedSubject.doSomething` knows that it requires exactly one parameter, but `any[]` (which is the default for `TArgs`) can have fewer.


The equivalent snippet in Jest, when using `jest.Mocked<Subject>` and `jest.fn()` doesn't result in an error, because in Jest the [fn() without arguments returns a `Mock`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/af319cfd1b58be68166cfb117bed37f1e4d45baa/types/jest/index.d.ts#L247-L250), which [has it's parameters initialized to `any` by default](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/af319cfd1b58be68166cfb117bed37f1e4d45baa/types/jest/index.d.ts#L1189-L1192).
This pull request makes the types of `vi.fn()` consistent with the types of `jest.fn()`, by setting the default value of `TArgs` to `any`.