### PR TITLE
fix: address conflicts in port usage for browser-related test suites.

### DIFF
--- a/examples/playwright/test/basic.test.ts
+++ b/examples/playwright/test/basic.test.ts
@@ -5,6 +5,8 @@ import { chromium } from 'playwright'
 import type { Browser, Page } from 'playwright'
 import { expect } from '@playwright/test'
 
+const PORT = 3001
+
 // unstable in Windows, TODO: investigate
 describe.runIf(process.platform !== 'win32')('basic', async () => {
   let server: PreviewServer
@@ -12,8 +14,8 @@ describe.runIf(process.platform !== 'win32')('basic', async () => {
   let page: Page
 
   beforeAll(async () => {
-    server = await preview({ preview: { port: 3000 } })
-    browser = await chromium.launch()
+    server = await preview({ preview: { port: PORT } })
+    browser = await chromium.launch({ headless: true })
     page = await browser.newPage()
   })
 
@@ -25,7 +27,7 @@ describe.runIf(process.platform !== 'win32')('basic', async () => {
   })
 
   test('should change count when button clicked', async () => {
-    await page.goto('http://localhost:3000')
+    await page.goto(`http://localhost:${PORT}`)
     const button = page.getByRole('button', { name: /Clicked/ })
     await expect(button).toBeVisible()
 

--- a/examples/puppeteer/test/basic.test.ts
+++ b/examples/puppeteer/test/basic.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 import { preview } from 'vite'
 import type { PreviewServer } from 'vite'
-import puppeteer from 'puppeteer'
+import { launch } from 'puppeteer'
 import type { Browser, Page } from 'puppeteer'
 
 describe('basic', async () => {
@@ -11,7 +11,7 @@ describe('basic', async () => {
 
   beforeAll(async () => {
     server = await preview({ preview: { port: 3000 } })
-    browser = await puppeteer.launch()
+    browser = await launch({ headless: true })
     page = await browser.newPage()
   })
 
@@ -22,22 +22,16 @@ describe('basic', async () => {
     })
   })
 
-  // TODO make more stable
-  test.skip('should have the correct title', async () => {
-    try {
-      await page.goto('http://localhost:3000')
-      const button = (await page.$('#btn'))!
-      expect(button).toBeDefined()
+  test('should have the correct title', async () => {
+    await page.goto('http://localhost:3000')
+    const button = (await page.$<HTMLButtonElement>('#btn'))!
+    expect(button).toBeDefined()
 
-      let text = await page.evaluate(btn => btn.textContent, button)
-      expect(text).toBe('Clicked 0 time(s)')
+    let text = await page.evaluate(btn => btn.textContent, button)
+    expect(text).toBe('Clicked 0 time(s)')
 
-      await button.click()
-      text = await page.evaluate(btn => btn.textContent, button)
-    }
-    catch (e) {
-      console.error(e)
-      expect(e).toBeUndefined()
-    }
+    await button.click()
+    text = await page.evaluate(btn => btn.textContent, button)
+    expect(text).toBe('Clicked 1 time(s)')
   }, 60_000)
 })

--- a/examples/puppeteer/test/basic.test.ts
+++ b/examples/puppeteer/test/basic.test.ts
@@ -4,13 +4,15 @@ import type { PreviewServer } from 'vite'
 import { launch } from 'puppeteer'
 import type { Browser, Page } from 'puppeteer'
 
+const PORT = 3000
+
 describe('basic', async () => {
   let server: PreviewServer
   let browser: Browser
   let page: Page
 
   beforeAll(async () => {
-    server = await preview({ preview: { port: 3000 } })
+    server = await preview({ preview: { port: PORT } })
     browser = await launch({ headless: true })
     page = await browser.newPage()
   })
@@ -23,7 +25,7 @@ describe('basic', async () => {
   })
 
   test('should have the correct title', async () => {
-    await page.goto('http://localhost:3000')
+    await page.goto(`http://localhost:${PORT}`)
     const button = (await page.$<HTMLButtonElement>('#btn'))!
     expect(button).toBeDefined()
 


### PR DESCRIPTION
### Description

When running browser tests in parallel, there is a potential issue where multiple instances may attempt to use the same port for communication. This port conflict can lead to scenarios where a test instance communicates with the wrong port, causing inaccurate results or failures in test execution.

### Solution

To mitigate the issue, this pull request introduces a solution that ensures each test instance receives a unique port for communication. This is achieved by assigning a constant port value to each instance, preventing conflicts and enhancing the reliability of parallel test execution.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] ~It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.~ Although it lacks an issue reference, it addresses an outstanding TODO in the code.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
