### PR TITLE
fix: Typo in config suggestion

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -171,7 +171,7 @@ function printModuleWarningForPackage(logger: Logger, path: string, name: string
     deps: {
       inline: [
         ${c.yellow(c.bold(`"${name}"`))}
-      }
+      ]
     }
   }
 }\n`)))


### PR DESCRIPTION
This fixes a typo in the current configuration suggestion in the error output. 
`deps.inline` has type `(string | RegExp)[] | true`.