### PR TITLE
fix(test): vitest module directories and projects in vitest repo path

### DIFF
--- a/examples/mocks/vite.config.ts
+++ b/examples/mocks/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     deps: {
       external: [/src\/external/],
       interopDefault: true,
-      moduleDirectories: ['node_modules', 'projects'],
+      moduleDirectories: ['node_modules', 'mocks/projects'],
     },
   },
 })

--- a/test/core/vitest.config.ts
+++ b/test/core/vitest.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     deps: {
       external: ['tinyspy', /src\/external/],
       inline: ['inline-lib'],
-      moduleDirectories: ['node_modules', 'projects', 'packages'],
+      moduleDirectories: ['node_modules', 'core/projects', 'packages/vitest', 'packages/runner', 'packages/utils'],
     },
     alias: [
       {


### PR DESCRIPTION
This PR only fixes Vitest tests configuration files when Vitest is cloned in local under paths containing `packages` and/or `projects`.