### PR TITLE
refactor(browser): remove process mock

### DIFF
--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -9,10 +9,6 @@ import { setupDialogsSpy } from './dialog'
 import { BrowserSnapshotEnvironment } from './snapshot'
 import { VitestBrowserClientMocker } from './mocker'
 
-// @ts-expect-error mocking some node apis
-globalThis.process = { env: {}, argv: [], cwd: () => '/', stdout: { write: () => {} }, nextTick: cb => cb() }
-globalThis.global = globalThis
-
 export const PORT = import.meta.hot ? '51204' : location.port
 export const HOST = [location.hostname, PORT].filter(Boolean).join(':')
 export const ENTRY_URL = `${

--- a/packages/browser/src/client/rpc.ts
+++ b/packages/browser/src/client/rpc.ts
@@ -10,16 +10,19 @@ function withSafeTimers(getTimers: typeof getSafeTimers, fn: () => void) {
 
   const currentSetTimeout = globalThis.setTimeout
   const currentClearTimeout = globalThis.clearTimeout
-  const currentNextTick = globalThis.process.nextTick
   const currentSetImmediate = globalThis.setImmediate
   const currentClearImmediate = globalThis.clearImmediate
+
+  const currentNextTick = globalThis.process?.nextTick
 
   try {
     globalThis.setTimeout = setTimeout
     globalThis.clearTimeout = clearTimeout
-    globalThis.process.nextTick = nextTick
     globalThis.setImmediate = setImmediate
     globalThis.clearImmediate = clearImmediate
+
+    if (globalThis.process)
+      globalThis.process.nextTick = nextTick
 
     const result = fn()
     return result
@@ -29,9 +32,12 @@ function withSafeTimers(getTimers: typeof getSafeTimers, fn: () => void) {
     globalThis.clearTimeout = currentClearTimeout
     globalThis.setImmediate = currentSetImmediate
     globalThis.clearImmediate = currentClearImmediate
-    nextTick(() => {
-      globalThis.process.nextTick = currentNextTick
-    })
+
+    if (globalThis.process) {
+      nextTick(() => {
+        globalThis.process.nextTick = currentNextTick
+      })
+    }
   }
 }
 

--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -10,16 +10,19 @@ function withSafeTimers(fn: () => void) {
 
   const currentSetTimeout = globalThis.setTimeout
   const currentClearTimeout = globalThis.clearTimeout
-  const currentNextTick = globalThis.process.nextTick
   const currentSetImmediate = globalThis.setImmediate
   const currentClearImmediate = globalThis.clearImmediate
+
+  const currentNextTick = globalThis.process?.nextTick
 
   try {
     globalThis.setTimeout = setTimeout
     globalThis.clearTimeout = clearTimeout
-    globalThis.process.nextTick = nextTick
     globalThis.setImmediate = setImmediate
     globalThis.clearImmediate = clearImmediate
+
+    if (globalThis.process)
+      globalThis.process.nextTick = nextTick
 
     const result = fn()
     return result
@@ -29,9 +32,12 @@ function withSafeTimers(fn: () => void) {
     globalThis.clearTimeout = currentClearTimeout
     globalThis.setImmediate = currentSetImmediate
     globalThis.clearImmediate = currentClearImmediate
-    nextTick(() => {
-      globalThis.process.nextTick = currentNextTick
-    })
+
+    if (globalThis.process) {
+      nextTick(() => {
+        globalThis.process.nextTick = currentNextTick
+      })
+    }
   }
 }
 

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -6,7 +6,7 @@ import { runDynamicFileCJS, runDynamicFileESM } from '../src/dynamic-files'
 
 // Browser mode crashes with dynamic files. Enable this when browser mode works.
 // To keep istanbul report consistent between browser and node, skip dynamic tests when istanbul is used.
-const skipDynamicFiles = process.env.COVERAGE_PROVIDER === 'istanbul' || !process.env.COVERAGE_PROVIDER
+const skipDynamicFiles = globalThis.process?.env.COVERAGE_PROVIDER === 'istanbul' || !globalThis.process?.env.COVERAGE_PROVIDER
 
 const { pythagoras } = await (() => {
   if ('__vitest_browser__' in globalThis)


### PR DESCRIPTION
Removes manual mock of `process`. This change unblocks https://github.com/vitest-dev/vitest/pull/3648