### PR TITLE
fix(coverage): stackblitz hangs with c8

### DIFF
--- a/packages/coverage-c8/src/takeCoverage.ts
+++ b/packages/coverage-c8/src/takeCoverage.ts
@@ -4,6 +4,7 @@
 
 import inspector from 'node:inspector'
 import type { Profiler } from 'node:inspector'
+import { provider } from 'std-env'
 
 const session = new inspector.Session()
 
@@ -27,6 +28,9 @@ export async function takeCoverage() {
 
       resolve({ result })
     })
+
+    if (provider === 'stackblitz')
+      resolve({ result: [] })
   })
 }
 


### PR DESCRIPTION
Vitest should log warning when `@vitest/coverage-c8` is used on Stackblitz: #2735. This broke during #2786 as `takeCoverage` creates a `Promise` that never resolves in Stackblitz where the webcontainers don't implement the Session/Profiler API completely.

This was reported as broken in #3220:

> Vitest hangs when generating coverage in StackBlitz  

Tested in Stackblitz Codeflow. 