### PR TITLE
Enable custom coverage reporters & ui coverage provider

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -5,7 +5,7 @@ import { coverageConfigDefaults, defaultExclude, defaultInclude } from 'vitest/c
 import { BaseCoverageProvider } from 'vitest/coverage'
 import c from 'picocolors'
 import libReport from 'istanbul-lib-report'
-import reports from 'istanbul-reports'
+import reports, { type ReportOptions } from 'istanbul-reports'
 import type { CoverageMap } from 'istanbul-lib-coverage'
 import libCoverage from 'istanbul-lib-coverage'
 import libSourceMaps from 'istanbul-lib-source-maps'
@@ -143,7 +143,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       this.ctx.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.name))
 
     for (const reporter of this.options.reporter) {
-      reports.create(reporter[0], {
+      reports.create(reporter[0] as keyof ReportOptions, {
         skipFull: this.options.skipFull,
         projectRoot: this.ctx.config.root,
         ...reporter[1],

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -4,7 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import v8ToIstanbul from 'v8-to-istanbul'
 import { mergeProcessCovs } from '@bcoe/v8-coverage'
 import libReport from 'istanbul-lib-report'
-import reports from 'istanbul-reports'
+import reports, { type ReportOptions } from 'istanbul-reports'
 import type { CoverageMap } from 'istanbul-lib-coverage'
 import libCoverage from 'istanbul-lib-coverage'
 import libSourceMaps from 'istanbul-lib-source-maps'
@@ -147,7 +147,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       this.ctx.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.name))
 
     for (const reporter of this.options.reporter) {
-      reports.create(reporter[0], {
+      reports.create(reporter[0] as keyof ReportOptions, {
         skipFull: this.options.skipFull,
         projectRoot: this.ctx.config.root,
         ...reporter[1],

--- a/packages/ui/client/composables/navigation.ts
+++ b/packages/ui/client/composables/navigation.ts
@@ -21,14 +21,14 @@ export const coverageUrl = computed(() => {
   if (coverageEnabled.value) {
     const url = `${window.location.protocol}//${window.location.hostname}:${config.value!.api!.port!}`
     const idx = coverage.value!.reportsDirectory.lastIndexOf('/')
-    const htmlReporter = coverage.value!.reporter.find((reporter) => {
-      if (reporter[0] !== 'html')
+    const providerReporter = coverage.value!.reporter.find((reporter) => {
+      if (reporter[0] !== config.value!.ui.coverageProvider)
         return undefined
 
       return reporter
     })
-    return htmlReporter && 'subdir' in htmlReporter[1]
-      ? `${url}/${coverage.value!.reportsDirectory.slice(idx + 1)}/${htmlReporter[1].subdir}/index.html`
+    return providerReporter && 'subdir' in providerReporter[1]
+      ? `${url}/${coverage.value!.reportsDirectory.slice(idx + 1)}/${providerReporter[1].subdir}/index.html`
       : `${url}/${coverage.value!.reportsDirectory.slice(idx + 1)}/index.html`
   }
 

--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -10,8 +10,8 @@ export default (ctx: Vitest) => {
     name: 'vitest:ui',
     apply: 'serve',
     configureServer(server) {
-      const uiOptions = ctx.config
-      const base = uiOptions.uiBase
+      const uiOptions = ctx.config.ui
+      const base = uiOptions.baseURL
       const coverageFolder = resolveCoverageFolder(ctx)
       const coveragePath = coverageFolder ? coverageFolder[1] : undefined
       if (coveragePath && base === coveragePath)
@@ -35,16 +35,17 @@ export default (ctx: Vitest) => {
 
 function resolveCoverageFolder(ctx: Vitest) {
   const options = ctx.config
-  const htmlReporter = (options.api?.port && options.coverage?.enabled)
+  const provider = ctx.config.ui.coverageProvider
+  const providerReporter = (options.api?.port && options.coverage?.enabled)
     ? options.coverage.reporter.find((reporter) => {
       if (typeof reporter === 'string')
-        return reporter === 'html'
+        return reporter === provider
 
-      return reporter[0] === 'html'
+      return reporter[0] === provider
     })
     : undefined
 
-  if (!htmlReporter)
+  if (!providerReporter)
     return undefined
 
   // reportsDirectory not resolved yet
@@ -53,8 +54,8 @@ function resolveCoverageFolder(ctx: Vitest) {
     options.coverage.reportsDirectory || coverageConfigDefaults.reportsDirectory,
   )
 
-  const subdir = (Array.isArray(htmlReporter) && htmlReporter.length > 1 && 'subdir' in htmlReporter[1])
-    ? htmlReporter[1].subdir
+  const subdir = (Array.isArray(providerReporter) && providerReporter.length > 1 && 'subdir' in providerReporter[1])
+    ? providerReporter[1].subdir
     : undefined
 
   if (!subdir)

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -81,9 +81,12 @@ const config = {
   silent: false,
   hideSkippedTests: false,
   api: false,
-  ui: false,
-  uiBase: '/__vitest__/',
-  open: true,
+  ui: {
+    enabled: false,
+    baseURL: '/__vitest__/',
+    coverageProvider: 'html',
+    open: !isCI,
+  },
   css: {
     include: [],
   },
@@ -97,6 +100,6 @@ const config = {
     exclude: defaultExclude,
   },
   slowTestThreshold: 300,
-}
+} satisfies UserConfig
 
 export const configDefaults: Required<Pick<UserConfig, keyof typeof config>> = Object.freeze(config)

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -151,6 +151,13 @@ function normalizeCliOptions(argv: CliOptions): CliOptions {
   else
     delete argv.dir
 
+  argv.ui = {
+    enabled: argv.ui as boolean,
+    open: argv.open,
+  }
+
+  delete argv.open
+
   if (argv.coverage) {
     const coverage = argv.coverage
     if (coverage.exclude)

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -175,6 +175,29 @@ export function resolveConfig(
       resolved.server.deps![option] = resolved.deps[option] as any
   })
 
+  // Covert boolean config to object
+  if (typeof resolved.ui === 'boolean') {
+    (resolved as any).ui = {
+      enabled: resolved.ui,
+    }
+  }
+
+  const deprecatedUIOptions = [['open', 'open'], ['uiBase', 'baseURL']] as const
+  deprecatedUIOptions.forEach(([option, useInstead]) => {
+    if (options[option] === undefined)
+      return
+
+    console.warn(c.yellow(`${c.inverse(c.yellow(' Vitest '))} "${option}" is deprecated. Use "ui.${useInstead}" instead`))
+    delete (resolved as any)[option];
+    (resolved.ui as any)[useInstead] ??= options[option]
+  })
+
+  // Fill with default values
+  resolved.ui = {
+    ...(configDefaults.ui as ResolvedConfig['ui']),
+    ...resolved.ui,
+  }
+
   // vitenode will try to import such file with native node,
   // but then our mocker will not work properly
   if (resolved.server.deps.inline !== true) {

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -138,7 +138,7 @@ export class Logger {
     })
 
     if (this.ctx.config.ui)
-      this.log(c.dim(c.green(`      UI started at http://${this.ctx.config.api?.host || 'localhost'}:${c.bold(`${this.ctx.server.config.server.port}`)}${this.ctx.config.uiBase}`)))
+      this.log(c.dim(c.green(`      UI started at http://${this.ctx.config.api?.host || 'localhost'}:${c.bold(`${this.ctx.server.config.server.port}`)}${this.ctx.config.ui.baseURL}`)))
     else if (this.ctx.config.api?.port)
       this.log(c.dim(c.green(`      API started at http://${this.ctx.config.api?.host || 'localhost'}:${c.bold(`${this.ctx.config.api.port}`)}`)))
 

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -59,8 +59,14 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
 
         let open: string | boolean | undefined = false
 
-        if (testConfig.ui && testConfig.open)
-          open = testConfig.uiBase ?? '/__vitest__/'
+        if (testConfig.ui && (testConfig.open || (typeof testConfig.ui === 'object' && testConfig.ui.open))) {
+          const uiConfig = typeof testConfig.ui === 'object'
+            ? testConfig.ui
+            : {
+                baseURL: testConfig.uiBase,
+              }
+          open = uiConfig.baseURL ?? '/__vitest__/'
+        }
 
         const config: ViteConfig = {
           root: viteConfig.test?.root || options.root,

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -461,7 +461,28 @@ export interface InlineConfig {
    * Enable Vitest UI
    * @internal WIP
    */
-  ui?: boolean
+  ui?: boolean | {
+    /**
+     * Enable Vitest UI
+     */
+    enabled?: boolean
+    /**
+     * Coverage report provider
+     * @default 'html'
+     */
+    coverageProvider?: string
+    /**
+     * Base url for the UI
+     * @default '/__vitest__/''
+     */
+    baseURL?: string
+    /**
+     * Open UI automatically.
+     *
+     * @default true
+     */
+    open?: boolean
+  }
 
   /**
    * options for test in a browser environment
@@ -475,6 +496,7 @@ export interface InlineConfig {
    * Open UI automatically.
    *
    * @default true
+   * @deprecated see ui.open
    */
   open?: boolean
 
@@ -482,6 +504,7 @@ export interface InlineConfig {
    * Base url for the UI
    *
    * @default '/__vitest__/'
+   * @deprecated see ui.baseURL
    */
   uiBase?: string
 
@@ -704,7 +727,7 @@ export interface UserConfig extends InlineConfig {
   shard?: string
 }
 
-export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'browser' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'benchmark' | 'shard' | 'cache' | 'sequence' | 'typecheck' | 'runner' | 'poolOptions'> {
+export interface ResolvedConfig extends Omit<Required<UserConfig>, 'uiBase' | 'open' | 'ui' | 'config' | 'filters' | 'browser' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'benchmark' | 'shard' | 'cache' | 'sequence' | 'typecheck' | 'runner' | 'poolOptions'> {
   mode: VitestRunMode
 
   base?: string
@@ -726,6 +749,8 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
   defines: Record<string, any>
 
   api?: ApiConfig
+
+  ui: Required<Exclude<InlineConfig['ui'], boolean | undefined>>
 
   benchmark?: Required<Omit<BenchmarkUserOptions, 'outputFile'>> & {
     outputFile?: BenchmarkUserOptions['outputFile']

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -52,14 +52,11 @@ export interface CoverageProviderModule {
   stopCoverage?(): unknown | Promise<unknown>
 }
 
-export type CoverageReporter = keyof ReportOptions
+type CoverageReporterWithOptions = {
+  [key in keyof ReportOptions]: [key, ReportOptions[key] extends never ? {} : Partial<ReportOptions[key]>]
+}[keyof ReportOptions] | [string, Record<string, any>]
 
-type CoverageReporterWithOptions<ReporterName extends CoverageReporter = CoverageReporter> =
-   ReporterName extends CoverageReporter
-     ? ReportOptions[ReporterName] extends never
-       ? [ReporterName, {}] // E.g. the "none" reporter
-       : [ReporterName, Partial<ReportOptions[ReporterName]>]
-     : never
+export type CoverageReporter = CoverageReporterWithOptions[0]
 
 type Provider = 'v8' | 'istanbul' | 'custom' | undefined
 


### PR DESCRIPTION
### Description

This PR solves https://github.com/vitest-dev/vitest/issues/4150
What changed:
- (deprecated) `open` option - use `ui.open` instead
- (depreacted) `uiBase` option - use `ui.baseURL` instead
- added new `ui.enabled` option as alternative to *boolean* `ui` option
- [!] added new `ui.coverageProvider` option to enable using preview of custom coverage reporters (instead of harcoded html reporter)
- [!] added `string` type as correct reporter name

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
