### PR TITLE
fix(ui): navigate to dashboard when re-running tests from coverage page

### DIFF
--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -32,7 +32,7 @@ async function onRunAll(files?: File[]) {
   if (coverageEnabled.value) {
     disableCoverage.value = true
     await nextTick()
-    if (coverageEnabled.value) {
+    if (coverageVisible.value) {
       showDashboard(true)
       await nextTick()
     }
@@ -94,7 +94,7 @@ async function onRunAll(files?: File[]) {
           v-tooltip.bottom="filteredTests ? (filteredTests.length === 0 ? 'No test to run (clear filter)' : 'Rerun filtered') : 'Rerun all'"
           :disabled="filteredTests?.length === 0"
           icon="i-carbon:play"
-          @click="runAll(filteredTests)"
+          @click="onRunAll(filteredTests)"
         />
         <IconButton
           v-tooltip.bottom="`Toggle to ${toggleMode} mode`"


### PR DESCRIPTION
There was a few bugs on original PR including html coverage:
- run all test button must call `onRunAll` instead `runAll` function 
- once coverage enabled checked, if coverage visible we should navigate to dashboard

EDIT: we can improve this, but we'll need to include more logic and a new ref to refresh/reload coverage iframe page, it seems the cache headers are ok.

closes #3504