### PR TITLE
fix(watch): clear screen on all terminals

### DIFF
--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -8,6 +8,12 @@ import { RandomSequencer } from './sequencers/RandomSequencer'
 import type { Vitest } from './core'
 import { printError } from './error'
 
+const ESC = '\x1B['
+const ERASE_DOWN = `${ESC}J`
+const ERASE_SCROLLBACK = `${ESC}3J`
+const CURSOR_TO_START = `${ESC}1;1H`
+const CLEAR_SCREEN = '\x1Bc'
+
 export class Logger {
   outputStream = process.stdout
   errorStream = process.stderr
@@ -43,7 +49,7 @@ export class Logger {
       return
     }
 
-    this.console.log(`\x1Bc${message}`)
+    this.console.log(`${ERASE_SCROLLBACK}${CLEAR_SCREEN}${message}`)
   }
 
   clearScreen(message: string, force = false) {
@@ -63,9 +69,7 @@ export class Logger {
 
     const log = this._clearScreenPending
     this._clearScreenPending = undefined
-    // equivalent to ansi-escapes:
-    // stdout.write(ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown + log)
-    this.console.log(`\u001B[1;1H\u001B[J${log}`)
+    this.console.log(`${CURSOR_TO_START}${ERASE_DOWN}${log}`)
   }
 
   printError(err: unknown, fullStack = false, type?: string) {


### PR DESCRIPTION
- Fixes #3608

Mac's Terminal App does not reset scrollback buffer when `\x1Bc` (RIS) is printed. Similar report is found from here: https://github.com/xtermjs/xterm.js/issues/3315.
As fix, let's explicitly print `ESC 3J` to erase scrollback.  

Tested on
- Windows 11 21H2, virtualized on MacOS
  - Powershell
  - CMD
  - Git Bash
  - VS Code Terminal
- MacOS
  - VS Code Terminal
  - Warp
  - Terminal App
