### PR TITLE
fix(vitest): also check for vite relative to vitest package

### DIFF
--- a/packages/vitest/src/node/pkg.ts
+++ b/packages/vitest/src/node/pkg.ts
@@ -1,13 +1,16 @@
+import url from 'node:url'
 import c from 'picocolors'
 import { isPackageExists } from 'local-pkg'
 import { EXIT_CODE_RESTART } from '../constants'
 import { isCI } from '../utils/env'
 
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
 export async function ensurePackageInstalled(
   dependency: string,
   root: string,
 ) {
-  if (isPackageExists(dependency, { paths: [root] }))
+  if (isPackageExists(dependency, { paths: [root, __dirname] }))
     return true
 
   const promptInstall = !isCI && process.stdout.isTTY


### PR DESCRIPTION
Changes `ensurePackageInstalled` to also check relative to a file within the `vitest` package. That way, packages like `vitest` that maybe installed as nested dependencies can still be resolved by the `require.resolve` inside `isPackageExists`.

This is my first PR in vitest (hello! happy to be here!). Left a couple of questions inline. 😄 

Fixes #3112.