### PR TITLE
docs: improve spyOn example with a contextual example

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -567,14 +567,14 @@ IntersectionObserver === undefined
 
   ```ts
   let apples = 0
-  const obj = {
+  const cart = {
     getApples: () => 13,
   }
 
-  const spy = vi.spyOn(obj, 'getApples').mockImplementation(() => apples)
+  const spy = vi.spyOn(cart, 'getApples').mockImplementation(() => apples)
   apples = 1
 
-  expect(obj.getApples()).toBe(1)
+  expect(cart.getApples()).toBe(1)
 
   expect(spy).toHaveBeenCalled()
   expect(spy).toHaveReturnedWith(1)


### PR DESCRIPTION
As I was reading this example, I noticed that the naming of `obj` is rather generic given that one would expect students to understand what an object is. 

Given that the example talks about apples in a contextual way, the suggestion to replace `obj` with `cart` should help improve comprehension for people analyzing the code example.

Happy to chat more if people have questions!