### PR TITLE
fix(happy-dom): don't crash when calling useFakeTimers with empty config

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -217,7 +217,7 @@ function createVitest(): VitestUtils {
       }
 
       if (config)
-        _timers.configure(config)
+        _timers.configure({ ...workerState.config.fakeTimers, ...config })
       else
         _timers.configure(workerState.config.fakeTimers)
 

--- a/test/core/test/environments/happy-dom.spec.ts
+++ b/test/core/test/environments/happy-dom.spec.ts
@@ -1,0 +1,11 @@
+// @vitest-environment happy-dom
+
+import { afterEach, test, vi } from 'vitest'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test('fake timers don\'t fail when using empty config', () => {
+  vi.useFakeTimers({})
+})


### PR DESCRIPTION
### Description

Fixes #4131

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
