### PR TITLE
feat: backport types of defineConfig from vite

### DIFF
--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -10,12 +10,24 @@ export { configDefaults, defaultInclude, defaultExclude, coverageConfigDefaults 
 export { mergeConfig } from 'vite'
 
 export type { ConfigEnv, ViteUserConfig as UserConfig }
+
+export type UserConfigFnObject = (env: ConfigEnv) => ViteUserConfig
+export type UserConfigFnPromise = (env: ConfigEnv) => Promise<ViteUserConfig>
 export type UserConfigFn = (env: ConfigEnv) => ViteUserConfig | Promise<ViteUserConfig>
-export type UserConfigExport = ViteUserConfig | Promise<ViteUserConfig> | UserConfigFn
+export type UserConfigExport =
+  | ViteUserConfig
+  | Promise<ViteUserConfig>
+  | UserConfigFnObject
+  | UserConfigFnPromise
+  | UserConfigFn
 
 export type UserProjectConfigFn = (env: ConfigEnv) => UserWorkspaceConfig | Promise<UserWorkspaceConfig>
 export type UserProjectConfigExport = UserWorkspaceConfig | Promise<UserWorkspaceConfig> | UserProjectConfigFn
 
+export function defineConfig(config: ViteUserConfig): ViteUserConfig
+export function defineConfig(config: Promise<ViteUserConfig>): Promise<ViteUserConfig>
+export function defineConfig(config: UserConfigFnObject): UserConfigFnObject
+export function defineConfig(config: UserConfigExport): UserConfigExport
 export function defineConfig(config: UserConfigExport) {
   return config
 }


### PR DESCRIPTION
I'm just porting the updates of the types of `defineConfig` to match [how it's done in vite](https://github.com/vitejs/vite/blob/24c12fef604438826d76f49c244ae8e76574b929/packages/vite/src/node/config.ts#L103-L126)

Tell me if something's wrong with that!