### PR TITLE
docs: mention `-t, --testNamePattern` option on filtering page

### DIFF
--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -22,6 +22,8 @@ basic-foo.test.ts
 basic/foo.test.ts
 ```
 
+You can also use the `-t, --testNamePattern <pattern>	` option to filter tests by full name. This can be helpful when you want to filter by the name defined within a file rather than the filename itself.
+
 ## Specifying a Timeout
 
 You can optionally pass a timeout in milliseconds as third argument to tests. The default is 5 seconds.


### PR DESCRIPTION
### Description

I expected the `-t` option to be mentioned on the filtering page

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
