### PR TITLE
fix: port the latest `defineConfig` type from vite

### DIFF
--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -20,6 +20,7 @@ export type UserProjectConfigExport = UserWorkspaceConfig | Promise<UserWorkspac
 
 export function defineConfig(config: ViteUserConfig): ViteUserConfig
 export function defineConfig(config: Promise<ViteUserConfig>): Promise<ViteUserConfig>
+export function defineConfig(config: UserConfigFnObject): UserConfigFnObject
 export function defineConfig(config: UserConfigExport): UserConfigExport
 export function defineConfig(config: UserConfigExport): UserConfigExport {
   return config

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -10,13 +10,18 @@ export { configDefaults, defaultInclude, defaultExclude, coverageConfigDefaults 
 export { mergeConfig } from 'vite'
 
 export type { ConfigEnv, ViteUserConfig as UserConfig }
+export type UserConfigFnObject = (env: ConfigEnv) => ViteUserConfig
+export type UserConfigFnPromise = (env: ConfigEnv) => Promise<ViteUserConfig>
 export type UserConfigFn = (env: ConfigEnv) => ViteUserConfig | Promise<ViteUserConfig>
-export type UserConfigExport = ViteUserConfig | Promise<ViteUserConfig> | UserConfigFn
+export type UserConfigExport = ViteUserConfig | Promise<ViteUserConfig> | UserConfigFnObject | UserConfigFnPromise | UserConfigFn
 
 export type UserProjectConfigFn = (env: ConfigEnv) => UserWorkspaceConfig | Promise<UserWorkspaceConfig>
 export type UserProjectConfigExport = UserWorkspaceConfig | Promise<UserWorkspaceConfig> | UserProjectConfigFn
 
-export function defineConfig(config: UserConfigExport) {
+export function defineConfig(config: ViteUserConfig): ViteUserConfig
+export function defineConfig(config: Promise<ViteUserConfig>): Promise<ViteUserConfig>
+export function defineConfig(config: UserConfigExport): UserConfigExport
+export function defineConfig(config: UserConfigExport): UserConfigExport {
   return config
 }
 


### PR DESCRIPTION
Ported from https://github.com/vitejs/vite/pull/13792

Fully fixes issues like https://github.com/vuejs/create-vue/issues/317 and https://github.com/vuejs/create-vue/issues/313

For easy reproduction, please refer to https://github.com/sodatea/viteste-define-config-bug-repro

I didn't include a test in this PR because:

1. The reproduction is a bit complicated, it only fails on the very latest Vite versions, but updating Vite would mess up the lockfile.
2. By not updating the dependencies, we can make sure that this fix is compatible with older versions of Vite, too.