### PR TITLE
fix: gracefully exit when first `SIGINT` is received

### DIFF
--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -79,6 +79,8 @@ export async function startVitest(
 
   if (process.stdin.isTTY && ctx.config.watch)
     registerConsoleShortcuts(ctx)
+  else
+    process.on('SIGINT', () => ctx.cancelCurrentRun('keyboard-input'))
 
   ctx.onServerRestart((reason) => {
     ctx.report('onServerRestart', reason)

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -28,9 +28,15 @@ export function registerConsoleShortcuts(ctx: Vitest) {
   let latestFilename = ''
 
   async function _keypressHandler(str: string, key: any) {
-    // ctrl-c or esc
-    if (str === '\x03' || str === '\x1B' || (key && key.ctrl && key.name === 'c'))
+    // Cancel run and exit when ctrl-c or esc is pressed.
+    // If cancelling takes long and key is pressed multiple times, exit forcefully.
+    if (str === '\x03' || str === '\x1B' || (key && key.ctrl && key.name === 'c')) {
+      if (!ctx.isCancelling) {
+        await ctx.cancelCurrentRun('keyboard-input')
+        await ctx.runningPromise
+      }
       return ctx.exit(true)
+    }
 
     // window not support suspend
     if (!isWindows && key && key.ctrl && key.name === 'z') {


### PR DESCRIPTION
- Fixes #3373

When `CTRL + c` is pressed once Vitest will start to gracefully stop the tests. If the key is pressed again it'll forcefully exit the process. 

When running in non-watch mode, the underlying dependencies (`signal-exit`, I think) seem to take over the `SIGINT` handling and `process.exit()` calls. During the first `SIGINT` they'll let our listener to run without exiting the process. On the second `SIGNINT` their own listener kicks in and stops the process. 