### PR TITLE
fix(vite-node): check more precisely for root/base paths

### DIFF
--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -251,7 +251,7 @@ export class ViteNodeServer {
         result = await this.server.ssrTransform(result.code, result.map, id)
     }
     else {
-      result = await this.server.transformRequest(filepath, { ssr: true })
+      result = await this.server.transformRequest(id, { ssr: true })
     }
 
     const sourcemap = this.options.sourcemap ?? 'inline'

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -182,7 +182,7 @@ export class ViteNodeServer {
     const cacheDir = this.options.deps?.cacheDir
 
     if (cacheDir && id.includes(cacheDir)) {
-      if (!id.startsWith(withTrailingSlash(this.server.config.root))
+      if (!id.startsWith(withTrailingSlash(this.server.config.root)))
         id = join(this.server.config.root, id)
       const timeout = setTimeout(() => {
         throw new Error(`ViteNodeServer: ${id} not found. This is a bug, please report it.`)

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -6,7 +6,7 @@ import createDebug from 'debug'
 import type { EncodedSourceMap } from '@jridgewell/trace-mapping'
 import type { DebuggerOptions, FetchResult, ViteNodeResolveId, ViteNodeServerOptions } from './types'
 import { shouldExternalize } from './externalize'
-import { normalizeModuleId, toArray, toFilePath } from './utils'
+import { normalizeModuleId, toArray, toFilePath, withTrailingSlash } from './utils'
 import { Debugger } from './debug'
 import { withInlineSourcemap } from './source-map'
 
@@ -106,7 +106,7 @@ export class ViteNodeServer {
   }
 
   async resolveId(id: string, importer?: string, transformMode?: 'web' | 'ssr'): Promise<ViteNodeResolveId | null> {
-    if (importer && !importer.startsWith(`${this.server.config.root}/`))
+    if (importer && !importer.startsWith(withTrailingSlash(this.server.config.root)))
       importer = resolve(this.server.config.root, importer)
     const mode = transformMode ?? ((importer && this.getTransformMode(importer)) || 'ssr')
     return this.server.pluginContainer.resolveId(id, importer, { ssr: mode === 'ssr' })
@@ -182,7 +182,7 @@ export class ViteNodeServer {
     const cacheDir = this.options.deps?.cacheDir
 
     if (cacheDir && id.includes(cacheDir)) {
-      if (!id.startsWith(`${this.server.config.root}/`))
+      if (!id.startsWith(withTrailingSlash(this.server.config.root))
         id = join(this.server.config.root, id)
       const timeout = setTimeout(() => {
         throw new Error(`ViteNodeServer: ${id} not found. This is a bug, please report it.`)

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -106,7 +106,7 @@ export class ViteNodeServer {
   }
 
   async resolveId(id: string, importer?: string, transformMode?: 'web' | 'ssr'): Promise<ViteNodeResolveId | null> {
-    if (importer && !importer.startsWith(this.server.config.root))
+    if (importer && !importer.startsWith(`${this.server.config.root}/`))
       importer = resolve(this.server.config.root, importer)
     const mode = transformMode ?? ((importer && this.getTransformMode(importer)) || 'ssr')
     return this.server.pluginContainer.resolveId(id, importer, { ssr: mode === 'ssr' })
@@ -182,7 +182,7 @@ export class ViteNodeServer {
     const cacheDir = this.options.deps?.cacheDir
 
     if (cacheDir && id.includes(cacheDir)) {
-      if (!id.startsWith(this.server.config.root))
+      if (!id.startsWith(`${this.server.config.root}/`))
         id = join(this.server.config.root, id)
       const timeout = setTimeout(() => {
         throw new Error(`ViteNodeServer: ${id} not found. This is a bug, please report it.`)

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -251,7 +251,7 @@ export class ViteNodeServer {
         result = await this.server.ssrTransform(result.code, result.map, id)
     }
     else {
-      result = await this.server.transformRequest(id, { ssr: true })
+      result = await this.server.transformRequest(filepath, { ssr: true })
     }
 
     const sourcemap = this.options.sourcemap ?? 'inline'

--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -1,6 +1,7 @@
 import type { TransformResult } from 'vite'
 import { dirname, isAbsolute, relative, resolve } from 'pathe'
 import type { EncodedSourceMap } from '@jridgewell/trace-mapping'
+import { withTrailingSlash } from 'vite-node/utils'
 import { install } from './source-map-handler'
 
 interface InstallSourceMapSupportOptions {
@@ -32,7 +33,7 @@ export function withInlineSourcemap(result: TransformResult, options: {
     // this is a bug in Vite
     // all files should be either absolute to the file system or relative to the source map file
     if (isAbsolute(source)) {
-      const actualPath = (!source.startsWith(`${options.root}/`) && source.startsWith('/'))
+      const actualPath = (!source.startsWith(withTrailingSlash(options.root)) && source.startsWith('/'))
         ? resolve(options.root, source.slice(1))
         : source
       return relative(dirname(options.filepath), actualPath)

--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -1,7 +1,7 @@
 import type { TransformResult } from 'vite'
 import { dirname, isAbsolute, relative, resolve } from 'pathe'
 import type { EncodedSourceMap } from '@jridgewell/trace-mapping'
-import { withTrailingSlash } from 'vite-node/utils'
+import { withTrailingSlash } from './utils'
 import { install } from './source-map-handler'
 
 interface InstallSourceMapSupportOptions {

--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -32,7 +32,7 @@ export function withInlineSourcemap(result: TransformResult, options: {
     // this is a bug in Vite
     // all files should be either absolute to the file system or relative to the source map file
     if (isAbsolute(source)) {
-      const actualPath = (!source.startsWith(options.root) && source.startsWith('/'))
+      const actualPath = (!source.startsWith(`${options.root}/`) && source.startsWith('/'))
         ? resolve(options.root, source.slice(1))
         : source
       return relative(dirname(options.filepath), actualPath)

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -22,7 +22,7 @@ export function slash(str: string) {
 export const VALID_ID_PREFIX = '/@id/'
 
 export function normalizeRequestId(id: string, base?: string): string {
-  if (base && id.startsWith(base))
+  if (base && id.startsWith(`${base}/`))
     id = `/${id.slice(base.length)}`
 
   // keep drive the same as in process cwd
@@ -105,12 +105,12 @@ export function toFilePath(id: string, root: string): { path: string; exists: bo
     if (id.startsWith('/@fs/'))
       return { absolute: id.slice(4), exists: true }
     // check if /src/module.js -> <root>/src/module.js
-    if (!id.startsWith(root) && id.startsWith('/')) {
+    if (!id.startsWith(`${root}/`) && id.startsWith('/')) {
       const resolved = resolve(root, id.slice(1))
       if (existsSync(cleanUrl(resolved)))
         return { absolute: resolved, exists: true }
     }
-    else if (id.startsWith(root) && existsSync(cleanUrl(id))) {
+    else if (id.startsWith(`${root}/`) && existsSync(cleanUrl(id))) {
       return { absolute: id, exists: true }
     }
     return { absolute: id, exists: false }

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -22,7 +22,7 @@ export function slash(str: string) {
 export const VALID_ID_PREFIX = '/@id/'
 
 export function normalizeRequestId(id: string, base?: string): string {
-  if (base && id.startsWith(`${base}/`))
+  if (base && id.startsWith(withTrailingSlash(base)))
     id = `/${id.slice(base.length)}`
 
   // keep drive the same as in process cwd
@@ -105,12 +105,12 @@ export function toFilePath(id: string, root: string): { path: string; exists: bo
     if (id.startsWith('/@fs/'))
       return { absolute: id.slice(4), exists: true }
     // check if /src/module.js -> <root>/src/module.js
-    if (!id.startsWith(`${root}/`) && id.startsWith('/')) {
+    if (!id.startsWith(withTrailingSlash(root)) && id.startsWith('/')) {
       const resolved = resolve(root, id.slice(1))
       if (existsSync(cleanUrl(resolved)))
         return { absolute: resolved, exists: true }
     }
-    else if (id.startsWith(`${root}/`) && existsSync(cleanUrl(id))) {
+    else if (id.startsWith(withTrailingSlash(root)) && existsSync(cleanUrl(id))) {
       return { absolute: id, exists: true }
     }
     return { absolute: id, exists: false }
@@ -198,6 +198,13 @@ function traverseBetweenDirs(
     cb(longerDir)
     longerDir = dirname(longerDir)
   }
+}
+
+export function withTrailingSlash(path: string): string {
+  if (path[path.length - 1] !== '/')
+    return `${path}/`
+
+  return path
 }
 
 export function createImportMetaEnvProxy() {


### PR DESCRIPTION
### Description

Discovered when debugging nuxt/nuxt#20446, if the root starts with the same path as something being resolved - for example if the root is `/app` and we are resolve the id `/app.vue` then we were not correctly prefixing the root directory to the incoming id.

In actual fact this PR is not required to fix the linked issue, which can be resolved entirely in vite (for which I have opened https://github.com/vitejs/vite/pull/14241). But I do think it is safer to test with trailing slash to ensure that we are indeed talking about files _within_ the directory and not within a sibling directory with a similar name.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
