### PR TITLE
fix!: only support Node.js 14.18.0 or newer

### DIFF
--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -67,7 +67,7 @@
     "*.mjs"
   ],
   "engines": {
-    "node": ">=v14.16.0"
+    "node": ">=v14.18.0"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -86,7 +86,7 @@
     "*.cjs"
   ],
   "engines": {
-    "node": ">=v14.16.0"
+    "node": ">=v14.18.0"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -30,7 +30,7 @@
     "*.mjs"
   ],
   "engines": {
-    "node": ">=v14.16.0"
+    "node": ">=v14.18.0"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",


### PR DESCRIPTION
BREAKING CHANGE: Node.js 14.16.0 and 14.17.0 are not supported anymore.

Vite only supports 14.18.0 as minimum as discussed [here](https://github.com/vitejs/vite/pull/12332)

Fixes #2956 