### PR TITLE
fix!(runner): correctly process custom tasks, update runner hooks naming

### DIFF
--- a/docs/advanced/runner.md
+++ b/docs/advanced/runner.md
@@ -20,26 +20,26 @@ export interface VitestRunner {
   /**
    * Called when test runner should cancel next test runs.
    * Runner should listen for this method and mark tests and suites as skipped in
-   * "onBeforeRunSuite" and "onBeforeRunTest" when called.
+   * "onBeforeRunSuite" and "onBeforeRunTask" when called.
    */
   onCancel?(reason: CancelReason): unknown
 
   /**
    * Called before running a single test. Doesn't have "result" yet.
    */
-  onBeforeRunTest?(test: Test): unknown
+  onBeforeRunTask?(test: TaskPopulated): unknown
   /**
    * Called before actually running the test function. Already has "result" with "state" and "startTime".
    */
-  onBeforeTryTest?(test: Test, retryCount: number): unknown
+  onBeforeTryTask?(test: TaskPopulated, options: { retry: number; repeats: number }): unknown
   /**
    * Called after result and state are set.
    */
-  onAfterRunTest?(test: Test): unknown
+  onAfterRunTask?(test: TaskPopulated): unknown
   /**
    * Called right after running the test function. Doesn't have new state yet. Will not be called, if the test function throws.
    */
-  onAfterTryTest?(test: Test, retryCount: number): unknown
+  onAfterTryTask?(test: TaskPopulated, options: { retry: number; repeats: number }): unknown
 
   /**
    * Called before running a single suite. Doesn't have "result" yet.
@@ -59,7 +59,7 @@ export interface VitestRunner {
    * If defined, will be called instead of usual Vitest handling. Useful, if you have your custom test function.
    * "before" and "after" hooks will not be ignored.
    */
-  runTest?(test: Test): Promise<void>
+  runTask?(test: TaskPopulated): Promise<void>
 
   /**
    * Called, when a task is updated. The same as "onTaskUpdate" in a reporter, but this is running in the same thread as tests.
@@ -69,16 +69,20 @@ export interface VitestRunner {
   /**
    * Called before running all tests in collected paths.
    */
-  onBeforeRun?(files: File[]): unknown
+  onBeforeRunFiles?(files: File[]): unknown
   /**
    * Called right after running all tests in collected paths.
    */
-  onAfterRun?(files: File[]): unknown
+  onAfterRunFiles?(files: File[]): unknown
   /**
    * Called when new context for a test is defined. Useful, if you want to add custom properties to the context.
    * If you only want to define custom context with a runner, consider using "beforeAll" in "setupFiles" instead.
+   *
+   * This method is called for both "test" and "custom" handlers.
+   *
+   * @see https://vitest.dev/advanced/runner.html#your-task-function
    */
-  extendTestContext?(context: TestContext): TestContext
+  extendTaskContext?<T extends Test | Custom>(context: TaskContext<T>): TaskContext<T>
   /**
    * Called, when certain files are imported. Can be called in two situations: when collecting tests and when importing setup files.
    */
@@ -108,18 +112,23 @@ You can extend Vitest task system with your tasks. A task is an object that is p
 
 ```js
 // ./utils/custom.js
-import { getCurrentSuite, setFn } from 'vitest/suite'
+import { createTaskCollector, getCurrentSuite, setFn } from 'vitest/suite'
 
 export { describe, beforeAll, afterAll } from 'vitest'
 
-// this function will be called, when Vitest collects tasks
-export const myCustomTask = function (name, fn) {
-  const task = getCurrentSuite().custom(name)
-  task.meta = {
-    customPropertyToDifferentiateTask: true
-  }
-  setFn(task, fn || (() => {}))
-}
+// this function will be called when Vitest collects tasks
+// createTaskCollector just provides all "todo"/"each"/... support, you don't have to use it
+// To support custom tasks, you just need to call "getCurrentSuite().task()"
+export const myCustomTask = createTaskCollector(function (name, fn, timeout) {
+  getCurrentSuite().task(name, {
+    ...this, // so "todo"/"skip" is tracked correctly
+    meta: {
+      customPropertyToDifferentiateTask: true
+    },
+    handler: fn,
+    timeout,
+  })
+})
 ```
 
 ```js
@@ -134,6 +143,9 @@ describe('take care of the garden', () => {
 
   myCustomTask('weed the grass', () => {
     gardener.weedTheGrass()
+  })
+  myCustomTask.todo('mow the lawn', () => {
+    gardener.mowerTheLawn()
   })
   myCustomTask('water flowers', () => {
     gardener.waterFlowers()

--- a/packages/browser/src/client/runner.ts
+++ b/packages/browser/src/client/runner.ts
@@ -22,7 +22,7 @@ export function createBrowserRunner(original: any, coverageModule: CoverageHandl
       this.hashMap = options.browserHashMap
     }
 
-    async onAfterRunTest(task: Test) {
+    async onAfterRunTask(task: Test) {
       await super.onAfterRunTest?.(task)
       task.result?.errors?.forEach((error) => {
         console.error(error.message)
@@ -39,7 +39,7 @@ export function createBrowserRunner(original: any, coverageModule: CoverageHandl
       }
     }
 
-    async onAfterRun() {
+    async onAfterRunFiles() {
       await super.onAfterRun?.()
       const coverage = await coverageModule?.takeCoverage?.()
       if (coverage)

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -1,6 +1,6 @@
 import type { Awaitable } from '@vitest/utils'
 import { getSafeTimers } from '@vitest/utils'
-import type { RuntimeContext, SuiteCollector, Test, TestContext } from './types'
+import type { Custom, ExtendedContext, RuntimeContext, SuiteCollector, TaskContext, Test } from './types'
 import type { VitestRunner } from './types/runner'
 import { PendingError } from './errors'
 
@@ -42,10 +42,10 @@ export function withTimeout<T extends((...args: any[]) => any)>(
   }) as T
 }
 
-export function createTestContext(test: Test, runner: VitestRunner): TestContext {
+export function createTestContext<T extends Test | Custom>(test: T, runner: VitestRunner): ExtendedContext<T> {
   const context = function () {
     throw new Error('done() callback is deprecated, use promise instead')
-  } as unknown as TestContext
+  } as unknown as TaskContext<T>
 
   context.meta = test
   context.task = test
@@ -60,7 +60,7 @@ export function createTestContext(test: Test, runner: VitestRunner): TestContext
     test.onFailed.push(fn)
   }
 
-  return runner.extendTestContext?.(context) || context
+  return runner.extendTaskContext?.(context) as ExtendedContext<T> || context
 }
 
 function makeTimeoutMsg(isHook: boolean, timeout: number) {

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -47,7 +47,6 @@ export function createTestContext<T extends Test | Custom>(test: T, runner: Vite
     throw new Error('done() callback is deprecated, use promise instead')
   } as unknown as TaskContext<T>
 
-  context.meta = test
   context.task = test
 
   context.skip = () => {

--- a/packages/runner/src/hooks.ts
+++ b/packages/runner/src/hooks.ts
@@ -1,4 +1,4 @@
-import type { OnTestFailedHandler, SuiteHooks, Test } from './types'
+import type { OnTestFailedHandler, SuiteHooks, TaskPopulated } from './types'
 import { getCurrentSuite, getRunner } from './suite'
 import { getCurrentTest } from './test-state'
 import { withTimeout } from './context'
@@ -27,7 +27,7 @@ export const onTestFailed = createTestHook<OnTestFailedHandler>('onTestFailed', 
   test.onFailed.push(handler)
 })
 
-function createTestHook<T>(name: string, handler: (test: Test, handler: T) => void) {
+function createTestHook<T>(name: string, handler: (test: TaskPopulated, handler: T) => void) {
   return (fn: T) => {
     const current = getCurrentTest()
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,5 +1,5 @@
 export { startTests, updateTask } from './run'
-export { test, it, describe, suite, getCurrentSuite } from './suite'
+export { test, it, describe, suite, getCurrentSuite, createTaskCollector } from './suite'
 export { beforeAll, beforeEach, afterAll, afterEach, onTestFailed } from './hooks'
 export { setFn, getFn } from './map'
 export { getCurrentTest } from './test-state'

--- a/packages/runner/src/map.ts
+++ b/packages/runner/src/map.ts
@@ -1,5 +1,5 @@
 import type { Awaitable } from '@vitest/utils'
-import type { Suite, SuiteHooks, Test, TestContext } from './types'
+import type { Custom, Suite, SuiteHooks, Test, TestContext } from './types'
 import type { FixtureItem } from './fixture'
 
 // use WeakMap here to make the Test and Suite object serializable
@@ -7,11 +7,11 @@ const fnMap = new WeakMap()
 const fixtureMap = new WeakMap()
 const hooksMap = new WeakMap()
 
-export function setFn(key: Test, fn: (() => Awaitable<void>)) {
+export function setFn(key: Test | Custom, fn: (() => Awaitable<void>)) {
   fnMap.set(key, fn)
 }
 
-export function getFn<Task = Test>(key: Task): (() => Awaitable<void>) {
+export function getFn<Task = Test | Custom>(key: Task): (() => Awaitable<void>) {
   return fnMap.get(key as any)
 }
 

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -1,5 +1,5 @@
 import { format, isObject, noop, objDisplay, objectAttr } from '@vitest/utils'
-import type { File, Fixtures, RunMode, Suite, SuiteAPI, SuiteCollector, SuiteFactory, SuiteHooks, Task, TaskCustom, Test, TestAPI, TestFunction, TestOptions } from './types'
+import type { Custom, CustomAPI, File, Fixtures, RunMode, Suite, SuiteAPI, SuiteCollector, SuiteFactory, SuiteHooks, Task, TaskCustomOptions, Test, TestAPI, TestFunction, TestOptions } from './types'
 import type { VitestRunner } from './types/runner'
 import { createChainable } from './utils/chain'
 import { collectTask, collectorContext, createTestContext, runWithSuite, withTimeout } from './context'
@@ -54,16 +54,53 @@ export function createSuiteHooks() {
 
 // implementations
 function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, mode: RunMode, concurrent?: boolean, sequential?: boolean, shuffle?: boolean, each?: boolean, suiteOptions?: TestOptions) {
-  const tasks: (Test | TaskCustom | Suite | SuiteCollector)[] = []
+  const tasks: (Test | Custom | Suite | SuiteCollector)[] = []
   const factoryQueue: (Test | Suite | SuiteCollector)[] = []
 
   let suite: Suite
 
   initSuite()
 
-  const test = createTest(function (name: string | Function, fn = noop, options) {
-    const mode = this.only ? 'only' : this.skip ? 'skip' : this.todo ? 'todo' : 'run'
+  const task = function (name = '', options: TaskCustomOptions = {}) {
+    const task: Custom = {
+      id: '',
+      name,
+      suite: undefined!,
+      each: options.each,
+      fails: options.fails,
+      context: undefined!,
+      type: 'custom',
+      retry: options.retry ?? runner.config.retry,
+      repeats: options.repeats,
+      mode: options.only ? 'only' : options.skip ? 'skip' : options.todo ? 'todo' : 'run',
+      meta: options.meta ?? Object.create(null),
+    }
+    const handler = options.handler
+    if (options.concurrent || (!sequential && (concurrent || runner.config.sequence.concurrent)))
+      task.concurrent = true
+    if (shuffle)
+      task.shuffle = true
 
+    const context = createTestContext(task, runner)
+    // create test context
+    Object.defineProperty(task, 'context', {
+      value: context,
+      enumerable: false,
+    })
+    setFixture(context, options.fixtures)
+
+    if (handler) {
+      setFn(task, withTimeout(
+        withFixtures(handler, context),
+        options?.timeout ?? runner.config.testTimeout,
+      ))
+    }
+
+    tasks.push(task)
+    return task
+  }
+
+  const test = createTest(function (name: string | Function, fn = noop, options) {
     if (typeof options === 'number')
       options = { timeout: options }
 
@@ -71,52 +108,13 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
     if (typeof suiteOptions === 'object')
       options = Object.assign({}, suiteOptions, options)
 
-    const test: Test = {
-      id: '',
-      type: 'test',
-      name: formatName(name),
-      each: this.each,
-      mode,
-      suite: undefined!,
-      fails: this.fails,
-      retry: options?.retry ?? runner.config.retry,
-      repeats: options?.repeats,
-      meta: Object.create(null),
-    } as Omit<Test, 'context'> as Test
+    const test = task(
+      formatName(name),
+      { ...this, ...options, handler: fn as any },
+    ) as unknown as Test
 
-    if (this.concurrent || (!sequential && (concurrent || runner.config.sequence.concurrent)))
-      test.concurrent = true
-    if (shuffle)
-      test.shuffle = true
-
-    const context = createTestContext(test, runner)
-    // create test context
-    Object.defineProperty(test, 'context', {
-      value: context,
-      enumerable: false,
-    })
-
-    setFixture(context, this.fixtures)
-    setFn(test, withTimeout(
-      withFixtures(fn, context),
-      options?.timeout ?? runner.config.testTimeout,
-    ))
-
-    tasks.push(test)
+    test.type = 'test'
   })
-
-  const custom = function (this: Record<string, boolean>, name = '') {
-    const self = this || {}
-    const task: TaskCustom = {
-      id: '',
-      name,
-      type: 'custom',
-      mode: self.only ? 'only' : self.skip ? 'skip' : self.todo ? 'todo' : 'run',
-      meta: Object.create(null),
-    }
-    tasks.push(task)
-    return task
-  }
 
   const collector: SuiteCollector = {
     type: 'collector',
@@ -126,7 +124,7 @@ function createSuiteCollector(name: string, factory: SuiteFactory = () => { }, m
     test,
     tasks,
     collect,
-    custom,
+    task,
     clear,
     on: addHook,
   }
@@ -230,17 +228,13 @@ function createSuite() {
   ) as unknown as SuiteAPI
 }
 
-function createTest(fn: (
-  (
-    this: Record<'concurrent' | 'sequential' | 'skip' | 'only' | 'todo' | 'fails' | 'each', boolean | undefined> & { fixtures?: FixtureItem[] },
-    title: string,
-    fn?: TestFunction,
-    options?: number | TestOptions
-  ) => void
-), context?: Record<string, any>) {
-  const testFn = fn as any
+export function createTaskCollector(
+  fn: (...args: any[]) => any,
+  context?: Record<string, unknown>,
+) {
+  const taskFn = fn as any
 
-  testFn.each = function<T>(this: { withContext: () => SuiteAPI; setContext: (key: string, value: boolean | undefined) => SuiteAPI }, cases: ReadonlyArray<T>, ...args: any[]) {
+  taskFn.each = function<T>(this: { withContext: () => SuiteAPI; setContext: (key: string, value: boolean | undefined) => SuiteAPI }, cases: ReadonlyArray<T>, ...args: any[]) {
     const test = this.withContext()
     this.setContext('each', true)
 
@@ -262,10 +256,10 @@ function createTest(fn: (
     }
   }
 
-  testFn.skipIf = (condition: any) => (condition ? test.skip : test) as TestAPI
-  testFn.runIf = (condition: any) => (condition ? test : test.skip) as TestAPI
+  taskFn.skipIf = (condition: any) => (condition ? test.skip : test) as TestAPI
+  taskFn.runIf = (condition: any) => (condition ? test : test.skip) as TestAPI
 
-  testFn.extend = function (fixtures: Fixtures<Record<string, any>>) {
+  taskFn.extend = function (fixtures: Fixtures<Record<string, any>>) {
     const _context = mergeContextFixtures(fixtures, context)
 
     return createTest(function fn(name: string | Function, fn?: TestFunction, options?: number | TestOptions) {
@@ -275,13 +269,24 @@ function createTest(fn: (
 
   const _test = createChainable(
     ['concurrent', 'skip', 'only', 'todo', 'fails'],
-    testFn,
-  ) as TestAPI
+    taskFn,
+  ) as CustomAPI
 
   if (context)
     (_test as any).mergeContext(context)
 
   return _test
+}
+
+function createTest(fn: (
+  (
+    this: Record<'concurrent' | 'sequential' | 'skip' | 'only' | 'todo' | 'fails' | 'each', boolean | undefined> & { fixtures?: FixtureItem[] },
+    title: string,
+    fn?: TestFunction,
+    options?: number | TestOptions
+  ) => void
+), context?: Record<string, any>) {
+  return createTaskCollector(fn, context) as TestAPI
 }
 
 function formatName(name: string | Function) {

--- a/packages/runner/src/test-state.ts
+++ b/packages/runner/src/test-state.ts
@@ -1,11 +1,11 @@
-import type { Test } from './types'
+import type { Custom, Test } from './types'
 
-let _test: Test | undefined
+let _test: Test | Custom | undefined
 
-export function setCurrentTest(test: Test | undefined) {
+export function setCurrentTest<T extends Test | Custom>(test: T | undefined) {
   _test = test
 }
 
-export function getCurrentTest() {
-  return _test
+export function getCurrentTest<T extends Test | Custom | undefined>(): T {
+  return _test as T
 }

--- a/packages/runner/src/types/runner.ts
+++ b/packages/runner/src/types/runner.ts
@@ -1,5 +1,5 @@
 import type { DiffOptions } from '@vitest/utils/diff'
-import type { File, SequenceHooks, SequenceSetupFiles, Suite, TaskResultPack, Test, TestContext } from './tasks'
+import type { Custom, ExtendedContext, File, SequenceHooks, SequenceSetupFiles, Suite, TaskContext, TaskPopulated, TaskResultPack, Test } from './tasks'
 
 export interface VitestRunnerConfig {
   root: string
@@ -46,26 +46,26 @@ export interface VitestRunner {
   /**
    * Called when test runner should cancel next test runs.
    * Runner should listen for this method and mark tests and suites as skipped in
-   * "onBeforeRunSuite" and "onBeforeRunTest" when called.
+   * "onBeforeRunSuite" and "onBeforeRunTask" when called.
    */
   onCancel?(reason: CancelReason): unknown
 
   /**
    * Called before running a single test. Doesn't have "result" yet.
    */
-  onBeforeRunTest?(test: Test): unknown
+  onBeforeRunTask?(test: TaskPopulated): unknown
   /**
    * Called before actually running the test function. Already has "result" with "state" and "startTime".
    */
-  onBeforeTryTest?(test: Test, options: { retry: number; repeats: number }): unknown
+  onBeforeTryTask?(test: TaskPopulated, options: { retry: number; repeats: number }): unknown
   /**
    * Called after result and state are set.
    */
-  onAfterRunTest?(test: Test): unknown
+  onAfterRunTask?(test: TaskPopulated): unknown
   /**
    * Called right after running the test function. Doesn't have new state yet. Will not be called, if the test function throws.
    */
-  onAfterTryTest?(test: Test, options: { retry: number; repeats: number }): unknown
+  onAfterTryTask?(test: TaskPopulated, options: { retry: number; repeats: number }): unknown
 
   /**
    * Called before running a single suite. Doesn't have "result" yet.
@@ -85,7 +85,7 @@ export interface VitestRunner {
    * If defined, will be called instead of usual Vitest handling. Useful, if you have your custom test function.
    * "before" and "after" hooks will not be ignored.
    */
-  runTest?(test: Test): Promise<void>
+  runTask?(test: TaskPopulated): Promise<void>
 
   /**
    * Called, when a task is updated. The same as "onTaskUpdate" in a reporter, but this is running in the same thread as tests.
@@ -95,16 +95,20 @@ export interface VitestRunner {
   /**
    * Called before running all tests in collected paths.
    */
-  onBeforeRun?(files: File[]): unknown
+  onBeforeRunFiles?(files: File[]): unknown
   /**
    * Called right after running all tests in collected paths.
    */
-  onAfterRun?(files: File[]): unknown
+  onAfterRunFiles?(files: File[]): unknown
   /**
    * Called when new context for a test is defined. Useful, if you want to add custom properties to the context.
    * If you only want to define custom context, consider using "beforeAll" in "setupFiles" instead.
+   *
+   * This method is called for both "test" and "custom" handlers.
+   *
+   * @see https://vitest.dev/advanced/runner.html#your-task-function
    */
-  extendTestContext?(context: TestContext): TestContext
+  extendTaskContext?<T extends Test | Custom>(context: TaskContext<T>): ExtendedContext<T>
   /**
    * Called, when files are imported. Can be called in two situations: when collecting tests and when importing setup files.
    */

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -1,5 +1,6 @@
 import type { Awaitable, ErrorWithDiff } from '@vitest/utils'
 import type { ChainableFunction } from '../utils/chain'
+import type { FixtureItem } from '../fixture'
 
 export type RunMode = 'run' | 'skip' | 'only' | 'todo'
 export type TaskState = RunMode | 'pass' | 'fail'
@@ -19,11 +20,19 @@ export interface TaskBase {
   repeats?: number
 }
 
-export interface TaskMeta {}
-
-export interface TaskCustom extends TaskBase {
-  type: 'custom'
+export interface TaskPopulated extends TaskBase {
+  suite: Suite
+  pending?: boolean
+  result?: TaskResult
+  fails?: boolean
+  onFailed?: OnTestFailedHandler[]
+  /**
+   * Store promises (from async expects) to wait for them before finishing the test
+   */
+  promises?: Promise<any>[]
 }
+
+export interface TaskMeta {}
 
 export interface TaskResult {
   state: TaskState
@@ -56,24 +65,20 @@ export interface File extends Suite {
   setupDuration?: number
 }
 
-export interface Test<ExtraContext = {}> extends TaskBase {
+export interface Test<ExtraContext = {}> extends TaskPopulated {
   type: 'test'
-  suite: Suite
-  pending?: boolean
-  result?: TaskResult
-  fails?: boolean
-  context: TestContext & ExtraContext
-  onFailed?: OnTestFailedHandler[]
-  /**
-   * Store promises (from async expects) to wait for them before finishing the test
-   */
-  promises?: Promise<any>[]
+  context: TaskContext<Test> & ExtraContext & TestContext
 }
 
-export type Task = Test | Suite | TaskCustom | File
+export interface Custom<ExtraContext = {}> extends TaskPopulated {
+  type: 'custom'
+  context: TaskContext<Custom> & ExtraContext & TestContext
+}
+
+export type Task = Test | Suite | Custom | File
 
 export type DoneCallback = (error?: any) => void
-export type TestFunction<ExtraContext = {}> = (context: TestContext & ExtraContext) => Awaitable<any> | void
+export type TestFunction<ExtraContext = {}> = (context: ExtendedContext<Test> & ExtraContext) => Awaitable<any> | void
 
 // jest's ExtractEachCallbackArgs
 type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
@@ -179,10 +184,20 @@ export interface TestOptions {
   repeats?: number
 }
 
-export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & {
+interface ExtendedAPI<ExtraContext> {
   each: TestEachFunction
   skipIf(condition: any): ChainableTestAPI<ExtraContext>
   runIf(condition: any): ChainableTestAPI<ExtraContext>
+}
+
+export type CustomAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & ExtendedAPI<ExtraContext> & {
+  extend<T extends Record<string, any> = {}>(fixtures: Fixtures<T, ExtraContext>): CustomAPI<{
+    [K in keyof T | keyof ExtraContext]:
+    K extends keyof T ? T[K] :
+      K extends keyof ExtraContext ? ExtraContext[K] : never }>
+}
+
+export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & ExtendedAPI<ExtraContext> & {
   extend<T extends Record<string, any> = {}>(fixtures: Fixtures<T, ExtraContext>): TestAPI<{
     [K in keyof T | keyof ExtraContext]:
     K extends keyof T ? T[K] :
@@ -208,9 +223,13 @@ export type Fixture<
   ) => Promise<void>,
 > = OnlyFunction extends true ? FN : (FN | V)
 export type Fixtures<T extends Record<string, any>, ExtraContext = {}> = {
-  [K in keyof T]: Fixture<T, K, false, ExtraContext>
-} | {
-  [K in keyof T]: Fixture<T, K, true, ExtraContext>
+  [K in keyof T]: T[K] | ((context: {
+    [P in keyof T | keyof ExtraContext as P extends K ?
+      P extends keyof ExtraContext ? P : never : P
+    ]:
+    K extends P ? K extends keyof ExtraContext ? ExtraContext[K] : never :
+      P extends keyof T ? T[P] : never
+  } & ExtendedContext<Test>, use: (fixture: T[K]) => Promise<void>) => Promise<void>)
 }
 
 export type InferFixturesTypes<T> = T extends TestAPI<infer C> ? C : T
@@ -238,8 +257,21 @@ export type HookCleanupCallback = (() => Awaitable<unknown>) | void
 export interface SuiteHooks<ExtraContext = {}> {
   beforeAll: HookListener<[Readonly<Suite | File>], HookCleanupCallback>[]
   afterAll: HookListener<[Readonly<Suite | File>]>[]
-  beforeEach: HookListener<[TestContext & ExtraContext, Readonly<Suite>], HookCleanupCallback>[]
-  afterEach: HookListener<[TestContext & ExtraContext, Readonly<Suite>]>[]
+  beforeEach: HookListener<[ExtendedContext<Test | Custom> & ExtraContext, Readonly<Suite>], HookCleanupCallback>[]
+  afterEach: HookListener<[ExtendedContext<Test | Custom> & ExtraContext, Readonly<Suite>]>[]
+}
+
+export interface TaskCustomOptions extends TestOptions {
+  concurrent?: boolean
+  sequential?: boolean
+  skip?: boolean
+  only?: boolean
+  todo?: boolean
+  fails?: boolean
+  each?: boolean
+  meta?: Record<string, unknown>
+  fixtures?: FixtureItem[]
+  handler?: (context: TaskContext<Custom>) => Awaitable<void>
 }
 
 export interface SuiteCollector<ExtraContext = {}> {
@@ -248,8 +280,8 @@ export interface SuiteCollector<ExtraContext = {}> {
   options?: TestOptions
   type: 'collector'
   test: TestAPI<ExtraContext>
-  tasks: (Suite | TaskCustom | Test | SuiteCollector<ExtraContext>)[]
-  custom: (name: string) => TaskCustom
+  tasks: (Suite | Custom<ExtraContext> | Test<ExtraContext> | SuiteCollector<ExtraContext>)[]
+  task: (name: string, options?: TaskCustomOptions) => Custom<ExtraContext>
   collect: (file?: File) => Promise<Suite>
   clear: () => void
   on: <T extends keyof SuiteHooks<ExtraContext>>(name: T, ...fn: SuiteHooks<ExtraContext>[T]) => void
@@ -262,18 +294,20 @@ export interface RuntimeContext {
   currentSuite: SuiteCollector | null
 }
 
-export interface TestContext {
+export interface TestContext {}
+
+export interface TaskContext<Task extends Custom | Test = Custom | Test> {
   /**
    * Metadata of the current test
    *
    * @deprecated Use `task` instead
    */
-  meta: Readonly<Test>
+  meta: Readonly<Task>
 
   /**
    * Metadata of the current test
    */
-  task: Readonly<Test>
+  task: Readonly<Task>
 
   /**
    * Extract hooks on test failed
@@ -285,6 +319,8 @@ export interface TestContext {
    */
   skip: () => void
 }
+
+export type ExtendedContext<T extends Custom | Test> = TaskContext<T> & TestContext
 
 export type OnTestFailedHandler = (result: TaskResult) => Awaitable<void>
 

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -223,13 +223,9 @@ export type Fixture<
   ) => Promise<void>,
 > = OnlyFunction extends true ? FN : (FN | V)
 export type Fixtures<T extends Record<string, any>, ExtraContext = {}> = {
-  [K in keyof T]: T[K] | ((context: {
-    [P in keyof T | keyof ExtraContext as P extends K ?
-      P extends keyof ExtraContext ? P : never : P
-    ]:
-    K extends P ? K extends keyof ExtraContext ? ExtraContext[K] : never :
-      P extends keyof T ? T[P] : never
-  } & ExtendedContext<Test>, use: (fixture: T[K]) => Promise<void>) => Promise<void>)
+  [K in keyof T]: Fixture<T, K, false, ExtraContext>
+} | {
+  [K in keyof T]: Fixture<T, K, true, ExtraContext>
 }
 
 export type InferFixturesTypes<T> = T extends TestAPI<infer C> ? C : T
@@ -297,13 +293,6 @@ export interface RuntimeContext {
 export interface TestContext {}
 
 export interface TaskContext<Task extends Custom | Test = Custom | Test> {
-  /**
-   * Metadata of the current test
-   *
-   * @deprecated Use `task` instead
-   */
-  meta: Readonly<Task>
-
   /**
    * Metadata of the current test
    */

--- a/packages/runner/src/utils/tasks.ts
+++ b/packages/runner/src/utils/tasks.ts
@@ -1,12 +1,12 @@
 import { type Arrayable, toArray } from '@vitest/utils'
-import type { Suite, Task, TaskCustom, Test } from '../types'
+import type { Custom, Suite, Task, Test } from '../types'
 
-function isAtomTest(s: Task): s is Test | TaskCustom {
+function isAtomTest(s: Task): s is Test | Custom {
   return s.type === 'test' || s.type === 'custom'
 }
 
-export function getTests(suite: Arrayable<Task>): (Test | TaskCustom)[] {
-  const tests: (Test | TaskCustom)[] = []
+export function getTests(suite: Arrayable<Task>): (Test | Custom)[] {
+  const tests: (Test | Custom)[] = []
   const suite_arr = toArray(suite)
   for (const s of suite_arr) {
     if (isAtomTest(s)) {

--- a/packages/snapshot/README.md
+++ b/packages/snapshot/README.md
@@ -9,16 +9,12 @@ import { SnapshotClient } from '@vitest/snapshot'
 import { NodeSnapshotEnvironment } from '@vitest/snapshot/environment'
 import { SnapshotManager } from '@vitest/snapshot/manager'
 
-export class CustomSnapshotClient extends SnapshotClient {
-  // by default, @vitest/snapshot checks equality with `!==`
-  // you need to provide your own equality check implementation
+const client = new SnapshotClient({
+  // you need to provide your own equality check implementation if you use it
   // this function is called when `.toMatchSnapshot({ property: 1 })` is called
-  equalityCheck(received, expected) {
-    return equals(received, expected, [iterableEquality, subsetEquality])
-  }
-}
+  isEqual: (received, expected) => equals(received, expected, [iterableEquality, subsetEquality]),
+})
 
-const client = new CustomSnapshotClient()
 // class that implements snapshot saving and reading
 // by default uses fs module, but you can provide your own implementation depending on the environment
 const environment = new NodeSnapshotEnvironment()
@@ -30,6 +26,8 @@ function getCurrentTestName() {
   return 'test1'
 }
 
+// example for inline snapshots, nothing is required to support regular snapshots,
+// just call `assert` with `isInline: false`
 function wrapper(received) {
   function __INLINE_SNAPSHOT__(inlineSnapshot, message) {
     client.assert({
@@ -55,14 +53,14 @@ const options = {
   snapshotEnvironment: environment,
 }
 
-await client.setTest(getCurrentFilepath(), getCurrentTestName(), options)
+await client.startCurrentRun(getCurrentFilepath(), getCurrentTestName(), options)
 
 // uses "pretty-format", so it requires quotes
 // also naming is hard-coded when parsing test files
 wrapper('text 1').toMatchInlineSnapshot()
 wrapper('text 2').toMatchInlineSnapshot('"text 2"')
 
-const result = await client.resetCurrent() // this saves files and returns SnapshotResult
+const result = await client.finishCurrentRun() // this saves files and returns SnapshotResult
 
 // you can use manager to manage several clients
 const manager = new SnapshotManager(options)

--- a/packages/snapshot/README.md
+++ b/packages/snapshot/README.md
@@ -19,6 +19,8 @@ const client = new SnapshotClient({
 // by default uses fs module, but you can provide your own implementation depending on the environment
 const environment = new NodeSnapshotEnvironment()
 
+// you need to implement this yourselves,
+// this depends on your runner
 function getCurrentFilepath() {
   return '/file.spec.ts'
 }
@@ -35,8 +37,6 @@ function wrapper(received) {
       message,
       isInline: true,
       inlineSnapshot,
-      // you need to implement this yourselves,
-      // this depends on your runner
       filepath: getCurrentFilepath(),
       name: getCurrentTestName(),
     })
@@ -54,6 +54,12 @@ const options = {
 }
 
 await client.startCurrentRun(getCurrentFilepath(), getCurrentTestName(), options)
+
+// this will save snapshot to a file which is returned by "snapshotEnvironment.resolvePath"
+client.assert({
+  received: 'some text',
+  isInline: false,
+})
 
 // uses "pretty-format", so it requires quotes
 // also naming is hard-coded when parsing test files

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -2,7 +2,7 @@
 
 import * as chai from 'chai'
 import './setup'
-import type { Test } from '@vitest/runner'
+import type { TaskPopulated, Test } from '@vitest/runner'
 import { getCurrentTest } from '@vitest/runner'
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect'
 import type { Assertion, ExpectStatic } from '@vitest/expect'
@@ -10,7 +10,7 @@ import type { MatcherState } from '../../types/chai'
 import { getFullName } from '../../utils/tasks'
 import { getCurrentEnvironment } from '../../utils/global'
 
-export function createExpect(test?: Test) {
+export function createExpect(test?: TaskPopulated) {
   const expect = ((value: any, message?: string): Assertion => {
     const { assertionCalls } = getState(expect)
     setState({ assertionCalls: assertionCalls + 1, soft: false }, expect)
@@ -40,7 +40,7 @@ export function createExpect(test?: Test) {
     expectedAssertionsNumberErrorGen: null,
     environment: getCurrentEnvironment(),
     testPath: test ? test.suite.file?.filepath : globalState.testPath,
-    currentTestName: test ? getFullName(test) : globalState.currentTestName,
+    currentTestName: test ? getFullName(test as Test) : globalState.currentTestName,
   }, expect)
 
   // @ts-expect-error untyped

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -1,16 +1,20 @@
 import type { ChaiPlugin } from '@vitest/expect'
+import { equals, iterableEquality, subsetEquality } from '@vitest/expect'
+import { SnapshotClient, addSerializer, stripSnapshotIndentation } from '@vitest/snapshot'
 import type { Test } from '@vitest/runner'
 import { getNames } from '@vitest/runner/utils'
-import type { SnapshotClient } from '@vitest/snapshot'
-import { addSerializer, stripSnapshotIndentation } from '@vitest/snapshot'
 import { recordAsyncExpect } from '../../../../expect/src/utils'
-import { VitestSnapshotClient } from './client'
 
 let _client: SnapshotClient
 
 export function getSnapshotClient(): SnapshotClient {
-  if (!_client)
-    _client = new VitestSnapshotClient()
+  if (!_client) {
+    _client = new SnapshotClient({
+      isEqual: (received, expected) => {
+        return equals(received, expected, [iterableEquality, subsetEquality])
+      },
+    })
+  }
   return _client
 }
 

--- a/packages/vitest/src/integrations/snapshot/client.ts
+++ b/packages/vitest/src/integrations/snapshot/client.ts
@@ -1,8 +1,0 @@
-import { equals, iterableEquality, subsetEquality } from '@vitest/expect'
-import { SnapshotClient } from '@vitest/snapshot'
-
-export class VitestSnapshotClient extends SnapshotClient {
-  equalityCheck(received: unknown, expected: unknown): boolean {
-    return equals(received, expected, [iterableEquality, subsetEquality])
-  }
-}

--- a/packages/vitest/src/runtime/benchmark.ts
+++ b/packages/vitest/src/runtime/benchmark.ts
@@ -1,18 +1,18 @@
-import type { TaskCustom } from '@vitest/runner'
+import type { Custom } from '@vitest/runner'
 import { getCurrentSuite } from '@vitest/runner'
 import { createChainable } from '@vitest/runner/utils'
 import { noop } from '@vitest/utils'
 import type { BenchFunction, BenchOptions, BenchmarkAPI } from '../types'
 import { isRunningInBenchmark } from '../utils'
 
-const benchFns = new WeakMap<TaskCustom, BenchFunction>()
+const benchFns = new WeakMap<Custom, BenchFunction>()
 const benchOptsMap = new WeakMap()
 
-export function getBenchOptions(key: TaskCustom): BenchOptions {
+export function getBenchOptions(key: Custom): BenchOptions {
   return benchOptsMap.get(key)
 }
 
-export function getBenchFn(key: TaskCustom): BenchFunction {
+export function getBenchFn(key: Custom): BenchFunction {
   return benchFns.get(key)!
 }
 
@@ -21,10 +21,12 @@ export const bench = createBenchmark(
     if (!isRunningInBenchmark())
       throw new Error('`bench()` is only available in benchmark mode.')
 
-    const task = getCurrentSuite().custom.call(this, formatName(name))
-    task.meta = {
-      benchmark: true,
-    }
+    const task = getCurrentSuite().task(formatName(name), {
+      ...this,
+      meta: {
+        benchmark: true,
+      },
+    })
     benchFns.set(task, fn)
     benchOptsMap.set(task, options)
   },

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -142,7 +142,7 @@ export class NodeBenchmarkRunner implements VitestRunner {
     await runBenchmarkSuite(suite, this)
   }
 
-  async runTest(): Promise<void> {
+  async runTask(): Promise<void> {
     throw new Error('`test()` and `it()` is only available in test mode.')
   }
 }

--- a/packages/vitest/src/runtime/runners/index.ts
+++ b/packages/vitest/src/runtime/runners/index.ts
@@ -62,15 +62,15 @@ export async function resolveTestRunner(config: ResolvedConfig, executor: Vitest
     await originalOnCollected?.call(testRunner, files)
   }
 
-  const originalOnAfterRun = testRunner.onAfterRun
-  testRunner.onAfterRun = async (files) => {
+  const originalOnAfterRun = testRunner.onAfterRunFiles
+  testRunner.onAfterRunFiles = async (files) => {
     const coverage = await takeCoverageInsideWorker(config.coverage, executor)
     rpc().onAfterSuiteRun({ coverage })
     await originalOnAfterRun?.call(testRunner, files)
   }
 
-  const originalOnAfterRunTest = testRunner.onAfterRunTest
-  testRunner.onAfterRunTest = async (test) => {
+  const originalOnAfterRunTask = testRunner.onAfterRunTask
+  testRunner.onAfterRunTask = async (test) => {
     if (config.bail && test.result?.state === 'fail') {
       const previousFailures = await rpc().getCountOfFailedTests()
       const currentFailures = 1 + previousFailures
@@ -80,7 +80,7 @@ export async function resolveTestRunner(config: ResolvedConfig, executor: Vitest
         testRunner.onCancel?.('test-failure')
       }
     }
-    await originalOnAfterRunTest?.call(testRunner, test)
+    await originalOnAfterRunTask?.call(testRunner, test)
   }
 
   return testRunner

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -27,8 +27,8 @@ export class VitestTestRunner implements VitestRunner {
     this.snapshotClient.clear()
   }
 
-  async onAfterRunFile() {
-    const result = await this.snapshotClient.resetCurrent()
+  async onAfterRunFiles() {
+    const result = await this.snapshotClient.finishCurrentRun()
     if (result)
       await rpc().snapshotSaved(result)
   }
@@ -63,7 +63,7 @@ export class VitestTestRunner implements VitestRunner {
     }
 
     clearModuleMocks(this.config)
-    await this.snapshotClient.setTest(test.file!.filepath, name, this.workerState.config.snapshotOptions)
+    await this.snapshotClient.startCurrentRun(test.file!.filepath, name, this.workerState.config.snapshotOptions)
 
     this.workerState.current = test
   }

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -1,4 +1,4 @@
-import type { CancelReason, Suite, Test, TestContext, VitestRunner, VitestRunnerImportSource } from '@vitest/runner'
+import type { CancelReason, Custom, ExtendedContext, Suite, TaskContext, Test, VitestRunner, VitestRunnerImportSource } from '@vitest/runner'
 import type { ExpectStatic } from '@vitest/expect'
 import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect'
 import { getSnapshotClient } from '../../integrations/snapshot/chai'
@@ -23,11 +23,11 @@ export class VitestTestRunner implements VitestRunner {
     return this.__vitest_executor.executeId(filepath)
   }
 
-  onBeforeRun() {
+  onBeforeRunFiles() {
     this.snapshotClient.clear()
   }
 
-  async onAfterRun() {
+  async onAfterRunFile() {
     const result = await this.snapshotClient.resetCurrent()
     if (result)
       await rpc().snapshotSaved(result)
@@ -38,7 +38,7 @@ export class VitestTestRunner implements VitestRunner {
       suite.result!.heap = process.memoryUsage().heapUsed
   }
 
-  onAfterRunTest(test: Test) {
+  onAfterRunTask(test: Test) {
     this.snapshotClient.clearTest()
 
     if (this.config.logHeapUsage && typeof process !== 'undefined')
@@ -51,7 +51,7 @@ export class VitestTestRunner implements VitestRunner {
     this.cancelRun = true
   }
 
-  async onBeforeRunTest(test: Test) {
+  async onBeforeRunTask(test: Test) {
     const name = getNames(test).slice(1).join(' > ')
 
     if (this.cancelRun)
@@ -73,7 +73,7 @@ export class VitestTestRunner implements VitestRunner {
       suite.mode = 'skip'
   }
 
-  onBeforeTryTest(test: Test) {
+  onBeforeTryTask(test: Test) {
     setState({
       assertionCalls: 0,
       isExpectingAssertions: false,
@@ -86,7 +86,7 @@ export class VitestTestRunner implements VitestRunner {
     }, (globalThis as any)[GLOBAL_EXPECT])
   }
 
-  onAfterTryTest(test: Test) {
+  onAfterTryTask(test: Test) {
     const {
       assertionCalls,
       expectedAssertionsNumber,
@@ -103,12 +103,12 @@ export class VitestTestRunner implements VitestRunner {
       throw isExpectingAssertionsError
   }
 
-  extendTestContext(context: TestContext): TestContext {
+  extendTaskContext<T extends Test | Custom>(context: TaskContext<T>): ExtendedContext<T> {
     let _expect: ExpectStatic | undefined
     Object.defineProperty(context, 'expect', {
       get() {
         if (!_expect)
-          _expect = createExpect(context.meta)
+          _expect = createExpect(context.task)
         return _expect
       },
     })
@@ -117,7 +117,7 @@ export class VitestTestRunner implements VitestRunner {
         return _expect != null
       },
     })
-    return context
+    return context as ExtendedContext<T>
   }
 }
 

--- a/packages/vitest/src/suite.ts
+++ b/packages/vitest/src/suite.ts
@@ -1,2 +1,2 @@
-export { getCurrentSuite, getFn, setFn } from '@vitest/runner'
+export { getCurrentSuite, createTaskCollector, getFn, setFn } from '@vitest/runner'
 export { createChainable } from '@vitest/runner/utils'

--- a/packages/vitest/src/types/benchmark.ts
+++ b/packages/vitest/src/types/benchmark.ts
@@ -1,4 +1,4 @@
-import type { TaskCustom } from '@vitest/runner'
+import type { Custom } from '@vitest/runner'
 import type { ChainableFunction } from '@vitest/runner/utils'
 import type { Arrayable } from '@vitest/utils'
 import type { Bench as BenchFactory, Options as BenchOptions, Task as BenchTask, TaskResult as BenchTaskResult, TaskResult as TinybenchResult } from 'tinybench'
@@ -39,7 +39,7 @@ export interface BenchmarkUserOptions {
   outputFile?: string | (Partial<Record<BenchmarkBuiltinReporters, string>> & Record<string, string>)
 }
 
-export interface Benchmark extends TaskCustom {
+export interface Benchmark extends Custom {
   meta: {
     benchmark: true
     result?: BenchTaskResult

--- a/packages/vitest/src/types/tasks.ts
+++ b/packages/vitest/src/types/tasks.ts
@@ -20,6 +20,10 @@ export type {
   SuiteFactory,
   RuntimeContext,
   TestContext,
+  TaskContext,
+  ExtendedContext,
+  Custom,
+  TaskCustomOptions,
   OnTestFailedHandler,
   TaskMeta,
 } from '@vitest/runner'

--- a/test/core/src/custom/gardener.ts
+++ b/test/core/src/custom/gardener.ts
@@ -1,0 +1,42 @@
+export class Gardener {
+  _state = 'wake up'
+
+  states: string[] = [this._state]
+
+  get state() {
+    return this._state
+  }
+
+  set state(state: string) {
+    this._state = state
+    this.states.push(state)
+  }
+
+  putWorkingClothes() {
+    this.state = 'working clothes'
+  }
+
+  weedTheGrass() {
+    this.state = 'weed the grass'
+  }
+
+  mowerTheLawn() {
+    this.state = 'mower the lawn'
+  }
+
+  waterFlowers() {
+    this.state = 'water flowers'
+  }
+
+  rest() {
+    this.state = 'rest'
+  }
+
+  standup() {
+    this.state = 'standup'
+  }
+
+  goHome() {
+    this.state = 'home'
+  }
+}

--- a/test/core/test/custom.test.ts
+++ b/test/core/test/custom.test.ts
@@ -1,0 +1,66 @@
+import { createChainable, getCurrentSuite } from 'vitest/suite'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'vitest'
+import { Gardener } from '../src/custom/gardener.js'
+
+// this function will be called, when Vitest collects tasks
+const myCustomTask = createChainable(['todo'], function (name: string, fn: () => void) {
+  getCurrentSuite().task(name, {
+    ...this,
+    meta: {
+      customPropertyToDifferentiateTask: true,
+    },
+    handler: fn,
+  })
+})
+
+const gardener = new Gardener()
+
+describe('take care of the garden', () => {
+  beforeAll(() => {
+    gardener.putWorkingClothes()
+  })
+
+  beforeEach(() => {
+    gardener.standup()
+  })
+
+  afterEach(() => {
+    gardener.rest()
+  })
+
+  myCustomTask('weed the grass', () => {
+    gardener.weedTheGrass()
+  })
+  myCustomTask.todo('mow the lawn', () => {
+    gardener.mowerTheLawn()
+  })
+  myCustomTask('water flowers', () => {
+    gardener.waterFlowers()
+  })
+
+  afterAll(() => {
+    gardener.goHome()
+  })
+})
+
+test('states are filled correctly', () => {
+  expect(gardener.states).toEqual([
+    'wake up',
+    'working clothes',
+    'standup',
+    'weed the grass',
+    'rest',
+    'standup',
+    'water flowers',
+    'rest',
+    'home',
+  ])
+})


### PR DESCRIPTION
### Description

This is a breaking change. Previous support for custom tasks has been rewritten a little bit.

Fixes #3404

1. Methods on custom runner that referenced "test" now mention "task" (`onAfterRunTest` is now `onAfterRunTask` and so on, `onBeforeRun` and `onAfterRun` are now named `onBeforeRunFiles` and `onAfterRunFiles`). They now also accept tasks with type "custom" (the shape of the object is identical)
2. To collect custom tasks you now need to call `getCurrentSuite().task()` instead of `getCurrentSuite().custom()`. It now accepts a second arguments which are options. You can pass down handler as `handler` instead of saving it using `setFn`. If you used `createChainable` before, you can spread `this` in options instead of calling `custom.call(this)` - this now has no effect, it no longer relies on `this` at all:

```ts
  getCurrentSuite().task(name, {
    ...this, // so "todo"/"skip" is tracked correctly
    meta: {
      customPropertyToDifferentiateTask: true
    },
    handler: fn,
    timeout,
  })
```

3. Vitest also now provides a `createTaskCollector` utility - this will define a function that supports `todo/skip/each/skipIf/runIf` and other `.test` chainables. The difference with `createChainable` is that you don't need to specify what you need to support, and it also supports more methods (`each/runIf/skipIf`):

```ts
const myCustomTask = createTaskCollector(function (name, fn, timeout) {
   getCurrentSuite().task(name, {
     ...this, // so "todo"/"skip" is tracked correctly
     meta: {
       customPropertyToDifferentiateTask: true
     },
     handler: fn,
     timeout,
   })
 })

myCustomTask.each([1, 2])('name', (data: number) => {
  // ... do whatever you want
})

myCustomTask.skipIf(isWindows)('name', () => {
   // ...
})
```

3. `SnapshotClient` now accepts options - instead of overriding `equalityCheck` you need to pass down `isEqual` function. If you don't rely on `.toMatchSnapshot({ ... })` tests (checking an object shape AND a snapshot string), you don't need to pass anything.
5. Some of the methods on `SnapshotClient` were renamed to better represent what they do: `setTest` -> `startCurrentRun`, `resetCurrent` -> `finishCurrentRun` (you need to call `.assert` between those two calls)
6. This PR also removes `context.meta`. It was deprecated for some time, please use `context.task` instead.

And now it actually works :)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
