### PR TITLE
fix: extend logging of process timeout errors

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -700,14 +700,15 @@ export class Vitest {
 
   async close() {
     if (!this.closingPromise) {
-      const closePromises = this.projects.map(w => w.close())
+      const closePromises = this.projects.map(w => w.close().then(() => w.server = undefined as any))
       // close the core workspace server only once
       if (this.coreWorkspace && !this.projects.includes(this.coreWorkspace))
-        closePromises.push(this.server.close())
-      this.closingPromise = Promise.allSettled([
-        this.pool?.close(),
-        ...closePromises,
-      ].filter(Boolean)).then((results) => {
+        closePromises.push(this.server.close().then(() => this.server = undefined as any))
+
+      if (this.pool)
+        closePromises.push(this.pool.close().then(() => this.pool = undefined))
+
+      this.closingPromise = Promise.allSettled(closePromises).then((results) => {
         results.filter(r => r.status === 'rejected').forEach((err) => {
           this.logger.error('error during close', (err as PromiseRejectedResult).reason)
         })
@@ -724,6 +725,20 @@ export class Vitest {
       this.report('onProcessTimeout').then(() => {
         console.warn(`close timed out after ${this.config.teardownTimeout}ms`)
         this.state.getProcessTimeoutCauses().forEach(cause => console.warn(cause))
+
+        if (!this.pool) {
+          const runningServers = [this.server, ...this.projects.map(p => p.server)].filter(Boolean).length
+
+          if (runningServers === 1)
+            console.warn('Tests closed successfully but something prevents Vite server from exiting')
+          else if (runningServers > 1)
+            console.warn(`Tests closed successfully but something prevents ${runningServers} Vite servers from exiting`)
+          else
+            console.warn('Tests closed successfully but something prevents the main process from exiting')
+
+          console.warn('You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters')
+        }
+
         process.exit()
       })
     }, this.config.teardownTimeout).unref()


### PR DESCRIPTION
- Related to https://github.com/vitest-dev/vitest/issues/2008#issuecomment-1533226906

Log informative warning when something prevents Vite server from exiting. This is only done when pool (tests/workers) have successfully exited. If workers are stuck we'll log the name of the stuck test file as before: #3031.

This only adds more logging and does not solve the root cause. The root cause is typically in third party code so I'm still not sure how those cases could be caught. 

Minimal reproduction:

```js
import { defineConfig } from "vitest/config";
import chokidar from "chokidar";

export default defineConfig({
  plugins: [
    {
      name: "bad-plugin-preventing-vite-from-exiting",
      configureServer() {
        chokidar.watch("./").on("all", () => {});
      },
    },
  ],

  test: {
    reporters: ["verbose"],
  },
});
```

```sh
> example-project@1.0.0 test /x/y/vitest-example-project
> vitest run


 RUN  v0.31.1 /x/y/vitest-example-project

 ✓ tests/animals.test.ts (3)
   ✓ Dog says woof
   ✓ Dog doesn't meow
   ✓ Cat can't fly
 ✓ tests/math.test.ts (1)
   ✓ sum

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  11:44:15
   Duration  257ms (transform 48ms, setup 0ms, collect 33ms, tests 5ms, environment 0ms, prepare 112ms)

close timed out after 10000ms
Tests closed successfully but something prevents Vite server from exiting
```

