### PR TITLE
fix(vitest): use esm module resolution to resolve env

### DIFF
--- a/packages/vitest/src/integrations/env/index.ts
+++ b/packages/vitest/src/integrations/env/index.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'node:url'
 import { normalize, resolve } from 'pathe'
-import { resolveModule } from 'local-pkg'
+import { resolvePath } from 'mlly'
 import type { BuiltinEnvironment, VitestEnvironment } from '../../types/config'
 import type { Environment } from '../../types'
 import node from './node'
@@ -40,7 +40,7 @@ export async function loadEnvironment(name: VitestEnvironment, root: string): Pr
     return environments[name]
   const packageId = name[0] === '.' || name[0] === '/'
     ? resolve(root, name)
-    : resolveModule(`vitest-environment-${name}`, { paths: [root] }) ?? resolve(root, name)
+    : await resolvePath(`vitest-environment-${name}`, { url: [root] }) ?? resolve(root, name)
   const pkg = await import(pathToFileURL(normalize(packageId)).href)
   if (!pkg || !pkg.default || typeof pkg.default !== 'object') {
     throw new TypeError(

--- a/test/env-custom/vitest-environment-custom/package.json
+++ b/test/env-custom/vitest-environment-custom/package.json
@@ -1,5 +1,7 @@
 {
   "name": "vitest-environment-custom",
   "private": true,
-  "main": "index.mjs"
+  "exports": {
+    ".": "./index.mjs"
+  }
 }


### PR DESCRIPTION
### Description

Sourcing from https://github.com/danielroe/nuxt-vitest/pull/290#issuecomment-1678093293

While triaging issue I discovered that there's an issue with loading a pure ESM custom environment. It fails with the following issue:

```
Error: Cannot find module '/Users/daniel/code/vitest-environment-nuxt/playground/nuxt' imported from /Users/daniel/code/vitest-environment-nuxt/node_modules/.pnpm/vitest@0.34.1_happy-dom@10.8.0_jsdom@22.1.0/node_modules/vitest/dist/vendor-environments.443ecd82.js
 ❯ new NodeError node:internal/errors:387:5
 ❯ finalizeResolution node:internal/modules/esm/resolve:330:11
 ❯ moduleResolve node:internal/modules/esm/resolve:907:10
 ❯ defaultResolve node:internal/modules/esm/resolve:1115:11
 ❯ nextResolve node:internal/modules/esm/loader:163:28
 ❯ ESMLoader.resolve node:internal/modules/esm/loader:841:30
 ❯ ESMLoader.getModuleJob node:internal/modules/esm/loader:424:18
 ❯ ESMLoader.import node:internal/modules/esm/loader:525:22
 ❯ importModuleDynamically node:internal/modules/esm/translators:110:35
 ❯ importModuleDynamicallyCallback node:internal/process/esm_loader:35:14
```

That is because `local-pkg` doesn't implement the ESM module resolution strategy but uses the CJS `require.resolve` strategy: https://github.com/antfu/local-pkg/blob/main/index.mjs#L11.

This instead uses `mlly` which wraps https://github.com/wooorm/import-meta-resolve to adopt the ESM module resolution strategy.

There are some other places in the code that could also be replaced.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
