### PR TITLE
fix(ui): add support for ui coverage with subdir option

### DIFF
--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -169,7 +169,9 @@ To see all configurable options for coverage, see the [coverage Config Reference
 
 Since Vitest 0.31.0, you can check your coverage report in [Vitest UI](./ui).
 
-If you have configured coverage reporters, don't forget to add `html` reporter to the list, Vitest UI will only enable html coverage report if it is present.
+Vitest UI will enable coverage report when it is enabled explicitly and the html coverage reporter is present, otherwise it will not be available:
+- enable `coverage.enabled=true` in your configuration or run Vitest with `--coverage.enabled=true` flag
+- add `html` to the `coverage.reporters` list: you can also enable `subdir` option to put coverage report in a subdirectory
 
 <img alt="html coverage activation in Vitest UI" img-light src="/vitest-ui-show-coverage-light.png">
 <img alt="html coverage activation in Vitest UI" img-dark src="/vitest-ui-show-coverage-dark.png">

--- a/packages/ui/client/composables/navigation.ts
+++ b/packages/ui/client/composables/navigation.ts
@@ -21,7 +21,15 @@ export const coverageUrl = computed(() => {
   if (coverageEnabled.value) {
     const url = `${window.location.protocol}//${window.location.hostname}:${config.value!.api!.port!}`
     const idx = coverage.value!.reportsDirectory.lastIndexOf('/')
-    return `${url}/${coverage.value!.reportsDirectory.slice(idx + 1)}/index.html`
+    const htmlReporter = coverage.value!.reporter.find((reporter) => {
+      if (reporter[0] !== 'html')
+        return undefined
+
+      return reporter
+    })
+    return htmlReporter && 'subdir' in htmlReporter[1]
+      ? `${url}/${coverage.value!.reportsDirectory.slice(idx + 1)}/${htmlReporter[1].subdir}/index.html`
+      : `${url}/${coverage.value!.reportsDirectory.slice(idx + 1)}/index.html`
   }
 
   return undefined

--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -53,7 +53,7 @@ function resolveCoverageFolder(ctx: Vitest) {
     options.coverage.reportsDirectory || coverageConfigDefaults.reportsDirectory,
   )
 
-  const subdir = (htmlReporter && Array.isArray(htmlReporter) && htmlReporter.length > 1 && 'subdir' in htmlReporter[1])
+  const subdir = (Array.isArray(htmlReporter) && htmlReporter.length > 1 && 'subdir' in htmlReporter[1])
     ? htmlReporter[1].subdir
     : undefined
 

--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -35,32 +35,27 @@ export default (ctx: Vitest) => {
 
 function resolveCoverageFolder(ctx: Vitest) {
   const options = ctx.config
-  let subdir: string | undefined
-  const enabled = options.api?.port
-    && options.coverage?.enabled
-    && options.coverage.reporter.some((reporter) => {
+  const htmlReporter = (options.api?.port && options.coverage?.enabled)
+    ? options.coverage.reporter.find((reporter) => {
       if (typeof reporter === 'string')
         return reporter === 'html'
 
-      if (reporter[0] !== 'html')
-        return false
-
-      if ('subdir' in reporter[1])
-        subdir = reporter[1].subdir as string
-
-      return true
+      return reporter[0] === 'html'
     })
-
-  // reportsDirectory not resolved yet
-  const root = enabled
-    ? resolve(
-      ctx.config?.root || options.root || process.cwd(),
-      options.coverage.reportsDirectory || coverageConfigDefaults.reportsDirectory,
-    )
     : undefined
 
-  if (!root)
+  if (!htmlReporter)
     return undefined
+
+  // reportsDirectory not resolved yet
+  const root = resolve(
+    ctx.config?.root || options.root || process.cwd(),
+    options.coverage.reportsDirectory || coverageConfigDefaults.reportsDirectory,
+  )
+
+  const subdir = (htmlReporter && Array.isArray(htmlReporter) && htmlReporter.length > 1 && 'subdir' in htmlReporter[1])
+    ? htmlReporter[1].subdir
+    : undefined
 
   if (!subdir)
     return [root, `/${basename(root)}/`]


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
If you provide `subdir` option in the html coverage reporter, Vitest UI  Coverage will not work since the `index.html` is inside the `subdir` and not in the `reportsDirectory`.

This PR configures properly the middleware when `subdir` is configured and the client will check also for `subdir` option to change the url.

This PR also updates the `Vitest UI` subsection in the Coverage docs.

<!-- You can also add additional context here -->
From this discussion: https://github.com/vitest-dev/vitest/discussions/3916

To check Vitest UI Coverage is working:
- build Vitest: run `pnpm run build` from root folder
- change `'html'` in the `coverage.reporter` list with  `['html', { subdir: 'somepath' }]` in `test/core/vitest.config.ts` configuration file
- change to `test/core` folder (`cd test/core`) and run `pnpm vitest --open --ui --coverage.enabled=true`

In the current version, adding the `subdir` option will not work, check the linked discussion.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
