### PR TITLE
fix(snapshot): normalize EOL for `toMatchFileSnapshot`

### DIFF
--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -18,6 +18,7 @@ import {
   addExtraLineBreaks,
   getSnapshotData,
   keyToTestName,
+  normalizeNewlines,
   prepareExpected,
   removeExtraLineBreaks,
   saveSnapshotFile,
@@ -243,6 +244,12 @@ export default class SnapshotState {
 
     if (!rawSnapshot)
       receivedSerialized = addExtraLineBreaks(receivedSerialized)
+
+    if (rawSnapshot) {
+      // normalize EOL when snapshot contains CRLF but received is LF
+      if (rawSnapshot.content && rawSnapshot.content.match(/\r\n/) && !receivedSerialized.match(/\r\n/))
+        rawSnapshot.content = normalizeNewlines(rawSnapshot.content)
+    }
 
     const expected = isInline
       ? inlineSnapshot

--- a/packages/snapshot/src/port/utils.ts
+++ b/packages/snapshot/src/port/utils.ts
@@ -135,7 +135,7 @@ export async function ensureDirectoryExists(environment: SnapshotEnvironment, fi
   catch { }
 }
 
-function normalizeNewlines(string: string) {
+export function normalizeNewlines(string: string) {
   return string.replace(/\r\n|\r/g, '\n')
 }
 


### PR DESCRIPTION
This make it easy for testing across OS.