### PR TITLE
feat!: enable `coverage.all` by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1042,7 +1042,7 @@ List of files excluded from coverage as glob patterns.
 #### coverage.all
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true` (since Vitest `1.0.0`)
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.all`, `--coverage.all=false`
 

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -32,6 +32,7 @@ const defaultCoverageExcludes = [
 export const coverageConfigDefaults: ResolvedCoverageOptions = {
   provider: 'v8',
   enabled: false,
+  all: true,
   clean: true,
   cleanOnRerun: true,
   reportsDirectory: './coverage',

--- a/test/coverage-test/testing-options.mjs
+++ b/test/coverage-test/testing-options.mjs
@@ -44,6 +44,7 @@ for (const provider of ['v8', 'istanbul']) {
       coverage: {
         enabled: true,
         clean: true,
+        all: false,
         provider,
         ...testConfig.coverage,
       },

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -45,7 +45,6 @@ export default defineConfig({
       customProviderModule: provider === 'custom' ? 'custom-provider' : undefined,
       include: ['src/**'],
       clean: true,
-      all: true,
       reporter: [
         'text',
         ['html'],

--- a/test/workspaces/vitest.config.ts
+++ b/test/workspaces/vitest.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   test: {
     coverage: {
       enabled: true,
-      all: true,
     },
     reporters: ['default', 'json'],
     outputFile: './results.json',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Fixes https://github.com/vitest-dev/vitest/issues/2674. 

There's more reasoning on the linked issue, but overall `all: true` is better default. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
