### PR TITLE
docs: fix cac's dot notation reference link

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -149,3 +149,5 @@ vitest --api=false
 :::warning
 You cannot use this option with `--watch` enabled (enabled in dev by default).
 :::
+
+[cac's dot notation]: https://github.com/cacjs/cac#dot-nested-options

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -138,5 +138,3 @@ Then go to the project where you are using Vitest and run `pnpm link --global vi
 ## Community
 
 If you have questions or need help, reach out to the community at [Discord](https://chat.vitest.dev) and [GitHub Discussions](https://github.com/vitest-dev/vitest/discussions).
-
-[cac's dot notation]: https://github.com/cacjs/cac#dot-nested-options


### PR DESCRIPTION
The CLI options table was moved from `index.md` to `cli.md` in https://github.com/vitest-dev/vitest/commit/f741c7e6fba449893049526f5ab48d81ab50cf5a, but the `[cac's dot notation]` reference link was left behind in `index.md`.

### Before

![](https://user-images.githubusercontent.com/42867097/226523653-3b84dbc9-e595-460d-b2bd-dd768ec99d45.png)

### After

![](https://user-images.githubusercontent.com/42867097/226523668-8a4b4697-daa9-4778-8e47-e9105153e30d.png)

