### PR TITLE
fix: don't fail empty test suite with passWithNoTests (fix #3779)

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -314,7 +314,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
     }
 
     if (suite.mode === 'run') {
-      if (!hasTests(suite)) {
+      if (!hasTests(suite) && !runner.config.passWithNoTests) {
         suite.result.state = 'fail'
         if (!suite.result.error) {
           const error = processError(new Error(`No test found in suite ${suite.name}`))

--- a/test/fails/fixtures/empty-suite.test.ts
+++ b/test/fails/fixtures/empty-suite.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest'
+
+describe('no tests here', () => {})
+
+describe('this suite has tests though', () => {
+  test('simple addition', () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -6,6 +6,8 @@ exports[`should fail each-timeout.test.ts > each-timeout.test.ts 1`] = `"Error: 
 
 exports[`should fail empty.test.ts > empty.test.ts 1`] = `"Error: No test suite found in file <rootDir>/empty.test.ts"`;
 
+exports[`should fail empty-suite.test.ts > empty-suite.test.ts 1`] = `"Error: No test found in suite no tests here"`;
+
 exports[`should fail expect.test.ts > expect.test.ts 1`] = `"AssertionError: expected 2 to deeply equal 3"`;
 
 exports[`should fail expect-soft.test.ts > expect-soft.test.ts 1`] = `"Error: expect.soft() can only be used inside a test"`;

--- a/test/fails/test/runner.test.ts
+++ b/test/fails/test/runner.test.ts
@@ -6,6 +6,8 @@ import { runVitest } from '../../test-utils'
 
 const root = resolve(__dirname, '../fixtures')
 const files = await fg('**/*.test.ts', { cwd: root, dot: true })
+const emptyTestFile = await fg('**/empty.test.ts', { cwd: root, dot: true })
+const emptySuiteTestFile = await fg('**/empty-suite.test.ts', { cwd: root, dot: true })
 
 it.each(files)('should fail %s', async (file) => {
   const { stderr } = await runVitest({ root }, [file])
@@ -19,6 +21,15 @@ it.each(files)('should fail %s', async (file) => {
     ).join('\n')
   expect(msg).toMatchSnapshot(file)
 }, 30_000)
+
+it.each(emptyTestFile.concat(emptySuiteTestFile))('should pass %s when passWithNoTests enabled', async (file) => {
+  const { stdout, stderr, exitCode } = await runVitest({
+    root,
+    passWithNoTests: true,
+  }, [file])
+
+  expect(exitCode).toBe(0)
+})
 
 it('should report coverage when "coverag.reportOnFailure: true" and tests fail', async () => {
   const { stdout } = await runVitest({


### PR DESCRIPTION
Fix #3779 