### PR TITLE
fix: add generic to expect.objectContaining type

### DIFF
--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -59,7 +59,7 @@ declare global {
 
     interface AsymmetricMatchersContaining {
       stringContaining(expected: string): any
-      objectContaining(expected: any): any
+      objectContaining<T = any>(expected: T): any
       arrayContaining<T = unknown>(expected: Array<T>): any
       stringMatching(expected: string | RegExp): any
     }


### PR DESCRIPTION
closes https://github.com/vitest-dev/vitest/issues/3052