### PR TITLE
fix: report file error as a <failure> on JUnit

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ coverage
 docs/.vitepress/cache/deps/*.*
 test/core/src/self
 test/workspaces/results.json
+test/reporters/fixtures/with-syntax-error.test.js

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -216,6 +216,23 @@ export class JUnitReporter implements Reporter {
           skipped: 0,
         })
 
+        // If there are no tests, but the file failed to load, we still want to report it as a failure
+        if (tasks.length === 0 && file.result?.state === 'fail') {
+          stats.failures = 1
+
+          tasks.push({
+            id: file.id,
+            type: 'test',
+            name: file.name,
+            mode: 'run',
+            result: file.result,
+            meta: {},
+            // NOTE: not used in JUnitReporter
+            context: null as any,
+            suite: null as any,
+          } satisfies Task)
+        }
+
         return {
           ...file,
           tasks,

--- a/test/reporters/fixtures/with-syntax-error.test.js
+++ b/test/reporters/fixtures/with-syntax-error.test.js
@@ -1,0 +1,4 @@
+// NOTE: This file is intentionally not valid JavaScript.
+
+it('should fail', () => {
+)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes #3423.

This pull request makes the JUnit reporter to report a file error as a `<failure>`, which was otherwise ignored. This would be helpful for testing possibly broken code (e.g. code with an syntax error) with Vitest + JUnit-compatible testing tools.

Before:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<testsuites name="vitest tests" tests="0" failures="0" errors="0" time="1.556">
    <testsuite name="with-syntax-error.test.js" timestamp="TIMESTAMP" hostname="HOSTNAME" tests="0" failures="0" errors="0" skipped="0" time="0">
    </testsuite>
</testsuites>
```

After:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<testsuites name="vitest tests" tests="1" failures="1" errors="0" time="2.529">
    <testsuite name="with-syntax-error.test.js" timestamp="TIMESTAMP" hostname="HOSTNAME" tests="1" failures="1" errors="0" skipped="0" time="0">
        <testcase classname="with-syntax-error.test.js" name="with-syntax-error.test.js" time="0">
            <failure message="Failed to parse source for import analysis because the content contains invalid JS syntax. If you are using JSX, make sure to name the file with the .jsx or .tsx extension." type="Error">
Error: Failed to parse source for import analysis because the content contains invalid JS syntax. If you are using JSX, make sure to name the file with the .jsx or .tsx extension.
 ❯ formatError ../../../node_modules/.pnpm/vite@4.3.9_@types+node@18.7.13/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:42645:46
 ❯ TransformContext.error ../../../node_modules/.pnpm/vite@4.3.9_@types+node@18.7.13/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:42641:19
 ❯ TransformContext.transform ../../../node_modules/.pnpm/vite@4.3.9_@types+node@18.7.13/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:40447:22
 ❯ Object.transform ../../../node_modules/.pnpm/vite@4.3.9_@types+node@18.7.13/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:42919:30
 ❯ loadAndTransform ../../../node_modules/.pnpm/vite@4.3.9_@types+node@18.7.13/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:53385:29
            </failure>
        </testcase>
    </testsuite>
</testsuites>
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
