### PR TITLE
fix(coverage): throw error if fail to load built-in provider

### DIFF
--- a/packages/vitest/src/integrations/coverage.ts
+++ b/packages/vitest/src/integrations/coverage.ts
@@ -17,6 +17,10 @@ async function resolveCoverageProviderModule(options: CoverageOptions | undefine
 
   if (provider === 'c8' || provider === 'istanbul') {
     const { default: coverageModule } = await loader.executeId(CoverageProviderMap[provider])
+
+    if (!coverageModule)
+      throw new Error(`Failed to load ${CoverageProviderMap[provider]}. Default export is missing.`)
+
     return coverageModule
   }
 


### PR DESCRIPTION
- Closes #3213

In the issue's reproduction case the `@vitest/coverage-c8` does not provide `default` export which causes `coverageModule` to be `undefined`. This makes `core.ts` to think that coverage is disabled.
As solution we should fail whole process if default export is missing. 