### PR TITLE
docs: add bench command to cli documentation

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -49,6 +49,10 @@ export default {
   '*.{js,ts}': 'vitest related --run',
 }
 ```
+
+### `vitest bench`
+
+Run only [benchmark](https://vitest.dev/guide/features.html#benchmarking-experimental) tests, which compare performance results.
 :::
 
 ## Options

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -49,11 +49,11 @@ export default {
   '*.{js,ts}': 'vitest related --run',
 }
 ```
+:::
 
 ### `vitest bench`
 
 Run only [benchmark](https://vitest.dev/guide/features.html#benchmarking-experimental) tests, which compare performance results.
-:::
 
 ## Options
 

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -37,7 +37,6 @@ export function createPool(ctx: Vitest): ProcessPool {
           suppressLoaderWarningsPath,
           '--experimental-loader',
           loaderPath,
-          ...execArgv,
         ]
       : [
           ...execArgv,


### PR DESCRIPTION
Adds [bench](https://vitest.dev/guide/features.html#benchmarking-experimental) command to [CLI](https://vitest.dev/guide/cli.html#commands) documentation.

Closes #2807 