### PR TITLE
doc: add define config example with triple slash command

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -49,6 +49,19 @@ One of the main advantages of Vitest is its unified configuration with Vite. If 
 To configure `vitest` itself, add `test` property in your Vite config. You'll also need to add a reference to Vitest types using a [triple slash command](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) at the top of your config file, if you are importing `defineConfig` from `vite` itself.
 
 ```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    // ...
+  },
+})
+```
+
+Another way is importing `defineConfig` from `vitest/config`.
+
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
The current `defineConfig` configuration section is a bit confusing, the text in the docs describes using the triple slash command, however the examples use the alternative method imported from `vitest/config`.

I think there needs to an example to hint at exactly how we should write the triple slash command, so I've added this section to the documentation.

#2989 also attempts to address this issue.