### PR TITLE
fix: resolve reporters passed down to the CLI relative to the running directory

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -216,7 +216,7 @@ export function resolveConfig(
     // it is passed down as "vitest --reporter ../reporter.js"
     const cliReporters = toArray(resolved.reporter || []).map((reporter: string) => {
       // ./reporter.js || ../reporter.js, but not .reporters/reporter.js
-      if (reporter[0] === '.' && (reporter[1] === '/' || reporter[2] === '/'))
+      if (/^\.\.?\//.test(reporter))
         return resolve(process.cwd(), reporter)
       return reporter
     })

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -212,8 +212,14 @@ export function resolveConfig(
     resolved.related = toArray(options.related).map(file => resolve(resolved.root, file))
 
   if (mode !== 'benchmark') {
-    // @ts-expect-error from CLI
-    const reporters = resolved.reporter ?? resolved.reporters
+    // @ts-expect-error "reporter" is from CLI, should be absolute to the running directory
+    // it is passed down as "vitest --reporter ../reporter.js"
+    const reporters = resolved.reporter?.map((reporter: string) => {
+      // ./reporter.js || ../reporter.js, but not .reporters/reporter.js
+      if (reporter[0] === '.' && (reporter[1] === '/' || reporter[2] === '/'))
+        return resolve(process.cwd(), reporter)
+      return reporter
+    }) ?? resolved.reporters
     resolved.reporters = Array.from(new Set(toArray(reporters))).filter(Boolean)
   }
 

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -214,13 +214,13 @@ export function resolveConfig(
   if (mode !== 'benchmark') {
     // @ts-expect-error "reporter" is from CLI, should be absolute to the running directory
     // it is passed down as "vitest --reporter ../reporter.js"
-    const reporters = resolved.reporter?.map((reporter: string) => {
+    const reporters = toArray(resolved.reporter || []).map((reporter: string) => {
       // ./reporter.js || ../reporter.js, but not .reporters/reporter.js
       if (reporter[0] === '.' && (reporter[1] === '/' || reporter[2] === '/'))
         return resolve(process.cwd(), reporter)
       return reporter
     }) ?? resolved.reporters
-    resolved.reporters = Array.from(new Set(toArray(reporters))).filter(Boolean)
+    resolved.reporters = Array.from(new Set(toArray(reporters))).filter(Boolean) as 'json'[]
   }
 
   if (!resolved.reporters.length)

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -214,13 +214,14 @@ export function resolveConfig(
   if (mode !== 'benchmark') {
     // @ts-expect-error "reporter" is from CLI, should be absolute to the running directory
     // it is passed down as "vitest --reporter ../reporter.js"
-    const reporters = toArray(resolved.reporter || []).map((reporter: string) => {
+    const cliReporters = toArray(resolved.reporter || []).map((reporter: string) => {
       // ./reporter.js || ../reporter.js, but not .reporters/reporter.js
       if (reporter[0] === '.' && (reporter[1] === '/' || reporter[2] === '/'))
         return resolve(process.cwd(), reporter)
       return reporter
-    }) ?? resolved.reporters
-    resolved.reporters = Array.from(new Set(toArray(reporters))).filter(Boolean) as 'json'[]
+    })
+    const reporters = cliReporters.length ? cliReporters : resolved.reporters
+    resolved.reporters = Array.from(new Set(toArray(reporters as 'json'[]))).filter(Boolean)
   }
 
   if (!resolved.reporters.length)


### PR DESCRIPTION
This is expected behavior, when you run something in the terminal as `vitest --reporter=../path.js`