### PR TITLE
fix(runner): suite options do not propagate to nested suites (fix: #3467)

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -199,10 +199,9 @@ function createSuite() {
     if (typeof options === 'number')
       options = { timeout: options }
 
-    if (currentSuite && typeof currentSuite.options?.repeats === 'number') {
-      // inherit repeats from current suite
-      options = { repeats: currentSuite.options.repeats, ...options }
-    }
+    // inherit options from current suite
+    if (currentSuite?.options)
+      options = { ...currentSuite.options, ...options }
 
     return createSuiteCollector(name, factory, mode, this.concurrent, this.shuffle, this.each, options)
   }

--- a/test/core/test/propagate-options-nested-suite.test.ts
+++ b/test/core/test/propagate-options-nested-suite.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+describe(
+  'suite name',
+  () => {
+    let outerCount = 0
+
+    it('should retry until success', () => {
+      outerCount++
+      expect(outerCount).toBe(5)
+    })
+
+    describe('nested', () => {
+      let innerCount = 0
+
+      it('should retry until success (nested)', () => {
+        innerCount++
+        expect(innerCount).toBe(5)
+      })
+    })
+  },
+  { retry: 10 },
+)


### PR DESCRIPTION
fix #3467 