### PR TITLE
fix: don't bundle utils' source-map entry

### DIFF
--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -67,6 +67,7 @@ const external = [
   'vite-node/utils',
   '@vitest/utils/diff',
   '@vitest/utils/error',
+  '@vitest/utils/source-map',
   '@vitest/runner/utils',
   '@vitest/runner/types',
   '@vitest/snapshot/environment',


### PR DESCRIPTION
### Description

Currently we bundle `@vitest/utils/source-map` alongside vitest by mistake.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
