### PR TITLE
feat(browser): add support for custom browser capabilities

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1035,7 +1035,7 @@ Path to a provider that will be used when running browser tests. Vitest provides
 export interface BrowserProvider {
   name: string
   getSupportedBrowsers(): readonly string[]
-  initialize(ctx: Vitest, options: { browser: string }): Awaitable<void>
+  initialize(ctx: Vitest, options: { browser: string; options?: ProviderSpecificOptions }): Awaitable<void>
   openPage(url: string): Awaitable<void>
   close(): Awaitable<void>
 }

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -108,7 +108,50 @@ npx vitest --browser.name=chrome --browser.headless
 
 In this case, Vitest will run in headless mode using the Chrome browser.
 
+## Custom Provider Options
+
+You may pass provider-specific options, such as [WebdriverIO custom capabilities](https://webdriver.io/docs/capabilities#custom-capabilities) like:
+
+```ts
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      name: 'webdriverio',
+      options: {
+        webdriverio: {
+          'goog:chromeOptions': {
+            args: ['disable-gpu'],
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+or in case of [Playwright-specific options](https://playwright.dev/docs/api/class-browsertype#browser-type-launch):
+
+```ts
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      name: 'playwright',
+      options: {
+        playwright: {
+          args: ['disable-gpu'], // chromium
+        },
+      },
+    },
+  },
+})
+```
+
 ## Limitations
+
 ### Thread Blocking Dialogs
 
 When using Vitest Browser, it's important to note that thread blocking dialogs like `alert` or `confirm` cannot be used natively. This is because they block the web page, which means Vitest cannot continue communicating with the page, causing the execution to hang.

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -285,6 +285,7 @@ export function resolveConfig(
 
   resolved.browser ??= {} as any
   resolved.browser.enabled ??= false
+  resolved.browser.options ??= {}
   resolved.browser.headless ??= isCI
   resolved.browser.slowHijackESM ??= true
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -338,11 +338,12 @@ export class WorkspaceProject {
     const Provider = await getBrowserProvider(this.config.browser, this.runner)
     this.browserProvider = new Provider()
     const browser = this.config.browser.name
+    const options = this.config.browser.options
     const supportedBrowsers = this.browserProvider.getSupportedBrowsers()
     if (!browser)
       throw new Error(`[${this.getName()}] Browser name is required. Please, set \`test.browser.name\` option manually.`)
     if (!supportedBrowsers.includes(browser))
       throw new Error(`[${this.getName()}] Browser "${browser}" is not supported by the browser provider "${this.browserProvider.name}". Supported browsers: ${supportedBrowsers.join(', ')}.`)
-    await this.browserProvider.initialize(this, { browser })
+    await this.browserProvider.initialize(this, { browser, options })
   }
 }

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -2,14 +2,23 @@ import type { Awaitable } from '@vitest/utils'
 import type { WorkspaceProject } from '../node/workspace'
 import type { ApiConfig } from './config'
 
+export interface ProviderSpecificOptions {
+  webdriverio?: unknown
+  playwright?: unknown
+}
+
 export interface BrowserProviderOptions {
   browser: string
+  options?: ProviderSpecificOptions
 }
 
 export interface BrowserProvider {
   name: string
   getSupportedBrowsers(): readonly string[]
-  initialize(ctx: WorkspaceProject, options: BrowserProviderOptions): Awaitable<void>
+  initialize(
+    ctx: WorkspaceProject,
+    options: BrowserProviderOptions
+  ): Awaitable<void>
   openPage(url: string): Awaitable<void>
   catchError(cb: (error: Error) => Awaitable<void>): () => Awaitable<void>
   close(): Awaitable<void>
@@ -61,6 +70,12 @@ export interface BrowserConfigOptions {
    * @experimental
    */
   slowHijackESM?: boolean
+
+  /**
+   * Custom provider/capabilities options passed on for the specific provider.
+   *
+   */
+  options?: ProviderSpecificOptions | {}
 }
 
 export interface ResolvedBrowserOptions extends BrowserConfigOptions {


### PR DESCRIPTION
The aim of this PR is to add support for passing [custom browser capability arguments for WebdriverIO](https://webdriver.io/docs/capabilities#custom-capabilities). This was done rather quickly so improvements and suggestions are welcome, I only saw tests for playwiright.