### PR TITLE
fix: [#3905] default url when using happy-dom as environment

### DIFF
--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -1,51 +1,51 @@
-import { importModule } from "local-pkg";
-import type { Environment } from "../../types";
-import { populateGlobal } from "./utils";
+import { importModule } from 'local-pkg'
+import type { Environment } from '../../types'
+import { populateGlobal } from './utils'
 
 export default <Environment>{
-  name: "happy-dom",
-  transformMode: "web",
+  name: 'happy-dom',
+  transformMode: 'web',
   async setupVM() {
     const { Window } = (await importModule(
-      "happy-dom"
-    )) as typeof import("happy-dom");
-    const win = new Window() as any;
+      'happy-dom',
+    )) as typeof import('happy-dom')
+    const win = new Window() as any
 
     // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
-    win.Buffer = Buffer;
-    win.Uint8Array = Uint8Array;
+    win.Buffer = Buffer
+    win.Uint8Array = Uint8Array
 
     // inject structuredClone if it exists
-    if (typeof structuredClone !== "undefined" && !win.structuredClone)
-      win.structuredClone = structuredClone;
+    if (typeof structuredClone !== 'undefined' && !win.structuredClone)
+      win.structuredClone = structuredClone
 
     return {
       getVmContext() {
-        return win;
+        return win
       },
       teardown() {
-        win.happyDOM.cancelAsync();
+        win.happyDOM.cancelAsync()
       },
-    };
+    }
   },
   async setup(global) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
     const { Window, GlobalWindow } = (await importModule(
-      "happy-dom"
-    )) as typeof import("happy-dom");
-    const win = new (GlobalWindow || Window)({ url: "http://localhost:3000" });
+      'happy-dom',
+    )) as typeof import('happy-dom')
+    const win = new (GlobalWindow || Window)({ url: 'http://localhost:3000' })
 
     const { keys, originals } = populateGlobal(global, win, {
       bindFunctions: true,
-    });
+    })
 
     return {
       teardown(global) {
-        win.happyDOM.cancelAsync();
-        keys.forEach((key) => delete global[key]);
-        originals.forEach((v, k) => (global[k] = v));
+        win.happyDOM.cancelAsync()
+        keys.forEach(key => delete global[key])
+        originals.forEach((v, k) => (global[k] = v))
       },
-    };
+    }
   },
-};
+}

--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -1,45 +1,51 @@
-import { importModule } from 'local-pkg'
-import type { Environment } from '../../types'
-import { populateGlobal } from './utils'
+import { importModule } from "local-pkg";
+import type { Environment } from "../../types";
+import { populateGlobal } from "./utils";
 
-export default <Environment>({
-  name: 'happy-dom',
-  transformMode: 'web',
+export default <Environment>{
+  name: "happy-dom",
+  transformMode: "web",
   async setupVM() {
-    const { Window } = await importModule('happy-dom') as typeof import('happy-dom')
-    const win = new Window() as any
+    const { Window } = (await importModule(
+      "happy-dom"
+    )) as typeof import("happy-dom");
+    const win = new Window() as any;
 
     // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
-    win.Buffer = Buffer
-    win.Uint8Array = Uint8Array
+    win.Buffer = Buffer;
+    win.Uint8Array = Uint8Array;
 
     // inject structuredClone if it exists
-    if (typeof structuredClone !== 'undefined' && !win.structuredClone)
-      win.structuredClone = structuredClone
+    if (typeof structuredClone !== "undefined" && !win.structuredClone)
+      win.structuredClone = structuredClone;
 
     return {
       getVmContext() {
-        return win
+        return win;
       },
       teardown() {
-        win.happyDOM.cancelAsync()
+        win.happyDOM.cancelAsync();
       },
-    }
+    };
   },
   async setup(global) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
-    const { Window, GlobalWindow } = await importModule('happy-dom') as typeof import('happy-dom')
-    const win = new (GlobalWindow || Window)()
+    const { Window, GlobalWindow } = (await importModule(
+      "happy-dom"
+    )) as typeof import("happy-dom");
+    const win = new (GlobalWindow || Window)({ url: "http://localhost:3000" });
 
-    const { keys, originals } = populateGlobal(global, win, { bindFunctions: true })
+    const { keys, originals } = populateGlobal(global, win, {
+      bindFunctions: true,
+    });
 
     return {
       teardown(global) {
-        win.happyDOM.cancelAsync()
-        keys.forEach(key => delete global[key])
-        originals.forEach((v, k) => global[k] = v)
+        win.happyDOM.cancelAsync();
+        keys.forEach((key) => delete global[key]);
+        originals.forEach((v, k) => (global[k] = v));
       },
-    }
+    };
   },
-})
+};


### PR DESCRIPTION
### Description

Sets the default page URL for Happy DOM to the same URL as JSDOM.

Closes #3905 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
