### PR TITLE
fix: pass `--experimental-vm-worker-memory-limit` to `tinypool`

### DIFF
--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -66,6 +66,7 @@ export function createVmThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessO
     ],
 
     terminateTimeout: ctx.config.teardownTimeout,
+    maxMemoryLimitBeforeRecycle: ctx.config.experimentalVmWorkerMemoryLimit || undefined,
   }
 
   if (ctx.config.singleThread) {


### PR DESCRIPTION
### Description

- Not included in https://github.com/vitest-dev/vitest/pull/3203
- Ref. https://github.com/tinylibs/tinypool/pull/58

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
