### PR TITLE
feat: process timeout to log names of stuck test files

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -137,7 +137,7 @@
     "std-env": "^3.3.1",
     "strip-literal": "^1.0.0",
     "tinybench": "^2.3.1",
-    "tinypool": "^0.3.1",
+    "tinypool": "^0.4.0",
     "tinyspy": "^1.0.2",
     "vite": "^3.0.0 || ^4.0.0",
     "vite-node": "workspace:*",

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -597,6 +597,7 @@ export class Vitest {
     setTimeout(() => {
       this.report('onProcessTimeout').then(() => {
         console.warn(`close timed out after ${this.config.teardownTimeout}ms`)
+        this.state.getProcessTimeoutCauses().forEach(cause => console.warn(cause))
         process.exit()
       })
     }, this.config.teardownTimeout).unref()

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -54,6 +54,8 @@ export function createThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessOpt
 
     env,
     execArgv,
+
+    terminateTimeout: ctx.config.teardownTimeout,
   }
 
   if (ctx.config.isolate) {
@@ -86,6 +88,13 @@ export function createThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessOpt
       }
       try {
         await pool.run(data, { transferList: [workerPort], name })
+      }
+      catch (error) {
+        // Worker got stuck and won't terminate - this may cause process to hang
+        if (error instanceof Error && /Failed to terminate worker/.test(error.message))
+          ctx.state.addProcessTimeoutCause(`Failed to terminate worker while running ${files.join(', ')}.`)
+        else
+          throw error
       }
       finally {
         port.close()

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -22,6 +22,7 @@ export class StateManager {
   idMap = new Map<string, Task>()
   taskFileMap = new WeakMap<Task, File>()
   errorsSet = new Set<unknown>()
+  processTimeoutCauses = new Set<string>()
 
   catchError(err: unknown, type: string): void {
     if (isAggregateError(err))
@@ -37,6 +38,14 @@ export class StateManager {
 
   getUnhandledErrors() {
     return Array.from(this.errorsSet.values())
+  }
+
+  addProcessTimeoutCause(cause: string) {
+    this.processTimeoutCauses.add(cause)
+  }
+
+  getProcessTimeoutCauses() {
+    return Array.from(this.processTimeoutCauses.values())
   }
 
   getPaths() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,7 +890,7 @@ importers:
       strip-ansi: ^7.0.1
       strip-literal: ^1.0.0
       tinybench: ^2.3.1
-      tinypool: ^0.3.1
+      tinypool: ^0.4.0
       tinyspy: ^1.0.2
       typescript: ^4.9.4
       vite: ^4.0.0
@@ -917,7 +917,7 @@ importers:
       std-env: 3.3.1
       strip-literal: 1.0.0
       tinybench: 2.3.1
-      tinypool: 0.3.1
+      tinypool: 0.4.0
       tinyspy: 1.0.2
       vite: 4.0.0_@types+node@18.7.13
       vite-node: link:../vite-node
@@ -20168,8 +20168,8 @@ packages:
     resolution: {integrity: sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==}
     dev: false
 
-  /tinypool/0.3.1:
-    resolution: {integrity: sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==}
+  /tinypool/0.4.0:
+    resolution: {integrity: sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==}
     engines: {node: '>=14.0.0'}
     dev: false
 


### PR DESCRIPTION
- Related to #2008
- Enabled in https://github.com/tinylibs/tinypool/issues/49

Include names of the test files that prevent Worker from terminating. This will help users to identify which test files are causing their Vitest process to hang. **This does not fix** process hangs but just helps debugging them. 

For example with `trpc` repository there are two test cases which can make the process hang. If these two test cases are excluded from the test run, the process never hangs. I'm not familiar with trpc's codebase but I was able to spot that those two test cases are the only ones that use Miniflare which could be the root cause (?) in their case. Ideally this feature would allow users to spot these kind of differences from their test cases and narrow down the root cause. 

Example log from trpc repository:

```
 Test Files  124 passed (124)
      Tests  613 passed | 2 skipped (615)
   Start at  10:06:39
   Duration  23.23s (transform 1.78s, setup 10.16s, collect 42.84s, tests 31.86s)

close timed out after 10000ms
Failed to terminate worker while running /x/y/z/trpc/packages/tests/server/interop/adapters/fetch.test.ts.
```
