### PR TITLE
fix(vite-node): normalize drive letter to keep the same reference to a module

### DIFF
--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -6,6 +6,15 @@ import type { Arrayable, Nullable } from './types'
 
 export const isWindows = process.platform === 'win32'
 
+const drive = isWindows ? process.cwd()[0] : null
+const driveOpposite = drive
+  ? (drive === drive.toUpperCase()
+      ? drive.toLowerCase()
+      : drive.toUpperCase())
+  : null
+const driveRegexp = drive ? new RegExp(`${drive}(\:[\\/])`) : null
+const driveOppositeRegext = driveOpposite ? new RegExp(`${driveOpposite}(\:[\\/])`) : null
+
 export function slash(str: string) {
   return str.replace(/\\/g, '/')
 }
@@ -15,6 +24,10 @@ export const VALID_ID_PREFIX = '/@id/'
 export function normalizeRequestId(id: string, base?: string): string {
   if (base && id.startsWith(base))
     id = `/${id.slice(base.length)}`
+
+  // keep drive the same as in process cwd
+  if (driveRegexp && !driveRegexp?.test(id) && driveOppositeRegext?.test(id))
+    id = id.replace(driveOppositeRegext, `${drive}$1`)
 
   return id
     .replace(/^\/@id\/__x00__/, '\0') // virtual modules start with `\0`

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -12,8 +12,8 @@ const driveOpposite = drive
       ? drive.toLowerCase()
       : drive.toUpperCase())
   : null
-const driveRegexp = drive ? new RegExp(`${drive}(\:[\\/])`) : null
-const driveOppositeRegext = driveOpposite ? new RegExp(`${driveOpposite}(\:[\\/])`) : null
+const driveRegexp = drive ? new RegExp(`(?:^|/@fs/)${drive}(\:[\\/])`) : null
+const driveOppositeRegext = driveOpposite ? new RegExp(`(?:^|/@fs/)${driveOpposite}(\:[\\/])`) : null
 
 export function slash(str: string) {
   return str.replace(/\\/g, '/')

--- a/test/core/src/esm/esm.js
+++ b/test/core/src/esm/esm.js
@@ -1,0 +1,1 @@
+export const test = 1

--- a/test/core/src/esm/package.json
+++ b/test/core/src/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/core/vitest.config.ts
+++ b/test/core/vitest.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
       seed: 101,
     },
     deps: {
-      external: ['tinyspy', /src\/external/],
+      external: ['tinyspy', /src\/external/, /esm\/esm/],
       inline: ['inline-lib'],
       moduleDirectories: ['node_modules', 'projects', 'packages'],
     },


### PR DESCRIPTION
Fixes #3776