### PR TITLE
Add missing JSDom living keys

### DIFF
--- a/packages/vitest/src/integrations/env/jsdom-keys.ts
+++ b/packages/vitest/src/integrations/env/jsdom-keys.ts
@@ -115,6 +115,7 @@ const LIVING_KEYS = [
   'StorageEvent',
   'ProgressEvent',
   'PageTransitionEvent',
+  'SubmitEvent',
   'UIEvent',
   'FocusEvent',
   'InputEvent',

--- a/packages/vitest/src/integrations/env/jsdom-keys.ts
+++ b/packages/vitest/src/integrations/env/jsdom-keys.ts
@@ -164,6 +164,8 @@ const LIVING_KEYS = [
   'AbortController',
   'AbortSignal',
   'ArrayBuffer',
+  'DOMRectReadOnly',
+  'DOMRect',
 
   // not specified in docs, but is available
   'Image',


### PR DESCRIPTION
This PR adds `SubmitEvent`, `DOMRectReadOnly` and `DOMRect` to the JSDom living keys so that they are available in tests when running in the JSDom environment.

- `SubmitEvent` was added to the living interfaces in version 21.1.0 (see [commit](https://github.com/jsdom/jsdom/commit/79c351bc5a#diff-192ca7362e7fb7c4aeae2fa4d091fc7fc66238b69bc2da2ca4e45e73b7511c03)) 
- `DOMRectReadOnly` and `DOMRect` were added to the living interfaces in version 22.1.0 (see [commit](https://github.com/jsdom/jsdom/commit/c9d6b72500#diff-192ca7362e7fb7c4aeae2fa4d091fc7fc66238b69bc2da2ca4e45e73b7511c03)) 