### PR TITLE
fix: correctly restore vi.fn implementation

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -324,7 +324,7 @@ export function fn<TArgs extends any[] = any[], R = any>(
 export function fn<TArgs extends any[] = any[], R = any>(
   implementation?: (...args: TArgs) => R,
 ): Mock<TArgs, R> {
-  const enhancedSpy = enhanceSpy(tinyspy.internalSpyOn({ spy: () => {} }, 'spy'))
+  const enhancedSpy = enhanceSpy(tinyspy.internalSpyOn({ spy: implementation || (() => {}) }, 'spy'))
   if (implementation)
     enhancedSpy.mockImplementation(implementation)
 

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -322,7 +322,7 @@ describe('jest mock compat layer', () => {
     expect(Fn.mock.instances[1]).toBe(instance2)
   })
 
-  test('.mockRestore() should restore initial implementation', () => {
+  it('.mockRestore() should restore initial implementation', () => {
     const testFn = vi.fn(() => true)
     expect(testFn()).toBe(true)
 

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -321,4 +321,15 @@ describe('jest mock compat layer', () => {
     const instance2 = new Fn()
     expect(Fn.mock.instances[1]).toBe(instance2)
   })
+
+  test('.mockRestore() should restore initial implementation', () => {
+    const testFn = vi.fn(() => true)
+    expect(testFn()).toBe(true)
+
+    testFn.mockReturnValue(false)
+    expect(testFn()).toBe(false)
+
+    testFn.mockRestore()
+    expect(testFn()).toBe(true)
+  })
 })


### PR DESCRIPTION
Closes #3335
Closes #3340