### PR TITLE
feat: support use function/class as `bench` name

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -344,7 +344,7 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 
 ## bench
 
-- **Type:** `(name: string, fn: BenchFunction, options?: BenchOptions) => void`
+- **Type:** `(name: string | Function, fn: BenchFunction, options?: BenchOptions) => void`
 
 `bench` defines a benchmark. In Vitest terms benchmark is a function that defines a series of operations. Vitest runs this function multiple times to display different performance results.
 
@@ -411,7 +411,7 @@ Vitest uses [`tinybench`](https://github.com/tinylibs/tinybench) library under t
 
 ### bench.skip
 
-- **Type:** `(name: string, fn: BenchFunction, options?: BenchOptions) => void`
+- **Type:** `(name: string | Function, fn: BenchFunction, options?: BenchOptions) => void`
 
 You can use `bench.skip` syntax to skip running certain benchmarks.
 
@@ -428,7 +428,7 @@ You can use `bench.skip` syntax to skip running certain benchmarks.
 
 ### bench.only
 
-- **Type:** `(name: string, fn: BenchFunction, options?: BenchOptions) => void`
+- **Type:** `(name: string | Function, fn: BenchFunction, options?: BenchOptions) => void`
 
 Use `bench.only` to only run certain benchmarks in a given suite. This is useful when debugging.
 
@@ -445,7 +445,7 @@ Use `bench.only` to only run certain benchmarks in a given suite. This is useful
 
 ### bench.todo
 
-- **Type:** `(name: string) => void`
+- **Type:** `(name: string | Function) => void`
 
 Use `bench.todo` to stub benchmarks to be implemented later.
 

--- a/packages/vitest/src/runtime/benchmark.ts
+++ b/packages/vitest/src/runtime/benchmark.ts
@@ -21,7 +21,7 @@ export const bench = createBenchmark(
     if (!isRunningInBenchmark())
       throw new Error('`bench()` is only available in benchmark mode.')
 
-    const task = getCurrentSuite().custom.call(this, name)
+    const task = getCurrentSuite().custom.call(this, formatName(name))
     task.meta = {
       benchmark: true,
     }
@@ -33,7 +33,7 @@ export const bench = createBenchmark(
 function createBenchmark(fn: (
   (
     this: Record<'skip' | 'only' | 'todo', boolean | undefined>,
-    name: string,
+    name: string | Function,
     fn?: BenchFunction,
     options?: BenchOptions
   ) => void
@@ -47,4 +47,8 @@ function createBenchmark(fn: (
   benchmark.runIf = (condition: any) => (condition ? benchmark : benchmark.skip) as BenchmarkAPI
 
   return benchmark as BenchmarkAPI
+}
+
+function formatName(name: string | Function) {
+  return typeof name === 'string' ? name : name instanceof Function ? (name.name || '<anonymous>') : String(name)
 }

--- a/packages/vitest/src/types/benchmark.ts
+++ b/packages/vitest/src/types/benchmark.ts
@@ -54,7 +54,7 @@ export interface BenchmarkResult extends TinybenchResult {
 export type BenchFunction = (this: BenchFactory) => Promise<void> | void
 export type BenchmarkAPI = ChainableFunction<
 'skip' | 'only' | 'todo',
-[name: string, fn?: BenchFunction, options?: BenchOptions],
+[name: string | Function, fn?: BenchFunction, options?: BenchOptions],
 void
 > & {
   skipIf(condition: any): BenchmarkAPI

--- a/test/reporters/fixtures/function-as-name.bench.ts
+++ b/test/reporters/fixtures/function-as-name.bench.ts
@@ -1,0 +1,8 @@
+import { bench } from 'vitest'
+
+function foo() {}
+class Bar {}
+
+bench(foo, () => {})
+bench(Bar, () => {})
+bench(() => {}, () => {})

--- a/test/reporters/tests/function-as-name.test.ts
+++ b/test/reporters/tests/function-as-name.test.ts
@@ -14,3 +14,13 @@ test('should print function name', async () => {
   expect(stdout).toContain('function-as-name.test.ts > foo > foo')
   expect(stdout).toContain('function-as-name.test.ts > Bar > Bar')
 })
+
+test('should print function name in benchmark', async () => {
+  const filename = resolve('./fixtures/function-as-name.bench.ts')
+  const { stdout } = await runVitest({ root: './fixtures' }, [filename], 'benchmark')
+
+  expect(stdout).toBeTruthy()
+  expect(stdout).toContain('Bar')
+  expect(stdout).toContain('foo')
+  expect(stdout).toContain('<anonymous>')
+})


### PR DESCRIPTION
Like #3497, but for benchmark API.