### PR TITLE
perf(reporters): overall improvements

### DIFF
--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -101,8 +101,8 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('  ')
 }
 
-export function renderTree(tasks: Task[], options: ListRendererOptions, level = 0) {
-  let output: string[] = []
+export function renderTree(tasks: Task[], options: ListRendererOptions, level = 0): string {
+  const output: string[] = []
 
   let idx = 0
   for (const task of tasks) {
@@ -154,7 +154,7 @@ export function renderTree(tasks: Task[], options: ListRendererOptions, level = 
 
     if (task.type === 'suite' && task.tasks.length > 0) {
       if (task.result?.state)
-        output = output.concat(renderTree(task.tasks, options, level + 1))
+        output.push(renderTree(task.tasks, options, level + 1))
     }
     idx++
   }


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/2602

Reduces the workload of expensive `renderTree` by bailing out once enough lines to fill the screen has been constructed. I think this fixes #2602 completely as `wrap-ansi` and related dependencies of `log-update` are not called that much anymore. The [`log-update` already limits the printed rows to fit the screen](https://github.com/sindresorhus/log-update/blob/91822b659b249238602e8a69394fdcef63231f5c/index.js#L20-L33) but as it's using `slice-ansi` for this it is slow. We can help it by reducing the passed rows ourselves as we already know "what makes a row" and don't need to care about ANSIs when reducing the rows.  

Using the reproduction case from https://github.com/vitest-dev/vitest/issues/579#issuecomment-1462503600 as reference with Apple M2 Air:

- Vitest `0.29.2` with `--isolate false`: 5667.68s
- Jest without Babel: 46.271s
- Vitest with PR fix applied and `--isolate false`: 7.98s 
- Vitest with PR fix applied, `--isolate false` and latest `vite`: 4.63s

Before:
![image](https://user-images.githubusercontent.com/14806298/224672813-469decd8-a899-4c60-9aea-781731239ab0.png)

After:
![image](https://user-images.githubusercontent.com/14806298/224672979-663b4518-c8ed-49bb-8ec1-6d6559ce9a9f.png)


In the __After__ picture its seen that there is a performance issue on Vite's side. I'm working on fixing that one and with my current WIP changes the tests run 2.7s faster, in 5.25s with the fix applied. 
![image](https://user-images.githubusercontent.com/14806298/224674371-a209d14b-f92a-4f40-a35c-29665171567d.png)


Before merging:
- [x] More manual testing
- [x] Check other test reporters as well, e.g. `dot`