### PR TITLE
fix: resolving dep optimizer issues with workspace

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -319,7 +319,7 @@ export function resolveConfig(
 
   resolved.cache ??= { dir: '' }
   if (resolved.cache)
-    resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir)
+    resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir, resolved.name)
 
   resolved.sequence ??= {} as any
   if (!resolved.sequence?.sequencer) {

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -2,6 +2,7 @@ import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
 import type { DepOptimizationOptions, ResolvedConfig, UserConfig as ViteConfig } from 'vite'
 import { dirname } from 'pathe'
 import type { DepsOptimizationOptions, InlineConfig } from '../../types'
+import { VitestCache } from '../cache'
 
 export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | undefined, viteOptions: DepOptimizationOptions | undefined, testConfig: InlineConfig) {
   const testOptions = _testOptions || {}
@@ -22,7 +23,8 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
     }
   }
   else {
-    const cacheDir = testConfig.cache !== false ? testConfig.cache?.dir : null
+    const root = testConfig.root ?? process.cwd()
+    const cacheDir = testConfig.cache !== false ? testConfig.cache?.dir : undefined
     const currentInclude = (testOptions.include || viteOptions?.include || [])
     const exclude = [
       'vitest',
@@ -34,7 +36,8 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
     exclude.push(...runtime)
 
     const include = (testOptions.include || viteOptions?.include || []).filter((n: string) => !exclude.includes(n))
-    newConfig.cacheDir = cacheDir ?? 'node_modules/.vitest'
+
+    newConfig.cacheDir = cacheDir ?? VitestCache.resolveCacheDir(root, cacheDir, testConfig.name)
     newConfig.optimizeDeps = {
       ...viteOptions,
       ...testOptions,


### PR DESCRIPTION
### Description

We now use a different cache directory per project in the workspace this way we don't wind up accidentally deleting the cache directory from one project as the next one starts running.

I'm using a hash of the project name as the basis for constructing the cache sub-directory. Using a hash here is primarily done as a way to avoid sanitizing the project name to remove characters that aren't valid directory names and dealing with collisions for similarly named projects that contain invalid characters ("Foo<" and "Foo>" might both sanitize to "Foo_") for example.

A potential downside to using project name (hashed or not) is that workspaces which don't define project names for their projects will fall back to using an index as the project name. As a result, changing the order of the projects in a workspace, can result in the wrong cache directory being used.

In some ways, it might be better to do something like hash the resolved config that way order wouldn't matter, and changing the config would result in a different hash, but I don't necessarily love that approach either since it would result in more directories being created and we don't currently ever clean-up the `node_modules/.vitest` directory to remove stale project dirs.

@sheremet-va please let me know if you have a preference for the above

Fixes #4020 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
