### PR TITLE
fix: handle cloning proxied classes w/ enumerable getters

### DIFF
--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -88,7 +88,7 @@ export function clone<T>(val: T, seen: WeakMap<any, any>): T {
     const props = getOwnProperties(val)
     for (const k of props) {
       Object.defineProperty(out, k, {
-        ...Object.getOwnPropertyDescriptor(val, k),
+        enumerable: true,
         value: clone((val as any)[k], seen),
       })
     }

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -86,8 +86,12 @@ export function clone<T>(val: T, seen: WeakMap<any, any>): T {
     seen.set(val, out)
     // we don't need properties from prototype
     const props = getOwnProperties(val)
-    for (const k of props)
-      out[k] = clone((val as any)[k], seen)
+    for (const k of props) {
+      Object.defineProperty(out, k, {
+        ...Object.getOwnPropertyDescriptor(val, k),
+        value: clone((val as any)[k], seen),
+      })
+    }
     return out
   }
 

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -87,10 +87,24 @@ export function clone<T>(val: T, seen: WeakMap<any, any>): T {
     // we don't need properties from prototype
     const props = getOwnProperties(val)
     for (const k of props) {
-      Object.defineProperty(out, k, {
-        enumerable: true,
-        value: clone((val as any)[k], seen),
-      })
+      const descriptor = Object.getOwnPropertyDescriptor(val, k)
+      if (!descriptor)
+        continue
+      const cloned = clone((val as any)[k], seen)
+      if ('get' in descriptor) {
+        Object.defineProperty(out, k, {
+          ...descriptor,
+          get() {
+            return cloned
+          },
+        })
+      }
+      else {
+        Object.defineProperty(out, k, {
+          ...descriptor,
+          value: cloned,
+        })
+      }
     }
     return out
   }

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -152,9 +152,10 @@ describe('deepClone', () => {
 
   test('can clone classes with proxied enumerable getters', () => {
     const obj = Symbol.for('aClass')
+    interface TestShape { a: number; b: string }
     class A {
-      [obj]: { a: number; b: string }
-      constructor(data: { a: number; b: string }) {
+      [obj]: TestShape
+      constructor(data: TestShape) {
         this[obj] = data
         return new Proxy(this, {
           ownKeys() {
@@ -164,7 +165,6 @@ describe('deepClone', () => {
             return {
               ...Reflect.getOwnPropertyDescriptor(data, p),
               enumerable: true,
-              writable: false,
             }
           },
         })
@@ -178,7 +178,13 @@ describe('deepClone', () => {
         return this[obj].b
       }
     }
-    const aClass = new A({ a: 1, b: 'B' })
+    const shape = { a: 1 } as TestShape
+    Object.defineProperty(shape, 'b', {
+      configurable: true,
+      enumerable: true,
+      get: () => 'B',
+    })
+    const aClass = new A(shape)
     expect(aClass.a).toEqual(1)
     expect(aClass.b).toEqual('B')
     expect(Object.keys(aClass)).toEqual(['a', 'b'])


### PR DESCRIPTION
Fixes a very, very edge case I ran into with Vitest's `clone`, where a class is proxied in a way that exposes its getters as enumerable properties.

```ts
const dataSym = Symbol.for('MyClass.data')

class MyClass {
  constructor(obj) {
    this[dataSym] = obj
    return new Proxy(this, {
      ownKeys() {
        return Reflect.ownKeys(obj);
      },
      getOwnPropertyDescriptor(target, p) {
        return {
          ...Reflect.getOwnPropertyDescriptor(obj, p),
          enumerable: true,
        };
      }
    });
  }
  
  get a() {
    return this[dataSym].a
  }
  
  get b() {
    return this[dataSym].b    
  }
}
```

```ts
deepClone(new MyClass({a: 1, b: 2}))
```

Previously:

```
TypeError: Cannot set property a of #<MyClass> which has only a getter
```

New Behavior: clones properly