### PR TITLE
feat: `--test-timeout` CLI argument

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -536,6 +536,7 @@ This can improve performance in some cases, but might cause segfault in older No
 
 - **Type:** `number`
 - **Default:** `5000`
+- **CLI:** `--test-timeout=5000`
 
 Default timeout of a test in milliseconds
 

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -4,6 +4,10 @@ title: Debugging | Guide
 
 # Debugging
 
+:::tip
+When debugging tests you might want to use `--test-timeout` CLI argument to prevent tests from timing out when stopping at breakpoints.
+:::
+
 ## VSCode
 
 Quick way to debug tests in VSCode is via `JavaScript Debug Terminal`. Open a new `JavaScript Debug Terminal` and run `npm run test` or `vitest` directly. *this works with any code ran in Node, so will work with most JS testing frameworks*

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -48,6 +48,7 @@ cli
   .option('--no-color', 'Removes colors from the console output')
   .option('--inspect', 'Enable Node.js inspector')
   .option('--inspect-brk', 'Enable Node.js inspector with break')
+  .option('--test-timeout <time>', 'Default timeout of a test in milliseconds (default: 5000)')
   .help()
 
 cli


### PR DESCRIPTION
- Closes https://github.com/vitest-dev/vitest/issues/1771

Exposes `testTimeout` configuration option to be configured via CLI, e.g. `vitest run --test-timeout=50000`.