### PR TITLE
fix(coverage): c8 to ignore vite's generated helpers

### DIFF
--- a/packages/coverage-c8/package.json
+++ b/packages/coverage-c8/package.json
@@ -45,7 +45,9 @@
     "vitest": ">=0.30.0 <1"
   },
   "dependencies": {
+    "@ampproject/remapping": "^2.2.0",
     "c8": "^7.13.0",
+    "magic-string": "^0.30.0",
     "picocolors": "^1.0.0",
     "std-env": "^3.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1476,6 +1476,9 @@ importers:
 
   test/coverage-test:
     devDependencies:
+      '@types/istanbul-lib-coverage':
+        specifier: ^2.0.4
+        version: 2.0.4
       '@vitejs/plugin-vue':
         specifier: latest
         version: 4.1.0(vite@4.2.1)(vue@3.2.47)
@@ -1488,6 +1491,9 @@ importers:
       happy-dom:
         specifier: latest
         version: 9.1.7
+      istanbul-lib-coverage:
+        specifier: ^3.2.0
+        version: 3.2.0
       vite:
         specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,9 +873,15 @@ importers:
 
   packages/coverage-c8:
     dependencies:
+      '@ampproject/remapping':
+        specifier: ^2.2.0
+        version: 2.2.0
       c8:
         specifier: ^7.13.0
         version: 7.13.0
+      magic-string:
+        specifier: ^0.30.0
+        version: 0.30.0
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0

--- a/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
@@ -695,68 +695,10 @@ exports[`c8 json report 1`] = `
   },
   "<process-cwd>/src/Counter/index.ts": {
     "all": false,
-    "b": {
-      "0": [
-        1,
-      ],
-    },
-    "branchMap": {
-      "0": {
-        "line": 4,
-        "loc": {
-          "end": {
-            "column": 39,
-            "line": 4,
-          },
-          "start": {
-            "column": 27,
-            "line": 4,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 39,
-              "line": 4,
-            },
-            "start": {
-              "column": 27,
-              "line": 4,
-            },
-          },
-        ],
-        "type": "branch",
-      },
-    },
-    "f": {
-      "0": 1,
-    },
-    "fnMap": {
-      "0": {
-        "decl": {
-          "end": {
-            "column": 39,
-            "line": 4,
-          },
-          "start": {
-            "column": 27,
-            "line": 4,
-          },
-        },
-        "line": 4,
-        "loc": {
-          "end": {
-            "column": 39,
-            "line": 4,
-          },
-          "start": {
-            "column": 27,
-            "line": 4,
-          },
-        },
-        "name": "get",
-      },
-    },
+    "b": {},
+    "branchMap": {},
+    "f": {},
+    "fnMap": {},
     "path": "<process-cwd>/src/Counter/index.ts",
     "s": {
       "0": 1,
@@ -1312,9 +1254,6 @@ exports[`c8 json report 1`] = `
       "2": [
         1,
       ],
-      "3": [
-        1,
-      ],
     },
     "branchMap": {
       "0": {
@@ -1370,32 +1309,6 @@ exports[`c8 json report 1`] = `
         "type": "branch",
       },
       "2": {
-        "line": 21,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 21,
-          },
-          "start": {
-            "column": 0,
-            "line": 21,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 21,
-            },
-            "start": {
-              "column": 0,
-              "line": 21,
-            },
-          },
-        ],
-        "type": "branch",
-      },
-      "3": {
         "line": 34,
         "loc": {
           "end": {
@@ -1425,11 +1338,9 @@ exports[`c8 json report 1`] = `
     "f": {
       "0": 1,
       "1": 1,
-      "2": 1,
+      "2": 0,
       "3": 0,
-      "4": 0,
-      "5": 0,
-      "6": 1,
+      "4": 1,
     },
     "fnMap": {
       "0": {
@@ -1484,30 +1395,6 @@ exports[`c8 json report 1`] = `
         "decl": {
           "end": {
             "column": 1,
-            "line": 21,
-          },
-          "start": {
-            "column": 0,
-            "line": 21,
-          },
-        },
-        "line": 21,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 21,
-          },
-          "start": {
-            "column": 0,
-            "line": 21,
-          },
-        },
-        "name": "get",
-      },
-      "3": {
-        "decl": {
-          "end": {
-            "column": 1,
             "line": 26,
           },
           "start": {
@@ -1528,31 +1415,7 @@ exports[`c8 json report 1`] = `
         },
         "name": "third",
       },
-      "4": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 26,
-          },
-          "start": {
-            "column": 0,
-            "line": 26,
-          },
-        },
-        "line": 26,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 26,
-          },
-          "start": {
-            "column": 0,
-            "line": 26,
-          },
-        },
-        "name": "get",
-      },
-      "5": {
+      "3": {
         "decl": {
           "end": {
             "column": 1,
@@ -1576,7 +1439,7 @@ exports[`c8 json report 1`] = `
         },
         "name": "fourth",
       },
-      "6": {
+      "4": {
         "decl": {
           "end": {
             "column": 1,
@@ -2009,9 +1872,6 @@ exports[`c8 json report 1`] = `
       "0": [
         1,
       ],
-      "1": [
-        1,
-      ],
     },
     "branchMap": {
       "0": {
@@ -2040,36 +1900,9 @@ exports[`c8 json report 1`] = `
         ],
         "type": "branch",
       },
-      "1": {
-        "line": 8,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 8,
-          },
-          "start": {
-            "column": 0,
-            "line": 8,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 8,
-            },
-            "start": {
-              "column": 0,
-              "line": 8,
-            },
-          },
-        ],
-        "type": "branch",
-      },
     },
     "f": {
       "0": 1,
-      "1": 1,
     },
     "fnMap": {
       "0": {
@@ -2095,30 +1928,6 @@ exports[`c8 json report 1`] = `
           },
         },
         "name": "implicitElse",
-      },
-      "1": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 8,
-          },
-          "start": {
-            "column": 0,
-            "line": 8,
-          },
-        },
-        "line": 8,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 8,
-          },
-          "start": {
-            "column": 0,
-            "line": 8,
-          },
-        },
-        "name": "get",
       },
     },
     "path": "<process-cwd>/src/implicitElse.ts",
@@ -2221,9 +2030,6 @@ exports[`c8 json report 1`] = `
       "0": [
         1,
       ],
-      "1": [
-        1,
-      ],
     },
     "branchMap": {
       "0": {
@@ -2252,36 +2058,9 @@ exports[`c8 json report 1`] = `
         ],
         "type": "branch",
       },
-      "1": {
-        "line": 3,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 3,
-          },
-          "start": {
-            "column": 0,
-            "line": 3,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 3,
-            },
-            "start": {
-              "column": 0,
-              "line": 3,
-            },
-          },
-        ],
-        "type": "branch",
-      },
     },
     "f": {
       "0": 1,
-      "1": 1,
     },
     "fnMap": {
       "0": {
@@ -2307,30 +2086,6 @@ exports[`c8 json report 1`] = `
           },
         },
         "name": "useImportEnv",
-      },
-      "1": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 3,
-          },
-          "start": {
-            "column": 0,
-            "line": 3,
-          },
-        },
-        "line": 3,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 3,
-          },
-          "start": {
-            "column": 0,
-            "line": 3,
-          },
-        },
-        "name": "get",
       },
     },
     "path": "<process-cwd>/src/importEnv.ts",
@@ -2378,9 +2133,6 @@ exports[`c8 json report 1`] = `
       "0": [
         1,
       ],
-      "1": [
-        1,
-      ],
     },
     "branchMap": {
       "0": {
@@ -2409,36 +2161,9 @@ exports[`c8 json report 1`] = `
         ],
         "type": "branch",
       },
-      "1": {
-        "line": 7,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 7,
-          },
-          "start": {
-            "column": 0,
-            "line": 7,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 7,
-            },
-            "start": {
-              "column": 0,
-              "line": 7,
-            },
-          },
-        ],
-        "type": "branch",
-      },
     },
     "f": {
       "0": 1,
-      "1": 1,
     },
     "fnMap": {
       "0": {
@@ -2464,30 +2189,6 @@ exports[`c8 json report 1`] = `
           },
         },
         "name": "pythagoras",
-      },
-      "1": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 7,
-          },
-          "start": {
-            "column": 0,
-            "line": 7,
-          },
-        },
-        "line": 7,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 7,
-          },
-          "start": {
-            "column": 0,
-            "line": 7,
-          },
-        },
-        "name": "get",
       },
     },
     "path": "<process-cwd>/src/index.mts",
@@ -3013,22 +2714,13 @@ exports[`c8 json report 1`] = `
         1,
       ],
       "1": [
-        1,
+        2,
       ],
       "2": [
-        2,
+        1,
       ],
       "3": [
-        2,
-      ],
-      "4": [
-        1,
-      ],
-      "5": [
         0,
-      ],
-      "6": [
-        1,
       ],
     },
     "branchMap": {
@@ -3059,32 +2751,6 @@ exports[`c8 json report 1`] = `
         "type": "branch",
       },
       "1": {
-        "line": 3,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 3,
-          },
-          "start": {
-            "column": 0,
-            "line": 3,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 3,
-            },
-            "start": {
-              "column": 0,
-              "line": 3,
-            },
-          },
-        ],
-        "type": "branch",
-      },
-      "2": {
         "line": 5,
         "loc": {
           "end": {
@@ -3110,33 +2776,7 @@ exports[`c8 json report 1`] = `
         ],
         "type": "branch",
       },
-      "3": {
-        "line": 7,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 7,
-          },
-          "start": {
-            "column": 0,
-            "line": 7,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 7,
-            },
-            "start": {
-              "column": 0,
-              "line": 7,
-            },
-          },
-        ],
-        "type": "branch",
-      },
-      "4": {
+      "2": {
         "line": 14,
         "loc": {
           "end": {
@@ -3162,7 +2802,7 @@ exports[`c8 json report 1`] = `
         ],
         "type": "branch",
       },
-      "5": {
+      "3": {
         "line": 16,
         "loc": {
           "end": {
@@ -3188,46 +2828,14 @@ exports[`c8 json report 1`] = `
         ],
         "type": "branch",
       },
-      "6": {
-        "line": 19,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 19,
-          },
-          "start": {
-            "column": 0,
-            "line": 19,
-          },
-        },
-        "locations": [
-          {
-            "end": {
-              "column": 1,
-              "line": 19,
-            },
-            "start": {
-              "column": 0,
-              "line": 19,
-            },
-          },
-        ],
-        "type": "branch",
-      },
     },
     "f": {
       "0": 1,
-      "1": 1,
-      "10": 1,
-      "11": 1,
-      "2": 2,
-      "3": 2,
+      "1": 2,
+      "2": 0,
+      "3": 1,
       "4": 0,
-      "5": 0,
-      "6": 1,
-      "7": 1,
-      "8": 0,
-      "9": 0,
+      "5": 1,
     },
     "fnMap": {
       "0": {
@@ -3258,78 +2866,6 @@ exports[`c8 json report 1`] = `
         "decl": {
           "end": {
             "column": 1,
-            "line": 3,
-          },
-          "start": {
-            "column": 0,
-            "line": 3,
-          },
-        },
-        "line": 3,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 3,
-          },
-          "start": {
-            "column": 0,
-            "line": 3,
-          },
-        },
-        "name": "get",
-      },
-      "10": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 30,
-          },
-          "start": {
-            "column": 7,
-            "line": 28,
-          },
-        },
-        "line": 28,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 30,
-          },
-          "start": {
-            "column": 7,
-            "line": 28,
-          },
-        },
-        "name": "ignoredFunction",
-      },
-      "11": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 30,
-          },
-          "start": {
-            "column": 0,
-            "line": 30,
-          },
-        },
-        "line": 30,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 30,
-          },
-          "start": {
-            "column": 0,
-            "line": 30,
-          },
-        },
-        "name": "get",
-      },
-      "2": {
-        "decl": {
-          "end": {
-            "column": 1,
             "line": 7,
           },
           "start": {
@@ -3350,31 +2886,7 @@ exports[`c8 json report 1`] = `
         },
         "name": "multiply",
       },
-      "3": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 7,
-          },
-          "start": {
-            "column": 0,
-            "line": 7,
-          },
-        },
-        "line": 7,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 7,
-          },
-          "start": {
-            "column": 0,
-            "line": 7,
-          },
-        },
-        "name": "get",
-      },
-      "4": {
+      "2": {
         "decl": {
           "end": {
             "column": 1,
@@ -3398,31 +2910,7 @@ exports[`c8 json report 1`] = `
         },
         "name": "divide",
       },
-      "5": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 12,
-          },
-          "start": {
-            "column": 0,
-            "line": 12,
-          },
-        },
-        "line": 12,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 12,
-          },
-          "start": {
-            "column": 0,
-            "line": 12,
-          },
-        },
-        "name": "get",
-      },
-      "6": {
+      "3": {
         "decl": {
           "end": {
             "column": 1,
@@ -3446,31 +2934,7 @@ exports[`c8 json report 1`] = `
         },
         "name": "sqrt",
       },
-      "7": {
-        "decl": {
-          "end": {
-            "column": 1,
-            "line": 19,
-          },
-          "start": {
-            "column": 0,
-            "line": 19,
-          },
-        },
-        "line": 19,
-        "loc": {
-          "end": {
-            "column": 1,
-            "line": 19,
-          },
-          "start": {
-            "column": 0,
-            "line": 19,
-          },
-        },
-        "name": "get",
-      },
-      "8": {
+      "4": {
         "decl": {
           "end": {
             "column": 1,
@@ -3494,29 +2958,29 @@ exports[`c8 json report 1`] = `
         },
         "name": "run",
       },
-      "9": {
+      "5": {
         "decl": {
           "end": {
             "column": 1,
-            "line": 24,
+            "line": 30,
           },
           "start": {
-            "column": 0,
-            "line": 24,
+            "column": 7,
+            "line": 28,
           },
         },
-        "line": 24,
+        "line": 28,
         "loc": {
           "end": {
             "column": 1,
-            "line": 24,
+            "line": 30,
           },
           "start": {
-            "column": 0,
-            "line": 24,
+            "column": 7,
+            "line": 28,
           },
         },
-        "name": "get",
+        "name": "ignoredFunction",
       },
     },
     "path": "<process-cwd>/src/utils.ts",

--- a/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
@@ -1300,6 +1300,709 @@ exports[`c8 json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/function-count.ts": {
+    "all": false,
+    "b": {
+      "0": [
+        1,
+      ],
+      "1": [
+        1,
+      ],
+      "2": [
+        1,
+      ],
+      "3": [
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "line": 11,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 13,
+          },
+          "start": {
+            "column": 17,
+            "line": 11,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 13,
+            },
+            "start": {
+              "column": 17,
+              "line": 11,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "1": {
+        "line": 18,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 21,
+          },
+          "start": {
+            "column": 7,
+            "line": 18,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 21,
+            },
+            "start": {
+              "column": 7,
+              "line": 18,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "2": {
+        "line": 21,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 21,
+          },
+          "start": {
+            "column": 0,
+            "line": 21,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 21,
+            },
+            "start": {
+              "column": 0,
+              "line": 21,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "3": {
+        "line": 34,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 36,
+          },
+          "start": {
+            "column": 0,
+            "line": 34,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 36,
+            },
+            "start": {
+              "column": 0,
+              "line": 34,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 0,
+      "4": 0,
+      "5": 0,
+      "6": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 13,
+          },
+          "start": {
+            "column": 17,
+            "line": 11,
+          },
+        },
+        "line": 11,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 13,
+          },
+          "start": {
+            "column": 17,
+            "line": 11,
+          },
+        },
+        "name": "first",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 21,
+          },
+          "start": {
+            "column": 7,
+            "line": 18,
+          },
+        },
+        "line": 18,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 21,
+          },
+          "start": {
+            "column": 7,
+            "line": 18,
+          },
+        },
+        "name": "second",
+      },
+      "2": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 21,
+          },
+          "start": {
+            "column": 0,
+            "line": 21,
+          },
+        },
+        "line": 21,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 21,
+          },
+          "start": {
+            "column": 0,
+            "line": 21,
+          },
+        },
+        "name": "get",
+      },
+      "3": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 26,
+          },
+          "start": {
+            "column": 7,
+            "line": 24,
+          },
+        },
+        "line": 24,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 26,
+          },
+          "start": {
+            "column": 7,
+            "line": 24,
+          },
+        },
+        "name": "third",
+      },
+      "4": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 26,
+          },
+          "start": {
+            "column": 0,
+            "line": 26,
+          },
+        },
+        "line": 26,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 26,
+          },
+          "start": {
+            "column": 0,
+            "line": 26,
+          },
+        },
+        "name": "get",
+      },
+      "5": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 31,
+          },
+          "start": {
+            "column": 0,
+            "line": 29,
+          },
+        },
+        "line": 29,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 31,
+          },
+          "start": {
+            "column": 0,
+            "line": 29,
+          },
+        },
+        "name": "fourth",
+      },
+      "6": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 36,
+          },
+          "start": {
+            "column": 0,
+            "line": 34,
+          },
+        },
+        "line": 34,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 36,
+          },
+          "start": {
+            "column": 0,
+            "line": 34,
+          },
+        },
+        "name": "fifth",
+      },
+    },
+    "path": "<process-cwd>/src/function-count.ts",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "10": 1,
+      "11": 1,
+      "12": 1,
+      "13": 1,
+      "14": 1,
+      "15": 1,
+      "16": 1,
+      "17": 1,
+      "18": 1,
+      "19": 1,
+      "2": 1,
+      "20": 1,
+      "21": 1,
+      "22": 1,
+      "23": 1,
+      "24": 0,
+      "25": 0,
+      "26": 1,
+      "27": 1,
+      "28": 0,
+      "29": 0,
+      "3": 1,
+      "30": 0,
+      "31": 1,
+      "32": 1,
+      "33": 1,
+      "34": 1,
+      "35": 1,
+      "4": 1,
+      "5": 1,
+      "6": 1,
+      "7": 1,
+      "8": 1,
+      "9": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "1": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "10": {
+        "end": {
+          "column": 18,
+          "line": 11,
+        },
+        "start": {
+          "column": 0,
+          "line": 11,
+        },
+      },
+      "11": {
+        "end": {
+          "column": 10,
+          "line": 12,
+        },
+        "start": {
+          "column": 0,
+          "line": 12,
+        },
+      },
+      "12": {
+        "end": {
+          "column": 1,
+          "line": 13,
+        },
+        "start": {
+          "column": 0,
+          "line": 13,
+        },
+      },
+      "13": {
+        "end": {
+          "column": 0,
+          "line": 14,
+        },
+        "start": {
+          "column": 0,
+          "line": 14,
+        },
+      },
+      "14": {
+        "end": {
+          "column": 7,
+          "line": 15,
+        },
+        "start": {
+          "column": 0,
+          "line": 15,
+        },
+      },
+      "15": {
+        "end": {
+          "column": 0,
+          "line": 16,
+        },
+        "start": {
+          "column": 0,
+          "line": 16,
+        },
+      },
+      "16": {
+        "end": {
+          "column": 27,
+          "line": 17,
+        },
+        "start": {
+          "column": 0,
+          "line": 17,
+        },
+      },
+      "17": {
+        "end": {
+          "column": 26,
+          "line": 18,
+        },
+        "start": {
+          "column": 0,
+          "line": 18,
+        },
+      },
+      "18": {
+        "end": {
+          "column": 9,
+          "line": 19,
+        },
+        "start": {
+          "column": 0,
+          "line": 19,
+        },
+      },
+      "19": {
+        "end": {
+          "column": 10,
+          "line": 20,
+        },
+        "start": {
+          "column": 0,
+          "line": 20,
+        },
+      },
+      "2": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "20": {
+        "end": {
+          "column": 1,
+          "line": 21,
+        },
+        "start": {
+          "column": 0,
+          "line": 21,
+        },
+      },
+      "21": {
+        "end": {
+          "column": 0,
+          "line": 22,
+        },
+        "start": {
+          "column": 0,
+          "line": 22,
+        },
+      },
+      "22": {
+        "end": {
+          "column": 31,
+          "line": 23,
+        },
+        "start": {
+          "column": 0,
+          "line": 23,
+        },
+      },
+      "23": {
+        "end": {
+          "column": 25,
+          "line": 24,
+        },
+        "start": {
+          "column": 0,
+          "line": 24,
+        },
+      },
+      "24": {
+        "end": {
+          "column": 46,
+          "line": 25,
+        },
+        "start": {
+          "column": 0,
+          "line": 25,
+        },
+      },
+      "25": {
+        "end": {
+          "column": 1,
+          "line": 26,
+        },
+        "start": {
+          "column": 0,
+          "line": 26,
+        },
+      },
+      "26": {
+        "end": {
+          "column": 0,
+          "line": 27,
+        },
+        "start": {
+          "column": 0,
+          "line": 27,
+        },
+      },
+      "27": {
+        "end": {
+          "column": 31,
+          "line": 28,
+        },
+        "start": {
+          "column": 0,
+          "line": 28,
+        },
+      },
+      "28": {
+        "end": {
+          "column": 19,
+          "line": 29,
+        },
+        "start": {
+          "column": 0,
+          "line": 29,
+        },
+      },
+      "29": {
+        "end": {
+          "column": 10,
+          "line": 30,
+        },
+        "start": {
+          "column": 0,
+          "line": 30,
+        },
+      },
+      "3": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "30": {
+        "end": {
+          "column": 1,
+          "line": 31,
+        },
+        "start": {
+          "column": 0,
+          "line": 31,
+        },
+      },
+      "31": {
+        "end": {
+          "column": 0,
+          "line": 32,
+        },
+        "start": {
+          "column": 0,
+          "line": 32,
+        },
+      },
+      "32": {
+        "end": {
+          "column": 27,
+          "line": 33,
+        },
+        "start": {
+          "column": 0,
+          "line": 33,
+        },
+      },
+      "33": {
+        "end": {
+          "column": 18,
+          "line": 34,
+        },
+        "start": {
+          "column": 0,
+          "line": 34,
+        },
+      },
+      "34": {
+        "end": {
+          "column": 10,
+          "line": 35,
+        },
+        "start": {
+          "column": 0,
+          "line": 35,
+        },
+      },
+      "35": {
+        "end": {
+          "column": 1,
+          "line": 36,
+        },
+        "start": {
+          "column": 0,
+          "line": 36,
+        },
+      },
+      "4": {
+        "end": {
+          "column": 26,
+          "line": 5,
+        },
+        "start": {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "5": {
+        "end": {
+          "column": 3,
+          "line": 6,
+        },
+        "start": {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "6": {
+        "end": {
+          "column": 0,
+          "line": 7,
+        },
+        "start": {
+          "column": 0,
+          "line": 7,
+        },
+      },
+      "7": {
+        "end": {
+          "column": 50,
+          "line": 8,
+        },
+        "start": {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "8": {
+        "end": {
+          "column": 0,
+          "line": 9,
+        },
+        "start": {
+          "column": 0,
+          "line": 9,
+        },
+      },
+      "9": {
+        "end": {
+          "column": 27,
+          "line": 10,
+        },
+        "start": {
+          "column": 0,
+          "line": 10,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/implicitElse.ts": {
     "all": false,
     "b": {

--- a/test/coverage-test/coverage-report-tests/__snapshots__/custom.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/custom.report.test.ts.snap
@@ -16,6 +16,7 @@ exports[`custom json report 1`] = `
     "<process-cwd>/src/Defined.vue",
     "<process-cwd>/src/Hello.vue",
     "<process-cwd>/src/another-setup.ts",
+    "<process-cwd>/src/function-count.ts",
     "<process-cwd>/src/implicitElse.ts",
     "<process-cwd>/src/importEnv.ts",
     "<process-cwd>/src/index.mts",

--- a/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
@@ -519,6 +519,216 @@ exports[`istanbul json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/function-count.ts": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 1,
+      "1": 1,
+      "2": 0,
+      "3": 0,
+      "4": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 17,
+            "line": 11,
+          },
+          "start": {
+            "column": 9,
+            "line": 11,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 13,
+          },
+          "start": {
+            "column": 17,
+            "line": 11,
+          },
+        },
+        "name": "first",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 25,
+            "line": 18,
+          },
+          "start": {
+            "column": 16,
+            "line": 18,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 21,
+          },
+          "start": {
+            "column": 25,
+            "line": 18,
+          },
+        },
+        "name": "second",
+      },
+      "2": {
+        "decl": {
+          "end": {
+            "column": 24,
+            "line": 24,
+          },
+          "start": {
+            "column": 16,
+            "line": 24,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 26,
+          },
+          "start": {
+            "column": 24,
+            "line": 24,
+          },
+        },
+        "name": "third",
+      },
+      "3": {
+        "decl": {
+          "end": {
+            "column": 18,
+            "line": 29,
+          },
+          "start": {
+            "column": 9,
+            "line": 29,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 31,
+          },
+          "start": {
+            "column": 18,
+            "line": 29,
+          },
+        },
+        "name": "fourth",
+      },
+      "4": {
+        "decl": {
+          "end": {
+            "column": 17,
+            "line": 34,
+          },
+          "start": {
+            "column": 9,
+            "line": 34,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 36,
+          },
+          "start": {
+            "column": 17,
+            "line": 34,
+          },
+        },
+        "name": "fifth",
+      },
+    },
+    "path": "<process-cwd>/src/function-count.ts",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 1,
+      "4": 0,
+      "5": 0,
+      "6": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 12,
+        },
+        "start": {
+          "column": 2,
+          "line": 12,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 15,
+        },
+        "start": {
+          "column": 0,
+          "line": 15,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 19,
+        },
+        "start": {
+          "column": 2,
+          "line": 19,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 20,
+        },
+        "start": {
+          "column": 2,
+          "line": 20,
+        },
+      },
+      "4": {
+        "end": {
+          "column": null,
+          "line": 25,
+        },
+        "start": {
+          "column": 2,
+          "line": 25,
+        },
+      },
+      "5": {
+        "end": {
+          "column": null,
+          "line": 30,
+        },
+        "start": {
+          "column": 2,
+          "line": 30,
+        },
+      },
+      "6": {
+        "end": {
+          "column": null,
+          "line": 35,
+        },
+        "start": {
+          "column": 2,
+          "line": 35,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/implicitElse.ts": {
     "b": {
       "0": [

--- a/test/coverage-test/coverage-report-tests/generic.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/generic.report.test.ts
@@ -5,6 +5,9 @@
 import fs from 'node:fs'
 import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
+import libCoverage from 'istanbul-lib-coverage'
+
+import { readCoverageJson } from './utils'
 
 test('html report', async () => {
   const coveragePath = resolve('./coverage/src')
@@ -79,4 +82,15 @@ test('thresholdAutoUpdate updates thresholds', async () => {
   // Update thresholds back to fixed values
   const updatedConfig = configContents.replace(/(branches|functions|lines|statements): ([\d|\.])+/g, '$1: 1.01')
   fs.writeFileSync(configFilename, updatedConfig)
+})
+
+test.skip('function count is correct', async () => {
+  const coverageJson = await readCoverageJson()
+  const coverageMap = libCoverage.createCoverageMap(coverageJson as any)
+  const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/src/function-count.ts')
+
+  const { functions } = fileCoverage.toSummary()
+
+  expect(functions.total).toBe(5)
+  expect(functions.covered).toBe(3)
 })

--- a/test/coverage-test/coverage-report-tests/generic.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/generic.report.test.ts
@@ -84,7 +84,7 @@ test('thresholdAutoUpdate updates thresholds', async () => {
   fs.writeFileSync(configFilename, updatedConfig)
 })
 
-test.skip('function count is correct', async () => {
+test('function count is correct', async () => {
   const coverageJson = await readCoverageJson()
   const coverageMap = libCoverage.createCoverageMap(coverageJson as any)
   const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/src/function-count.ts')

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -10,10 +10,12 @@
     "test:types": "vitest typecheck --run --reporter verbose"
   },
   "devDependencies": {
+    "@types/istanbul-lib-coverage": "^2.0.4",
     "@vitejs/plugin-vue": "latest",
     "@vitest/browser": "workspace:*",
     "@vue/test-utils": "latest",
     "happy-dom": "latest",
+    "istanbul-lib-coverage": "^3.2.0",
     "vite": "latest",
     "vitest": "workspace:*",
     "vue": "latest",

--- a/test/coverage-test/src/function-count.ts
+++ b/test/coverage-test/src/function-count.ts
@@ -1,0 +1,36 @@
+/*
+ * This file should have:
+ * - 5 functions in total
+ * - 3 covered functions
+ * - 2 uncovered functions
+ */
+
+/* eslint-disable unused-imports/no-unused-vars */
+
+// This function is covered
+function first() {
+  return 1
+}
+
+first()
+
+// This function is covered
+export function second() {
+  fifth()
+  return 2
+}
+
+// This function is NOT covered
+export function third() {
+  throw new Error('Do not call this function')
+}
+
+// This function is NOT covered
+function fourth() {
+  return 4
+}
+
+// This function is covered
+function fifth() {
+  return 5
+}

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { implicitElse } from '../src/implicitElse'
 import { useImportEnv } from '../src/importEnv'
+import { second } from '../src/function-count'
 
 const { pythagoras } = await (() => {
   if ('__vitest_browser__' in globalThis)
@@ -21,4 +22,8 @@ test('implicit else', () => {
 
 test('import meta env', () => {
   expect(useImportEnv()).toBe(true)
+})
+
+test('cover function counts', () => {
+  expect(second()).toBe(2)
 })


### PR DESCRIPTION
- Fixes #3237

Users may see changes in their coverage summary's `functions` and `branches`. Previously these have included some generated code that should not have ended up in the coverage report. Now the `branch` and `function` counts should correspond the source files. 