### PR TITLE
fix: reduce the memory consumption when running --experimental-vm-threads

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -215,7 +215,7 @@ export function resolveConfig(
 
   resolved.experimentalVmWorkerMemoryLimit = stringToBytes(
     getWorkerMemoryLimit(resolved),
-    totalmem(),
+    resolved.watch ? totalmem() / 2 : totalmem(),
   )
 
   if (options.resolveSnapshotPath)


### PR DESCRIPTION
### Description

Currently, even in watch mode, Vitest determines the memory limit based on all available memory. This PR halves it if tests are running in watch mode.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
