### PR TITLE
feat(runner): improve text.extend types

### DIFF
--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -189,15 +189,31 @@ export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & {
       K extends keyof ExtraContext ? ExtraContext[K] : never }>
 }
 
-export type Fixtures<T extends Record<string, any>, ExtraContext = {}> = {
-  [K in keyof T]: T[K] | ((context: {
-    [P in keyof T | keyof ExtraContext as P extends K ?
-      P extends keyof ExtraContext ? P : never : P
-    ]:
-    K extends P ? K extends keyof ExtraContext ? ExtraContext[K] : never :
-      P extends keyof T ? T[P] : never
-  } & TestContext, use: (fixture: T[K]) => Promise<void>) => Promise<void>)
+type FixtureType<T> = T extends (context: any, use: (fixture: infer F) => any) => any ? F : T
+type Fixture<
+  T,
+  K extends keyof T,
+  OnlyFunction,
+  ExtraContext = {},
+  V = FixtureType<T[K]>,
+  FN = (
+    context: {
+      [P in keyof T | keyof ExtraContext as P extends K ?
+        P extends keyof ExtraContext ? P : never : P
+      ]:
+      K extends P ? K extends keyof ExtraContext ? ExtraContext[K] : V :
+        P extends keyof T ? T[P] : never
+    } & TestContext,
+    use: (fixture: V) => Promise<void>
+  ) => Promise<void>,
+> = OnlyFunction extends true ? FN : (FN | V)
+type Fixtures<T extends Record<string, any>, ExtraContext> = {
+  [K in keyof T]: Fixture<T, K, false, ExtraContext>
+} | {
+  [K in keyof T]: Fixture<T, K, true, ExtraContext>
 }
+
+export type InferFixturesTypes<T> = T extends TestAPI<infer C> ? C : T
 
 type ChainableSuiteAPI<ExtraContext = {}> = ChainableFunction<
   'concurrent' | 'sequential' | 'only' | 'skip' | 'todo' | 'shuffle',

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -190,7 +190,7 @@ export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & {
 }
 
 type FixtureType<T> = T extends (context: any, use: (fixture: infer F) => any) => any ? F : T
-type Fixture<
+export type Fixture<
   T,
   K extends keyof T,
   OnlyFunction,
@@ -207,7 +207,7 @@ type Fixture<
     use: (fixture: V) => Promise<void>
   ) => Promise<void>,
 > = OnlyFunction extends true ? FN : (FN | V)
-type Fixtures<T extends Record<string, any>, ExtraContext> = {
+export type Fixtures<T extends Record<string, any>, ExtraContext = {}> = {
   [K in keyof T]: Fixture<T, K, false, ExtraContext>
 } | {
   [K in keyof T]: Fixture<T, K, true, ExtraContext>

--- a/test/core/test/test-extend.test.ts
+++ b/test/core/test/test-extend.test.ts
@@ -40,7 +40,7 @@ const myTest = test
   })
 
 describe('test.extend()', () => {
-  describe('types', () => {
+  test('types', () => {
     interface TypesContext {
       number: number
       array: number[]

--- a/test/core/test/test-extend.test.ts
+++ b/test/core/test/test-extend.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable prefer-rest-params */
 /* eslint-disable no-empty-pattern */
+import type { InferFixturesTypes } from '@vitest/runner'
+import type { TestAPI } from 'vitest'
 import { describe, expect, expectTypeOf, test, vi } from 'vitest'
 
 interface Fixtures {
@@ -38,6 +40,29 @@ const myTest = test
   })
 
 describe('test.extend()', () => {
+  describe('types', () => {
+    interface TypesContext {
+      number: number
+      array: number[]
+      string: string
+      any: any
+      boolean: boolean
+    }
+
+    const typesTest = test.extend<TypesContext>({
+      number: 1,
+      array: [1, 2, 3],
+      async string({ }, use) {
+        await use('string')
+      },
+      async any({}, use) {
+        await use({})
+      },
+      boolean: true,
+    })
+
+    expectTypeOf(typesTest).toEqualTypeOf<TestAPI<InferFixturesTypes<typeof typesTest>>>()
+  })
   myTest('todoList and doneList', ({ todoList, doneList, archiveList }) => {
     expect(todoFn).toBeCalledTimes(1)
     expect(doneFn).toBeCalledTimes(1)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
Partial close - #3915.

### Mainly changes

1. Better `any` type supports
2. Add the `InferFixturesTypes` helper type, which can get fixtures type from `TestApi`
3. Some improvement

### `InferFixturesTypes` 

```ts
interface TypesContext {
  number: number
  array: number[]
  string: string
  any: any
  boolean: boolean
}

const myTest = test.extend<TypesContext>({
  number: 1,
  array: [1, 2, 3],
  async string({ }, use) {
    await use('string')
  },
  async any({}, use) {
    await use({})
  },
  boolean: true,
})

// The type is equal
TypesContext === InferFixturesTypes<typeof typesTest>>
```



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
