### PR TITLE
fix: add multiple globals in VM+JSDOM (fix #4199)

### DIFF
--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -80,14 +80,14 @@ export default <Environment>({
       'MessageChannel',
       'MessagePort',
     ]
-    globalNames.forEach(name => {
+    for (const name of globalNames) {
       const value = globalThis[name]
       if (
         typeof value !== 'undefined' &&
         typeof dom.window[name] === 'undefined'
       )
         dom.window[name] = value
-    })       
+    }
 
     return {
       getVmContext() {

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -69,9 +69,25 @@ export default <Environment>({
     // TODO: browser doesn't expose Buffer, but a lot of dependencies use it
     dom.window.Buffer = Buffer
 
-    // inject structuredClone if it exists
-    if (typeof structuredClone !== 'undefined' && !dom.window.structuredClone)
-      dom.window.structuredClone = structuredClone
+    // inject web globals if they missing in JSDOM but otherwise available in Nodejs
+    // https://nodejs.org/dist/latest/docs/api/globals.html
+    const globalNames = [
+      'structuredClone',
+      'fetch',
+      'Request',
+      'Response',
+      'BroadcastChannel',
+      'MessageChannel',
+      'MessagePort',
+    ]
+    globalNames.forEach(name => {
+      const value = globalThis[name]
+      if (
+        typeof value !== 'undefined' &&
+        typeof dom.window[name] === 'undefined'
+      )
+        dom.window[name] = value
+    })       
 
     return {
       getVmContext() {

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -79,12 +79,12 @@ export default <Environment>({
       'BroadcastChannel',
       'MessageChannel',
       'MessagePort',
-    ]
+    ] as const
     for (const name of globalNames) {
       const value = globalThis[name]
       if (
-        typeof value !== 'undefined' &&
-        typeof dom.window[name] === 'undefined'
+        typeof value !== 'undefined'
+        && typeof dom.window[name] === 'undefined'
       )
         dom.window[name] = value
     }

--- a/test/core/test/environments/jsdom.spec.ts
+++ b/test/core/test/environments/jsdom.spec.ts
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { expect, test } from 'vitest'
+
+const nodeMajor = Number(process.version.slice(1).split('.')[0])
+
+test.runIf(nodeMajor >= 15)('MessageChannel and MessagePort are available', () => {
+  expect(MessageChannel).toBeDefined()
+  expect(MessagePort).toBeDefined()
+})
+
+test.runIf(nodeMajor >= 17)('structuredClone is available', () => {
+  expect(structuredClone).toBeDefined()
+})
+
+test.runIf(nodeMajor >= 18)('fetch, Request, Response, and BroadcastChannel are available', () => {
+  expect(fetch).toBeDefined()
+  expect(Request).toBeDefined()
+  expect(Response).toBeDefined()
+  expect(BroadcastChannel).toBeDefined()
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This adds the following Nodejs/Web globals into the JSDOM environment, as they are otherwise unavailable when running with `experimentalVmThreads` enabled:
- `fetch`
- `Request`
- `Response`
- `BroadcastChannel`
- `MessageChannel`
- `MessagePort`

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
