### PR TITLE
docs: add example for merging vite config defined as a function

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -68,6 +68,21 @@ export default mergeConfig(viteConfig, defineConfig({
 `mergeConfig` helper is availabe in Vitest since v0.30.0. You can import it from `vite` directly, if you use lower version.
 :::
 
+If your vite config is defined as a function, you can define the config like this:
+```ts
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default defineConfig(configEnv => mergeConfig(
+  viteConfig(configEnv),
+  defineConfig({
+    test: {
+      exclude: ['packages/template/*'],
+    },
+  })
+))
+```
+
 ## Options
 
 :::tip


### PR DESCRIPTION
### Description

As discussed in [this comment](https://github.com/vitejs/vite/issues/13950#issuecomment-1670085440), it's not trivial to understand how to merge a vite config defined as a function. Here's what I added concerning it:
![image](https://github.com/vitest-dev/vitest/assets/15926755/38d7626b-ba03-4ad1-814e-aed3ba91ade7)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
