### PR TITLE
fix(vitest): show error when calling API on files that user has no access to

### DIFF
--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -35,7 +35,7 @@ function escapeHtml(unsafe: string) {
 
 function createHtmlError(filter: Convert, error: ErrorWithDiff) {
   let htmlError = ''
-  if (error.message.includes('\x1B'))
+  if (error.message?.includes('\x1B'))
     htmlError = `<b>${error.nameStr || error.name}</b>: ${filter.toHtml(escapeHtml(error.message))}`
 
   const startStrWithX1B = error.stackStr?.includes('\x1B')

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -71,12 +71,12 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, server?: Vit
         },
         async readSnapshotFile(snapshotPath) {
           if (!ctx.snapshot.resolvedPaths.has(snapshotPath) || !existsSync(snapshotPath))
-            throw new Error(`Snapshot file "${snapshotPath}" does not exist.`)
+            return null
           return fs.readFile(snapshotPath, 'utf-8')
         },
         async readTestFile(id) {
           if (!ctx.state.filesMap.has(id) || !existsSync(id))
-            throw new Error(`Test file "${id}" was not registered, so it cannot be read using the API.`)
+            return null
           return fs.readFile(id, 'utf-8')
         },
         async saveTestFile(id, content) {

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -71,29 +71,28 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, server?: Vit
         },
         async readSnapshotFile(snapshotPath) {
           if (!ctx.snapshot.resolvedPaths.has(snapshotPath) || !existsSync(snapshotPath))
-            return null
+            throw new Error(`Snapshot file "${snapshotPath}" does not exist.`)
           return fs.readFile(snapshotPath, 'utf-8')
         },
         async readTestFile(id) {
           if (!ctx.state.filesMap.has(id) || !existsSync(id))
-            return null
+            throw new Error(`Test file "${id}" was not registered, so it cannot be read using the API.`)
           return fs.readFile(id, 'utf-8')
         },
         async saveTestFile(id, content) {
-          // can save only already existing test file
           if (!ctx.state.filesMap.has(id) || !existsSync(id))
-            return
+            throw new Error(`Test file "${id}" was not registered, so it cannot be updated using the API.`)
           return fs.writeFile(id, content, 'utf-8')
         },
         async saveSnapshotFile(id, content) {
           if (!ctx.snapshot.resolvedPaths.has(id))
-            return
+            throw new Error(`Snapshot file "${id}" does not exist.`)
           await fs.mkdir(dirname(id), { recursive: true })
           return fs.writeFile(id, content, 'utf-8')
         },
         async removeSnapshotFile(id) {
           if (!ctx.snapshot.resolvedPaths.has(id) || !existsSync(id))
-            return
+            throw new Error(`Snapshot file "${id}" does not exist.`)
           return fs.unlink(id)
         },
         snapshotSaved(snapshot) {


### PR DESCRIPTION
### Description

When the caller has no access to an API, the API will throw an error instead of doing nothing. Currently we have a problem with snapshots in browser that we were not able to caught because of this.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
