### PR TITLE
fix(coverage): `v8` to prevent crash on dynamic CJS files

### DIFF
--- a/test/coverage-test/.gitignore
+++ b/test/coverage-test/.gitignore
@@ -1,0 +1,1 @@
+src/dynamic-file.ignore.*

--- a/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/c8.report.test.ts.snap
@@ -1242,6 +1242,913 @@ exports[`c8 json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/dynamic-file-esm.ignore.mjs": {
+    "all": false,
+    "b": {
+      "0": [
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "line": 2,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 4,
+          },
+          "start": {
+            "column": 7,
+            "line": 2,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 4,
+            },
+            "start": {
+              "column": 7,
+              "line": 2,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 4,
+          },
+          "start": {
+            "column": 7,
+            "line": 2,
+          },
+        },
+        "line": 2,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 4,
+          },
+          "start": {
+            "column": 7,
+            "line": 2,
+          },
+        },
+        "name": "run",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 23,
+            "line": 5,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "line": 5,
+        "loc": {
+          "end": {
+            "column": 23,
+            "line": 5,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "name": "uncovered",
+      },
+    },
+    "path": "<process-cwd>/src/dynamic-file-esm.ignore.mjs",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 1,
+      "4": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "1": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "2": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "3": {
+        "end": {
+          "column": 1,
+          "line": 4,
+        },
+        "start": {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "4": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 0,
+          "line": 5,
+        },
+      },
+    },
+  },
+  "<process-cwd>/src/dynamic-files.ts": {
+    "all": false,
+    "b": {
+      "0": [
+        1,
+      ],
+      "1": [
+        0,
+      ],
+      "2": [
+        0,
+      ],
+      "3": [
+        1,
+      ],
+      "4": [
+        0,
+      ],
+      "5": [
+        0,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "line": 5,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 25,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 25,
+            },
+            "start": {
+              "column": 0,
+              "line": 5,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "1": {
+        "line": 9,
+        "loc": {
+          "end": {
+            "column": 20,
+            "line": 9,
+          },
+          "start": {
+            "column": 4,
+            "line": 9,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 20,
+              "line": 9,
+            },
+            "start": {
+              "column": 4,
+              "line": 9,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "2": {
+        "line": 22,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 22,
+          },
+          "start": {
+            "column": 4,
+            "line": 22,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 48,
+              "line": 22,
+            },
+            "start": {
+              "column": 4,
+              "line": 22,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "3": {
+        "line": 27,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 47,
+          },
+          "start": {
+            "column": 0,
+            "line": 27,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 47,
+            },
+            "start": {
+              "column": 0,
+              "line": 27,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "4": {
+        "line": 31,
+        "loc": {
+          "end": {
+            "column": 20,
+            "line": 31,
+          },
+          "start": {
+            "column": 4,
+            "line": 31,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 20,
+              "line": 31,
+            },
+            "start": {
+              "column": 4,
+              "line": 31,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "5": {
+        "line": 44,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 44,
+          },
+          "start": {
+            "column": 4,
+            "line": 44,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 48,
+              "line": 44,
+            },
+            "start": {
+              "column": 4,
+              "line": 44,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 25,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "line": 5,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 25,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "name": "runDynamicFileESM",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 47,
+          },
+          "start": {
+            "column": 0,
+            "line": 27,
+          },
+        },
+        "line": 27,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 47,
+          },
+          "start": {
+            "column": 0,
+            "line": 27,
+          },
+        },
+        "name": "runDynamicFileCJS",
+      },
+    },
+    "path": "<process-cwd>/src/dynamic-files.ts",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "10": 1,
+      "11": 1,
+      "12": 1,
+      "13": 1,
+      "14": 1,
+      "15": 1,
+      "16": 1,
+      "17": 1,
+      "18": 1,
+      "19": 1,
+      "2": 1,
+      "20": 1,
+      "21": 1,
+      "22": 1,
+      "23": 1,
+      "24": 1,
+      "25": 1,
+      "26": 1,
+      "27": 1,
+      "28": 1,
+      "29": 1,
+      "3": 1,
+      "30": 1,
+      "31": 1,
+      "32": 1,
+      "33": 1,
+      "34": 1,
+      "35": 1,
+      "36": 1,
+      "37": 1,
+      "38": 1,
+      "39": 1,
+      "4": 1,
+      "40": 1,
+      "41": 1,
+      "42": 1,
+      "43": 1,
+      "44": 1,
+      "45": 1,
+      "46": 1,
+      "5": 1,
+      "6": 1,
+      "7": 1,
+      "8": 1,
+      "9": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "1": {
+        "end": {
+          "column": 43,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "10": {
+        "end": {
+          "column": 27,
+          "line": 11,
+        },
+        "start": {
+          "column": 0,
+          "line": 11,
+        },
+      },
+      "11": {
+        "end": {
+          "column": 53,
+          "line": 12,
+        },
+        "start": {
+          "column": 0,
+          "line": 12,
+        },
+      },
+      "12": {
+        "end": {
+          "column": 23,
+          "line": 13,
+        },
+        "start": {
+          "column": 0,
+          "line": 13,
+        },
+      },
+      "13": {
+        "end": {
+          "column": 23,
+          "line": 14,
+        },
+        "start": {
+          "column": 0,
+          "line": 14,
+        },
+      },
+      "14": {
+        "end": {
+          "column": 1,
+          "line": 15,
+        },
+        "start": {
+          "column": 0,
+          "line": 15,
+        },
+      },
+      "15": {
+        "end": {
+          "column": 23,
+          "line": 16,
+        },
+        "start": {
+          "column": 0,
+          "line": 16,
+        },
+      },
+      "16": {
+        "end": {
+          "column": 20,
+          "line": 17,
+        },
+        "start": {
+          "column": 0,
+          "line": 17,
+        },
+      },
+      "17": {
+        "end": {
+          "column": 0,
+          "line": 18,
+        },
+        "start": {
+          "column": 0,
+          "line": 18,
+        },
+      },
+      "18": {
+        "end": {
+          "column": 40,
+          "line": 19,
+        },
+        "start": {
+          "column": 0,
+          "line": 19,
+        },
+      },
+      "19": {
+        "end": {
+          "column": 0,
+          "line": 20,
+        },
+        "start": {
+          "column": 0,
+          "line": 20,
+        },
+      },
+      "2": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "20": {
+        "end": {
+          "column": 31,
+          "line": 21,
+        },
+        "start": {
+          "column": 0,
+          "line": 21,
+        },
+      },
+      "21": {
+        "end": {
+          "column": 48,
+          "line": 22,
+        },
+        "start": {
+          "column": 0,
+          "line": 22,
+        },
+      },
+      "22": {
+        "end": {
+          "column": 0,
+          "line": 23,
+        },
+        "start": {
+          "column": 0,
+          "line": 23,
+        },
+      },
+      "23": {
+        "end": {
+          "column": 18,
+          "line": 24,
+        },
+        "start": {
+          "column": 0,
+          "line": 24,
+        },
+      },
+      "24": {
+        "end": {
+          "column": 1,
+          "line": 25,
+        },
+        "start": {
+          "column": 0,
+          "line": 25,
+        },
+      },
+      "25": {
+        "end": {
+          "column": 0,
+          "line": 26,
+        },
+        "start": {
+          "column": 0,
+          "line": 26,
+        },
+      },
+      "26": {
+        "end": {
+          "column": 43,
+          "line": 27,
+        },
+        "start": {
+          "column": 0,
+          "line": 27,
+        },
+      },
+      "27": {
+        "end": {
+          "column": 90,
+          "line": 28,
+        },
+        "start": {
+          "column": 0,
+          "line": 28,
+        },
+      },
+      "28": {
+        "end": {
+          "column": 0,
+          "line": 29,
+        },
+        "start": {
+          "column": 0,
+          "line": 29,
+        },
+      },
+      "29": {
+        "end": {
+          "column": 27,
+          "line": 30,
+        },
+        "start": {
+          "column": 0,
+          "line": 30,
+        },
+      },
+      "3": {
+        "end": {
+          "column": 0,
+          "line": 4,
+        },
+        "start": {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "30": {
+        "end": {
+          "column": 20,
+          "line": 31,
+        },
+        "start": {
+          "column": 0,
+          "line": 31,
+        },
+      },
+      "31": {
+        "end": {
+          "column": 0,
+          "line": 32,
+        },
+        "start": {
+          "column": 0,
+          "line": 32,
+        },
+      },
+      "32": {
+        "end": {
+          "column": 27,
+          "line": 33,
+        },
+        "start": {
+          "column": 0,
+          "line": 33,
+        },
+      },
+      "33": {
+        "end": {
+          "column": 53,
+          "line": 34,
+        },
+        "start": {
+          "column": 0,
+          "line": 34,
+        },
+      },
+      "34": {
+        "end": {
+          "column": 37,
+          "line": 35,
+        },
+        "start": {
+          "column": 0,
+          "line": 35,
+        },
+      },
+      "35": {
+        "end": {
+          "column": 23,
+          "line": 36,
+        },
+        "start": {
+          "column": 0,
+          "line": 36,
+        },
+      },
+      "36": {
+        "end": {
+          "column": 1,
+          "line": 37,
+        },
+        "start": {
+          "column": 0,
+          "line": 37,
+        },
+      },
+      "37": {
+        "end": {
+          "column": 23,
+          "line": 38,
+        },
+        "start": {
+          "column": 0,
+          "line": 38,
+        },
+      },
+      "38": {
+        "end": {
+          "column": 20,
+          "line": 39,
+        },
+        "start": {
+          "column": 0,
+          "line": 39,
+        },
+      },
+      "39": {
+        "end": {
+          "column": 0,
+          "line": 40,
+        },
+        "start": {
+          "column": 0,
+          "line": 40,
+        },
+      },
+      "4": {
+        "end": {
+          "column": 43,
+          "line": 5,
+        },
+        "start": {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "40": {
+        "end": {
+          "column": 58,
+          "line": 41,
+        },
+        "start": {
+          "column": 0,
+          "line": 41,
+        },
+      },
+      "41": {
+        "end": {
+          "column": 0,
+          "line": 42,
+        },
+        "start": {
+          "column": 0,
+          "line": 42,
+        },
+      },
+      "42": {
+        "end": {
+          "column": 31,
+          "line": 43,
+        },
+        "start": {
+          "column": 0,
+          "line": 43,
+        },
+      },
+      "43": {
+        "end": {
+          "column": 48,
+          "line": 44,
+        },
+        "start": {
+          "column": 0,
+          "line": 44,
+        },
+      },
+      "44": {
+        "end": {
+          "column": 0,
+          "line": 45,
+        },
+        "start": {
+          "column": 0,
+          "line": 45,
+        },
+      },
+      "45": {
+        "end": {
+          "column": 18,
+          "line": 46,
+        },
+        "start": {
+          "column": 0,
+          "line": 46,
+        },
+      },
+      "46": {
+        "end": {
+          "column": 1,
+          "line": 47,
+        },
+        "start": {
+          "column": 0,
+          "line": 47,
+        },
+      },
+      "5": {
+        "end": {
+          "column": 91,
+          "line": 6,
+        },
+        "start": {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "6": {
+        "end": {
+          "column": 0,
+          "line": 7,
+        },
+        "start": {
+          "column": 0,
+          "line": 7,
+        },
+      },
+      "7": {
+        "end": {
+          "column": 27,
+          "line": 8,
+        },
+        "start": {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "8": {
+        "end": {
+          "column": 20,
+          "line": 9,
+        },
+        "start": {
+          "column": 0,
+          "line": 9,
+        },
+      },
+      "9": {
+        "end": {
+          "column": 0,
+          "line": 10,
+        },
+        "start": {
+          "column": 0,
+          "line": 10,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/function-count.ts": {
     "all": false,
     "b": {

--- a/test/coverage-test/coverage-report-tests/__snapshots__/custom.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/custom.report.test.ts.snap
@@ -16,6 +16,8 @@ exports[`custom json report 1`] = `
     "<process-cwd>/src/Defined.vue",
     "<process-cwd>/src/Hello.vue",
     "<process-cwd>/src/another-setup.ts",
+    "<process-cwd>/src/dynamic-file-esm.ignore.mjs",
+    "<process-cwd>/src/dynamic-files.ts",
     "<process-cwd>/src/function-count.ts",
     "<process-cwd>/src/implicitElse.ts",
     "<process-cwd>/src/importEnv.ts",

--- a/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
@@ -519,6 +519,401 @@ exports[`istanbul json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/dynamic-files.ts": {
+    "b": {
+      "0": [
+        0,
+        0,
+      ],
+      "1": [
+        0,
+        0,
+      ],
+      "2": [
+        0,
+        0,
+      ],
+      "3": [
+        0,
+        0,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 9,
+          },
+          "start": {
+            "column": 2,
+            "line": 8,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 9,
+            },
+            "start": {
+              "column": 2,
+              "line": 8,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 9,
+            },
+            "start": {
+              "column": 2,
+              "line": 8,
+            },
+          },
+        ],
+        "type": "if",
+      },
+      "1": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 22,
+          },
+          "start": {
+            "column": 2,
+            "line": 21,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 22,
+            },
+            "start": {
+              "column": 2,
+              "line": 21,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 22,
+            },
+            "start": {
+              "column": 2,
+              "line": 21,
+            },
+          },
+        ],
+        "type": "if",
+      },
+      "2": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 31,
+          },
+          "start": {
+            "column": 2,
+            "line": 30,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 31,
+            },
+            "start": {
+              "column": 2,
+              "line": 30,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 31,
+            },
+            "start": {
+              "column": 2,
+              "line": 30,
+            },
+          },
+        ],
+        "type": "if",
+      },
+      "3": {
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 44,
+          },
+          "start": {
+            "column": 2,
+            "line": 43,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": null,
+              "line": 44,
+            },
+            "start": {
+              "column": 2,
+              "line": 43,
+            },
+          },
+          {
+            "end": {
+              "column": null,
+              "line": 44,
+            },
+            "start": {
+              "column": 2,
+              "line": 43,
+            },
+          },
+        ],
+        "type": "if",
+      },
+    },
+    "f": {
+      "0": 0,
+      "1": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 42,
+            "line": 5,
+          },
+          "start": {
+            "column": 22,
+            "line": 5,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 25,
+          },
+          "start": {
+            "column": 42,
+            "line": 5,
+          },
+        },
+        "name": "runDynamicFileESM",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 42,
+            "line": 27,
+          },
+          "start": {
+            "column": 22,
+            "line": 27,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": null,
+            "line": 47,
+          },
+          "start": {
+            "column": 42,
+            "line": 27,
+          },
+        },
+        "name": "runDynamicFileCJS",
+      },
+    },
+    "path": "<process-cwd>/src/dynamic-files.ts",
+    "s": {
+      "0": 0,
+      "1": 0,
+      "10": 0,
+      "11": 0,
+      "12": 0,
+      "13": 0,
+      "14": 0,
+      "15": 0,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "5": 0,
+      "6": 0,
+      "7": 0,
+      "8": 0,
+      "9": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": null,
+          "line": 6,
+        },
+        "start": {
+          "column": 19,
+          "line": 6,
+        },
+      },
+      "1": {
+        "end": {
+          "column": null,
+          "line": 9,
+        },
+        "start": {
+          "column": 2,
+          "line": 8,
+        },
+      },
+      "10": {
+        "end": {
+          "column": null,
+          "line": 31,
+        },
+        "start": {
+          "column": 4,
+          "line": 31,
+        },
+      },
+      "11": {
+        "end": {
+          "column": null,
+          "line": 39,
+        },
+        "start": {
+          "column": 2,
+          "line": 33,
+        },
+      },
+      "12": {
+        "end": {
+          "column": null,
+          "line": 41,
+        },
+        "start": {
+          "column": 18,
+          "line": 41,
+        },
+      },
+      "13": {
+        "end": {
+          "column": null,
+          "line": 44,
+        },
+        "start": {
+          "column": 2,
+          "line": 43,
+        },
+      },
+      "14": {
+        "end": {
+          "column": null,
+          "line": 44,
+        },
+        "start": {
+          "column": 4,
+          "line": 44,
+        },
+      },
+      "15": {
+        "end": {
+          "column": null,
+          "line": 46,
+        },
+        "start": {
+          "column": 2,
+          "line": 46,
+        },
+      },
+      "2": {
+        "end": {
+          "column": null,
+          "line": 9,
+        },
+        "start": {
+          "column": 4,
+          "line": 9,
+        },
+      },
+      "3": {
+        "end": {
+          "column": null,
+          "line": 17,
+        },
+        "start": {
+          "column": 2,
+          "line": 11,
+        },
+      },
+      "4": {
+        "end": {
+          "column": null,
+          "line": 19,
+        },
+        "start": {
+          "column": 18,
+          "line": 19,
+        },
+      },
+      "5": {
+        "end": {
+          "column": null,
+          "line": 22,
+        },
+        "start": {
+          "column": 2,
+          "line": 21,
+        },
+      },
+      "6": {
+        "end": {
+          "column": null,
+          "line": 22,
+        },
+        "start": {
+          "column": 4,
+          "line": 22,
+        },
+      },
+      "7": {
+        "end": {
+          "column": null,
+          "line": 24,
+        },
+        "start": {
+          "column": 2,
+          "line": 24,
+        },
+      },
+      "8": {
+        "end": {
+          "column": null,
+          "line": 28,
+        },
+        "start": {
+          "column": 19,
+          "line": 28,
+        },
+      },
+      "9": {
+        "end": {
+          "column": null,
+          "line": 31,
+        },
+        "start": {
+          "column": 2,
+          "line": 30,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/function-count.ts": {
     "b": {},
     "branchMap": {},

--- a/test/coverage-test/coverage-report-tests/__snapshots__/v8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/v8.report.test.ts.snap
@@ -1242,6 +1242,1048 @@ exports[`v8 json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/dynamic-file-cjs.ignore.js": {
+    "all": false,
+    "b": {
+      "0": [
+        1,
+      ],
+      "1": [
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 141,
+            "line": 1,
+          },
+          "start": {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 141,
+              "line": 1,
+            },
+            "start": {
+              "column": 0,
+              "line": 1,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "1": {
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 117,
+            "line": 1,
+          },
+          "start": {
+            "column": 75,
+            "line": 1,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 117,
+              "line": 1,
+            },
+            "start": {
+              "column": 75,
+              "line": 1,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 117,
+            "line": 1,
+          },
+          "start": {
+            "column": 75,
+            "line": 1,
+          },
+        },
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 117,
+            "line": 1,
+          },
+          "start": {
+            "column": 75,
+            "line": 1,
+          },
+        },
+        "name": "run",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 141,
+            "line": 1,
+          },
+          "start": {
+            "column": 118,
+            "line": 1,
+          },
+        },
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 141,
+            "line": 1,
+          },
+          "start": {
+            "column": 118,
+            "line": 1,
+          },
+        },
+        "name": "uncovered",
+      },
+    },
+    "path": "<process-cwd>/src/dynamic-file-cjs.ignore.js",
+    "s": {
+      "0": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 141,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+  },
+  "<process-cwd>/src/dynamic-file-esm.ignore.mjs": {
+    "all": false,
+    "b": {
+      "0": [
+        1,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "line": 2,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 4,
+          },
+          "start": {
+            "column": 7,
+            "line": 2,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 4,
+            },
+            "start": {
+              "column": 7,
+              "line": 2,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 4,
+          },
+          "start": {
+            "column": 7,
+            "line": 2,
+          },
+        },
+        "line": 2,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 4,
+          },
+          "start": {
+            "column": 7,
+            "line": 2,
+          },
+        },
+        "name": "run",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 23,
+            "line": 5,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "line": 5,
+        "loc": {
+          "end": {
+            "column": 23,
+            "line": 5,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "name": "uncovered",
+      },
+    },
+    "path": "<process-cwd>/src/dynamic-file-esm.ignore.mjs",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 1,
+      "4": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "1": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "2": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "3": {
+        "end": {
+          "column": 1,
+          "line": 4,
+        },
+        "start": {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "4": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 0,
+          "line": 5,
+        },
+      },
+    },
+  },
+  "<process-cwd>/src/dynamic-files.ts": {
+    "all": false,
+    "b": {
+      "0": [
+        1,
+      ],
+      "1": [
+        0,
+      ],
+      "2": [
+        0,
+      ],
+      "3": [
+        1,
+      ],
+      "4": [
+        0,
+      ],
+      "5": [
+        0,
+      ],
+    },
+    "branchMap": {
+      "0": {
+        "line": 5,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 25,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 25,
+            },
+            "start": {
+              "column": 0,
+              "line": 5,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "1": {
+        "line": 9,
+        "loc": {
+          "end": {
+            "column": 20,
+            "line": 9,
+          },
+          "start": {
+            "column": 4,
+            "line": 9,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 20,
+              "line": 9,
+            },
+            "start": {
+              "column": 4,
+              "line": 9,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "2": {
+        "line": 22,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 22,
+          },
+          "start": {
+            "column": 4,
+            "line": 22,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 48,
+              "line": 22,
+            },
+            "start": {
+              "column": 4,
+              "line": 22,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "3": {
+        "line": 27,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 47,
+          },
+          "start": {
+            "column": 0,
+            "line": 27,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 1,
+              "line": 47,
+            },
+            "start": {
+              "column": 0,
+              "line": 27,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "4": {
+        "line": 31,
+        "loc": {
+          "end": {
+            "column": 20,
+            "line": 31,
+          },
+          "start": {
+            "column": 4,
+            "line": 31,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 20,
+              "line": 31,
+            },
+            "start": {
+              "column": 4,
+              "line": 31,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+      "5": {
+        "line": 44,
+        "loc": {
+          "end": {
+            "column": 48,
+            "line": 44,
+          },
+          "start": {
+            "column": 4,
+            "line": 44,
+          },
+        },
+        "locations": [
+          {
+            "end": {
+              "column": 48,
+              "line": 44,
+            },
+            "start": {
+              "column": 4,
+              "line": 44,
+            },
+          },
+        ],
+        "type": "branch",
+      },
+    },
+    "f": {
+      "0": 1,
+      "1": 1,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 25,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "line": 5,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 25,
+          },
+          "start": {
+            "column": 0,
+            "line": 5,
+          },
+        },
+        "name": "runDynamicFileESM",
+      },
+      "1": {
+        "decl": {
+          "end": {
+            "column": 1,
+            "line": 47,
+          },
+          "start": {
+            "column": 0,
+            "line": 27,
+          },
+        },
+        "line": 27,
+        "loc": {
+          "end": {
+            "column": 1,
+            "line": 47,
+          },
+          "start": {
+            "column": 0,
+            "line": 27,
+          },
+        },
+        "name": "runDynamicFileCJS",
+      },
+    },
+    "path": "<process-cwd>/src/dynamic-files.ts",
+    "s": {
+      "0": 1,
+      "1": 1,
+      "10": 1,
+      "11": 1,
+      "12": 1,
+      "13": 1,
+      "14": 1,
+      "15": 1,
+      "16": 1,
+      "17": 1,
+      "18": 1,
+      "19": 1,
+      "2": 1,
+      "20": 1,
+      "21": 1,
+      "22": 1,
+      "23": 1,
+      "24": 1,
+      "25": 1,
+      "26": 1,
+      "27": 1,
+      "28": 1,
+      "29": 1,
+      "3": 1,
+      "30": 1,
+      "31": 1,
+      "32": 1,
+      "33": 1,
+      "34": 1,
+      "35": 1,
+      "36": 1,
+      "37": 1,
+      "38": 1,
+      "39": 1,
+      "4": 1,
+      "40": 1,
+      "41": 1,
+      "42": 1,
+      "43": 1,
+      "44": 1,
+      "45": 1,
+      "46": 1,
+      "5": 1,
+      "6": 1,
+      "7": 1,
+      "8": 1,
+      "9": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "1": {
+        "end": {
+          "column": 43,
+          "line": 2,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "10": {
+        "end": {
+          "column": 27,
+          "line": 11,
+        },
+        "start": {
+          "column": 0,
+          "line": 11,
+        },
+      },
+      "11": {
+        "end": {
+          "column": 53,
+          "line": 12,
+        },
+        "start": {
+          "column": 0,
+          "line": 12,
+        },
+      },
+      "12": {
+        "end": {
+          "column": 23,
+          "line": 13,
+        },
+        "start": {
+          "column": 0,
+          "line": 13,
+        },
+      },
+      "13": {
+        "end": {
+          "column": 23,
+          "line": 14,
+        },
+        "start": {
+          "column": 0,
+          "line": 14,
+        },
+      },
+      "14": {
+        "end": {
+          "column": 1,
+          "line": 15,
+        },
+        "start": {
+          "column": 0,
+          "line": 15,
+        },
+      },
+      "15": {
+        "end": {
+          "column": 23,
+          "line": 16,
+        },
+        "start": {
+          "column": 0,
+          "line": 16,
+        },
+      },
+      "16": {
+        "end": {
+          "column": 20,
+          "line": 17,
+        },
+        "start": {
+          "column": 0,
+          "line": 17,
+        },
+      },
+      "17": {
+        "end": {
+          "column": 0,
+          "line": 18,
+        },
+        "start": {
+          "column": 0,
+          "line": 18,
+        },
+      },
+      "18": {
+        "end": {
+          "column": 40,
+          "line": 19,
+        },
+        "start": {
+          "column": 0,
+          "line": 19,
+        },
+      },
+      "19": {
+        "end": {
+          "column": 0,
+          "line": 20,
+        },
+        "start": {
+          "column": 0,
+          "line": 20,
+        },
+      },
+      "2": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "20": {
+        "end": {
+          "column": 31,
+          "line": 21,
+        },
+        "start": {
+          "column": 0,
+          "line": 21,
+        },
+      },
+      "21": {
+        "end": {
+          "column": 48,
+          "line": 22,
+        },
+        "start": {
+          "column": 0,
+          "line": 22,
+        },
+      },
+      "22": {
+        "end": {
+          "column": 0,
+          "line": 23,
+        },
+        "start": {
+          "column": 0,
+          "line": 23,
+        },
+      },
+      "23": {
+        "end": {
+          "column": 18,
+          "line": 24,
+        },
+        "start": {
+          "column": 0,
+          "line": 24,
+        },
+      },
+      "24": {
+        "end": {
+          "column": 1,
+          "line": 25,
+        },
+        "start": {
+          "column": 0,
+          "line": 25,
+        },
+      },
+      "25": {
+        "end": {
+          "column": 0,
+          "line": 26,
+        },
+        "start": {
+          "column": 0,
+          "line": 26,
+        },
+      },
+      "26": {
+        "end": {
+          "column": 43,
+          "line": 27,
+        },
+        "start": {
+          "column": 0,
+          "line": 27,
+        },
+      },
+      "27": {
+        "end": {
+          "column": 90,
+          "line": 28,
+        },
+        "start": {
+          "column": 0,
+          "line": 28,
+        },
+      },
+      "28": {
+        "end": {
+          "column": 0,
+          "line": 29,
+        },
+        "start": {
+          "column": 0,
+          "line": 29,
+        },
+      },
+      "29": {
+        "end": {
+          "column": 27,
+          "line": 30,
+        },
+        "start": {
+          "column": 0,
+          "line": 30,
+        },
+      },
+      "3": {
+        "end": {
+          "column": 0,
+          "line": 4,
+        },
+        "start": {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "30": {
+        "end": {
+          "column": 20,
+          "line": 31,
+        },
+        "start": {
+          "column": 0,
+          "line": 31,
+        },
+      },
+      "31": {
+        "end": {
+          "column": 0,
+          "line": 32,
+        },
+        "start": {
+          "column": 0,
+          "line": 32,
+        },
+      },
+      "32": {
+        "end": {
+          "column": 27,
+          "line": 33,
+        },
+        "start": {
+          "column": 0,
+          "line": 33,
+        },
+      },
+      "33": {
+        "end": {
+          "column": 53,
+          "line": 34,
+        },
+        "start": {
+          "column": 0,
+          "line": 34,
+        },
+      },
+      "34": {
+        "end": {
+          "column": 37,
+          "line": 35,
+        },
+        "start": {
+          "column": 0,
+          "line": 35,
+        },
+      },
+      "35": {
+        "end": {
+          "column": 23,
+          "line": 36,
+        },
+        "start": {
+          "column": 0,
+          "line": 36,
+        },
+      },
+      "36": {
+        "end": {
+          "column": 1,
+          "line": 37,
+        },
+        "start": {
+          "column": 0,
+          "line": 37,
+        },
+      },
+      "37": {
+        "end": {
+          "column": 23,
+          "line": 38,
+        },
+        "start": {
+          "column": 0,
+          "line": 38,
+        },
+      },
+      "38": {
+        "end": {
+          "column": 20,
+          "line": 39,
+        },
+        "start": {
+          "column": 0,
+          "line": 39,
+        },
+      },
+      "39": {
+        "end": {
+          "column": 0,
+          "line": 40,
+        },
+        "start": {
+          "column": 0,
+          "line": 40,
+        },
+      },
+      "4": {
+        "end": {
+          "column": 43,
+          "line": 5,
+        },
+        "start": {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "40": {
+        "end": {
+          "column": 58,
+          "line": 41,
+        },
+        "start": {
+          "column": 0,
+          "line": 41,
+        },
+      },
+      "41": {
+        "end": {
+          "column": 0,
+          "line": 42,
+        },
+        "start": {
+          "column": 0,
+          "line": 42,
+        },
+      },
+      "42": {
+        "end": {
+          "column": 31,
+          "line": 43,
+        },
+        "start": {
+          "column": 0,
+          "line": 43,
+        },
+      },
+      "43": {
+        "end": {
+          "column": 48,
+          "line": 44,
+        },
+        "start": {
+          "column": 0,
+          "line": 44,
+        },
+      },
+      "44": {
+        "end": {
+          "column": 0,
+          "line": 45,
+        },
+        "start": {
+          "column": 0,
+          "line": 45,
+        },
+      },
+      "45": {
+        "end": {
+          "column": 18,
+          "line": 46,
+        },
+        "start": {
+          "column": 0,
+          "line": 46,
+        },
+      },
+      "46": {
+        "end": {
+          "column": 1,
+          "line": 47,
+        },
+        "start": {
+          "column": 0,
+          "line": 47,
+        },
+      },
+      "5": {
+        "end": {
+          "column": 91,
+          "line": 6,
+        },
+        "start": {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "6": {
+        "end": {
+          "column": 0,
+          "line": 7,
+        },
+        "start": {
+          "column": 0,
+          "line": 7,
+        },
+      },
+      "7": {
+        "end": {
+          "column": 27,
+          "line": 8,
+        },
+        "start": {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "8": {
+        "end": {
+          "column": 20,
+          "line": 9,
+        },
+        "start": {
+          "column": 0,
+          "line": 9,
+        },
+      },
+      "9": {
+        "end": {
+          "column": 0,
+          "line": 10,
+        },
+        "start": {
+          "column": 0,
+          "line": 10,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/function-count.ts": {
     "all": false,
     "b": {

--- a/test/coverage-test/src/dynamic-files.ts
+++ b/test/coverage-test/src/dynamic-files.ts
@@ -1,0 +1,47 @@
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+export async function runDynamicFileESM() {
+  const filename = fileURLToPath(new URL('./dynamic-file-esm.ignore.mjs', import.meta.url))
+
+  if (existsSync(filename))
+    rmSync(filename)
+
+  writeFileSync(filename, `
+// File created by coverage-test/src/dynamic-files.ts
+export function run() {
+  return "Import works"
+}
+function uncovered() {}
+  `.trim(), 'utf-8')
+
+  const { run } = await import(filename)
+
+  if (run() !== 'Import works')
+    throw new Error(`Failed to run ${filename}`)
+
+  rmSync(filename)
+}
+
+export async function runDynamicFileCJS() {
+  const filename = fileURLToPath(new URL('./dynamic-file-cjs.ignore.js', import.meta.url))
+
+  if (existsSync(filename))
+    rmSync(filename)
+
+  writeFileSync(filename, `
+// File created by coverage-test/src/dynamic-files.ts
+module.exports.run = function run() {
+  return "Import works"
+}
+function uncovered() {}
+  `.trim(), 'utf-8')
+
+  const { run } = createRequire(import.meta.url)(filename)
+
+  if (run() !== 'Import works')
+    throw new Error(`Failed to run ${filename}`)
+
+  rmSync(filename)
+}

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -2,6 +2,11 @@ import { expect, test } from 'vitest'
 import { implicitElse } from '../src/implicitElse'
 import { useImportEnv } from '../src/importEnv'
 import { second } from '../src/function-count'
+import { runDynamicFileCJS, runDynamicFileESM } from '../src/dynamic-files'
+
+// Browser mode crashes with dynamic files. Enable this when browser mode works.
+// To keep istanbul report consistent between browser and node, skip dynamic tests when istanbul is used.
+const skipDynamicFiles = process.env.COVERAGE_PROVIDER === 'istanbul' || !process.env.COVERAGE_PROVIDER
 
 const { pythagoras } = await (() => {
   if ('__vitest_browser__' in globalThis)
@@ -26,4 +31,12 @@ test('import meta env', () => {
 
 test('cover function counts', () => {
   expect(second()).toBe(2)
+})
+
+test.skipIf(skipDynamicFiles)('run dynamic ESM file', async () => {
+  await runDynamicFileESM()
+})
+
+test.skipIf(skipDynamicFiles)('run dynamic CJS file', async () => {
+  await runDynamicFileCJS()
 })

--- a/test/coverage-test/testing.mjs
+++ b/test/coverage-test/testing.mjs
@@ -5,6 +5,7 @@ const UPDATE_SNAPSHOTS = false
 
 const provider = process.argv[1 + process.argv.indexOf('--provider')]
 const isBrowser = process.argv.includes('--browser')
+process.env.COVERAGE_PROVIDER = provider
 
 const threadsConfig = [{ threads: true }, { threads: false }, { singleThread: true }]
 


### PR DESCRIPTION
- Fixes #3646
- This only affects files that are `require()`'d and are included in coverage
- Dynamic files that are `import()`'d work already

Using the reproduction case from #3646 (:wave: @vekunz), we can now see the actual coverage of the generated file and don't crash. The branches and functions of the report look a bit weird but those are just the CJS wrapper added by `esbuild` (via `module-from-string`).

```
 RUN  v0.32.2 /x/y/vitest-coverage-error
      Coverage enabled with v8

 ✓ src/importModule.spec.js (1)
   ✓ do something

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  11:15:13
   Duration  185ms (transform 13ms, setup 0ms, collect 9ms, tests 10ms, environment 0ms, prepare 48ms)

 % Coverage report from v8
--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |    85.71 |   83.33 |     100 |                   
 ZB4ypQHrEoDtCYb92sqGU.js |     100 |    85.71 |   83.33 |     100 | 1                 
--------------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 100% ( 1/1 )
Branches     : 85.71% ( 6/7 )
Functions    : 83.33% ( 5/6 )
Lines        : 100% ( 1/1 )
================================================================================
```
