### PR TITLE
fix: config errors not visible

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -38,6 +38,10 @@ export async function printError(error: unknown, ctx: Vitest, options: PrintErro
     } as any
   }
 
+  // Error may have occured even before the configuration was resolved
+  if (!ctx.config)
+    return printErrorMessage(e, ctx.logger)
+
   const stacks = parseErrorStacktrace(e, fullStack)
 
   const nearest = error instanceof TypeCheckError

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -233,7 +233,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             (await import('../../api/setup')).setup(ctx)
         }
         catch (err) {
-          ctx.logger.printError(err, true)
+          await ctx.logger.printError(err, true)
           process.exit(1)
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,18 @@ importers:
       temp-dir: 2.0.0
       vitest: link:../../packages/vitest
 
+  test/config:
+    specifiers:
+      execa: ^7.0.0
+      strip-ansi: ^7.0.1
+      vite: ^4.0.0
+      vitest: workspace:*
+    devDependencies:
+      execa: 7.0.0
+      strip-ansi: 7.0.1
+      vite: 4.0.0
+      vitest: link:../../packages/vitest
+
   test/core:
     specifiers:
       '@vitest/expect': workspace:*

--- a/test/config/fixtures/test/example.test.ts
+++ b/test/config/fixtures/test/example.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('it works', () => {
+  expect(true).toBe(true)
+})

--- a/test/config/package.json
+++ b/test/config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vitest/test-config",
+  "private": true,
+  "scripts": {
+    "test": "vitest run test/**"
+  },
+  "devDependencies": {
+    "execa": "^7.0.0",
+    "strip-ansi": "^7.0.1",
+    "vite": "latest",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+
+import { runVitest } from './utils'
+
+test('shard cannot be used with watch mode', async () => {
+  const { error } = await runVitest('watch', ['--shard', '1/2'])
+
+  expect(error).toMatch('Error: You cannot use --shard option with enabled watch')
+})
+
+test('shard must be positive number', async () => {
+  const { error } = await runVitest('run', ['--shard', '"-1"'])
+
+  expect(error).toMatch('Error: --shard <count> must be a positive number')
+})
+
+test('shard index must be smaller than count', async () => {
+  const { error } = await runVitest('run', ['--shard', '2/1'])
+
+  expect(error).toMatch('Error: --shard <index> must be a positive number less then <count>')
+})

--- a/test/config/test/utils.ts
+++ b/test/config/test/utils.ts
@@ -1,0 +1,15 @@
+import { execa } from 'execa'
+import stripAnsi from 'strip-ansi'
+
+export async function runVitest(mode: 'run' | 'watch', cliArguments: string[]) {
+  const subprocess = execa('vitest', [mode, 'fixtures/test/', ...cliArguments])
+  let error = ''
+
+  subprocess.stderr?.on('data', (data) => {
+    error += stripAnsi(data.toString())
+  })
+
+  await new Promise(resolve => subprocess.on('exit', resolve))
+
+  return { error }
+}


### PR DESCRIPTION
- Preparation for https://github.com/vitest-dev/vitest/pull/2983#discussion_r1130697960

Minimal repro with `0.29.2` to show the silent fail:

```sh
$ pnpm run watch --shard 1/2

> example-project@1.0.0 watch /x/vitest-example-project
> vitest watch "--shard" "1/2"

 ELIFECYCLE  Command failed with exit code 1.
```

With fix:

```sh
 $ pnpm run watch --shard 1/2

> example-project@1.0.0 watch /x/vitest-example-project
> vitest watch "--shard" "1/2"

Error: You cannot use --shard option with enabled watch
 ELIFECYCLE  Command failed with exit code 1.
```

