### PR TITLE
docs: fix VP rc24 styles

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -54,8 +54,8 @@ export default withPwa(defineConfig({
   lastUpdated: true,
   markdown: {
     theme: {
-      light: 'vitesse-light',
-      dark: 'vitesse-dark',
+      light: 'github-light',
+      dark: 'github-dark',
     },
   },
   themeConfig: {

--- a/docs/.vitepress/scripts/pwa.ts
+++ b/docs/.vitepress/scripts/pwa.ts
@@ -65,7 +65,9 @@ export const pwa: PwaOptions = {
   },
   workbox: {
     navigateFallbackDenylist: [/^\/new$/],
-    globPatterns: ['**/*.{css,js,html,png,svg,ico,txt,woff2}'],
+    // warning: sponsors/antfu.svg is 2.51 MB, and won't be precached
+    maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // <== 5 MB
+    globPatterns: ['**/*.{css,js,html,png,svg,ico,txt,woff2,json}'],
     runtimeCaching: [
       {
         urlPattern: pwaFontsRegex,
@@ -110,5 +112,8 @@ export const pwa: PwaOptions = {
         },
       },
     ],
+  },
+  experimental: {
+    includeAllowlist: true,
   },
 }

--- a/docs/.vitepress/scripts/pwa.ts
+++ b/docs/.vitepress/scripts/pwa.ts
@@ -66,7 +66,7 @@ export const pwa: PwaOptions = {
   workbox: {
     navigateFallbackDenylist: [/^\/new$/],
     // warning: sponsors/antfu.svg is 2.51 MB, and won't be precached
-    maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // <== 5 MB
+    maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // <== 3MB
     globPatterns: ['**/*.{css,js,html,png,svg,ico,txt,woff2,json}'],
     runtimeCaching: [
       {

--- a/docs/.vitepress/style/main.css
+++ b/docs/.vitepress/style/main.css
@@ -46,6 +46,16 @@ html:not(.dark) .custom-block.tip code {
   transform: scale(0.9);
 }
 
+.vp-doc a {
+  text-decoration-style: dotted;
+}
+.vp-doc a:focus,
+.vp-doc a:active,
+.vp-doc a:hover,
+.vp-doc a:active {
+  text-decoration: underline;
+}
+
 .vp-doc th, .vp-doc td {
   padding: 6px 10px;
   border: 1px solid #8882;

--- a/docs/.vitepress/style/main.css
+++ b/docs/.vitepress/style/main.css
@@ -8,6 +8,40 @@ html:not(.dark) [img-dark] {
 
 /* Overrides */
 
+.sp .sp-link.link:hover,
+.sp .sp-link.link:focus {
+  background-color: var(--vp-c-sponsor-hover) !important;
+}
+
+/* outline styles for buttons and VPButton anchors */
+button:focus,
+button:focus-visible,
+.DocSearch-Button:focus,
+.DocSearch-Button:focus-visible,
+a:focus-visible,
+a:focus {
+  border-radius: 2px;
+  outline: 2px solid var(--vp-c-text-1);
+}
+
+a:focus:not(:focus-visible),
+button:focus:not(:focus-visible) {
+  outline: none !important;
+}
+
+/* custom block styles */
+html:not(.dark) .custom-block.tip code {
+  color: #4a680c !important;
+}
+
+/* search # styles */
+:not(.dark) .title-icon {
+  opacity: 1 !important;
+}
+.dark .title-icon {
+  opacity: 0.67 !important;
+}
+
 .VPSocialLink {
   transform: scale(0.9);
 }

--- a/docs/.vitepress/style/main.css
+++ b/docs/.vitepress/style/main.css
@@ -33,6 +33,34 @@ button:focus:not(:focus-visible) {
 html:not(.dark) .custom-block.tip code {
   color: #4a680c !important;
 }
+html:not(.dark) .custom-block.info code {
+  color: #394f0c !important;
+}
+.custom-block.tip a:hover,
+.vp-doc .custom-block.tip a:hover > code {
+  color: var(--vp-c-brand-1) !important;
+  opacity: 1;
+}
+.custom-block.info a:hover,
+.vp-doc .custom-block.info a:hover > code {
+  color: var(--vp-c-brand-1) !important;
+  opacity: 1;
+}
+html:not(.dark) .custom-block.info a:hover,
+html:not(.dark) .vp-doc .custom-block.info a:hover > code {
+  color: #394f0c !important;
+  opacity: 1;
+}
+.custom-block.warning a:hover,
+.vp-doc .custom-block.warning a:hover > code {
+  color: var(--vp-c-warning-1) !important;
+  opacity: 1;
+}
+.custom-block.danger a:hover,
+.vp-doc .custom-block.danger a:hover > code {
+  color: var(--vp-c-danger-1) !important;
+  opacity: 1;
+}
 
 /* search # styles */
 :not(.dark) .title-icon {
@@ -49,6 +77,10 @@ html:not(.dark) .custom-block.tip code {
 .vp-doc a {
   text-decoration-style: dotted;
 }
+.custom-block a:focus,
+.custom-block a:active,
+.custom-block a:hover,
+.custom-block a:active,
 .vp-doc a:focus,
 .vp-doc a:active,
 .vp-doc a:hover,

--- a/docs/.vitepress/style/main.css
+++ b/docs/.vitepress/style/main.css
@@ -10,7 +10,7 @@ html:not(.dark) [img-dark] {
 
 .sp .sp-link.link:hover,
 .sp .sp-link.link:focus {
-  background-color: var(--vp-c-sponsor-hover) !important;
+  background-color: var(--vitest-c-sponsor-hover) !important;
 }
 
 /* outline styles for buttons and VPButton anchors */
@@ -31,10 +31,10 @@ button:focus:not(:focus-visible) {
 
 /* custom block styles */
 html:not(.dark) .custom-block.tip code {
-  color: #4a680c !important;
+  color: var(--vitest-custom-block-tip-code-text) !important;
 }
 html:not(.dark) .custom-block.info code {
-  color: #394f0c !important;
+  color: var(--vitest-custom-block-info-code-text) !important;
 }
 .custom-block.tip a:hover,
 .vp-doc .custom-block.tip a:hover > code {
@@ -48,7 +48,7 @@ html:not(.dark) .custom-block.info code {
 }
 html:not(.dark) .custom-block.info a:hover,
 html:not(.dark) .vp-doc .custom-block.info a:hover > code {
-  color: #394f0c !important;
+  color: var(--vitest-custom-block-info-code-text) !important;
   opacity: 1;
 }
 .custom-block.warning a:hover,

--- a/docs/.vitepress/style/vars.css
+++ b/docs/.vitepress/style/vars.css
@@ -4,7 +4,7 @@
 
 :root {
   --vp-c-brand-1: #52730d;
-  --vp-c-brand-2: #517012;
+  --vp-c-brand-2: #57791b;
   --vp-c-brand-3: #506e10;
   --vp-c-sponsor: #ca2971;
   --vp-c-sponsor-hover: #c13071;
@@ -12,7 +12,7 @@
 
 .dark {
   --vp-c-brand-1: #add467;
-  --vp-c-brand-2: #a7cc66;
+  --vp-c-brand-2: #c6eb86;
   --vp-c-brand-3: #acd268;
   --vp-c-sponsor: #ee4e95;
   --vp-c-sponsor-hover: #e51370;

--- a/docs/.vitepress/style/vars.css
+++ b/docs/.vitepress/style/vars.css
@@ -12,7 +12,7 @@
 
 .dark {
   --vp-c-brand-1: #add467;
-  --vp-c-brand-2: #c6eb86;
+  --vp-c-brand-2: #a7cc66;
   --vp-c-brand-3: #acd268;
   --vp-c-sponsor: #ee4e95;
   --vp-c-sponsor-hover: #e51370;

--- a/docs/.vitepress/style/vars.css
+++ b/docs/.vitepress/style/vars.css
@@ -7,7 +7,7 @@
   --vp-c-brand-2: #57791b;
   --vp-c-brand-3: #506e10;
   --vp-c-sponsor: #ca2971;
-  --vp-c-sponsor-hover: #c13071;
+  --vitest-c-sponsor-hover: #c13071;
 }
 
 .dark {
@@ -15,7 +15,7 @@
   --vp-c-brand-2: #a7cc66;
   --vp-c-brand-3: #acd268;
   --vp-c-sponsor: #ee4e95;
-  --vp-c-sponsor-hover: #e51370;
+  --vitest-c-sponsor-hover: #e51370;
 }
 
 
@@ -25,6 +25,8 @@
 :root {
   --vp-custom-block-tip-code-bg: var(--vp-c-brand-soft);
   --vp-custom-block-danger-code-bg: #a79fa029;
+  --vitest-custom-block-tip-code-text: #4a680c;
+  --vitest-custom-block-info-code-text: #394f0c
 }
 
 .dark {

--- a/docs/.vitepress/style/vars.css
+++ b/docs/.vitepress/style/vars.css
@@ -3,47 +3,42 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-  --vp-c-accent: #dab40b;
-  --vp-c-brand: #6da13f;
-  --vp-c-brand-1: var(--vp-c-brand-dark);
-  --vp-c-brand-2: var(--vp-c-brand-darker);
-  --vp-c-brand-light: #7ec242;
-  --vp-c-brand-lighter: #93d31c;
-  --vp-c-brand-dark: #668d11;
-  --vp-c-brand-darker: #52730d;
-  --vp-c-text-code: #5d6f5d;
-  --vp-code-block-bg: rgba(125,125,125,0.04);
-  --vp-c-text-light-2: rgba(56 56 56 / 70%);
-  /* fix contrast: lang name on gray code block */
-  --vp-c-text-dark-3: rgba(180, 180, 180, 0.7);
-  --vp-code-copy-code-bg: rgba(125,125,125,0.1);
-  --vp-code-copy-code-hover-bg: rgba(125,125,125,0.2);
-  --vp-c-disabled-bg: rgba(125,125,125,0.2);
+  --vp-c-brand-1: #52730d;
+  --vp-c-brand-2: #517012;
+  --vp-c-brand-3: #506e10;
+  --vp-c-sponsor: #ca2971;
+  --vp-c-sponsor-hover: #c13071;
 }
 
 .dark {
-  --vp-code-block-bg: rgba(0,0,0,0.2);
-  --vp-c-text-code: #c0cec0;
-  /* fix contrast on gray cards: check the same above (this is the default) */
-  --vp-c-text-dark-2: rgba(235, 235, 235, 0.60);
-  /* fix lang name: check the same above (this is the default) */
-  --vp-c-text-dark-3: rgba(235, 235, 235, 0.38);
+  --vp-c-brand-1: #add467;
+  --vp-c-brand-2: #a7cc66;
+  --vp-c-brand-3: #acd268;
+  --vp-c-sponsor: #ee4e95;
+  --vp-c-sponsor-hover: #e51370;
+}
+
+
+/**
+ * Component: Custom Block
+ * -------------------------------------------------------------------------- */
+:root {
+  --vp-custom-block-tip-code-bg: var(--vp-c-brand-soft);
+  --vp-custom-block-danger-code-bg: #a79fa029;
+}
+
+.dark {
+  --vp-custom-block-tip-code-bg: var(--vp-c-brand-soft);
+  --vp-custom-block-danger-code-bg: #6c6a6a2b;
 }
 
 /**
  * Component: Button
  * -------------------------------------------------------------------------- */
-
-:root {
-  --vp-button-brand-border: var(--vp-c-brand-light);
-  --vp-button-brand-text: var(--vp-c-text-dark-1);
-  --vp-button-brand-bg: var(--vp-c-brand);
-  --vp-button-brand-hover-border: var(--vp-c-brand-light);
-  --vp-button-brand-hover-text: var(--vp-c-text-dark-1);
-  --vp-button-brand-hover-bg: var(--vp-c-brand-light);
-  --vp-button-brand-active-border: var(--vp-c-brand-light);
-  --vp-button-brand-active-text: var(--vp-c-text-dark-1);
-  --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+.dark {
+  --vp-button-brand-text: #243600;
+  --vp-button-brand-active-text: #243600;
+  --vp-button-brand-hover-text: #243600;
 }
 
 /**

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,15 @@ hero:
 
 features:
   - title: Vite Powered
+    icon: <span class="i-logos:vitejs"></span>
     details: Reuse Vite's config and plugins - consistent across your app and tests. But it's not required to use Vitest!
   - title: Jest Compatible
+    icon: <span class="i-logos:jest"></span>
     details: Expect, snapshot, coverage, and more - migrating from Jest is straightforward.
   - title: Smart & instant watch mode
+    icon: ⚡
     details: Only rerun the related changes, just like HMR for tests!
   - title: ESM, TypeScript, JSX
+    icon: <span class="i-logos:typescript-icon"></span>
     details: Out-of-box ESM, TypeScript and JSX support powered by esbuild.
 ---

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@iconify-json/carbon": "^1.1.21",
+    "@iconify-json/logos": "^1.1.37",
     "@unocss/reset": "^0.53.4",
     "@vite-pwa/assets-generator": "^0.0.10",
     "@vite-pwa/vitepress": "^0.2.3",

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,11 +13,6 @@
   to = "https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/basic?initialPath=__vitest__/"
   status = 302
 
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-
 [[headers]]
   for = "/manifest.webmanifest"
   [headers.values]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@iconify-json/carbon':
         specifier: ^1.1.21
         version: 1.1.21
+      '@iconify-json/logos':
+        specifier: ^1.1.37
+        version: 1.1.37
       '@unocss/reset':
         specifier: ^0.53.4
         version: 0.53.4


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

This PR includes:
- fix VP styles, css vars changed in rc10 version: missing review of #4400
- adds icons to the home features
- changes markdown theme from `vitesse-dark` and `vitesse-light` to `github-dark` and `github-light`  respectively: fix wcag aa color contrast
- includes experimental allowlist PWA feature to avoid breaking VP layout when requesting missing page: check https://github.com/vite-pwa/vitepress/issues/22
- removes SPA from Netlify
- includes VP `hashmap.json` file, required for hydration
- increases the max size asset allowed to be precached, Anthony's svg sponsor file now 2.5MB...

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
