### PR TITLE
docs: Fix incorrect word in getting started docs

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -109,7 +109,7 @@ export default defineConfig({
 Even if you do not use Vite yourself, Vitest relies heavily on it for its transformation pipeline. For that reason, you can also configure any property described in [Vite documentation](https://vitejs.dev/config/).
 :::
 
-If you are already using Vite, add `test` property in your Vite config. You'll also need to add a reference to Vitest types using a [triple slash command](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) at the top of your config file.
+If you are already using Vite, add `test` property in your Vite config. You'll also need to add a reference to Vitest types using a [triple slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) at the top of your config file.
 
 ```ts 
 /// <reference types="vitest" />


### PR DESCRIPTION
### Description

The docs talk about TypeScript's `triple slash commands` but they are called `triple slash directives` in TypeScript's docs.
