### PR TITLE
docs: elaboration for resetModules

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -295,20 +295,20 @@ test('importing the next module imports mocked one', async () => {
 
   ```ts
   import { vi } from 'vitest'
-  import { data } from './data'  // Will not get reevaluated beforeEach test
+  import { data } from './data' // Will not get reevaluated beforeEach test
 
   beforeEach(() => {
     vi.resetModules()
   })
 
   test('change state', async () => {
-    const mod = await import('./some/path')   // Will get reevaluated
+    const mod = await import('./some/path') // Will get reevaluated
     mod.changeLocalState('new value')
     expect(mod.getLocalState()).toBe('new value')
   })
 
   test('module has old state', async () => {
-    const mod = await import('./some/path')  // Will get reevaluated
+    const mod = await import('./some/path') // Will get reevaluated
     expect(mod.getLocalState()).toBe('old value')
   })
   ```

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -291,24 +291,24 @@ test('importing the next module imports mocked one', async () => {
 
 - **Type**: `() => Vitest`
 
-  Resets modules registry by clearing cache of all modules.  This allows modules to be reevaluated when reimported.  Top-level imports cannot be reevaluated.  Might be useful to isolate modules where local state conflicts between tests.
+  Resets modules registry by clearing cache of all modules. This allows modules to be reevaluated when reimported. Top-level imports cannot be reevaluated. Might be useful to isolate modules where local state conflicts between tests.
 
   ```ts
   import { vi } from 'vitest'
-  import { data } from './data' // Will not get reevaluated beforeEach test
+  import { data } from './data.js' // Will not get reevaluated beforeEach test
 
   beforeEach(() => {
     vi.resetModules()
   })
 
   test('change state', async () => {
-    const mod = await import('./some/path') // Will get reevaluated
+    const mod = await import('./some/path.js') // Will get reevaluated
     mod.changeLocalState('new value')
     expect(mod.getLocalState()).toBe('new value')
   })
 
   test('module has old state', async () => {
-    const mod = await import('./some/path') // Will get reevaluated
+    const mod = await import('./some/path.js') // Will get reevaluated
     expect(mod.getLocalState()).toBe('old value')
   })
   ```

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -291,23 +291,24 @@ test('importing the next module imports mocked one', async () => {
 
 - **Type**: `() => Vitest`
 
-  Resets modules registry by clearing cache of all modules. Might be useful to isolate modules where local state conflicts between tests.
+  Resets modules registry by clearing cache of all modules.  This allows modules to be reevaluated when reimported.  Top-level imports cannot be reevaluated.  Might be useful to isolate modules where local state conflicts between tests.
 
   ```ts
   import { vi } from 'vitest'
+  import { data } from './data'  // Will not get reevaluated beforeEach test
 
-  beforeAll(() => {
+  beforeEach(() => {
     vi.resetModules()
   })
 
   test('change state', async () => {
-    const mod = await import('./some/path')
+    const mod = await import('./some/path')   // Will get reevaluated
     mod.changeLocalState('new value')
     expect(mod.getLocalState()).toBe('new value')
   })
 
   test('module has old state', async () => {
-    const mod = await import('./some/path')
+    const mod = await import('./some/path')  // Will get reevaluated
     expect(mod.getLocalState()).toBe('old value')
   })
   ```


### PR DESCRIPTION
Documentation elaboration for issue #3058.

I wasn't sure if also adding a note about **idempotence** here would be useful.  I didn't want to cloud the documentation with philosophy, even though this is a critical philosophy and practice.