### PR TITLE
fix: support accessing task from test context without accessing fixtures

### DIFF
--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -74,6 +74,10 @@ export function withFixtures(fn: Function, testContext?: TestContext) {
 
     const usedFixtures = fixtures.filter(({ prop }) => usedProps.includes(prop))
     const pendingFixtures = resolveDeps(usedFixtures)
+
+    if (!pendingFixtures.length)
+      return fn(context)
+
     let cursor = 0
 
     return new Promise((resolve, reject) => {

--- a/test/core/test/fixture-initialization.test.ts
+++ b/test/core/test/fixture-initialization.test.ts
@@ -1,5 +1,5 @@
 import type { Use } from '@vitest/runner'
-import { describe, expect, expectTypeOf, test, vi } from 'vitest'
+import { beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest'
 
 interface Fixtures {
   a: number
@@ -177,6 +177,18 @@ describe('fixture initialization', () => {
       archive.push(todos.pop() as number)
       expect(todos.length).toBe(2)
       expect(archive.length).toBe(1)
+    })
+  })
+
+  describe('accessing non-fixture context', () => {
+    const myTest = test.extend({ a: 1 })
+
+    beforeEach(async ({ task }) => {
+      expect(task).toBeTruthy()
+    })
+
+    myTest('non-fixture context can be accessed without accessing fixtures', ({ task }) => {
+      expect(task).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes https://github.com/vitest-dev/vitest/issues/4418

<!-- You can also add additional context here -->
Currently, when extending a test function with fixtures, if the fixtures are unused within a given test or hook, when accessing non-fixture context (e.g. `task`) the test fails with an error:
`TypeError: Cannot destructure property 'isFn' of 'fixture' as it is undefined.`

Example:
```
const myTest = test.extend({ a: 1 })

myTest('accessing non-fixture context', ({ task }) => {
  expect(task).toBeTruthy()
})
```

This PR addresses the above error by making `withFixtures` return early if the `pendingFixtures` array is empty after having been filtered.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
