### PR TITLE
fix(vite-node): allow returning id not wrapped in promise

### DIFF
--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -41,7 +41,7 @@ export type HotContext = Omit<ViteHotContext, 'acceptDeps' | 'decline'>
 
 export type FetchFunction = (id: string) => Promise<FetchResult>
 
-export type ResolveIdFunction = (id: string, importer?: string) => Promise<ViteNodeResolveId | null>
+export type ResolveIdFunction = (id: string, importer?: string) => Promise<ViteNodeResolveId | null> | ViteNodeResolveId | null
 
 export type CreateHotContextFunction = (runner: ViteNodeRunner, url: string) => HotContext
 

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -4,6 +4,7 @@ import type { ModuleCacheMap, ViteNodeRunner } from './client'
 
 export type Nullable<T> = T | null | undefined
 export type Arrayable<T> = T | Array<T>
+export type Awaitable<T> = T | PromiseLike<T>
 
 export interface DepsHandlingOptions {
   external?: (string | RegExp)[]
@@ -41,7 +42,7 @@ export type HotContext = Omit<ViteHotContext, 'acceptDeps' | 'decline'>
 
 export type FetchFunction = (id: string) => Promise<FetchResult>
 
-export type ResolveIdFunction = (id: string, importer?: string) => Promise<ViteNodeResolveId | null> | ViteNodeResolveId | null
+export type ResolveIdFunction = (id: string, importer?: string) => Awaitable<ViteNodeResolveId | null | undefined | void>
 
 export type CreateHotContextFunction = (runner: ViteNodeRunner, url: string) => HotContext
 


### PR DESCRIPTION
This is a small change to the type of `resolveId`. I believe it is only ever awaited, which means it should be safe to synchronously return an id.

I didn't think it was worth adding `@vitest/utils` to benefit from the `Awaitable` type but happy if you think otherwise.

(Might we also want to allow `void`?)