### PR TITLE
fix: `CTRL+C` to terminate run

### DIFF
--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -87,10 +87,8 @@ export async function startVitest(
     return ctx
   }
 
-  if (process.stdin.isTTY && ctx.config.watch)
+  if (process.stdin.isTTY)
     registerConsoleShortcuts(ctx)
-  else
-    process.on('SIGINT', () => ctx.cancelCurrentRun('keyboard-input'))
 
   ctx.onServerRestart((reason) => {
     ctx.report('onServerRestart', reason)

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -32,6 +32,10 @@ export function registerConsoleShortcuts(ctx: Vitest) {
     // If cancelling takes long and key is pressed multiple times, exit forcefully.
     if (str === '\x03' || str === '\x1B' || (key && key.ctrl && key.name === 'c')) {
       if (!ctx.isCancelling) {
+        ctx.logger.logUpdate.clear()
+        ctx.logger.log(c.red('Cancelling test run. Press CTRL+c again to exit forcefully.\n'))
+        process.exitCode = 130
+
         await ctx.cancelCurrentRun('keyboard-input')
         await ctx.runningPromise
       }
@@ -44,6 +48,10 @@ export function registerConsoleShortcuts(ctx: Vitest) {
       process.kill(process.pid, 'SIGTSTP')
       return
     }
+
+    // Other keys are for watch mode only
+    if (!ctx.config.watch)
+      return
 
     const name = key?.name
 


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/3569

Instead of listening for `SIGINT`, let's listen for keypress and decide how to handle `CTRL` + `c`. The `process.on("SIGINT")` seems to be too difficult to handle: https://github.com/vitest-dev/vitest/issues/3569#issuecomment-1600330892.


https://github.com/vitest-dev/vitest/assets/14806298/51099026-4727-44e7-96e1-6620da7a6a09

Windows + Powershell:

https://github.com/vitest-dev/vitest/assets/14806298/8c884681-2b03-40d1-9e08-9f286c02359d

