### PR TITLE
ci: fix `browser-actions/setup-edge` setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
       - uses: browser-actions/setup-firefox@v1
       - uses: browser-actions/setup-edge@v1
+        with:
+          edge-version: beta
 
       - name: Install
         run: pnpm i


### PR DESCRIPTION
- Fixes failing CIs

The API does not return download link for Stable+x64+Linux: https://edgeupdates.microsoft.com/api/products