### PR TITLE
docs: updated "vi.mock" documentation link

### DIFF
--- a/examples/mocks/test/error-mock.spec.ts
+++ b/examples/mocks/test/error-mock.spec.ts
@@ -4,5 +4,5 @@ vi.mock('../src/default', () => {
 
 test('when using top level variable, gives helpful message', async () => {
   await expect(() => import('../src/default').then(m => m.default)).rejects
-    .toThrowErrorMatchingInlineSnapshot('"[vitest] There was an error when mocking a module. If you are using \\"vi.mock\\" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/#vi-mock"')
+    .toThrowErrorMatchingInlineSnapshot('"[vitest] There was an error when mocking a module. If you are using \\"vi.mock\\" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock"')
 })

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -116,7 +116,7 @@ export class VitestMocker {
       const vitestError = new Error(
         '[vitest] There was an error when mocking a module. '
       + 'If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. '
-      + 'Read more: https://vitest.dev/api/#vi-mock')
+      + 'Read more: https://vitest.dev/api/vi.html#vi-mock')
       vitestError.cause = err
       throw vitestError
     }


### PR DESCRIPTION
Error message contains an outdated link:

<img width="757" alt="image" src="https://user-images.githubusercontent.com/919328/232174578-f72a2ada-7da6-4e06-adbd-224b67e10b6b.png">

The change modifies the URL to go to https://vitest.dev/api/vi.html#vi-mock