### PR TITLE
fix(vite-node): coerce to string in import(dep)

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -267,6 +267,7 @@ export class ViteNodeRunner {
     const mod = this.moduleCache.getByModuleId(moduleId)
 
     const request = async (dep: string) => {
+      dep = `${dep}`
       const [id, depFsPath] = await this.resolveUrl(dep, fsPath)
       return this.dependencyRequest(id, depFsPath, callstack)
     }

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -267,8 +267,7 @@ export class ViteNodeRunner {
     const mod = this.moduleCache.getByModuleId(moduleId)
 
     const request = async (dep: string) => {
-      dep = `${dep}`
-      const [id, depFsPath] = await this.resolveUrl(dep, fsPath)
+      const [id, depFsPath] = await this.resolveUrl(`${dep}`, fsPath)
       return this.dependencyRequest(id, depFsPath, callstack)
     }
 

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -52,6 +52,12 @@ test('data with dynamic import works', async () => {
   expect(hi).toBe('hi')
 })
 
+test('dynamic import coerces to string', async () => {
+  const dataUri = 'data:text/javascript;charset=utf-8,export default "hi"'
+  const { default: hi } = await import({ toString: () => dataUri } as string)
+  expect(hi).toBe('hi')
+})
+
 test('dynamic import has Module symbol', async () => {
   const stringTimeoutMod = await import('./../src/timeout')
 


### PR DESCRIPTION
This PR would...
- Coerce `dep` to string using the string coercion algorithm in `import(dep)`

Need to use `` `${s}` `` instead of `"" + s` in order to get the right hint in `Symbol.toPrimitive`

> ```js
> const obj2 = {
>   [Symbol.toPrimitive](hint) {
>     if (hint === "number") {
>       return 10;
>     }
>     if (hint === "string") {
>       return "hello";
>     }
>     return true;
>   },
> };
> console.log(+obj2); // 10        — hint is "number"
> console.log(`${obj2}`); // "hello"   — hint is "string"
> console.log(obj2 + ""); // "true"    — hint is "default"
> ```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive#description

closes  #3429 

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/jcbhmr/vitest/tree/jcbhmr%2Fissue3429"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/jcbhmr/vitest/tree/jcbhmr%2Fissue3429)._