### PR TITLE
fix(browser): relax vitest peer dependency

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -34,7 +34,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.30.0"
+    "vitest": ">=0.29.4"
   },
   "dependencies": {
     "@vitest/runner": "workspace:*",


### PR DESCRIPTION
vitest v0.29.4 was just released, but trying to install `@vitest/browser` currently fails because its peer-dependency is set to vitest `>= 0.30.0`

Maybe this is on purpose, but this PR would avoid passing `--force` or `--legacy-peer-deps` when installing the browser package:

```
npm ERR! Could not resolve dependency:
npm ERR! peer vitest@">=0.30.0" from @vitest/browser@0.29.4
npm ERR! node_modules/@vitest/browser
npm ERR!   dev @vitest/browser@"0.29.4" from the root project
npm ERR!   peerOptional @vitest/browser@"*" from vitest@0.29.4
npm ERR!   node_modules/vitest
npm ERR!     dev vitest@"0.29.4" from the root project
```