### PR TITLE
Another way to allow leading space in `testNamePattern`

### DIFF
--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -27,8 +27,14 @@ export function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, 
       }
     }
     if (t.type === 'test') {
-      if (namePattern && !getTaskFullName(t).match(namePattern))
-        t.mode = 'skip'
+      if (namePattern) {
+        const taskFullName = getTaskFullName(t)
+        // Match also the task full name with a leading space to be backward-compatible with tools like
+        // IntelliJ/WebStorm. Previous Vitest versions (<= 0.34.3) had the task full name starting
+        // with a space, and the tools passed `testNamePattern` matching it.
+        if (!(taskFullName.match(namePattern) || ` ${taskFullName}`.match(namePattern)))
+          t.mode = 'skip'
+      }
     }
     else if (t.type === 'suite') {
       if (t.mode === 'skip')

--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -46,7 +46,8 @@ export function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, 
 }
 
 function getTaskFullName(task: TaskBase): string {
-  return `${task.suite ? `${getTaskFullName(task.suite)} ` : ''}${task.name}`
+  const fullName = task.suite ? getTaskFullName(task.suite) : null
+  return fullName ? `${fullName} ${task.name}` : task.name
 }
 
 export function someTasksAreOnly(suite: Suite): boolean {

--- a/test/filters/test/testname-pattern.test.ts
+++ b/test/filters/test/testname-pattern.test.ts
@@ -30,3 +30,14 @@ test('match by pattern that also matches current working directory', async () =>
   expect(stdout).toMatch('Test Files  1 passed (1)')
   expect(stdout).not.toMatch('test/example.test.ts')
 })
+
+test('match by test name pattern with ^', async () => {
+  const { stdout } = await runVitest({
+    root: './fixtures',
+    testNamePattern: '^this',
+  }, ['filters'])
+
+  expect(stdout).toMatch('✓ test/filters.test.ts > this will pass')
+  expect(stdout).toMatch('Test Files  1 passed (1)')
+  expect(stdout).not.toMatch('test/example.test.ts')
+})


### PR DESCRIPTION
### Description

This is another attempt to fix #4103.
Pro: the fixed version of `getTaskFullName` is restored: no leading space makes #4045 fixed again.
Con: `taskFullName.match(namePattern)` is called twice.

@sheremet-va @Dunqing

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
