### PR TITLE
feat!(snapshot): make snapshots more visually pleasing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
     // prefer global Buffer to not initialize the whole module
     "n/prefer-global/buffer": "off",
     "@typescript-eslint/no-invalid-this": "off",
+    "@typescript-eslint/quotes": ["error", "single", {
+      "allowTemplateLiterals": true
+    }],
     "no-restricted-imports": [
       "error",
       {

--- a/examples/basic/test/__snapshots__/suite.test.ts.snap
+++ b/examples/basic/test/__snapshots__/suite.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`suite name > snapshot 1`] = `
 {

--- a/examples/mocks/test/error-mock.spec.ts
+++ b/examples/mocks/test/error-mock.spec.ts
@@ -4,5 +4,5 @@ vi.mock('../src/default', () => {
 
 test('when using top level variable, gives helpful message', async () => {
   await expect(() => import('../src/default').then(m => m.default)).rejects
-    .toThrowErrorMatchingInlineSnapshot('"[vitest] There was an error when mocking a module. If you are using \\"vi.mock\\" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock"')
+    .toThrowErrorMatchingInlineSnapshot('"[vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock"')
 })

--- a/examples/react/test/__snapshots__/basic.test.tsx.snap
+++ b/examples/react/test/__snapshots__/basic.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Link changes the class when hovered 1`] = `
 <a

--- a/examples/vitesse/test/__snapshots__/basic.test.ts.snap
+++ b/examples/vitesse/test/__snapshots__/basic.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`mount component 1`] = `
 <div

--- a/examples/vue-jsx/test/__snapshots__/case.test.ts.snap
+++ b/examples/vue-jsx/test/__snapshots__/case.test.ts.snap
@@ -1,3 +1,3 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`mount component 1`] = `"<a-select-stub value=\\"test\\"></a-select-stub>"`;
+exports[`mount component 1`] = `"<a-select-stub value="test"></a-select-stub>"`;

--- a/examples/vue/test/imports.test.ts
+++ b/examples/vue/test/imports.test.ts
@@ -5,7 +5,6 @@ describe('import vue components', () => {
   })
 
   test('template string imports as expected', async () => {
-    // eslint-disable-next-line @typescript-eslint/quotes
     const cmp = await import(`../components/Hello.vue`)
     expect(cmp).toBeDefined()
   })

--- a/examples/vue2/test/__snapshots__/basic.test.ts.snap
+++ b/examples/vue2/test/__snapshots__/basic.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`mount component 1`] = `
 "<div>

--- a/examples/vue2/test/__snapshots__/script-setup.test.ts.snap
+++ b/examples/vue2/test/__snapshots__/script-setup.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`mount component 1`] = `
 "<div>

--- a/packages/snapshot/src/port/inlineSnapshot.ts
+++ b/packages/snapshot/src/port/inlineSnapshot.ts
@@ -87,11 +87,10 @@ function prepareSnapString(snap: string, source: string, index: number) {
     .split(/\n/g)
 
   const isOneline = lines.length <= 1
-  const quote = isOneline ? '\'' : '`'
+  const quote = '`'
   if (isOneline)
-    return `'${lines.join('\n').replace(/'/g, '\\\'')}'`
-  else
-    return `${quote}\n${lines.map(i => i ? indentNext + i : '').join('\n').replace(/`/g, '\\`').replace(/\${/g, '\\${')}\n${indent}${quote}`
+    return `${quote}${lines.join('\n').replace(/`/g, '\\`').replace(/\${/g, '\\${')}${quote}`
+  return `${quote}\n${lines.map(i => i ? indentNext + i : '').join('\n').replace(/`/g, '\\`').replace(/\${/g, '\\${')}\n${indent}${quote}`
 }
 
 const startRegex = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*(?:\/\*[\S\s]*\*\/\s*|\/\/.*\s+)*\s*[\w_$]*(['"`\)])/m

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -84,6 +84,7 @@ export default class SnapshotState {
     this.updated = 0
     this._snapshotFormat = {
       printBasicPrototype: false,
+      escapeString: false,
       ...options.snapshotFormat,
     }
     this._environment = options.snapshotEnvironment

--- a/test/browser/test/mocked.test.ts
+++ b/test/browser/test/mocked.test.ts
@@ -25,6 +25,5 @@ test('imports are still the same', async () => {
   // @ts-expect-error typescript resolution
   await expect(import('../src/calculator')).resolves.toBe(calculatorModule)
   // @ts-expect-error typescript resolution
-  // eslint-disable-next-line @typescript-eslint/quotes
   await expect(import(`../src/calculator`)).resolves.toBe(calculatorModule)
 })

--- a/test/core/test/__snapshots__/mocked.test.ts.snap
+++ b/test/core/test/__snapshots__/mocked.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`mocked function which fails on toReturnWith > just one call 1`] = `
-"expected \\"spy\\" to return with: 2 at least once
+"expected "spy" to return with: 2 at least once
 
 Received: 
 
@@ -16,7 +16,7 @@ Number of calls: 1
 `;
 
 exports[`mocked function which fails on toReturnWith > multi calls 1`] = `
-"expected \\"spy\\" to return with: 2 at least once
+"expected "spy" to return with: 2 at least once
 
 Received: 
 
@@ -41,29 +41,29 @@ Number of calls: 3
 `;
 
 exports[`mocked function which fails on toReturnWith > oject type 1`] = `
-"expected \\"spy\\" to return with: { a: '4' } at least once
+"expected "spy" to return with: { a: '4' } at least once
 
 Received: 
 
   1st spy call return:
 
   Object {
--   \\"a\\": \\"4\\",
-+   \\"a\\": \\"1\\",
+-   "a": "4",
++   "a": "1",
   }
 
   2nd spy call return:
 
   Object {
--   \\"a\\": \\"4\\",
-+   \\"a\\": \\"1\\",
+-   "a": "4",
++   "a": "1",
   }
 
   3rd spy call return:
 
   Object {
--   \\"a\\": \\"4\\",
-+   \\"a\\": \\"1\\",
+-   "a": "4",
++   "a": "1",
   }
 
 
@@ -72,7 +72,7 @@ Number of calls: 3
 `;
 
 exports[`mocked function which fails on toReturnWith > zero call 1`] = `
-"expected \\"spy\\" to return with: 2 at least once
+"expected "spy" to return with: 2 at least once
 
 Received: 
 

--- a/test/core/test/__snapshots__/snapshot.test.ts.snap
+++ b/test/core/test/__snapshots__/snapshot.test.ts.snap
@@ -46,6 +46,20 @@ exports[`renders mock snapshot 2`] = `
 }
 `;
 
+exports[`single line snapshot 1`] = `"some string"`;
+
+exports[`single line snapshot 2`] = `"some "string""`;
+
+exports[`single line snapshot 3`] = `"some "string"`;
+
+exports[`single line snapshot 4`] = `"som\`e\` string"`;
+
+exports[`single line snapshot 5`] = `"some string\`"`;
+
+exports[`single line snapshot 6`] = `"some string'"`;
+
+exports[`single line snapshot 7`] = `"some 'string'"`;
+
 exports[`throwing 1`] = `"omega"`;
 
 exports[`throwing 2`] = `"omega"`;

--- a/test/core/test/diff.test.ts
+++ b/test/core/test/diff.test.ts
@@ -15,9 +15,9 @@ test('displays object diff', () => {
     + Received
 
       Object {
-        \\"a\\": 1,
-    -   \\"b\\": 2,
-    +   \\"b\\": 3,
+        "a": 1,
+    -   "b": 2,
+    +   "b": 3,
       }
     "
   `)

--- a/test/core/test/injector-esm.test.ts
+++ b/test/core/test/injector-esm.test.ts
@@ -45,9 +45,9 @@ test('namespace import', async () => {
 test('export function declaration', async () => {
   expect(injectSimpleCode('export function foo() {}'))
     .toMatchInlineSnapshot(`
-      "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+      "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
       function foo() {}
-      Object.defineProperty(__vi_inject__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }});
+      Object.defineProperty(__vi_inject__, "foo", { enumerable: true, configurable: true, get(){ return foo }});
       export { __vi_inject__ }"
     `)
 })
@@ -55,9 +55,9 @@ test('export function declaration', async () => {
 test('export class declaration', async () => {
   expect(await injectSimpleCode('export class foo {}'))
     .toMatchInlineSnapshot(`
-      "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+      "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
       class foo {}
-      Object.defineProperty(__vi_inject__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }});
+      Object.defineProperty(__vi_inject__, "foo", { enumerable: true, configurable: true, get(){ return foo }});
       export { __vi_inject__ }"
     `)
 })
@@ -65,10 +65,10 @@ test('export class declaration', async () => {
 test('export var declaration', async () => {
   expect(await injectSimpleCode('export const a = 1, b = 2'))
     .toMatchInlineSnapshot(`
-      "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+      "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
       const a = 1, b = 2
-      Object.defineProperty(__vi_inject__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }});
-      Object.defineProperty(__vi_inject__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }});
+      Object.defineProperty(__vi_inject__, "a", { enumerable: true, configurable: true, get(){ return a }});
+      Object.defineProperty(__vi_inject__, "b", { enumerable: true, configurable: true, get(){ return b }});
       export { __vi_inject__ }"
     `)
 })
@@ -77,10 +77,10 @@ test('export named', async () => {
   expect(
     injectSimpleCode('const a = 1, b = 2; export { a, b as c }'),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     const a = 1, b = 2; 
-    Object.defineProperty(__vi_inject__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }});
-    Object.defineProperty(__vi_inject__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }});
+    Object.defineProperty(__vi_inject__, "a", { enumerable: true, configurable: true, get(){ return a }});
+    Object.defineProperty(__vi_inject__, "c", { enumerable: true, configurable: true, get(){ return b }});
     export { __vi_inject__ }"
   `)
 })
@@ -89,11 +89,11 @@ test('export named from', async () => {
   expect(
     injectSimpleCode('export { ref, computed as c } from \'vue\''),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
-    const { __vi_inject__: __vi_esm_0__ } = await import(\\"vue\\");
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
+    const { __vi_inject__: __vi_esm_0__ } = await import("vue");
 
-    Object.defineProperty(__vi_inject__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vi_esm_0__.ref }});
-    Object.defineProperty(__vi_inject__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vi_esm_0__.computed }});
+    Object.defineProperty(__vi_inject__, "ref", { enumerable: true, configurable: true, get(){ return __vi_esm_0__.ref }});
+    Object.defineProperty(__vi_inject__, "c", { enumerable: true, configurable: true, get(){ return __vi_esm_0__.computed }});
     export { __vi_inject__ }"
   `)
 })
@@ -104,10 +104,10 @@ test('named exports of imported binding', async () => {
       'import {createApp} from \'vue\';export {createApp}',
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     import { __vi_inject__ as __vi_esm_0__ } from 'vue'
 
-    Object.defineProperty(__vi_inject__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vi_esm_0__.createApp }});
+    Object.defineProperty(__vi_inject__, "createApp", { enumerable: true, configurable: true, get(){ return __vi_esm_0__.createApp }});
     export { __vi_inject__ }"
   `)
 })
@@ -118,10 +118,10 @@ test('export * from', async () => {
       'export * from \'vue\'\n' + 'export * from \'react\'',
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
-    const { __vi_inject__: __vi_esm_0__ } = await import(\\"vue\\");
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
+    const { __vi_inject__: __vi_esm_0__ } = await import("vue");
     __vi_export_all__(__vi_inject__, __vi_esm_0__);
-    const { __vi_inject__: __vi_esm_1__ } = await import(\\"react\\");
+    const { __vi_inject__: __vi_esm_1__ } = await import("react");
     __vi_export_all__(__vi_inject__, __vi_esm_1__);
 
 
@@ -132,10 +132,10 @@ test('export * from', async () => {
 test('export * as from', async () => {
   expect(injectSimpleCode('export * as foo from \'vue\''))
     .toMatchInlineSnapshot(`
-      "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
-      const { __vi_inject__: __vi_esm_0__ } = await import(\\"vue\\");
+      "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
+      const { __vi_inject__: __vi_esm_0__ } = await import("vue");
 
-      Object.defineProperty(__vi_inject__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vi_esm_0__ }});
+      Object.defineProperty(__vi_inject__, "foo", { enumerable: true, configurable: true, get(){ return __vi_esm_0__ }});
       export { __vi_inject__ }"
     `)
 })
@@ -144,7 +144,7 @@ test('export default', async () => {
   expect(
     injectSimpleCode('export default {}'),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     __vi_inject__.default = {}
     export default { __vi_inject__: __vi_inject__.default };
 
@@ -158,9 +158,9 @@ test('export then import minified', async () => {
       'export * from \'vue\';import {createApp} from \'vue\';',
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     import { __vi_inject__ as __vi_esm_0__ } from 'vue'
-    const { __vi_inject__: __vi_esm_1__ } = await import(\\"vue\\");
+    const { __vi_inject__: __vi_esm_1__ } = await import("vue");
     __vi_export_all__(__vi_inject__, __vi_esm_1__);
 
     export { __vi_inject__ }"
@@ -189,7 +189,7 @@ test('dynamic import', async () => {
     'export const i = () => import(\'./foo\')',
   )
   expect(result).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     const i = () => __vi_wrap_module__(import('./foo'))
     export { __vi_inject__ }"
   `)
@@ -301,13 +301,13 @@ test('should declare variable for imported super class', async () => {
         + 'export class B extends Foo {}',
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     import { __vi_inject__ as __vi_esm_0__ } from './dependency'
     const Foo = __vi_esm_0__.Foo;
     class A extends Foo {}
     class B extends Foo {}
-    Object.defineProperty(__vi_inject__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }});
-    Object.defineProperty(__vi_inject__, \\"default\\", { enumerable: true, configurable: true, value: A });
+    Object.defineProperty(__vi_inject__, "B", { enumerable: true, configurable: true, get(){ return B }});
+    Object.defineProperty(__vi_inject__, "default", { enumerable: true, configurable: true, value: A });
     export { __vi_inject__ }"
   `)
 })
@@ -317,7 +317,7 @@ test('should handle default export variants', async () => {
   // default anonymous functions
   expect(injectSimpleCode('export default function() {}\n'))
     .toMatchInlineSnapshot(`
-      "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+      "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
       __vi_inject__.default = function() {}
 
       export default { __vi_inject__: __vi_inject__.default };
@@ -327,7 +327,7 @@ test('should handle default export variants', async () => {
   // default anonymous class
   expect(injectSimpleCode('export default class {}\n'))
     .toMatchInlineSnapshot(`
-      "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+      "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
       __vi_inject__.default = class {}
 
       export default { __vi_inject__: __vi_inject__.default };
@@ -341,10 +341,10 @@ test('should handle default export variants', async () => {
         + 'foo.prototype = Object.prototype;',
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     function foo() {}
     foo.prototype = Object.prototype;
-    Object.defineProperty(__vi_inject__, \\"default\\", { enumerable: true, configurable: true, value: foo });
+    Object.defineProperty(__vi_inject__, "default", { enumerable: true, configurable: true, value: foo });
     export { __vi_inject__ }"
   `)
   // default named classes
@@ -353,11 +353,11 @@ test('should handle default export variants', async () => {
       'export default class A {}\n' + 'export class B extends A {}',
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     class A {}
     class B extends A {}
-    Object.defineProperty(__vi_inject__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }});
-    Object.defineProperty(__vi_inject__, \\"default\\", { enumerable: true, configurable: true, value: A });
+    Object.defineProperty(__vi_inject__, "B", { enumerable: true, configurable: true, get(){ return B }});
+    Object.defineProperty(__vi_inject__, "default", { enumerable: true, configurable: true, value: A });
     export { __vi_inject__ }"
   `)
 })
@@ -718,13 +718,13 @@ export function fn1() {
         `,
     ),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
 
     function fn1() {
     }
-    Object.defineProperty(__vi_inject__, \\"fn1\\", { enumerable: true, configurable: true, get(){ return fn1 }});function fn2() {
+    Object.defineProperty(__vi_inject__, "fn1", { enumerable: true, configurable: true, get(){ return fn1 }});function fn2() {
     }
-    Object.defineProperty(__vi_inject__, \\"fn2\\", { enumerable: true, configurable: true, get(){ return fn2 }});
+    Object.defineProperty(__vi_inject__, "fn2", { enumerable: true, configurable: true, get(){ return fn2 }});
             
     export { __vi_inject__ }"
   `)
@@ -743,7 +743,7 @@ export default (function getRandom() {
 `.trim()
 
   expect(injectSimpleCode(code)).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     __vi_inject__.default = (function getRandom() {
       return Math.random();
     });
@@ -755,7 +755,7 @@ export default (function getRandom() {
   expect(
     injectSimpleCode('export default (class A {});'),
   ).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     __vi_inject__.default = (class A {});
     export default { __vi_inject__: __vi_inject__.default };
 
@@ -848,7 +848,7 @@ export class Test {
 };`.trim()
 
   expect(injectSimpleCode(code)).toMatchInlineSnapshot(`
-    "const __vi_inject__ = { [Symbol.toStringTag]: \\"Module\\" };
+    "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     import { __vi_inject__ as __vi_esm_0__ } from 'foobar'
 
     if (false) {
@@ -875,7 +875,7 @@ export class Test {
         }
       }
     }
-    Object.defineProperty(__vi_inject__, \\"Test\\", { enumerable: true, configurable: true, get(){ return Test }});;
+    Object.defineProperty(__vi_inject__, "Test", { enumerable: true, configurable: true, get(){ return Test }});;
     export { __vi_inject__ }"
   `)
 })

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -16,7 +16,7 @@ test('hoists mock, unmock, hoisted', () => {
   vi.unmock('path')
   vi.hoisted(() => {})
   `)).toMatchInlineSnapshot(`
-    "if (typeof globalThis.vi === \\"undefined\\" && typeof globalThis.vitest === \\"undefined\\") { throw new Error(\\"There are some problems in resolving the mocks API.\\\\nYou may encounter this issue when importing the mocks API from another module other than 'vitest'.\\\\nTo fix this issue you can either:\\\\n- import the mocks API directly from 'vitest'\\\\n- enable the 'globals' options\\") }
+    "if (typeof globalThis.vi === "undefined" && typeof globalThis.vitest === "undefined") { throw new Error("There are some problems in resolving the mocks API.\\nYou may encounter this issue when importing the mocks API from another module other than 'vitest'.\\nTo fix this issue you can either:\\n- import the mocks API directly from 'vitest'\\n- enable the 'globals' options") }
     vi.mock('path', () => {})
     vi.unmock('path')
     vi.hoisted(() => {})"

--- a/test/core/test/inline-snap.test.ts
+++ b/test/core/test/inline-snap.test.ts
@@ -15,10 +15,10 @@ expect('foo').toMatchInlineSnapshot(\`{
     replaceInlineSnap(code, s, 40, '"bar\nfoo"')
     expect(s.toString()).toMatchInlineSnapshot(`
       "
-      expect('foo').toMatchInlineSnapshot('\\"bar\\"')
+      expect('foo').toMatchInlineSnapshot('"bar"')
       expect('foo').toMatchInlineSnapshot(\`
-        \\"bar
-        foo\\"
+        "bar
+        foo"
       \`)
       "
     `)
@@ -37,10 +37,10 @@ ${indent}}\`)
     replaceInlineSnap(code, s, 60, '"bar\nfoo"')
     expect(s.toString()).toMatchInlineSnapshot(`
       "
-        expect('foo').toMatchInlineSnapshot('\\"bar\\"')
+        expect('foo').toMatchInlineSnapshot('"bar"')
         expect('foo').toMatchInlineSnapshot(\`
-          \\"bar
-          foo\\"
+          "bar
+          foo"
         \`)
       "
     `)
@@ -54,7 +54,7 @@ ${indent}}\`)
     replaceInlineSnap(code, s, 0, '"bar"')
     expect(s.toString()).toMatchInlineSnapshot(`
       "
-        expect('foo').toMatchInlineSnapshot(/* comment1 */'\\"bar\\"')
+        expect('foo').toMatchInlineSnapshot(/* comment1 */'"bar"')
         "
     `)
   })
@@ -77,7 +77,7 @@ ${indent}}\`)
              comment2
           */
 
-          '\\"bar\\"')
+          '"bar"')
         "
     `)
   })
@@ -96,7 +96,7 @@ ${indent}}\`)
         expect('foo').toMatchInlineSnapshot(
           // comment1
           // comment2
-          '\\"bar\\"')
+          '"bar"')
         "
     `)
   })
@@ -137,9 +137,9 @@ ${indent}}\`)
           */
           \`
         {
-              \\"bar\\": {
-                \\"map2\\": Map {},
-                \\"type\\": \\"object1\\",
+              "bar": {
+                "map2": Map {},
+                "type": "object1",
               },
             }
       \`)
@@ -161,7 +161,7 @@ ${indent}}\`)
       expect(s.toString()).toMatchInlineSnapshot(`
         "expect({ foo: 'bar' }).toMatchInlineSnapshot({ foo: expect.any(String) }, \`
           {
-                  \\"foo\\": Any<String>,
+                  "foo": Any<String>,
                 }
         \`)"
       `)
@@ -180,7 +180,7 @@ ${indent}}\`)
       expect(s.toString()).toMatchInlineSnapshot(`
         "expect({ foo: 'bar' }).toMatchInlineSnapshot({ foo: expect.any(String) }, \`
           {
-                  \\"foo\\": Any<String>,
+                  "foo": Any<String>,
                 }
         \`)"
       `)

--- a/test/core/test/inline-snap.test.ts
+++ b/test/core/test/inline-snap.test.ts
@@ -15,7 +15,7 @@ expect('foo').toMatchInlineSnapshot(\`{
     replaceInlineSnap(code, s, 40, '"bar\nfoo"')
     expect(s.toString()).toMatchInlineSnapshot(`
       "
-      expect('foo').toMatchInlineSnapshot('"bar"')
+      expect('foo').toMatchInlineSnapshot(\`"bar"\`)
       expect('foo').toMatchInlineSnapshot(\`
         "bar
         foo"
@@ -37,7 +37,7 @@ ${indent}}\`)
     replaceInlineSnap(code, s, 60, '"bar\nfoo"')
     expect(s.toString()).toMatchInlineSnapshot(`
       "
-        expect('foo').toMatchInlineSnapshot('"bar"')
+        expect('foo').toMatchInlineSnapshot(\`"bar"\`)
         expect('foo').toMatchInlineSnapshot(\`
           "bar
           foo"
@@ -54,7 +54,7 @@ ${indent}}\`)
     replaceInlineSnap(code, s, 0, '"bar"')
     expect(s.toString()).toMatchInlineSnapshot(`
       "
-        expect('foo').toMatchInlineSnapshot(/* comment1 */'"bar"')
+        expect('foo').toMatchInlineSnapshot(/* comment1 */\`"bar"\`)
         "
     `)
   })
@@ -77,7 +77,7 @@ ${indent}}\`)
              comment2
           */
 
-          '"bar"')
+          \`"bar"\`)
         "
     `)
   })
@@ -96,7 +96,7 @@ ${indent}}\`)
         expect('foo').toMatchInlineSnapshot(
           // comment1
           // comment2
-          '"bar"')
+          \`"bar"\`)
         "
     `)
   })

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -277,7 +277,7 @@ describe('jest-expect', () => {
 
     expect(() => {
       expect(complex).toHaveProperty('a-b', false)
-    }).toThrowErrorMatchingInlineSnapshot('"expected { \'0\': \'zero\', foo: 1, …(4) } to have property \\"a-b\\" with value false"')
+    }).toThrowErrorMatchingInlineSnapshot('"expected { \'0\': \'zero\', foo: 1, …(4) } to have property "a-b" with value false"')
   })
 
   it('assertions', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -770,7 +770,7 @@ describe('async expect', () => {
       expect.unreachable()
     }
     catch (err: any) {
-      expect(err.message).toMatchInlineSnapshot('"promise resolved \\"{ foo: { bar: 42 } }\\" instead of rejecting"')
+      expect(err.message).toMatchInlineSnapshot(`"promise resolved "{ foo: { bar: 42 } }" instead of rejecting"`)
       expect(err.stack).toContain('jest-expect.test.ts')
     }
 
@@ -781,7 +781,7 @@ describe('async expect', () => {
       expect.unreachable()
     }
     catch (err: any) {
-      expect(err.message).toMatchInlineSnapshot('"promise rejected \\"Error: some error { foo: { bar: 42 } }\\" instead of resolving"')
+      expect(err.message).toMatchInlineSnapshot(`"promise rejected "Error: some error { foo: { bar: 42 } }" instead of resolving"`)
       expect(err.stack).toContain('jest-expect.test.ts')
     }
   })
@@ -849,9 +849,9 @@ it('correctly prints diff with asymmetric matchers', () => {
       + Received
 
         Object {
-          \\"a\\": Any<Number>,
-      -   \\"b\\": Any<Function>,
-      +   \\"b\\": \\"string\\",
+          "a": Any<Number>,
+      -   "b": Any<Function>,
+      +   "b": "string",
         }"
     `)
   }

--- a/test/core/test/snapshot.test.ts
+++ b/test/core/test/snapshot.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/quotes */
+
 import { expect, test, vi } from 'vitest'
 import { testOutsideInlineSnapshot } from './snapshots-outside'
 
@@ -5,6 +7,26 @@ test('object', () => {
   expect({
     this: { is: new Set(['of', 'snapshot']) },
   }).toMatchSnapshot()
+})
+
+test('single line inline', () => {
+  expect('some string').toMatchInlineSnapshot(`"some string"`)
+  expect('some "string"').toMatchInlineSnapshot(`"some "string""`)
+  expect('some "string').toMatchInlineSnapshot(`"some "string"`)
+  expect('som`e` string').toMatchInlineSnapshot(`"som\`e\` string"`)
+  expect('some string`').toMatchInlineSnapshot(`"some string\`"`)
+  expect("some string'").toMatchInlineSnapshot(`"some string'"`)
+  expect("some 'string'").toMatchInlineSnapshot(`"some 'string'"`)
+})
+
+test('single line snapshot', () => {
+  expect('some string').toMatchSnapshot()
+  expect('some "string"').toMatchSnapshot()
+  expect('some "string').toMatchSnapshot()
+  expect('som`e` string').toMatchSnapshot()
+  expect('some string`').toMatchSnapshot()
+  expect("some string'").toMatchSnapshot()
+  expect("some 'string'").toMatchSnapshot()
 })
 
 test('multiline', () => {

--- a/test/coverage-test/coverage-report-tests/__snapshots__/custom.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/custom.report.test.ts.snap
@@ -6,8 +6,8 @@ exports[`custom json report 1`] = `
     "initialized with context",
     "resolveOptions",
     "clean with force",
-    "onAfterSuiteRun with {\\"coverage\\":{\\"customCoverage\\":\\"Coverage report passed from workers to main thread\\"}}",
-    "reportCoverage with {\\"allTestsRun\\":true}",
+    "onAfterSuiteRun with {"coverage":{"customCoverage":"Coverage report passed from workers to main thread"}}",
+    "reportCoverage with {"allTestsRun":true}",
   ],
   "transformedFiles": [
     "<process-cwd>/src/Counter/Counter.component.ts",

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -10,7 +10,7 @@ exports[`should fail expect.test.ts > expect.test.ts 1`] = `"AssertionError: exp
 
 exports[`should fail expect-soft.test.ts > expect-soft.test.ts 1`] = `"Error: expect.soft() can only be used inside a test"`;
 
-exports[`should fail expect-unreachable.test.ts > expect-unreachable.test.ts 1`] = `"AssertionError: expected \\"hi\\" not to be reached"`;
+exports[`should fail expect-unreachable.test.ts > expect-unreachable.test.ts 1`] = `"AssertionError: expected "hi" not to be reached"`;
 
 exports[`should fail hook-timeout.test.ts > hook-timeout.test.ts 1`] = `"Error: Hook timed out in 10ms."`;
 

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -1,34 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`JUnit reporter (no outputFile entry) 1`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"2\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.001442286\\">
-            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="9" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="9" failures="1" errors="0" skipped="2" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; inner suite &gt; Math.sqrt()" time="0.001442286">
+            <failure message="expected 2.23606797749979 to equal 2" type="AssertionError">
 AssertionError: expected 2.23606797749979 to equal 2
  ❯ test/core/test/basic.test.ts:8:32
             </failure>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.001023711\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; JSON" time="0.001023711">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; async with timeout" time="0">
             <skipped/>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; timeout" time="0.1005059841">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.020184875\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success " time="0.020184875">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success " time="0.0003324542">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.019738606\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success done(false)" time="0.019738606">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
 [33merror[39m
             </system-err>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; todo test\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
             <skipped/>
         </testcase>
     </testsuite>
@@ -37,34 +37,34 @@ AssertionError: expected 2.23606797749979 to equal 2
 `;
 
 exports[`JUnit reporter 1`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"2\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.001442286\\">
-            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="9" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="9" failures="1" errors="0" skipped="2" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; inner suite &gt; Math.sqrt()" time="0.001442286">
+            <failure message="expected 2.23606797749979 to equal 2" type="AssertionError">
 AssertionError: expected 2.23606797749979 to equal 2
  ❯ test/core/test/basic.test.ts:8:32
             </failure>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.001023711\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; JSON" time="0.001023711">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; async with timeout" time="0">
             <skipped/>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; timeout" time="0.1005059841">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.020184875\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success " time="0.020184875">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success " time="0.0003324542">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.019738606\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success done(false)" time="0.019738606">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
 [33merror[39m
             </system-err>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; todo test\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
             <skipped/>
         </testcase>
     </testsuite>
@@ -78,34 +78,34 @@ exports[`JUnit reporter with outputFile 1`] = `
 `;
 
 exports[`JUnit reporter with outputFile 2`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"2\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.001442286\\">
-            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="9" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="9" failures="1" errors="0" skipped="2" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; inner suite &gt; Math.sqrt()" time="0.001442286">
+            <failure message="expected 2.23606797749979 to equal 2" type="AssertionError">
 AssertionError: expected 2.23606797749979 to equal 2
  ❯ test/core/test/basic.test.ts:8:32
             </failure>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.001023711\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; JSON" time="0.001023711">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; async with timeout" time="0">
             <skipped/>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; timeout" time="0.1005059841">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.020184875\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success " time="0.020184875">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success " time="0.0003324542">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.019738606\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success done(false)" time="0.019738606">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
 [33merror[39m
             </system-err>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; todo test\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
             <skipped/>
         </testcase>
     </testsuite>
@@ -119,34 +119,34 @@ exports[`JUnit reporter with outputFile in non-existing directory 1`] = `
 `;
 
 exports[`JUnit reporter with outputFile in non-existing directory 2`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"2\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.001442286\\">
-            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="9" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="9" failures="1" errors="0" skipped="2" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; inner suite &gt; Math.sqrt()" time="0.001442286">
+            <failure message="expected 2.23606797749979 to equal 2" type="AssertionError">
 AssertionError: expected 2.23606797749979 to equal 2
  ❯ test/core/test/basic.test.ts:8:32
             </failure>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.001023711\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; JSON" time="0.001023711">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; async with timeout" time="0">
             <skipped/>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; timeout" time="0.1005059841">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.020184875\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success " time="0.020184875">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success " time="0.0003324542">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.019738606\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success done(false)" time="0.019738606">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
 [33merror[39m
             </system-err>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; todo test\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
             <skipped/>
         </testcase>
     </testsuite>
@@ -160,34 +160,34 @@ exports[`JUnit reporter with outputFile object 1`] = `
 `;
 
 exports[`JUnit reporter with outputFile object 2`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"2\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.001442286\\">
-            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="9" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="9" failures="1" errors="0" skipped="2" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; inner suite &gt; Math.sqrt()" time="0.001442286">
+            <failure message="expected 2.23606797749979 to equal 2" type="AssertionError">
 AssertionError: expected 2.23606797749979 to equal 2
  ❯ test/core/test/basic.test.ts:8:32
             </failure>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.001023711\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; JSON" time="0.001023711">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; async with timeout" time="0">
             <skipped/>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; timeout" time="0.1005059841">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.020184875\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success " time="0.020184875">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success " time="0.0003324542">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.019738606\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success done(false)" time="0.019738606">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
 [33merror[39m
             </system-err>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; todo test\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
             <skipped/>
         </testcase>
     </testsuite>
@@ -201,34 +201,34 @@ exports[`JUnit reporter with outputFile object in non-existing directory 1`] = `
 `;
 
 exports[`JUnit reporter with outputFile object in non-existing directory 2`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"9\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"2\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; inner suite &gt; Math.sqrt()\\" time=\\"0.001442286\\">
-            <failure message=\\"expected 2.23606797749979 to equal 2\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="9" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="9" failures="1" errors="0" skipped="2" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; inner suite &gt; Math.sqrt()" time="0.001442286">
+            <failure message="expected 2.23606797749979 to equal 2" type="AssertionError">
 AssertionError: expected 2.23606797749979 to equal 2
  ❯ test/core/test/basic.test.ts:8:32
             </failure>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; JSON\\" time=\\"0.001023711\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; JSON" time="0.001023711">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; async with timeout\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; async with timeout" time="0">
             <skipped/>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; timeout\\" time=\\"0.1005059841\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; timeout" time="0.1005059841">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success \\" time=\\"0.020184875\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success " time="0.020184875">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success \\" time=\\"0.0003324542\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success " time="0.0003324542">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback setup success done(false)\\" time=\\"0.019738606\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback setup success done(false)" time="0.019738606">
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; callback test success done(false)\\" time=\\"0.0001923509\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
 [33merror[39m
             </system-err>
         </testcase>
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; todo test\\" time=\\"0\\">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
             <skipped/>
         </testcase>
     </testsuite>
@@ -242,11 +242,11 @@ exports[`JUnit reporter with outputFile with XML in error message 1`] = `
 `;
 
 exports[`JUnit reporter with outputFile with XML in error message 2`] = `
-"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
-<testsuites name=\\"vitest tests\\" tests=\\"1\\" failures=\\"1\\" errors=\\"0\\" time=\\"0\\">
-    <testsuite name=\\"test/core/test/basic.test.ts\\" timestamp=\\"2022-01-19T10:10:01.759Z\\" hostname=\\"hostname\\" tests=\\"1\\" failures=\\"1\\" errors=\\"0\\" skipped=\\"0\\" time=\\"0.145992842\\">
-        <testcase classname=\\"test/core/test/basic.test.ts\\" name=\\"suite &gt; test with xml in error\\" time=\\"0.0021231231\\">
-            <failure message=\\"error message that has XML in it &lt;tag&gt;\\" type=\\"AssertionError\\">
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="1" failures="1" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="1" errors="0" skipped="0" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="suite &gt; test with xml in error" time="0.0021231231">
+            <failure message="error message that has XML in it &lt;tag&gt;" type="AssertionError">
 AssertionError: error message that has XML in it &lt;tag&gt;
  ❯ test/core/test/basic.test.ts:8:32
  ❯ test/core/test/&lt;bracket-name&gt;.ts:3:11
@@ -508,121 +508,121 @@ exports[`json reporter with outputFile 1`] = `
 
 exports[`json reporter with outputFile 2`] = `
 "{
-  \\"numTotalTestSuites\\": 3,
-  \\"numPassedTestSuites\\": 3,
-  \\"numFailedTestSuites\\": 0,
-  \\"numPendingTestSuites\\": 0,
-  \\"numTotalTests\\": 9,
-  \\"numPassedTests\\": 8,
-  \\"numFailedTests\\": 1,
-  \\"numPendingTests\\": 0,
-  \\"numTodoTests\\": 1,
-  \\"startTime\\": 1642587001759,
-  \\"success\\": false,
-  \\"testResults\\": [
+  "numTotalTestSuites": 3,
+  "numPassedTestSuites": 3,
+  "numFailedTestSuites": 0,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 9,
+  "numPassedTests": 8,
+  "numFailedTests": 1,
+  "numPendingTests": 0,
+  "numTodoTests": 1,
+  "startTime": 1642587001759,
+  "success": false,
+  "testResults": [
     {
-      \\"assertionResults\\": [
+      "assertionResults": [
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\",
-            \\"inner suite\\"
+          "ancestorTitles": [
+            "suite",
+            "inner suite"
           ],
-          \\"fullName\\": \\"suite inner suite Math.sqrt()\\",
-          \\"status\\": \\"failed\\",
-          \\"title\\": \\"Math.sqrt()\\",
-          \\"duration\\": 1.4422860145568848,
-          \\"failureMessages\\": [
-            \\"expected 2.23606797749979 to equal 2\\"
+          "fullName": "suite inner suite Math.sqrt()",
+          "status": "failed",
+          "title": "Math.sqrt()",
+          "duration": 1.4422860145568848,
+          "failureMessages": [
+            "expected 2.23606797749979 to equal 2"
           ],
-          \\"location\\": {
-            \\"line\\": 8,
-            \\"column\\": 32
+          "location": {
+            "line": 8,
+            "column": 32
           }
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite JSON\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"JSON\\",
-          \\"duration\\": 1.0237109661102295,
-          \\"failureMessages\\": []
+          "fullName": "suite JSON",
+          "status": "passed",
+          "title": "JSON",
+          "duration": 1.0237109661102295,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite async with timeout\\",
-          \\"status\\": \\"skipped\\",
-          \\"title\\": \\"async with timeout\\",
-          \\"failureMessages\\": []
+          "fullName": "suite async with timeout",
+          "status": "skipped",
+          "title": "async with timeout",
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite timeout\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"timeout\\",
-          \\"duration\\": 100.50598406791687,
-          \\"failureMessages\\": []
+          "fullName": "suite timeout",
+          "status": "passed",
+          "title": "timeout",
+          "duration": 100.50598406791687,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success \\",
-          \\"duration\\": 20.184875011444092,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success ",
+          "status": "passed",
+          "title": "callback setup success ",
+          "duration": 20.184875011444092,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success \\",
-          \\"duration\\": 0.33245420455932617,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success ",
+          "status": "passed",
+          "title": "callback test success ",
+          "duration": 0.33245420455932617,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success done(false)\\",
-          \\"duration\\": 19.738605976104736,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success done(false)",
+          "status": "passed",
+          "title": "callback setup success done(false)",
+          "duration": 19.738605976104736,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success done(false)\\",
-          \\"duration\\": 0.1923508644104004,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success done(false)",
+          "status": "passed",
+          "title": "callback test success done(false)",
+          "duration": 0.1923508644104004,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite todo test\\",
-          \\"status\\": \\"todo\\",
-          \\"title\\": \\"todo test\\",
-          \\"failureMessages\\": []
+          "fullName": "suite todo test",
+          "status": "todo",
+          "title": "todo test",
+          "failureMessages": []
         }
       ],
-      \\"startTime\\": 1642587001759,
-      \\"endTime\\": 1642587001759,
-      \\"status\\": \\"failed\\",
-      \\"message\\": \\"\\",
-      \\"name\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "startTime": 1642587001759,
+      "endTime": 1642587001759,
+      "status": "failed",
+      "message": "",
+      "name": "/vitest/test/core/test/basic.test.ts"
     }
   ]
 }"
@@ -635,121 +635,121 @@ exports[`json reporter with outputFile in non-existing directory 1`] = `
 
 exports[`json reporter with outputFile in non-existing directory 2`] = `
 "{
-  \\"numTotalTestSuites\\": 3,
-  \\"numPassedTestSuites\\": 3,
-  \\"numFailedTestSuites\\": 0,
-  \\"numPendingTestSuites\\": 0,
-  \\"numTotalTests\\": 9,
-  \\"numPassedTests\\": 8,
-  \\"numFailedTests\\": 1,
-  \\"numPendingTests\\": 0,
-  \\"numTodoTests\\": 1,
-  \\"startTime\\": 1642587001759,
-  \\"success\\": false,
-  \\"testResults\\": [
+  "numTotalTestSuites": 3,
+  "numPassedTestSuites": 3,
+  "numFailedTestSuites": 0,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 9,
+  "numPassedTests": 8,
+  "numFailedTests": 1,
+  "numPendingTests": 0,
+  "numTodoTests": 1,
+  "startTime": 1642587001759,
+  "success": false,
+  "testResults": [
     {
-      \\"assertionResults\\": [
+      "assertionResults": [
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\",
-            \\"inner suite\\"
+          "ancestorTitles": [
+            "suite",
+            "inner suite"
           ],
-          \\"fullName\\": \\"suite inner suite Math.sqrt()\\",
-          \\"status\\": \\"failed\\",
-          \\"title\\": \\"Math.sqrt()\\",
-          \\"duration\\": 1.4422860145568848,
-          \\"failureMessages\\": [
-            \\"expected 2.23606797749979 to equal 2\\"
+          "fullName": "suite inner suite Math.sqrt()",
+          "status": "failed",
+          "title": "Math.sqrt()",
+          "duration": 1.4422860145568848,
+          "failureMessages": [
+            "expected 2.23606797749979 to equal 2"
           ],
-          \\"location\\": {
-            \\"line\\": 8,
-            \\"column\\": 32
+          "location": {
+            "line": 8,
+            "column": 32
           }
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite JSON\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"JSON\\",
-          \\"duration\\": 1.0237109661102295,
-          \\"failureMessages\\": []
+          "fullName": "suite JSON",
+          "status": "passed",
+          "title": "JSON",
+          "duration": 1.0237109661102295,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite async with timeout\\",
-          \\"status\\": \\"skipped\\",
-          \\"title\\": \\"async with timeout\\",
-          \\"failureMessages\\": []
+          "fullName": "suite async with timeout",
+          "status": "skipped",
+          "title": "async with timeout",
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite timeout\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"timeout\\",
-          \\"duration\\": 100.50598406791687,
-          \\"failureMessages\\": []
+          "fullName": "suite timeout",
+          "status": "passed",
+          "title": "timeout",
+          "duration": 100.50598406791687,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success \\",
-          \\"duration\\": 20.184875011444092,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success ",
+          "status": "passed",
+          "title": "callback setup success ",
+          "duration": 20.184875011444092,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success \\",
-          \\"duration\\": 0.33245420455932617,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success ",
+          "status": "passed",
+          "title": "callback test success ",
+          "duration": 0.33245420455932617,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success done(false)\\",
-          \\"duration\\": 19.738605976104736,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success done(false)",
+          "status": "passed",
+          "title": "callback setup success done(false)",
+          "duration": 19.738605976104736,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success done(false)\\",
-          \\"duration\\": 0.1923508644104004,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success done(false)",
+          "status": "passed",
+          "title": "callback test success done(false)",
+          "duration": 0.1923508644104004,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite todo test\\",
-          \\"status\\": \\"todo\\",
-          \\"title\\": \\"todo test\\",
-          \\"failureMessages\\": []
+          "fullName": "suite todo test",
+          "status": "todo",
+          "title": "todo test",
+          "failureMessages": []
         }
       ],
-      \\"startTime\\": 1642587001759,
-      \\"endTime\\": 1642587001759,
-      \\"status\\": \\"failed\\",
-      \\"message\\": \\"\\",
-      \\"name\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "startTime": 1642587001759,
+      "endTime": 1642587001759,
+      "status": "failed",
+      "message": "",
+      "name": "/vitest/test/core/test/basic.test.ts"
     }
   ]
 }"
@@ -762,121 +762,121 @@ exports[`json reporter with outputFile object 1`] = `
 
 exports[`json reporter with outputFile object 2`] = `
 "{
-  \\"numTotalTestSuites\\": 3,
-  \\"numPassedTestSuites\\": 3,
-  \\"numFailedTestSuites\\": 0,
-  \\"numPendingTestSuites\\": 0,
-  \\"numTotalTests\\": 9,
-  \\"numPassedTests\\": 8,
-  \\"numFailedTests\\": 1,
-  \\"numPendingTests\\": 0,
-  \\"numTodoTests\\": 1,
-  \\"startTime\\": 1642587001759,
-  \\"success\\": false,
-  \\"testResults\\": [
+  "numTotalTestSuites": 3,
+  "numPassedTestSuites": 3,
+  "numFailedTestSuites": 0,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 9,
+  "numPassedTests": 8,
+  "numFailedTests": 1,
+  "numPendingTests": 0,
+  "numTodoTests": 1,
+  "startTime": 1642587001759,
+  "success": false,
+  "testResults": [
     {
-      \\"assertionResults\\": [
+      "assertionResults": [
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\",
-            \\"inner suite\\"
+          "ancestorTitles": [
+            "suite",
+            "inner suite"
           ],
-          \\"fullName\\": \\"suite inner suite Math.sqrt()\\",
-          \\"status\\": \\"failed\\",
-          \\"title\\": \\"Math.sqrt()\\",
-          \\"duration\\": 1.4422860145568848,
-          \\"failureMessages\\": [
-            \\"expected 2.23606797749979 to equal 2\\"
+          "fullName": "suite inner suite Math.sqrt()",
+          "status": "failed",
+          "title": "Math.sqrt()",
+          "duration": 1.4422860145568848,
+          "failureMessages": [
+            "expected 2.23606797749979 to equal 2"
           ],
-          \\"location\\": {
-            \\"line\\": 8,
-            \\"column\\": 32
+          "location": {
+            "line": 8,
+            "column": 32
           }
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite JSON\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"JSON\\",
-          \\"duration\\": 1.0237109661102295,
-          \\"failureMessages\\": []
+          "fullName": "suite JSON",
+          "status": "passed",
+          "title": "JSON",
+          "duration": 1.0237109661102295,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite async with timeout\\",
-          \\"status\\": \\"skipped\\",
-          \\"title\\": \\"async with timeout\\",
-          \\"failureMessages\\": []
+          "fullName": "suite async with timeout",
+          "status": "skipped",
+          "title": "async with timeout",
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite timeout\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"timeout\\",
-          \\"duration\\": 100.50598406791687,
-          \\"failureMessages\\": []
+          "fullName": "suite timeout",
+          "status": "passed",
+          "title": "timeout",
+          "duration": 100.50598406791687,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success \\",
-          \\"duration\\": 20.184875011444092,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success ",
+          "status": "passed",
+          "title": "callback setup success ",
+          "duration": 20.184875011444092,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success \\",
-          \\"duration\\": 0.33245420455932617,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success ",
+          "status": "passed",
+          "title": "callback test success ",
+          "duration": 0.33245420455932617,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success done(false)\\",
-          \\"duration\\": 19.738605976104736,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success done(false)",
+          "status": "passed",
+          "title": "callback setup success done(false)",
+          "duration": 19.738605976104736,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success done(false)\\",
-          \\"duration\\": 0.1923508644104004,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success done(false)",
+          "status": "passed",
+          "title": "callback test success done(false)",
+          "duration": 0.1923508644104004,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite todo test\\",
-          \\"status\\": \\"todo\\",
-          \\"title\\": \\"todo test\\",
-          \\"failureMessages\\": []
+          "fullName": "suite todo test",
+          "status": "todo",
+          "title": "todo test",
+          "failureMessages": []
         }
       ],
-      \\"startTime\\": 1642587001759,
-      \\"endTime\\": 1642587001759,
-      \\"status\\": \\"failed\\",
-      \\"message\\": \\"\\",
-      \\"name\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "startTime": 1642587001759,
+      "endTime": 1642587001759,
+      "status": "failed",
+      "message": "",
+      "name": "/vitest/test/core/test/basic.test.ts"
     }
   ]
 }"
@@ -889,121 +889,121 @@ exports[`json reporter with outputFile object in non-existing directory 1`] = `
 
 exports[`json reporter with outputFile object in non-existing directory 2`] = `
 "{
-  \\"numTotalTestSuites\\": 3,
-  \\"numPassedTestSuites\\": 3,
-  \\"numFailedTestSuites\\": 0,
-  \\"numPendingTestSuites\\": 0,
-  \\"numTotalTests\\": 9,
-  \\"numPassedTests\\": 8,
-  \\"numFailedTests\\": 1,
-  \\"numPendingTests\\": 0,
-  \\"numTodoTests\\": 1,
-  \\"startTime\\": 1642587001759,
-  \\"success\\": false,
-  \\"testResults\\": [
+  "numTotalTestSuites": 3,
+  "numPassedTestSuites": 3,
+  "numFailedTestSuites": 0,
+  "numPendingTestSuites": 0,
+  "numTotalTests": 9,
+  "numPassedTests": 8,
+  "numFailedTests": 1,
+  "numPendingTests": 0,
+  "numTodoTests": 1,
+  "startTime": 1642587001759,
+  "success": false,
+  "testResults": [
     {
-      \\"assertionResults\\": [
+      "assertionResults": [
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\",
-            \\"inner suite\\"
+          "ancestorTitles": [
+            "suite",
+            "inner suite"
           ],
-          \\"fullName\\": \\"suite inner suite Math.sqrt()\\",
-          \\"status\\": \\"failed\\",
-          \\"title\\": \\"Math.sqrt()\\",
-          \\"duration\\": 1.4422860145568848,
-          \\"failureMessages\\": [
-            \\"expected 2.23606797749979 to equal 2\\"
+          "fullName": "suite inner suite Math.sqrt()",
+          "status": "failed",
+          "title": "Math.sqrt()",
+          "duration": 1.4422860145568848,
+          "failureMessages": [
+            "expected 2.23606797749979 to equal 2"
           ],
-          \\"location\\": {
-            \\"line\\": 8,
-            \\"column\\": 32
+          "location": {
+            "line": 8,
+            "column": 32
           }
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite JSON\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"JSON\\",
-          \\"duration\\": 1.0237109661102295,
-          \\"failureMessages\\": []
+          "fullName": "suite JSON",
+          "status": "passed",
+          "title": "JSON",
+          "duration": 1.0237109661102295,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite async with timeout\\",
-          \\"status\\": \\"skipped\\",
-          \\"title\\": \\"async with timeout\\",
-          \\"failureMessages\\": []
+          "fullName": "suite async with timeout",
+          "status": "skipped",
+          "title": "async with timeout",
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite timeout\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"timeout\\",
-          \\"duration\\": 100.50598406791687,
-          \\"failureMessages\\": []
+          "fullName": "suite timeout",
+          "status": "passed",
+          "title": "timeout",
+          "duration": 100.50598406791687,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success \\",
-          \\"duration\\": 20.184875011444092,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success ",
+          "status": "passed",
+          "title": "callback setup success ",
+          "duration": 20.184875011444092,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success \\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success \\",
-          \\"duration\\": 0.33245420455932617,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success ",
+          "status": "passed",
+          "title": "callback test success ",
+          "duration": 0.33245420455932617,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback setup success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback setup success done(false)\\",
-          \\"duration\\": 19.738605976104736,
-          \\"failureMessages\\": []
+          "fullName": "suite callback setup success done(false)",
+          "status": "passed",
+          "title": "callback setup success done(false)",
+          "duration": 19.738605976104736,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite callback test success done(false)\\",
-          \\"status\\": \\"passed\\",
-          \\"title\\": \\"callback test success done(false)\\",
-          \\"duration\\": 0.1923508644104004,
-          \\"failureMessages\\": []
+          "fullName": "suite callback test success done(false)",
+          "status": "passed",
+          "title": "callback test success done(false)",
+          "duration": 0.1923508644104004,
+          "failureMessages": []
         },
         {
-          \\"ancestorTitles\\": [
-            \\"suite\\"
+          "ancestorTitles": [
+            "suite"
           ],
-          \\"fullName\\": \\"suite todo test\\",
-          \\"status\\": \\"todo\\",
-          \\"title\\": \\"todo test\\",
-          \\"failureMessages\\": []
+          "fullName": "suite todo test",
+          "status": "todo",
+          "title": "todo test",
+          "failureMessages": []
         }
       ],
-      \\"startTime\\": 1642587001759,
-      \\"endTime\\": 1642587001759,
-      \\"status\\": \\"failed\\",
-      \\"message\\": \\"\\",
-      \\"name\\": \\"/vitest/test/core/test/basic.test.ts\\"
+      "startTime": 1642587001759,
+      "endTime": 1642587001759,
+      "status": "failed",
+      "message": "",
+      "name": "/vitest/test/core/test/basic.test.ts"
     }
   ]
 }"
@@ -1021,11 +1021,11 @@ not ok 1 - test/core/test/basic.test.ts # time=145.99ms {
             not ok 1 - Math.sqrt() # time=1.44ms
                 ---
                 error:
-                    name: \\"AssertionError\\"
-                    message: \\"expected 2.23606797749979 to equal 2\\"
-                at: \\"/vitest/test/core/test/basic.test.ts:8:32\\"
-                actual: \\"2.23606797749979\\"
-                expected: \\"2\\"
+                    name: "AssertionError"
+                    message: "expected 2.23606797749979 to equal 2"
+                at: "/vitest/test/core/test/basic.test.ts:8:32"
+                actual: "2.23606797749979"
+                expected: "2"
                 ...
         }
         ok 2 - JSON # time=1.02ms
@@ -1047,11 +1047,11 @@ exports[`tap-flat reporter 1`] = `
 not ok 1 - test/core/test/basic.test.ts > suite > inner suite > Math.sqrt() # time=1.44ms
     ---
     error:
-        name: \\"AssertionError\\"
-        message: \\"expected 2.23606797749979 to equal 2\\"
-    at: \\"/vitest/test/core/test/basic.test.ts:8:32\\"
-    actual: \\"2.23606797749979\\"
-    expected: \\"2\\"
+        name: "AssertionError"
+        message: "expected 2.23606797749979 to equal 2"
+    at: "/vitest/test/core/test/basic.test.ts:8:32"
+    actual: "2.23606797749979"
+    expected: "2"
     ...
 ok 2 - test/core/test/basic.test.ts > suite > JSON # time=1.02ms
 ok 3 - test/core/test/basic.test.ts > suite > async with timeout # SKIP

--- a/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
+++ b/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
@@ -9,8 +9,8 @@ describe('snapshots are generated in correct order', async () => {
   test('first snapshot', () => {
     expect({ foo: ['bar'] }).toMatchInlineSnapshot(\`
       Object {
-        \\"foo\\": Array [
-          \\"bar\\",
+        "foo": Array [
+          "bar",
         ],
       }
     \`)
@@ -19,8 +19,8 @@ describe('snapshots are generated in correct order', async () => {
   test('second snapshot', () => {
     expect({ foo: ['zed'] }).toMatchInlineSnapshot(\`
       Object {
-        \\"foo\\": Array [
-          \\"zed\\",
+        "foo": Array [
+          "zed",
         ],
       }
     \`)
@@ -31,7 +31,7 @@ describe('snapshots with properties', () => {
   test('without snapshot', () => {
     expect({ foo: 'bar' }).toMatchInlineSnapshot({ foo: expect.any(String) }, \`
       Object {
-        \\"foo\\": Any<String>,
+        "foo": Any<String>,
       }
     \`)
   })

--- a/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
+++ b/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
@@ -39,9 +39,9 @@ describe('snapshots with properties', () => {
   test('with snapshot', () => {
     expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, \`
       Object {
-        \\"first\\": Object {
-          \\"second\\": Object {
-            \\"foo\\": Any<String>,
+        "first": Object {
+          "second": Object {
+            "foo": Any<String>,
           },
         },
       }
@@ -51,9 +51,9 @@ describe('snapshots with properties', () => {
   test('mixed with and without snapshot', () => {
     expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, \`
       Object {
-        \\"first\\": Object {
-          \\"second\\": Object {
-            \\"foo\\": Any<String>,
+        "first": Object {
+          "second": Object {
+            "foo": Any<String>,
           },
         },
       }
@@ -61,9 +61,9 @@ describe('snapshots with properties', () => {
 
     expect({ first: { second: { foo: 'zed' } } }).toMatchInlineSnapshot(\`
       Object {
-        \\"first\\": Object {
-          \\"second\\": Object {
-            \\"foo\\": \\"zed\\",
+        "first": Object {
+          "second": Object {
+            "foo": "zed",
           },
         },
       }

--- a/test/stacktraces/test/__snapshots__/runner.test.ts.snap
+++ b/test/stacktraces/test/__snapshots__/runner.test.ts.snap
@@ -22,7 +22,7 @@ ReferenceError: bar is not defined
 exports[`stacktraces should pick error frame if present > frame.spec.imba > frame.spec.imba 1`] = `
 " FAIL  frame.spec.imba [ frame.spec.imba ]
 imba-parser error: Unexpected 'CALL_END'
-4 | test(\\"1+1\\") do
+4 | test("1+1") do
 5 |  expect(1+1).toBe 2
 6 |  frame.
   |        ^
@@ -43,7 +43,7 @@ exports[`stacktraces should respect sourcemaps > add.test.ts > add.test.ts 1`] =
 
 exports[`stacktraces should respect sourcemaps > add-in-imba.test.imba > add-in-imba.test.imba 1`] = `
 " ❯ add-in-imba.test.imba:8:17
-      6| it \\"add\\", do
+      6| it "add", do
       7|  expect(add()).toBe 0
       8|  expect(add(1)).toBe 3
        |                 ^

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -92,7 +92,7 @@ exports[`should fail > typechecks empty "include" but with tests 1`] = `
 Breaking changes might not follow semver, please pin Vitest's version when using it.
 
 ⎯⎯⎯⎯⎯⎯ Typecheck Error ⎯⎯⎯⎯⎯⎯⎯
-Error: error TS18003: No inputs were found in config file '<root>/tsconfig.vitest-temp.json'. Specified 'include' paths were '[\\"src\\"]' and 'exclude' paths were '[\\"**/dist/**\\",\\"./dist\\"]'.
+Error: error TS18003: No inputs were found in config file '<root>/tsconfig.vitest-temp.json'. Specified 'include' paths were '["src"]' and 'exclude' paths were '["**/dist/**","./dist"]'.
 
 
 "

--- a/test/workspaces-browser/package.json
+++ b/test/workspaces-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/test-workspaces",
+  "name": "@vitest/test-workspaces-browser",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Description

This changes the output for snapshots:

1. Quotes are no longer escaped:

```diff
expect({ foo: 'bar' }).toMatchInlineSnapshot(`
  Object {
-    \\"foo\\": \\"bar\\",
+    "foo": "bar",
  }
`)
```

2. One-line snapshots now use "`" quotes instead of ':

```diff
- expect('some string').toMatchInlineSnapshot('"some string"')
+ expect('some string').toMatchInlineSnapshot(`"some string"`)
```

This is a breaking change, but it's long overdue. If you prefer the old behavior or want to have more time to migrate, you can keep escaping with this config:

```ts
export default defineConfig({
  test: {
    snapshotFormat: {
      escapeString: true,
    },
  },
})
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
