### PR TITLE
fix: add workspace config files to default coverage excludes

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -899,6 +899,7 @@ List of files included in coverage as glob patterns
   '**/*{.,-}{test,spec}.?(c|m)[jt]s?(x)',
   '**/__tests__/**',
   '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+  '**/vitest.{workspace,projects}.[jt]s',
   '**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}',
 ]
 ```

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -899,7 +899,7 @@ List of files included in coverage as glob patterns
   '**/*{.,-}{test,spec}.?(c|m)[jt]s?(x)',
   '**/__tests__/**',
   '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
-  '**/vitest.{workspace,projects}.[jt]s',
+  '**/vitest.{workspace,projects}.[jt]s?(on)',
   '**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}',
 ]
 ```

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -24,7 +24,7 @@ const defaultCoverageExcludes = [
   '**/*{.,-}{test,spec}.?(c|m)[jt]s?(x)',
   '**/__tests__/**',
   '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
-  '**/vitest.{workspace,projects}.[jt]s',
+  '**/vitest.{workspace,projects}.[jt]s?(on)',
   '**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}',
 ]
 

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -24,6 +24,7 @@ const defaultCoverageExcludes = [
   '**/*{.,-}{test,spec}.?(c|m)[jt]s?(x)',
   '**/__tests__/**',
   '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+  '**/vitest.{workspace,projects}.[jt]s',
   '**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}',
 ]
 


### PR DESCRIPTION
### Description

When running the coverage report in a Vitest workspace will `all: true`, the `vitest.workspace.ts` file is analyzed for the coverage generation.

This PR adds the potential file names (from [docs](https://vitest.dev/guide/workspace.html#defining-a-workspace)) to the default coverage excludes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
