### PR TITLE
fix(spy): update to set initial implementation through normal logic (fixes #3260)

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -324,5 +324,9 @@ export function fn<TArgs extends any[] = any[], R = any>(
 export function fn<TArgs extends any[] = any[], R = any>(
   implementation?: (...args: TArgs) => R,
 ): Mock<TArgs, R> {
-  return enhanceSpy(tinyspy.internalSpyOn({ fn: implementation || (() => {}) }, 'fn')) as unknown as Mock
+  const enhancedSpy = enhanceSpy(tinyspy.internalSpyOn({ spy: () => {} }, 'spy'))
+  if (implementation)
+    enhancedSpy.mockImplementation(implementation)
+
+  return enhancedSpy as Mock
 }

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -41,6 +41,17 @@ describe('jest mock compat layer', () => {
     expect(Spy.mock.instances).toHaveLength(0)
   })
 
+  it('implementation is set correctly on init', () => {
+    const impl = () => 1
+    const mock1 = vi.fn(impl)
+
+    expect(mock1.getMockImplementation()).toEqual(impl)
+
+    const mock2 = vi.fn()
+
+    expect(mock2.getMockImplementation()).toBeUndefined()
+  })
+
   it('implementation sync fn', () => {
     const originalFn = function () {
       return 'original'
@@ -49,7 +60,7 @@ describe('jest mock compat layer', () => {
 
     spy() // returns 'original'
 
-    expect(spy.getMockImplementation()).toBe(undefined)
+    expect(spy.getMockImplementation()).toBe(originalFn)
 
     spy.mockReturnValueOnce('2-once').mockReturnValueOnce('3-once')
 


### PR DESCRIPTION
Fixes: #3260

The issue currently with `vi.fn` and providing an initial mock implementation (i.e. `vi.fn(() => true)`) is that the provided implementation does not get set by the `enhanceSpy` wrapping. This means that while `stub` is extended to provide the supporting functions that are added by `enhanceSpy`, the state of `implementation` is left `undefined`.

We could go down the path of adding extra parameters and such to `enhanceSpy`, but if we simply call `mockImplementation` during `vi.fn` we can follow the existing logic and have consistent behaviour, allowing the mocked implementation to follow the behaviour we expect.

I've added a test for both the provided implementation and no-implementation cases, as well as updated the other testing / snapshots to reflect this change.

Would love to hear your thoughts or feedback on this :) 