### PR TITLE
docs: filtering update demo

### DIFF
--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -19,6 +19,7 @@ Will only execute test files that contain `basic`, e.g.
 ```
 basic.test.ts
 basic-foo.test.ts
+basic/foo.test.ts
 ```
 
 ## Specifying a Timeout


### PR DESCRIPTION
Not only test files whose file names contain keywords will be executed, but also test files whose paths contain keywords will also be executed. So I thought it would be better to add an example where the path contains keywords.