### PR TITLE
fix: prevent running test cases timers after environment teardown

### DIFF
--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -42,10 +42,6 @@ function withSafeTimers(fn: () => void) {
 const promises = new Set<Promise<unknown>>()
 
 export const rpcDone = async () => {
-  // Run possible setTimeouts, e.g. the onces used by ConsoleLogSpy
-  const { setTimeout } = getSafeTimers()
-  await new Promise(resolve => setTimeout(resolve))
-
   if (!promises.size)
     return
   const awaitable = Array.from(promises)

--- a/packages/vitest/src/runtime/setup.node.ts
+++ b/packages/vitest/src/runtime/setup.node.ts
@@ -183,6 +183,10 @@ export async function withEnv(
     await fn()
   }
   finally {
+    // Run possible setTimeouts, e.g. the onces used by ConsoleLogSpy
+    const { setTimeout } = getSafeTimers()
+    await new Promise(resolve => setTimeout(resolve))
+
     await env.teardown(globalThis)
   }
 }

--- a/test/core/test/dom.test.ts
+++ b/test/core/test/dom.test.ts
@@ -171,3 +171,19 @@ it('doesn\'t throw, if listening for error', () => {
   dispatchEvent(new Event('custom'))
   expect(spy).toHaveBeenCalled()
 })
+
+it('timers are not run after environment teardown', async () => {
+  setInterval(() => {
+    try {
+      window.document.createElement('div')
+    }
+    catch (err) {
+      if (/window is not defined/.test((err as any).message))
+        throw new Error('setInterval was called after environment teardown')
+
+      throw err
+    }
+  }, 1)
+
+  expect(window.document).toBeDefined()
+})

--- a/test/watch/test/stdout.test.ts
+++ b/test/watch/test/stdout.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { afterEach, expect, test } from 'vitest'
+
+import { startWatchMode, waitFor } from './utils'
+
+const testFile = 'fixtures/math.test.ts'
+const testFileContent = readFileSync(testFile, 'utf-8')
+
+afterEach(() => {
+  writeFileSync(testFile, testFileContent, 'utf8')
+})
+
+test('console.log is visible on test re-run', async () => {
+  const vitest = await startWatchMode()
+  const testCase = `
+test('test with logging', () => {
+  console.log('First')
+  console.log('Second')
+  console.log('Third')
+  expect(true).toBe(true)
+})
+`
+
+  writeFileSync(testFile, `${testFileContent}${testCase}`, 'utf8')
+
+  await waitFor(() => {
+    expect(vitest.getOutput()).toMatch('stdout | math.test.ts > test with logging')
+    expect(vitest.getOutput()).toMatch('First')
+    expect(vitest.getOutput()).toMatch('Second')
+    expect(vitest.getOutput()).toMatch('Third')
+  })
+})


### PR DESCRIPTION
- Fixes cases where test cases `setTimeout` and `setInterval` could run after environment's teardown was already run
- This bug is only in `main` branch and is not part of any Vitest release. Caused by https://github.com/vitest-dev/vitest/pull/2943.
- Adds test case for #2943

When test run has finished and test environment (jsdom, happydom, custom...) has run its teardown, the `setInterval` and `setTimeout` set by tests may still be running. This was seen on CI where React's 16ms batch runs occasionally ran after JSDOM's `window.close()` was called.

<details>
  <summary>Example error log from CI</summary>
  
```
 ✓ __tests__/Home.test.tsx  (1 test) 225ms
stderr | unknown test
Warning: React has detected a change in the order of Hooks called by Image. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks
   Previous render            Next render
   ------------------------------------------------------
1. useContext                 useContext
2. useMemo                    useMemo
3. useState                   useState
4. useRef                     useRef
5. useState                   useState
6. useState                   useState
7. useCallback                useCallback
8. useCallback                useCallback
9. useEffect                  useEffect
10. useEffect                 useEffect
11. useRef                    useRef
12. useRef                    useRef
13. useEffect                 useEffect
14. useLayoutEffect           useEffect
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    at Image (/home/runner/work/vitest/vitest/node_modules/.pnpm/next@12.1.5_zpnidt7m3osuk7shl3s4oenomq/node_modules/next/dist/client/image.js:14:11)
    at span
    at a
    at footer
    at main
    at Home
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  15:43:51
   Duration  2.36s (transform 191ms, setup 0ms, collect 513ms, tests 225ms)
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
ReferenceError: window is not defined
 ❯ getActiveElementDeep ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:8412:13
 ❯ getSelectionInformation ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:8446:21
 ❯ prepareForCommit ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:10887:26
 ❯ commitBeforeMutationEffects ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:22778:27
 ❯ commitRootImpl ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:26629:45
 ❯ commitRoot ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:26517:5
 ❯ finishConcurrentRender ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:25820:9
 ❯ performConcurrentWorkOnRoot ../../node_modules/.pnpm/react-dom@18.0.0_react@18.0.0/node_modules/react-dom/cjs/react-dom.development.js:25648:7
 ❯ workLoop ../../node_modules/.pnpm/scheduler@0.21.0/node_modules/scheduler/cjs/scheduler.development.js:266:34
 ❯ flushWork ../../node_modules/.pnpm/scheduler@0.21.0/node_modules/scheduler/cjs/scheduler.development.js:239:14
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Failed
```

</details>


Minimal repro for current (a1954cc0de1f3ea6f60ea3e17a082cf795e09d52) `main`:

```ts
test("testing", async () => {
  setInterval(() => {
    globalThis.window.document.createElement("div");
  }, 1);

  expect(window.document).toBeTruthy();
});
```

<details>
  <summary>Test logs</summary>
  
```
 ✓ test/example.test.ts (1)
   ✓ testing

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  14:00:22
   Duration  8ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: Cannot read properties of undefined (reading 'document')
 ❯ Timeout._onTimeout test/example.test.ts:11:23
      9| 
     10|   setInterval(() => {
     11|     globalThis.window.document.createElement("div");
       |                       ^
     12|   }, 1);
     13| 
 ❯ listOnTimeout node:internal/timers:569:17
 ❯ processTimers node:internal/timers:512:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

</details>


But in long term I think Vitest should be intercepting the `setTimeout` and `setInterval` calls and collect the returned IDs. Once tests have finished running, those IDs should be used for manual clean up using `clearTimeout` etc.
Otherwise we'll need to be careful not to use any `setTimeout` in code that is run between `environment.teardown` and worker termination. 