### PR TITLE
feat(vitest): add "strict" option to node environment

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -288,7 +288,7 @@ export class ViteNodeRunner {
 
     if (externalize) {
       debugNative(externalize)
-      const exports = await this.interopedImport(externalize)
+      const exports = await this.interopedImport(externalize, undefined, moduleId)
       mod.exports = exports
       return exports
     }
@@ -436,15 +436,15 @@ export class ViteNodeRunner {
     return !path.endsWith('.mjs') && 'default' in mod
   }
 
-  protected importExternalModule(path: string) {
-    return import(path)
+  protected importExternalModule(path: string, options?: ImportCallOptions, _referencer?: string) {
+    return import(path, options)
   }
 
   /**
    * Import a module and interop it
    */
-  async interopedImport(path: string) {
-    const importedModule = await this.importExternalModule(path)
+  async interopedImport(path: string, options?: ImportCallOptions, referencer?: string) {
+    const importedModule = await this.importExternalModule(path, options, referencer)
 
     if (!this.shouldInterop(path, importedModule))
       return importedModule

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -151,6 +151,7 @@
     "@vitest/spy": "workspace:*",
     "@vitest/utils": "workspace:*",
     "acorn": "^8.9.0",
+    "acorn-import-assertions": "^1.9.0",
     "acorn-walk": "^8.2.0",
     "cac": "^6.7.14",
     "chai": "^4.3.7",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -182,6 +182,7 @@
     "@types/sinonjs__fake-timers": "^8.1.2",
     "birpc": "0.2.12",
     "chai-subset": "^1.6.0",
+    "cjs-module-lexer": "^1.2.3",
     "cli-truncate": "^3.1.0",
     "event-target-polyfill": "^0.0.3",
     "execa": "^7.1.1",

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -1,5 +1,9 @@
 import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
 import { relative } from 'pathe'
+
+// @ts-expect-error not typed
+import { importAssertions as importAssertionsPlugin } from 'acorn-import-assertions'
+
 import { configDefaults } from '../../defaults'
 import type { ResolvedConfig, UserConfig } from '../../types'
 import { deepMerge, notNullish, removeUndefinedValues } from '../../utils'
@@ -32,6 +36,9 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
       enforce: 'pre',
       options() {
         this.meta.watchMode = false
+        return {
+          acornInjectPlugins: [importAssertionsPlugin],
+        }
       },
       async config(viteConfig) {
         if (options.watch) {

--- a/packages/vitest/src/node/plugins/ssrReplacer.ts
+++ b/packages/vitest/src/node/plugins/ssrReplacer.ts
@@ -10,7 +10,7 @@ export function SsrReplacerPlugin(): Plugin {
     name: 'vitest:ssr-replacer',
     enforce: 'pre',
     transform(code, id) {
-      if (!/\bimport\.meta\.env\b/.test(code) && !/\bimport\.meta\.url\b/.test(code))
+      if (!/\bimport\.meta\.env\b/.test(code))
         return null
 
       let s: MagicString | null = null

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -261,10 +261,13 @@ export class VitestExecutor extends ViteNodeRunner {
     await fn(...Object.values(context))
   }
 
-  public async importExternalModule(path: string): Promise<any> {
-    if (this.externalModules)
-      return this.externalModules.import(path)
-    return super.importExternalModule(path)
+  public async importExternalModule(path: string, options?: ImportCallOptions, referencer?: string): Promise<any> {
+    if (!this.externalModules)
+      return super.importExternalModule(path, options, referencer)
+    return this.externalModules.import(path, {
+      ...options,
+      $_referencer: referencer ? pathToFileURL(referencer).href : undefined,
+    })
   }
 
   async dependencyRequest(id: string, fsPath: string, callstack: string[]): Promise<any> {

--- a/packages/vitest/src/runtime/external-executor.ts
+++ b/packages/vitest/src/runtime/external-executor.ts
@@ -112,7 +112,7 @@ export class ExternalModulesExecutor {
 
   private wrapCoreSynteticModule(identifier: string, exports: Record<string, unknown>) {
     const moduleKeys = Object.keys(exports)
-    const m: any = new SyntheticModule(
+    const m = new SyntheticModule(
       [...moduleKeys, 'default'],
       () => {
         for (const key of moduleKeys)
@@ -130,7 +130,7 @@ export class ExternalModulesExecutor {
   private wrapCommonJsSynteticModule(identifier: string, exports: Record<string, unknown>) {
     // TODO: technically module should be parsed to find static exports, implement for strict mode in #2854
     const { keys, moduleExports, defaultExport } = interopCommonJsModule(this.options.interopDefault, exports)
-    const m: any = new SyntheticModule(
+    const m = new SyntheticModule(
       [...keys, 'default'],
       () => {
         for (const key of keys)

--- a/packages/vitest/src/runtime/vm/errors.ts
+++ b/packages/vitest/src/runtime/vm/errors.ts
@@ -1,0 +1,16 @@
+// https://github.com/nodejs/node/blob/62b2cf30f2d1326dde9d4bc047f5611f17c4a20f/lib/internal/errors.js
+
+export default {
+  VITEST_ERR_IMPORT_ASSERTION_TYPE_MISSING: 'ERR_IMPORT_ASSERTION_TYPE_MISSING', // An import assertion is missing, preventing the specified module to be imported
+  VITEST_ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED', // An import assertion is not supported by this version of Node.js
+  VITEST_ERR_IMPORT_ASSERTION_TYPE_FAILED: 'ERR_IMPORT_ASSERTION_TYPE_FAILED', // An import assertion has failed, preventing the specified module to be imported
+
+  // TODO
+  VITEST_ERR_UNKNOWN_BUILTIN_MODULE: 'ERR_UNKNOWN_BUILTIN_MODULE', // Importing with node: but module is not found
+  VITEST_ERR_REQUIRE_ESM: 'ERR_REQUIRE_ESM', // An attempt was made to require() an ES Module.
+  // this might be resolved by import.meta.resolve
+  VITEST_ERR_UNKNOWN_FILE_EXTENSION: 'ERR_UNKNOWN_FILE_EXTENSION', // An attempt was made to load a module with an unknown or unsupported file extension
+  VITEST_ERR_UNKNOWN_MODULE_FORMAT: 'ERR_UNKNOWN_MODULE_FORMAT', // An attempt was made to load a module with an unknown or unsupported format
+  VITEST_ERR_UNSUPPORTED_DIR_IMPORT: 'ERR_UNSUPPORTED_DIR_IMPORT', // import a directory URL is unsupported
+  VITEST_ERR_UNSUPPORTED_ESM_URL_SCHEME: 'ERR_UNSUPPORTED_ESM_URL_SCHEME', // import with URL schemes other than file and data is unsupported.
+}

--- a/packages/vitest/src/runtime/vm/types.ts
+++ b/packages/vitest/src/runtime/vm/types.ts
@@ -70,3 +70,9 @@ export declare class VMSourceTextModule extends VMModule {
    */
   constructor(code: string, options?: SourceTextModuleOptions)
 }
+
+export interface CreateModuleOptions extends ImportCallOptions {
+  $_referencer?: string
+}
+
+export type ModuleFormat = 'data' | 'builtin' | 'vite' | 'module' | 'commonjs' | 'wasm' | 'json'

--- a/packages/vitest/src/runtime/vm/validate-assertion.ts
+++ b/packages/vitest/src/runtime/vm/validate-assertion.ts
@@ -1,0 +1,72 @@
+// https://github.com/nodejs/node/blob/62b2cf30f2d1326dde9d4bc047f5611f17c4a20f/lib/internal/modules/esm/assert.js
+
+import { assertTypes } from '@vitest/utils'
+import type { CreateModuleOptions, ModuleFormat } from './types'
+import { capitalize, createStrictNodeError, moduleString } from './utils'
+
+const kImplicitAssertType = 'javascript'
+
+const formatTypeMap = {
+  __proto__: null,
+  builtin: kImplicitAssertType,
+  commonjs: kImplicitAssertType,
+  json: 'json',
+  module: kImplicitAssertType,
+  data: kImplicitAssertType,
+  vite: kImplicitAssertType,
+  wasm: kImplicitAssertType, // It's unclear whether the HTML spec will require an assertion type or not for Wasm; see https://github.com/WebAssembly/esm-integration/issues/42
+}
+
+export const supportedAssertionTypes = Object.values(formatTypeMap).filter(name => name !== kImplicitAssertType)
+
+export function validateAssertion(
+  url: string,
+  format: ModuleFormat,
+  options?: CreateModuleOptions,
+) {
+  const assertions = options?.assert || {}
+  const validType = formatTypeMap[format]
+  if (validType === undefined)
+    return true
+
+  if (validType === kImplicitAssertType) {
+    if (!('type' in assertions))
+      return true
+    return handleInvalidType(url, options?.$_referencer, assertions.type)
+  }
+
+  // valid type
+  if (validType === assertions.type)
+    return true
+
+  if (!('type' in assertions)) {
+    throw createStrictNodeError(
+      `Cannot import ${moduleString(url, options?.$_referencer)} without specifying \`assert: { type: "${validType}" }\`.`,
+      'VITEST_ERR_IMPORT_ASSERTION_TYPE_MISSING',
+    )
+  }
+
+  return handleInvalidType(url, options?.$_referencer, assertions.type)
+}
+
+const supportedTypesMessage = `Node.js supports only these explicit types: ${supportedAssertionTypes.join(', ')}.`
+
+function handleInvalidType(url: string, referencer: string | undefined, type: string) {
+  assertTypes(type, 'type', ['string'])
+
+  let typesMessage = supportedTypesMessage
+  if (type === kImplicitAssertType)
+    typesMessage += ` You should omit the "type" option to use the default type for this file format since HTML spec forbids explicit usage of "${kImplicitAssertType}" type.`
+
+  if (!supportedAssertionTypes.includes(type)) {
+    throw createStrictNodeError(
+      `Type "${type}" on ${moduleString(url, referencer)} is not supported in Node.js. ${typesMessage}`,
+      'VITEST_ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED',
+    )
+  }
+
+  throw createStrictNodeError(
+    `${capitalize(moduleString(url, referencer))} is not of type "${type}". ${typesMessage}`,
+    'VITEST_ERR_IMPORT_ASSERTION_TYPE_FAILED',
+  )
+}

--- a/packages/vitest/src/runtime/vm/vite-executor.ts
+++ b/packages/vitest/src/runtime/vm/vite-executor.ts
@@ -58,7 +58,7 @@ export class ViteExecutor {
       return cached
     const result = await this.options.transform(fileUrl, 'web')
     if (!result.code)
-      throw new Error(`[vitest] Failed to transform ${fileUrl}. Does the file exists?`)
+      throw new Error(`[vitest] Failed to transform ${fileUrl}. Does the file exist?`)
     return this.esm.createEsModule(fileUrl, result.code)
   }
 

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -14,6 +14,7 @@ import type { SnapshotStateOptions } from './snapshot'
 import type { Arrayable } from './general'
 import type { BenchmarkUserOptions } from './benchmark'
 import type { BrowserConfigOptions, ResolvedBrowserOptions } from './browser'
+import type { NodeEnvironmentOptions } from './node-env-options'
 
 export type { SequenceHooks, SequenceSetupFiles } from '@vitest/runner'
 
@@ -28,11 +29,9 @@ export type ApiConfig = Pick<CommonServerOptions, 'port' | 'strictPort' | 'host'
 export type { JSDOMOptions, HappyDOMOptions }
 
 export interface EnvironmentOptions {
-  /**
-   * jsdom options.
-   */
   jsdom?: JSDOMOptions
   happyDOM?: HappyDOMOptions
+  node?: NodeEnvironmentOptions
   [x: string]: unknown
 }
 

--- a/packages/vitest/src/types/core.ts
+++ b/packages/vitest/src/types/core.ts
@@ -1,0 +1,4 @@
+import type { WorkspaceProject } from '../node/workspace'
+import type { Vitest } from '../node/core'
+
+export type VitestOrProject = Vitest | WorkspaceProject

--- a/packages/vitest/src/types/node-env-options.ts
+++ b/packages/vitest/src/types/node-env-options.ts
@@ -1,0 +1,12 @@
+export interface NodeEnvironmentOptions {
+  /**
+   * Should Vitest follow Node.js rules about ESM/CJS interop.
+   * TODO: extend description
+   *
+   * 1. CJS module will be parsed to find exports instead of using `Object.keys(module.exports)`.
+   * 2. CJS module will not have interoped default export (can have default.default).
+   *
+   * @default false
+   */
+  strict?: boolean
+}

--- a/packages/vitest/src/types/node-env-options.ts
+++ b/packages/vitest/src/types/node-env-options.ts
@@ -9,4 +9,7 @@ export interface NodeEnvironmentOptions {
    * @default false
    */
   strict?: boolean
+
+  // don't provide ESM for CJS context, and vice versa - consider as a separate flag
+  strictESM?: boolean
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
         version: 0.2.0(vite-plugin-pwa@0.16.4)
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+        version: 4.3.3(vite@4.3.9)(vue@3.3.4)
       esno:
         specifier: ^0.16.3
         version: 0.16.3
@@ -725,7 +725,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+        version: 4.3.3(vite@4.3.9)(vue@3.3.4)
       '@vue/test-utils':
         specifier: latest
         version: 2.4.0(vue@3.3.4)
@@ -835,7 +835,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+        version: 4.3.3(vite@4.3.9)(vue@3.3.4)
       '@vue/test-utils':
         specifier: ^2.0.2
         version: 2.0.2(vue@3.3.4)
@@ -863,7 +863,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+        version: 4.3.3(vite@4.3.9)(vue@3.3.4)
       '@vue/test-utils':
         specifier: ^2.0.0
         version: 2.0.0(vue@3.3.4)
@@ -881,7 +881,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+        version: 4.3.3(vite@4.3.9)(vue@3.3.4)
       '@vitejs/plugin-vue-jsx':
         specifier: latest
         version: 3.0.1(vite@4.3.9)(vue@3.3.4)
@@ -1317,6 +1317,9 @@ importers:
       acorn:
         specifier: ^8.9.0
         version: 8.9.0
+      acorn-import-assertions:
+        specifier: ^1.9.0
+        version: 1.9.0(acorn@8.9.0)
       acorn-walk:
         specifier: ^8.2.0
         version: 8.2.0
@@ -1631,7 +1634,7 @@ importers:
         version: 2.0.4
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+        version: 4.3.3(vite@4.3.9)(vue@3.3.4)
       '@vitest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -1779,6 +1782,12 @@ importers:
         version: link:../../packages/vitest
 
   test/mixed-pools:
+    devDependencies:
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+
+  test/node-strict:
     devDependencies:
       vitest:
         specifier: workspace:*
@@ -9111,6 +9120,10 @@ packages:
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
 
+  /@types/node@20.5.2:
+    resolution: {integrity: sha512-5j/lXt7unfPOUlrKC34HIaedONleyLtwkKggiD/0uuMfT8gg2EOpg0dz4lCD15Ga7muC+1WzJZAjIB9simWd6Q==}
+    dev: true
+
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
@@ -9538,7 +9551,7 @@ packages:
       colorette: 2.0.20
       consola: 3.1.0
       fast-glob: 3.3.0
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
@@ -9560,7 +9573,7 @@ packages:
       colorette: 2.0.20
       consola: 3.1.0
       fast-glob: 3.3.0
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
@@ -9602,7 +9615,7 @@ packages:
       '@unocss/core': 0.53.4
       css-tree: 2.3.1
       fast-glob: 3.3.0
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       postcss: 8.4.24
     dev: true
 
@@ -9717,7 +9730,7 @@ packages:
       '@unocss/transformer-directives': 0.53.4
       chokidar: 3.5.3
       fast-glob: 3.3.0
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       vite: 4.3.9(@types/node@18.16.19)(less@4.1.3)
     transitivePeerDependencies:
       - rollup
@@ -9737,7 +9750,7 @@ packages:
       '@unocss/transformer-directives': 0.53.4
       chokidar: 3.5.3
       fast-glob: 3.3.0
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       vite: 4.3.9(@types/node@18.16.19)(less@4.1.3)
     transitivePeerDependencies:
       - rollup
@@ -9848,8 +9861,8 @@ packages:
       vue: 3.3.4
     dev: true
 
-  /@vitejs/plugin-vue@4.3.2(vite@4.3.9)(vue@3.3.4):
-    resolution: {integrity: sha512-iDDhGruwhKkwNwT5qgtGaeTxF4ULs52xpQbsC27F01kf3aQBHtrDP738pmHw4oclVAUA3m+Vk8gxhDV5KbfM+A==}
+  /@vitejs/plugin-vue@4.3.3(vite@4.3.9)(vue@3.3.4):
+    resolution: {integrity: sha512-ssxyhIAZqB0TrpUg6R0cBpCuMk9jTIlO1GNSKKQD6S8VjnXi6JXKfUXjSsxey9IwQiaRGsO1WnW9Rkl1L6AJVw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.0.0
@@ -10316,14 +10329,14 @@ packages:
     resolution: {integrity: sha512-VZ1WFHTNKjR8Ga97TtV2SZM6fvRjWbYI2i/f4pJB4PtusorKvONAMJf2LQcUBIyzbVobqr7KSrcjmSwRolI+yw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 20.5.2
     dev: true
 
   /@wdio/types@8.10.4:
     resolution: {integrity: sha512-aLJ1QQW+hhALeRK3bvMLjIrlUVyhOs3Od+91pR4Z4pLwyeNG1bJZCJRD5bAJK/mm7CnFa0NsdixPS9jJxZcRrw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 20.5.2
     dev: true
 
   /@wdio/utils@8.12.1:
@@ -10691,6 +10704,14 @@ packages:
     dependencies:
       acorn: 8.9.0
     dev: true
+
+  /acorn-import-assertions@1.9.0(acorn@8.9.0):
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.9.0
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@7.4.1):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -12309,7 +12330,7 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 20.5.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.3.0
@@ -12345,10 +12366,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
-    dev: true
-
-  /cjs-module-lexer@1.2.2:
-    resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: true
 
   /cjs-module-lexer@1.2.3:
@@ -13612,7 +13629,7 @@ packages:
     resolution: {integrity: sha512-R72raQLN1lDSqbr2DVj9SRh07JRyojzmrcLa33VBa2nw3cf5ZyHOHe0DgxlJ/5c2Dfs1+wGNJy16gWKGBq+xgg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 20.5.2
       '@wdio/config': 8.12.1
       '@wdio/logger': 8.11.0
       '@wdio/protocols': 8.11.0
@@ -18046,7 +18063,7 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
-      cjs-module-lexer: 1.2.2
+      cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
       glob: 7.2.3
@@ -25283,7 +25300,7 @@ packages:
     dependencies:
       '@docsearch/css': 3.5.1
       '@docsearch/js': 3.5.1(search-insights@2.6.0)
-      '@vitejs/plugin-vue': 4.3.2(vite@4.3.9)(vue@3.3.4)
+      '@vitejs/plugin-vue': 4.3.3(vite@4.3.9)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 10.2.1(vue@3.3.4)
       '@vueuse/integrations': 10.2.1(focus-trap@7.4.3)(vue@3.3.4)
@@ -25559,7 +25576,7 @@ packages:
     resolution: {integrity: sha512-Ca+MUYUXfl5gsnX40xAIUgfoa76qQsfX7REGFzMl09Cb7vHKtM17bEOGDaTbXIX4kbkXylyUSAuBpe3gCtDDKg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 20.5.2
       '@types/ws': 8.5.5
       '@wdio/config': 8.12.1
       '@wdio/logger': 8.11.0
@@ -25579,7 +25596,7 @@ packages:
     resolution: {integrity: sha512-lW0Qo3fy64cVbYWWAZbXxLIOK0pbTARgpY89J+0Sr6zh2K2NKtd/0D11k3WfMeYxd0b0he7E7XC1b6M6w4h75A==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.1
+      '@types/node': 20.5.2
       '@wdio/config': 8.12.1
       '@wdio/logger': 8.11.0
       '@wdio/protocols': 8.11.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,7 +325,7 @@ importers:
         version: 13.3.0(react-dom@18.0.0)(react@18.0.0)
       '@types/node':
         specifier: latest
-        version: 20.5.0
+        version: 20.5.1
       '@types/react':
         specifier: latest
         version: 18.2.20
@@ -1405,6 +1405,9 @@ importers:
       chai-subset:
         specifier: ^1.6.0
         version: 1.6.0
+      cjs-module-lexer:
+        specifier: ^1.2.3
+        version: 1.2.3
       cli-truncate:
         specifier: ^3.1.0
         version: 3.1.0
@@ -6016,7 +6019,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -6037,7 +6040,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -6074,7 +6077,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       jest-mock: 27.5.1
     dev: true
 
@@ -6091,7 +6094,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -6120,7 +6123,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -6233,7 +6236,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: true
@@ -6244,7 +6247,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -6256,7 +6259,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       '@types/yargs': 17.0.12
       chalk: 4.1.2
     dev: true
@@ -8867,7 +8870,7 @@ packages:
   /@types/cheerio@0.22.31:
     resolution: {integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/codemirror@5.60.8:
@@ -8943,27 +8946,27 @@ packages:
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/glob@8.0.0:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/hast@2.3.4:
@@ -9047,7 +9050,7 @@ packages:
   /@types/jsonfile@6.1.1:
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/lodash@4.14.195:
@@ -9081,7 +9084,7 @@ packages:
   /@types/node-fetch@2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       form-data: 3.0.1
     dev: true
 
@@ -9102,6 +9105,10 @@ packages:
 
   /@types/node@20.5.0:
     resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
+    dev: true
+
+  /@types/node@20.5.1:
+    resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -9207,7 +9214,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/resolve@1.20.2:
@@ -9224,7 +9231,7 @@ packages:
   /@types/set-cookie-parser@2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/sinonjs__fake-timers@8.1.1:
@@ -9266,7 +9273,7 @@ packages:
   /@types/through@0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /@types/tough-cookie@4.0.2:
@@ -9304,7 +9311,7 @@ packages:
   /@types/webpack-sources@3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: true
@@ -9312,7 +9319,7 @@ packages:
   /@types/webpack@4.41.32:
     resolution: {integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.17.0
       '@types/webpack-sources': 3.2.0
@@ -9356,7 +9363,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
     optional: true
 
@@ -9798,7 +9805,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.9)
       react-refresh: 0.14.0
-      vite: 4.3.9(@types/node@20.5.0)
+      vite: 4.3.9(@types/node@20.5.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9832,6 +9839,17 @@ packages:
 
   /@vitejs/plugin-vue@4.2.3(vite@4.3.9)(vue@3.3.4):
     resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 4.3.9(@types/node@18.16.19)(less@4.1.3)
+      vue: 3.3.4
+    dev: true
+
+  /@vitejs/plugin-vue@4.3.2(vite@4.3.9)(vue@3.3.4):
+    resolution: {integrity: sha512-iDDhGruwhKkwNwT5qgtGaeTxF4ULs52xpQbsC27F01kf3aQBHtrDP738pmHw4oclVAUA3m+Vk8gxhDV5KbfM+A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.0.0
@@ -10298,14 +10316,14 @@ packages:
     resolution: {integrity: sha512-VZ1WFHTNKjR8Ga97TtV2SZM6fvRjWbYI2i/f4pJB4PtusorKvONAMJf2LQcUBIyzbVobqr7KSrcjmSwRolI+yw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
     dev: true
 
   /@wdio/types@8.10.4:
     resolution: {integrity: sha512-aLJ1QQW+hhALeRK3bvMLjIrlUVyhOs3Od+91pR4Z4pLwyeNG1bJZCJRD5bAJK/mm7CnFa0NsdixPS9jJxZcRrw==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
     dev: true
 
   /@wdio/utils@8.12.1:
@@ -12291,7 +12309,7 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.3.0
@@ -12331,6 +12349,10 @@ packages:
 
   /cjs-module-lexer@1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: true
+
+  /cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
     dev: true
 
   /class-utils@0.3.6:
@@ -13590,7 +13612,7 @@ packages:
     resolution: {integrity: sha512-R72raQLN1lDSqbr2DVj9SRh07JRyojzmrcLa33VBa2nw3cf5ZyHOHe0DgxlJ/5c2Dfs1+wGNJy16gWKGBq+xgg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       '@wdio/config': 8.12.1
       '@wdio/logger': 8.11.0
       '@wdio/protocols': 8.11.0
@@ -17610,7 +17632,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -17746,7 +17768,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -17764,7 +17786,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -17785,7 +17807,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -17808,7 +17830,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -17848,7 +17870,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -17928,7 +17950,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -17989,7 +18011,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.10
@@ -18046,7 +18068,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       graceful-fs: 4.2.10
     dev: true
 
@@ -18054,7 +18076,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       graceful-fs: 4.2.10
     dev: true
 
@@ -18093,7 +18115,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       graceful-fs: 4.2.10
       is-ci: 2.0.0
@@ -18105,7 +18127,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.10
@@ -18117,7 +18139,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.0.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.10
@@ -18142,7 +18164,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -18153,7 +18175,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -18162,7 +18184,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 18.16.19
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -24782,7 +24804,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.0
       local-pkg: 0.4.3
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       minimatch: 9.0.3
       resolve: 1.22.3
       unplugin: 1.3.2
@@ -25200,7 +25222,7 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /vite@4.3.9(@types/node@20.5.0):
+  /vite@4.3.9(@types/node@20.5.1):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -25225,7 +25247,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       esbuild: 0.17.18
       postcss: 8.4.24
       rollup: 3.23.0
@@ -25261,7 +25283,7 @@ packages:
     dependencies:
       '@docsearch/css': 3.5.1
       '@docsearch/js': 3.5.1(search-insights@2.6.0)
-      '@vitejs/plugin-vue': 4.2.3(vite@4.3.9)(vue@3.3.4)
+      '@vitejs/plugin-vue': 4.3.2(vite@4.3.9)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 10.2.1(vue@3.3.4)
       '@vueuse/integrations': 10.2.1(focus-trap@7.4.3)(vue@3.3.4)
@@ -25537,7 +25559,7 @@ packages:
     resolution: {integrity: sha512-Ca+MUYUXfl5gsnX40xAIUgfoa76qQsfX7REGFzMl09Cb7vHKtM17bEOGDaTbXIX4kbkXylyUSAuBpe3gCtDDKg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       '@types/ws': 8.5.5
       '@wdio/config': 8.12.1
       '@wdio/logger': 8.11.0
@@ -25557,7 +25579,7 @@ packages:
     resolution: {integrity: sha512-lW0Qo3fy64cVbYWWAZbXxLIOK0pbTARgpY89J+0Sr6zh2K2NKtd/0D11k3WfMeYxd0b0he7E7XC1b6M6w4h75A==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@types/node': 20.5.0
+      '@types/node': 20.5.1
       '@wdio/config': 8.12.1
       '@wdio/logger': 8.11.0
       '@wdio/protocols': 8.11.0

--- a/test/node-strict/package.json
+++ b/test/node-strict/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-node-strict",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "vitest": "workspace:*"
+  }
+}

--- a/test/node-strict/src/external/import-json.js
+++ b/test/node-strict/src/external/import-json.js
@@ -1,0 +1,1 @@
+import '../table.json'

--- a/test/node-strict/src/external/table.json
+++ b/test/node-strict/src/external/table.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Bulbasaur",
+    "type": "Grass"
+  },
+  {
+    "name": "Ivysaur",
+    "type": "Grass"
+  }
+]

--- a/test/node-strict/src/import-json.js
+++ b/test/node-strict/src/import-json.js
@@ -1,0 +1,1 @@
+import './table.json'

--- a/test/node-strict/src/table.json
+++ b/test/node-strict/src/table.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Bulbasaur",
+    "type": "Grass"
+  },
+  {
+    "name": "Ivysaur",
+    "type": "Grass"
+  }
+]

--- a/test/node-strict/tests/importing-json.spec.js
+++ b/test/node-strict/tests/importing-json.spec.js
@@ -1,0 +1,20 @@
+import { expect, it } from 'vitest'
+
+it('cannot import json without an assertion in an external file', async () => {
+  try {
+    await import('../src/external/import-json.js')
+    expect.unreachable()
+  }
+  catch (err) {
+    const message = err.message.replace(new RegExp(process.cwd(), 'g'), '<root>')
+    expect(message).toMatchInlineSnapshot(`
+      "Cannot import JSON file \\"file://<root>/src/table.json\\" (imported from \\"file://<root>/src/external/import-json.js\\") without specifying \`assert: { type: \\"json\\" }\`.
+
+      This error happened because you enabled \\"strict\\" option in your \\"test.environmentOptions.node\\" configuration and have \\"node\\" environment enabled.
+      To not see this error, fix the issue described above or disable this behavior by setting \\"strict\\" to \\"false\\".
+      "
+    `)
+  }
+})
+
+// TODO: importing other typesm check "validate-assertion" conditions

--- a/test/node-strict/tests/importing-json.spec.js
+++ b/test/node-strict/tests/importing-json.spec.js
@@ -2,7 +2,7 @@ import { expect, it } from 'vitest'
 
 it('cannot import json without an assertion in an external file', async () => {
   try {
-    await import('../src/external/import-json.js')
+    await import('../src/external/import-json.js', { assert: { type: 'javascript' } })
     expect.unreachable()
   }
   catch (err) {

--- a/test/node-strict/vitest.config.ts
+++ b/test/node-strict/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        external: [/src\/external/],
+      },
+    },
+    environment: 'node',
+    environmentOptions: {
+      node: {
+        strict: true,
+      },
+    },
+    experimentalVmThreads: true,
+  },
+})


### PR DESCRIPTION
### Description

Currently Vitest "just works" when testing native Node.js applications even when the regular application would fail due to ESM incompatibilities. It is a good idea to run tests in the same environment where the actual application is running, but there are some pitfalls when providing such an environment.

This PR aims to cover all possible ESM/CJS issues that might arise when running code in Node.js env. For the first iteration, we assume that the code is bundled as ESM (even if tsconfig says otherwise).

Closes #2841
Closes #2198

TODO:
- [ ] Tests
- [ ] Docs
- [ ] Examples
- [ ] Better error messages

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
