### PR TITLE
fix: compat with frozen Math

### DIFF
--- a/packages/browser/src/client/rpc.ts
+++ b/packages/browser/src/client/rpc.ts
@@ -4,14 +4,12 @@ import type {
 import type { VitestClient } from '@vitest/ws-client'
 
 const { get } = Reflect
-const safeRandom = Math.random
 
 function withSafeTimers(getTimers: typeof getSafeTimers, fn: () => void) {
   const { setTimeout, clearTimeout, nextTick, setImmediate, clearImmediate } = getTimers()
 
   const currentSetTimeout = globalThis.setTimeout
   const currentClearTimeout = globalThis.clearTimeout
-  const currentRandom = globalThis.Math.random
   const currentNextTick = globalThis.process.nextTick
   const currentSetImmediate = globalThis.setImmediate
   const currentClearImmediate = globalThis.clearImmediate
@@ -19,7 +17,6 @@ function withSafeTimers(getTimers: typeof getSafeTimers, fn: () => void) {
   try {
     globalThis.setTimeout = setTimeout
     globalThis.clearTimeout = clearTimeout
-    globalThis.Math.random = safeRandom
     globalThis.process.nextTick = nextTick
     globalThis.setImmediate = setImmediate
     globalThis.clearImmediate = clearImmediate
@@ -30,7 +27,6 @@ function withSafeTimers(getTimers: typeof getSafeTimers, fn: () => void) {
   finally {
     globalThis.setTimeout = currentSetTimeout
     globalThis.clearTimeout = currentClearTimeout
-    globalThis.Math.random = currentRandom
     globalThis.setImmediate = currentSetImmediate
     globalThis.clearImmediate = currentClearImmediate
     nextTick(() => {

--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -4,14 +4,12 @@ import {
 import { getWorkerState } from '../utils/global'
 
 const { get } = Reflect
-const safeRandom = Math.random
 
 function withSafeTimers(fn: () => void) {
   const { setTimeout, clearTimeout, nextTick, setImmediate, clearImmediate } = getSafeTimers()
 
   const currentSetTimeout = globalThis.setTimeout
   const currentClearTimeout = globalThis.clearTimeout
-  const currentRandom = globalThis.Math.random
   const currentNextTick = globalThis.process.nextTick
   const currentSetImmediate = globalThis.setImmediate
   const currentClearImmediate = globalThis.clearImmediate
@@ -19,7 +17,6 @@ function withSafeTimers(fn: () => void) {
   try {
     globalThis.setTimeout = setTimeout
     globalThis.clearTimeout = clearTimeout
-    globalThis.Math.random = safeRandom
     globalThis.process.nextTick = nextTick
     globalThis.setImmediate = setImmediate
     globalThis.clearImmediate = clearImmediate
@@ -30,7 +27,6 @@ function withSafeTimers(fn: () => void) {
   finally {
     globalThis.setTimeout = currentSetTimeout
     globalThis.clearTimeout = currentClearTimeout
-    globalThis.Math.random = currentRandom
     globalThis.setImmediate = currentSetImmediate
     globalThis.clearImmediate = currentClearImmediate
     nextTick(() => {


### PR DESCRIPTION
Some applications defend themselves by freezing their intrinsics. The assignments to `Math.random` break in such an environment.

https://github.com/vitest-dev/vitest/pull/2254/ in 2022 started the assignments to fix compatibility with birpc but it looks like there's a better solution now in https://github.com/vitest-dev/vitest/pull/3460 landed last week. (h/t @mhofman) 

This removes the assignments.