### PR TITLE
fix(vitest): correctly resolve optimizer status

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -207,7 +207,7 @@ You will not be able to edit your `node_modules` code for debugging, since the c
 #### deps.optimizer.{mode}.enabled
 
 - **Type:** `boolean`
-- **Default:** `false` since 0.34.3
+- **Default:** `true`
 
 Enable dependency optimization.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -207,7 +207,7 @@ You will not be able to edit your `node_modules` code for debugging, since the c
 #### deps.optimizer.{mode}.enabled
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false` since 0.34.3
 
 Enable dependency optimization.
 
@@ -227,7 +227,7 @@ Usually, files inside `node_modules` are externalized, but these options also af
 
 Should Vitest process assets (.png, .svg, .jpg, etc) files and resolve them like Vite does in the browser.
 
-hese module will have a default export equal to the path to the asset, if no query is specified.
+This module will have a default export equal to the path to the asset, if no query is specified.
 
 ::: warning
 At the moment, this option only works with [`experimentalVmThreads`](#experimentalvmthreads) pool.
@@ -240,7 +240,7 @@ At the moment, this option only works with [`experimentalVmThreads`](#experiment
 
 Should Vitest process CSS (.css, .scss, .sass, etc) files and resolve them like Vite does in the browser.
 
-If CSS files are disabled with [`css`](#css) options, this option will just silence `UNKNOWN_EXTENSION` errors.
+If CSS files are disabled with [`css`](#css) options, this option will just silence `ERR_UNKNOWN_FILE_EXTENSION` errors.
 
 ::: warning
 At the moment, this option only works with [`experimentalVmThreads`](#experimentalvmthreads) pool.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -207,9 +207,13 @@ You will not be able to edit your `node_modules` code for debugging, since the c
 #### deps.optimizer.{mode}.enabled
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `true` if using >= Vite 4.3.2, `false` otherwise
 
 Enable dependency optimization.
+
+::: warning
+This option only works with Vite 4.3.2 and higher.
+:::
 
 #### deps.web
 

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -137,6 +137,12 @@ export function resolveConfig(
   if (!resolved.deps.moduleDirectories.includes('/node_modules/'))
     resolved.deps.moduleDirectories.push('/node_modules/')
 
+  resolved.deps.optimizer ??= {}
+  resolved.deps.optimizer.ssr ??= {}
+  resolved.deps.optimizer.ssr.enabled ??= true
+  resolved.deps.optimizer.web ??= {}
+  resolved.deps.optimizer.web.enabled ??= true
+
   resolved.deps.web ??= {}
   resolved.deps.web.transformAssets ??= true
   resolved.deps.web.transformCss ??= true

--- a/packages/vitest/src/node/plugins/optimizer.ts
+++ b/packages/vitest/src/node/plugins/optimizer.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from 'vite'
+import { resolveOptimizerConfig } from './utils'
+
+export function VitestOptimizer(): Plugin {
+  return {
+    name: 'vitest:normalize-optimizer',
+    config: {
+      order: 'post',
+      handler(viteConfig) {
+        const testConfig = viteConfig.test || {}
+        const webOptimizer = resolveOptimizerConfig(testConfig.deps?.optimizer?.web, viteConfig.optimizeDeps, testConfig)
+        const ssrOptimizer = resolveOptimizerConfig(testConfig.deps?.optimizer?.ssr, viteConfig.ssr?.optimizeDeps, testConfig)
+
+        viteConfig.cacheDir = webOptimizer.cacheDir || ssrOptimizer.cacheDir || viteConfig.cacheDir
+        viteConfig.optimizeDeps = webOptimizer.optimizeDeps
+        viteConfig.ssr = {
+          optimizeDeps: ssrOptimizer.optimizeDeps,
+        }
+      },
+    },
+  }
+}

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -7,10 +7,10 @@ import type { DepsOptimizationOptions, InlineConfig } from '../../types'
 export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | undefined, viteOptions: DepOptimizationOptions | undefined, testConfig: InlineConfig) {
   const testOptions = _testOptions || {}
   const newConfig: { cacheDir?: string; optimizeDeps: DepOptimizationOptions } = {} as any
-  const [major, minor] = viteVersion.split('.').map(Number)
-  const allowed = major >= 5 || (major === 4 && minor >= 3)
+  const [major, minor, fix] = viteVersion.split('.').map(Number)
+  const allowed = major >= 5 || (major === 4 && minor >= 4) || (major === 4 && minor === 3 && fix >= 2)
   if (!allowed && testOptions?.enabled === true)
-    console.warn(`Vitest: "deps.optimizer" is only available in Vite >= 4.3.0, current Vite version: ${viteVersion}`)
+    console.warn(`Vitest: "deps.optimizer" is only available in Vite >= 4.3.2, current Vite version: ${viteVersion}`)
   else
     // enable by default
     testOptions.enabled ??= true

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,4 +1,3 @@
-import { builtinModules } from 'node:module'
 import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
 import type { DepOptimizationOptions, ResolvedConfig, UserConfig as ViteConfig } from 'vite'
 import { dirname } from 'pathe'
@@ -24,6 +23,17 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
   }
   else {
     const cacheDir = testConfig.cache !== false ? testConfig.cache?.dir : null
+    const currentInclude = (testOptions.include || viteOptions?.include || [])
+    const exclude = [
+      'vitest',
+      // Ideally, we shouldn't optimize react in test mode, otherwise we need to optimize _every_ dependency that uses react.
+      'react',
+      ...(testOptions.exclude || viteOptions?.exclude || []),
+    ]
+    const runtime = currentInclude.filter(n => n.endsWith('jsx-dev-runtime'))
+    exclude.push(...runtime)
+
+    const include = (testOptions.include || viteOptions?.include || []).filter((n: string) => !exclude.includes(n))
     newConfig.cacheDir = cacheDir ?? 'node_modules/.vitest'
     newConfig.optimizeDeps = {
       ...viteOptions,
@@ -31,8 +41,8 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
       noDiscovery: true,
       disabled: false,
       entries: [],
-      exclude: ['vitest', ...builtinModules, ...(testOptions.exclude || viteOptions?.exclude || [])],
-      include: (testOptions.include || viteOptions?.include || []).filter((n: string) => n !== 'vitest'),
+      exclude,
+      include,
     }
   }
   return newConfig

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -10,8 +10,9 @@ import { CSSEnablerPlugin } from './cssEnabler'
 import { SsrReplacerPlugin } from './ssrReplacer'
 import { GlobalSetupPlugin } from './globalSetup'
 import { MocksPlugin } from './mocks'
-import { deleteDefineConfig, hijackVitePluginInject, resolveFsAllow, resolveOptimizerConfig } from './utils'
+import { deleteDefineConfig, hijackVitePluginInject, resolveFsAllow } from './utils'
 import { VitestResolver } from './vitestResolver'
+import { VitestOptimizer } from './optimizer'
 
 interface WorkspaceOptions extends UserWorkspaceConfig {
   root?: string
@@ -95,15 +96,6 @@ export function WorkspaceVitestPlugin(project: WorkspaceProject, options: Worksp
           }
         }
 
-        const webOptimizer = resolveOptimizerConfig(testConfig.deps?.optimizer?.web, viteConfig.optimizeDeps, testConfig)
-        const ssrOptimizer = resolveOptimizerConfig(testConfig.deps?.optimizer?.ssr, viteConfig.ssr?.optimizeDeps, testConfig)
-
-        config.cacheDir = webOptimizer.cacheDir || ssrOptimizer.cacheDir || config.cacheDir
-        config.optimizeDeps = webOptimizer.optimizeDeps
-        config.ssr = {
-          optimizeDeps: ssrOptimizer.optimizeDeps,
-        }
-
         return config
       },
       configResolved(viteConfig) {
@@ -132,5 +124,6 @@ export function WorkspaceVitestPlugin(project: WorkspaceProject, options: Worksp
     GlobalSetupPlugin(project, project.ctx.logger),
     MocksPlugin(),
     VitestResolver(project.ctx),
+    VitestOptimizer(),
   ]
 }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -316,6 +316,7 @@ export class WorkspaceProject {
       },
       inspect: this.ctx.config.inspect,
       inspectBrk: this.ctx.config.inspectBrk,
+      alias: [],
     }, this.ctx.configOverride || {} as any,
     ) as ResolvedConfig
   }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -285,6 +285,7 @@ export class WorkspaceProject {
   }
 
   getSerializableConfig() {
+    const optimizer = this.config.deps?.optimizer
     return deepMerge({
       ...this.config,
       coverage: this.ctx.config.coverage,
@@ -293,10 +294,10 @@ export class WorkspaceProject {
         ...this.config.deps,
         optimizer: {
           web: {
-            enabled: this.config.deps?.optimizer?.web?.enabled ?? true,
+            enabled: optimizer?.web?.enabled ?? false,
           },
           ssr: {
-            enabled: this.config.deps?.optimizer?.ssr?.enabled ?? true,
+            enabled: optimizer?.ssr?.enabled ?? false,
           },
         },
       },

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -294,10 +294,10 @@ export class WorkspaceProject {
         ...this.config.deps,
         optimizer: {
           web: {
-            enabled: optimizer?.web?.enabled ?? false,
+            enabled: optimizer?.web?.enabled ?? true,
           },
           ssr: {
-            enabled: optimizer?.ssr?.enabled ?? false,
+            enabled: optimizer?.ssr?.enabled ?? true,
           },
         },
       },


### PR DESCRIPTION
### Description

Currently, optimizer doesn't work when `--api` or `--ui` is not passed down (this is happening because Vitest incorrectly extended optimizer configuration from Vite). This should be resolve separately before releasing 1.0.0.

Closes #3861

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
