### PR TITLE
fix(runner): the fixture of `test.extend` should be init once time in all test

### DIFF
--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -90,7 +90,9 @@ export function withFixtures(fn: Function, testContext?: TestContext) {
           catch (err) {
             reject(err)
           }
-          return new Promise<void>(fixtureCleanupSet.add)
+          return new Promise<void>((resolve) => {
+            fixtureCleanupSet.add(resolve)
+          })
         }
       }
 

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -316,14 +316,13 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
           }
         }
       }
-
-      await callFixtureCleanup()
     }
     catch (e) {
       failTask(suite.result, e, runner.config.diffOptions)
     }
 
     try {
+      await callFixtureCleanup()
       await callSuiteHook(suite, suite, 'afterAll', runner, [suite])
       await callCleanupHooks(beforeAllCleanups)
     }

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -10,6 +10,7 @@ import { collectTests } from './collect'
 import { setCurrentTest } from './test-state'
 import { hasFailed, hasTests } from './utils/tasks'
 import { PendingError } from './errors'
+import { callFixtureCleanup } from './fixture'
 
 const now = Date.now
 
@@ -315,6 +316,8 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
           }
         }
       }
+
+      await callFixtureCleanup()
     }
     catch (e) {
       failTask(suite.result, e, runner.config.diffOptions)

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -322,7 +322,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
     }
 
     try {
-      await callFixtureCleanup()
+      await callFixtureCleanup(suite.id)
       await callSuiteHook(suite, suite, 'afterAll', runner, [suite])
       await callCleanupHooks(beforeAllCleanups)
     }

--- a/test/core/test/test-extend.test.ts
+++ b/test/core/test/test-extend.test.ts
@@ -38,39 +38,34 @@ const myTest = test
   })
 
 describe('test.extend()', () => {
-  myTest('todoList and doneList', ({ todoList, doneList, archiveList }) => {
-    expect(todoFn).toBeCalledTimes(1)
-    expect(doneFn).toBeCalledTimes(1)
+  describe('basic', () => {
+    myTest('todoList and doneList', ({ todoList, doneList, archiveList }) => {
+      expect(todoFn).toBeCalledTimes(1)
+      expect(doneFn).toBeCalledTimes(1)
 
-    expectTypeOf(todoList).toEqualTypeOf<number[]>()
-    expectTypeOf(doneList).toEqualTypeOf<number[]>()
-    expectTypeOf(doneList).toEqualTypeOf<number[]>()
+      expectTypeOf(todoList).toEqualTypeOf<number[]>()
+      expectTypeOf(doneList).toEqualTypeOf<number[]>()
+      expectTypeOf(doneList).toEqualTypeOf<number[]>()
 
-    expect(todoList).toEqual([1, 2, 3])
-    expect(doneList).toEqual([])
-    expect(archiveList).toEqual([])
+      expect(todoList).toEqual([1, 2, 3])
+      expect(doneList).toEqual([])
+      expect(archiveList).toEqual([])
 
-    doneList.push(todoList.shift()!)
-    expect(todoList).toEqual([2, 3])
-    expect(doneList).toEqual([1])
+      doneList.push(todoList.shift()!)
+      expect(todoList).toEqual([2, 3])
+      expect(doneList).toEqual([1])
 
-    doneList.push(todoList.shift()!)
-    expect(todoList).toEqual([3])
-    expect(doneList).toEqual([1, 2])
+      doneList.push(todoList.shift()!)
+      expect(todoList).toEqual([3])
+      expect(doneList).toEqual([1, 2])
 
-    archiveList.push(todoList.shift()!)
-    expect(todoList).toEqual([])
-    expect(archiveList).toEqual([3])
+      archiveList.push(todoList.shift()!)
+      expect(todoList).toEqual([])
+      expect(archiveList).toEqual([3])
 
-    archiveList.pop()
+      archiveList.pop()
+    })
   })
-
-  myTest('should called cleanup functions', ({ todoList, doneList, archiveList }) => {
-    expect(todoList).toEqual([1, 2, 3])
-    expect(doneList).toEqual([])
-    expect(archiveList).toEqual([])
-  })
-
   describe('smartly init fixtures', () => {
     myTest('should not init any fixtures', function () {
       expect(todoFn).not.toBeCalled()


### PR DESCRIPTION
### Description

close: #4165 

I noticed that the previous implementation of teardown was incorrect, in playwright, teardown is executed before `afterAll` hook.

#### The main changes in this PR are as follows

1. Correct teardown implement (should be called teardown before calling `afterAll` hook, follow the rule by the playwright)
2. Each fixture of the same `test.extend` instance is setup only once


#### Execution order

The following example describes the execution order

```ts
  describe('fixture in nested describe', () => {
    interface Fixture {
      foo: number
      bar: number
    }

    const fooFn = vi.fn(() => 0)
    const fooCleanup = vi.fn()

    const barFn = vi.fn(() => 0)
    const barCleanup = vi.fn()

    const nestedTest = test.extend<Fixture>({
      async foo({}, use) {
        await use(fooFn())
        fooCleanup()
      },
      async bar({}, use) {
        await use(barFn())
        barCleanup()
      },
    })

    beforeEach<Fixture>(({ foo }) => {
      expect(foo).toBe(0)
    })

    nestedTest('should only initialize foo', ({ foo }) => {
      expect(foo).toBe(0)
      expect(fooFn).toBeCalledTimes(1)
      expect(barFn).toBeCalledTimes(0)
    })

    describe('level 2, using both foo and bar together', () => {
      beforeEach<Fixture>(({ foo, bar }) => {
        expect(foo).toBe(0)
        expect(bar).toBe(0)
      })

      nestedTest('should only initialize bar', ({ foo, bar }) => {
        expect(foo).toBe(0)
        expect(bar).toBe(0)
        expect(fooFn).toBeCalledTimes(1)
        expect(barFn).toBeCalledTimes(1)
      })

      afterEach<Fixture>(({ foo, bar }) => {
        expect(foo).toBe(0)
        expect(bar).toBe(0)
      })

      afterAll(() => {
        // foo setup in outside describe
        // cleanup also called in outside describe
        expect(fooCleanup).toHaveBeenCalledTimes(0)
        // bar setup in inside describe
        // cleanup also called in inside describe
        expect(barCleanup).toHaveBeenCalledTimes(1)
      })
    })

    nestedTest('level 2 will not call foo cleanup', ({ foo }) => {
      expect(foo).toBe(0)
      expect(fooFn).toBeCalledTimes(1)
    })

    afterEach<Fixture>(({ foo }) => {
      expect(foo).toBe(0)
    })

    afterAll(() => {
      // foo setup in this describe
      // cleanup also called in this describe
      expect(fooCleanup).toHaveBeenCalledTimes(1)
      expect(barCleanup).toHaveBeenCalledTimes(1)
    })
  })
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
