### PR TITLE
fix(runner): restore leading space in `testNamePattern` (#4103)

### DIFF
--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -46,8 +46,7 @@ export function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, 
 }
 
 function getTaskFullName(task: TaskBase): string {
-  const fullName = task.suite ? getTaskFullName(task.suite) : null
-  return fullName ? `${fullName} ${task.name}` : task.name
+  return `${task.suite ? `${getTaskFullName(task.suite)} ` : ''}${task.name}`
 }
 
 export function someTasksAreOnly(suite: Suite): boolean {

--- a/test/filters/test/testname-pattern.test.ts
+++ b/test/filters/test/testname-pattern.test.ts
@@ -30,14 +30,3 @@ test('match by pattern that also matches current working directory', async () =>
   expect(stdout).toMatch('Test Files  1 passed (1)')
   expect(stdout).not.toMatch('test/example.test.ts')
 })
-
-test('match by test name pattern with ^', async () => {
-  const { stdout } = await runVitest({
-    root: './fixtures',
-    testNamePattern: '^this',
-  }, ['filters'])
-
-  expect(stdout).toMatch('✓ test/filters.test.ts > this will pass')
-  expect(stdout).toMatch('Test Files  1 passed (1)')
-  expect(stdout).not.toMatch('test/example.test.ts')
-})


### PR DESCRIPTION
This reverts commit b5bf32907fae8b8b4508689a32205f94056a721e.

Reverting looks like the most straightforward option to me. Once WebStorm 2024.1 is released, the original commit can simply be merged again.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
