### PR TITLE
fix(inline-snapshot): support mix of normal/with placeholders snapshots

### DIFF
--- a/packages/snapshot/src/port/inlineSnapshot.ts
+++ b/packages/snapshot/src/port/inlineSnapshot.ts
@@ -96,12 +96,17 @@ function prepareSnapString(snap: string, source: string, index: number) {
 
 const startRegex = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*(?:\/\*[\S\s]*\*\/\s*|\/\/.*\s+)*\s*[\w_$]*(['"`\)])/m
 export function replaceInlineSnap(code: string, s: MagicString, index: number, newSnap: string) {
-  const startMatch = startRegex.exec(code.slice(index))
-  if (!startMatch)
+  const codeStartingAtIndex = code.slice(index)
+
+  const startMatch = startRegex.exec(codeStartingAtIndex)
+
+  const firstKeywordMatch = /toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot/.exec(codeStartingAtIndex)
+
+  if (!startMatch || startMatch.index !== firstKeywordMatch?.index)
     return replaceObjectSnap(code, s, index, newSnap)
 
   const quote = startMatch[1]
-  const startIndex = index + startMatch.index! + startMatch[0].length
+  const startIndex = index + startMatch.index + startMatch[0].length
   const snapString = prepareSnapString(newSnap, code, index)
 
   if (quote === ')') {

--- a/test/snapshots/test-update/snapshots-inline-js.test.js
+++ b/test/snapshots/test-update/snapshots-inline-js.test.js
@@ -34,9 +34,35 @@ describe('snapshots with properties', () => {
   })
 
   test('with snapshot', () => {
-    expect({ foo: 'bar' }).toMatchInlineSnapshot({ foo: expect.any(String) }, `
+    expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, `
       Object {
-        "foo": Any<String>,
+        "first": Object {
+          "second": Object {
+            "foo": Any<String>,
+          },
+        },
+      }
+    `)
+  })
+
+  test('mixed with and without snapshot', () => {
+    expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, `
+      Object {
+        "first": Object {
+          "second": Object {
+            "foo": Any<String>,
+          },
+        },
+      }
+    `)
+
+    expect({ first: { second: { foo: 'zed' } } }).toMatchInlineSnapshot(`
+      Object {
+        "first": Object {
+          "second": Object {
+            "foo": "zed",
+          },
+        },
       }
     `)
   })

--- a/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
+++ b/test/snapshots/test/__snapshots__/shapshots.test.ts.snap
@@ -37,9 +37,35 @@ describe('snapshots with properties', () => {
   })
 
   test('with snapshot', () => {
-    expect({ foo: 'bar' }).toMatchInlineSnapshot({ foo: expect.any(String) }, \`
+    expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, \`
       Object {
-        \\"foo\\": Any<String>,
+        \\"first\\": Object {
+          \\"second\\": Object {
+            \\"foo\\": Any<String>,
+          },
+        },
+      }
+    \`)
+  })
+
+  test('mixed with and without snapshot', () => {
+    expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, \`
+      Object {
+        \\"first\\": Object {
+          \\"second\\": Object {
+            \\"foo\\": Any<String>,
+          },
+        },
+      }
+    \`)
+
+    expect({ first: { second: { foo: 'zed' } } }).toMatchInlineSnapshot(\`
+      Object {
+        \\"first\\": Object {
+          \\"second\\": Object {
+            \\"foo\\": \\"zed\\",
+          },
+        },
       }
     \`)
   })

--- a/test/snapshots/tools/inline-test-template.js
+++ b/test/snapshots/tools/inline-test-template.js
@@ -18,6 +18,34 @@ describe('snapshots with properties', () => {
   })
 
   test('with snapshot', () => {
-    expect({ foo: 'bar' }).toMatchInlineSnapshot({ foo: expect.any(String) }, '')
+    expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, `
+      Object {
+        "first": Object {
+          "wrong": Any<String>,
+          "second": null,
+        }
+      }
+    `)
+  })
+
+  test('mixed with and without snapshot', () => {
+    expect({ first: { second: { foo: 'bar' } } }).toMatchInlineSnapshot({ first: { second: { foo: expect.any(String) } } }, `
+      Object {
+        "first": Object {
+          "wrong": Any<String>,
+          "second": null,
+        }
+      }
+    `)
+
+    expect({ first: { second: { foo: 'zed' } } }).toMatchInlineSnapshot(`
+      Object {
+        "first": Object {
+          "second": {
+            "foo": "zed"
+          }
+        }
+      }
+    `)
   })
 })


### PR DESCRIPTION
### Description

- Undesired behavior happens when you use multiple `expect(...).toMatchInlineSnapshot()` methods within same `it` or `test` block and you mix method with shape object with placeholders as 1st argument and method without that.
- Vitest either doesn't update any inline snapshot or it may update even wrong inline snapshot under rare curcumstances.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
