### PR TITLE
fix(vitest): run globalSetup from the root config even if it's not in a workspace

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -438,7 +438,12 @@ export class Vitest {
   }
 
   async initializeGlobalSetup(paths: WorkspaceSpec[]) {
-    await Promise.all(paths.map(async ([project]) => project.initializeGlobalSetup()))
+    const projects = new Set(paths.map(([project]) => project))
+    if (!projects.has(this.coreWorkspaceProject))
+      projects.add(this.coreWorkspaceProject)
+    await Promise.all(
+      Array.from(projects).map(project => project.initializeGlobalSetup()),
+    )
   }
 
   async runFiles(paths: WorkspaceSpec[]) {

--- a/packages/vitest/src/node/globalSetup.ts
+++ b/packages/vitest/src/node/globalSetup.ts
@@ -9,7 +9,10 @@ export interface GlobalSetupFile {
 }
 
 export async function loadGlobalSetupFiles(project: WorkspaceProject): Promise<GlobalSetupFile[]> {
-  const globalSetupFiles = toArray(project.server.config.test?.globalSetup)
+  const globalSetupFiles = [
+    ...toArray(project.config.globalSetup),
+    ...toArray(project.ctx.config.globalSetup),
+  ]
   return Promise.all(globalSetupFiles.map(file => loadGlobalSetupFile(file, project.runner)))
 }
 

--- a/packages/vitest/src/node/globalSetup.ts
+++ b/packages/vitest/src/node/globalSetup.ts
@@ -9,10 +9,7 @@ export interface GlobalSetupFile {
 }
 
 export async function loadGlobalSetupFiles(project: WorkspaceProject): Promise<GlobalSetupFile[]> {
-  const globalSetupFiles = [
-    ...toArray(project.config.globalSetup),
-    ...toArray(project.ctx.config.globalSetup),
-  ]
+  const globalSetupFiles = toArray(project.config.globalSetup)
   return Promise.all(globalSetupFiles.map(file => loadGlobalSetupFile(file, project.runner)))
 }
 

--- a/packages/vitest/src/node/globalSetup.ts
+++ b/packages/vitest/src/node/globalSetup.ts
@@ -1,6 +1,5 @@
 import { toArray } from '@vitest/utils'
 import type { ViteNodeRunner } from 'vite-node/client'
-import type { WorkspaceProject } from './workspace'
 
 export interface GlobalSetupFile {
   file: string
@@ -8,9 +7,9 @@ export interface GlobalSetupFile {
   teardown?: Function
 }
 
-export async function loadGlobalSetupFiles(project: WorkspaceProject): Promise<GlobalSetupFile[]> {
-  const globalSetupFiles = toArray(project.config.globalSetup)
-  return Promise.all(globalSetupFiles.map(file => loadGlobalSetupFile(file, project.runner)))
+export async function loadGlobalSetupFiles(runner: ViteNodeRunner, globalSetup: string | string[]): Promise<GlobalSetupFile[]> {
+  const globalSetupFiles = toArray(globalSetup)
+  return Promise.all(globalSetupFiles.map(file => loadGlobalSetupFile(file, runner)))
 }
 
 async function loadGlobalSetupFile(file: string, runner: ViteNodeRunner): Promise<GlobalSetupFile> {

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -112,7 +112,7 @@ export class WorkspaceProject {
   async teardownGlobalSetup() {
     if (!this._globalSetupInit || !this._globalSetups.length)
       return
-    for (const globalSetupFile of this._globalSetups.reverse()) {
+    for (const globalSetupFile of [...this._globalSetups].reverse()) {
       try {
         await globalSetupFile.teardown?.()
       }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -90,7 +90,7 @@ export class WorkspaceProject {
 
     this._globalSetupInit = true
 
-    this._globalSetups = await loadGlobalSetupFiles(this)
+    this._globalSetups = await loadGlobalSetupFiles(this.runner, this.config.globalSetup)
 
     try {
       for (const globalSetupFile of this._globalSetups) {
@@ -241,12 +241,17 @@ export class WorkspaceProject {
     this.browser = await createBrowserServer(this, configFile)
   }
 
-  static async createCoreProject(ctx: Vitest) {
+  static createBasicProject(ctx: Vitest) {
     const project = new WorkspaceProject(ctx.config.name || ctx.config.root, ctx)
     project.vitenode = ctx.vitenode
     project.server = ctx.server
     project.runner = ctx.runner
     project.config = ctx.config
+    return project
+  }
+
+  static async createCoreProject(ctx: Vitest) {
+    const project = WorkspaceProject.createBasicProject(ctx)
     await project.initBrowserServer(ctx.server.config.configFile)
     return project
   }


### PR DESCRIPTION
### Description

Previously Vitest ignored the global setup inside a root config if there was a workspace defined, and the main config was not in the workspace configuration.

This reverts the behaviour to the one we had before the rewrite of global setup.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
