### PR TITLE
docs: specify release version for `--bail` option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1403,6 +1403,7 @@ This config option affects truncating values in `test.each` titles and inside th
 - **Type:** `number`
 - **Default:** `0`
 - **CLI**: `--bail=<value>`
+- **Version:** Since Vitest 0.31.0
 
 Stop test execution when given number of tests have failed.
 


### PR DESCRIPTION
- Closes #3285

Related to #3163.