### PR TITLE
feat(coverage): watermarks for c8

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -902,7 +902,7 @@ See [istanbul documentation](https://github.com/istanbuljs/nyc#ignoring-methods)
 }
 ```
 
-- **Available for providers:** `'istanbul'`
+- **Available for providers:** `'c8' | 'istanbul'`
 
 Watermarks for statements, lines, branches and functions. See [istanbul documentation](https://github.com/istanbuljs/nyc#high-and-low-watermarks) for more information.
 

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -188,6 +188,18 @@ export interface BaseCoverageOptions {
   statements?: number
 
   /**
+   * Watermarks for statements, lines, branches and functions.
+   *
+   * Default value is `[50,80]` for each property.
+   */
+  watermarks?: {
+    statements?: [number, number]
+    functions?: [number, number]
+    branches?: [number, number]
+    lines?: [number, number]
+  }
+
+  /**
    * Update threshold values automatically when current coverage is higher than earlier thresholds
    *
    * @default false
@@ -202,18 +214,6 @@ export interface CoverageIstanbulOptions extends BaseCoverageOptions {
    * @default []
    */
   ignoreClassMethods?: string[]
-
-  /**
-   * Watermarks for statements, lines, branches and functions.
-   *
-   * Default value is `[50,80]` for each property.
-   */
-  watermarks?: {
-    statements?: [number, number]
-    functions?: [number, number]
-    branches?: [number, number]
-    lines?: [number, number]
-  }
 }
 
 export interface CoverageC8Options extends BaseCoverageOptions {

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -26,12 +26,19 @@ test('provider options, generic', () => {
     provider: 'c8',
     enabled: true,
     include: ['string'],
+    watermarks: {
+      functions: [80, 95],
+      lines: [80, 95],
+    },
   })
 
   assertType<Coverage>({
     provider: 'istanbul',
     enabled: true,
     include: ['string'],
+    watermarks: {
+      statements: [80, 95],
+    },
   })
 })
 
@@ -55,12 +62,6 @@ test('provider specific options, istanbul', () => {
   assertType<Coverage>({
     provider: 'istanbul',
     ignoreClassMethods: ['string'],
-    watermarks: {
-      statements: [80, 95],
-      functions: [80, 95],
-      branches: [80, 95],
-      lines: [80, 95],
-    },
   })
 
   assertType<Coverage>({


### PR DESCRIPTION
- Closes #3253

Exposes `coverage.watermarks` to `c8` provider in typings. The implementation already works as `c8` seems to support these even though they haven't documented it: https://github.com/bcoe/c8/blob/2f36fe9d00bf2f3b869ce890ed11416304c903fe/lib/report.js#L71

