### PR TITLE
fix: don't restore methods in automocked dependencies

### DIFF
--- a/examples/mocks/test/automocking.spec.ts
+++ b/examples/mocks/test/automocking.spec.ts
@@ -48,6 +48,8 @@ test('automock properly restores mock', async () => {
   expect(moduleWithSymbol.warn()).toBeUndefined()
   expect(moduleWithSymbol[methodSymbol]()).toBeUndefined()
 
+  expect(log.warn).toHaveProperty('mockImplementation')
+
   vi.restoreAllMocks()
 
   expect(() => {
@@ -56,6 +58,8 @@ test('automock properly restores mock', async () => {
 
   expect(moduleWithSymbol[methodSymbol]()).toBe('hello')
   expect(moduleWithSymbol.warn()).toBe('hello')
+
+  expect(log.warn).toHaveProperty('mockImplementation')
 })
 
 test('automock has a getter', () => {

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -267,7 +267,12 @@ export class VitestMocker {
           continue
 
         if (isFunction) {
-          spyOn(newContainer, property).mockImplementation(() => undefined)
+          const mock = spyOn(newContainer, property).mockImplementation(() => undefined)
+          mock.mockRestore = () => {
+            mock.mockReset()
+            mock.mockImplementation(undefined!)
+            return mock
+          }
           // tinyspy retains length, but jest doesn't.
           Object.defineProperty(newContainer[property], 'length', { value: 0 })
         }


### PR DESCRIPTION
Closes #3410