### PR TITLE
feat: playwright as browser provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      BROWSER: ${{ matrix.browser.0 }}
+      BROWSER: ${{ matrix.browser[0] }}
     steps:
       - uses: actions/checkout@v3
 
@@ -135,7 +135,7 @@ jobs:
       - name: Test Browser (playwright)
         run: pnpm run browser:playwright:test
         env:
-          BROWSER: ${{ matrix.browser.1 }}
+          BROWSER: ${{ matrix.browser[1] }}
           PLAYWRIGHT: true
 
   test-browser-safari:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        browser: [chrome, firefox, edge]
+        browser: [[chrome, chromium], [firefox, firefox], [edge, chromium]]
 
     timeout-minutes: 10
 
     env:
-      BROWSER: ${{ matrix.browser }}
+      BROWSER: ${{ matrix.browser.0 }}
     steps:
       - uses: actions/checkout@v3
 
@@ -131,6 +131,12 @@ jobs:
 
       - name: Test Browser
         run: pnpm run browser:test
+
+      - name: Test Browser (playwright)
+        run: pnpm run browser:playwright:test
+        env:
+          BROWSER: ${{ matrix.browser.1 }}
+          PLAYWRIGHT: true
 
   test-browser-safari:
     runs-on: macos-latest
@@ -159,3 +165,9 @@ jobs:
 
       - name: Test Browser
         run: sudo pnpm run browser:test
+
+      - name: Test Browser (playwright)
+        run: sudo pnpm run browser:playwright:test
+        env:
+          BROWSER: webkit
+          PLAYWRIGHT: true

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1025,8 +1025,12 @@ Run all tests inside a browser by default. Can be overriden with [`poolMatchGlob
 - **Default:** _tries to find default browser automatically_
 - **CLI:** `--browser=safari`
 
-Run all tests in a specific browser. If not specified, tries to find a browser automatically.
+Run all tests in a specific browser. If not specified, tries to find a browser
+automatically. Possible options in different providers:
 
+- `webdriverio`: `firefox`, `chrome`, `edge`, `safari`
+- `playwright`: `firefox`, `webkit`, `chromium`
+- custom: any string value
 
 #### browser.headless
 
@@ -1050,7 +1054,8 @@ Configure options for Vite server that serves code in the browser. Does not affe
 - **Default:** `'webdriverio'`
 - **CLI:** `--browser.provider=./custom-provider.ts`
 
-Path to a provider that will be used when running browser tests. Provider should be exported using `default` export and have this shape:
+Path to a provider that will be used when running browser tests. Vitest provides
+two providers which are `webdriverio` (default) and `playwright`. Provider should be exported using `default` export and have this shape:
 
 ```ts
 export interface BrowserProvider {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "ui:build": "vite build packages/ui",
     "ui:dev": "vite packages/ui",
     "ui:test": "npm -C packages/ui run test:run",
-    "browser:test": "npm -C test/browser run test"
+    "browser:test": "npm -C test/browser run test",
+    "browser:playwright:test": "npm -C test/browser run test:playwright"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.34.1",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -123,6 +123,9 @@
     "safaridriver": {
       "optional": true
     },
+    "playwright": {
+      "optional": true
+    },
     "@edge-runtime/vm": {
       "optional": true
     }
@@ -186,6 +189,7 @@
     "natural-compare": "^1.4.0",
     "p-limit": "^4.0.0",
     "pkg-types": "^1.0.1",
+    "playwright": "^1.28.0",
     "pretty-format": "^27.5.1",
     "prompts": "^2.4.2",
     "rollup": "^2.79.1",

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -53,6 +53,7 @@ const external = [
   'inspector',
   'webdriverio',
   'safaridriver',
+  'playwright',
   'vite-node/source-map',
   'vite-node/client',
   'vite-node/server',

--- a/packages/vitest/src/integrations/browser.ts
+++ b/packages/vitest/src/integrations/browser.ts
@@ -1,3 +1,4 @@
+import { PlaywrightBrowserProvider } from '../node/browser/playwright'
 import { WebdriverBrowserProvider } from '../node/browser/webdriver'
 import type { BrowserProviderModule, ResolvedBrowserOptions } from '../types/browser'
 
@@ -6,8 +7,17 @@ interface Loader {
 }
 
 export async function getBrowserProvider(options: ResolvedBrowserOptions, loader: Loader): Promise<BrowserProviderModule> {
-  if (!options.provider || options.provider === 'webdriverio')
-    return WebdriverBrowserProvider
+  switch (options.provider) {
+    case undefined:
+    case 'webdriverio':
+      return WebdriverBrowserProvider
+
+    case 'playwright':
+      return PlaywrightBrowserProvider
+
+    default:
+      break
+  }
 
   let customProviderModule
 

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -26,14 +26,14 @@ export interface BrowserConfigOptions {
    *
    * @default tries to find the first available browser
    */
-  name?: 'firefox' | 'chrome' | 'edge' | 'safari'
+  name?: 'firefox' | 'chrome' | 'edge' | 'safari' | 'webkit' | 'chromium' | (string & {})
 
   /**
    * browser provider
    *
-   * @default 'webdriver'
+   * @default 'webdriverio'
    */
-  provider?: string
+  provider?: 'webdriverio' | 'playwright' | (string & {})
 
   /**
    * enable headless mode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,6 +885,7 @@ importers:
       pathe: ^1.1.0
       picocolors: ^1.0.0
       pkg-types: ^1.0.1
+      playwright: ^1.28.0
       pretty-format: ^27.5.1
       prompts: ^2.4.2
       rollup: ^2.79.1
@@ -961,6 +962,7 @@ importers:
       natural-compare: 1.4.0
       p-limit: 4.0.0
       pkg-types: 1.0.1
+      playwright: 1.28.0
       pretty-format: 27.5.1
       prompts: 2.4.2
       rollup: 2.79.1

--- a/test/browser/vitest.config.ts
+++ b/test/browser/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 
 const noop = () => {}
+const isPlaywright = !!process.env.PLAYWRIGHT
 
 export default defineConfig({
   test: {
@@ -9,6 +10,7 @@ export default defineConfig({
       enabled: true,
       name: 'chrome',
       headless: true,
+      provider: isPlaywright ? 'playwright' : 'webdriverio',
     },
     open: false,
     isolate: false,


### PR DESCRIPTION
Resolves #3056 

As mentioned in #2999, it was planned to add a playwright provider so Sveltekit users find it easier to use the browser feature without the need to add another dependency (`webdriverio`) in their project! cc @benmccann

Feel free to sponsor [Me](https://github.com/sponsors/Aslemammad) or the [Vitest org](https://github.com/sponsors/vitest-dev) to keep our work sustainable and make Vitest keep getting better! Thanks