### PR TITLE
docs: update extending-matchers.md

### DIFF
--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -26,7 +26,7 @@ expect.extend({
 If you are using TypeScript, since Vitest 0.31.0 you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
 ```ts
-import type { Assertion, AsymmetricMatchersContaining } from 'vitest';
+import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
 
 interface CustomMatchers<R = unknown> {
   toBeFoo(): R

--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -26,6 +26,8 @@ expect.extend({
 If you are using TypeScript, since Vitest 0.31.0 you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
 ```ts
+import type { Assertion, AsymmetricMatchersContaining } from 'vitest';
+
 interface CustomMatchers<R = unknown> {
   toBeFoo(): R
 }


### PR DESCRIPTION
Interfaces `Assertion` and `AsymmetricMatchersContaining` must be imported from `'vitest'` for correct module augmentation. Otherwise, it will declare whole new interfaces.