### PR TITLE
fix(coverage): log info only when terminal reporter is used

### DIFF
--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -50,6 +50,7 @@
     "istanbul-lib-report": "^3.0.1",
     "istanbul-lib-source-maps": "^4.0.1",
     "istanbul-reports": "^3.1.5",
+    "picocolors": "^1.0.0",
     "test-exclude": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -3,6 +3,7 @@ import { resolve } from 'pathe'
 import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, ReportContext, ResolvedCoverageOptions, Vitest } from 'vitest'
 import { coverageConfigDefaults, defaultExclude, defaultInclude } from 'vitest/config'
 import { BaseCoverageProvider } from 'vitest/coverage'
+import c from 'picocolors'
 import libReport from 'istanbul-lib-report'
 import reports from 'istanbul-reports'
 import type { CoverageMap } from 'istanbul-lib-coverage'
@@ -134,6 +135,9 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       watermarks: this.options.watermarks,
     })
 
+    if (hasTerminalReporter(this.options.reporter))
+      this.ctx.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.name))
+
     for (const reporter of this.options.reporter) {
       reports.create(reporter[0], {
         skipFull: this.options.skipFull,
@@ -252,4 +256,12 @@ function isEmptyCoverageRange(range: libCoverage.Range) {
     || range.end.line === undefined
     || range.end.column === undefined
   )
+}
+
+function hasTerminalReporter(reporters: Options['reporter']) {
+  return reporters.some(([reporter]) =>
+    reporter === 'text'
+    || reporter === 'text-summary'
+    || reporter === 'text-lcov'
+    || reporter === 'teamcity')
 }

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -143,6 +143,9 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       watermarks: this.options.watermarks,
     })
 
+    if (hasTerminalReporter(this.options.reporter))
+      this.ctx.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.name))
+
     for (const reporter of this.options.reporter) {
       reports.create(reporter[0], {
         skipFull: this.options.skipFull,
@@ -294,4 +297,12 @@ function normalizeTransformResults(fetchCaches: Map<string, { result: FetchResul
   }
 
   return normalized
+}
+
+function hasTerminalReporter(reporters: Options['reporter']) {
+  return reporters.some(([reporter]) =>
+    reporter === 'text'
+    || reporter === 'text-summary'
+    || reporter === 'text-lcov'
+    || reporter === 'teamcity')
 }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -730,10 +730,8 @@ export class Vitest {
     if (!this.config.coverage.reportOnFailure && this.state.getCountOfFailedTests() > 0)
       return
 
-    if (this.coverageProvider) {
-      this.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.coverageProvider.name))
+    if (this.coverageProvider)
       await this.coverageProvider.reportCoverage({ allTestsRun })
-    }
   }
 
   async close() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -983,6 +983,9 @@ importers:
       istanbul-reports:
         specifier: ^3.1.5
         version: 3.1.5
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.0.0
       test-exclude:
         specifier: ^6.0.0
         version: 6.0.0


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Fixes https://github.com/vitest-dev/vitest/discussions/4013.

When using coverage reporters which don't output anything to terminal, there is no need to log the info message.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  -  The `test/fails` has a test case that is verifying this info message
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
