### PR TITLE
feat(vitest): run typecheck during tests

### DIFF
--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -52,7 +52,6 @@ Vitest instance requires the current test mode. It can be either:
 
 - `test` when running runtime tests
 - `benchmark` when running benchmarks
-- `typecheck` when running type tests
 
 ### mode
 
@@ -63,10 +62,6 @@ Test mode will only call functions inside `test` or `it`, and throws an error wh
 #### benchmark
 
 Benchmark mode calls `bench` functions and throws an error, when it encounters `test` or `it`. This mode uses `benchmark.include` and `benchmark.exclude` options in the config to find benchmark files.
-
-#### typecheck
-
-Typecheck mode doesn't _run_ tests. It only analyses types and gives a summary. This mode uses `typecheck.include` and `typecheck.exclude` options in the config to find files to analyze.
 
 ### start
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1646,6 +1646,15 @@ Options for configuring [typechecking](/guide/testing-types) test environment.
 
 Enable typechecking alongside your regular tests.
 
+#### typecheck.only
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **CLI**: `--typecheck.only`
+- **Version**: Since Vitest 1.0.0-beta.3
+
+Run only typecheck tests, when typechecking is enabled. When using CLI, this option will automatically enable typechecking.
+
 #### typecheck.checker
 
 - **Type**: `'tsc' | 'vue-tsc' | string`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1637,6 +1637,15 @@ Changes the order in which setup files are executed.
 
 Options for configuring [typechecking](/guide/testing-types) test environment.
 
+#### typecheck.enabled
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **CLI**: `--typecheck`, `--typecheck.enabled`
+- **Version**: Since Vitest 1.0.0-beta.3
+
+Enable typechecking alongside your regular tests.
+
 #### typecheck.checker
 
 - **Type**: `'tsc' | 'vue-tsc' | string`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -547,7 +547,7 @@ export default defineConfig({
 
 ### poolMatchGlobs
 
-- **Type:** `[string, 'threads' | 'forks' | 'vmThreads'][]`
+- **Type:** `[string, 'threads' | 'forks' | 'vmThreads' | 'typescript'][]`
 - **Default:** `[]`
 - **Version:** Since Vitest 0.29.4
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -98,6 +98,7 @@ Run only [benchmark](https://vitest.dev/guide/features.html#benchmarking-experim
 | `--retry <times>` | Retry the test specific number of times if it fails |
 | `--typecheck [options]` | Custom options for typecheck pool. If passed without options, enables typechecking |
 | `--typecheck.enabled` | Enable typechecking alongside tests (default: `false`) |
+| `--typecheck.only` | Run only typecheck tests. This automatically enables typecheck (default: `false`) |
 | `-h, --help` | Display available CLI options |
 
 ::: tip

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -96,6 +96,8 @@ Run only [benchmark](https://vitest.dev/guide/features.html#benchmarking-experim
 | `--inspect-brk` | Enables Node.js inspector with break |
 | `--bail <number>` | Stop test execution when given number of tests have failed |
 | `--retry <times>` | Retry the test specific number of times if it fails |
+| `--typecheck [options]` | Custom options for typecheck pool. If passed without options, enables typechecking |
+| `--typecheck.enabled` | Enable typechecking alongside tests (default: `false`) |
 | `-h, --help` | Display available CLI options |
 
 ::: tip

--- a/docs/guide/testing-types.md
+++ b/docs/guide/testing-types.md
@@ -66,12 +66,12 @@ assertType<string>(answr) //
 
 ## Run typechecking
 
-Add this command to your `scripts` section in `package.json`:
+To enabled typechecking, just add `--typecheck` flag to your Vitest command in `package.json`:
 
 ```json
 {
   "scripts": {
-    "typecheck": "vitest typecheck"
+    "test": "vitest --typecheck"
   }
 }
 ```
@@ -80,13 +80,13 @@ Now you can run typecheck:
 
 ```sh
 # npm
-npm run typecheck
+npm run test
 
 # yarn
-yarn typecheck
+yarn test
 
 # pnpm
-pnpm run typecheck
+pnpm run test
 ```
 
 Vitest uses `tsc --noEmit` or `vue-tsc --noEmit`, depending on your configuration, so you can remove these scripts from your pipeline.

--- a/packages/runner/src/utils/tasks.ts
+++ b/packages/runner/src/utils/tasks.ts
@@ -7,8 +7,8 @@ function isAtomTest(s: Task): s is Test | Custom {
 
 export function getTests(suite: Arrayable<Task>): (Test | Custom)[] {
   const tests: (Test | Custom)[] = []
-  const suite_arr = toArray(suite)
-  for (const s of suite_arr) {
+  const arraySuites = toArray(suite)
+  for (const s of arraySuites) {
     if (isAtomTest(s)) {
       tests.push(s)
     }

--- a/packages/ui/client/components/Suites.vue
+++ b/packages/ui/client/components/Suites.vue
@@ -23,6 +23,7 @@ async function onRunCurrent() {
     <TasksList :tasks="current.tasks" :nested="true">
       <template #header>
         <StatusIcon mx-1 :task="current" />
+        <div v-if="current.type === 'suite' && current.meta.typecheck" i-logos:typescript-icon flex-shrink-0 mr-1 />
         <span data-testid="filenames" font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate>{{ name }}</span>
         <div class="flex text-lg">
           <IconButton

--- a/packages/ui/client/components/TaskItem.vue
+++ b/packages/ui/client/components/TaskItem.vue
@@ -22,6 +22,7 @@ const duration = computed(() => {
     hover="bg-active"
   >
     <StatusIcon :task="task" mr-2 />
+    <div v-if="task.type === 'suite' && task.meta.typecheck" i-logos:typescript-icon flex-shrink-0 mr-2 />
     <div flex items-end gap-2 :text="task?.result?.state === 'fail' ? 'red-500' : ''">
       <span text-sm truncate font-light>{{ task.name }}</span>
       <span v-if="typeof duration === 'number'" text="xs" op20 style="white-space: nowrap">

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -72,7 +72,7 @@ function createErrorElement(e: ErrorWithDiff) {
   div.className = 'op80 flex gap-x-2 items-center'
   const pre = document.createElement('pre')
   pre.className = 'c-red-600 dark:c-red-400'
-  pre.textContent = `${' '.repeat(stack.column)}^ ${e?.nameStr}: ${e?.message}`
+  pre.textContent = `${' '.repeat(stack.column)}^ ${e?.nameStr || e.name}: ${e?.message || ''}`
   div.appendChild(pre)
   const span = document.createElement('span')
   span.className = 'i-carbon-launch c-red-600 dark:c-red-400 hover:cursor-pointer min-w-1em min-h-1em'

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
+    "@iconify-json/logos": "^1.1.37",
     "@testing-library/cypress": "^9.0.0",
     "@types/codemirror": "^5.60.8",
     "@types/d3-force": "^3.0.4",

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -56,6 +56,9 @@ export async function startVitest(
   if (typeof options.browser === 'object' && !('enabled' in options.browser))
     options.browser.enabled = true
 
+  if (typeof options.typecheck === 'boolean')
+    options.typecheck = { enabled: true }
+
   const ctx = await createVitest(mode, options, viteOverrides)
 
   if (mode === 'test' && ctx.config.coverage.enabled) {

--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -59,6 +59,12 @@ export async function startVitest(
   if (typeof options.typecheck === 'boolean')
     options.typecheck = { enabled: true }
 
+  if (typeof options.typecheck?.only === 'boolean') {
+    options.typecheck ??= {}
+    options.typecheck.only = true
+    options.typecheck.enabled = true
+  }
+
   const ctx = await createVitest(mode, options, viteOverrides)
 
   if (mode === 'test' && ctx.config.coverage.enabled) {

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -51,6 +51,8 @@ cli
   .option('--bail <number>', 'Stop test execution when given number of tests have failed', { default: 0 })
   .option('--retry <times>', 'Retry the test specific number of times if it fails', { default: 0 })
   .option('--diff <path>', 'Path to a diff config that will be used to generate diff interface')
+  .option('--typecheck [options]', 'Custom options for typecheck pool')
+  .option('--typecheck.enabled', 'Enable typechecking alongside tests (default: false)')
   .help()
 
 cli
@@ -72,10 +74,6 @@ cli
 cli
   .command('bench [...filters]')
   .action(benchmark)
-
-cli
-  .command('typecheck [...filters]')
-  .action(typecheck)
 
 cli
   .command('[...filters]')
@@ -128,11 +126,6 @@ async function run(cliFilters: string[], options: CliOptions): Promise<void> {
 async function benchmark(cliFilters: string[], options: CliOptions): Promise<void> {
   console.warn(c.yellow('Benchmarking is an experimental feature.\nBreaking changes might not follow semver, please pin Vitest\'s version when using it.'))
   await start('benchmark', cliFilters, options)
-}
-
-async function typecheck(cliFilters: string[] = [], options: CliOptions = {}) {
-  console.warn(c.yellow('Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow semver, please pin Vitest\'s version when using it.'))
-  await start('typecheck', cliFilters, options)
 }
 
 function normalizeCliOptions(argv: CliOptions): CliOptions {

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -53,6 +53,7 @@ cli
   .option('--diff <path>', 'Path to a diff config that will be used to generate diff interface')
   .option('--typecheck [options]', 'Custom options for typecheck pool')
   .option('--typecheck.enabled', 'Enable typechecking alongside tests (default: false)')
+  .option('--typecheck.only', 'Run only typecheck tests. This automatically enables typecheck (default: false)')
   .help()
 
 cli

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -378,10 +378,11 @@ export function resolveConfig(
 
   resolved.environmentMatchGlobs = (resolved.environmentMatchGlobs || []).map(i => [resolve(resolved.root, i[0]), i[1]])
 
-  if (mode === 'typecheck') {
-    resolved.include = resolved.typecheck.include
-    resolved.exclude = resolved.typecheck.exclude
-  }
+  resolved.typecheck ??= {} as any
+  resolved.typecheck.enabled ??= false
+
+  if (resolved.typecheck.enabled)
+    console.warn(c.yellow('Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow semver, please pin Vitest\'s version when using it.'))
 
   resolved.browser ??= {} as any
   resolved.browser.enabled ??= false

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -310,6 +310,8 @@ export class Vitest {
   }
 
   async start(filters?: string[]) {
+    this._onClose = []
+
     try {
       await this.initCoverageProvider()
       await this.coverageProvider?.clean(this.config.coverage.clean)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -93,7 +93,7 @@ export class Vitest {
     this.cache = new VitestCache()
     this.snapshot = new SnapshotManager({ ...resolved.snapshotOptions })
 
-    if (this.config.watch && this.mode !== 'typecheck')
+    if (this.config.watch)
       this.registerWatcher()
 
     this.vitenode = new ViteNodeServer(server, this.config.server)
@@ -308,16 +308,7 @@ export class Vitest {
     return Promise.all(this.projects.map(w => w.initBrowserProvider()))
   }
 
-  typecheck(filters?: string[]) {
-    return Promise.all(this.projects.map(project => project.typecheck(filters)))
-  }
-
   async start(filters?: string[]) {
-    if (this.mode === 'typecheck') {
-      await this.typecheck(filters)
-      return
-    }
-
     try {
       await this.initCoverageProvider()
       await this.coverageProvider?.clean(this.config.coverage.clean)

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -95,10 +95,21 @@ export class Logger {
     const comma = c.dim(', ')
     if (filters?.length)
       this.console.error(c.dim('filter:  ') + c.yellow(filters.join(comma)))
-    if (config.include)
-      this.console.error(c.dim('include: ') + c.yellow(config.include.join(comma)))
-    if (config.exclude)
-      this.console.error(c.dim('exclude:  ') + c.yellow(config.exclude.join(comma)))
+    this.ctx.projects.forEach((project) => {
+      const config = project.config
+      const name = project.getName()
+      const output = project.isCore() || !name ? '' : `[${name}]`
+      if (output)
+        this.console.error(c.bgCyan(`${output} Config`))
+      if (config.include)
+        this.console.error(c.dim('include: ') + c.yellow(config.include.join(comma)))
+      if (config.exclude)
+        this.console.error(c.dim('exclude:  ') + c.yellow(config.exclude.join(comma)))
+      if (config.typecheck.enabled) {
+        this.console.error(c.dim('typecheck include: ') + c.yellow(config.typecheck.include.join(comma)))
+        this.console.error(c.dim('typecheck exclude: ') + c.yellow(config.typecheck.exclude.join(comma)))
+      }
+    })
     if (config.watchExclude)
       this.console.error(c.dim('watch exclude:  ') + c.yellow(config.watchExclude.join(comma)))
 

--- a/packages/vitest/src/node/pools/typecheck.ts
+++ b/packages/vitest/src/node/pools/typecheck.ts
@@ -1,0 +1,123 @@
+import type { DeferPromise } from '@vitest/utils'
+import { createDefer } from '@vitest/utils'
+import type { TypecheckResults } from '../../typecheck/typechecker'
+import { Typechecker } from '../../typecheck/typechecker'
+import { groupBy } from '../../utils/base'
+import { hasFailed } from '../../utils/tasks'
+import type { Vitest } from '../core'
+import type { ProcessPool, WorkspaceSpec } from '../pool'
+import type { WorkspaceProject } from '../workspace'
+
+export function createTypecheckPool(ctx: Vitest): ProcessPool {
+  const promisesMap = new WeakMap<WorkspaceProject, DeferPromise<void>>()
+  const rerunTriggered = new WeakMap<WorkspaceProject, boolean>()
+
+  async function onParseEnd(project: WorkspaceProject, { files, sourceErrors }: TypecheckResults) {
+    const checker = project.typechecker!
+
+    await ctx.report('onTaskUpdate', checker.getTestPacks())
+
+    if (!project.config.typecheck.ignoreSourceErrors)
+      sourceErrors.forEach(error => ctx.state.catchError(error, 'Unhandled Source Error'))
+
+    const processError = !hasFailed(files) && checker.getExitCode()
+    if (processError) {
+      const error = new Error(checker.getOutput())
+      error.stack = ''
+      ctx.state.catchError(error, 'Typecheck Error')
+    }
+
+    promisesMap.get(project)?.resolve()
+
+    rerunTriggered.set(project, false)
+
+    // triggered by TSC watcher, not Vitest watcher, so we need to emulate what Vitest does in this case
+    if (ctx.config.watch && !ctx.runningPromise) {
+      await ctx.report('onFinished', files)
+      await ctx.report('onWatcherStart', files, [
+        ...(project.config.typecheck.ignoreSourceErrors ? [] : sourceErrors),
+        ...ctx.state.getUnhandledErrors(),
+      ])
+    }
+  }
+
+  async function createWorkspaceTypechecker(project: WorkspaceProject, files: string[]) {
+    const checker = project.typechecker ?? new Typechecker(project)
+    if (project.typechecker)
+      return checker
+
+    project.typechecker = checker
+    checker.setFiles(files)
+
+    checker.onParseStart(async () => {
+      ctx.state.collectFiles(checker.getTestFiles())
+      await ctx.report('onCollected')
+    })
+
+    checker.onParseEnd(result => onParseEnd(project, result))
+
+    checker.onWatcherRerun(async () => {
+      rerunTriggered.set(project, true)
+
+      if (!ctx.runningPromise) {
+        ctx.state.clearErrors()
+        await ctx.report('onWatcherRerun', files, 'File change detected. Triggering rerun.')
+      }
+
+      await checker.collectTests()
+      ctx.state.collectFiles(checker.getTestFiles())
+
+      await ctx.report('onTaskUpdate', checker.getTestPacks())
+      await ctx.report('onCollected')
+    })
+
+    await checker.prepare()
+    await checker.collectTests()
+    checker.start()
+    return checker
+  }
+
+  async function runTests(specs: WorkspaceSpec[]) {
+    const specsByProject = groupBy(specs, ([project]) => project.getName())
+    const promises: Promise<void>[] = []
+
+    for (const name in specsByProject) {
+      const project = specsByProject[name][0][0]
+      const files = specsByProject[name].map(([_, file]) => file)
+      const promise = createDefer<void>()
+      // check that watcher actually triggered rerun
+      const _p = new Promise<boolean>((resolve) => {
+        const _i = setInterval(() => {
+          if (!project.typechecker || rerunTriggered.get(project)) {
+            resolve(true)
+            clearInterval(_i)
+          }
+        })
+        setTimeout(() => {
+          resolve(false)
+          clearInterval(_i)
+        }, 500)
+      })
+      const triggered = await _p
+      if (project.typechecker && !triggered) {
+        ctx.state.collectFiles(project.typechecker.getTestFiles())
+        await ctx.report('onCollected')
+        await onParseEnd(project, project.typechecker.getResult())
+        continue
+      }
+      promises.push(promise)
+      promisesMap.set(project, promise)
+      createWorkspaceTypechecker(project, files)
+    }
+
+    await Promise.all(promises)
+  }
+
+  return {
+    runTests,
+    async close() {
+      const promises = ctx.projects.map(project => project.typechecker?.stop())
+      await Promise.all(promises)
+    },
+  }
+}

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -370,11 +370,15 @@ export abstract class BaseReporter implements Reporter {
   }
 
   registerUnhandledRejection() {
-    process.on('unhandledRejection', async (err) => {
+    const onUnhandledRejection = async (err: unknown) => {
       process.exitCode = 1
       await this.ctx.logger.printError(err, { fullStack: true, type: 'Unhandled Rejection' })
       this.ctx.logger.error('\n\n')
       process.exit(1)
+    }
+    process.on('unhandledRejection', onUnhandledRejection)
+    this.ctx.onClose(() => {
+      process.off('unhandledRejection', onUnhandledRejection)
     })
   }
 }

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -30,6 +30,7 @@ export abstract class BaseReporter implements Reporter {
   private _lastRunTimer: NodeJS.Timer | undefined
   private _lastRunCount = 0
   private _timeStart = new Date()
+  private _offUnhandledRejection?: () => void
 
   constructor() {
     this.registerUnhandledRejection()
@@ -41,6 +42,9 @@ export abstract class BaseReporter implements Reporter {
 
   onInit(ctx: Vitest) {
     this.ctx = ctx
+    ctx.onClose(() => {
+      this._offUnhandledRejection?.()
+    })
     ctx.logger.printBanner()
     this.start = performance.now()
   }
@@ -377,8 +381,8 @@ export abstract class BaseReporter implements Reporter {
       process.exit(1)
     }
     process.on('unhandledRejection', onUnhandledRejection)
-    this.ctx.onClose(() => {
+    this._offUnhandledRejection = () => {
       process.off('unhandledRejection', onUnhandledRejection)
-    })
+    }
   }
 }

--- a/packages/vitest/src/node/reporters/renderers/listRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/listRenderer.ts
@@ -103,7 +103,7 @@ export function renderTree(tasks: Task[], options: ListRendererOptions, level = 
     if (task.type === 'test' && task.result?.retryCount && task.result.retryCount > 0)
       suffix += c.yellow(` (retry x${task.result.retryCount})`)
 
-    if (task.type === 'suite' && !task.meta?.typecheck) {
+    if (task.type === 'suite') {
       const tests = getTests(task)
       suffix += c.dim(` (${tests.length})`)
     }

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -65,10 +65,6 @@ export function registerConsoleShortcuts(ctx: Vitest) {
     if (name === 'q')
       return ctx.exit(true)
 
-    // TODO typechecking doesn't support shortcuts this yet
-    if (ctx.mode === 'typecheck')
-      return
-
     // help
     if (name === 'h')
       return printShortcutsHelp()

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -159,7 +159,7 @@ export class WorkspaceProject {
     const typecheck = this.config.typecheck
 
     const [testFiles, typecheckTestFiles] = await Promise.all([
-      this.globAllTestFiles(this.config, dir),
+      typecheck.enabled && typecheck.only ? [] : this.globAllTestFiles(this.config, dir),
       typecheck.enabled ? this.globFiles(typecheck.include, typecheck.exclude, dir) : [],
     ])
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -8,8 +8,8 @@ import { ViteNodeServer } from 'vite-node/server'
 import c from 'picocolors'
 import { createBrowserServer } from '../integrations/browser/server'
 import type { ArgumentsType, Reporter, ResolvedConfig, UserConfig, UserWorkspaceConfig, Vitest } from '../types'
-import { deepMerge, hasFailed } from '../utils'
-import { Typechecker } from '../typecheck/typechecker'
+import { deepMerge } from '../utils'
+import type { Typechecker } from '../typecheck/typechecker'
 import type { BrowserProvider } from '../types/browser'
 import { getBrowserProvider } from '../integrations/browser'
 import { isBrowserEnabled, resolveConfig } from './config'
@@ -156,9 +156,14 @@ export class WorkspaceProject {
   async globTestFiles(filters: string[] = []) {
     const dir = this.config.dir || this.config.root
 
-    const testFiles = await this.globAllTestFiles(this.config, dir)
+    const typecheck = this.config.typecheck
 
-    return this.filterFiles(testFiles, filters, dir)
+    const [testFiles, typecheckTestFiles] = await Promise.all([
+      this.globAllTestFiles(this.config, dir),
+      typecheck.enabled ? this.globFiles(typecheck.include, typecheck.exclude, dir) : [],
+    ])
+
+    return this.filterFiles([...testFiles, ...typecheckTestFiles], filters, dir)
   }
 
   async globAllTestFiles(config: ResolvedConfig, cwd: string) {
@@ -273,68 +278,6 @@ export class WorkspaceProject {
 
   async report<T extends keyof Reporter>(name: T, ...args: ArgumentsType<Reporter[T]>) {
     return this.ctx.report(name, ...args)
-  }
-
-  async typecheck(filters: string[] = []) {
-    const dir = this.config.dir || this.config.root
-    const { include, exclude } = this.config.typecheck
-
-    const testFiles = await this.globFiles(include, exclude, dir)
-    const testsFilesList = this.filterFiles(testFiles, filters, dir)
-
-    const checker = new Typechecker(this, testsFilesList)
-    this.typechecker = checker
-    checker.onParseEnd(async ({ files, sourceErrors }) => {
-      this.ctx.state.collectFiles(checker.getTestFiles())
-      await this.report('onTaskUpdate', checker.getTestPacks())
-      await this.report('onCollected')
-      const failedTests = hasFailed(files)
-      const exitCode = !failedTests && checker.getExitCode()
-      if (exitCode) {
-        const error = new Error(checker.getOutput())
-        error.stack = ''
-        this.ctx.state.catchError(error, 'Typecheck Error')
-      }
-      if (!files.length) {
-        this.ctx.logger.printNoTestFound()
-      }
-      else {
-        if (failedTests)
-          process.exitCode = 1
-        await this.report('onFinished', files)
-      }
-      if (sourceErrors.length && !this.config.typecheck.ignoreSourceErrors) {
-        process.exitCode = 1
-        await this.ctx.logger.printSourceTypeErrors(sourceErrors)
-      }
-      // if there are source errors, we are showing it, and then terminating process
-      if (!files.length) {
-        const exitCode = this.config.passWithNoTests ? (process.exitCode ?? 0) : 1
-        await this.close()
-        process.exit(exitCode)
-      }
-      if (this.config.watch) {
-        await this.report('onWatcherStart', files, [
-          ...(this.config.typecheck.ignoreSourceErrors ? [] : sourceErrors),
-          ...this.ctx.state.getUnhandledErrors(),
-        ])
-      }
-    })
-    checker.onParseStart(async () => {
-      await this.report('onInit', this.ctx)
-      this.ctx.state.collectFiles(checker.getTestFiles())
-      await this.report('onCollected')
-    })
-    checker.onWatcherRerun(async () => {
-      await this.report('onWatcherRerun', testsFilesList, 'File change detected. Triggering rerun.')
-      await checker.collectTests()
-      this.ctx.state.collectFiles(checker.getTestFiles())
-      await this.report('onTaskUpdate', checker.getTestPacks())
-      await this.report('onCollected')
-    })
-    await checker.prepare()
-    await checker.collectTests()
-    await checker.start()
   }
 
   isBrowserEnabled() {

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -87,6 +87,8 @@ export async function startVitestExecutor(options: ContextExecutorOptions) {
     rpc().onUnhandledError(error, type)
   }
 
+  process.setMaxListeners(25)
+
   process.on('uncaughtException', e => catchError(e, 'Uncaught Exception'))
   process.on('unhandledRejection', e => catchError(e, 'Unhandled Rejection'))
 

--- a/packages/vitest/src/typecheck/collect.ts
+++ b/packages/vitest/src/typecheck/collect.ts
@@ -57,6 +57,7 @@ export async function collectTests(ctx: WorkspaceProject, filepath: string): Pro
     tasks: [],
     start: ast.start,
     end: ast.end,
+    projectName: ctx.getName(),
     meta: { typecheck: true },
   }
   const definitions: LocalCallDefinition[] = []
@@ -122,6 +123,7 @@ export async function collectTests(ctx: WorkspaceProject, filepath: string): Pro
         name: definition.name,
         end: definition.end,
         start: definition.start,
+        projectName: ctx.getName(),
         meta: {
           typecheck: true,
         },

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -198,7 +198,14 @@ export class Typechecker {
         Error.stackTraceLimit = limit
         return {
           originalError: info,
-          error,
+          error: {
+            name: error.name,
+            nameStr: String(error.name),
+            message: info.errMsg,
+            stacks: error.stacks,
+            stack: '',
+            stackStr: '',
+          },
         }
       })
       typesErrors.set(filepath, suiteErrors)
@@ -303,6 +310,6 @@ export class Typechecker {
     return Object.values(this._tests || {})
       .map(({ file }) => getTasks(file))
       .flat()
-      .map<TaskResultPack>(i => [i.id, undefined, { typecheck: true }])
+      .map<TaskResultPack>(i => [i.id, i.result, { typecheck: true }])
   }
 }

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -1,4 +1,5 @@
 import { rm } from 'node:fs/promises'
+import { performance } from 'node:perf_hooks'
 import type { ExecaChildProcess } from 'execa'
 import { execa } from 'execa'
 import { basename, extname, resolve } from 'pathe'
@@ -21,35 +22,44 @@ export class TypeCheckError extends Error {
   }
 }
 
-interface ErrorsCache {
+export interface TypecheckResults {
   files: File[]
   sourceErrors: TypeCheckError[]
+  time: number
 }
 
 type Callback<Args extends Array<any> = []> = (...args: Args) => Awaitable<void>
 
 export class Typechecker {
   private _onParseStart?: Callback
-  private _onParseEnd?: Callback<[ErrorsCache]>
+  private _onParseEnd?: Callback<[TypecheckResults]>
   private _onWatcherRerun?: Callback
-  private _result: ErrorsCache = {
+  private _result: TypecheckResults = {
     files: [],
     sourceErrors: [],
+    time: 0,
   }
 
+  private _startTime = 0
   private _output = ''
   private _tests: Record<string, FileInformation> | null = {}
   private tempConfigPath?: string
   private allowJs?: boolean
   private process?: ExecaChildProcess
 
-  constructor(protected ctx: WorkspaceProject, protected files: string[]) { }
+  protected files: string[] = []
+
+  constructor(protected ctx: WorkspaceProject) { }
+
+  public setFiles(files: string[]) {
+    this.files = files
+  }
 
   public onParseStart(fn: Callback) {
     this._onParseStart = fn
   }
 
-  public onParseEnd(fn: Callback<[ErrorsCache]>) {
+  public onParseEnd(fn: Callback<[TypecheckResults]>) {
     this._onParseEnd = fn
   }
 
@@ -165,6 +175,7 @@ export class Typechecker {
     return {
       files,
       sourceErrors,
+      time: performance.now() - this._startTime,
     }
   }
 
@@ -243,6 +254,7 @@ export class Typechecker {
     if (typecheck.allowJs)
       args.push('--allowJs', '--checkJs')
     this._output = ''
+    this._startTime = performance.now()
     const child = execa(typecheck.checker, args, {
       cwd: root,
       stdout: 'pipe',
@@ -257,6 +269,7 @@ export class Typechecker {
         return
       if (this._output.includes('File change detected') && !rerunTriggered) {
         this._onWatcherRerun?.()
+        this._startTime = performance.now()
         this._result.sourceErrors = []
         this._result.files = []
         this._tests = null // test structure might've changed

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -635,7 +635,14 @@ export interface InlineConfig {
 }
 
 export interface TypecheckConfig {
+  /**
+   * Run typechecking tests alongisde regular tests.
+   */
   enabled?: boolean
+  /**
+   * When typechecking is enabled, only run typechecking tests.
+   */
+  only?: boolean
   /**
    * What tools to use for type checking.
    */

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -37,7 +37,7 @@ export interface EnvironmentOptions {
   [x: string]: unknown
 }
 
-export type VitestRunMode = 'test' | 'benchmark' | 'typecheck'
+export type VitestRunMode = 'test' | 'benchmark'
 
 interface SequenceOptions {
   /**
@@ -635,6 +635,7 @@ export interface InlineConfig {
 }
 
 export interface TypecheckConfig {
+  enabled?: boolean
   /**
    * What tools to use for type checking.
    */
@@ -749,7 +750,9 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
     seed: number
   }
 
-  typecheck: TypecheckConfig
+  typecheck: Omit<TypecheckConfig, 'enabled'> & {
+    enabled: boolean
+  }
   runner?: string
 }
 

--- a/packages/vitest/src/types/pool-options.ts
+++ b/packages/vitest/src/types/pool-options.ts
@@ -1,4 +1,4 @@
-export type Pool = 'browser' | 'threads' | 'forks' | 'vmThreads' // | 'vmForks'
+export type Pool = 'browser' | 'threads' | 'forks' | 'vmThreads' | 'typescript' // | 'vmForks'
 
 export interface PoolOptions {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1194,6 +1194,9 @@ importers:
       '@faker-js/faker':
         specifier: ^8.0.2
         version: 8.0.2
+      '@iconify-json/logos':
+        specifier: ^1.1.37
+        version: 1.1.37
       '@testing-library/cypress':
         specifier: ^9.0.0
         version: 9.0.0(cypress@12.16.0)
@@ -2948,7 +2951,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
@@ -6262,6 +6265,12 @@ packages:
 
   /@iconify-json/carbon@1.1.18:
     resolution: {integrity: sha512-RbKET6KS9xUMeYVq1FUH3UUA7AYNcnApkHt2AccCwTWTQQs/O58ji4Of6z6PhRajGlbfvrJzT/Uqh19OKECRvA==}
+    dependencies:
+      '@iconify/types': 2.0.0
+    dev: true
+
+  /@iconify-json/logos@1.1.37:
+    resolution: {integrity: sha512-H2S8frTEznk6paX2kMzeUGn4KSiykghvO0b8UvEDd1fFFzt0WxCXpP1tBv67XaWK99e6JgA34hhv4lRGAm1hJg==}
     dependencies:
       '@iconify/types': 2.0.0
     dev: true
@@ -18535,7 +18544,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
       '@types/node': 18.16.19
-      anymatch: 3.1.2
+      anymatch: 3.1.3
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
       jest-regex-util: 27.5.1

--- a/test/core/test/types.test-d.ts
+++ b/test/core/test/types.test-d.ts
@@ -1,0 +1,6 @@
+import { expectTypeOf, it } from 'vitest'
+
+it('typecheck works', () => {
+  expectTypeOf(4).toBeNumber()
+  expectTypeOf('').not.toBeNumber()
+})

--- a/test/core/test/types.test-d.ts
+++ b/test/core/test/types.test-d.ts
@@ -1,6 +1,0 @@
-import { expectTypeOf, it } from 'vitest'
-
-it('typecheck works', () => {
-  expectTypeOf(4).toBeNumber()
-  expectTypeOf('').not.toBeNumber()
-})

--- a/test/core/vite.config.ts
+++ b/test/core/vite.config.ts
@@ -88,5 +88,8 @@ export default defineConfig({
         customResolver: () => resolve(__dirname, 'src', 'aliased-mod.ts'),
       },
     ],
+    typecheck: {
+      enabled: true,
+    },
   },
 })

--- a/test/core/vite.config.ts
+++ b/test/core/vite.config.ts
@@ -88,8 +88,5 @@ export default defineConfig({
         customResolver: () => resolve(__dirname, 'src', 'aliased-mod.ts'),
       },
     ],
-    typecheck: {
-      enabled: true,
-    },
   },
 })

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -8,7 +8,7 @@
     "test:istanbul": "node ./testing.mjs --provider istanbul",
     "test:browser": "node ./testing.mjs --browser --provider istanbul",
     "test:options": "node ./testing-options.mjs",
-    "test:types": "vitest typecheck --run --reporter verbose"
+    "test:types": "vitest --typecheck --run --reporter verbose"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.4",

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -8,7 +8,7 @@
     "test:istanbul": "node ./testing.mjs --provider istanbul",
     "test:browser": "node ./testing.mjs --browser --provider istanbul",
     "test:options": "node ./testing-options.mjs",
-    "test:types": "vitest --typecheck --run --reporter verbose"
+    "test:types": "vitest --typecheck.only --run --reporter verbose"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.4",

--- a/test/typescript/package.json
+++ b/test/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "vitest",
-    "types": "vitest typecheck --run",
+    "types": "vitest --typecheck --run",
     "tsc": "tsc --watch --pretty false --noEmit"
   },
   "dependencies": {

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -13,10 +13,11 @@ describe('should fail', async () => {
       root,
       dir: './failing',
       typecheck: {
+        enabled: true,
         allowJs: true,
         include: ['**/*.test-d.*'],
       },
-    }, [], 'typecheck')
+    }, [])
 
     expect(stderr).toBeTruthy()
     const lines = String(stderr).split(/\n/g)
@@ -44,12 +45,12 @@ describe('should fail', async () => {
   it('typecheks with custom tsconfig', async () => {
     const { stderr } = await runVitestCli(
       { cwd: root, env: { ...process.env, CI: 'true' } },
-      'typecheck',
       '--run',
       '--dir',
       resolve(__dirname, '..', './failing'),
       '--config',
       resolve(__dirname, './vitest.custom.config.ts'),
+      '--typecheck.enabled',
     )
 
     expect(stderr).toBeTruthy()
@@ -85,12 +86,12 @@ describe('should fail', async () => {
           NO_COLOR: 'true',
         },
       },
-      'typecheck',
       '--run',
       '--dir',
       resolve(__dirname, '..', './failing'),
       '--config',
       resolve(__dirname, './vitest.empty.config.ts'),
+      '--typecheck.enabled',
     )
 
     expect(stderr.replace(resolve(__dirname, '..'), '<root>')).toMatchSnapshot()

--- a/test/typescript/test/vitest.custom.config.ts
+++ b/test/typescript/test/vitest.custom.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     typecheck: {
+      enabled: true,
       allowJs: true,
       include: ['**/*.test-d.*'],
       tsconfig: '../tsconfig.custom.json',

--- a/test/typescript/test/vitest.empty.config.ts
+++ b/test/typescript/test/vitest.empty.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     typecheck: {
+      enabled: true,
       include: ['**/fail.test-d.ts'],
       tsconfig: '../tsconfig.empty.json',
     },


### PR DESCRIPTION
### Description

Closes #2299

Tests inside type files are now treated as regular tests. They are available in `ctx.state` and inside reporters. These tests are also displayed when running with `--ui` flag. If `typecheck.include` overlaps with `test.include`, then typecheck will have priority and the test __WILL NOT__ actually run (only typechecking will be performed). If you want to have it both ways, use [workspace feature](https://vitest.dev/guide/workspace.html).

It's also possible now to use [`poolMatchGlobs`](https://vitest.dev/config/#poolmatchglobs) config option with `typescript` value.

This PR also adds `--typecheck.only` flag which will force Vitest to run only typecheck tests.

Also made sure typecheck tests in the UI can be distinguished with TS icon:

<img width="1213" alt="Screenshot 2023-10-17 at 14 04 01" src="https://github.com/vitest-dev/vitest/assets/16173870/84f8ecd5-be3b-4cff-b6f6-a02773410a0d">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
