### PR TITLE
fix(browser): resolve `pretty-format` in yarn

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -57,6 +57,7 @@ export default (project: any, base = '/'): Plugin[] => {
               'vitest > pretty-format > ansi-styles',
               'vitest > pretty-format > ansi-regex',
               'vitest > chai',
+              'pretty-format',
             ],
           },
         }


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/3434#issuecomment-1598948147

#### Minimal reproduction

```sh
git clone https://github.com/AriPerkkio/aria-live-capture.git
cd aria-live-capture
git checkout 27031730f0bfa51e66c25900f380580c95b0a17c

# Switch to yarn
rm -rf node_modules/ pnpm-lock.yaml
yarn install
yarn test
```

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
ReferenceError: exports is not defined
 ❯ http:/localhost:63315/node_modules/@vitest/utils/node_modules/pretty-format/build/index.js?v=5c8adf77:3:23
```

```sh
# Apply PR's fix:
# Add "pretty-format" to line 1944
code node_modules/@vitest/browser/dist/index.js

# Success
yarn test
```

However `pnpm` with `hoist=false` is still broken:

```sh
git clone https://github.com/AriPerkkio/aria-live-capture.git
cd aria-live-capture
git checkout 27031730f0bfa51e66c25900f380580c95b0a17c
echo "hoist=false" >> .npmrc
pnpm i
pnpm test
```

```
ReferenceError: exports is not defined
 ❯ http:/localhost:63315/node_modules/.pnpm/pretty-format@27.5.1/node_modules/pretty-format/build/index.js?v=a19edd20:3:23
```

