### PR TITLE
revert: "fix(vite-node): circular import stuck" #3418

### DIFF
--- a/examples/mocks/src/main.js
+++ b/examples/mocks/src/main.js
@@ -1,10 +1,5 @@
 import { funcA } from './A'
-import { funcB } from './B'
 
 export function main() {
   return funcA()
-}
-
-export function mainB() {
-  return funcB()
 }

--- a/examples/mocks/test/circular.spec.ts
+++ b/examples/mocks/test/circular.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { main, mainB } from '../src/main.js'
+import { main } from '../src/main.js'
 import x from '../src/export-default-circle-index'
 
 vi.mock('../src/A', async () => ({
@@ -7,19 +7,10 @@ vi.mock('../src/A', async () => ({
   funcA: () => 'mockedA',
 }))
 
-vi.mock('../src/B', async () => ({
-  ...(await vi.importActual<any>('../src/B')),
-  funcB: () => 'mockedB',
-}))
-
 vi.mock('../src/export-default-circle-b')
 
 test('can import actual inside mock factory', () => {
   expect(main()).toBe('mockedA')
-})
-
-test('can import in top level and inside mock factory', () => {
-  expect(mainB()).toBe('mockedB')
 })
 
 test('can mock a circular dependency', () => {

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -188,13 +188,16 @@ export class ViteNodeRunner {
 
     if (!mod.importers)
       mod.importers = new Set()
+
+    const isCircular = mod.importers.has(importee)
+
     if (importee)
       mod.importers.add(importee)
 
     const getStack = () => `stack:\n${[...callstack, fsPath].reverse().map(p => `  - ${p}`).join('\n')}`
 
     // check circular dependency
-    if (callstack.includes(fsPath) || callstack.some(c => this.moduleCache.get(c).importers?.has(fsPath)) || mod.importers.has(importee)) {
+    if (isCircular || callstack.includes(fsPath) || callstack.some(c => this.moduleCache.get(c).importers?.has(fsPath))) {
       if (mod.exports)
         return mod.exports
     }

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -188,16 +188,13 @@ export class ViteNodeRunner {
 
     if (!mod.importers)
       mod.importers = new Set()
-
-    const isCircular = mod.importers.has(importee)
-
     if (importee)
       mod.importers.add(importee)
 
     const getStack = () => `stack:\n${[...callstack, fsPath].reverse().map(p => `  - ${p}`).join('\n')}`
 
     // check circular dependency
-    if (isCircular || callstack.includes(fsPath) || callstack.some(c => this.moduleCache.get(c).importers?.has(fsPath))) {
+    if (callstack.includes(fsPath) || callstack.some(c => this.moduleCache.get(c).importers?.has(fsPath))) {
       if (mod.exports)
         return mod.exports
     }


### PR DESCRIPTION
Reverts #3418

`mod.importers.has(importee)` is always true because we add "importee" to importers a few lines prior
