### PR TITLE
fix(expect): improve the error message when nothing is thrown when ing `toThrow`

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -529,7 +529,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       }
 
       if (!isThrow && !isNot) {
-        const message = utils.flag(this, 'message') || 'expected function to throw an error, but it didn`t'
+        const message = utils.flag(this, 'message') || 'expected function to throw an error, but it didn\'t'
         const error = {
           showDiff: false,
         }

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -499,6 +499,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const promise = utils.flag(this, 'promise')
     const isNot = utils.flag(this, 'negate') as boolean
     let thrown: any = null
+
     if (promise === 'rejects') {
       thrown = obj
     }

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -499,7 +499,6 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const promise = utils.flag(this, 'promise')
     const isNot = utils.flag(this, 'negate') as boolean
     let thrown: any = null
-
     if (promise === 'rejects') {
       thrown = obj
     }
@@ -519,11 +518,21 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       }
     }
     else {
+      let isThrow = false
       try {
         obj()
       }
       catch (err) {
+        isThrow = true
         thrown = err
+      }
+
+      if (!isThrow && !isNot) {
+        const message = utils.flag(this, 'message') || 'expected function to throw an error, but it didn`t'
+        const error = {
+          showDiff: false,
+        }
+        throw new AssertionError(message, error, utils.flag(this, 'ssfi'))
       }
     }
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -332,6 +332,13 @@ describe('jest-expect', () => {
     expect(null).toBe(true)
   })
 
+  it.fails('toThrow should failure when does not throw ', () => {
+    expect(() => {
+    }).toThrow(Error)
+    expect(async () => {
+    }).toThrow(Error)
+  })
+
   // https://jestjs.io/docs/expect#tostrictequalvalue
 
   class LaCroix {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -332,13 +332,6 @@ describe('jest-expect', () => {
     expect(null).toBe(true)
   })
 
-  it.fails('toThrow should failure when does not throw ', () => {
-    expect(() => {
-    }).toThrow(Error)
-    expect(async () => {
-    }).toThrow(Error)
-  })
-
   // https://jestjs.io/docs/expect#tostrictequalvalue
 
   class LaCroix {
@@ -374,6 +367,18 @@ describe('jest-expect', () => {
         bar: { foo: 'foo', bar: 100, arr: ['first', { zoo: 'monkey' }] },
       },
     ])
+  })
+
+  it('toThrow didn\'t throw', () => {
+    expect(() => {
+      expect(async () => {
+      }).toThrow(Error)
+    }).toThrowErrorMatchingInlineSnapshot('"expected function to throw an error, but it didn\'t"')
+
+    expect(() => {
+      expect(() => {
+      }).toThrow(Error)
+    }).toThrowErrorMatchingInlineSnapshot('"expected function to throw an error, but it didn\'t"')
   })
 })
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -369,16 +369,20 @@ describe('jest-expect', () => {
     ])
   })
 
-  it('toThrow didn\'t throw', () => {
-    expect(() => {
-      expect(async () => {
-      }).toThrow(Error)
-    }).toThrowErrorMatchingInlineSnapshot('"expected function to throw an error, but it didn\'t"')
-
-    expect(() => {
+  describe('toThrow', () => {
+    it('error wasn\'t thrown', () => {
       expect(() => {
-      }).toThrow(Error)
-    }).toThrowErrorMatchingInlineSnapshot('"expected function to throw an error, but it didn\'t"')
+        expect(() => {
+        }).toThrow(Error)
+      }).toThrowErrorMatchingInlineSnapshot('"expected function to throw an error, but it didn\'t"')
+    })
+
+    it('async wasn\'t awaited', () => {
+      expect(() => {
+        expect(async () => {
+        }).toThrow(Error)
+      }).toThrowErrorMatchingInlineSnapshot('"expected function to throw an error, but it didn\'t"')
+    })
   })
 })
 


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix: #3941 
<img width="550" alt="image" src="https://github.com/vitest-dev/vitest/assets/29533304/bb83621c-c625-4cc0-9d2f-d8b3d2c23504">


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
