### PR TITLE
fix: import `performance` from `perf_hooks` (fix #3578)

### DIFF
--- a/packages/vitest/src/runtime/child.ts
+++ b/packages/vitest/src/runtime/child.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import v8 from 'node:v8'
 import { createBirpc } from 'birpc'
 import { parseRegexp } from '@vitest/utils'


### PR DESCRIPTION
Fixes https://github.com/vitest-dev/vitest/issues/3578