### PR TITLE
chore: making vite a peer depencency

### DIFF
--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -82,16 +82,19 @@
     "prepublishOnly": "pnpm build",
     "typecheck": "tsc --noEmit"
   },
+  "peerDependencies": {
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+  },
   "dependencies": {
     "cac": "^6.7.14",
     "debug": "^4.3.4",
     "mlly": "^1.4.0",
     "pathe": "^1.1.1",
-    "picocolors": "^1.0.0",
-    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+    "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@jridgewell/trace-mapping": "^0.3.18",
-    "@types/debug": "^4.1.8"
+    "@types/debug": "^4.1.8",
+    "vite": "^4.0.0"
   }
 }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -113,6 +113,7 @@
     "jsdom": "*",
     "playwright": "*",
     "safaridriver": "*",
+    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
     "webdriverio": "*"
   },
   "peerDependenciesMeta": {
@@ -163,7 +164,6 @@
     "strip-literal": "^1.0.1",
     "tinybench": "^2.5.0",
     "tinypool": "^0.7.0",
-    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
     "vite-node": "workspace:*",
     "why-is-node-running": "^2.2.2"
   },
@@ -202,6 +202,7 @@
     "prompts": "^2.4.2",
     "safaridriver": "^0.0.5",
     "strip-ansi": "^7.1.0",
+    "vite": "^4.0.0",
     "webdriverio": "^8.11.2",
     "ws": "^8.13.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,9 +1268,6 @@ importers:
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0
-      vite:
-        specifier: ^4.4.9
-        version: 4.4.9(@types/node@18.16.19)(less@4.1.3)
     devDependencies:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.18
@@ -1278,6 +1275,9 @@ importers:
       '@types/debug':
         specifier: ^4.1.8
         version: 4.1.8
+      vite:
+        specifier: ^4.4.9
+        version: 4.4.9(@types/node@18.16.19)(less@4.1.3)
 
   packages/vitest:
     dependencies:
@@ -1350,9 +1350,6 @@ importers:
       tinypool:
         specifier: ^0.7.0
         version: 0.7.0
-      vite:
-        specifier: ^4.4.9
-        version: 4.4.9(@types/node@18.7.13)
       vite-node:
         specifier: workspace:*
         version: link:../vite-node
@@ -1462,6 +1459,9 @@ importers:
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
+      vite:
+        specifier: ^4.4.9
+        version: 4.4.9(@types/node@18.7.13)
       webdriverio:
         specifier: ^8.11.2
         version: 8.12.1(typescript@5.1.6)


### PR DESCRIPTION
### Description

Breaking Change:
vitest and vite-node now both specify vite as a peerDependency and thus require that you add vite as an explicit dependency wherever you are using vitest or vite-node.

Closes: #4142 
Closes: #4112

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
