### PR TITLE
fix: throw an error, if tests are collected with a different vitest version

### DIFF
--- a/packages/runner/rollup.config.js
+++ b/packages/runner/rollup.config.js
@@ -1,5 +1,6 @@
 import { builtinModules } from 'node:module'
 import esbuild from 'rollup-plugin-esbuild'
+import json from '@rollup/plugin-json'
 import dts from 'rollup-plugin-dts'
 import { defineConfig } from 'rollup'
 import pkg from './package.json' assert { type: 'json' }
@@ -21,6 +22,7 @@ const plugins = [
   esbuild({
     target: 'node14',
   }),
+  json(),
 ]
 
 export default defineConfig([

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -8,6 +8,7 @@ import { collectTests } from './collect'
 import { processError } from './utils/error'
 import { setCurrentTest } from './test-state'
 import { hasFailed, hasTests } from './utils/tasks'
+import { markVersion } from './version'
 
 const now = Date.now
 
@@ -350,6 +351,8 @@ export async function runFiles(files: File[], runner: VitestRunner) {
 }
 
 export async function startTests(paths: string[], runner: VitestRunner) {
+  markVersion()
+
   await runner.onBeforeCollect?.(paths)
 
   const files = await collectTests(paths, runner)

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -4,11 +4,13 @@ import type { VitestRunner } from './types/runner'
 import { createChainable } from './utils/chain'
 import { collectTask, collectorContext, createTestContext, runWithSuite, withTimeout } from './context'
 import { getHooks, setFn, setHooks } from './map'
+import { checkVersion } from './version'
 
 // apis
 export const suite = createSuite()
 export const test = createTest(
   function (name: string, fn?: TestFunction, options?: number | TestOptions) {
+    checkVersion()
     getCurrentSuite().test.fn.call(this, name, fn, options)
   },
 )
@@ -182,6 +184,7 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
 
 function createSuite() {
   function suiteFn(this: Record<string, boolean | undefined>, name: string, factory?: SuiteFactory, options?: number | TestOptions) {
+    checkVersion()
     const mode: RunMode = this.only ? 'only' : this.skip ? 'skip' : this.todo ? 'todo' : 'run'
     return createSuiteCollector(name, factory, mode, this.concurrent, this.shuffle, options)
   }

--- a/packages/runner/src/version.ts
+++ b/packages/runner/src/version.ts
@@ -1,0 +1,22 @@
+import { version as VERSION } from '../package.json'
+
+export function getVersion(): string {
+  // @ts-expect-error internal variable
+  return globalThis.__vitest_runner_version__ || VERSION
+}
+
+export function markVersion(): void {
+  // @ts-expect-error internal variable
+  globalThis.__vitest_runner_version__ = VERSION
+}
+
+export function checkVersion() {
+  const collectVersion = getVersion()
+
+  if (collectVersion !== VERSION) {
+    const error = `Version mismatch: Vitest started as ${collectVersion}, but tests are collected with ${VERSION} version.`
+      + '\n\n- If you are using global Vitest, make sure your package has the same version.'
+      + '\n- If you have a monorepo setup, make sure your main package has the same version as your test packages.'
+    throw new Error(error)
+  }
+}


### PR DESCRIPTION
Closes #3296