### PR TITLE
chore: use node: protocol when importing built-in modules

### DIFF
--- a/packages/browser/scripts/copy-ui-to-browser.ts
+++ b/packages/browser/scripts/copy-ui-to-browser.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from 'url'
-import fs from 'fs'
+import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
 import { resolve } from 'pathe'
 import fg from 'fast-glob'
 

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -1,7 +1,7 @@
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 // eslint-disable-next-line no-restricted-imports
-import { resolve } from 'path'
-import { builtinModules } from 'module'
+import { resolve } from 'node:path'
+import { builtinModules } from 'node:module'
 import { polyfillPath } from 'modern-node-polyfills'
 import sirv from 'sirv'
 import type { Plugin } from 'vite'

--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -1,5 +1,5 @@
-import { existsSync, promises as fs } from 'fs'
-import _url from 'url'
+import { existsSync, promises as fs } from 'node:fs'
+import _url from 'node:url'
 import type { Profiler } from 'inspector'
 import { extname, resolve } from 'pathe'
 import c from 'picocolors'

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-imports */
-import { existsSync, promises as fs } from 'fs'
+import { existsSync, promises as fs } from 'node:fs'
 import { relative, resolve } from 'pathe'
 import type { TransformPluginContext } from 'rollup'
 import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, ReportContext, ResolvedCoverageOptions, Vitest } from 'vitest'

--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import { resolve } from 'pathe'
 import sirv from 'sirv'
 import type { Plugin } from 'vite'

--- a/packages/utils/src/display.ts
+++ b/packages/utils/src/display.ts
@@ -1,4 +1,4 @@
-import util from 'util'
+import util from 'node:util'
 // @ts-expect-error doesn't have types
 import loupeImport from 'loupe'
 

--- a/packages/vitest/src/node/cli-wrapper.ts
+++ b/packages/vitest/src/node/cli-wrapper.ts
@@ -2,7 +2,7 @@
 /**
  * Wrapper of the CLI with child process to manage segfaults and retries.
  */
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import c from 'picocolors'
 import { execa } from 'execa'
 import { EXIT_CODE_RESTART } from '../constants'

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prefer-template */
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { normalize, relative } from 'pathe'
 import c from 'picocolors'
 import cliTruncate from 'cli-truncate'

--- a/packages/vitest/src/node/sequencers/BaseSequencer.ts
+++ b/packages/vitest/src/node/sequencers/BaseSequencer.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto'
+import { createHash } from 'node:crypto'
 import { resolve } from 'pathe'
 import { slash } from 'vite-node/utils'
 import type { Vitest } from '../core'

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -1,4 +1,4 @@
-import readline from 'readline'
+import readline from 'node:readline'
 import c from 'picocolors'
 import prompt from 'prompts'
 import { isWindows, stdout } from '../utils'

--- a/scripts/update-examples.ts
+++ b/scripts/update-examples.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from 'url'
-import { promises as fs } from 'fs'
+import { fileURLToPath } from 'node:url'
+import { promises as fs } from 'node:fs'
 import { basename, dirname, resolve } from 'pathe'
 import fg from 'fast-glob'
 import { notNullish } from '../packages/vitest/src/utils'


### PR DESCRIPTION
`import fs from 'fs'`


->

`import fs from 'node:fs'`