### PR TITLE
feat!: disable `coverage.reportOnFailure` by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -804,7 +804,7 @@ Since Vitest 0.31.0, you can check your coverage report in Vitest UI: check [Vit
 #### coverage.reportOnFailure
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false` (since Vitest `0.33.0`)
 - **Available for providers:** `'c8' | 'v8' | 'istanbul'`
 - **CLI:** `--coverage.reportOnFailure`, `--coverage.reportOnFailure=false`
 - **Version:** Since Vitest 0.31.2

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -804,7 +804,7 @@ Since Vitest 0.31.0, you can check your coverage report in Vitest UI: check [Vit
 #### coverage.reportOnFailure
 
 - **Type:** `boolean`
-- **Default:** `false` (since Vitest `0.33.0`)
+- **Default:** `false` (since Vitest `0.34.0`)
 - **Available for providers:** `'c8' | 'v8' | 'istanbul'`
 - **CLI:** `--coverage.reportOnFailure`, `--coverage.reportOnFailure=false`
 - **Version:** Since Vitest 0.31.2

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -32,7 +32,7 @@ export const coverageConfigDefaults: ResolvedCoverageOptions = {
   cleanOnRerun: true,
   reportsDirectory: './coverage',
   exclude: defaultCoverageExcludes,
-  reportOnFailure: true,
+  reportOnFailure: false,
   reporter: [['text', {}], ['html', {}], ['clover', {}], ['json', {}]],
   // default extensions used by c8, plus '.vue' and '.svelte'
   // see https://github.com/istanbuljs/schema/blob/master/default-extension.js

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -214,7 +214,7 @@ export interface BaseCoverageOptions {
   /**
    * Generate coverage report even when tests fail.
    *
-   * @default true
+   * @default false
    */
   reportOnFailure?: boolean
 }

--- a/test/fails/test/runner.test.ts
+++ b/test/fails/test/runner.test.ts
@@ -34,13 +34,12 @@ it('should report coverage when "coverag.reportOnFailure: true" and tests fail',
   expect(stdout).toMatch('Coverage report from istanbul')
 })
 
-it('should not report coverage when "coverag.reportOnFailure: false" and tests fail', async () => {
+it('should not report coverage when "coverag.reportOnFailure" has default value and tests fail', async () => {
   const { stdout } = await runVitest({
     root,
     coverage: {
       enabled: true,
       provider: 'istanbul',
-      reportOnFailure: false,
       reporter: ['text'],
     },
   }, [files[0]])


### PR DESCRIPTION
- Continues #3453
- It makes more sense to have reports not generated when test failures occur

### BREAKING CHANGES:

- `coverage.reportOnFailure` is now `false` by default