### PR TITLE
feat!(vitest): add "vitest list" command to output test names

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -613,6 +613,15 @@ Custom reporters for output. Reporters can be [a Reporter instance](https://gith
   - `'hanging-process'` - displays a list of hanging processes, if Vitest cannot exit process safely. This might be a heavy operation, enable it only if Vitest consistently cannot exit process
   - path of a custom reporter (e.g. `'./path/to/reporter.ts'`, `'@scope/reporter'`)
 
+### collectors<NonProjectOption />
+
+- **Type:** `Reporter | Reporter[]`
+- **Default:** `[]`
+- **CLI:** `--collector=<name>`, `--collector=<name1> --collector=<name2>`
+- **Version:** Since Vitest 1.0.0-beta.1
+
+Custom collectors that are called during `vitest list` command. This is useful to track test collection in real time.
+
 ### outputFile<NonProjectOption />
 
 - **Type:** `string | Record<string, string>`

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -30,6 +30,22 @@ Run all test suites but watch for changes and rerun tests when they change. Same
 
 Alias to `vitest watch`.
 
+### `vitest list`
+
+Outputs a list of test names that will be called with current filters. This works as a regular `vitest` command, but it will not run tests, only collect them.
+
+For performance reasons, this command disables [isolation](/config#pooloptions). If you rely on isolated environment for collecting tests, you can enable it manually. For example, if you use threads pool (which is a default), you can call `vitest list` as:
+
+```bash
+vitest list --poolOptions.threads.isolate=true
+```
+
+By default, it will output test names to stdout. This command also supports `--json` flag. If specified without an argument, it will output an array of file names and test names to stdout. If it receives a value, Vitest will create a file in that path (relative to current working directory or `--root` flag):
+
+```bash
+vitest list --json=./test-names.js
+```
+
 ### `vitest related`
 
 Run only tests that cover a list of source files. Works with static imports (e.g., `import('./index.ts')` or `import index from './index.ts`), but not the dynamic ones (e.g., `import(filepath)`). All files should be relative to root folder.

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,4 +1,4 @@
-export { startTests, updateTask } from './run'
+export { startTests, updateTask, collectTests } from './run'
 export { test, it, describe, suite, getCurrentSuite, createTaskCollector } from './suite'
 export { beforeAll, beforeEach, afterAll, afterEach, onTestFailed } from './hooks'
 export { setFn, getFn } from './map'

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -6,7 +6,7 @@ import type { VitestRunner } from './types/runner'
 import type { Custom, File, HookCleanupCallback, HookListener, SequenceHooks, Suite, SuiteHooks, Task, TaskMeta, TaskResult, TaskResultPack, TaskState, Test } from './types'
 import { partitionSuiteChildren } from './utils/suite'
 import { getFn, getHooks } from './map'
-import { collectTests } from './collect'
+import { collectTests as collect } from './collect'
 import { setCurrentTest } from './test-state'
 import { hasFailed, hasTests } from './utils/tasks'
 import { PendingError } from './errors'
@@ -382,7 +382,7 @@ export async function runFiles(files: File[], runner: VitestRunner) {
 export async function startTests(paths: string[], runner: VitestRunner) {
   await runner.onBeforeCollect?.(paths)
 
-  const files = await collectTests(paths, runner)
+  const files = await collect(paths, runner)
 
   runner.onCollected?.(files)
   await runner.onBeforeRunFiles?.(files)
@@ -393,5 +393,16 @@ export async function startTests(paths: string[], runner: VitestRunner) {
 
   await sendTasksUpdate(runner)
 
+  return files
+}
+
+export async function collectTests(paths: string[], runner: VitestRunner) {
+  await runner.onBeforeCollect?.(paths)
+
+  const files = await collect(paths, runner)
+
+  runner.onCollected?.(files)
+
+  await sendTasksUpdate(runner)
   return files
 }

--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -26,7 +26,7 @@ export function interpretTaskModes(suite: Suite, namePattern?: string | RegExp, 
         t.mode = 'run'
       }
     }
-    if (t.type === 'test') {
+    if (t.type === 'test' || t.type === 'custom') {
       if (namePattern && !getTaskFullName(t).match(namePattern))
         t.mode = 'skip'
     }

--- a/packages/vitest/src/browser.ts
+++ b/packages/vitest/src/browser.ts
@@ -1,3 +1,3 @@
-export { startTests } from '@vitest/runner'
+export { startTests, collectTests } from '@vitest/runner'
 export { setupCommonEnv, loadDiffConfig } from './runtime/setup.common'
 export { takeCoverageInsideWorker, stopCoverageInsideWorker, getCoverageProvider, startCoverageInsideWorker } from './integrations/coverage'

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -135,9 +135,18 @@ export function collectTests(
   options.run = true
   options.watch = false
 
+  // don't isolate test files in collect mode by default to improve speed, but allow overwrite
+  options.poolOptions ??= {}
+  options.poolOptions.threads ??= {}
+  options.poolOptions.threads.isolate ??= false
+  options.poolOptions.forks ??= {}
+  options.poolOptions.forks.isolate ??= false
+
   return new Promise<CollectedTests>((resolve, reject) => {
     executeVitest(
       async (ctx) => {
+        if (ctx.config.browser)
+          ctx.config.browser.isolate = options.browser?.isolate ?? false
         const tests = await ctx.collect(cliFilters)
         resolve(tests)
       },

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -13,6 +13,11 @@ export interface CliOptions extends UserConfig {
    * Override the watch mode
    */
   run?: boolean
+
+  /**
+   * During collection, this can be set to "true" to output tests in a json format
+   */
+  json?: string | boolean
 }
 
 /**

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -61,7 +61,7 @@ cli
 cli
   .command('list [...filters]')
   .option('--json [path]', 'Output results in JSON format')
-  .option('--colector <name>', 'Specify collectors')
+  .option('--collector <name>', 'Specify collectors')
   .action(list)
 
 cli

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -7,6 +7,7 @@ import type { BaseCoverageOptions, CoverageIstanbulOptions, Vitest, VitestRunMod
 import type { CliOptions } from './cli-api'
 import { collectTests, startVitest } from './cli-api'
 import { divider } from './reporters/renderers/utils'
+import { processCollected } from './collect'
 
 const cli = cac('vitest')
 
@@ -59,6 +60,7 @@ cli
 
 cli
   .command('list [...filters]')
+  .option('--json [path]', 'Output results in JSON format')
   .action(list)
 
 cli
@@ -206,8 +208,7 @@ async function list(cliFilters: string[], options: CliOptions): Promise<void> {
       process.exit(1)
     }
 
-    // TODO: how to print tests?
-    console.log(tests)
+    processCollected(tests, options)
   }
   catch (e) {
     console.error(`\n${c.red(divider(c.bold(c.inverse(' Unhandled Error '))))}`)

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -61,6 +61,7 @@ cli
 cli
   .command('list [...filters]')
   .option('--json [path]', 'Output results in JSON format')
+  .option('--colector <name>', 'Specify collectors')
   .action(list)
 
 cli

--- a/packages/vitest/src/node/collect.ts
+++ b/packages/vitest/src/node/collect.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
-import { writeFileSync } from 'node:fs'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import type { File } from '@vitest/runner'
-import { resolve } from 'pathe'
+import { dirname, resolve } from 'pathe'
 import { getNames, getTests } from '../utils'
 import type { CliOptions } from './cli-api'
 
@@ -12,6 +12,7 @@ export function processCollected(files: File[], options: CliOptions) {
 
   if (typeof options.json === 'string') {
     const jsonPath = resolve(options.root || process.cwd(), options.json)
+    mkdirSync(dirname(jsonPath), { recursive: true })
     writeFileSync(jsonPath, JSON.stringify(formatCollectedAsJSON(files), null, 2))
     return
   }

--- a/packages/vitest/src/node/collect.ts
+++ b/packages/vitest/src/node/collect.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+
+import { writeFileSync } from 'node:fs'
+import type { File } from '@vitest/runner'
+import { resolve } from 'pathe'
+import { getNames, getTests } from '../utils'
+import type { CliOptions } from './cli-api'
+
+export function processCollected(files: File[], options: CliOptions) {
+  if (typeof options.json === 'boolean')
+    return console.log(JSON.stringify(formatCollectedAsJSON(files), null, 2))
+
+  if (typeof options.json === 'string') {
+    const jsonPath = resolve(options.root || process.cwd(), options.json)
+    writeFileSync(jsonPath, JSON.stringify(formatCollectedAsJSON(files), null, 2))
+    return
+  }
+
+  return formatCollectedAsString(files).forEach(test => console.log(test))
+}
+
+export function formatCollectedAsJSON(files: File[]) {
+  return files.map((file) => {
+    const tests = getTests(file)
+    return tests.map(test => ({ name: getNames(test).slice(1).join(' > '), file: file.filepath }))
+  }).flat()
+}
+
+export function formatCollectedAsString(files: File[]) {
+  return files.map((file) => {
+    const tests = getTests(file).filter(test => test.mode === 'run' || test.mode === 'only')
+    return tests.map(test => getNames(test).join(' > '))
+  }).flat()
+}

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -347,7 +347,11 @@ export class Vitest {
 
   async collect(filters?: string[]): Promise<CollectedTests> {
     const collectors = this.collectors
-      || (this.collectors = await createReporters(toArray(this.config.collectors), this.runner))
+      || (this.collectors = await createReporters([
+        // @ts-expect-error CLI type
+        ...toArray(this.config.collector),
+        ...toArray(this.config.collectors),
+      ], this.runner))
 
     const reporters = this.reporters
     this.reporters = collectors

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -529,8 +529,10 @@ export class Vitest {
         this.state.catchError(err, 'Unhandled Error')
       }
     })()
-      .finally(() => {
+      .finally(async () => {
         this.collectingPromise = undefined
+        const specs = Array.from(new Set(paths.map(([, p]) => p)))
+        await this.report('onFinished', this.state.getFiles(specs), this.state.getUnhandledErrors())
       })
 
     return await this.collectingPromise

--- a/packages/vitest/src/node/pools/child.ts
+++ b/packages/vitest/src/node/pools/child.ts
@@ -229,6 +229,7 @@ export function createChildProcessPool(ctx: Vitest, { execArgv, env }: PoolProce
 
   return {
     runTests: runWithFiles('run'),
+    collectTests: runWithFiles('collect'),
     close: async () => {
       await pool.destroy()
     },

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -209,6 +209,7 @@ export function createThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessOpt
 
   return {
     runTests: runWithFiles('run'),
+    collectTests: runWithFiles('collect'),
     close: async () => {
       // node before 16.17 has a bug that causes FATAL ERROR because of the race condition
       const nodeVersion = Number(process.version.match(/v(\d+)\.(\d+)/)?.[0].slice(1))

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -153,6 +153,7 @@ export function createVmThreadsPool(ctx: Vitest, { execArgv, env }: PoolProcessO
 
   return {
     runTests: runWithFiles('run'),
+    collectTests: runWithFiles('collect'),
     close: async () => {
       // node before 16.17 has a bug that causes FATAL ERROR because of the race condition
       const nodeVersion = Number(process.version.match(/v(\d+)\.(\d+)/)?.[0].slice(1))

--- a/packages/vitest/src/runtime/child.ts
+++ b/packages/vitest/src/runtime/child.ts
@@ -121,3 +121,19 @@ export async function run(ctx: ChildContext) {
     process.exit = exit
   }
 }
+
+export async function collect(ctx: ChildContext) {
+  const exit = process.exit
+
+  ctx.config = unwrapConfig(ctx.config)
+
+  try {
+    const state = await init(ctx)
+    const { collect, executor } = await startViteNode({ state })
+    await collect(ctx.files, ctx.config, { environment: state.environment, options: ctx.environment.options }, executor)
+    await rpcDone()
+  }
+  finally {
+    process.exit = exit
+  }
+}

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -33,8 +33,11 @@ export async function createVitestExecutor(options: ExecuteOptions) {
   return runner
 }
 
+type ViteNodeRunnerMethod = (files: string[], config: ResolvedConfig, environment: ResolvedTestEnvironment, executor: VitestExecutor) => Promise<void>
+
 let _viteNode: {
-  run: (files: string[], config: ResolvedConfig, environment: ResolvedTestEnvironment, executor: VitestExecutor) => Promise<void>
+  collect: ViteNodeRunnerMethod
+  run: ViteNodeRunnerMethod
   executor: VitestExecutor
 }
 
@@ -49,9 +52,9 @@ export async function startViteNode(options: ContextExecutorOptions) {
 
   const executor = await startVitestExecutor(options)
 
-  const { run } = await import(entryUrl)
+  const { run, collect } = await import(entryUrl)
 
-  _viteNode = { run, executor }
+  _viteNode = { run, executor, collect }
 
   return _viteNode
 }

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -87,3 +87,10 @@ export async function run(ctx: WorkerContext) {
     inspectorCleanup()
   }
 }
+
+export async function collect(ctx: WorkerContext) {
+  const state = await init(ctx)
+  const { collect, executor } = await startViteNode({ state })
+  await collect(ctx.files, ctx.config, { environment: state.environment, options: ctx.environment.options }, executor)
+  await rpcDone()
+}

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -344,6 +344,11 @@ export interface InlineConfig {
   reporters?: Arrayable<BuiltinReporters | 'html' | Reporter | Omit<string, BuiltinReporters>>
 
   /**
+   * Custom reporters that are called during "vitest list" command. They share the same API as reporters.
+   */
+  collectors?: Arrayable<Reporter>
+
+  /**
    * Write test results to a file when the --reporter=json` or `--reporter=junit` option is also specified.
    * Also definable individually per reporter by using an object instead.
    */

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -1,3 +1,5 @@
+import type { File } from '@vitest/runner'
+
 export type { ErrorWithDiff, ParsedStack } from '@vitest/utils'
 
 export type Awaitable<T> = T | PromiseLike<T>
@@ -31,6 +33,11 @@ export interface Environment {
   transformMode: 'web' | 'ssr'
   setupVM?(options: Record<string, any>): Awaitable<VmEnvironmentReturn>
   setup(global: any, options: Record<string, any>): Awaitable<EnvironmentReturn>
+}
+
+export interface CollectedTests {
+  tests: File[]
+  errors: unknown[]
 }
 
 export interface UserConsoleLog {

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "test": "vitest",
     "dev": "vite",
+    "test:list": "vitest list",
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Closes #2901

This PR adds a new command:

```
vitest list
```

It outputs the list of tests that would be running with passed-down filters. For example, like this:

```
vitest list filename another-filename -t "some kind of filter"
```

By default, it just prints a list of names to stdout. You can pass down `--json` flag to output it as json (it will also include a filename as a separate field). `--json` flag also accepts a path to the file: `vitest list --json=./tests.json`

This PR also adds a new config option called `collectors` which has the same interface as a reporter - so you can collect tests in real-time (`onCollected` will be called after each test _file_ is collected). This will probably be useful for tools like VS Code extension.

To improve performance, Vitest ignores "isolate" flag (always set to `false`), unless it's overridden in CLI.

TODO:

- [ ] Update browser peer dependency
- [ ] Documentation

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
