### PR TITLE
fix: Improve Jest compatibility by widening the return type for tests and hooks to `Assertable<unknown>` from `Assertable<void>` (fix #3146)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,7 +8,7 @@ The following types are used in the type signatures below
 
 ```ts
 type Awaitable<T> = T | PromiseLike<T>
-type TestFunction = () => Awaitable<void>
+type TestFunction = () => Awaitable<unknown>
 
 interface TestOptions {
   timeout?: number
@@ -680,7 +680,7 @@ These functions allow you to hook into the life cycle of tests to avoid repeatin
 
 ### beforeEach
 
-- **Type:** `beforeEach(fn: () => Awaitable<void>, timeout?: number)`
+- **Type:** `beforeEach(fn: () => Awaitable<unknown>, timeout?: number)`
 
   Register a callback to be called before each of the tests in the current context runs.
   If the function returns a promise, Vitest waits until the promise resolve before running the test.
@@ -717,7 +717,7 @@ These functions allow you to hook into the life cycle of tests to avoid repeatin
 
 ### afterEach
 
-- **Type:** `afterEach(fn: () => Awaitable<void>, timeout?: number)`
+- **Type:** `afterEach(fn: () => Awaitable<unknown>, timeout?: number)`
 
   Register a callback to be called after each one of the tests in the current context completes.
   If the function returns a promise, Vitest waits until the promise resolve before continuing.
@@ -735,7 +735,7 @@ These functions allow you to hook into the life cycle of tests to avoid repeatin
 
 ### beforeAll
 
-- **Type:** `beforeAll(fn: () => Awaitable<void>, timeout?: number)`
+- **Type:** `beforeAll(fn: () => Awaitable<unknown>, timeout?: number)`
 
   Register a callback to be called once before starting to run all tests in the current context.
   If the function returns a promise, Vitest waits until the promise resolve before running tests.
@@ -770,7 +770,7 @@ These functions allow you to hook into the life cycle of tests to avoid repeatin
 
 ### afterAll
 
-- **Type:** `afterAll(fn: () => Awaitable<void>, timeout?: number)`
+- **Type:** `afterAll(fn: () => Awaitable<unknown>, timeout?: number)`
 
   Register a callback to be called once after all tests have run in the current context.
   If the function returns a promise, Vitest waits until the promise resolve before continuing.

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -108,37 +108,37 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
 interface SuiteEachFunction {
   <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
     name: string,
-    fn: (...args: T) => Awaitable<void>,
+    fn: (...args: T) => Awaitable<unknown>,
   ) => void
   <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
     name: string,
-    fn: (...args: ExtractEachCallbackArgs<T>) => Awaitable<void>,
+    fn: (...args: ExtractEachCallbackArgs<T>) => Awaitable<unknown>,
   ) => void
   <T>(cases: ReadonlyArray<T>): (
     name: string,
-    fn: (...args: T[]) => Awaitable<void>,
+    fn: (...args: T[]) => Awaitable<unknown>,
   ) => void
 }
 
 interface TestEachFunction {
   <T extends any[] | [any]>(cases: ReadonlyArray<T>): (
     name: string,
-    fn: (...args: T) => Awaitable<void>,
+    fn: (...args: T) => Awaitable<unknown>,
     options?: number | TestOptions,
   ) => void
   <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): (
     name: string,
-    fn: (...args: ExtractEachCallbackArgs<T>) => Awaitable<void>,
+    fn: (...args: ExtractEachCallbackArgs<T>) => Awaitable<unknown>,
     options?: number | TestOptions,
   ) => void
   <T>(cases: ReadonlyArray<T>): (
     name: string,
-    fn: (...args: T[]) => Awaitable<void>,
+    fn: (...args: T[]) => Awaitable<unknown>,
     options?: number | TestOptions,
   ) => void
   (...args: [TemplateStringsArray, ...any]): (
     name: string,
-    fn: (...args: any[]) => Awaitable<void>,
+    fn: (...args: any[]) => Awaitable<unknown>,
     options?: number | TestOptions,
   ) => void
 }
@@ -189,9 +189,9 @@ export type SuiteAPI<ExtraContext = {}> = ChainableSuiteAPI<ExtraContext> & {
   runIf(condition: any): ChainableSuiteAPI<ExtraContext>
 }
 
-export type HookListener<T extends any[], Return = void> = (...args: T) => Awaitable<Return>
+export type HookListener<T extends any[], Return = unknown> = (...args: T) => Awaitable<Return>
 
-export type HookCleanupCallback = (() => Awaitable<unknown>) | void
+export type HookCleanupCallback = (() => Awaitable<unknown>) | unknown
 
 export interface SuiteHooks<ExtraContext = {}> {
   beforeAll: HookListener<[Suite | File], HookCleanupCallback>[]


### PR DESCRIPTION
This fixes #3146, improving Jest API compatibility by widening the type for hooks and tests to `Assertable<unknown>` from `Assertable<void>`.

I'm new to the source, so I might have misread something. Some comments / callouts:

* Unless I'm misreading it, it seems to me that the `TestFunction` type is actually `Assertable<any>`. I changed the documentation from `Assertable<void>` to `Assertable<unknown>`, but I didn't actually touch the type.
* I also changed the types for `TestEachFunction` and `SuiteEachFunction`. It's possible this is inappropriate.

`pnpm test` passes. However, for me `pnpm test:all` didn't pass before or after this change (but the change didn't affect the way it failed).