### PR TITLE
feat: filter stacktraces (fix #1999)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1785,6 +1785,34 @@ export default defineConfig({
 })
 ```
 
+### onStackTrace
+
+- **Type**: `(error: Error, frame: ParsedStack) => boolean | void`
+- **Version**: Since Vitest 1.0.0-beta.3
+
+Apply a filtering function to each frame of each stacktrace when handling errors. The first argument, `error`, is an object with the same properties as a standard `Error`, but it is not an actual instance.
+
+Can be useful for filtering out stacktrace frames from third-party libraries.
+
+```ts
+import type { ParsedStack } from 'vitest'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    onStackTrace(error: Error, { file }: ParsedStack): boolean | void {
+      // If we've encountered a ReferenceError, show the whole stack.
+      if (error.name === 'ReferenceError')
+        return
+
+      // Reject all frames from third party libraries.
+      if (file.includes('node_modules'))
+        return false
+    },
+  },
+})
+```
+
 ### diff
 
 - **Type:** `string`

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -49,6 +49,7 @@ export async function printError(error: unknown, project: WorkspaceProject | und
   const parserOptions: StackTraceParserOptions = {
     // only browser stack traces require remapping
     getSourceMap: file => project.getBrowserSourceMapModuleById(file),
+    frameFilter: project.config.onStackTrace,
   }
 
   if (fullStack)

--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -186,6 +186,7 @@ export class JsonReporter implements Reporter {
     const project = this.ctx.getProjectByTaskId(test.id)
     const stack = parseErrorStacktrace(error, {
       getSourceMap: file => project.getBrowserSourceMapModuleById(file),
+      frameFilter: this.ctx.config.onStackTrace,
     })
     const frame = stack[0]
     if (!frame)

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -135,6 +135,7 @@ export class JUnitReporter implements Reporter {
     const project = this.ctx.getProjectByTaskId(task.id)
     const stack = parseErrorStacktrace(error, {
       getSourceMap: file => project.getBrowserSourceMapModuleById(file),
+      frameFilter: this.ctx.config.onStackTrace,
     })
 
     // TODO: This is same as printStack but without colors. Find a way to reuse code.

--- a/packages/vitest/src/node/reporters/tap.ts
+++ b/packages/vitest/src/node/reporters/tap.ts
@@ -76,6 +76,7 @@ export class TapReporter implements Reporter {
           task.result.errors.forEach((error) => {
             const stacks = parseErrorStacktrace(error, {
               getSourceMap: file => project.getBrowserSourceMapModuleById(file),
+              frameFilter: this.ctx.config.onStackTrace,
             })
             const stack = stacks[0]
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -315,6 +315,7 @@ export class WorkspaceProject {
         resolveSnapshotPath: undefined,
       },
       onConsoleLog: undefined!,
+      onStackTrace: undefined!,
       sequence: {
         ...this.ctx.config.sequence,
         sequencer: undefined!,

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -11,7 +11,7 @@ import type { JSDOMOptions } from './jsdom-options'
 import type { HappyDOMOptions } from './happy-dom-options'
 import type { Reporter } from './reporter'
 import type { SnapshotStateOptions } from './snapshot'
-import type { Arrayable } from './general'
+import type { Arrayable, ParsedStack } from './general'
 import type { BenchmarkUserOptions } from './benchmark'
 import type { BrowserConfigOptions, ResolvedBrowserOptions } from './browser'
 import type { Pool, PoolOptions } from './pool-options'
@@ -538,6 +538,14 @@ export interface InlineConfig {
   onConsoleLog?: (log: string, type: 'stdout' | 'stderr') => false | void
 
   /**
+   * Enable stack trace filtering. If absent, all stack trace frames
+   * will be shown.
+   *
+   * Return `false` to omit the frame.
+   */
+  onStackTrace?: (error: Error, frame: ParsedStack) => boolean | void
+
+  /**
    * Indicates if CSS files should be processed.
    *
    * When excluded, the CSS files will be replaced with empty strings to bypass the subsequent processing.
@@ -788,6 +796,7 @@ export type ProjectConfig = Omit<
   | 'resolveSnapshotPath'
   | 'passWithNoTests'
   | 'onConsoleLog'
+  | 'onStackTrace'
   | 'dangerouslyIgnoreUnhandledErrors'
   | 'slowTestThreshold'
   | 'inspect'

--- a/test/stacktraces/fixtures/error-with-stack.test.js
+++ b/test/stacktraces/fixtures/error-with-stack.test.js
@@ -1,0 +1,21 @@
+import { test } from 'vitest'
+
+test('error in deps', () => {
+  a()
+})
+
+function a() {
+  b()
+}
+
+function b() {
+  c()
+}
+
+function c() {
+  d()
+}
+
+function d() {
+  throw new Error('Something truly horrible has happened!')
+}

--- a/test/stacktraces/test/__snapshots__/runner.test.ts.snap
+++ b/test/stacktraces/test/__snapshots__/runner.test.ts.snap
@@ -1,5 +1,26 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`stacktrace filtering > filters stacktraces > stacktrace-filtering 1`] = `
+"⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  error-with-stack.test.js > error in deps
+Error: Something truly horrible has happened!
+ ❯ d error-with-stack.test.js:20:9
+     18| 
+     19| function d() {
+     20|   throw new Error('Something truly horrible has happened!')
+       |         ^
+     21| }
+     22| 
+ ❯ c error-with-stack.test.js:16:3
+ ❯ a error-with-stack.test.js:8:3
+ ❯ error-with-stack.test.js:4:3
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+"
+`;
+
 exports[`stacktrace should print error frame source file correctly > error-in-deps > error-in-deps 1`] = `
 "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 
@@ -69,6 +90,17 @@ exports[`stacktraces should respect sourcemaps > error-in-deps.test.js > error-i
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 
 "
+`;
+
+exports[`stacktraces should respect sourcemaps > error-with-stack.test.js > error-with-stack.test.js 1`] = `
+" ❯ d error-with-stack.test.js:20:9
+     18| 
+     19| function d() {
+     20|   throw new Error('Something truly horrible has happened!')
+       |         ^
+     21| }
+     22| 
+ ❯ c error-with-stack.test.js:16:3"
 `;
 
 exports[`stacktraces should respect sourcemaps > mocked-global.test.js > mocked-global.test.js 1`] = `

--- a/test/stacktraces/test/runner.test.ts
+++ b/test/stacktraces/test/runner.test.ts
@@ -52,3 +52,17 @@ describe('stacktrace should print error frame source file correctly', async () =
     expect(stderr).toMatchSnapshot('error-in-deps')
   }, 30000)
 })
+
+describe('stacktrace filtering', async () => {
+  const root = resolve(__dirname, '../fixtures')
+  const testFile = resolve(root, './error-with-stack.test.js')
+
+  it('filters stacktraces', async () => {
+    const { stderr } = await runVitest({
+      root,
+      onStackTrace: (_error, { method }) => method !== 'b',
+    }, [testFile])
+
+    expect(stderr).toMatchSnapshot('stacktrace-filtering')
+  }, 30000)
+})


### PR DESCRIPTION
### Description
This change introduces a new optional configuration parameter, `onStackTrace`. If included, each frame of each error stacktrace encountered during the test run will be tested by the provided function. If the test fails, the frame will be omitted from the displayed trace.

The only real note is that this might not give enough information for more complex situations (e.g. filtering that depends on the error, or the other frames).

Fixes #1999.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
