### PR TITLE
fix: pass environmentOptions to happy-dom integration

### DIFF
--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -5,9 +5,12 @@ import { populateGlobal } from './utils'
 export default <Environment>({
   name: 'happy-dom',
   transformMode: 'web',
-  async setupVM() {
+  async setupVM({ 'happy-dom': happyDom = {} }) {
     const { Window } = await importModule('happy-dom') as typeof import('happy-dom')
-    const win = new Window() as any
+    const win = new Window({
+      ...happyDom,
+      url: happyDom.url || 'http://localhost:3000',
+    }) as any
 
     // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
     win.Buffer = Buffer
@@ -26,11 +29,14 @@ export default <Environment>({
       },
     }
   },
-  async setup(global) {
+  async setup(global, { 'happy-dom': happyDom = {} }) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
     const { Window, GlobalWindow } = await importModule('happy-dom') as typeof import('happy-dom')
-    const win = new (GlobalWindow || Window)()
+    const win = new (GlobalWindow || Window)({
+      ...happyDom,
+      url: happyDom.url || 'http://localhost:3000',
+    })
 
     const { keys, originals } = populateGlobal(global, win, { bindFunctions: true })
 

--- a/test/core/test/happy-dom.test.ts
+++ b/test/core/test/happy-dom.test.ts
@@ -2,6 +2,7 @@
 
 /**
  * @vitest-environment happy-dom
+ * @vitest-environment-options { "settings": { "disableCSSFileLoading": true }, "width": 1920 }
  */
 
 /* eslint-disable vars-on-top */
@@ -11,7 +12,18 @@ import { expect, it, vi } from 'vitest'
 declare global {
   // eslint-disable-next-line no-var
   var __property_dom: unknown
+  // eslint-disable-next-line no-var
+  var happyDOM: unknown
 }
+
+it('defaults URL to localhost:3000', () => {
+  expect(location.href).toBe('http://localhost:3000/')
+})
+
+it('accepts custom environment options', () => {
+  // default is false
+  expect((window.happyDOM as any).settings.disableCSSFileLoading).toBe(true)
+})
 
 it('defined on self/window are defined on global', () => {
   expect(self).toBeDefined()


### PR DESCRIPTION
### Description

This PR forwards the `environmentOptions` to `happy-dom` integration.

It follows the same principle defined in the `jsdom` integration

https://github.com/vitest-dev/vitest/blob/f4e6e99fa3a81fd7a97fb9b435da367dddba7fa4/packages/vitest/src/integrations/env/jsdom.ts#L32

> Reference: https://github.com/capricorn86/happy-dom/wiki/Getting-started#usage

Closes #3903 
Closes #3905

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
