### PR TITLE
fix: coverage.100 crash when using as an cli argument

### DIFF
--- a/packages/vitest/src/node/cli-api.ts
+++ b/packages/vitest/src/node/cli-api.ts
@@ -44,6 +44,12 @@ export async function startVitest(
   if (typeof options.coverage === 'boolean')
     options.coverage = { enabled: options.coverage }
 
+  // running "vitest --coverage.all" or "vitest --coverage.100"
+  // @ts-expect-error Element implicitly has an any type for options.coverage["100"]
+  if (typeof options.coverage === 'object' && !('enabled' in options.coverage) && (options.coverage['100'] === true
+    || Object.keys(options.coverage).length > 1))
+    options.coverage.enabled = true
+
   // running "vitest --browser", assumes browser name is set in the config
   if (typeof options.browser === 'boolean')
     options.browser = { enabled: options.browser } as any

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -25,7 +25,7 @@ cli
   .option('--hideSkippedTests', 'Hide logs for skipped tests')
   .option('--reporter <name>', 'Specify reporters')
   .option('--outputFile <filename/-s>', 'Write test results to a file when supporter reporter is also specified, use cac\'s dot notation for individual outputs of multiple reporters')
-  .option('--coverage', 'Enable coverage report')
+  .option('--coverage', 'Enable coverage report', { default: { 100: false } })
   .option('--run', 'Disable watch mode')
   .option('--mode <name>', 'Override Vite mode (default: test)')
   .option('--globals', 'Inject apis globally')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Set a default value for the option --coverage to fix a crash that happen when using the option --coverage.100
CAC is not handling a key with only numbers alone.
Also add an coverage option check to add the value `enabled: true` when using a dotted coverage option.

Fixes #4307 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
