### PR TITLE
feat(benchmark):  move importTinybench to runner

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -184,7 +184,6 @@
     "birpc": "0.2.14",
     "chai-subset": "^1.6.0",
     "cli-truncate": "^3.1.0",
-    "event-target-polyfill": "^0.0.3",
     "execa": "^7.1.1",
     "expect-type": "^0.16.0",
     "fast-glob": "^3.3.0",

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -8,13 +8,6 @@ import type { BenchTask, Benchmark, BenchmarkResult } from '../../types/benchmar
 import type { ResolvedConfig } from '../../types/config'
 import type { VitestExecutor } from '../execute'
 
-async function importTinybench() {
-  if (!globalThis.EventTarget)
-    await import('event-target-polyfill' as any)
-
-  return (await import('tinybench'))
-}
-
 function createBenchmarkResult(name: string): BenchmarkResult {
   return {
     name,
@@ -26,8 +19,9 @@ function createBenchmarkResult(name: string): BenchmarkResult {
 
 const benchmarkTasks = new WeakMap<Benchmark, import('tinybench').Task>()
 
-async function runBenchmarkSuite(suite: Suite, runner: VitestRunner) {
-  const { Task, Bench } = await importTinybench()
+async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
+  const { Task, Bench } = await runner.importTinybench()
+
   const start = performance.now()
 
   const benchmarkGroup: Benchmark[] = []
@@ -131,6 +125,10 @@ export class NodeBenchmarkRunner implements VitestRunner {
   private __vitest_executor!: VitestExecutor
 
   constructor(public config: ResolvedConfig) {}
+
+  async importTinybench() {
+    return await import('tinybench')
+  }
 
   importFile(filepath: string, source: VitestRunnerImportSource): unknown {
     if (source === 'setup')

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -736,10 +736,7 @@ export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'f
 
   api?: ApiConfig
 
-  benchmark?: Required<Omit<BenchmarkUserOptions, 'outputFile'>> & {
-    outputFile?: BenchmarkUserOptions['outputFile']
-  }
-
+  benchmark?: Required<Omit<BenchmarkUserOptions, 'outputFile'>> & Pick<BenchmarkUserOptions, 'outputFile'>
   shard?: {
     index: number
     count: number

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1428,9 +1428,6 @@ importers:
       cli-truncate:
         specifier: ^3.1.0
         version: 3.1.0
-      event-target-polyfill:
-        specifier: ^0.0.3
-        version: 0.0.3
       execa:
         specifier: ^7.1.1
         version: 7.1.1
@@ -17200,10 +17197,6 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-    dev: true
-
-  /event-target-polyfill@0.0.3:
-    resolution: {integrity: sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==}
     dev: true
 
   /event-target-shim@5.0.1:


### PR DESCRIPTION
### Description

This way we can change the instance of `tinybench` by inherting `NodeBenchmarkRunner` and overriding `importTinyBench`.

But unfortunately, `@codspeed/tinybench-plugin` is incompatible with `vitest`. We need still to wait for `codespeed` to support `vitest`.  I see them doing it. https://github.com/CodSpeedHQ/codspeed-node/pull/26

close: #4081

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
