### PR TITLE
chore: update sources type for vite 5

### DIFF
--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -25,21 +25,23 @@ export function withInlineSourcemap(result: TransformResult, options: {
   if (!map || code.includes(VITE_NODE_SOURCEMAPPING_SOURCE))
     return result
 
-  map.sources = map.sources?.map((source) => {
-    if (!source)
+  if ('sources' in map) {
+    map.sources = map.sources?.map((source) => {
+      if (!source)
+        return source
+      // sometimes files here are absolute,
+      // but they are considered absolute to the server url, not the file system
+      // this is a bug in Vite
+      // all files should be either absolute to the file system or relative to the source map file
+      if (isAbsolute(source)) {
+        const actualPath = (!source.startsWith(withTrailingSlash(options.root)) && source.startsWith('/'))
+          ? resolve(options.root, source.slice(1))
+          : source
+        return relative(dirname(options.filepath), actualPath)
+      }
       return source
-    // sometimes files here are absolute,
-    // but they are considered absolute to the server url, not the file system
-    // this is a bug in Vite
-    // all files should be either absolute to the file system or relative to the source map file
-    if (isAbsolute(source)) {
-      const actualPath = (!source.startsWith(withTrailingSlash(options.root)) && source.startsWith('/'))
-        ? resolve(options.root, source.slice(1))
-        : source
-      return relative(dirname(options.filepath), actualPath)
-    }
-    return source
-  })
+    })
+  }
 
   // to reduce the payload size, we only inline vite node source map, because it's also the only one we use
   const OTHER_SOURCE_MAP_REGEXP = new RegExp(`//# ${SOURCEMAPPING_URL}=data:application/json[^,]+base64,([A-Za-z0-9+/=]+)$`, 'gm')


### PR DESCRIPTION
### Description

In Vite 5, the `map` type is `SourceMap | { mappings: '' }` and the new `{ mappings: '' }` type trips up TypeScript. This PR handles the typecheck fail from[ vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6069325893/job/16463576124#step:8:795)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Disable whitespace when reviewing the git diff, as I'm only wrapping `if ('sources' in map) { ... }` between the affected code. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
