### PR TITLE
fix: exclude `cwd` from test name filter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1613,6 +1613,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest
 
+  test/filters:
+    devDependencies:
+      vite:
+        specifier: ^4.2.1
+        version: 4.2.1(@types/node@18.16.3)
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+
   test/global-setup:
     devDependencies:
       vitest:

--- a/test/filters/fixtures/test/dont-run-this.test.ts
+++ b/test/filters/fixtures/test/dont-run-this.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('this will fail', () => {
+  expect('This test should not be run').toBeFalsy()
+})

--- a/test/filters/fixtures/test/example.test.ts
+++ b/test/filters/fixtures/test/example.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('this will pass', () => {
+  expect(1 + 1).toBe(2)
+})

--- a/test/filters/fixtures/test/filters.test.ts
+++ b/test/filters/fixtures/test/filters.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('this will pass', () => {
+  expect('This test should be run').toBeTruthy()
+})

--- a/test/filters/package.json
+++ b/test/filters/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitest/test-filters",
+  "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vite": "latest",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/filters/test/testname-pattern.test.ts
+++ b/test/filters/test/testname-pattern.test.ts
@@ -1,0 +1,50 @@
+import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
+import type { File } from 'vitest'
+import { startVitest } from 'vitest/node'
+
+test('match by partial pattern', async () => {
+  const output = await runVitest('example')
+
+  expect(output).toMatchInlineSnapshot('"pass: test/example.test.ts"')
+})
+
+test('match by full test file name', async () => {
+  const filename = resolve('./fixtures/test/example.test.ts')
+  const output = await runVitest(filename)
+
+  expect(output).toMatchInlineSnapshot('"pass: test/example.test.ts"')
+})
+
+test('match by pattern that also matches current working directory', async () => {
+  const filter = 'filters'
+  expect(process.cwd()).toMatch(filter)
+
+  const output = await runVitest(filter)
+  expect(output).toMatchInlineSnapshot('"pass: test/filters.test.ts"')
+})
+
+async function runVitest(...cliArgs: string[]) {
+  let resolve: (value: string) => void
+  const promise = new Promise<string>((_resolve) => {
+    resolve = _resolve
+  })
+
+  await startVitest('test', cliArgs, {
+    root: './fixtures',
+    watch: false,
+    reporters: [{
+      onFinished(files?: File[], errors?: unknown[]) {
+        if (errors?.length)
+          resolve(`Error: ${JSON.stringify(errors, null, 2)}`)
+
+        if (files)
+          resolve(files.map(file => `${file.result?.state}: ${file.name}`).join('\n'))
+        else
+          resolve('No files')
+      },
+    }],
+  })
+
+  return promise
+}

--- a/test/filters/vitest.config.ts
+++ b/test/filters/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    reporters: 'verbose',
+    include: ['test/**/*.test.*'],
+  },
+})


### PR DESCRIPTION
- Fixes #3344

Example of test case failure without PR changes:

```
/root/to/vitest/test/filters
└── fixtures
   └── test
      ├── dont-run-this.test.ts
      ├── example.test.ts
      └── filters.test.ts
```

Running pattern `filter` in `/root/to/vitest/test/filters/fixtures`:

```
 FAIL  test/testname-pattern.test.ts > match by pattern that also matches current working directory
Error: Snapshot `match by pattern that also matches current working directory 1` mismatched
 ❯ test/testname-pattern.test.ts:24:18
     22| 
     23|   const output = await runVitest(filter)
     24|   expect(output).toMatchInlineSnapshot('"pass: test/filters.test.ts"')
       |                  ^
     25| })
     26| 

  - Expected  - 1
  + Received  + 1

  - `"pass: test/filters.test.ts"
  + `"fail: test/dont-run-this.test.ts␊
```

