### PR TITLE
fix: use flatMap instead of map_flat in rollup config

### DIFF
--- a/packages/ui/rollup.config.js
+++ b/packages/ui/rollup.config.js
@@ -21,7 +21,7 @@ const external = [
 export default () => [
   'index',
   'reporter',
-].map(entry => [
+].flatMap(entry => [
   {
     input: `./node/${entry}.ts`,
     output: {
@@ -57,7 +57,7 @@ export default () => [
       dts(),
     ],
   },
-]).flat()
+])
 
 function onwarn(message) {
   if (['EMPTY_BUNDLE', 'CIRCULAR_DEPENDENCY'].includes(message.code))


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
I just did a little simplification. `map` + `flat` can be replaced by single `flatMap`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
