### PR TITLE
fix: make asynchronous fixtures work concurrently

### DIFF
--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -44,7 +44,7 @@ export function mergeContextFixtures(fixtures: Record<string, any>, context: { f
   return context
 }
 
-const fixtureValueMap = new Map<FixtureItem, any>()
+const fixtureValueMaps = new Map<TestContext, Map<FixtureItem, any>>()
 let cleanupFnArray = new Array<() => void | Promise<void>>()
 
 export async function callFixtureCleanup() {
@@ -67,6 +67,10 @@ export function withFixtures(fn: Function, testContext?: TestContext) {
     const usedProps = getUsedProps(fn)
     if (!usedProps.length)
       return fn(context)
+
+    if (!fixtureValueMaps.get(context))
+      fixtureValueMaps.set(context, new Map<FixtureItem, any>())
+    const fixtureValueMap: Map<FixtureItem, any> = fixtureValueMaps.get(context)!
 
     const usedFixtures = fixtures.filter(({ prop }) => usedProps.includes(prop))
     const pendingFixtures = resolveDeps(usedFixtures)

--- a/test/core/test/fixture-concurrent.test.ts
+++ b/test/core/test/fixture-concurrent.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+
+export const myTest = test.extend<{
+  a: string
+  b: string
+}>({
+  a: async ({ task }: any, use) => {
+    await new Promise<void>(resolve => setTimeout(resolve, 200))
+    await use(task.id)
+  },
+  b: async ({ a }, use) => {
+    await use(a)
+  },
+})
+
+myTest.concurrent('fixture - concurrent test 1', ({ a, b, task }) => {
+  expect(a).toBe(task.id)
+  expect(b).toBe(task.id)
+})
+
+myTest.concurrent('fixture - concurrent test 2', ({ a, b, task }) => {
+  expect(a).toBe(task.id)
+  expect(b).toBe(task.id)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes https://github.com/vitest-dev/vitest/issues/4402

<!-- You can also add additional context here -->
When multiple tests concurrently use an asynchronous fixture, the fixture value is not necessarily isolated between tests. This leads to a race condition and unpredictable behaviour where a fixture value created in one test may or may not be attached to the context of a separate test, sometimes causing Vitest to hang as the promise returned in the call to use() is awaited but never resolved. This PR addresses the race condition by isolating fixture values between tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
