### PR TITLE
fix: Remove reference to vi.restoreCurrentDate() from doc (does not exist)

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -398,12 +398,6 @@ Does not reset mocks registry. To clear mocks registry, use [`vi.unmock`](#vi-un
 
   Will call [`.mockRestore()`](/api/mock#mockrestore) on all spies. This will clear mock history and reset its implementation to the original one.
 
-## vi.restoreCurrentDate
-
-- **Type:** `() => void`
-
-  Restores `Date` back to its native implementation.
-
 ## vi.stubEnv
 
 - **Type:** `(name: string, value: string) => Vitest`


### PR DESCRIPTION
### Description

I was trying to make some tests that required mocking the system date, and noticed the docs refer to `vi.restoreCurrentDate()` which does not exist.

The documentation of `setSystemTime()` includes in its example `vi.useRealTimers()`, so I don't think another function is needed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
