### PR TITLE
fix: allow importing .css and assets inside node_modules

### DIFF
--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -137,6 +137,30 @@ export class ViteNodeServer {
     return this.fetchPromiseMap.get(id)!
   }
 
+  async transformModule(id: string, transformMode?: 'web' | 'ssr'): Promise<FetchResult> {
+    id = normalizeModuleId(id)
+    // reuse transform for concurrent requests
+    // if (!this.fetchPromiseMap.has(id)) {
+    //   this.fetchPromiseMap.set(id,
+    //     this._fetchModule(id, transformMode)
+    //       .then((r) => {
+    //         return this.options.sourcemap !== true ? { ...r, map: undefined } : r
+    //       })
+    //       .finally(() => {
+    //         this.fetchPromiseMap.delete(id)
+    //       }),
+    //   )
+    // }
+    if (transformMode !== 'web')
+      throw new Error('Can only transform web modules.')
+    const r = await this.server.transformRequest(id)
+
+    return {
+      code: r?.code,
+      map: r?.map as any,
+    }
+  }
+
   async transformRequest(id: string, filepath = id) {
     // reuse transform for concurrent requests
     if (!this.transformPromiseMap.has(id)) {

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -27,6 +27,9 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
     fetch(id, transformMode) {
       return project.vitenode.fetchModule(id, transformMode)
     },
+    transform(id, transformMode) {
+      return project.vitenode.transformModule(id, transformMode)
+    },
     resolveId(id, importer, transformMode) {
       return project.vitenode.resolveId(id, importer, transformMode)
     },

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -285,6 +285,7 @@ export class WorkspaceProject {
   }
 
   getSerializableConfig() {
+    const optimizer = this.config.deps?.optimizer
     return deepMerge({
       ...this.config,
       coverage: this.ctx.config.coverage,
@@ -294,6 +295,9 @@ export class WorkspaceProject {
         optimizer: {
           web: {
             enabled: this.config.deps?.optimizer?.web?.enabled ?? false,
+            transformAssets: optimizer?.web?.transformAssets ?? true,
+            transformCss: optimizer?.web?.transformCss ?? true,
+            transformGlobPattern: optimizer?.web?.transformGlobPattern ?? [],
           },
           ssr: {
             enabled: this.config.deps?.optimizer?.ssr?.enabled ?? false,

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -78,6 +78,30 @@ interface SequenceOptions {
 
 export type DepsOptimizationOptions = Omit<DepOptimizationConfig, 'disabled' | 'noDiscovery'> & {
   enabled?: boolean
+  /**
+   * Should Vitest process .png/.svg/.jpg/... files and resolve them like Vite does in the browser.
+   *
+   * These module will have a default export equal to the path to the asset, if no query is specified.
+   *
+   * @default true
+   */
+  transformAssets?: boolean
+  /**
+   * Should Vitest process .css/.scss/.sass/... files and resolve them like Vite does in the browser.
+   *
+   * This option is affected by `css` option.
+   *
+   * @default true
+   */
+  transformCss?: boolean
+  /**
+   * Regexp pattern to match external files that should be transformed.
+   *
+   * By default, files inside `node_modules` are externalized and not transformed.
+   *
+   * @default []
+   */
+  transformGlobPattern?: RegExp | RegExp[]
 }
 
 export interface TransformModePatterns {

--- a/packages/vitest/src/types/rpc.ts
+++ b/packages/vitest/src/types/rpc.ts
@@ -10,6 +10,7 @@ type TransformMode = 'web' | 'ssr'
 
 export interface RuntimeRPC {
   fetch: (id: string, environment: TransformMode) => Promise<FetchResult>
+  transform: (id: string, environment: TransformMode) => Promise<Omit<FetchResult, 'externalize'>>
   resolveId: (id: string, importer: string | undefined, environment: TransformMode) => Promise<ViteNodeResolveId | null>
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>
 


### PR DESCRIPTION
### Description

Fixes #3862

New `--experimental-vm-threads` allows us to process `.css` files and assets inside Node.js modules without manually inlining them. We can give better performance inside this pool by enabling CSS and asset processing without asking people to manually inline the whole library.

Unfortunately, other pools cannot support this until [Node.js loader](https://github.com/nodejs/loaders) is standardized (the development is very fast, we can't keep up with the changes to be honest).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
