### PR TITLE
feat!: bump coverage packages vitest peer dependency

### DIFF
--- a/packages/coverage-c8/package.json
+++ b/packages/coverage-c8/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.29.0 <1"
+    "vitest": ">=0.30.0 <1"
   },
   "dependencies": {
     "c8": "^7.13.0",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.28.0 <1"
+    "vitest": ">=0.30.0 <1"
   },
   "dependencies": {
     "istanbul-lib-coverage": "^3.2.0",


### PR DESCRIPTION
BREAKING CHANGE: Coverage packages require latest vitest

- Fixes https://github.com/vitest-dev/vitest/issues/3125
- Context https://github.com/vitest-dev/vitest/pull/3040#discussion_r1155944848

When users are using `vitest@0.29.7` and `@vitest/coverage-*@0.29.8`, Vitest is unable to import the provider. As fix, they should update to `vitest@0.29.8` as well. 