### PR TITLE
feat: support import.meta.hot.off for vite 5

### DIFF
--- a/packages/vite-node/src/hmr/hmr.ts
+++ b/packages/vite-node/src/hmr/hmr.ts
@@ -288,6 +288,28 @@ export function createHotContext(
       addToMap(newListeners)
     },
 
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+    // @ts-ignore added in vite 5
+    off<T extends string>(
+      event: T,
+      cb: (payload: InferCustomEventPayload<T>) => void,
+    ) {
+      const removeFromMap = (map: Map<string, any[]>) => {
+        const existing = map.get(event)
+        if (existing === undefined)
+          return
+
+        const pruned = existing.filter(l => l !== cb)
+        if (pruned.length === 0) {
+          map.delete(event)
+          return
+        }
+        map.set(event, pruned)
+      }
+      removeFromMap(maps.customListenersMap)
+      removeFromMap(newListeners)
+    },
+
     send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void {
       maps.messageBuffer.push(JSON.stringify({ type: 'custom', event, data }))
       sendMessageBuffer(runner, emitter)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
https://github.com/vitejs/vite/pull/14518 added support for `import.meta.hot.off` in vite 5. Without this it's causing the ecosystem-ci to fail on build: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6529244403/job/17726630802#step:8:1218

I used `@ts-ignore` so the typecheck passes in both vite 4 and vite 5

<!-- You can also add additional context here -->

After running the `pnpm test:ci` locally, I'm getting fails for:

```
test/run test:  × test/tty.test.ts > run mode does not get stuck when TTY
test/run test:    → expected 'The CJS build of Vite\'s Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n' to be '' // Object.is equality
test/run test: ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
test/run test:  FAIL  test/tty.test.ts > run mode does not get stuck when TTY
test/run test: AssertionError: expected 'The CJS build of Vite\'s Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n' to be '' // Object.is equality
test/run test: - Expected
test/run test: + Received
test/run test: + The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
test/run test: +
```

Maybe this is expected. However it won't fail on ecosystem ci because it runs `pnpm test:run` only (which passed after this PR).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
