### PR TITLE
fix: `toMatchInlineSnapshot` fails when file path includes parentheses (fix #3370)

### DIFF
--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -23,7 +23,7 @@ function extractLocation(urlLike: string) {
     return [urlLike]
 
   const regExp = /(.+?)(?::(\d+))?(?::(\d+))?$/
-  const parts = regExp.exec(urlLike.replace(/[()]/g, ''))
+  const parts = regExp.exec(urlLike.replace(/^\(|\)$/g, ''))
   if (!parts)
     return [urlLike]
   return [parts[1], parts[2] || undefined, parts[3] || undefined]

--- a/test/core/test/snapshot-inline-(parentheses).test.ts
+++ b/test/core/test/snapshot-inline-(parentheses).test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from 'vitest'
 
 test('object', () => {
-    expect({
-      foo: {
-        type: 'object',
-        map: new Map(),
-      },
-    })
-      .toMatchInlineSnapshot(`
+  expect({
+    foo: {
+      type: 'object',
+      map: new Map(),
+    },
+  })
+    .toMatchInlineSnapshot(`
         {
           "foo": {
             "map": Map {},
@@ -15,5 +15,4 @@ test('object', () => {
           },
         }
       `)
-  })
-  
+})

--- a/test/core/test/snapshot-inline-(parentheses).test.ts
+++ b/test/core/test/snapshot-inline-(parentheses).test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+
+test('object', () => {
+    expect({
+      foo: {
+        type: 'object',
+        map: new Map(),
+      },
+    })
+      .toMatchInlineSnapshot(`
+        {
+          "foo": {
+            "map": Map {},
+            "type": "object",
+          },
+        }
+      `)
+  })
+  


### PR DESCRIPTION
fix #3370 

Previously, we use `urlLike.replace(/[()]/g, '')` to remove all parentheses in `urlLike`, this will also remove parentheses in file path (`D:\...\snapshot-inline-(parentheses).test.ts:10:8`). We should remove only the leading and trailing parentheses (`(file:///D:/.../index.js:585:15)`).

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/pacexy/vitest/tree/pacexy%2Fissue3370"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/pacexy/vitest/tree/pacexy%2Fissue3370)._