### PR TITLE
fix: support accessing fixture at same index of dependency fixture

### DIFF
--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -37,7 +37,7 @@ export function mergeContextFixtures(fixtures: Record<string, any>, context: { f
     if (fixture.isFn) {
       const usedProps = getUsedProps(fixture.value)
       if (usedProps.length)
-        fixture.deps = context.fixtures!.filter(({ index, prop }) => index !== fixture.index && usedProps.includes(prop))
+        fixture.deps = context.fixtures!.filter(({ prop }) => prop !== fixture.prop && usedProps.includes(prop))
     }
   })
 

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -200,28 +200,15 @@ export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & Extend
       K extends keyof ExtraContext ? ExtraContext[K] : never }>
 }
 
-type FixtureType<T> = T extends (context: any, use: (fixture: infer F) => any) => any ? F : T
-export type Fixture<
-  T,
-  K extends keyof T,
-  OnlyFunction,
-  ExtraContext = {},
-  V = FixtureType<T[K]>,
-  FN = (
-    context: {
-      [P in keyof T | keyof ExtraContext as P extends K ?
-        P extends keyof ExtraContext ? P : never : P
-      ]:
-      K extends P ? K extends keyof ExtraContext ? ExtraContext[K] : V :
-        P extends keyof T ? T[P] : never
-    } & TestContext,
-    use: (fixture: V) => Promise<void>
-  ) => Promise<void>,
-> = OnlyFunction extends true ? FN : (FN | V)
+export type Use<T> = (value: T) => Promise<void>
+export type FixtureFn<T, K extends keyof T, ExtraContext> =
+  (context: Omit<T, K> & ExtraContext, use: Use<T[K]>) => Promise<void>
+export type Fixture<T, K extends keyof T, ExtraContext = {}> =
+  ((...args: any) => any) extends T[K]
+    ? (T[K] extends any ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>> : never)
+    : T[K] | (T[K] extends any ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>> : never)
 export type Fixtures<T extends Record<string, any>, ExtraContext = {}> = {
-  [K in keyof T]: Fixture<T, K, false, ExtraContext>
-} | {
-  [K in keyof T]: Fixture<T, K, true, ExtraContext>
+  [K in keyof T]: Fixture<T, K, ExtraContext & ExtendedContext<Test>>
 }
 
 export type InferFixturesTypes<T> = T extends TestAPI<infer C> ? C : T

--- a/test/core/test/fixture-initialization.test.ts
+++ b/test/core/test/fixture-initialization.test.ts
@@ -1,3 +1,4 @@
+import type { Use } from '@vitest/runner'
 import { describe, expect, expectTypeOf, test, vi } from 'vitest'
 
 interface Fixtures {
@@ -125,6 +126,22 @@ describe('fixture initialization', () => {
       expect(fnB2).toBeCalledTimes(1)
       expect(fnC).toBeCalledTimes(1)
       expect(fnD).toBeCalledTimes(1)
+    })
+  })
+
+  describe('fixture dependency', () => {
+    const myTest = test
+      .extend({ a: 1 })
+      .extend({
+        b: async ({ a }, use: Use<number>) => {
+          expectTypeOf(a).toEqualTypeOf<number>()
+          await use(a * 2)
+        },
+      })
+
+    myTest('b => a', ({ b }) => {
+      expectTypeOf(b).toEqualTypeOf<number>()
+      expect(b).toBe(2)
     })
   })
 })

--- a/test/core/test/test-extend.test.ts
+++ b/test/core/test/test-extend.test.ts
@@ -47,6 +47,7 @@ describe('test.extend()', () => {
       string: string
       any: any
       boolean: boolean
+      func: (a: number, b: string) => void
     }
 
     const typesTest = test.extend<TypesContext>({
@@ -59,6 +60,9 @@ describe('test.extend()', () => {
         await use({})
       },
       boolean: true,
+      func: async ({}, use): Promise<void> => {
+        await use(() => undefined)
+      },
     })
 
     expectTypeOf(typesTest).toEqualTypeOf<TestAPI<InferFixturesTypes<typeof typesTest>>>()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes https://github.com/vitest-dev/vitest/issues/4386


Given the following test:

```
  describe('fixture dependency', () => {
    const myTest = test
      .extend<{ a: number; b: number }>({ a: 1, b: 2 })
      .extend<{ c: number }>({
        c: async ({ a, b }, use) => {
          await use(`${a}, ${b}`)
        },
      })

    myTest('c => [a, b]', ({ c }) => {
      expect(c).toBe('1, 2')
    })
  })
```

I expect the test to pass. However, the test fails with the following error:

```
AssertionError: expected 'undefined, 2' to be '1, 2' // Object.is equality

- Expected
+ Received

- 1, 2
+ undefined, 2
```

The fixture `a` is not initialised despite the fixture `c` depending upon it.

This PR amends the check when updating the list of dependencies for each fixture so that a fixture is excluded from its own dependency list by comparing the name of the prop instead of its index in the fixtures array.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
