### PR TITLE
fix: copy custom asymmetric matchers to local `expect`

### DIFF
--- a/packages/expect/src/constants.ts
+++ b/packages/expect/src/constants.ts
@@ -1,3 +1,4 @@
 export const MATCHERS_OBJECT = Symbol.for('matchers-object')
 export const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object')
 export const GLOBAL_EXPECT = Symbol.for('expect-global')
+export const ASYMMETRIC_MATCHERS_OBJECT = Symbol.for('asymmetric-matchers-object')

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -108,6 +108,13 @@ function JestExtendPlugin(expect: ExpectStatic, matchers: MatchersObject): ChaiP
         }
       }
 
+      Object.defineProperty(((globalThis as any).__hackAsymmetricMatchers), expectAssertionName, {
+        configurable: true,
+        enumerable: true,
+        value: (...sample: [unknown, ...unknown[]]) => new CustomMatcher(false, ...sample),
+        writable: true,
+      })
+
       Object.defineProperty(expect, expectAssertionName, {
         configurable: true,
         enumerable: true,

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -108,10 +108,12 @@ function JestExtendPlugin(expect: ExpectStatic, matchers: MatchersObject): ChaiP
         }
       }
 
+      const customMatcher = (...sample: [unknown, ...unknown[]]) => new CustomMatcher(false, ...sample)
+
       Object.defineProperty(expect, expectAssertionName, {
         configurable: true,
         enumerable: true,
-        value: (...sample: [unknown, ...unknown[]]) => new CustomMatcher(false, ...sample),
+        value: customMatcher,
         writable: true,
       })
 
@@ -127,7 +129,7 @@ function JestExtendPlugin(expect: ExpectStatic, matchers: MatchersObject): ChaiP
       Object.defineProperty(((globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT]), expectAssertionName, {
         configurable: true,
         enumerable: true,
-        value: (...sample: [unknown, ...unknown[]]) => new CustomMatcher(false, ...sample),
+        value: customMatcher,
         writable: true,
       })
     })

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -123,7 +123,7 @@ function JestExtendPlugin(expect: ExpectStatic, matchers: MatchersObject): ChaiP
       })
 
       // keep track of asymmetric matchers on global so that it can be copied over to local context's `expect`.
-      // note that the negated variant is automatically shared since it's directly assigned on single `expect.not` object.
+      // note that the negated variant is automatically shared since it's assigned on the single `expect.not` object.
       Object.defineProperty(((globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT]), expectAssertionName, {
         configurable: true,
         enumerable: true,

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -6,7 +6,7 @@ import type {
   MatchersObject,
   SyncExpectationResult,
 } from './types'
-import { JEST_MATCHERS_OBJECT } from './constants'
+import { ASYMMETRIC_MATCHERS_OBJECT, JEST_MATCHERS_OBJECT } from './constants'
 import { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import { getState } from './state'
 
@@ -108,13 +108,6 @@ function JestExtendPlugin(expect: ExpectStatic, matchers: MatchersObject): ChaiP
         }
       }
 
-      Object.defineProperty(((globalThis as any).__hackAsymmetricMatchers), expectAssertionName, {
-        configurable: true,
-        enumerable: true,
-        value: (...sample: [unknown, ...unknown[]]) => new CustomMatcher(false, ...sample),
-        writable: true,
-      })
-
       Object.defineProperty(expect, expectAssertionName, {
         configurable: true,
         enumerable: true,
@@ -126,6 +119,15 @@ function JestExtendPlugin(expect: ExpectStatic, matchers: MatchersObject): ChaiP
         configurable: true,
         enumerable: true,
         value: (...sample: [unknown, ...unknown[]]) => new CustomMatcher(true, ...sample),
+        writable: true,
+      })
+
+      // keep track of asymmetric matchers on global so that it can be copied over to local context's `expect`.
+      // note that the negated variant is automatically shared since it's directly assigned on single `expect.not` object.
+      Object.defineProperty(((globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT]), expectAssertionName, {
+        configurable: true,
+        enumerable: true,
+        value: (...sample: [unknown, ...unknown[]]) => new CustomMatcher(false, ...sample),
         writable: true,
       })
     })

--- a/packages/expect/src/state.ts
+++ b/packages/expect/src/state.ts
@@ -1,9 +1,10 @@
 import type { ExpectStatic, MatcherState } from './types'
-import { GLOBAL_EXPECT, JEST_MATCHERS_OBJECT, MATCHERS_OBJECT } from './constants'
+import { ASYMMETRIC_MATCHERS_OBJECT, GLOBAL_EXPECT, JEST_MATCHERS_OBJECT, MATCHERS_OBJECT } from './constants'
 
 if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {
   const globalState = new WeakMap<ExpectStatic, MatcherState>()
   const matchers = Object.create(null)
+  const assymetricMatchers = Object.create(null)
   Object.defineProperty(globalThis, MATCHERS_OBJECT, {
     get: () => globalState,
   })
@@ -13,6 +14,9 @@ if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {
       state: globalState.get((globalThis as any)[GLOBAL_EXPECT]),
       matchers,
     }),
+  })
+  Object.defineProperty(globalThis, ASYMMETRIC_MATCHERS_OBJECT, {
+    get: () => assymetricMatchers,
   })
 }
 

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -22,6 +22,9 @@ export function createExpect(test?: TaskPopulated) {
     else
       return assert
   }) as ExpectStatic
+
+  // quick and dirty way to share custom asymmetric matchers between global expect and local expect
+  Object.assign(expect, (globalThis as any).__hackAsymmetricMatchers ??= {})
   Object.assign(expect, chai.expect)
 
   expect.getState = () => getState<MatcherState>(expect)

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -4,7 +4,7 @@ import * as chai from 'chai'
 import './setup'
 import type { TaskPopulated, Test } from '@vitest/runner'
 import { getCurrentTest } from '@vitest/runner'
-import { GLOBAL_EXPECT, getState, setState } from '@vitest/expect'
+import { ASYMMETRIC_MATCHERS_OBJECT, GLOBAL_EXPECT, getState, setState } from '@vitest/expect'
 import type { Assertion, ExpectStatic } from '@vitest/expect'
 import type { MatcherState } from '../../types/chai'
 import { getFullName } from '../../utils/tasks'
@@ -23,9 +23,8 @@ export function createExpect(test?: TaskPopulated) {
       return assert
   }) as ExpectStatic
 
-  // quick and dirty way to share custom asymmetric matchers between global expect and local expect
-  Object.assign(expect, (globalThis as any).__hackAsymmetricMatchers ??= {})
   Object.assign(expect, chai.expect)
+  Object.assign(expect, (globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT])
 
   expect.getState = () => getState<MatcherState>(expect)
   expect.setState = state => setState(state as Partial<MatcherState>, expect)

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -22,7 +22,6 @@ export function createExpect(test?: TaskPopulated) {
     else
       return assert
   }) as ExpectStatic
-
   Object.assign(expect, chai.expect)
   Object.assign(expect, (globalThis as any)[ASYMMETRIC_MATCHERS_OBJECT])
 

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -39,7 +39,7 @@ describe('context expect', () => {
 
 describe('custom matcher inherited from global to local', () => {
   expect.extend({
-    testCustomInheritance() {
+    toFooTest() {
       return {
         pass: true,
         message: () => `foo`,
@@ -49,13 +49,15 @@ describe('custom matcher inherited from global to local', () => {
 
   it('basic', ({ expect: localExpect }) => {
     // as assertion
-    expect(expect('test')).toHaveProperty('testCustomInheritance')
-    expect(localExpect('test')).toHaveProperty('testCustomInheritance')
+    expect(expect('test')).toHaveProperty('toFooTest')
+    expect(expect.soft('test')).toHaveProperty('toFooTest')
+    expect(localExpect('test')).toHaveProperty('toFooTest')
+    expect(localExpect.soft('test')).toHaveProperty('toFooTest')
 
     // as asymmetric matcher
-    expect(expect).toHaveProperty('testCustomInheritance')
-
-    // TODO: not working
-    // expect(localExpect).toHaveProperty('testCustomInheritance')
+    expect(expect).toHaveProperty('toFooTest')
+    expect(expect.not).toHaveProperty('toFooTest')
+    expect(localExpect).toHaveProperty('toFooTest')
+    expect(localExpect.not).toHaveProperty('toFooTest')
   })
 })

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -36,3 +36,26 @@ describe('context expect', () => {
     expect(localExpect.getState().snapshotState).toBeDefined()
   })
 })
+
+describe('custom matcher inherited from global to local', () => {
+  expect.extend({
+    testCustomInheritance() {
+      return {
+        pass: true,
+        message: () => `foo`,
+      }
+    },
+  })
+
+  it('basic', ({ expect: localExpect }) => {
+    // as assertion
+    expect(expect('test')).toHaveProperty('testCustomInheritance')
+    expect(localExpect('test')).toHaveProperty('testCustomInheritance')
+
+    // as asymmetric matcher
+    expect(expect).toHaveProperty('testCustomInheritance')
+
+    // TODO: not working
+    // expect(localExpect).toHaveProperty('testCustomInheritance')
+  })
+})

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -39,7 +39,7 @@ describe('context expect', () => {
 
 describe('custom matcher are inherited by local context', () => {
   expect.extend({
-    toEqualTestLocalMatcher(received, expected) {
+    toEqual_testCustom(received, expected) {
       return {
         pass: received === expected,
         message: () => `test`,
@@ -49,22 +49,22 @@ describe('custom matcher are inherited by local context', () => {
 
   it('basic', ({ expect: localExpect }) => {
     // as assertion
-    expect(expect('test')).toHaveProperty('toEqualTestLocalMatcher')
-    expect(expect.soft('test')).toHaveProperty('toEqualTestLocalMatcher')
-    expect(localExpect('test')).toHaveProperty('toEqualTestLocalMatcher')
-    expect(localExpect.soft('test')).toHaveProperty('toEqualTestLocalMatcher')
+    expect(expect('test')).toHaveProperty('toEqual_testCustom')
+    expect(expect.soft('test')).toHaveProperty('toEqual_testCustom')
+    expect(localExpect('test')).toHaveProperty('toEqual_testCustom')
+    expect(localExpect.soft('test')).toHaveProperty('toEqual_testCustom')
 
     // as asymmetric matcher
-    expect(expect).toHaveProperty('toEqualTestLocalMatcher')
-    expect(expect.not).toHaveProperty('toEqualTestLocalMatcher')
-    expect(localExpect).toHaveProperty('toEqualTestLocalMatcher')
-    expect(localExpect.not).toHaveProperty('toEqualTestLocalMatcher');
+    expect(expect).toHaveProperty('toEqual_testCustom')
+    expect(expect.not).toHaveProperty('toEqual_testCustom')
+    expect(localExpect).toHaveProperty('toEqual_testCustom')
+    expect(localExpect.not).toHaveProperty('toEqual_testCustom');
 
-    (expect(0) as any).toEqualTestLocalMatcher(0);
-    (expect(0) as any).not.toEqualTestLocalMatcher(1);
-    (localExpect(0) as any).toEqualTestLocalMatcher(0);
-    (localExpect(0) as any).not.toEqualTestLocalMatcher(1)
-    expect(0).toEqual((expect as any).not.toEqualTestLocalMatcher(1))
-    localExpect(0).toEqual((localExpect as any).not.toEqualTestLocalMatcher(1))
+    (expect(0) as any).toEqual_testCustom(0);
+    (expect(0) as any).not.toEqual_testCustom(1);
+    (localExpect(0) as any).toEqual_testCustom(0);
+    (localExpect(0) as any).not.toEqual_testCustom(1)
+    expect(0).toEqual((expect as any).not.toEqual_testCustom(1))
+    localExpect(0).toEqual((localExpect as any).not.toEqual_testCustom(1))
   })
 })

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -39,25 +39,32 @@ describe('context expect', () => {
 
 describe('custom matcher are inherited by local context', () => {
   expect.extend({
-    toFooTest() {
+    toEqualTestLocalMatcher(received, expected) {
       return {
-        pass: true,
-        message: () => `foo`,
+        pass: received === expected,
+        message: () => `test`,
       }
     },
   })
 
   it('basic', ({ expect: localExpect }) => {
     // as assertion
-    expect(expect('test')).toHaveProperty('toFooTest')
-    expect(expect.soft('test')).toHaveProperty('toFooTest')
-    expect(localExpect('test')).toHaveProperty('toFooTest')
-    expect(localExpect.soft('test')).toHaveProperty('toFooTest')
+    expect(expect('test')).toHaveProperty('toEqualTestLocalMatcher')
+    expect(expect.soft('test')).toHaveProperty('toEqualTestLocalMatcher')
+    expect(localExpect('test')).toHaveProperty('toEqualTestLocalMatcher')
+    expect(localExpect.soft('test')).toHaveProperty('toEqualTestLocalMatcher')
 
     // as asymmetric matcher
-    expect(expect).toHaveProperty('toFooTest')
-    expect(expect.not).toHaveProperty('toFooTest')
-    expect(localExpect).toHaveProperty('toFooTest')
-    expect(localExpect.not).toHaveProperty('toFooTest')
+    expect(expect).toHaveProperty('toEqualTestLocalMatcher')
+    expect(expect.not).toHaveProperty('toEqualTestLocalMatcher')
+    expect(localExpect).toHaveProperty('toEqualTestLocalMatcher')
+    expect(localExpect.not).toHaveProperty('toEqualTestLocalMatcher');
+
+    (expect(0) as any).toEqualTestLocalMatcher(0);
+    (expect(0) as any).not.toEqualTestLocalMatcher(1);
+    (localExpect(0) as any).toEqualTestLocalMatcher(0);
+    (localExpect(0) as any).not.toEqualTestLocalMatcher(1)
+    expect(0).toEqual((expect as any).not.toEqualTestLocalMatcher(1))
+    localExpect(0).toEqual((localExpect as any).not.toEqualTestLocalMatcher(1))
   })
 })

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -37,7 +37,7 @@ describe('context expect', () => {
   })
 })
 
-describe('custom matcher inherited from global to local', () => {
+describe('custom matcher are inherited by local context', () => {
   expect.extend({
     toFooTest() {
       return {

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -64,7 +64,14 @@ describe('custom matcher are inherited by local context', () => {
     (expect(0) as any).not.toEqual_testCustom(1);
     (localExpect(0) as any).toEqual_testCustom(0);
     (localExpect(0) as any).not.toEqual_testCustom(1)
-    expect(0).toEqual((expect as any).not.toEqual_testCustom(1))
-    localExpect(0).toEqual((localExpect as any).not.toEqual_testCustom(1))
+
+    expect(0).toEqual((expect as any).toEqual_testCustom(0))
+    localExpect(0).toEqual((localExpect as any).toEqual_testCustom(0))
+    expect(0).toEqual((expect.not as any).toEqual_testCustom(1))
+    localExpect(0).toEqual((localExpect.not as any).toEqual_testCustom(1))
+
+    // asymmetric matcher function is identical
+    expect((expect as any).toEqual_testCustom).toBe((localExpect as any).toEqual_testCustom)
+    expect((expect.not as any).toEqual_testCustom).toBe((localExpect.not as any).toEqual_testCustom)
   })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Closes https://github.com/vitest-dev/vitest/issues/4360

~Draft PR to start with probably too quick-and-dirty ideas.
I will continue to see if there is a clear way and also see if some test breaks.~

After the investigation https://github.com/vitest-dev/vitest/issues/4360#issuecomment-1786694374, I found that custom asymmetric matchers defined on global `expect` is not propagated to local context's `expect`.
This PR fixes the issue by keeping track of asymmetric matchers object on `globalThis[ASYMMETRIC_MATCHERS_OBJECT]` then copying them over during `createExpect`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
