### PR TITLE
fix(coverage): c8 aliased paths

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -289,7 +289,8 @@ export class ViteNodeRunner {
 
     const modulePath = cleanUrl(moduleId)
     // disambiguate the `<UNIT>:/` on windows: see nodejs/node#31710
-    const href = pathToFileURL(modulePath).href
+    const [moduleUrl] = await this.resolveUrl(modulePath)
+    const href = pathToFileURL(moduleUrl).href
     const meta = { url: href }
     const exports = Object.create(null)
     Object.defineProperty(exports, Symbol.toStringTag, {


### PR DESCRIPTION
- Fixes #3268

`vitenode.fetchCache` contains file path without extension when module is imported using alias. This does not end up in coverage report due to missing extension.