### PR TITLE
fix: run benchmarks sequentially (fix #2004)

### DIFF
--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -88,30 +88,31 @@ async function runBenchmarkSuite(suite: Suite, runner: VitestRunner) {
       })
     })
 
-    Promise.all(benchmarkGroup.map(async (benchmark) => {
+    const tasks: BenchTask[] = []
+    for (const benchmark of benchmarkGroup) {
       await benchmark.meta.task!.warmup()
       const { setTimeout } = getSafeTimers()
-      return await new Promise<BenchTask>(resolve => setTimeout(async () => {
+      tasks.push(await new Promise<BenchTask>(resolve => setTimeout(async () => {
         resolve(await benchmark.meta.task!.run())
-      }))
-    })).then((tasks) => {
-      suite.result!.duration = performance.now() - start
-      suite.result!.state = 'pass'
+      })))
+    }
 
-      tasks
-        .sort((a, b) => a.result!.mean - b.result!.mean)
-        .forEach((cycle, idx) => {
-          const benchmark = benchmarkMap[cycle.name || '']
-          benchmark.result!.state = 'pass'
-          if (benchmark) {
-            const result = benchmark.result!.benchmark!
-            result.rank = Number(idx) + 1
-            updateTask(benchmark)
-          }
-        })
-      updateTask(suite)
-      defer.resolve(null)
-    })
+    suite.result!.duration = performance.now() - start
+    suite.result!.state = 'pass'
+
+    tasks
+      .sort((a, b) => a.result!.mean - b.result!.mean)
+      .forEach((cycle, idx) => {
+        const benchmark = benchmarkMap[cycle.name || '']
+        benchmark.result!.state = 'pass'
+        if (benchmark) {
+          const result = benchmark.result!.benchmark!
+          result.rank = Number(idx) + 1
+          updateTask(benchmark)
+        }
+      })
+    updateTask(suite)
+    defer.resolve(null)
 
     await defer
   }


### PR DESCRIPTION
There is a critical bug in `vitest bench` that causes the benchmarks to run in parallel. This defeats the whole point of having a benchmark because the results are all over the place. This PR makes each `bench` to run in sequence and in isolation to produce accurate results.

I also want to mention that `tinybench` (the library `vitest bench` depends on for benchmarking) has also made sequential benchmarks the only default.

This PR partially fixes the umbrella issue #2004 