### PR TITLE
docs: add nav config activeMatch

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -95,10 +95,10 @@ export default withPwa(defineConfig({
     },
 
     nav: [
-      { text: 'Guide', link: '/guide/' },
-      { text: 'API', link: '/api/' },
-      { text: 'Config', link: '/config/' },
-      { text: 'Advanced', link: '/advanced/api' },
+      { text: 'Guide', link: '/guide/', activeMatch: '^/guide/' },
+      { text: 'API', link: '/api/', activeMatch: '^/api/' },
+      { text: 'Config', link: '/config/', activeMatch: '^/config/' },
+      { text: 'Advanced', link: '/advanced/api', activeMatch: '^/advanced/' },
       {
         text: `v${version}`,
         items: [


### PR DESCRIPTION
add activeMatch option in nav config , it can highlight the nav title In the same place

![image](https://user-images.githubusercontent.com/96854855/234219289-ceb7f4a3-7b27-4225-abd9-10e4ee8ae375.png)
