### PR TITLE
test: fix hmr.accept test failing on windows

### DIFF
--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -113,7 +113,7 @@ export async function runCli(command: string, _options?: Options | string, ...ar
       this.resetOutput()
       subprocess.stdin!.write(text)
     },
-    waitForStdout(expected: string, timeout = process.env.CI ? 20_000 : 4_000) {
+    waitForStdout(expected: string, timeout = process.env.CI ? 30_000 : 4_000) {
       const error = new Error('Timeout error')
       Error.captureStackTrace(error, this.waitForStdout)
       return new Promise<void>((resolve, reject) => {
@@ -137,7 +137,7 @@ export async function runCli(command: string, _options?: Options | string, ...ar
         this.stdoutListeners.push(listener)
       })
     },
-    waitForStderr(expected: string, timeout = process.env.CI ? 20_000 : 4_000) {
+    waitForStderr(expected: string, timeout = process.env.CI ? 30_000 : 4_000) {
       const error = new Error('Timeout')
       Error.captureStackTrace(error, this.waitForStderr)
       return new Promise<void>((resolve, reject) => {

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -113,22 +113,22 @@ export async function runCli(command: string, _options?: Options | string, ...ar
       this.resetOutput()
       subprocess.stdin!.write(text)
     },
-    waitForStdout(expected: string) {
+    waitForStdout(expected: string, timeout = process.env.CI ? 20_000 : 4_000) {
       const error = new Error('Timeout error')
       Error.captureStackTrace(error, this.waitForStdout)
       return new Promise<void>((resolve, reject) => {
         if (this.stdout.includes(expected))
           return resolve()
 
-        const timeout = setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           error.message = `Timeout when waiting for output "${expected}".\nReceived:\n${this.stdout} \nStderr:\n${this.stderr}`
           reject(error)
-        }, process.env.CI ? 20_000 : 4_000)
+        }, timeout)
 
         const listener = () => {
           if (this.stdout.includes(expected)) {
-            if (timeout)
-              clearTimeout(timeout)
+            if (timeoutId)
+              clearTimeout(timeoutId)
 
             resolve()
           }
@@ -137,22 +137,22 @@ export async function runCli(command: string, _options?: Options | string, ...ar
         this.stdoutListeners.push(listener)
       })
     },
-    waitForStderr(expected: string) {
+    waitForStderr(expected: string, timeout = process.env.CI ? 20_000 : 4_000) {
       const error = new Error('Timeout')
       Error.captureStackTrace(error, this.waitForStderr)
       return new Promise<void>((resolve, reject) => {
         if (this.stderr.includes(expected))
           return resolve()
 
-        const timeout = setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           error.message = `Timeout when waiting for error "${expected}".\nReceived:\n${this.stderr}\nStdout:\n${this.stdout}`
           reject(error)
-        }, process.env.CI ? 20_000 : 4_000)
+        }, timeout)
 
         const listener = () => {
           if (this.stderr.includes(expected)) {
-            if (timeout)
-              clearTimeout(timeout)
+            if (timeoutId)
+              clearTimeout(timeoutId)
 
             resolve()
           }

--- a/test/vite-node/test/hmr.test.ts
+++ b/test/vite-node/test/hmr.test.ts
@@ -9,10 +9,11 @@ test('hmr.accept works correctly', async () => {
 
   await viteNode.waitForStderr('Hello!')
 
-  const promise = viteNode.waitForStderr('Hello world!')
+  const promises = [
+    viteNode.waitForStderr('Hello world!'),
+    viteNode.waitForStderr('Accept'),
+    viteNode.waitForStdout(`[vite-node] hot updated: ${scriptFile}`),
+  ]
   editFile(scriptFile, content => content.replace('Hello!', 'Hello world!'))
-
-  await promise
-  await viteNode.waitForStderr('Accept')
-  await viteNode.waitForStdout(`[vite-node] hot updated: ${scriptFile}`)
+  await Promise.all(promises)
 })

--- a/test/vite-node/test/hmr.test.ts
+++ b/test/vite-node/test/hmr.test.ts
@@ -11,7 +11,7 @@ test('hmr.accept works correctly', async () => {
 
   editFile(scriptFile, content => content.replace('Hello!', 'Hello world!'))
 
-  await viteNode.waitForStderr('Hello world!')
+  await viteNode.waitForStderr('Hello world!', 40_000)
   await viteNode.waitForStderr('Accept')
   await viteNode.waitForStdout(`[vite-node] hot updated: ${scriptFile}`)
 })

--- a/test/vite-node/test/hmr.test.ts
+++ b/test/vite-node/test/hmr.test.ts
@@ -9,9 +9,10 @@ test('hmr.accept works correctly', async () => {
 
   await viteNode.waitForStderr('Hello!')
 
+  const promise = viteNode.waitForStderr('Hello world!')
   editFile(scriptFile, content => content.replace('Hello!', 'Hello world!'))
 
-  await viteNode.waitForStderr('Hello world!', 40_000)
+  await promise
   await viteNode.waitForStderr('Accept')
   await viteNode.waitForStdout(`[vite-node] hot updated: ${scriptFile}`)
 })


### PR DESCRIPTION
### Description

Fixes: https://github.com/vitest-dev/vitest/actions/runs/6510527559/job/17684432483

The test always fails on windows, but some time will work. I think we should make its timeout a little longer to get this test to run steadily

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
