### PR TITLE
feat: implement provide/inject API to transfer data from the main thread

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -972,7 +972,7 @@ import { inject } from 'vitest'
 inject('wsPort') === 3000
 ```
 
-If you are using TypeScript with `provide/inject` methods, you can extend `ProvidedContext` type to have type safe access:
+If you are using TypeScript, you can extend `ProvidedContext` type to have type safe access to `provide/inject` methods:
 
 ```ts
 declare module 'vitest' {

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -957,7 +957,30 @@ Multiple globalSetup files are possible. setup and teardown are executed sequent
 :::
 
 ::: warning
-Beware that the global setup is running in a different global scope, so your tests don't have access to variables defined here. Also, since Vitest 1.0.0-beta, global setup runs only if there is at least one running test. This means that global setup might start running during watch mode after test file is changed, for example (the test file will wait for global setup to finish before running).
+Since Vitest 1.0.0-beta, global setup runs only if there is at least one running test. This means that global setup might start running during watch mode after test file is changed (the test file will wait for global setup to finish before running).
+
+Beware that the global setup is running in a different global scope, so your tests don't have access to variables defined here. Hovewer, since 1.0.0 you can pass down serializable data to tests via `provide` method:
+
+```ts
+// globalSetup.js
+export default function setup({ provide }) {
+  provide('wsPort', 3000)
+}
+// example.test.js
+import { inject } from 'vitest'
+
+inject('wsPort') === 3000
+```
+
+If you are using TypeScript with `provide/inject` methods, you can extend `ProvidedContext` type to have type safe access:
+
+```ts
+declare module 'vitest' {
+  export interface ProvidedContext {
+    wsPort: number
+  }
+}
+```
 :::
 
 

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -120,6 +120,7 @@ ws.addEventListener('open', async () => {
       environment: 0,
       prepare: 0,
     },
+    providedContext: await client.rpc.getProvidedContext(),
   }
   // @ts-expect-error mocking vitest apis
   globalThis.__vitest_mocker__ = new VitestBrowserClientMocker()

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -133,7 +133,7 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, server?: Vit
         },
         // browser should have a separate RPC in the future, UI doesn't care for provided context
         getProvidedContext() {
-          return 'ctx' in vitestOrWorkspace ? vitestOrWorkspace.getProvidedContext() : {}
+          return 'ctx' in vitestOrWorkspace ? vitestOrWorkspace.getProvidedContext() : ({} as any)
         },
       },
       {

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -131,6 +131,10 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, server?: Vit
         getCountOfFailedTests() {
           return ctx.state.getCountOfFailedTests()
         },
+        // browser should have a separate RPC in the future, UI doesn't care for provided context
+        getProvidedContext() {
+          return 'ctx' in vitestOrWorkspace ? vitestOrWorkspace.getProvidedContext() : {}
+        },
       },
       {
         post: msg => ws.send(msg),

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -1,6 +1,6 @@
 import type { TransformResult } from 'vite'
 import type { CancelReason } from '@vitest/runner'
-import type { AfterSuiteRunMeta, File, ModuleGraphData, Reporter, ResolvedConfig, SnapshotResult, TaskResultPack, UserConsoleLog } from '../types'
+import type { AfterSuiteRunMeta, File, ModuleGraphData, ProvidedContext, Reporter, ResolvedConfig, SnapshotResult, TaskResultPack, UserConsoleLog } from '../types'
 
 export interface TransformResultWithSource extends TransformResult {
   source?: string
@@ -30,6 +30,7 @@ export interface WebSocketHandlers {
   snapshotSaved(snapshot: SnapshotResult): void
   rerun(files: string[]): Promise<void>
   updateSnapshot(file?: File): Promise<void>
+  getProvidedContext(): ProvidedContext
 }
 
 export interface WebSocketEvents extends Pick<Reporter, 'onCollected' | 'onFinished' | 'onTaskUpdate' | 'onUserConsoleLog' | 'onPathsCollected'> {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -15,6 +15,7 @@ export { runOnce, isFirstRun } from './integrations/run-once'
 export * from './integrations/chai'
 export * from './integrations/vi'
 export * from './integrations/utils'
+export { inject } from './integrations/inject'
 export type { SnapshotEnvironment } from '@vitest/snapshot/environment'
 
 export * from './types'

--- a/packages/vitest/src/integrations/inject.ts
+++ b/packages/vitest/src/integrations/inject.ts
@@ -1,0 +1,11 @@
+import type { ProvidedContext } from '../types/general'
+import { getWorkerState } from '../utils/global'
+
+/**
+ * Gives access to injected context provided from the main thread.
+ * This usually returns a value provided by `globalSetup` or an external library.
+ */
+export function inject<T extends keyof ProvidedContext>(key: T): ProvidedContext[T] {
+  const workerState = getWorkerState()
+  return workerState.providedContext[key]
+}

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -2,7 +2,7 @@ import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
 import { assertTypes, createSimpleStackTrace } from '@vitest/utils'
 import { parseSingleStack } from '../utils/source-map'
 import type { VitestMocker } from '../runtime/mocker'
-import type { ResolvedConfig, RuntimeConfig } from '../types'
+import type { ProvidedContext, ResolvedConfig, RuntimeConfig } from '../types'
 import type { MockFactoryWithHelper } from '../types/mocker'
 import { getWorkerState } from '../utils/global'
 import { resetModules, waitForImportsToResolve } from '../utils/modules'
@@ -333,6 +333,12 @@ export interface VitestUtils {
    * If config was changed with `vi.setConfig`, this will reset it to the original state.
    */
   resetConfig(): void
+
+  /**
+   * Access to injected context provided from the main thread.
+   * This usually returns a value provided by `globalSetup` or an external library.
+   */
+  inject<T extends keyof ProvidedContext>(key: T): ProvidedContext[T]
 }
 
 function createVitest(): VitestUtils {
@@ -608,6 +614,10 @@ function createVitest(): VitestUtils {
         const state = getWorkerState()
         Object.assign(state.config, _config)
       }
+    },
+
+    inject<T extends keyof ProvidedContext>(key: T): ProvidedContext[T] {
+      return workerState.providedContext[key]
     },
   }
 

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -301,6 +301,12 @@ export function resolveConfig(
         ?? resolve(resolved.root, file),
     ),
   )
+  resolved.globalSetup = toArray(resolved.globalSetup || []).map(file =>
+    normalize(
+      resolveModule(file, { paths: [resolved.root] })
+        ?? resolve(resolved.root, file),
+    ),
+  )
   resolved.coverage.exclude.push(...resolved.setupFiles.map(file => `${resolved.coverage.allowExternal ? '**/' : ''}${relative(resolved.root, file)}`))
 
   resolved.forceRerunTriggers = [

--- a/packages/vitest/src/node/globalSetup.ts
+++ b/packages/vitest/src/node/globalSetup.ts
@@ -10,7 +10,7 @@ export interface GlobalSetupContext {
 
 export interface GlobalSetupFile {
   file: string
-  setup?: (utilities: GlobalSetupContext) => Promise<Function | void> | void
+  setup?: (context: GlobalSetupContext) => Promise<Function | void> | void
   teardown?: Function
 }
 

--- a/packages/vitest/src/node/globalSetup.ts
+++ b/packages/vitest/src/node/globalSetup.ts
@@ -3,14 +3,14 @@ import type { ViteNodeRunner } from 'vite-node/client'
 import type { ProvidedContext } from '../types/general'
 import type { ResolvedConfig } from '../types/config'
 
-interface GlobalSetupUtilities {
+export interface GlobalSetupContext {
   config: ResolvedConfig
   provide<T extends keyof ProvidedContext>(key: T, value: ProvidedContext[T]): void
 }
 
 export interface GlobalSetupFile {
   file: string
-  setup?: (utilities: GlobalSetupUtilities) => Promise<Function | void> | void
+  setup?: (utilities: GlobalSetupContext) => Promise<Function | void> | void
   teardown?: Function
 }
 

--- a/packages/vitest/src/node/globalSetup.ts
+++ b/packages/vitest/src/node/globalSetup.ts
@@ -1,9 +1,16 @@
 import { toArray } from '@vitest/utils'
 import type { ViteNodeRunner } from 'vite-node/client'
+import type { ProvidedContext } from '../types/general'
+import type { ResolvedConfig } from '../types/config'
+
+interface GlobalSetupUtilities {
+  config: ResolvedConfig
+  provide<T extends keyof ProvidedContext>(key: T, value: ProvidedContext[T]): void
+}
 
 export interface GlobalSetupFile {
   file: string
-  setup?: () => Promise<Function | void> | void
+  setup?: (utilities: GlobalSetupUtilities) => Promise<Function | void> | void
   teardown?: Function
 }
 

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -5,6 +5,7 @@ export { VitestPlugin } from './plugins'
 export { startVitest } from './cli-api'
 export { registerConsoleShortcuts } from './stdin'
 export type { WorkspaceSpec } from './pool'
+export type { GlobalSetupContext } from './globalSetup'
 
 export type { TestSequencer, TestSequencerConstructor } from './sequencers/types'
 export { BaseSequencer } from './sequencers/BaseSequencer'

--- a/packages/vitest/src/node/pools/child.ts
+++ b/packages/vitest/src/node/pools/child.ts
@@ -104,6 +104,7 @@ export function createChildProcessPool(ctx: Vitest, { execArgv, env, forksPath }
         environment,
         workerId,
         projectName: project.getName(),
+        providedContext: project.getProvidedContext(),
       }
       try {
         await pool.run(data, { name, channel })

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -92,6 +92,7 @@ export function createThreadsPool(ctx: Vitest, { execArgv, env, workerPath }: Po
         environment,
         workerId,
         projectName: project.getName(),
+        providedContext: project.getProvidedContext(),
       }
       try {
         await pool.run(data, { transferList: [workerPort], name })

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -97,6 +97,7 @@ export function createVmThreadsPool(ctx: Vitest, { execArgv, env, vmPath }: Pool
         environment,
         workerId,
         projectName: project.getName(),
+        providedContext: project.getProvidedContext(),
       }
       try {
         await pool.run(data, { transferList: [workerPort], name })

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -348,6 +348,7 @@ export class WorkspaceProject {
         this.typechecker?.stop(),
         this.browser?.close(),
         this.teardownGlobalSetup(),
+        () => this._provided = {},
       ].filter(Boolean))
     }
     return this.closingPromise

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -90,7 +90,7 @@ export class WorkspaceProject {
       structuredClone(value)
     }
     catch (err) {
-      throw new Error(`Cannot provide value because it's not serializable.`, {
+      throw new Error(`Cannot provide "${key}" because it's not serializable.`, {
         cause: err,
       })
     }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -70,7 +70,7 @@ export class WorkspaceProject {
   testFilesList: string[] = []
 
   private _globalSetups: GlobalSetupFile[] | undefined
-  private _provided: ProvidedContext = {}
+  private _provided: ProvidedContext = {} as any
 
   constructor(
     public path: string | number,

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -359,7 +359,7 @@ export class WorkspaceProject {
         this.server.close(),
         this.typechecker?.stop(),
         this.browser?.close(),
-        () => this._provided = {},
+        () => this._provided = ({} as any),
       ].filter(Boolean))
     }
     return this.closingPromise

--- a/packages/vitest/src/runtime/child.ts
+++ b/packages/vitest/src/runtime/child.ts
@@ -14,7 +14,7 @@ import { createSafeRpc, rpcDone } from './rpc'
 import { setupInspect } from './inspector'
 
 async function init(ctx: ChildContext) {
-  const { config, workerId } = ctx
+  const { config, workerId, providedContext } = ctx
 
   process.env.VITEST_WORKER_ID = String(workerId)
   process.env.VITEST_POOL_ID = String(poolId)
@@ -72,6 +72,7 @@ async function init(ctx: ChildContext) {
       prepare: performance.now(),
     },
     rpc,
+    providedContext,
     isChildProcess: true,
   }
 

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -8,7 +8,6 @@ import { processError } from '@vitest/utils/error'
 import type { MockMap } from '../types/mocker'
 import type { ResolvedConfig, ResolvedTestEnvironment, RuntimeRPC, WorkerGlobalState } from '../types'
 import { distDir } from '../paths'
-import { getWorkerState } from '../utils/global'
 import { VitestMocker } from './mocker'
 import { ExternalModulesExecutor } from './external-executor'
 import { FileMap } from './vm/file-map'
@@ -64,7 +63,8 @@ export interface ContextExecutorOptions {
 }
 
 export async function startVitestExecutor(options: ContextExecutorOptions) {
-  const state = () => getWorkerState() || options.state
+  // @ts-expect-error injected untyped global
+  const state = () => globalThis.__vitest_worker__ || options.state
   const rpc = () => state().rpc
 
   const processExit = process.exit
@@ -203,7 +203,8 @@ export class VitestExecutor extends ViteNodeRunner {
   }
 
   get state() {
-    return getWorkerState() || this.options.state
+    // @ts-expect-error injected untyped global
+    return globalThis.__vitest_worker__ || this.options.state
   }
 
   shouldResolveId(id: string, _importee?: string | undefined): boolean {

--- a/packages/vitest/src/runtime/vm.ts
+++ b/packages/vitest/src/runtime/vm.ts
@@ -19,7 +19,7 @@ const entryFile = pathToFileURL(resolve(distDir, 'entry-vm.js')).href
 export async function run(ctx: WorkerContext) {
   const moduleCache = new ModuleCacheMap()
   const mockMap = new Map()
-  const { config, port } = ctx
+  const { config, port, providedContext } = ctx
 
   let setCancel = (_reason: CancelReason) => {}
   const onCancel = new Promise<CancelReason>((resolve) => {
@@ -64,6 +64,7 @@ export async function run(ctx: WorkerContext) {
       prepare: performance.now(),
     },
     rpc,
+    providedContext,
   }
 
   installSourcemapsSupport({

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -17,7 +17,7 @@ async function init(ctx: WorkerContext) {
   if (isInitialized && isIsolatedThreads)
     throw new Error(`worker for ${ctx.files.join(',')} already initialized by ${getWorkerState().ctx.files.join(',')}. This is probably an internal bug of Vitest.`)
 
-  const { config, port, workerId } = ctx
+  const { config, port, workerId, providedContext } = ctx
 
   process.env.VITEST_WORKER_ID = String(workerId)
   process.env.VITEST_POOL_ID = String(poolId)
@@ -58,6 +58,7 @@ async function init(ctx: WorkerContext) {
       prepare: performance.now(),
     },
     rpc,
+    providedContext,
   }
 
   Object.defineProperty(globalThis, '__vitest_worker__', {

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -48,3 +48,5 @@ export interface ModuleGraphData {
 }
 
 export type OnServerRestartHandler = (reason?: string) => Promise<void> | void
+
+export interface ProvidedContext {}

--- a/packages/vitest/src/types/rpc.ts
+++ b/packages/vitest/src/types/rpc.ts
@@ -51,4 +51,5 @@ export interface ContextRPC {
   files: string[]
   invalidates?: string[]
   environment: ContextTestEnvironment
+  providedContext: Record<string, any>
 }

--- a/packages/vitest/src/types/worker.ts
+++ b/packages/vitest/src/types/worker.ts
@@ -33,6 +33,7 @@ export interface WorkerGlobalState {
   onCancel: Promise<CancelReason>
   moduleCache: ModuleCacheMap
   mockMap: MockMap
+  providedContext: Record<string, any>
   durations: {
     environment: number
     prepare: number

--- a/packages/vitest/src/utils/global.ts
+++ b/packages/vitest/src/utils/global.ts
@@ -2,7 +2,16 @@ import type { WorkerGlobalState } from '../types'
 
 export function getWorkerState(): WorkerGlobalState {
   // @ts-expect-error untyped global
-  return globalThis.__vitest_worker__
+  const workerState = globalThis.__vitest_worker__
+  if (!workerState) {
+    const errorMsg = 'Vitest failed to access its internal state.'
+      + '\n\nOne of the following is possible:'
+      + '\n- "vitest" is imported directly without running "vitest" command'
+      + '\n- "vitest" is imported inside "globalSetup" (to fix this, use "setupFiles" instead, because "globalSetup" runs in a different context)'
+      + '\n- Otherwise, it might be a Vitest bug. Please report it to https://github.com/vitest-dev/vitest/issues\n'
+    throw new Error(errorMsg)
+  }
+  return workerState
 }
 
 export function getCurrentEnvironment(): string {

--- a/test/workspaces/globalTest.ts
+++ b/test/workspaces/globalTest.ts
@@ -1,14 +1,37 @@
 import { readFile } from 'node:fs/promises'
 import assert from 'node:assert/strict'
+import type { GlobalSetupContext } from 'vitest/node'
+
+declare module 'vitest' {
+  interface ProvidedContext {
+    globalSetup: boolean
+    globalSetupOverriden: boolean
+    invalidValue: unknown
+  }
+}
+
+export function setup({ provide }: GlobalSetupContext) {
+  provide('globalSetup', true)
+  provide('globalSetupOverriden', false)
+  try {
+    provide('invalidValue', () => {})
+    throw new Error('Should throw')
+  }
+  catch (err: any) {
+    assert.equal(err.message, 'Cannot provide "invalidValue" because it\'s not serializable.')
+    assert.match(err.cause.message, /could not be cloned/)
+    assert.equal(err.cause.name, 'DataCloneError')
+  }
+}
 
 export async function teardown() {
   const results = JSON.parse(await readFile('./results.json', 'utf-8'))
 
   try {
     assert.ok(results.success)
-    assert.equal(results.numTotalTestSuites, 9)
-    assert.equal(results.numTotalTests, 10)
-    assert.equal(results.numPassedTests, 10)
+    assert.equal(results.numTotalTestSuites, 11)
+    assert.equal(results.numTotalTests, 12)
+    assert.equal(results.numPassedTests, 12)
 
     const shared = results.testResults.filter((r: any) => r.name.includes('space_shared/test.spec.ts'))
 

--- a/test/workspaces/space_3/global-provide.space-3-test.ts
+++ b/test/workspaces/space_3/global-provide.space-3-test.ts
@@ -1,7 +1,7 @@
-import { expect, test, vi } from 'vitest'
+import { expect, inject, test } from 'vitest'
 
 test('global setup provides data correctly', () => {
-  expect(vi.inject('globalSetup')).toBe(true)
-  expect(vi.inject('globalSetupOverriden')).toBe(true)
-  expect(vi.inject('invalidValue')).toBe(undefined)
+  expect(inject('globalSetup')).toBe(true)
+  expect(inject('globalSetupOverriden')).toBe(true)
+  expect(inject('invalidValue')).toBe(undefined)
 })

--- a/test/workspaces/space_3/global-provide.space-3-test.ts
+++ b/test/workspaces/space_3/global-provide.space-3-test.ts
@@ -1,0 +1,7 @@
+import { expect, test, vi } from 'vitest'
+
+test('global setup provides data correctly', () => {
+  expect(vi.inject('globalSetup')).toBe(true)
+  expect(vi.inject('globalSetupOverriden')).toBe(true)
+  expect(vi.inject('invalidValue')).toBe(undefined)
+})

--- a/test/workspaces/space_3/localSetup.ts
+++ b/test/workspaces/space_3/localSetup.ts
@@ -1,0 +1,5 @@
+import type { GlobalSetupContext } from 'vitest/node'
+
+export function setup({ provide }: GlobalSetupContext) {
+  provide('globalSetupOverriden', true)
+}

--- a/test/workspaces/space_3/vitest.config.ts
+++ b/test/workspaces/space_3/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineProject({
     include: ['**/*.space-3-test.ts'],
     name: 'space_3',
     environment: 'node',
+    globalSetup: './localSetup.ts',
   },
 })


### PR DESCRIPTION
### Description

Closes #4025

This PR adds `project.provide` API that allows transfering data from the main thread like global setup to tests. This API cannot be used to transfer data back to the main thread - users need to implement that themselves. If they want to keep communication inside Vitest, it's recommended to use [`task.meta`](https://vitest.dev/advanced/metadata.html) to transfer data back to the main thread alongside tests.

To get the data, you need to write `import('vitest').inject(key)` inside the test:

```ts
// globalSetup.ts
declare module 'vitest' {
  export interface ProvidedContext {
    dbUrl: string
  }
}

export default async ({ provide }) => {
  const db = new DB()
  const url = db.getUrl()
  provide('dbUrl', url) // has typechecking
}

// db.test.ts
import { inject } from 'vitest'
const dbUrl = inject('dbUrl') // typed as a string
const connection = new Connection(dbUrl)
```

`provide` is scoped to the project since global setup is also scoped the same way. `provide` API uses strings as keys because symbols are not transferable between threads/websocket/forks. It is possible to override values by using the same key (internally it's just an object with string keys)

You can only transfer serializable data! The rules for serialization are the same used for `task.meta`: https://vitest.dev/advanced/metadata.html

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
