### PR TITLE
ci: reduce running duplicate tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:run": "vitest run -r test/core",
     "test:all": "CI=true pnpm -r --stream run test --allowOnly",
     "test:ci": "CI=true pnpm -r --stream --filter !test-fails --filter !test-browser --filter !test-esm --filter !test-browser run test --allowOnly",
-    "test:ci:single-thread": "CI=true pnpm -r --stream --filter !test-fails --filter !test-esm --filter !test-browser run test --allowOnly --no-threads",
+    "test:ci:single-thread": "CI=true pnpm -r --stream --filter !test-fails --filter !test-coverage --filter !test-watch --filter !test-esm --filter !test-browser run test --allowOnly --no-threads",
     "typecheck": "tsc --noEmit",
     "typecheck:why": "tsc --noEmit --explainFiles > explainTypes.txt",
     "ui:build": "vite build packages/ui",


### PR DESCRIPTION
CI runs tests twice. One with default arguments and once with `--no-threads`. Test cases like `test/coverage` and `test/watch` do not respect such arguments coming from CLI. They run exactly the same on both test runs.

- Coverage tests are already testing multiple combinations, including all threading options
- Watch mode tests are using `execa` and do not pass the thread options at all