### PR TITLE
fix(watch): cancel using `h` key

### DIFF
--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -13,7 +13,7 @@ const keys = [
   ['t', 'filter by a test name regex pattern'],
   ['q', 'quit'],
 ]
-const cancelKeys = ['space', 'c', ...keys.map(key => key[0]).flat()]
+const cancelKeys = ['space', 'c', 'h', ...keys.map(key => key[0]).flat()]
 
 export function printShortcutsHelp() {
   stdout().write(


### PR DESCRIPTION
- Watch mode should be cancellable using any key that Vitest tracks
- Track `h` key for cancelling on-going test run
- Fixes #3612 completely

Tested manually. We have test case for testing cancelling with `c` key but testing all of these would be slow and flaky.
