### PR TITLE
docs: fix typo in browser mode guide

### DIFF
--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -51,7 +51,7 @@ To specify a browser using the CLI, use the `--browser` flag followed by the bro
 npx vitest --browser=chrome
 ```
 
-Or if you pass down several options, you dot-syntax:
+Or you can provide browser options to CLI with dot notation:
 
 ```sh
 npx vitest --browser.name=chrome --browser.headless


### PR DESCRIPTION
I believe the `you dot-syntax` wording here is an incomplete typo:

https://github.com/vitest-dev/vitest/blob/1531c4208d8a8c54cec9f4d48a17af28345792e2/docs/guide/browser.md?plain=1#L54-L58

This PR attempts to fix said typo, but follows the existing `dot notation` sentences for consistency:

- https://github.com/vitest-dev/vitest/blob/1531c4208d8a8c54cec9f4d48a17af28345792e2/docs/config/index.md?plain=1#L683-L687

- https://github.com/vitest-dev/vitest/blob/1531c4208d8a8c54cec9f4d48a17af28345792e2/docs/config/index.md?plain=1#L1271-L1275