### PR TITLE
feat: exclude e2e tests folder by default

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -2,7 +2,7 @@ import type { BenchmarkUserOptions, ResolvedCoverageOptions, UserConfig } from '
 import { isCI } from './utils/env'
 
 export const defaultInclude = ['**/__tests__/**/*.?(c|m)[jt]s?(x)', '**/?(*.){test,spec}.?(c|m)[jt]s?(x)']
-export const defaultExclude = ['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*']
+export const defaultExclude = ['**/{node_modules,dist,cypress,playwright,e2e-tests}/**', '**/.{idea,git,cache,output,temp}/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*']
 export const benchmarkConfigDefaults: Required<Omit<BenchmarkUserOptions, 'outputFile'>> = {
   include: ['**/*.{bench,benchmark}.?(c|m)[jt]s?(x)'],
   exclude: defaultExclude,


### PR DESCRIPTION
close https://github.com/vitest-dev/vitest/issues/3102

Hey @sheremet-va, I accidentally closed the previous PR (https://github.com/vitest-dev/vitest/pull/3469) while deleting my fork, apologies 🙏

I already removed the `**/tests/**` path from the default, leaving only `**/playwright/**` and `**/e2e-tests/**`