### PR TITLE
fix(vitest): "vi" doesn't rely on context

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -200,7 +200,7 @@ function createVitest(): VitestUtils {
     return stack?.file || ''
   }
 
-  return {
+  const utils: VitestUtils = {
     useFakeTimers(config?: FakeTimerInstallOpts) {
       if (config) {
         _timers.configure(config)
@@ -210,58 +210,58 @@ function createVitest(): VitestUtils {
         _timers.configure(workerState.config.fakeTimers)
       }
       _timers.useFakeTimers()
-      return this
+      return utils
     },
 
     useRealTimers() {
       _timers.useRealTimers()
       _mockedDate = null
-      return this
+      return utils
     },
 
     runOnlyPendingTimers() {
       _timers.runOnlyPendingTimers()
-      return this
+      return utils
     },
 
     async runOnlyPendingTimersAsync() {
       await _timers.runOnlyPendingTimersAsync()
-      return this
+      return utils
     },
 
     runAllTimers() {
       _timers.runAllTimers()
-      return this
+      return utils
     },
 
     async runAllTimersAsync() {
       await _timers.runAllTimersAsync()
-      return this
+      return utils
     },
 
     runAllTicks() {
       _timers.runAllTicks()
-      return this
+      return utils
     },
 
     advanceTimersByTime(ms: number) {
       _timers.advanceTimersByTime(ms)
-      return this
+      return utils
     },
 
     async advanceTimersByTimeAsync(ms: number) {
       await _timers.advanceTimersByTimeAsync(ms)
-      return this
+      return utils
     },
 
     advanceTimersToNextTimer() {
       _timers.advanceTimersToNextTimer()
-      return this
+      return utils
     },
 
     async advanceTimersToNextTimerAsync() {
       await _timers.advanceTimersToNextTimerAsync()
-      return this
+      return utils
     },
 
     getTimerCount() {
@@ -272,7 +272,7 @@ function createVitest(): VitestUtils {
       const date = time instanceof Date ? time : new Date(time)
       _mockedDate = date
       _timers.setSystemTime(date)
-      return this
+      return utils
     },
 
     getMockedSystemTime() {
@@ -285,7 +285,7 @@ function createVitest(): VitestUtils {
 
     clearAllTimers() {
       _timers.clearAllTimers()
-      return this
+      return utils
     },
 
     // mocks
@@ -337,17 +337,17 @@ function createVitest(): VitestUtils {
 
     clearAllMocks() {
       spies.forEach(spy => spy.mockClear())
-      return this
+      return utils
     },
 
     resetAllMocks() {
       spies.forEach(spy => spy.mockReset())
-      return this
+      return utils
     },
 
     restoreAllMocks() {
       spies.forEach(spy => spy.mockRestore())
-      return this
+      return utils
     },
 
     stubGlobal(name: string | symbol | number, value: any) {
@@ -359,14 +359,14 @@ function createVitest(): VitestUtils {
         configurable: true,
         enumerable: true,
       })
-      return this
+      return utils
     },
 
     stubEnv(name: string, value: string) {
       if (!_stubsEnv.has(name))
         _stubsEnv.set(name, process.env[name])
       process.env[name] = value
-      return this
+      return utils
     },
 
     unstubAllGlobals() {
@@ -377,7 +377,7 @@ function createVitest(): VitestUtils {
           Object.defineProperty(globalThis, name, original)
       })
       _stubsGlobal.clear()
-      return this
+      return utils
     },
 
     unstubAllEnvs() {
@@ -388,13 +388,13 @@ function createVitest(): VitestUtils {
           process.env[name] = original
       })
       _stubsEnv.clear()
-      return this
+      return utils
     },
 
     resetModules() {
       const state = getWorkerState()
       resetModules(state.moduleCache)
-      return this
+      return utils
     },
 
     async dynamicImportSettled() {
@@ -414,8 +414,9 @@ function createVitest(): VitestUtils {
         Object.assign(state.config, _config)
       }
     },
-
   }
+
+  return utils
 }
 
 export const vitest = createVitest()


### PR DESCRIPTION
### Description

Allow passing down `vi.{method}` and chaining its result:

```ts
function chainable(fn: () => VitestUtils) {
  fn().useRealTimers()
}
chainable(vi.useFakeTimers)
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
