### PR TITLE
fix: prevent `birpc` timeouts when `Math.random` mock is not restored

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -69,7 +69,7 @@
     "@vitest/ws-client": "workspace:*",
     "@vueuse/core": "^10.1.2",
     "ansi-to-html": "^0.7.2",
-    "birpc": "0.2.11",
+    "birpc": "0.2.12",
     "codemirror": "^5.65.13",
     "codemirror-theme-vars": "^0.1.2",
     "cypress": "^12.11.0",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -174,7 +174,7 @@
     "@types/micromatch": "^4.0.2",
     "@types/prompts": "^2.4.4",
     "@types/sinonjs__fake-timers": "^8.1.2",
-    "birpc": "0.2.11",
+    "birpc": "0.2.12",
     "chai-subset": "^1.6.0",
     "cli-truncate": "^3.1.0",
     "event-target-polyfill": "^0.0.3",

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -39,7 +39,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "birpc": "0.2.11",
+    "birpc": "0.2.12",
     "flatted": "^3.2.7",
     "ws": "^8.13.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1080,8 +1080,8 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2
       birpc:
-        specifier: 0.2.11
-        version: 0.2.11
+        specifier: 0.2.12
+        version: 0.2.12
       codemirror:
         specifier: ^5.65.13
         version: 5.65.13
@@ -1289,8 +1289,8 @@ importers:
         specifier: ^8.1.2
         version: 8.1.2
       birpc:
-        specifier: 0.2.11
-        version: 0.2.11
+        specifier: 0.2.12
+        version: 0.2.12
       chai-subset:
         specifier: ^1.6.0
         version: 1.6.0
@@ -1383,8 +1383,8 @@ importers:
   packages/ws-client:
     dependencies:
       birpc:
-        specifier: 0.2.11
-        version: 0.2.11
+        specifier: 0.2.12
+        version: 0.2.12
       flatted:
         specifier: ^3.2.7
         version: 3.2.7
@@ -11063,8 +11063,8 @@ packages:
     dev: true
     optional: true
 
-  /birpc@0.2.11:
-    resolution: {integrity: sha512-OcUm84SBHRsmvSQhOLZRt5Awmw8WVknVcMDMaPE8GPwYxzc4mGE0EIytkWXayPjheGvm7s/Ci1wQZGwk7YPU6A==}
+  /birpc@0.2.12:
+    resolution: {integrity: sha512-6Wz9FXuJ/FE4gDH+IGQhrYdalAvAQU1Yrtcu1UlMk3+9mMXxIRXiL+MxUcGokso42s+Fy+YoUXGLOdOs0siV3A==}
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}

--- a/test/core/test/mock-internals.test.ts
+++ b/test/core/test/mock-internals.test.ts
@@ -1,6 +1,6 @@
 import childProcess, { exec } from 'node:child_process'
 import timers from 'node:timers'
-import { expect, test, vi } from 'vitest'
+import { type SpyInstance, afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { execDefault, execHelloWorld, execImportAll } from '../src/exec'
 import { dynamicImport } from '../src/dynamic-import'
 
@@ -27,4 +27,32 @@ test('mocked dynamically imported packages', async () => {
   expect(mod).toHaveProperty('default')
   expect(mod.default).toHaveProperty('clearInterval')
   expect(mod.default.clearInterval()).toBe('foo')
+})
+
+describe('Math.random', () => {
+  describe('mock is restored', () => {
+    let spy: SpyInstance
+
+    beforeEach(() => {
+      spy = vi.spyOn(Math, 'random').mockReturnValue(0.1)
+    })
+    afterEach(() => {
+      spy.mockRestore()
+    })
+
+    test('is mocked', () => {
+      expect(Math.random()).toBe(0.1)
+    })
+  })
+
+  // This used to make dependencies stuck, e.g. birpc
+  describe('mock is not restored and leaks', () => {
+    beforeEach(() => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.1)
+    })
+
+    test('is mocked', () => {
+      expect(Math.random()).toBe(0.1)
+    })
+  })
 })


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/discussions/3457#discussioncomment-6021760
- Related to https://github.com/vitest-dev/vitest/issues/903
- Related to https://github.com/vitest-dev/vitest/issues/2230
- `birpc` changes https://github.com/antfu/birpc/pull/8

When users mock `Math.random` and do not correctly restore it back to original implementation, Vitest will freeze due to `birpc` being unable to pass messages.
It's wrong to not restore mocks after test execution but it's also bad to freeze the test runner.

Minimal reproduction:

```js
beforeEach(() => {
  // Math.random is mocked but not restored after test
  vi.spyOn(Math, 'random').mockReturnValue(0.1)
})

test('Math.random is mocked', () => {
  expect(Math.random()).toBe(0.1)
})
```

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: [birpc] timeout on calling "onAfterSuiteRun"
 ❯ Timeout._onTimeout ../../packages/vitest/dist/vendor-index.c934bc6b.js:138:22
 ❯ listOnTimeout ../../node:internal/timers:569:17
 ❯ processTimers ../../node:internal/timers:512:7

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```