### PR TITLE
fix!: set `vitest` peer dependency range for sub packages

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.34.0"
+    "vitest": "^1.0.0-0"
   },
   "dependencies": {
     "estree-walker": "^3.0.3",

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.32.0 <1"
+    "vitest": "^1.0.0-0"
   },
   "dependencies": {
     "istanbul-lib-coverage": "^3.2.0",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.32.0 <1"
+    "vitest": "^1.0.0-0"
   },
   "dependencies": {
     "@ampproject/remapping": "^2.2.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": ">=0.30.1 <1"
+    "vitest": "^1.0.0-0"
   },
   "dependencies": {
     "@vitest/utils": "workspace:*",

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "vitest": ">=0.34.0"
+    "vitest": "^1.0.0-0"
   },
   "dependencies": {
     "debug": "^4.3.4"


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Sub-packages to require v1 or v1-beta version of Vitest as peer dependency. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
