### PR TITLE
fix: remove duplicate execArgv when deps.registerNodeLoader: true

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -37,7 +37,6 @@ export function createPool(ctx: Vitest): ProcessPool {
           suppressLoaderWarningsPath,
           '--experimental-loader',
           loaderPath,
-          ...execArgv,
         ]
       : [
           ...execArgv,


### PR DESCRIPTION
`execArgv` is spread twice. Likely caused by a merge conflict during #2772.

@sheremet-va was this change intentional https://github.com/vitest-dev/vitest/commit/7bf54505a127b976c7e69cbec25cbb2c5bc6219e#diff-c381e6de43a918512ead544ce9b936666a7066fdfddd83c19221b433a01e4ee4R33-R45?

```diff
- ...conditions,
+ ...execArgv,
```

Should this be `...conditions` instead?