### PR TITLE
docs: fix `teardownTimeout` default JSDOC value

### DIFF
--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -333,7 +333,7 @@ export interface InlineConfig {
   /**
    * Default timeout to wait for close when Vitest shuts down, in milliseconds
    *
-   * @default 1000
+   * @default 10000
    */
   teardownTimeout?: number
 


### PR DESCRIPTION
Noticed conflict between actual default value and IDE's JSDOC hover info. 

https://github.com/vitest-dev/vitest/blob/1cd4eb0f1b568bdc6977fcdeb33ffb0b9dbd23dc/packages/vitest/src/defaults.ts#L70
