### PR TITLE
fix(vite-node): inline HMR types

### DIFF
--- a/packages/vite-node/rollup.config.js
+++ b/packages/vite-node/rollup.config.js
@@ -27,7 +27,6 @@ const external = [
   'pathe',
   'birpc',
   'vite',
-  'vite/types/hot',
   'node:url',
   'node:events',
   'node:vm',

--- a/packages/vite-node/src/hmr/emitter.ts
+++ b/packages/vite-node/src/hmr/emitter.ts
@@ -47,7 +47,7 @@ export function viteNodeHmrPlugin(): Plugin {
     configureServer(server) {
       const _send = server.ws.send
       server.emitter = emitter
-      server.ws.send = function (payload: HMRPayload) {
+      server.ws.send = function (payload: any) {
         _send(payload)
         emitter.emit('message', payload)
       }


### PR DESCRIPTION
### Description

Fixes #3704

Partial revert of #3291

The initial externalization happened because we had misalignment with Vite HMR types once in a while, but later it turned out that these types were not publically available, so we are reverting it back.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
