### PR TITLE
fix: warning suppression broken (fix #3270)

### DIFF
--- a/packages/vitest/suppress-warnings.cjs
+++ b/packages/vitest/suppress-warnings.cjs
@@ -4,6 +4,7 @@
 const ignoreWarnings = new Set([
   '--experimental-loader is an experimental feature. This feature could change at any time',
   'Custom ESM Loaders is an experimental feature. This feature could change at any time',
+  'Custom ESM Loaders is an experimental feature and might change at any time',
 ])
 
 const { emit } = process


### PR DESCRIPTION
this pr fix #3270 by adding another message to the suppression set in suppress-warning.cjs