### PR TITLE
fix(jest-expect): `Object.freeze` breaks `toEqual`

### DIFF
--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -163,8 +163,11 @@ export function replaceAsymmetricMatcher(actual: any, expected: any, actualRepla
         actualReplaced,
         expectedReplaced,
       )
-      actual[key] = replaced.replacedActual
-      expected[key] = replaced.replacedExpected
+      if (actualValue !== replaced.replacedActual)
+        actual[key] = replaced.replacedActual
+
+      if (expectedValue !== replaced.replacedExpected)
+        expected[key] = replaced.replacedExpected
     }
   })
   return {

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -163,11 +163,8 @@ export function replaceAsymmetricMatcher(actual: any, expected: any, actualRepla
         actualReplaced,
         expectedReplaced,
       )
-      if (actualValue !== replaced.replacedActual)
-        actual[key] = replaced.replacedActual
-
-      if (expectedValue !== replaced.replacedExpected)
-        expected[key] = replaced.replacedExpected
+      actual[key] = replaced.replacedActual
+      expected[key] = replaced.replacedExpected
     }
   })
   return {

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -97,7 +97,7 @@ export function clone<T>(
   if (Array.isArray(val)) {
     out = Array((k = val.length))
     seen.set(val, out)
-    while (k--) out[k] = clone(val[k], seen)
+    while (k--) out[k] = clone(val[k], seen, options)
     return out as any
   }
 

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -110,7 +110,7 @@ export function clone<T>(
       const descriptor = Object.getOwnPropertyDescriptor(val, k)
       if (!descriptor)
         continue
-      const cloned = clone((val as any)[k], seen)
+      const cloned = clone((val as any)[k], seen, options)
       if ('get' in descriptor) {
         Object.defineProperty(out, k, {
           ...descriptor,

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -303,6 +303,13 @@ describe('jest-expect', () => {
     expect(() => {
       expect(complex).toHaveProperty('a-b', false)
     }).toThrowErrorMatchingInlineSnapshot('"expected { \'0\': \'zero\', foo: 1, …(4) } to have property "a-b" with value false"')
+
+    expect(() => {
+      const x = { a: { b: { c: 1 } } }
+      const y = { a: { b: { c: 2 } } }
+      Object.freeze(x.a)
+      expect(x).toEqual(y)
+    }).toThrowErrorMatchingInlineSnapshot(`"expected { a: { b: { c: 1 } } } to deeply equal { a: { b: { c: 2 } } }"`)
   })
 
   it('assertions', () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

close: #4298
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
