### PR TITLE
ci: test-browser-safari to not update lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           node-version: 18
 
       - name: Install
-        run: sudo pnpm i
+        run: sudo pnpm i --frozen-lockfile
 
       - name: Build
         run: sudo pnpm run build


### PR DESCRIPTION
The `test-browser-safari` job keeps failing on CI. Some dependency updates on `pnpm i` and `packages/browser` loads `rollup@2.79.1` which fails to parse import assertions.

Normally `pnpm i` does not update lockfile on CI but I guess that `sudo` part skips it.