### PR TITLE
fix(vite-node): export `SourceMapInput` to fix CYCLIC_CROSS_CHUNK_REEXPORT

### DIFF
--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -31,7 +31,7 @@ export interface StartOfSourceMap {
   sourceRoot?: string
 }
 
-export type { EncodedSourceMap, DecodedSourceMap } from '@jridgewell/trace-mapping'
+export type { EncodedSourceMap, DecodedSourceMap, SourceMapInput } from '@jridgewell/trace-mapping'
 
 export interface RawSourceMap extends StartOfSourceMap {
   version: string


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

`pnpm run dev` still error occurred, export `SourceMapInput` will fixed
<img width="1016" alt="image" src="https://github.com/vitest-dev/vitest/assets/29533304/570fdc39-b718-4943-95af-bcaeabeca3ae">


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
