### PR TITLE
docs: Concurrent image downloading and `as` an attribute for prefetch links

### DIFF
--- a/docs/.vitepress/scripts/fetch-avatars.ts
+++ b/docs/.vitepress/scripts/fetch-avatars.ts
@@ -31,9 +31,11 @@ async function fetchAvatars() {
 
 async function fetchSponsors() {
   await fs.ensureDir(dirSponsors)
-  await download('https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg', join(dirSponsors, 'antfu.svg'))
-  await download('https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg', join(dirSponsors, 'patak-dev.svg'))
-  await download('https://cdn.jsdelivr.net/gh/sheremet-va/static/sponsors.svg', join(dirSponsors, 'sheremet-va.svg'))
+  await Promise.all([
+    download('https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg', join(dirSponsors, 'antfu.svg')),
+    download('https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg', join(dirSponsors, 'patak-dev.svg')),
+    download('https://cdn.jsdelivr.net/gh/sheremet-va/static/sponsors.svg', join(dirSponsors, 'sheremet-va.svg')),
+  ])
 }
 
 fetchAvatars()

--- a/docs/.vitepress/scripts/transformHead.ts
+++ b/docs/.vitepress/scripts/transformHead.ts
@@ -12,13 +12,13 @@ export async function transformHead({ pageData }: TransformContext): Promise<Hea
     head.push(['link', { rel: 'preconnect', href: link }])
   })
 
-  head.push(['link', { rel: 'prefetch', href: '/logo.svg' }])
+  head.push(['link', { rel: 'prefetch', href: '/logo.svg', type: 'image' }])
   if (home) {
-    head.push(['link', { rel: 'prefetch', href: '/logo-shadow.svg' }])
-    head.push(['link', { rel: 'prefetch', href: '/sponsors/antfu.svg' }])
-    head.push(['link', { rel: 'prefetch', href: '/sponsors/sheremet-va.svg' }])
-    head.push(['link', { rel: 'prefetch', href: '/sponsors/patak-dev.svg' }])
-    head.push(['link', { rel: 'prefetch', href: '/netlify.svg' }])
+    head.push(['link', { rel: 'prefetch', href: '/logo-shadow.svg', type: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/sponsors/antfu.svg', type: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/sponsors/sheremet-va.svg', type: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/sponsors/patak-dev.svg', type: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/netlify.svg', type: 'image' }])
   }
 
   return head

--- a/docs/.vitepress/scripts/transformHead.ts
+++ b/docs/.vitepress/scripts/transformHead.ts
@@ -12,13 +12,13 @@ export async function transformHead({ pageData }: TransformContext): Promise<Hea
     head.push(['link', { rel: 'preconnect', href: link }])
   })
 
-  head.push(['link', { rel: 'prefetch', href: '/logo.svg', type: 'image' }])
+  head.push(['link', { rel: 'prefetch', href: '/logo.svg', as: 'image' }])
   if (home) {
-    head.push(['link', { rel: 'prefetch', href: '/logo-shadow.svg', type: 'image' }])
-    head.push(['link', { rel: 'prefetch', href: '/sponsors/antfu.svg', type: 'image' }])
-    head.push(['link', { rel: 'prefetch', href: '/sponsors/sheremet-va.svg', type: 'image' }])
-    head.push(['link', { rel: 'prefetch', href: '/sponsors/patak-dev.svg', type: 'image' }])
-    head.push(['link', { rel: 'prefetch', href: '/netlify.svg', type: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/logo-shadow.svg', as: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/sponsors/antfu.svg', as: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/sponsors/sheremet-va.svg', as: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/sponsors/patak-dev.svg', as: 'image' }])
+    head.push(['link', { rel: 'prefetch', href: '/netlify.svg', as: 'image' }])
   }
 
   return head


### PR DESCRIPTION
Hi, this PR aims to make a minor improvement to the documentation. We are implementing concurrent image downloading to enhance performance and resource management. Additionally, we are adding the 'as' attribute to the `link rel="prefetch"` element, following the reference provided here: https://web.dev/codelab-two-ways-to-prefetch/#prefetch-the-product-page-with-lesslink-rel=prefetchgreater.