### PR TITLE
feat(watch): press `r` should rerun current pattern tests

### DIFF
--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -61,11 +61,11 @@ export function registerConsoleShortcuts(ctx: Vitest) {
     if (name === 'u')
       return ctx.updateSnapshot()
     // rerun all tests
-    if (name === 'a')
+    if (name === 'a' || name === 'return')
       return ctx.changeNamePattern('')
     // rerun current pattern tests
-    if (name === 'return')
-      return ctx.rerunFiles(ctx.state.getFilepaths(), 'rerun')
+    if (name === 'r')
+      return ctx.rerunFiles()
     // rerun only failed tests
     if (name === 'f')
       return ctx.rerunFailed()

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -13,7 +13,7 @@ const keys = [
   ['t', 'filter by a test name regex pattern'],
   ['q', 'quit'],
 ]
-const cancelKeys = ['space', 'c', ...keys.map(key => key[0])]
+const cancelKeys = ['space', 'c', ...keys.map(key => key[0]).flat()]
 
 export function printShortcutsHelp() {
   stdout().write(

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -6,6 +6,7 @@ import type { Vitest } from './core'
 
 const keys = [
   ['a', 'rerun all tests'],
+  ['r', 'rerun current pattern tests'],
   ['f', 'rerun only failed tests'],
   ['u', 'update snapshot'],
   ['p', 'filter by a filename'],

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -5,7 +5,7 @@ import { isWindows, stdout } from '../utils'
 import type { Vitest } from './core'
 
 const keys = [
-  [['a, return'], 'rerun all tests'],
+  [['a', 'return'], 'rerun all tests'],
   ['r', 'rerun current pattern tests'],
   ['f', 'rerun only failed tests'],
   ['u', 'update snapshot'],

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -61,8 +61,11 @@ export function registerConsoleShortcuts(ctx: Vitest) {
     if (name === 'u')
       return ctx.updateSnapshot()
     // rerun all tests
-    if (name === 'a' || name === 'return')
+    if (name === 'a')
       return ctx.changeNamePattern('')
+    // rerun current pattern tests
+    if (name === 'return')
+      return ctx.rerunFiles(ctx.state.getFilepaths(), 'rerun')
     // rerun only failed tests
     if (name === 'f')
       return ctx.rerunFailed()

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -5,7 +5,7 @@ import { isWindows, stdout } from '../utils'
 import type { Vitest } from './core'
 
 const keys = [
-  ['a', 'rerun all tests'],
+  [['a, return'], 'rerun all tests'],
   ['r', 'rerun current pattern tests'],
   ['f', 'rerun only failed tests'],
   ['u', 'update snapshot'],
@@ -19,7 +19,7 @@ export function printShortcutsHelp() {
   stdout().write(
     `
 ${c.bold('  Watch Usage')}
-${keys.map(i => c.dim('  press ') + c.reset(c.bold(i[0])) + c.dim(` to ${i[1]}`)).join('\n')}
+${keys.map(i => c.dim('  press ') + c.reset([i[0]].flat().map(c.bold).join(', ')) + c.dim(` to ${i[1]}`)).join('\n')}
 `,
   )
 }

--- a/test/watch/test/stdin.test.ts
+++ b/test/watch/test/stdin.test.ts
@@ -17,6 +17,15 @@ test('quit watch mode', async () => {
   await vitest.isDone
 })
 
+test('rerun current pattern tests', async () => {
+  const pattern = 'TEST_NAME_PATTERN'
+  const vitest = await startWatchMode(`-t ${pattern}`)
+
+  vitest.write('r')
+
+  await vitest.waitForOutput(`Test name pattern: ${pattern}`)
+})
+
 test('filter by filename', async () => {
   const vitest = await startWatchMode()
 

--- a/test/watch/test/stdin.test.ts
+++ b/test/watch/test/stdin.test.ts
@@ -18,12 +18,12 @@ test('quit watch mode', async () => {
 })
 
 test('rerun current pattern tests', async () => {
-  const pattern = 'TEST_NAME_PATTERN'
-  const vitest = await startWatchMode(`-t ${pattern}`)
+  const vitest = await startWatchMode('-t', 'sum')
 
   vitest.write('r')
 
-  await vitest.waitForOutput(`Test name pattern: ${pattern}`)
+  await vitest.waitForOutput('Test name pattern: /sum/')
+  await vitest.waitForOutput('1 passed')
 })
 
 test('filter by filename', async () => {


### PR DESCRIPTION
### Why?

In debugging, we may need to change the `node_modules` files, but it does not automatically trigger a re-run of the test.

>  Besides, I think press `enter` is a better way to execute rerun. but the `enter` has been used in rerun all tests.