### PR TITLE
feat: allow accessing "vi" methods without context, don't fail when mocker is not available

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@types/ws": "^8.5.4",
-    "@vitest/ws-client": "workspace:*",
     "@vitest/ui": "workspace:*",
+    "@vitest/ws-client": "workspace:*",
     "rollup": "^2.79.1",
     "vitest": "workspace:*"
   }

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -59,8 +59,6 @@ ws.addEventListener('open', async () => {
     rpc: client.rpc,
   }
 
-  // @ts-expect-error mocking vitest apis
-  globalThis.__vitest_mocker__ = {}
   const paths = getQueryPaths()
 
   const iFrame = document.getElementById('vitest-ui') as HTMLIFrameElement

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -9,130 +9,26 @@ import { FakeTimers } from './mock/timers'
 import type { EnhancedSpy, MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartiallyMockedDeep } from './spy'
 import { fn, isMockFunction, spies, spyOn } from './spy'
 
-class VitestUtils {
-  private _timers: FakeTimers
-  private _mockedDate: string | number | Date | null
-  private _mocker: VitestMocker
+interface VitestUtils {
+  useFakeTimers(config?: FakeTimerInstallOpts): this
+  useRealTimers(): this
+  runOnlyPendingTimers(): this
+  runOnlyPendingTimersAsync(): Promise<this>
+  runAllTimers(): this
+  runAllTimersAsync(): Promise<this>
+  runAllTicks(): this
+  advanceTimersByTime(ms: number): this
+  advanceTimersByTimeAsync(ms: number): Promise<this>
+  advanceTimersToNextTimer(): this
+  advanceTimersToNextTimerAsync(): Promise<this>
+  getTimerCount(): number
+  setSystemTime(time: number | string | Date): this
+  getMockedSystemTime(): Date | null
+  getRealSystemTime(): number
+  clearAllTimers(): this
 
-  constructor() {
-    // @ts-expect-error injected by vite-nide
-    this._mocker = typeof __vitest_mocker__ !== 'undefined' ? __vitest_mocker__ : null
-    this._mockedDate = null
-
-    if (!this._mocker) {
-      const errorMsg = 'Vitest was initialized with native Node instead of Vite Node.'
-      + '\n\nIt\'s possible that you are importing "vitest" directly inside "globalSetup". In that case, use "setupFiles" because "globalSetup" runs in a different context.'
-      + '\nOtherwise, it might be a Vitest bug. Please report it to https://github.com/vitest-dev/vitest/issues\n'
-      throw new Error(errorMsg)
-    }
-
-    const workerState = getWorkerState()
-    this._timers = new FakeTimers({
-      global: globalThis,
-      config: workerState.config.fakeTimers,
-    })
-  }
-
-  // timers
-
-  public useFakeTimers(config?: FakeTimerInstallOpts) {
-    if (config) {
-      this._timers.configure(config)
-    }
-    else {
-      const workerState = getWorkerState()
-      this._timers.configure(workerState.config.fakeTimers)
-    }
-    this._timers.useFakeTimers()
-    return this
-  }
-
-  public useRealTimers() {
-    this._timers.useRealTimers()
-    this._mockedDate = null
-    return this
-  }
-
-  public runOnlyPendingTimers() {
-    this._timers.runOnlyPendingTimers()
-    return this
-  }
-
-  public async runOnlyPendingTimersAsync() {
-    await this._timers.runOnlyPendingTimersAsync()
-    return this
-  }
-
-  public runAllTimers() {
-    this._timers.runAllTimers()
-    return this
-  }
-
-  public async runAllTimersAsync() {
-    await this._timers.runAllTimersAsync()
-    return this
-  }
-
-  public runAllTicks() {
-    this._timers.runAllTicks()
-    return this
-  }
-
-  public advanceTimersByTime(ms: number) {
-    this._timers.advanceTimersByTime(ms)
-    return this
-  }
-
-  public async advanceTimersByTimeAsync(ms: number) {
-    await this._timers.advanceTimersByTimeAsync(ms)
-    return this
-  }
-
-  public advanceTimersToNextTimer() {
-    this._timers.advanceTimersToNextTimer()
-    return this
-  }
-
-  public async advanceTimersToNextTimerAsync() {
-    await this._timers.advanceTimersToNextTimerAsync()
-    return this
-  }
-
-  public getTimerCount() {
-    return this._timers.getTimerCount()
-  }
-
-  public setSystemTime(time: number | string | Date) {
-    const date = time instanceof Date ? time : new Date(time)
-    this._mockedDate = date
-    this._timers.setSystemTime(date)
-    return this
-  }
-
-  public getMockedSystemTime() {
-    return this._mockedDate
-  }
-
-  public getRealSystemTime() {
-    return this._timers.getRealSystemTime()
-  }
-
-  public clearAllTimers() {
-    this._timers.clearAllTimers()
-    return this
-  }
-
-  // mocks
-
-  spyOn = spyOn
-  fn = fn
-
-  private getImporter() {
-    const stackTrace = createSimpleStackTrace({ stackTraceLimit: 4 })
-    const importerStack = stackTrace.split('\n')[4]
-    const stack = parseSingleStack(importerStack)
-    return stack?.file || ''
-  }
+  spyOn: typeof spyOn
+  fn: typeof fn
 
   /**
    * Makes all `imports` to passed module to be mocked.
@@ -145,31 +41,17 @@ class VitestUtils {
    * @param path Path to the module. Can be aliased, if your config supports it
    * @param factory Factory for the mocked module. Has the highest priority.
    */
-  public mock(path: string, factory?: MockFactoryWithHelper) {
-    const importer = this.getImporter()
-    this._mocker.queueMock(
-      path,
-      importer,
-      factory ? () => factory(() => this._mocker.importActual(path, importer)) : undefined,
-    )
-  }
+  mock(path: string, factory?: MockFactoryWithHelper): void
 
   /**
    * Removes module from mocked registry. All subsequent calls to import will
    * return original module even if it was mocked.
    * @param path Path to the module. Can be aliased, if your config supports it
    */
-  public unmock(path: string) {
-    this._mocker.queueUnmock(path, this.getImporter())
-  }
+  unmock(path: string): void
 
-  public doMock(path: string, factory?: () => any) {
-    this._mocker.queueMock(path, this.getImporter(), factory)
-  }
-
-  public doUnmock(path: string) {
-    this._mocker.queueUnmock(path, this.getImporter())
-  }
+  doMock(path: string, factory?: () => any): void
+  doUnmock(path: string): void
 
   /**
    * Imports module, bypassing all checks if it should be mocked.
@@ -183,9 +65,7 @@ class VitestUtils {
    * @param path Path to the module. Can be aliased, if your config supports it
    * @returns Actual module without spies
    */
-  public async importActual<T = unknown>(path: string): Promise<T> {
-    return this._mocker.importActual<T>(path, this.getImporter())
-  }
+  importActual<T = unknown>(path: string): Promise<T>
 
   /**
    * Imports a module with all of its properties and nested properties mocked.
@@ -193,9 +73,7 @@ class VitestUtils {
    * @param path Path to the module. Can be aliased, if your config supports it
    * @returns Fully mocked module
    */
-  public async importMock<T>(path: string): Promise<MaybeMockedDeep<T>> {
-    return this._mocker.importMock(path, this.getImporter())
-  }
+  importMock<T>(path: string): Promise<MaybeMockedDeep<T>>
 
   /**
    * Type helpers for TypeScript. In reality just returns the object that was passed.
@@ -216,131 +94,321 @@ class VitestUtils {
    * @param deep If the object is deeply mocked
    * @param options If the object is partially or deeply mocked
    */
-  public mocked<T>(item: T, deep?: false): MaybeMocked<T>
-  public mocked<T>(item: T, deep: true): MaybeMockedDeep<T>
-  public mocked<T>(item: T, options: { partial?: false; deep?: false }): MaybeMocked<T>
-  public mocked<T>(item: T, options: { partial?: false; deep: true }): MaybeMockedDeep<T>
-  public mocked<T>(item: T, options: { partial: true; deep?: false }): MaybePartiallyMocked<T>
-  public mocked<T>(item: T, options: { partial: true; deep: true }): MaybePartiallyMockedDeep<T>
-  public mocked<T>(item: T, _options = {}): MaybeMocked<T> {
-    return item as any
-  }
+  mocked<T>(item: T, deep?: false): MaybeMocked<T>
+  mocked<T>(item: T, deep: true): MaybeMockedDeep<T>
+  mocked<T>(item: T, options: { partial?: false; deep?: false }): MaybeMocked<T>
+  mocked<T>(item: T, options: { partial?: false; deep: true }): MaybeMockedDeep<T>
+  mocked<T>(item: T, options: { partial: true; deep?: false }): MaybePartiallyMocked<T>
+  mocked<T>(item: T, options: { partial: true; deep: true }): MaybePartiallyMockedDeep<T>
+  mocked<T>(item: T): MaybeMocked<T>
 
-  public isMockFunction(fn: any): fn is EnhancedSpy {
-    return isMockFunction(fn)
-  }
+  isMockFunction(fn: any): fn is EnhancedSpy
 
-  public clearAllMocks() {
-    spies.forEach(spy => spy.mockClear())
-    return this
-  }
-
-  public resetAllMocks() {
-    spies.forEach(spy => spy.mockReset())
-    return this
-  }
-
-  public restoreAllMocks() {
-    spies.forEach(spy => spy.mockRestore())
-    return this
-  }
-
-  private _stubsGlobal = new Map<string | symbol | number, PropertyDescriptor | undefined>()
-  private _stubsEnv = new Map()
+  clearAllMocks(): this
+  resetAllMocks(): this
+  restoreAllMocks(): this
 
   /**
    * Makes value available on global namespace.
    * Useful, if you want to have global variables available, like `IntersectionObserver`.
    * You can return it back to original value with `vi.unstubGlobals`, or by enabling `unstubGlobals` config option.
    */
-  public stubGlobal(name: string | symbol | number, value: any) {
-    if (!this._stubsGlobal.has(name))
-      this._stubsGlobal.set(name, Object.getOwnPropertyDescriptor(globalThis, name))
-    Object.defineProperty(globalThis, name, {
-      value,
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    })
-    return this
-  }
+  stubGlobal(name: string | symbol | number, value: unknown): this
 
   /**
    * Changes the value of `import.meta.env` and `process.env`.
    * You can return it back to original value with `vi.unstubEnvs`, or by enabling `unstubEnvs` config option.
    */
-  public stubEnv(name: string, value: string) {
-    if (!this._stubsEnv.has(name))
-      this._stubsEnv.set(name, process.env[name])
-    process.env[name] = value
-    return this
-  }
+  stubEnv(name: string, value: string): this
 
   /**
    * Reset the value to original value that was available before first `vi.stubGlobal` was called.
    */
-  public unstubAllGlobals() {
-    this._stubsGlobal.forEach((original, name) => {
-      if (!original)
-        Reflect.deleteProperty(globalThis, name)
-      else
-        Object.defineProperty(globalThis, name, original)
-    })
-    this._stubsGlobal.clear()
-    return this
-  }
+  unstubAllGlobals(): this
 
   /**
    * Reset environmental variables to the ones that were available before first `vi.stubEnv` was called.
    */
-  public unstubAllEnvs() {
-    this._stubsEnv.forEach((original, name) => {
-      if (original === undefined)
-        delete process.env[name]
-      else
-        process.env[name] = original
-    })
-    this._stubsEnv.clear()
-    return this
-  }
+  unstubAllEnvs(): this
 
-  public resetModules() {
-    const state = getWorkerState()
-    resetModules(state.moduleCache)
-    return this
-  }
+  resetModules(): this
 
   /**
    * Wait for all imports to load. Useful, if you have a synchronous call that starts
    * importing a module that you cannot await otherwise.
    * Will also wait for new imports, started during the wait.
    */
-  public async dynamicImportSettled() {
-    return waitForImportsToResolve()
-  }
-
-  private _config: null | ResolvedConfig = null
+  dynamicImportSettled(): Promise<void>
 
   /**
    * Updates runtime config. You can only change values that are used when executing tests.
    */
-  public setConfig(config: RuntimeConfig) {
-    const state = getWorkerState()
-    if (!this._config)
-      this._config = { ...state.config }
-    Object.assign(state.config, config)
-  }
+  setConfig(config: RuntimeConfig): void
 
   /**
    * If config was changed with `vi.setConfig`, this will reset it to the original state.
    */
-  public resetConfig() {
-    if (this._config) {
+  resetConfig(): void
+}
+
+function createVitest(): VitestUtils {
+  // @ts-expect-error injected by vite-nide
+  const _mocker: VitestMocker = typeof __vitest_mocker__ !== 'undefined'
+    // @ts-expect-error injected by vite-nide
+    ? __vitest_mocker__
+    : new Proxy({}, {
+      get(name) {
+        throw new Error(
+          'Vitest mocker was not initialized in this environment.'
+          + `vi.${name}() is forbidden.`,
+        )
+      },
+    })
+  let _mockedDate: Date | null = null
+  let _config: null | ResolvedConfig = null
+
+  const workerState = getWorkerState()
+  const _timers = new FakeTimers({
+    global: globalThis,
+    config: workerState.config.fakeTimers,
+  })
+
+  const _stubsGlobal = new Map<string | symbol | number, PropertyDescriptor | undefined>()
+  const _stubsEnv = new Map()
+
+  const getImporter = () => {
+    const stackTrace = createSimpleStackTrace({ stackTraceLimit: 4 })
+    const importerStack = stackTrace.split('\n')[4]
+    const stack = parseSingleStack(importerStack)
+    return stack?.file || ''
+  }
+
+  return {
+    useFakeTimers(config?: FakeTimerInstallOpts) {
+      if (config) {
+        _timers.configure(config)
+      }
+      else {
+        const workerState = getWorkerState()
+        _timers.configure(workerState.config.fakeTimers)
+      }
+      _timers.useFakeTimers()
+      return this
+    },
+
+    useRealTimers() {
+      _timers.useRealTimers()
+      _mockedDate = null
+      return this
+    },
+
+    runOnlyPendingTimers() {
+      _timers.runOnlyPendingTimers()
+      return this
+    },
+
+    async runOnlyPendingTimersAsync() {
+      await _timers.runOnlyPendingTimersAsync()
+      return this
+    },
+
+    runAllTimers() {
+      _timers.runAllTimers()
+      return this
+    },
+
+    async runAllTimersAsync() {
+      await _timers.runAllTimersAsync()
+      return this
+    },
+
+    runAllTicks() {
+      _timers.runAllTicks()
+      return this
+    },
+
+    advanceTimersByTime(ms: number) {
+      _timers.advanceTimersByTime(ms)
+      return this
+    },
+
+    async advanceTimersByTimeAsync(ms: number) {
+      await _timers.advanceTimersByTimeAsync(ms)
+      return this
+    },
+
+    advanceTimersToNextTimer() {
+      _timers.advanceTimersToNextTimer()
+      return this
+    },
+
+    async advanceTimersToNextTimerAsync() {
+      await _timers.advanceTimersToNextTimerAsync()
+      return this
+    },
+
+    getTimerCount() {
+      return _timers.getTimerCount()
+    },
+
+    setSystemTime(time: number | string | Date) {
+      const date = time instanceof Date ? time : new Date(time)
+      _mockedDate = date
+      _timers.setSystemTime(date)
+      return this
+    },
+
+    getMockedSystemTime() {
+      return _mockedDate
+    },
+
+    getRealSystemTime() {
+      return _timers.getRealSystemTime()
+    },
+
+    clearAllTimers() {
+      _timers.clearAllTimers()
+      return this
+    },
+
+    // mocks
+
+    spyOn,
+    fn,
+
+    mock(path: string, factory?: MockFactoryWithHelper) {
+      const importer = getImporter()
+      _mocker.queueMock(
+        path,
+        importer,
+        factory ? () => factory(() => _mocker.importActual(path, importer)) : undefined,
+      )
+    },
+
+    unmock(path: string) {
+      _mocker.queueUnmock(path, getImporter())
+    },
+
+    doMock(path: string, factory?: () => any) {
+      _mocker.queueMock(path, getImporter(), factory)
+    },
+
+    doUnmock(path: string) {
+      _mocker.queueUnmock(path, getImporter())
+    },
+
+    async importActual<T = unknown>(path: string): Promise<T> {
+      return _mocker.importActual<T>(path, getImporter())
+    },
+
+    async importMock<T>(path: string): Promise<MaybeMockedDeep<T>> {
+      return _mocker.importMock(path, getImporter())
+    },
+
+    mocked<T>(item: T, _options = {}): MaybeMocked<T> {
+      return item as any
+    },
+
+    isMockFunction(fn: any): fn is EnhancedSpy {
+      return isMockFunction(fn)
+    },
+
+    clearAllMocks() {
+      spies.forEach(spy => spy.mockClear())
+      return this
+    },
+
+    resetAllMocks() {
+      spies.forEach(spy => spy.mockReset())
+      return this
+    },
+
+    restoreAllMocks() {
+      spies.forEach(spy => spy.mockRestore())
+      return this
+    },
+
+    stubGlobal(name: string | symbol | number, value: any) {
+      if (!_stubsGlobal.has(name))
+        _stubsGlobal.set(name, Object.getOwnPropertyDescriptor(globalThis, name))
+      Object.defineProperty(globalThis, name, {
+        value,
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      })
+      return this
+    },
+
+    stubEnv(name: string, value: string) {
+      if (!_stubsEnv.has(name))
+        _stubsEnv.set(name, process.env[name])
+      process.env[name] = value
+      return this
+    },
+
+    unstubAllGlobals() {
+      _stubsGlobal.forEach((original, name) => {
+        if (!original)
+          Reflect.deleteProperty(globalThis, name)
+        else
+          Object.defineProperty(globalThis, name, original)
+      })
+      _stubsGlobal.clear()
+      return this
+    },
+
+    /**
+   * Reset environmental variables to the ones that were available before first `vi.stubEnv` was called.
+   */
+    unstubAllEnvs() {
+      _stubsEnv.forEach((original, name) => {
+        if (original === undefined)
+          delete process.env[name]
+        else
+          process.env[name] = original
+      })
+      _stubsEnv.clear()
+      return this
+    },
+
+    resetModules() {
       const state = getWorkerState()
-      Object.assign(state.config, this._config)
-    }
+      resetModules(state.moduleCache)
+      return this
+    },
+
+    /**
+   * Wait for all imports to load. Useful, if you have a synchronous call that starts
+   * importing a module that you cannot await otherwise.
+   * Will also wait for new imports, started during the wait.
+   */
+    async dynamicImportSettled() {
+      return waitForImportsToResolve()
+    },
+
+    /**
+   * Updates runtime config. You can only change values that are used when executing tests.
+   */
+    setConfig(config: RuntimeConfig) {
+      const state = getWorkerState()
+      if (!_config)
+        _config = { ...state.config }
+      Object.assign(state.config, config)
+    },
+
+    /**
+   * If config was changed with `vi.setConfig`, this will reset it to the original state.
+   */
+    resetConfig() {
+      if (_config) {
+        const state = getWorkerState()
+        Object.assign(state.config, _config)
+      }
+    },
+
   }
 }
 
-export const vitest = new VitestUtils()
+export const vitest = createVitest()
 export const vi = vitest

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -358,9 +358,6 @@ function createVitest(): VitestUtils {
       return this
     },
 
-    /**
-   * Reset environmental variables to the ones that were available before first `vi.stubEnv` was called.
-   */
     unstubAllEnvs() {
       _stubsEnv.forEach((original, name) => {
         if (original === undefined)
@@ -378,18 +375,10 @@ function createVitest(): VitestUtils {
       return this
     },
 
-    /**
-   * Wait for all imports to load. Useful, if you have a synchronous call that starts
-   * importing a module that you cannot await otherwise.
-   * Will also wait for new imports, started during the wait.
-   */
     async dynamicImportSettled() {
       return waitForImportsToResolve()
     },
 
-    /**
-   * Updates runtime config. You can only change values that are used when executing tests.
-   */
     setConfig(config: RuntimeConfig) {
       const state = getWorkerState()
       if (!_config)
@@ -397,9 +386,6 @@ function createVitest(): VitestUtils {
       Object.assign(state.config, config)
     },
 
-    /**
-   * If config was changed with `vi.setConfig`, this will reset it to the original state.
-   */
     resetConfig() {
       if (_config) {
         const state = getWorkerState()

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -159,7 +159,7 @@ function createVitest(): VitestUtils {
     : new Proxy({}, {
       get(name) {
         throw new Error(
-          'Vitest mocker was not initialized in this environment.'
+          'Vitest mocker was not initialized in this environment. '
           + `vi.${name}() is forbidden.`,
         )
       },


### PR DESCRIPTION
Refactor `vi`, so `vi.someName` can be passed down without losing a context.

It also throws an error, if the user tries to call mock API without having access to the mocker. Related: #3046