### PR TITLE
feat(vitest): support `vi.waitFor` method

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -715,6 +715,7 @@ unmockedIncrement(30) === 31
 ## vi.isFakeTimers
 
 - **Type:** `() => boolean`
+- **Version:** Since Vitest 0.34.5
 
   Returns `true` if fake timers are enabled.
 

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -254,10 +254,10 @@ import { vi } from 'vitest'
   ```ts
   // increment.test.js
   import { vi } from 'vitest'
-  
+
   // axios is a default export from `__mocks__/axios.js`
   import axios from 'axios'
-  
+
   // increment is a named export from `src/__mocks__/increment.js`
   import { increment } from '../increment.js'
 
@@ -371,7 +371,7 @@ test('importing the next module imports mocked one', async () => {
 
   ```ts
   import { vi } from 'vitest'
-  
+
   import { data } from './data.js' // Will not get reevaluated beforeEach test
 
   beforeEach(() => {
@@ -717,3 +717,60 @@ unmockedIncrement(30) === 31
 - **Type:** `() => Vitest`
 
   When timers are run out, you may call this method to return mocked timers to its original implementations. All timers that were run before will not be restored.
+
+### vi.waitFor
+
+- **Type:** `function waitFor<T>(callback: WaitForCallback<T>, options?: number | WaitForOptions): Promise<T>`
+- **Version**: Since Vitest 0.35.0
+
+Wait for the callback to execute successfully. If the callback throws an error or returns a rejected promise it will continue to wait until it succeeds or times out.
+
+This is very useful for testing, see the following example.
+
+```ts
+import { test, vi } from 'vitest'
+
+let server = false
+setTimeout(() => {
+  server = true
+}, 100)
+
+function checkServerStart() {
+  if (!server)
+    throw new Error('Server not started')
+
+  console.log('Server started')
+}
+
+test('Server started successfully', async () => {
+  const res = await vi.waitFor(checkServerStart, {
+    timeout: 500, // default is 1000
+    interval: 20, // default is 50
+  })
+  expect(server).toBe(true)
+})
+```
+
+It also works for asynchronous callbacks
+
+```ts
+import { test, vi } from 'vitest'
+
+async function startServer() {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      server = true
+      resolve('Server started')
+    }, 100)
+  })
+}
+
+test('Server started successfully', async () => {
+  const server = await vi.waitFor(startServer, {
+    timeout: 500, // default is 1000
+    interval: 20, // default is 50
+  })
+  expect(server).toBe('Server started')
+})
+```
+

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -775,4 +775,4 @@ test('Server started successfully', async () => {
 })
 ```
 
-If `vi.useFakeTimers` is used, `vi.waitFor` automatically calls `vi.AdvanceTimersByTime(interval)` in every check callback.
+If `vi.useFakeTimers` is used, `vi.waitFor` automatically calls `vi.advanceTimersByTime(interval)` in every check callback.

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -725,24 +725,25 @@ unmockedIncrement(30) === 31
 
 Wait for the callback to execute successfully. If the callback throws an error or returns a rejected promise it will continue to wait until it succeeds or times out.
 
-This is very useful for testing, see the following example.
+This is very useful when you need to wait for some asynchronous action to complete, for example, when you start a server and need to wait for it to start.
 
 ```ts
 import { test, vi } from 'vitest'
 
-let server = false
-setTimeout(() => {
-  server = true
-}, 100)
-
-function checkServerStart() {
-  if (!server)
-    throw new Error('Server not started')
-
-  console.log('Server started')
-}
-
 test('Server started successfully', async () => {
+  let server = false
+
+  setTimeout(() => {
+    server = true
+  }, 100)
+
+  function checkServerStart() {
+    if (!server)
+      throw new Error('Server not started')
+
+    console.log('Server started')
+  }
+
   const res = await vi.waitFor(checkServerStart, {
     timeout: 500, // default is 1000
     interval: 20, // default is 50
@@ -756,16 +757,16 @@ It also works for asynchronous callbacks
 ```ts
 import { test, vi } from 'vitest'
 
-async function startServer() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      server = true
-      resolve('Server started')
-    }, 100)
-  })
-}
-
 test('Server started successfully', async () => {
+  async function startServer() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        server = true
+        resolve('Server started')
+      }, 100)
+    })
+  }
+
   const server = await vi.waitFor(startServer, {
     timeout: 500, // default is 1000
     interval: 20, // default is 50

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -728,7 +728,7 @@ unmockedIncrement(30) === 31
 ### vi.waitFor
 
 - **Type:** `function waitFor<T>(callback: WaitForCallback<T>, options?: number | WaitForOptions): Promise<T>`
-- **Version**: Since Vitest 0.35.0
+- **Version**: Since Vitest 0.34.5
 
 Wait for the callback to execute successfully. If the callback throws an error or returns a rejected promise it will continue to wait until it succeeds or times out.
 

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -775,3 +775,4 @@ test('Server started successfully', async () => {
 })
 ```
 
+If `vi.useFakeTimers` is used, `vi.waitFor` automatically calls `vi.AdvanceTimersByTime(interval)` in every check callback.

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -712,6 +712,12 @@ unmockedIncrement(30) === 31
 
   The implementation is based internally on [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
 
+## vi.isFakeTimers
+
+- **Type:** `() => boolean`
+
+  Returns `true` if fake timers are enabled.
+
 ## vi.useRealTimers
 
 - **Type:** `() => Vitest`

--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -175,6 +175,10 @@ export class FakeTimers {
     this._userConfig = config
   }
 
+  isFakeTimers() {
+    return this._fakingTime
+  }
+
   private _checkFakeTimers() {
     if (!this._fakingTime) {
       throw new Error(

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -12,7 +12,7 @@ import { fn, isMockFunction, spies, spyOn } from './spy'
 import { waitFor } from './wait'
 
 interface VitestUtils {
-  isFakeTimers: () => boolean
+  isFakeTimers(): boolean
   useFakeTimers(config?: FakeTimerInstallOpts): this
   useRealTimers(): this
   runOnlyPendingTimers(): this

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -9,6 +9,7 @@ import { resetModules, waitForImportsToResolve } from '../utils/modules'
 import { FakeTimers } from './mock/timers'
 import type { EnhancedSpy, MaybeMocked, MaybeMockedDeep, MaybePartiallyMocked, MaybePartiallyMockedDeep } from './spy'
 import { fn, isMockFunction, spies, spyOn } from './spy'
+import { waitFor } from './wait'
 
 interface VitestUtils {
   useFakeTimers(config?: FakeTimerInstallOpts): this
@@ -30,6 +31,7 @@ interface VitestUtils {
 
   spyOn: typeof spyOn
   fn: typeof fn
+  waitFor: typeof waitFor
 
   /**
    * Run the factory before imports are evaluated. You can return a value from the factory
@@ -292,7 +294,7 @@ function createVitest(): VitestUtils {
 
     spyOn,
     fn,
-
+    waitFor,
     hoisted<T>(factory: () => T): T {
       assertTypes(factory, '"vi.hoisted" factory', ['function'])
       return factory()

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -12,6 +12,7 @@ import { fn, isMockFunction, spies, spyOn } from './spy'
 import { waitFor } from './wait'
 
 interface VitestUtils {
+  isFakeTimers: () => boolean
   useFakeTimers(config?: FakeTimerInstallOpts): this
   useRealTimers(): this
   runOnlyPendingTimers(): this
@@ -213,6 +214,10 @@ function createVitest(): VitestUtils {
       }
       _timers.useFakeTimers()
       return utils
+    },
+
+    isFakeTimers() {
+      return _timers.isFakeTimers()
     },
 
     useRealTimers() {

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -1,5 +1,7 @@
 import { getSafeTimers } from '@vitest/utils'
 
+// The waitFor function was inspired by https://github.com/testing-library/web-testing-library/pull/2
+
 export type WaitForCallback<T> = () => T | Promise<T>
 
 export interface WaitForOptions {

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -1,4 +1,5 @@
 import { getSafeTimers } from '@vitest/utils'
+import { vi } from './vi'
 
 // The waitFor function was inspired by https://github.com/testing-library/web-testing-library/pull/2
 
@@ -52,6 +53,10 @@ export function waitFor<T>(callback: WaitForCallback<T>, options: number | WaitF
     }
 
     const checkCallback = () => {
+      // use fake timers
+      if (globalThis.setTimeout !== setTimeout)
+        vi.advanceTimersByTime(interval)
+
       if (promiseStatus === 'pending')
         return
       try {

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -53,9 +53,12 @@ export function waitFor<T>(callback: WaitForCallback<T>, options: number | WaitF
     }
 
     const checkCallback = () => {
-      // use fake timers
-      if (globalThis.setTimeout !== setTimeout)
+      try {
+        // use fake timers
+        vi.getTimerCount()
         vi.advanceTimersByTime(interval)
+      }
+      catch {}
 
       if (promiseStatus === 'pending')
         return

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -3,13 +3,14 @@ import { getSafeTimers } from '@vitest/utils'
 export type WaitForCallback<T> = () => T | Promise<T>
 
 export interface WaitForOptions {
-
   /**
+   * @description Time in ms between each check callback
    * @default 50ms
    */
   interval?: number
   /**
-   * @default 5000
+   * @description Time in ms after which the throw a timeout error
+   * @default 1000ms
    */
   timeout?: number
 }
@@ -20,9 +21,9 @@ function copyStackTrace(target: Error, source: Error) {
   return target
 }
 
-export function waitFor<T>(callback: WaitForCallback<T>, options: WaitForOptions = {}) {
+export function waitFor<T>(callback: WaitForCallback<T>, options: number | WaitForOptions = {}) {
   const { setTimeout, setInterval, clearTimeout, clearInterval } = getSafeTimers()
-  const { interval = 50, timeout = 5000 } = options
+  const { interval = 50, timeout = 1000 } = typeof options === 'number' ? { timeout: options } : options
   const STACK_TRACE_ERROR = new Error('STACK_TRACE_ERROR')
 
   return new Promise<T>((resolve, reject) => {

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -1,0 +1,90 @@
+import { getSafeTimers } from '@vitest/utils'
+
+export type WaitForCallback<T> = () => T | Promise<T>
+
+export interface WaitForOptions {
+
+  /**
+   * @default 50ms
+   */
+  interval?: number
+  /**
+   * @default 5000
+   */
+  timeout?: number
+}
+
+function copyStackTrace(target: Error, source: Error) {
+  if (source.stack !== undefined)
+    target.stack = source.stack.replace(source.message, target.message)
+  return target
+}
+
+export function waitFor<T>(callback: WaitForCallback<T>, options: WaitForOptions = {}) {
+  const { setTimeout, setInterval, clearTimeout, clearInterval } = getSafeTimers()
+  const { interval = 50, timeout = 5000 } = options
+  const STACK_TRACE_ERROR = new Error('STACK_TRACE_ERROR')
+
+  return new Promise<T>((resolve, reject) => {
+    let lastError: unknown
+    let promiseStatus: 'idle' | 'pending' | 'resolved' | 'rejected' = 'idle'
+    let timeoutId: ReturnType<typeof setTimeout>
+    let intervalId: ReturnType<typeof setInterval>
+
+    const onResolve = (result: T) => {
+      if (timeoutId)
+        clearTimeout(timeoutId)
+      if (intervalId)
+        clearInterval(intervalId)
+
+      resolve(result)
+    }
+
+    const handleTimeout = () => {
+      let error = lastError
+      if (!error)
+        error = copyStackTrace(new Error('Timed out in waitFor!'), STACK_TRACE_ERROR)
+
+      reject(error)
+    }
+
+    const checkCallback = () => {
+      if (promiseStatus === 'pending')
+        return
+      try {
+        const result = callback()
+        if (
+          result !== null
+          && typeof result === 'object'
+          && typeof (result as any).then === 'function'
+        ) {
+          const thenable = result as PromiseLike<T>
+          promiseStatus = 'pending'
+          thenable.then(
+            (resolvedValue) => {
+              promiseStatus = 'resolved'
+              onResolve(resolvedValue)
+            },
+            (rejectedValue) => {
+              promiseStatus = 'rejected'
+              lastError = rejectedValue
+            },
+          )
+        }
+        else {
+          onResolve(result as T)
+          return true
+        }
+      }
+      catch (error) {
+        lastError = error
+      }
+    }
+
+    if (checkCallback() === true)
+      return
+
+    timeoutId = setTimeout(handleTimeout, timeout)
+    intervalId = setInterval(checkCallback, interval)
+  })
+}

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -53,12 +53,8 @@ export function waitFor<T>(callback: WaitForCallback<T>, options: number | WaitF
     }
 
     const checkCallback = () => {
-      try {
-        // use fake timers
-        vi.getTimerCount()
+      if (vi.isFakeTimers())
         vi.advanceTimersByTime(interval)
-      }
-      catch {}
 
       if (promiseStatus === 'pending')
         return

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -22,12 +22,12 @@ describe('waitFor', () => {
 
       await expect(
         vi.waitFor(callback, {
-          timeout: 45,
-          interval: 10,
+          timeout: 60,
+          interval: 30,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot('"interval error"')
 
-      expect(callback).toHaveBeenCalledTimes(5)
+      expect(callback).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -66,7 +66,7 @@ describe('waitFor', () => {
     }
     catch (error) {
       expect((error as Error).message).toMatchInlineSnapshot('"Assignment to constant variable."')
-      expect((error as Error).stack).toContain('/vitest/test/core/test/waitFor.test.ts:')
+      expect((error as Error).stack).toContain('/vitest/test/core/test/wait.test.ts:')
     }
   })
 

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -66,7 +66,7 @@ describe('waitFor', () => {
     }
     catch (error) {
       expect((error as Error).message).toMatchInlineSnapshot('"Assignment to constant variable."')
-      expect((error as Error).stack).toContain('/vitest/test/core/test/wait.test.ts:')
+      expect.soft((error as Error).stack).toMatch(/at check/)
     }
   })
 

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -9,9 +9,9 @@ describe('waitFor', () => {
           return new Promise((resolve) => {
             setTimeout(() => {
               resolve(true)
-            }, 1000)
+            }, 100)
           })
-        }, 500)
+        }, 50)
       }).rejects.toThrow('Timed out in waitFor!')
     })
 
@@ -22,10 +22,10 @@ describe('waitFor', () => {
 
       await expect(
         vi.waitFor(callback, {
-          timeout: 499,
-          interval: 100,
+          timeout: 49,
+          interval: 10,
         }),
-      ).rejects.toMatchInlineSnapshot('[Error: interval error]')
+      ).rejects.toThrowErrorMatchingInlineSnapshot('"interval error"')
 
       expect(callback).toHaveBeenCalledTimes(5)
     })
@@ -46,7 +46,7 @@ describe('waitFor', () => {
     let finished = false
     setTimeout(() => {
       finished = true
-    }, 500)
+    }, 50)
     await vi.waitFor(async () => {
       if (finished)
         return Promise.resolve(true)
@@ -62,7 +62,7 @@ describe('waitFor', () => {
       _a += 1
     }
     try {
-      await vi.waitFor(check)
+      await vi.waitFor(check, 100)
     }
     catch (error) {
       expect((error as Error).message).toMatchInlineSnapshot('"Assignment to constant variable."')
@@ -73,11 +73,11 @@ describe('waitFor', () => {
   test('stacktrace point to waitFor', async () => {
     const check = async () => {
       return new Promise((resolve) => {
-        setTimeout(resolve, 600)
+        setTimeout(resolve, 60)
       })
     }
     try {
-      await vi.waitFor(check, 500)
+      await vi.waitFor(check, 50)
     }
     catch (error) {
       expect(error).toMatchInlineSnapshot('[Error: Timed out in waitFor!]')
@@ -92,15 +92,15 @@ describe('waitFor', () => {
 
     safeSetTimeout(() => {
       vi.advanceTimersByTime(2000)
-    }, 500)
+    }, 50)
 
     await vi.waitFor(() => {
       return new Promise<void>((resolve) => {
         setTimeout(() => {
           resolve()
-        }, 1500)
+        }, 150)
       })
-    }, 500)
+    }, 50)
 
     vi.useRealTimers()
   })

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -1,4 +1,3 @@
-import { getSafeTimers } from '@vitest/utils'
 import { describe, expect, test, vi } from 'vitest'
 
 describe('waitFor', () => {
@@ -88,9 +87,7 @@ describe('waitFor', () => {
   test('fakeTimer works', async () => {
     vi.useFakeTimers()
 
-    const { setTimeout: safeSetTimeout } = getSafeTimers()
-
-    safeSetTimeout(() => {
+    setTimeout(() => {
       vi.advanceTimersByTime(200)
     }, 50)
 
@@ -100,7 +97,7 @@ describe('waitFor', () => {
           resolve()
         }, 150)
       })
-    }, 50)
+    }, 200)
 
     vi.useRealTimers()
   })

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -22,7 +22,7 @@ describe('waitFor', () => {
 
       await expect(
         vi.waitFor(callback, {
-          timeout: 49,
+          timeout: 45,
           interval: 10,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot('"interval error"')
@@ -91,7 +91,7 @@ describe('waitFor', () => {
     const { setTimeout: safeSetTimeout } = getSafeTimers()
 
     safeSetTimeout(() => {
-      vi.advanceTimersByTime(2000)
+      vi.advanceTimersByTime(200)
     }, 50)
 
     await vi.waitFor(() => {

--- a/test/core/test/waitFor.test.ts
+++ b/test/core/test/waitFor.test.ts
@@ -1,0 +1,117 @@
+import { getSafeTimers } from '@vitest/utils'
+import { describe, expect, test, vi } from 'vitest'
+
+describe('waitFor', () => {
+  describe('options', () => {
+    test('timeout', async () => {
+      expect(async () => {
+        await vi.waitFor(() => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(true)
+            }, 1000)
+          })
+        }, {
+          timeout: 500,
+        })
+      }).rejects.toThrow('Timed out in waitFor!')
+    })
+
+    test('interval', async () => {
+      const callback = vi.fn(() => {
+        throw new Error('interval error')
+      })
+
+      await expect(
+        vi.waitFor(callback, {
+          timeout: 499,
+          interval: 100,
+        }),
+      ).rejects.toMatchInlineSnapshot('[Error: interval error]')
+
+      expect(callback).toHaveBeenCalledTimes(5)
+    })
+  })
+
+  test('basic', async () => {
+    let throwError = false
+    await vi.waitFor(() => {
+      if (!throwError) {
+        throwError = true
+        throw new Error('basic error')
+      }
+    })
+    expect(throwError).toBe(true)
+  })
+
+  test('async function', async () => {
+    let finished = false
+    setTimeout(() => {
+      finished = true
+    }, 500)
+    await vi.waitFor(async () => {
+      if (finished)
+        return Promise.resolve(true)
+      else
+        return Promise.reject(new Error('async function error'))
+    })
+  })
+
+  test('stacktrace correctly', async () => {
+    const check = () => {
+      const _a = 1
+      // @ts-expect-error test
+      _a += 1
+    }
+    try {
+      await vi.waitFor(check, {
+        timeout: 1000,
+      })
+    }
+    catch (error) {
+      expect((error as Error).message).toMatchInlineSnapshot('"Assignment to constant variable."')
+      expect((error as Error).stack).toContain('/vitest/test/core/test/waitFor.test.ts:')
+    }
+  })
+
+  test('stacktrace point to waitFor', async () => {
+    const check = async () => {
+      return new Promise((resolve) => {
+        setTimeout(resolve, 600)
+      })
+    }
+    try {
+      await vi.waitFor(check, {
+        timeout: 500,
+      })
+    }
+    catch (error) {
+      expect(error).toMatchInlineSnapshot('[Error: Timed out in waitFor!]')
+      expect((error as Error).stack?.split('\n')[1]).toMatch(/waitFor\s*\(.*\)?/)
+    }
+  })
+
+  test('fakeTimer works', async () => {
+    vi.useFakeTimers()
+
+    const { setTimeout: safeSetTimeout } = getSafeTimers()
+
+    safeSetTimeout(() => {
+      vi.advanceTimersByTime(2000)
+    }, 500)
+
+    await vi.waitFor(() => {
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve()
+        }, 1500)
+      })
+    }, {
+      timeout: 500,
+    })
+
+    vi.useRealTimers()
+  })
+}, {
+  timeout: 6_000,
+})

--- a/test/core/test/waitFor.test.ts
+++ b/test/core/test/waitFor.test.ts
@@ -11,9 +11,7 @@ describe('waitFor', () => {
               resolve(true)
             }, 1000)
           })
-        }, {
-          timeout: 500,
-        })
+        }, 500)
       }).rejects.toThrow('Timed out in waitFor!')
     })
 
@@ -64,9 +62,7 @@ describe('waitFor', () => {
       _a += 1
     }
     try {
-      await vi.waitFor(check, {
-        timeout: 1000,
-      })
+      await vi.waitFor(check)
     }
     catch (error) {
       expect((error as Error).message).toMatchInlineSnapshot('"Assignment to constant variable."')
@@ -81,9 +77,7 @@ describe('waitFor', () => {
       })
     }
     try {
-      await vi.waitFor(check, {
-        timeout: 500,
-      })
+      await vi.waitFor(check, 500)
     }
     catch (error) {
       expect(error).toMatchInlineSnapshot('[Error: Timed out in waitFor!]')
@@ -106,12 +100,8 @@ describe('waitFor', () => {
           resolve()
         }, 1500)
       })
-    }, {
-      timeout: 500,
-    })
+    }, 500)
 
     vi.useRealTimers()
   })
-}, {
-  timeout: 6_000,
 })


### PR DESCRIPTION
### Description

Partial closes - #4061

The `waitFor` function was inspired by https://github.com/testing-library/web-testing-library/pull/2.

Currently only supports `timeout` and `interval` options. I think this is enough, Let me know if you need to add any other options! 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
