### PR TITLE
feat(coverage): add `coverage['100']` to istanbul provider

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1081,7 +1081,7 @@ See [istanbul documentation](https://github.com/istanbuljs/nyc#coverage-threshol
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.100`, `--coverage.100=false`
 
-Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`.
+Shortcut for `--coverage.lines 100 --coverage.functions 100 --coverage.branches 100 --coverage.statements 100`.
 
 #### coverage.ignoreClassMethods
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1078,7 +1078,7 @@ See [istanbul documentation](https://github.com/istanbuljs/nyc#coverage-threshol
 
 - **Type:** `boolean`
 - **Default:** `false`
-- **Available for providers:** `'v8'`
+- **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.100`, `--coverage.100=false`
 
 Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`.

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -61,6 +61,10 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       provider: 'istanbul',
       reportsDirectory: resolve(ctx.config.root, config.reportsDirectory || coverageConfigDefaults.reportsDirectory),
       reporter: this.resolveReporters(config.reporter || coverageConfigDefaults.reporter),
+      lines: config['100'] ? 100 : config.lines,
+      functions: config['100'] ? 100 : config.functions,
+      branches: config['100'] ? 100 : config.branches,
+      statements: config['100'] ? 100 : config.statements,
     }
 
     this.instrumenter = createInstrumenter({

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -226,7 +226,7 @@ export interface BaseCoverageOptions {
   allowExternal?: boolean
 
   /**
-   * Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`
+   * Shortcut for `{ lines: 100, functions: 100, branches: 100, statements: 100 }`
    *
    * @default false
    */

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -224,6 +224,13 @@ export interface BaseCoverageOptions {
    * @default false
    */
   allowExternal?: boolean
+
+  /**
+   * Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`
+   *
+   * @default false
+   */
+  100?: boolean
 }
 
 export interface CoverageIstanbulOptions extends BaseCoverageOptions {
@@ -235,14 +242,7 @@ export interface CoverageIstanbulOptions extends BaseCoverageOptions {
   ignoreClassMethods?: string[]
 }
 
-export interface CoverageV8Options extends BaseCoverageOptions {
-  /**
-   * Shortcut for `--check-coverage --lines 100 --functions 100 --branches 100 --statements 100`
-   *
-   * @default false
-   */
-  100?: boolean
-}
+export interface CoverageV8Options extends BaseCoverageOptions {}
 
 export interface CustomProviderOptions extends Pick<BaseCoverageOptions, FieldsWithDefaultValues> {
   /** Name of the module or path to a file to load the custom provider from */

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -30,6 +30,7 @@ test('provider options, generic', () => {
       functions: [80, 95],
       lines: [80, 95],
     },
+    100: true,
   })
 
   assertType<Coverage>({
@@ -39,15 +40,11 @@ test('provider options, generic', () => {
     watermarks: {
       statements: [80, 95],
     },
+    100: true,
   })
 })
 
 test('provider specific options, v8', () => {
-  assertType<Coverage>({
-    provider: 'v8',
-    100: true,
-  })
-
   assertType<Coverage>({
     provider: 'v8',
     // @ts-expect-error -- Istanbul-only option is not allowed
@@ -59,12 +56,6 @@ test('provider specific options, istanbul', () => {
   assertType<Coverage>({
     provider: 'istanbul',
     ignoreClassMethods: ['string'],
-  })
-
-  assertType<Coverage>({
-    provider: 'istanbul',
-    // @ts-expect-error -- V8-only option is not allowed
-    100: true,
   })
 })
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Add support for passing `100: true` for `@vitest/coverage-istanbul`
Close #3566 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
