### PR TITLE
perf(dot-renderer): speed up getTests

### DIFF
--- a/packages/runner/src/utils/tasks.ts
+++ b/packages/runner/src/utils/tasks.ts
@@ -6,7 +6,22 @@ function isAtomTest(s: Task): s is Test | TaskCustom {
 }
 
 export function getTests(suite: Arrayable<Task>): (Test | TaskCustom)[] {
-  return toArray(suite).flatMap(s => isAtomTest(s) ? [s] : s.tasks.flatMap(c => isAtomTest(c) ? [c] : getTests(c)))
+  const tests: (Test | TaskCustom)[] = []
+  const suite_arr = toArray(suite)
+  for (const s of suite_arr) {
+    if (isAtomTest(s)) {
+      tests.push(s)
+    }
+    else {
+      for (const task of s.tasks) {
+        if (isAtomTest(task))
+          tests.push(task)
+        else
+          tests.push(...getTests(task))
+      }
+    }
+  }
+  return tests
 }
 
 export function getTasks(tasks: Arrayable<Task> = []): Task[] {


### PR DESCRIPTION
### Description
![image](https://github.com/vitest-dev/vitest/assets/50981692/1e939151-b19f-4d51-b66d-e23ffe3a97fe)


This will probably not have an impact on test times because the reporter runs on a separate thread but should help with some flickering. Maybe it has an effect on lower end devices but hey why waste CPU cycles anyway right?

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
