### PR TITLE
fix: Update HappyDOMOptions to be compatible with v12

### DIFF
--- a/packages/vitest/src/types/happy-dom-options.ts
+++ b/packages/vitest/src/types/happy-dom-options.ts
@@ -12,6 +12,9 @@ export interface HappyDOMOptions {
     disableIframePageLoading?: boolean
     disableComputedStyleRendering?: boolean
     enableFileSystemHttpRequests?: boolean
+		navigator?: {
+			userAgent?: string
+		}
     device?: {
       prefersColorScheme?: string
       mediaType?: string

--- a/packages/vitest/src/types/happy-dom-options.ts
+++ b/packages/vitest/src/types/happy-dom-options.ts
@@ -12,9 +12,9 @@ export interface HappyDOMOptions {
     disableIframePageLoading?: boolean
     disableComputedStyleRendering?: boolean
     enableFileSystemHttpRequests?: boolean
-		navigator?: {
-			userAgent?: string
-		}
+    navigator?: {
+      userAgent?: string
+    }
     device?: {
       prefersColorScheme?: string
       mediaType?: string


### PR DESCRIPTION
### Description

Simply adds optional `navigator` property with optional `userAgent` subproperty to `HappyDOMOptions`.

happy-dom [release v12.0.0](https://github.com/capricorn86/happy-dom/releases/tag/v12.0.0) added a setting allowing the userAgent to be changed, as well as updating the default.

For example, the following configuration can be used but currently needs a `@ts-ignore`(a workaround for https://github.com/mui/mui-x/issues/10374):

```
    environmentOptions: {
      happyDOM: {
        settings: {
          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
          // @ts-ignore
          navigator: {
            userAgent: 'Mozilla/5.0 (linux) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/22.1.0',
          },
        },
      },
    },
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [-] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [-] Ideally, include a test that fails without this PR but passes with it.
- [✓] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [✓] Run the tests with `pnpm test:ci`.

### Documentation
- [✓] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [✓] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
