### PR TITLE
chore: update threadsCount logic to use availableParallelism

### DIFF
--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -1,5 +1,5 @@
 import { MessageChannel } from 'node:worker_threads'
-import { cpus } from 'node:os'
+import * as nodeos from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { createBirpc } from 'birpc'
 import { resolve } from 'pathe'
@@ -39,9 +39,14 @@ function createWorkerChannel(project: WorkspaceProject) {
 }
 
 export function createThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessOptions): ProcessPool {
+  const numCpus
+    = typeof nodeos.availableParallelism === 'function'
+      ? nodeos.availableParallelism()
+      : nodeos.cpus().length
+
   const threadsCount = ctx.config.watch
-    ? Math.max(Math.floor(cpus().length / 2), 1)
-    : Math.max(cpus().length - 1, 1)
+    ? Math.max(Math.floor(numCpus / 2), 1)
+    : Math.max(numCpus - 1, 1)
 
   const maxThreads = ctx.config.maxThreads ?? threadsCount
   const minThreads = ctx.config.minThreads ?? threadsCount

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -1,5 +1,5 @@
 import { MessageChannel } from 'node:worker_threads'
-import { cpus } from 'node:os'
+import * as nodeos from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { createBirpc } from 'birpc'
 import { resolve } from 'pathe'
@@ -40,9 +40,14 @@ function createWorkerChannel(project: WorkspaceProject) {
 }
 
 export function createVmThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessOptions): ProcessPool {
+  const numCpus
+    = typeof nodeos.availableParallelism === 'function'
+      ? nodeos.availableParallelism()
+      : nodeos.cpus().length
+
   const threadsCount = ctx.config.watch
-    ? Math.max(Math.floor(cpus().length / 2), 1)
-    : Math.max(cpus().length - 1, 1)
+    ? Math.max(Math.floor(numCpus / 2), 1)
+    : Math.max(numCpus - 1, 1)
 
   const maxThreads = ctx.config.maxThreads ?? threadsCount
   const minThreads = ctx.config.minThreads ?? threadsCount

--- a/packages/vitest/src/utils/memory-limit.ts
+++ b/packages/vitest/src/utils/memory-limit.ts
@@ -5,13 +5,18 @@
  * LICENSE file in the root directory of facebook/jest GitHub project tree.
  */
 
-import { cpus } from 'node:os'
+import * as nodeos from 'node:os'
 import type { ResolvedConfig } from '../types'
 
 function getDefaultThreadsCount(config: ResolvedConfig) {
+  const numCpus
+    = typeof nodeos.availableParallelism === 'function'
+      ? nodeos.availableParallelism()
+      : nodeos.cpus().length
+
   return config.watch
-    ? Math.max(Math.floor(cpus().length / 2), 1)
-    : Math.max(cpus().length - 1, 1)
+    ? Math.max(Math.floor(numCpus / 2), 1)
+    : Math.max(numCpus - 1, 1)
 }
 
 export function getWorkerMemoryLimit(config: ResolvedConfig) {


### PR DESCRIPTION
### Description
We found an issue running vitest in self-hosted github action runners where they use as MAX_THREADS the number of CPUs available in the node instead of respecting the resources.limits assigned to the pod.

Introduced in v19.4.0, v18.14.0, [`os.availableParallelism()`](https://nodejs.org/api/os.html#osavailableparallelism) allow us to estimate of the default amount of parallelism a program should use instead of using [`os.cpus`](https://nodejs.org/api/os.html#oscpus) .

> os.cpus().length should not be used to calculate the amount of parallelism available to an application. Use [os.availableParallelism()](https://nodejs.org/api/os.html#osavailableparallelism) for this purpose.

A similar work was already done in another libs like https://github.com/jestjs/jest/pull/13738.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
