### PR TITLE
fix(vitest): correctly hoist `vi.hoisted` if assigned

### DIFF
--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -46,10 +46,11 @@ function transformImportSpecifiers(node: ImportDeclaration) {
 }
 
 const regexpHoistable = /^[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/m
+const regexpAssignedHoisted = /=[ \t]*(\bawait|)[ \t]*\b(vi|vitest)\s*\.\s*hoisted\(/
 const hashbangRE = /^#!.*\n/
 
 export function hoistMocks(code: string, id: string, parse: (code: string, options: any) => AcornNode) {
-  const hasMocks = regexpHoistable.test(code)
+  const hasMocks = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
 
   if (!hasMocks)
     return

--- a/test/core/src/rely-on-hoisted.ts
+++ b/test/core/src/rely-on-hoisted.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error not typed global
+export const value = globalThis.someGlobalValue

--- a/test/core/test/hoisted-async-simple.test.ts
+++ b/test/core/test/hoisted-async-simple.test.ts
@@ -1,0 +1,19 @@
+// this test checks only vi.hoisted because vi.mock affects the regexp to find this
+
+import { afterAll, expect, it, vi } from 'vitest'
+import { value } from '../src/rely-on-hoisted'
+
+const globalValue = await vi.hoisted(async () => {
+  // @ts-expect-error not typed global
+  globalThis.someGlobalValue = 'globalValue'
+  return 'globalValue'
+})
+
+afterAll(() => {
+  // @ts-expect-error not typed global
+  delete globalThis.someGlobalValue
+})
+
+it('imported value is equal to returned from hoisted', () => {
+  expect(value).toBe(globalValue)
+})

--- a/test/core/test/hoisted-simple.test.ts
+++ b/test/core/test/hoisted-simple.test.ts
@@ -1,0 +1,19 @@
+// this test checks only vi.hoisted because vi.mock affects the regexp to find this
+
+import { afterAll, expect, it, vi } from 'vitest'
+import { value } from '../src/rely-on-hoisted'
+
+const globalValue = vi.hoisted(() => {
+  // @ts-expect-error not typed global
+  globalThis.someGlobalValue = 'globalValue'
+  return 'globalValue'
+})
+
+afterAll(() => {
+  // @ts-expect-error not typed global
+  delete globalThis.someGlobalValue
+})
+
+it('imported value is equal to returned from hoisted', () => {
+  expect(value).toBe(globalValue)
+})


### PR DESCRIPTION
### Description

Currently `vi.hoisted` is not hoisted if it's assigned to another variable and there are no `vi.mock/vi.unmock` inside the file.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
