### PR TITLE
deps(browser): remove modern-node-polyfills package

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "estree-walker": "^3.0.3",
     "magic-string": "^0.30.1",
-    "modern-node-polyfills": "^1.0.0",
     "sirv": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -2,14 +2,9 @@ import { fileURLToPath } from 'node:url'
 
 import { resolve } from 'node:path'
 import { builtinModules } from 'node:module'
-import { polyfillPath } from 'modern-node-polyfills'
 import sirv from 'sirv'
 import type { Plugin } from 'vite'
 import { injectVitestModule } from './esmInjector'
-
-const polyfills = [
-  'util',
-]
 
 // don't expose type to not bundle it here
 export default (project: any, base = '/'): Plugin[] => {
@@ -36,13 +31,12 @@ export default (project: any, base = '/'): Plugin[] => {
       },
     },
     {
-      name: 'modern-node-polyfills',
+      name: 'vitest:browser:tests',
       enforce: 'pre',
       config() {
         return {
           optimizeDeps: {
             exclude: [
-              ...polyfills,
               ...builtinModules,
               'vitest',
               'vitest/utils',
@@ -63,22 +57,17 @@ export default (project: any, base = '/'): Plugin[] => {
         }
       },
       async resolveId(id) {
-        if (!builtinModules.includes(id) && !polyfills.includes(id) && !id.startsWith('node:')) {
-          if (!/\?browserv=\w+$/.test(id))
-            return
+        if (!/\?browserv=\w+$/.test(id))
+          return
 
-          let useId = id.slice(0, id.lastIndexOf('?'))
-          if (useId.startsWith('/@fs/'))
-            useId = useId.slice(5)
+        let useId = id.slice(0, id.lastIndexOf('?'))
+        if (useId.startsWith('/@fs/'))
+          useId = useId.slice(5)
 
-          if (/^\w:/.test(useId))
-            useId = useId.replace(/\\/g, '/')
+        if (/^\w:/.test(useId))
+          useId = useId.replace(/\\/g, '/')
 
-          return useId
-        }
-
-        id = normalizeId(id)
-        return { id: await polyfillPath(id), moduleSideEffects: false }
+        return useId
       },
     },
     {
@@ -92,17 +81,4 @@ export default (project: any, base = '/'): Plugin[] => {
       },
     },
   ]
-}
-
-function normalizeId(id: string, base?: string): string {
-  if (base && id.startsWith(base))
-    id = `/${id.slice(base.length)}`
-
-  return id
-    .replace(/^\/@id\/__x00__/, '\0') // virtual modules start with `\0`
-    .replace(/^\/@id\//, '')
-    .replace(/^__vite-browser-external:/, '')
-    .replace(/^node:/, '')
-    .replace(/[?&]v=\w+/, '?') // remove ?v= query
-    .replace(/\?$/, '') // remove end query mark
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,9 +934,6 @@ importers:
       magic-string:
         specifier: ^0.30.1
         version: 0.30.1
-      modern-node-polyfills:
-        specifier: ^1.0.0
-        version: 1.0.0(esbuild@0.18.11)(rollup@3.26.0)
       sirv:
         specifier: ^2.0.3
         version: 2.0.3
@@ -7556,10 +7553,6 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@jspm/core@2.0.1:
-    resolution: {integrity: sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==}
-    dev: false
-
   /@lit/reactive-element@1.4.1:
     resolution: {integrity: sha512-qDv4851VFSaBWzpS02cXHclo40jsbAjRXnebNXpm0uVg32kCneZPo9RYVQtrTNICtZ+1wAYHu1ZtxWSWMbKrBw==}
     dev: false
@@ -8342,6 +8335,7 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 3.26.0
+    dev: true
 
   /@sinclair/typebox@0.25.24:
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
@@ -21102,20 +21096,6 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.1.2
 
-  /modern-node-polyfills@1.0.0(esbuild@0.18.11)(rollup@3.26.0):
-    resolution: {integrity: sha512-w1yb6ae5qSUJJ2u41krkUAxs+L7i9143Qam8EuXwDMeZHxl1JN8RfTSXG4S2bt0RHIRMeoWm/HCeO0pNIHmIYQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      esbuild: ^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0
-    dependencies:
-      '@jspm/core': 2.0.1
-      '@rollup/pluginutils': 5.0.2(rollup@3.26.0)
-      esbuild: 0.18.11
-      local-pkg: 0.4.3
-    transitivePeerDependencies:
-      - rollup
-    dev: false
-
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
     dev: true
@@ -24082,6 +24062,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rollup@3.29.0:
     resolution: {integrity: sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==}


### PR DESCRIPTION
resolves: https://github.com/vitest-dev/vitest/issues/3299

The browser runner indiscriminately applies pollyfills for node builtin modules. This PR removes completely removes the dependence on `modern-node-polyfills`.