### PR TITLE
chore: fix typescript performance

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -133,7 +133,7 @@ export class Vitest {
   }
 
   getSerializableConfig() {
-    return deepMerge<ResolvedConfig>({
+    return deepMerge({
       ...this.config,
       reporters: [],
       deps: {
@@ -154,7 +154,7 @@ export class Vitest {
       benchmark: {
         ...this.config.benchmark,
         reporters: [],
-      } as ResolvedConfig['benchmark'],
+      },
     },
     this.configOverride || {} as any,
     ) as ResolvedConfig

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -38,7 +38,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
       options() {
         this.meta.watchMode = false
       },
-      async config(viteConfig: any) {
+      async config(viteConfig) {
         if (options.watch) {
           // Earlier runs have overwritten values of the `options`.
           // Reset it back to initial user config before setting up the server again.
@@ -49,7 +49,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
         // however to allow vitest plugins to modify vitest config values
         // this is repeated in configResolved where the config is final
         const preOptions = deepMerge(
-          {},
+          {} as UserConfig,
           configDefaults,
           options,
           removeUndefinedValues(viteConfig.test ?? {}),
@@ -130,7 +130,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
           },
         }
 
-        const classNameStrategy = preOptions.css && preOptions.css?.modules?.classNameStrategy
+        const classNameStrategy = (typeof preOptions.css !== 'boolean' && preOptions.css?.modules?.classNameStrategy) || 'stable'
 
         if (classNameStrategy !== 'scoped') {
           config.css ??= {}
@@ -164,12 +164,13 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
               )
               entries.push(...setupFiles)
             }
-            optimizeConfig.cacheDir = preOptions.cache?.dir ?? 'node_modules/.vitest'
+            const cacheDir = preOptions.cache !== false ? preOptions.cache?.dir : null
+            optimizeConfig.cacheDir = cacheDir ?? 'node_modules/.vitest'
             optimizeConfig.optimizeDeps = {
               ...viteConfig.optimizeDeps,
               ...optimizer,
               disabled: false,
-              entries: [...(optimizer.entries || viteConfig.optimizeDeps?.entries || []), ...entries],
+              entries: [...(viteConfig.optimizeDeps?.entries || []), ...entries],
               exclude: ['vitest', ...builtinModules, ...(optimizer.exclude || viteConfig.optimizeDeps?.exclude || [])],
               include: (optimizer.include || viteConfig.optimizeDeps?.include || []).filter((n: string) => n !== 'vitest'),
             }

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -5,21 +5,6 @@ export type Nullable<T> = T | null | undefined
 export type Arrayable<T> = T | Array<T>
 export type ArgumentsType<T> = T extends (...args: infer U) => any ? U : never
 
-export type MergeInsertions<T> =
-  T extends object
-    ? { [K in keyof T]: MergeInsertions<T[K]> }
-    : T
-
-export type DeepMerge<F, S> = MergeInsertions<{
-  [K in keyof F | keyof S]: K extends keyof S & keyof F
-    ? DeepMerge<F[K], S[K]>
-    : K extends keyof S
-      ? S[K]
-      : K extends keyof F
-        ? F[K]
-        : never;
-}>
-
 export type MutableArray<T extends readonly any[]> = { -readonly [k in keyof T]: T[k] }
 
 export interface Constructable {

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -1,4 +1,4 @@
-import type { Arrayable, DeepMerge, Nullable, ResolvedConfig, VitestEnvironment } from '../types'
+import type { Arrayable, Nullable, ResolvedConfig, VitestEnvironment } from '../types'
 
 function isFinalObj(obj: any) {
   return obj === Object.prototype || obj === Function.prototype || obj === RegExp.prototype
@@ -89,7 +89,7 @@ export function isObject(item: unknown): boolean {
  *
  * Will merge objects only if they are plain
  */
-export function deepMerge<T extends object = object, S extends object = T>(target: T, ...sources: S[]): DeepMerge<T, S> {
+export function deepMerge<T extends object = object>(target: T, ...sources: any[]): T {
   if (!sources.length)
     return target as any
 
@@ -98,7 +98,7 @@ export function deepMerge<T extends object = object, S extends object = T>(targe
     return target as any
 
   if (isMergeableObject(target) && isMergeableObject(source)) {
-    (Object.keys(source) as (keyof S & keyof T)[]).forEach((key) => {
+    (Object.keys(source) as (keyof T)[]).forEach((key) => {
       if (isMergeableObject(source[key])) {
         if (!target[key])
           target[key] = {} as any

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -88,6 +88,8 @@ export function isObject(item: unknown): boolean {
  * Deep merge :P
  *
  * Will merge objects only if they are plain
+ *
+ * Do not merge types - it is very expensive and usually it's better to case a type here
  */
 export function deepMerge<T extends object = object>(target: T, ...sources: any[]): T {
   if (!sources.length)

--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -61,7 +61,7 @@ export function createMessageEvent(data: any, transferOrOptions: StructuredSeria
   }
 }
 
-export function getRunnerOptions() {
+export function getRunnerOptions(): any {
   const { config, ctx, rpc, mockMap, moduleCache } = getWorkerState()
 
   return {


### PR DESCRIPTION
I noticed we have a poor TS performance in the repo for quite some time now. I decided to check the performance on PC with 64GB, and it took a few seconds to update autocomplete 👀 

`tsc --generateTrace` showed that `deepMerge` takes _a lot of_ time to process in the `pools/child.ts` file:

![image](https://user-images.githubusercontent.com/16173870/226145607-3dd28e15-b46c-45ac-b02f-1a6af5fdb2aa.png)

Now it's a lot better:

![image](https://user-images.githubusercontent.com/16173870/226145626-7597b9dd-50ed-40d1-b018-64623cd39afa.png)

We don't really use the `deepMerge` type merging, so I decided to just remove it.