### PR TITLE
fix!(vitest, runner): removes deprecated `error` option from TaskResult

### DIFF
--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -65,7 +65,6 @@ export async function collectTests(paths: string[], runner: VitestRunner): Promi
       const error = processError(e)
       file.result = {
         state: 'fail',
-        error,
         errors: [error],
       }
     }

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -217,12 +217,10 @@ export async function runTest(test: Test | Custom, runner: VitestRunner) {
     if (test.result.state === 'pass') {
       const error = processError(new Error('Expect test to fail'))
       test.result.state = 'fail'
-      test.result.error = error
       test.result.errors = [error]
     }
     else {
       test.result.state = 'pass'
-      test.result.error = undefined
       test.result.errors = undefined
     }
   }
@@ -248,7 +246,6 @@ function failTask(result: TaskResult, err: unknown, diffOptions?: DiffOptions) {
     : [err]
   for (const e of errors) {
     const error = processError(e, diffOptions)
-    result.error ??= error
     result.errors ??= []
     result.errors.push(error)
   }
@@ -333,9 +330,8 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
     if (suite.mode === 'run') {
       if (!hasTests(suite)) {
         suite.result.state = 'fail'
-        if (!suite.result.error) {
+        if (!suite.result.errors?.length) {
           const error = processError(new Error(`No test found in suite ${suite.name}`))
-          suite.result.error = error
           suite.result.errors = [error]
         }
       }
@@ -370,7 +366,6 @@ export async function runFiles(files: File[], runner: VitestRunner) {
         const error = processError(new Error(`No test suite found in file ${file.filepath}`))
         file.result = {
           state: 'fail',
-          error,
           errors: [error],
         }
       }

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -39,10 +39,6 @@ export interface TaskResult {
   duration?: number
   startTime?: number
   heap?: number
-  /**
-   * @deprecated Use "errors" instead
-   */
-  error?: ErrorWithDiff
   errors?: ErrorWithDiff[]
   htmlError?: string
   hooks?: Partial<Record<keyof SuiteHooks, TaskState>>

--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -69,7 +69,6 @@ function checkAllowOnly(task: TaskBase, allowOnly?: boolean) {
   const error = processError(new Error('[Vitest] Unexpected .only modifier. Remove it or pass --allowOnly argument to bypass this error'))
   task.result = {
     state: 'fail',
-    error,
     errors: [error],
   }
 }

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -179,9 +179,6 @@ class WebSocketReporter implements Reporter {
         getSourceMap: file => project.getBrowserSourceMapModuleById(file),
       }
 
-      // TODO remove after "error" deprecation is removed
-      if (result?.error && !isPrimitive(result.error))
-        result.error.stacks = parseErrorStacktrace(result.error, parserOptions)
       result?.errors?.forEach((error) => {
         if (!isPrimitive(error))
           error.stacks = parseErrorStacktrace(error, parserOptions)

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -179,7 +179,7 @@ export class JUnitReporter implements Reporter {
           await this.logger.log('<skipped/>')
 
         if (task.result?.state === 'fail') {
-          const errors = task.result.errors?.length ? task.result.errors : [task.result.error]
+          const errors = task.result.errors ?? []
           for (const error of errors) {
             await this.writeElement('failure', {
               message: error?.message,

--- a/test/reporters/src/data-for-junit.ts
+++ b/test/reporters/src/data-for-junit.ts
@@ -45,7 +45,6 @@ function createSuiteHavingFailedTestWithXmlInError(): File[] {
       file,
       result: {
         state: 'fail',
-        error: errorWithXml,
         errors: [errorWithXml],
         duration: 2.123123123,
       },

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -66,7 +66,6 @@ const innerTasks: Task[] = [
     file,
     result: {
       state: 'fail',
-      error,
       errors: [error],
       duration: 1.4422860145568848,
     },


### PR DESCRIPTION
### Description

I think we can safely remove this deprecated option in 1.0

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
