### PR TITLE
fix: pass environmentOptions to happy-dom integration

### DIFF
--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -5,11 +5,11 @@ import { populateGlobal } from './utils'
 export default <Environment>({
   name: 'happy-dom',
   transformMode: 'web',
-  async setupVM({ 'happy-dom': happyDom = {} }) {
+  async setupVM({ happyDOM = {} }) {
     const { Window } = await importModule('happy-dom') as typeof import('happy-dom')
     const win = new Window({
-      ...happyDom,
-      url: happyDom.url || 'http://localhost:3000',
+      ...happyDOM,
+      url: happyDOM.url || 'http://localhost:3000',
     }) as any
 
     // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
@@ -29,13 +29,13 @@ export default <Environment>({
       },
     }
   },
-  async setup(global, { 'happy-dom': happyDom = {} }) {
+  async setup(global, { happyDOM = {} }) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
     const { Window, GlobalWindow } = await importModule('happy-dom') as typeof import('happy-dom')
     const win = new (GlobalWindow || Window)({
-      ...happyDom,
-      url: happyDom.url || 'http://localhost:3000',
+      ...happyDOM,
+      url: happyDOM.url || 'http://localhost:3000',
     })
 
     const { keys, originals } = populateGlobal(global, win, { bindFunctions: true })

--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -5,9 +5,12 @@ import { populateGlobal } from './utils'
 export default <Environment>({
   name: 'happy-dom',
   transformMode: 'web',
-  async setupVM() {
+  async setupVM({ 'happy-dom': happyDom = {} }) {
     const { Window } = await importModule('happy-dom') as typeof import('happy-dom')
-    const win = new Window() as any
+    const win = new Window({
+      ...happyDom,
+      url: happyDom.url || 'http://localhost:3000',
+    }) as any
 
     // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
     win.Buffer = Buffer
@@ -26,11 +29,14 @@ export default <Environment>({
       },
     }
   },
-  async setup(global) {
+  async setup(global, { 'happy-dom': happyDom = {} }) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
     const { Window, GlobalWindow } = await importModule('happy-dom') as typeof import('happy-dom')
-    const win = new (GlobalWindow || Window)()
+    const win = new (GlobalWindow || Window)({
+      ...happyDom,
+      url: happyDom.url || 'http://localhost:3000',
+    })
 
     const { keys, originals } = populateGlobal(global, win, { bindFunctions: true })
 

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -8,6 +8,7 @@ import type { TestSequencerConstructor } from '../node/sequencers/types'
 import type { ChaiConfig } from '../integrations/chai/config'
 import type { CoverageOptions, ResolvedCoverageOptions } from './coverage'
 import type { JSDOMOptions } from './jsdom-options'
+import type { HappyDOMOptions } from './happy-dom-options'
 import type { Reporter } from './reporter'
 import type { SnapshotStateOptions } from './snapshot'
 import type { Arrayable } from './general'
@@ -24,13 +25,14 @@ export type CSSModuleScopeStrategy = 'stable' | 'scoped' | 'non-scoped'
 
 export type ApiConfig = Pick<CommonServerOptions, 'port' | 'strictPort' | 'host'>
 
-export { JSDOMOptions }
+export type { JSDOMOptions, HappyDOMOptions }
 
 export interface EnvironmentOptions {
   /**
    * jsdom options.
    */
   jsdom?: JSDOMOptions
+  happyDOM?: HappyDOMOptions
   [x: string]: unknown
 }
 

--- a/packages/vitest/src/types/happy-dom-options.ts
+++ b/packages/vitest/src/types/happy-dom-options.ts
@@ -1,0 +1,20 @@
+/**
+ * Happy DOM options.
+ */
+export interface HappyDOMOptions {
+  width?: number
+  height?: number
+  url?: string
+  settings?: {
+    disableJavaScriptEvaluation?: boolean
+    disableJavaScriptFileLoading?: boolean
+    disableCSSFileLoading?: boolean
+    disableIframePageLoading?: boolean
+    disableComputedStyleRendering?: boolean
+    enableFileSystemHttpRequests?: boolean
+    device?: {
+      prefersColorScheme?: string
+      mediaType?: string
+    }
+  }
+}

--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -46,13 +46,14 @@ export async function groupFilesByEnv(files: (readonly [WorkspaceProject, string
     const transformMode = getTransformMode(project.config.testTransformMode, file)
 
     const envOptions = JSON.parse(code.match(/@(?:vitest|jest)-environment-options\s+?(.+)/)?.[1] || 'null')
+    const envKey = env === 'happy-dom' ? 'happyDOM' : env
     return {
       file,
       project,
       environment: {
         name: env as VitestEnvironment,
         transformMode,
-        options: envOptions ? { [env]: envOptions } as EnvironmentOptions : null,
+        options: envOptions ? { [envKey]: envOptions } as EnvironmentOptions : null,
       },
     }
   }))

--- a/test/core/test/happy-dom-custom.test.ts
+++ b/test/core/test/happy-dom-custom.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @vitest-environment happy-dom
+ * @vitest-environment-options { "url": "http://my-website:5435", "settings": { "disableCSSFileLoading": true } }
+ */
+
+/* eslint-disable vars-on-top */
+
+import { expect, it } from 'vitest'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var happyDOM: any
+}
+
+it('custom URL is changed to my-website:5435', () => {
+  expect(location.href).toBe('http://my-website:5435/')
+})
+
+it('accepts custom environment options', () => {
+  // default is false
+  expect(window.happyDOM.settings.disableCSSFileLoading).toBe(true)
+})

--- a/test/core/test/happy-dom.test.ts
+++ b/test/core/test/happy-dom.test.ts
@@ -2,7 +2,6 @@
 
 /**
  * @vitest-environment happy-dom
- * @vitest-environment-options { "settings": { "disableCSSFileLoading": true }, "width": 1920 }
  */
 
 /* eslint-disable vars-on-top */
@@ -13,16 +12,15 @@ declare global {
   // eslint-disable-next-line no-var
   var __property_dom: unknown
   // eslint-disable-next-line no-var
-  var happyDOM: unknown
+  var happyDOM: any
 }
 
 it('defaults URL to localhost:3000', () => {
   expect(location.href).toBe('http://localhost:3000/')
 })
 
-it('accepts custom environment options', () => {
-  // default is false
-  expect((window.happyDOM as any).settings.disableCSSFileLoading).toBe(true)
+it('disableCSSFileLoading is false by default because we didn\'t change options', () => {
+  expect(window.happyDOM.settings.disableCSSFileLoading).toBe(false)
 })
 
 it('defined on self/window are defined on global', () => {

--- a/test/core/test/happy-dom.test.ts
+++ b/test/core/test/happy-dom.test.ts
@@ -2,6 +2,7 @@
 
 /**
  * @vitest-environment happy-dom
+ * @vitest-environment-options { "settings": { "disableCSSFileLoading": true }, "width": 1920 }
  */
 
 /* eslint-disable vars-on-top */
@@ -11,7 +12,18 @@ import { expect, it, vi } from 'vitest'
 declare global {
   // eslint-disable-next-line no-var
   var __property_dom: unknown
+  // eslint-disable-next-line no-var
+  var happyDOM: unknown
 }
+
+it('defaults URL to localhost:3000', () => {
+  expect(location.href).toBe('http://localhost:3000/')
+})
+
+it('accepts custom environment options', () => {
+  // default is false
+  expect((window.happyDOM as any).settings.disableCSSFileLoading).toBe(true)
+})
 
 it('defined on self/window are defined on global', () => {
   expect(self).toBeDefined()


### PR DESCRIPTION
### Description

This PR forwards the `environmentOptions` to `happy-dom` integration.

It follows the same principle defined in the `jsdom` integration

https://github.com/vitest-dev/vitest/blob/f4e6e99fa3a81fd7a97fb9b435da367dddba7fa4/packages/vitest/src/integrations/env/jsdom.ts#L32

> Reference: https://github.com/capricorn86/happy-dom/wiki/Getting-started#usage

Closes #3903 
Closes #3905

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
