### PR TITLE
test: prevent typecheck conflict between watch and coverage tests

### DIFF
--- a/test/bail/test/bail.test.ts
+++ b/test/bail/test/bail.test.ts
@@ -32,5 +32,7 @@ for (const config of configs) {
     expect(stdout).not.toMatch('test/second.test.ts > 1 - second.test.ts - this should be skipped')
     expect(stdout).not.toMatch('test/second.test.ts > 2 - second.test.ts - this should be skipped')
     expect(stdout).not.toMatch('test/second.test.ts > 3 - second.test.ts - this should be skipped')
+  }, {
+    retry: config.browser?.enabled ? 3 : 0,
   })
 }

--- a/test/fails/vite.config.ts
+++ b/test/fails/vite.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   test: {
     include: ['test/*.test.ts'],
+    chaiConfig: {
+      truncateThreshold: 9999,
+    },
   },
 })

--- a/test/public-api/tests/runner.spec.ts
+++ b/test/public-api/tests/runner.spec.ts
@@ -67,4 +67,7 @@ it.each([
 
   expect(files[0].meta).toEqual(suiteMeta)
   expect(files[0].tasks[0].meta).toEqual(testMeta)
-}, 60_000)
+}, {
+  timeout: 60_000,
+  retry: 3,
+})

--- a/test/public-api/vitest.config.ts
+++ b/test/public-api/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['tests/**/*.spec.ts'],
+    chaiConfig: {
+      truncateThreshold: 9999,
+    },
   },
 })

--- a/test/watch/test/file-watching.test.ts
+++ b/test/watch/test/file-watching.test.ts
@@ -99,5 +99,5 @@ describe('browser', () => {
     await vitest.waitForStdout('1 passed')
 
     vitest.write('q')
-  })
+  }, { retry: 3 })
 })

--- a/test/watch/vitest.config.ts
+++ b/test/watch/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     reporters: 'verbose',
     include: ['test/**/*.test.*'],
+    chaiConfig: {
+      truncateThreshold: 9999,
+    },
 
     // For Windows CI mostly
     testTimeout: process.env.CI ? 30_000 : 10_000,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,7 @@
     "./examples/**/*.*",
     "./bench/**",
     "./test/typescript/**",
-    "./test/browser/**"
+    "./test/browser/**",
+    "./test/watch/fixtures/**"
   ]
 }


### PR DESCRIPTION
The typecheck tests of `test/coverage-test` can run into error if `test/watch/test/stdin.test.ts` is running at the same time. The watch test is creating a file that is picked up by typecheck tests and is deleted during the test. This error also came up on CI randomly.

```
 RUN  v0.31.3 /x/vitest/test/coverage-test
 
 ...
 
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Typecheck Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: error TS6053: File '/x/vitest/test/watch/fixtures/cancel.test.ts' not found.
  The file is in the program because:
    Matched by default include pattern '**/*'

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

As solution we can ignore the `watch/fixtures` in `tsconfig.json`.

\+ Attempts to fix those flaky browser tests.