### PR TITLE
fix(vitest): allow rewriting process.env.NODE_MODE when using web transform mode

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -12,7 +12,7 @@ import { GlobalSetupPlugin } from './globalSetup'
 import { CSSEnablerPlugin } from './cssEnabler'
 import { CoverageTransform } from './coverageTransform'
 import { MocksPlugin } from './mocks'
-import { deleteDefineConfig, resolveOptimizerConfig } from './utils'
+import { deleteDefineConfig, hijackVitePluginInject, resolveOptimizerConfig } from './utils'
 import { VitestResolver } from './vitestResolver'
 
 export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('test')): Promise<VitePlugin[]> {
@@ -158,6 +158,8 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             ignored: ['**/*'],
           }
         }
+
+        hijackVitePluginInject(viteConfig)
       },
       async configureServer(server) {
         if (options.watch && process.env.VITE_TEST_WATCHER_DEBUG) {

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -10,7 +10,7 @@ import { CSSEnablerPlugin } from './cssEnabler'
 import { SsrReplacerPlugin } from './ssrReplacer'
 import { GlobalSetupPlugin } from './globalSetup'
 import { MocksPlugin } from './mocks'
-import { deleteDefineConfig, resolveOptimizerConfig } from './utils'
+import { deleteDefineConfig, hijackVitePluginInject, resolveOptimizerConfig } from './utils'
 import { VitestResolver } from './vitestResolver'
 
 interface WorkspaceOptions extends UserWorkspaceConfig {
@@ -99,6 +99,9 @@ export function WorkspaceVitestPlugin(project: WorkspaceProject, options: Worksp
         }
 
         return config
+      },
+      configResolved(viteConfig) {
+        hijackVitePluginInject(viteConfig)
       },
       async configureServer(server) {
         try {

--- a/test/core/test/env-jsdom.test.ts
+++ b/test/core/test/env-jsdom.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { afterAll, expect, test } from 'vitest'
+import { getAuthToken } from '../src/env'
+
+const NODE_ENV = process.env.NODE_ENV
+
+afterAll(() => {
+  process.env.NODE_ENV = NODE_ENV
+})
+
+test('reassigning NODE_ENV', () => {
+  expect(process.env.NODE_ENV).toBeDefined()
+  process.env.NODE_ENV = 'development'
+  expect(process.env.NODE_ENV).toBe('development')
+})
+
+test('reads envs from .env file', () => {
+  expect(import.meta.env.VITE_TEST_ENV).toBe('local')
+})
+
+test('can reassign env locally', () => {
+  import.meta.env.VITEST_ENV = 'TEST'
+  expect(import.meta.env.VITEST_ENV).toBe('TEST')
+})
+
+test('can reassign env everywhere', () => {
+  import.meta.env.AUTH_TOKEN = '123'
+  expect(getAuthToken()).toBe('123')
+  process.env.AUTH_TOKEN = '321'
+  expect(getAuthToken()).toBe('321')
+})
+
+test('can see env in "define"', () => {
+  expect(import.meta.env.TEST_NAME).toBe('hello world')
+  expect(process.env.TEST_NAME).toBe('hello world')
+})
+
+test('has worker env', () => {
+  expect(process.env.VITEST_WORKER_ID).toBeDefined()
+  expect(process.env.VITEST_POOL_ID).toBeDefined()
+})
+
+test('custom env', () => {
+  expect(process.env.CUSTOM_ENV).toBe('foo')
+  expect(import.meta.env.CUSTOM_ENV).toBe('foo')
+})
+
+test('ignores import.meta.env in string literals', () => {
+  expect('import.meta.env').toBe('import' + '.meta.env')
+})


### PR DESCRIPTION
### Description

Fixes #3933 
Fixes #3948 
Fixes #3860

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
