### PR TITLE
fix(coverage): `thresholdAutoUpdate` to work with `perFile`

### DIFF
--- a/packages/coverage-c8/src/provider.ts
+++ b/packages/coverage-c8/src/provider.ts
@@ -187,6 +187,7 @@ export class C8CoverageProvider extends BaseCoverageProvider implements Coverage
           lines: this.options.lines,
           statements: this.options.statements,
         },
+        perFile: this.options.perFile,
         configurationFile: this.ctx.server.config.configFile,
       })
     }

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -164,6 +164,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
           lines: this.options.lines,
           statements: this.options.statements,
         },
+        perFile: this.options.perFile,
         configurationFile: this.ctx.server.config.configFile,
       })
     }

--- a/packages/vitest/src/utils/coverage.ts
+++ b/packages/vitest/src/utils/coverage.ts
@@ -10,9 +10,10 @@ export class BaseCoverageProvider {
   /**
    * Check if current coverage is above configured thresholds and bump the thresholds if needed
    */
-  updateThresholds({ configurationFile, coverageMap, thresholds }: {
+  updateThresholds({ configurationFile, coverageMap, thresholds, perFile }: {
     coverageMap: CoverageMap
     thresholds: Record<Threshold, number | undefined>
+    perFile?: boolean
     configurationFile?: string
   }) {
     // Thresholds cannot be updated if there is no configuration file and
@@ -20,15 +21,19 @@ export class BaseCoverageProvider {
     if (!configurationFile)
       throw new Error('Missing configurationFile. The "coverage.thresholdAutoUpdate" can only be enabled when configuration file is used.')
 
-    const summary = coverageMap.getCoverageSummary()
-    const thresholdsToUpdate: Threshold[] = []
+    const summaries = perFile
+      ? coverageMap.files()
+        .map((file: string) => coverageMap.fileCoverageFor(file).toSummary())
+      : [coverageMap.getCoverageSummary()]
+
+    const thresholdsToUpdate: [Threshold, number][] = []
 
     for (const key of THRESHOLD_KEYS) {
       const threshold = thresholds[key] || 100
-      const actual = summary[key].pct
+      const actual = Math.min(...summaries.map(summary => summary[key].pct))
 
       if (actual > threshold)
-        thresholdsToUpdate.push(key)
+        thresholdsToUpdate.push([key, actual])
     }
 
     if (thresholdsToUpdate.length === 0)
@@ -37,14 +42,14 @@ export class BaseCoverageProvider {
     const originalConfig = readFileSync(configurationFile, 'utf8')
     let updatedConfig = originalConfig
 
-    for (const threshold of thresholdsToUpdate) {
+    for (const [threshold, newValue] of thresholdsToUpdate) {
       // Find the exact match from the configuration file and replace the value
       const previousThreshold = (thresholds[threshold] || 100).toString()
       const pattern = new RegExp(`(${threshold}\\s*:\\s*)${previousThreshold.replace('.', '\\.')}`)
       const matches = originalConfig.match(pattern)
 
       if (matches)
-        updatedConfig = updatedConfig.replace(matches[0], matches[1] + summary[threshold].pct)
+        updatedConfig = updatedConfig.replace(matches[0], matches[1] + newValue)
       else
         console.error(`Unable to update coverage threshold ${threshold}. No threshold found using pattern ${pattern}`)
     }


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/3179

No breaking changes as `perFile` of `updateThresholds` is optional flag and defaults to false. 

Tested manually in locally linked project. The current test cases are only checking that `thresholdAutoUpdate` updates the values but doesn't exactly check what values there are.

https://github.com/vitest-dev/vitest/blob/baf902a20b5fdedc095828c081a32ce2baeb2197/test/coverage-test/coverage-report-tests/generic.report.test.ts#L67