### PR TITLE
fix: isolate workers between envs and workspaces

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -154,7 +154,7 @@
     "std-env": "^3.3.3",
     "strip-literal": "^1.0.1",
     "tinybench": "^2.5.0",
-    "tinypool": "^0.6.0",
+    "tinypool": "^0.7.0",
     "vite": "^3.0.0 || ^4.0.0",
     "vite-node": "workspace:*",
     "why-is-node-running": "^2.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1335,8 +1335,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       tinypool:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.0
+        version: 0.7.0
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@18.7.13)
@@ -1682,6 +1682,18 @@ importers:
 
   test/env-glob:
     devDependencies:
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+
+  test/env-mixed:
+    devDependencies:
+      happy-dom:
+        specifier: latest
+        version: 9.20.3
+      vite:
+        specifier: ^4.3.9
+        version: 4.3.9(@types/node@18.16.19)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -23640,8 +23652,8 @@ packages:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: false
 
-  /tinypool@0.6.0:
-    resolution: {integrity: sha512-FdswUUo5SxRizcBc6b1GSuLpLjisa8N8qMyYoP3rl+bym+QauhtJP5bvZY1ytt8krKGmMLYIRl36HBZfeAoqhQ==}
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
     dev: false
 

--- a/test/env-mixed/fixtures/project/test/happy-dom.test.ts
+++ b/test/env-mixed/fixtures/project/test/happy-dom.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { expect, test } from 'vitest'
+
+test('Leaking globals not found', async () => {
+  (globalThis as any).__leaking_from_happy_dom = 'leaking'
+  expect((globalThis as any).__leaking_from_node).toBe(undefined)
+  expect((globalThis as any).__leaking_from_jsdom).toBe(undefined)
+})

--- a/test/env-mixed/fixtures/project/test/jsdom.test.ts
+++ b/test/env-mixed/fixtures/project/test/jsdom.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { expect, test } from 'vitest'
+
+test('Leaking globals not found', async () => {
+  (globalThis as any).__leaking_from_jsdom = 'leaking'
+  expect((globalThis as any).__leaking_from_node).toBe(undefined)
+  expect((globalThis as any).__leaking_from_happy_dom).toBe(undefined)
+})

--- a/test/env-mixed/fixtures/project/test/node.test.ts
+++ b/test/env-mixed/fixtures/project/test/node.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @vitest-environment node
+ */
+
+import { expect, test } from 'vitest'
+
+test('Leaking globals not found', async () => {
+  (globalThis as any).__leaking_from_node = 'leaking'
+  expect((globalThis as any).__leaking_from_jsdom).toBe(undefined)
+  expect((globalThis as any).__leaking_from_happy_dom).toBe(undefined)
+})

--- a/test/env-mixed/fixtures/project/test/workspace-project.test.ts
+++ b/test/env-mixed/fixtures/project/test/workspace-project.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+
+test('Leaking globals not found', async () => {
+  expect((globalThis as any).__leaking_from_workspace_project).toBe(undefined)
+
+  ;(globalThis as any).__leaking_from_workspace_project = 'leaking'
+})

--- a/test/env-mixed/fixtures/vitest.config.ts
+++ b/test/env-mixed/fixtures/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {},
+})

--- a/test/env-mixed/fixtures/vitest.workspace.ts
+++ b/test/env-mixed/fixtures/vitest.workspace.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineWorkspace } from 'vitest/config'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = resolve(__filename, '..')
+
+export default defineWorkspace([
+  {
+    test: {
+      name: 'Project #1',
+      root: resolve(__dirname, './project'),
+    },
+  },
+  {
+    test: {
+      name: 'Project #2',
+      root: resolve(__dirname, './project'),
+    },
+  },
+])

--- a/test/env-mixed/package.json
+++ b/test/env-mixed/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-env-mixed",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "happy-dom": "latest",
+    "vite": "latest",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/env-mixed/test/mixed-environments.test.ts
+++ b/test/env-mixed/test/mixed-environments.test.ts
@@ -1,0 +1,26 @@
+import { type UserConfig, expect, test } from 'vitest'
+
+import { runVitest } from '../../test-utils'
+
+const configs: UserConfig[] = [
+  { isolate: false, singleThread: true },
+  { isolate: false, singleThread: false },
+  { isolate: false, threads: true, minThreads: 1, maxThreads: 1 },
+  { isolate: false, threads: false },
+]
+
+test.each(configs)('should isolate environments when %s', async (config) => {
+  const { stderr, stdout } = await runVitest({
+    root: './fixtures',
+    ...config,
+  })
+
+  expect(stderr).toBe('')
+
+  expect(stdout).toContain('✓ test/node.test.ts')
+  expect(stdout).toContain('✓ test/jsdom.test.ts')
+  expect(stdout).toContain('✓ test/happy-dom.test.ts')
+  expect(stdout).toContain('✓ test/workspace-project.test.ts')
+  expect(stdout).toContain('Test Files  8 passed (8)')
+  expect(stdout).toContain('Tests  8 passed (8)')
+})

--- a/test/env-mixed/vitest.config.ts
+++ b/test/env-mixed/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['./test/**/*'],
+    testTimeout: process.env.CI ? 30_000 : 10_000,
+    chaiConfig: {
+      truncateThreshold: 0,
+    },
+  },
+})


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/3659
- Requires: https://github.com/tinylibs/tinypool/pull/63
- Enables: https://github.com/vitest-dev/vitest/pull/3491

When running files with threads enabled, make sure workers are recycled when ever environment options or workspace changes. 

Also noticed that when running tests of workspace through `startVitest` Node API, the logger does not include project names in log entries. 
