### PR TITLE
fix: don't mock css-module if inline is specified

### DIFF
--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -16,6 +16,17 @@ function isCSSModule(id: string) {
   return cssModuleRE.test(id)
 }
 
+// inline css requests are expected to just return the
+// string content directly and not the proxy module
+function isInline(id: string) {
+  const queryStart = id.indexOf('?');
+  if (queryStart === -1) {
+    return false;
+  }
+  const queryParts = id.substring(queryStart + 1).split('&');
+  return queryParts.some(part => part === 'inline');
+}
+
 function getCSSModuleProxyReturn(strategy: CSSModuleScopeStrategy, filename: string) {
   if (strategy === 'non-scoped')
     return 'style'
@@ -55,7 +66,7 @@ export function CSSEnablerPlugin(ctx: { config: ResolvedConfig }): VitePlugin[] 
         if (!isCSS(id) || shouldProcessCSS(id))
           return
 
-        if (isCSSModule(id)) {
+        if (isCSSModule(id) && !isInline(id)) {
           // return proxy for css modules, so that imported module has names:
           // styles.foo returns a "foo" instead of "undefined"
           // we don't use code content to generate hash for "scoped", because it's empty

--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -7,6 +7,7 @@ import { toArray } from '../../utils'
 const cssLangs = '\\.(css|less|sass|scss|styl|stylus|pcss|postcss)($|\\?)'
 const cssLangRE = new RegExp(cssLangs)
 const cssModuleRE = new RegExp(`\\.module${cssLangs}`)
+const cssInlineRE = /[?&]inline(&|$)/
 
 function isCSS(id: string) {
   return cssLangRE.test(id)
@@ -19,12 +20,7 @@ function isCSSModule(id: string) {
 // inline css requests are expected to just return the
 // string content directly and not the proxy module
 function isInline(id: string) {
-  const queryStart = id.indexOf('?');
-  if (queryStart === -1) {
-    return false;
-  }
-  const queryParts = id.substring(queryStart + 1).split('&');
-  return queryParts.some(part => part === 'inline');
+  return cssInlineRE.test(id);
 }
 
 function getCSSModuleProxyReturn(strategy: CSSModuleScopeStrategy, filename: string) {

--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -20,7 +20,7 @@ function isCSSModule(id: string) {
 // inline css requests are expected to just return the
 // string content directly and not the proxy module
 function isInline(id: string) {
-  return cssInlineRE.test(id);
+  return cssInlineRE.test(id)
 }
 
 function getCSSModuleProxyReturn(strategy: CSSModuleScopeStrategy, filename: string) {

--- a/test/css/test/process-inline.spec.ts
+++ b/test/css/test/process-inline.spec.ts
@@ -15,7 +15,6 @@ describe('processing inline css', () => {
 
   test('returns a string', async () => {
     const { default: style } = await import('../src/App.module.css?inline')
-    expect(typeof style).toBe('string');
-    console.log(style);
+    expect(typeof style).toBe('string')
   })
 })

--- a/test/css/test/process-inline.spec.ts
+++ b/test/css/test/process-inline.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+import { useRemoveStyles } from './utils'
+
+describe('processing inline css', () => {
+  useRemoveStyles()
+
+  test('doesn\'t apply css', async () => {
+    await import('../src/App.module.css?inline')
+
+    const element = document.createElement('div')
+    element.className = 'main'
+    const computed = window.getComputedStyle(element)
+    expect(computed.display, 'css is not processed').toBe('block')
+  })
+
+  test('returns a string', async () => {
+    const { default: style } = await import('../src/App.module.css?inline')
+    expect(typeof style).toBe('string');
+    console.log(style);
+  })
+})

--- a/test/css/testing.mjs
+++ b/test/css/testing.mjs
@@ -3,15 +3,15 @@ import { startVitest } from 'vitest/node'
 const configs = [
   ['test/default-css', {}],
   ['test/process-css', { include: [/App\.css/] }],
-  ['test/process-module', { include: [/App\.module\.css/] }],
-  ['test/process-inline', { include: [/App\.module\.css/] }],
+  [['test/process-module', 'test/process-inline'], { include: [/App\.module\.css/] }],
   ['test/scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'scoped' } }],
   ['test/non-scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'non-scoped' } }],
 ]
 
 async function runTests() {
   for (const [name, config] of configs) {
-    await startVitest('test', [name], {
+    const names = Array.isArray(name) ? name : [name];
+    await startVitest('test', names, {
       run: true,
       css: config,
       update: false,

--- a/test/css/testing.mjs
+++ b/test/css/testing.mjs
@@ -4,6 +4,7 @@ const configs = [
   ['test/default-css', {}],
   ['test/process-css', { include: [/App\.css/] }],
   ['test/process-module', { include: [/App\.module\.css/] }],
+  ['test/process-inline', { include: [/App\.module\.css/] }],
   ['test/scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'scoped' } }],
   ['test/non-scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'non-scoped' } }],
 ]


### PR DESCRIPTION
### Description

As per the vite docs here: https://vitejs.dev/guide/features.html#disabling-css-injection-into-the-page

Using the 'inline' query parameter for CSS has different semantics than regular css imports and the expected return value should be a string as the default export.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

Fixes: #3954
