### PR TITLE
fix: `rejects` & `resolves` breaks with thenable objects

### DIFF
--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -1,6 +1,6 @@
-export function recordAsyncExpect(test: any, promise: Promise<any>) {
+export function recordAsyncExpect(test: any, promise: Promise<any> | PromiseLike<any>) {
   // record promise for test, that resolves before test ends
-  if (test) {
+  if (test && promise instanceof Promise) {
     // if promise is explicitly awaited, remove it from the list
     promise = promise.finally(() => {
       const index = test.promises.indexOf(promise)

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -720,6 +720,25 @@ describe('async expect', () => {
       expect(value).toBe(1)
     })
   })
+
+  it('handle thenable objects', async () => {
+    await expect({ then: (resolve: any) => resolve(0) }).resolves.toBe(0)
+    await expect({ then: (_: any, reject: any) => reject(0) }).rejects.toBe(0)
+
+    try {
+      await expect({ then: (resolve: any) => resolve(0) }).rejects.toBe(0)
+    }
+    catch (error) {
+      expect(error).toEqual(new Error('promise resolved "0" instead of rejecting'))
+    }
+
+    try {
+      await expect({ then: (_: any, reject: any) => reject(0) }).resolves.toBe(0)
+    }
+    catch (error) {
+      expect(error).toEqual(new Error('promise rejected "0" instead of resolving'))
+    }
+  })
 })
 
 it('compatible with jest', () => {


### PR DESCRIPTION
Fixes #3318 