### PR TITLE
doc(mocking/date): add caution on useFakeTimers

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -343,6 +343,11 @@ const mock = vi.fn(() => console.log('executed'))
 
 describe('delayed execution', () => {
   beforeEach(() => {
+    // Note: callng useFakeTimers can causes async function to hang
+    // Don't put this line if you only need to mock the date but not the timer,
+    // References:
+    // - https://github.com/vitest-dev/vitest/pull/639
+    // - https://github.com/vitest-dev/vitest/issues/621
     vi.useFakeTimers()
   })
   afterEach(() => {


### PR DESCRIPTION
I faced the same issue today when I followed the code in the doc, and then my tests started to hang; it took me some time to figure out that `useFakeTimers` was the culprit.