### PR TITLE
ci: fix cache restore keys on `pnpm@8`

### DIFF
--- a/.github/actions/setup-and-cache/action.yml
+++ b/.github/actions/setup-and-cache/action.yml
@@ -26,14 +26,27 @@ runs:
           node -e "
             const fs = require('fs');
             const lockfile = fs.readFileSync('./pnpm-lock.yaml', 'utf8');
-            const cypressVersion = lockfile.match(/cypress: (\d+\.\d+\.\d+)/)[1];
-            const playwrightVersion = lockfile.match(/playwright: (\d+\.\d+\.\d+)/)[1];
-            const puppeteerVersion = lockfile.match(/puppeteer: (\d+\.\d+\.\d+)/)[1];
+            const pattern = (name) => new RegExp(name + ':\\\s+specifier: [\\\s\\\w\\\.^]+version: (\\\d+\\\.\\\d+\\\.\\\d+)');
+            const cypressVersion = lockfile.match(pattern('cypress'))[1];
+            const playwrightVersion = lockfile.match(pattern('playwright'))[1];
+            const puppeteerVersion = lockfile.match(pattern('puppeteer'))[1];
             console.log('CYPRESS_VERSION=' + cypressVersion);
             console.log('PLAYWRIGHT_VERSION=' + playwrightVersion);
             console.log('PUPPETEER_VERSION=' + puppeteerVersion);
           "
         )" >> $GITHUB_OUTPUT
+
+    - name: Print versions
+      shell: bash
+      run: echo "${{ toJson(steps.resolve-package-versions.outputs) }}"
+
+    - name: Check resolved package versions
+      shell: bash
+      if: |
+        contains(fromJSON('[null, "", "undefined"]'), steps.resolve-package-versions.outputs.CYPRESS_VERSION) ||
+        contains(fromJSON('[null, "", "undefined"]'), steps.resolve-package-versions.outputs.PLAYWRIGHT_VERSION) ||
+        contains(fromJSON('[null, "", "undefined"]'), steps.resolve-package-versions.outputs.PUPPETEER_VERSION)
+      run: echo "Failed to resolve package versions. See log above." && exit 1
 
     - name: Cache Cypress v${{ steps.resolve-package-versions.outputs.CYPRESS_VERSION }}
       uses: actions/cache@v3


### PR DESCRIPTION
The script that parses package versions for cache keys broke after #3211 as `pnpm@8` uses different structure in `pnpm-lock.yaml`. 

Before with `pnpm@7`:

https://github.com/vitest-dev/vitest/blob/b1624db5d3baf26f7e1c69b23cf4c1335562ccde/pnpm-lock.yaml#L258

Now:

https://github.com/vitest-dev/vitest/blob/ddfeb0cfffb4bdf5cacf1bb757ba142d59ae61a6/pnpm-lock.yaml#L346-L348

This PR updates the version parsing patterns and adds a new step for CI to check that versions were somewhat successfully resolved.

