### PR TITLE
fix: show correct line numbers in stack trace when using vi.resetModules()

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -92,6 +92,14 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     return this.deleteByModuleId(this.normalizePath(fsPath))
   }
 
+  invalidateModule(mod: ModuleCache) {
+    delete mod.evaluated
+    delete mod.resolving
+    delete mod.promise
+    delete mod.exports
+    return true
+  }
+
   /**
    * Invalidate modules that dependent on the given modules, up to the main entry
    */

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -31,10 +31,10 @@ export function resetModules(modules: ModuleCacheMap, resetMocks = false) {
     // don't clear mocks
     ...(!resetMocks ? [/^mock:/] : []),
   ]
-  modules.forEach((_, path) => {
+  modules.forEach((mod, path) => {
     if (skipPaths.some(re => re.test(path)))
       return
-    modules.delete(path)
+    modules.invalidateModule(mod)
   })
 }
 

--- a/test/stacktraces/fixtures/reset-modules.test.ts
+++ b/test/stacktraces/fixtures/reset-modules.test.ts
@@ -1,0 +1,18 @@
+import { assert, describe, expect, it, vi } from 'vitest'
+
+describe('suite name', () => {
+  it('foo', () => {
+    vi.resetModules()
+    // a comment here
+    // another comment
+    // another comment
+    // another comment
+    // another comment
+    // another comment
+    // this will mess up the stacktrace lines
+    expect(1 + 1).eq(2)
+    expect(2 + 1).eq(3)
+    assert.equal(Math.sqrt(4), 2)
+    expect(Math.sqrt(4)).toBe(1)
+  })
+})

--- a/test/stacktraces/test/__snapshots__/runner.test.ts.snap
+++ b/test/stacktraces/test/__snapshots__/runner.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`stacktraces should pick error frame if present > frame.spec.imba > frame.spec.imba 1`] = `
 " FAIL  frame.spec.imba [ frame.spec.imba ]
@@ -41,5 +41,16 @@ exports[`stacktraces should respect sourcemaps > add-in-js.test.js > add-in-js.t
        |                 ^
       7|   expect(add(1)).toBe(1)
       8|   return expect(add(1, 2, 3)).toBe(6)
+"
+`;
+
+exports[`stacktraces should respect sourcemaps > reset-modules.test.ts > reset-modules.test.ts 1`] = `
+" ❯ reset-modules.test.ts:16:26
+     14|     expect(2 + 1).eq(3)
+     15|     assert.equal(Math.sqrt(4), 2)
+     16|     expect(Math.sqrt(4)).toBe(1)
+       |                          ^
+     17|   })
+     18| })
 "
 `;


### PR DESCRIPTION
Fixes #3001