### PR TITLE
feat(browser): Add `none` browser provider

### DIFF
--- a/packages/vitest/src/integrations/browser.ts
+++ b/packages/vitest/src/integrations/browser.ts
@@ -1,24 +1,22 @@
+import { provider } from 'std-env'
 import { NoneBrowserProvider } from '../node/browser/none'
 import { PlaywrightBrowserProvider } from '../node/browser/playwright'
 import { WebdriverBrowserProvider } from '../node/browser/webdriver'
 import type { BrowserProviderModule, ResolvedBrowserOptions } from '../types/browser'
-import { StackBlitzBrowserProvider } from '../node/browser/stackblitz'
 
 interface Loader {
   executeId: (id: string) => Promise<{ default: BrowserProviderModule }>
 }
 
 export async function getBrowserProvider(options: ResolvedBrowserOptions, loader: Loader): Promise<BrowserProviderModule> {
+  const stackblitz = provider === 'stackblitz'
   switch (options.provider) {
     case undefined:
     case 'webdriverio':
-      return WebdriverBrowserProvider
+      return stackblitz ? NoneBrowserProvider : WebdriverBrowserProvider
 
     case 'playwright':
-      return PlaywrightBrowserProvider
-
-    case 'stackblitz':
-      return StackBlitzBrowserProvider
+      return stackblitz ? NoneBrowserProvider : PlaywrightBrowserProvider
 
     case 'none':
       return NoneBrowserProvider

--- a/packages/vitest/src/integrations/browser.ts
+++ b/packages/vitest/src/integrations/browser.ts
@@ -1,6 +1,8 @@
+import { NoneBrowserProvider } from '../node/browser/none'
 import { PlaywrightBrowserProvider } from '../node/browser/playwright'
 import { WebdriverBrowserProvider } from '../node/browser/webdriver'
 import type { BrowserProviderModule, ResolvedBrowserOptions } from '../types/browser'
+import { StackBlitzBrowserProvider } from '../node/browser/stackblitz'
 
 interface Loader {
   executeId: (id: string) => Promise<{ default: BrowserProviderModule }>
@@ -14,6 +16,12 @@ export async function getBrowserProvider(options: ResolvedBrowserOptions, loader
 
     case 'playwright':
       return PlaywrightBrowserProvider
+
+    case 'stackblitz':
+      return StackBlitzBrowserProvider
+
+    case 'none':
+      return NoneBrowserProvider
 
     default:
       break

--- a/packages/vitest/src/integrations/browser/server.ts
+++ b/packages/vitest/src/integrations/browser/server.ts
@@ -8,6 +8,7 @@ import { resolveApiServerConfig } from '../../node/config'
 import { CoverageTransform } from '../../node/plugins/coverageTransform'
 import type { WorkspaceProject } from '../../node/workspace'
 import { MocksPlugin } from '../../node/plugins/mocks'
+import type { BrowserConfigOptions } from '../../types/browser'
 
 export async function createBrowserServer(project: WorkspaceProject, options: UserConfig) {
   const root = project.config.root
@@ -38,13 +39,17 @@ export async function createBrowserServer(project: WorkspaceProject, options: Us
         enforce: 'post',
         name: 'vitest:browser:config',
         async config(config) {
-          const server = resolveApiServerConfig(config.test?.browser || {}) || {
+          const browser: Pick<BrowserConfigOptions, 'api' | 'enabled' | 'provider'> = config.test?.browser ?? {}
+          const server = resolveApiServerConfig(browser) || {
             port: defaultBrowserPort,
           }
 
           config.server = server
           config.server.fs ??= {}
           config.server.fs.strict = false
+
+          if (browser.enabled === true && browser.provider === 'none')
+            config.server.open = true
 
           return {
             resolve: {

--- a/packages/vitest/src/integrations/browser/server.ts
+++ b/packages/vitest/src/integrations/browser/server.ts
@@ -39,7 +39,7 @@ export async function createBrowserServer(project: WorkspaceProject, options: Us
         enforce: 'post',
         name: 'vitest:browser:config',
         async config(config) {
-          const browser: Pick<BrowserConfigOptions, 'api' | 'enabled' | 'provider'> = config.test?.browser ?? {}
+          const browser: Pick<BrowserConfigOptions, 'api' | 'provider'> = config.test?.browser ?? {}
           const server = resolveApiServerConfig(browser) || {
             port: defaultBrowserPort,
           }
@@ -48,7 +48,7 @@ export async function createBrowserServer(project: WorkspaceProject, options: Us
           config.server.fs ??= {}
           config.server.fs.strict = false
 
-          if (browser.enabled === true && browser.provider === 'none')
+          if (browser.provider === 'none')
             config.server.open = true
 
           return {

--- a/packages/vitest/src/node/browser/none.ts
+++ b/packages/vitest/src/node/browser/none.ts
@@ -1,0 +1,40 @@
+import type { BrowserProvider, BrowserProviderOptions } from '../../types/browser'
+import type { WorkspaceProject } from '../workspace'
+import type { Awaitable } from '#types'
+
+export class NoneBrowserProvider implements BrowserProvider {
+  public name = 'none'
+  private ctx!: WorkspaceProject
+  private open = false
+  private browser!: string
+
+  requiresBrowser() {
+    return false
+  }
+
+  getSupportedBrowsers() {
+    // `none` supports any browser
+    return []
+  }
+
+  isOpen() {
+    return this.open
+  }
+
+  async initialize(ctx: WorkspaceProject, { browser }: BrowserProviderOptions) {
+    this.ctx = ctx
+    this.open = false
+    this.browser = browser
+  }
+
+  catchError(_cb: (error: Error) => Awaitable<void>) {
+    return () => {}
+  }
+
+  async openPage(_url: string) {
+    this.open = true
+  }
+
+  async close() {
+  }
+}

--- a/packages/vitest/src/node/browser/playwright.ts
+++ b/packages/vitest/src/node/browser/playwright.ts
@@ -18,6 +18,10 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
   private browser!: PlaywrightBrowser
   private ctx!: WorkspaceProject
 
+  requiresBrowser() {
+    return true
+  }
+
   getSupportedBrowsers() {
     return playwrightBrowsers
   }

--- a/packages/vitest/src/node/browser/stackblitz.ts
+++ b/packages/vitest/src/node/browser/stackblitz.ts
@@ -1,0 +1,5 @@
+import { NoneBrowserProvider } from './none'
+
+export class StackBlitzBrowserProvider extends NoneBrowserProvider {
+  public name = 'stackblitz'
+}

--- a/packages/vitest/src/node/browser/stackblitz.ts
+++ b/packages/vitest/src/node/browser/stackblitz.ts
@@ -1,5 +1,0 @@
-import { NoneBrowserProvider } from './none'
-
-export class StackBlitzBrowserProvider extends NoneBrowserProvider {
-  public name = 'stackblitz'
-}

--- a/packages/vitest/src/node/browser/webdriver.ts
+++ b/packages/vitest/src/node/browser/webdriver.ts
@@ -18,6 +18,10 @@ export class WebdriverBrowserProvider implements BrowserProvider {
   private browser!: WebdriverBrowser
   private ctx!: WorkspaceProject
 
+  requiresBrowser() {
+    return true
+  }
+
   getSupportedBrowsers() {
     return webdriverBrowsers
   }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -311,16 +311,20 @@ export class WorkspaceProject {
   async initBrowserProvider() {
     if (!this.isBrowserEnabled())
       return
+
     if (this.browserProvider)
       return
+
     const Provider = await getBrowserProvider(this.config.browser, this.runner)
     this.browserProvider = new Provider()
     const browser = this.config.browser.name
-    const supportedBrowsers = this.browserProvider.getSupportedBrowsers()
     if (!browser)
       throw new Error(`[${this.getName()}] Browser name is required. Please, set \`test.browser.name\` option manually.`)
-    if (!supportedBrowsers.includes(browser))
+
+    const supportedBrowsers = this.browserProvider.getSupportedBrowsers()
+    if (this.browserProvider.requiresBrowser() && !supportedBrowsers.includes(browser))
       throw new Error(`[${this.getName()}] Browser "${browser}" is not supported by the browser provider "${this.browserProvider.name}". Supported browsers: ${supportedBrowsers.join(', ')}.`)
+
     await this.browserProvider.initialize(this, { browser })
   }
 }

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -38,7 +38,7 @@ export interface BrowserConfigOptions {
    *
    * @default 'webdriverio'
    */
-  provider?: 'webdriverio' | 'playwright' | 'stackblitz' | 'none' | (string & {})
+  provider?: 'webdriverio' | 'playwright' | 'none' | (string & {})
 
   /**
    * enable headless mode

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -8,6 +8,7 @@ export interface BrowserProviderOptions {
 
 export interface BrowserProvider {
   name: string
+  requiresBrowser(): boolean
   getSupportedBrowsers(): readonly string[]
   initialize(ctx: WorkspaceProject, options: BrowserProviderOptions): Awaitable<void>
   openPage(url: string): Awaitable<void>
@@ -37,7 +38,7 @@ export interface BrowserConfigOptions {
    *
    * @default 'webdriverio'
    */
-  provider?: 'webdriverio' | 'playwright' | (string & {})
+  provider?: 'webdriverio' | 'playwright' | 'stackblitz' | 'none' | (string & {})
 
   /**
    * enable headless mode

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -34,14 +34,16 @@ export interface BrowserConfigOptions {
   name: string
 
   /**
-   * browser provider
+   * Browser provider
+   *
+   * When running in StackBlitz, Vitest will use the `none` provider (configured provider will be ignored).
    *
    * @default 'webdriverio'
    */
   provider?: 'webdriverio' | 'playwright' | 'none' | (string & {})
 
   /**
-   * enable headless mode
+   * Enable headless mode
    *
    * @default process.env.CI
    */


### PR DESCRIPTION
This PR should be merged once https://github.com/vitest-dev/vitest/pull/3584 merged.

I have left `webdriverio` as the default provider, ready to be used in `CI`.

We need to add some entries in the docs for local development and `CI`.

/cc @Aslemammad 

closes #3084
supersedes #3273