### PR TITLE
chore: upgrade github actions to node 20

### DIFF
--- a/.github/actions/setup-and-cache/action.yml
+++ b/.github/actions/setup-and-cache/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     required: false
     description: Node version for setup-node
-    default: 18.x
+    default: 20.x
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [16, 18]
+        node_version: [16, 18, 20]
         include:
           - os: macos-latest
-            node_version: 18
+            node_version: 20
           - os: windows-latest
-            node_version: 18
+            node_version: 20
       fail-fast: false
 
     steps:
@@ -117,7 +117,7 @@ jobs:
 
       - uses: ./.github/actions/setup-and-cache
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: browser-actions/setup-chrome@v1
       - uses: browser-actions/setup-firefox@v1
@@ -155,7 +155,7 @@ jobs:
 
       - uses: ./.github/actions/setup-and-cache
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: browser-actions/setup-chrome@v1
       - uses: browser-actions/setup-edge@v1
@@ -186,7 +186,7 @@ jobs:
 
       - uses: ./.github/actions/setup-and-cache
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install
         run: sudo pnpm i --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - run: npx changelogithub
         env:


### PR DESCRIPTION
Node 20 will enter LTS on 2023-10-24, it's good to test it already.