### PR TITLE
docs: Clarify external option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -137,7 +137,7 @@ You will not be able to edit your `node_modules` code for debugging, since the c
 
 Externalize means that Vite will bypass the package to native Node. Externalized dependencies will not be applied Vite's transformers and resolvers, so they do not support HMR on reload. Typically, packages under `node_modules` are externalized.
 
-When using strings they need to be paths inside your [`deps.moduleDirectories`](/config/#deps.moduleDirectories). For example `external: ['module/folder']` with the default `moduleDirectories` option will externalize `node_modules/module/folder`.
+When using strings they need to be paths inside your [`deps.moduleDirectories`](/config/#deps-moduledirectories). For example `external: ['module/folder']` with the default `moduleDirectories` option will externalize `node_modules/module/folder`.
 Regular expressions on the other hand are matched against the whole path.
 
 #### deps.inline

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -133,9 +133,12 @@ You will not be able to edit your `node_modules` code for debugging, since the c
 #### deps.external
 
 - **Type:** `(string | RegExp)[]`
-- **Default:** `['**/node_modules/**']`
+- **Default:** `[/\/node_modules\//]`
 
 Externalize means that Vite will bypass the package to native Node. Externalized dependencies will not be applied Vite's transformers and resolvers, so they do not support HMR on reload. Typically, packages under `node_modules` are externalized.
+
+When using strings they need to be paths inside your [`deps.moduleDirectories`](/config/#deps.moduleDirectories). For example `external: ['module/folder']` with the default `moduleDirectories` option will externalize `node_modules/module/folder`.
+Regular expressions on the other hand are matched against the whole path.
 
 #### deps.inline
 


### PR DESCRIPTION
I was using globs in the external option, which I noticed had no effect. After switching to regexes it started working.

I looked at [this code ](https://github.com/vitest-dev/vitest/blob/main/packages/vite-node/src/externalize.ts#L141-L150) and tried to explain what the option is doing and make it more clear that strings are not simply checked against the id, but rather the `moduleDirectories`.

