### PR TITLE
docs: remove extra spaces before paragraphs in documentation

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -6,22 +6,22 @@ The following types are used in the type signatures below
 type Awaitable<T> = T | PromiseLike<T>
 ```
 
-  `expect` is used to create assertions. In this context `assertions` are functions that can be called to assert a statement. Vitest provides `chai` assertions by default and also `Jest` compatible assertions build on top of `chai`.
+`expect` is used to create assertions. In this context `assertions` are functions that can be called to assert a statement. Vitest provides `chai` assertions by default and also `Jest` compatible assertions build on top of `chai`.
 
-  For example, this code asserts that an `input` value is equal to `2`. If it's not, the assertion will throw an error, and the test will fail.
+For example, this code asserts that an `input` value is equal to `2`. If it's not, the assertion will throw an error, and the test will fail.
 
-  ```ts
-  import { expect } from 'vitest'
+```ts
+import { expect } from 'vitest'
 
-  const input = Math.sqrt(4)
+const input = Math.sqrt(4)
 
-  expect(input).to.equal(2) // chai API
-  expect(input).toBe(2) // jest API
-  ```
+expect(input).to.equal(2) // chai API
+expect(input).toBe(2) // jest API
+```
 
-  Technically this example doesn't use [`test`](/api/#test) function, so in the console you will see Nodejs error instead of Vitest output. To learn more about `test`, please read [Test API Reference](/api/).
+Technically this example doesn't use [`test`](/api/#test) function, so in the console you will see Nodejs error instead of Vitest output. To learn more about `test`, please read [Test API Reference](/api/).
 
-  Also, `expect` can be used statically to access matchers functions, described later, and more.
+Also, `expect` can be used statically to access matchers functions, described later, and more.
 
 ::: warning
 `expect` has no effect on testing types, if the expression doesn't have a type error. If you want to use Vitest as [type checker](/guide/testing-types), use [`expectTypeOf`](/api/expect-typeof) or [`assertType`](/api/assert-type).
@@ -33,27 +33,27 @@ type Awaitable<T> = T | PromiseLike<T>
 
 `expect.soft` functions similarly to `expect`, but instead of terminating the test execution upon a failed assertion, it continues running and marks the failure as a test failure. All errors encountered during the test will be displayed until the test is completed.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('expect.soft test', () => {
-    expect.soft(1 + 1).toBe(3) // mark the test as fail and continue
-    expect.soft(1 + 2).toBe(4) // mark the test as fail and continue
-  })
-  // At the end of the test, the above errors will be output.
-  ```
+test('expect.soft test', () => {
+  expect.soft(1 + 1).toBe(3) // mark the test as fail and continue
+  expect.soft(1 + 2).toBe(4) // mark the test as fail and continue
+})
+// At the end of the test, the above errors will be output.
+```
 
-  It can also be used with `expect`. if `expect` assertion fails, the test will be terminated and all errors will be displayed.
+It can also be used with `expect`. if `expect` assertion fails, the test will be terminated and all errors will be displayed.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('expect.soft test', () => {
-    expect.soft(1 + 1).toBe(3) // mark the test as fail and continue
-    expect(1 + 2).toBe(3) // failed and terminate the test, all previous errors will be output
-    expect.soft(1 + 2).toBe(4) // do not run
-  })
-  ```
+test('expect.soft test', () => {
+  expect.soft(1 + 1).toBe(3) // mark the test as fail and continue
+  expect(1 + 2).toBe(3) // failed and terminate the test, all previous errors will be output
+  expect.soft(1 + 2).toBe(4) // do not run
+})
+```
 
 ::: warning
 `expect.soft` can only be used inside the [`test`](/api/#test) function.
@@ -61,482 +61,482 @@ type Awaitable<T> = T | PromiseLike<T>
 
 ## not
 
-  Using `not` will negate the assertion. For example, this code asserts that an `input` value is not equal to `2`. If it's equal, the assertion will throw an error, and the test will fail.
+Using `not` will negate the assertion. For example, this code asserts that an `input` value is not equal to `2`. If it's equal, the assertion will throw an error, and the test will fail.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const input = Math.sqrt(16)
+const input = Math.sqrt(16)
 
-  expect(input).not.to.equal(2) // chai API
-  expect(input).not.toBe(2) // jest API
-  ```
+expect(input).not.to.equal(2) // chai API
+expect(input).not.toBe(2) // jest API
+```
 
 ## toBe
 
 - **Type:** `(value: any) => Awaitable<void>`
 
-  `toBe` can be used to assert if primitives are equal or that objects share the same reference. It is equivalent of calling `expect(Object.is(3, 3)).toBe(true)`. If the objects are not the same, but you want to check if their structures are identical, you can use [`toEqual`](#toequal).
+`toBe` can be used to assert if primitives are equal or that objects share the same reference. It is equivalent of calling `expect(Object.is(3, 3)).toBe(true)`. If the objects are not the same, but you want to check if their structures are identical, you can use [`toEqual`](#toequal).
 
-  For example, the code below checks if the trader has 13 apples.
+For example, the code below checks if the trader has 13 apples.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const stock = {
-    type: 'apples',
-    count: 13,
-  }
+const stock = {
+  type: 'apples',
+  count: 13,
+}
 
-  test('stock has 13 apples', () => {
-    expect(stock.type).toBe('apples')
-    expect(stock.count).toBe(13)
-  })
+test('stock has 13 apples', () => {
+  expect(stock.type).toBe('apples')
+  expect(stock.count).toBe(13)
+})
 
-  test('stocks are the same', () => {
-    const refStock = stock // same reference
+test('stocks are the same', () => {
+  const refStock = stock // same reference
 
-    expect(stock).toBe(refStock)
-  })
-  ```
+  expect(stock).toBe(refStock)
+})
+```
 
-  Try not to use `toBe` with floating-point numbers. Since JavaScript rounds them, `0.1 + 0.2` is not strictly `0.3`. To reliably assert floating-point numbers, use [`toBeCloseTo`](#tobecloseto) assertion.
+Try not to use `toBe` with floating-point numbers. Since JavaScript rounds them, `0.1 + 0.2` is not strictly `0.3`. To reliably assert floating-point numbers, use [`toBeCloseTo`](#tobecloseto) assertion.
 
 ## toBeCloseTo
 
 - **Type:** `(value: number, numDigits?: number) => Awaitable<void>`
 
-  Use `toBeCloseTo` to compare floating-point numbers. The optional `numDigits` argument limits the number of digits to check _after_ the decimal point. For example:
+Use `toBeCloseTo` to compare floating-point numbers. The optional `numDigits` argument limits the number of digits to check _after_ the decimal point. For example:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test.fails('decimals are not equal in javascript', () => {
-    expect(0.2 + 0.1).toBe(0.3) // 0.2 + 0.1 is 0.30000000000000004
-  })
+test.fails('decimals are not equal in javascript', () => {
+  expect(0.2 + 0.1).toBe(0.3) // 0.2 + 0.1 is 0.30000000000000004
+})
 
-  test('decimals are rounded to 5 after the point', () => {
-    // 0.2 + 0.1 is 0.30000 | "000000000004" removed
-    expect(0.2 + 0.1).toBeCloseTo(0.3, 5)
-    // nothing from 0.30000000000000004 is removed
-    expect(0.2 + 0.1).not.toBeCloseTo(0.3, 50)
-  })
-  ```
+test('decimals are rounded to 5 after the point', () => {
+  // 0.2 + 0.1 is 0.30000 | "000000000004" removed
+  expect(0.2 + 0.1).toBeCloseTo(0.3, 5)
+  // nothing from 0.30000000000000004 is removed
+  expect(0.2 + 0.1).not.toBeCloseTo(0.3, 50)
+})
+```
 
 ## toBeDefined
 
 - **Type:** `() => Awaitable<void>`
 
-  `toBeDefined` asserts that the value is not equal to `undefined`. Useful use case would be to check if function _returned_ anything.
+`toBeDefined` asserts that the value is not equal to `undefined`. Useful use case would be to check if function _returned_ anything.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  function getApples() {
-    return 3
-  }
+function getApples() {
+  return 3
+}
 
-  test('function returned something', () => {
-    expect(getApples()).toBeDefined()
-  })
-  ```
+test('function returned something', () => {
+  expect(getApples()).toBeDefined()
+})
+```
 
 ## toBeUndefined
 
 - **Type:** `() => Awaitable<void>`
 
-  Opposite of `toBeDefined`, `toBeUndefined` asserts that the value _is_ equal to `undefined`. Useful use case would be to check if function hasn't _returned_ anything.
+Opposite of `toBeDefined`, `toBeUndefined` asserts that the value _is_ equal to `undefined`. Useful use case would be to check if function hasn't _returned_ anything.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  function getApplesFromStock(stock) {
-    if (stock === 'Bill')
-      return 13
-  }
+function getApplesFromStock(stock) {
+  if (stock === 'Bill')
+    return 13
+}
 
-  test('mary doesn\'t have a stock', () => {
-    expect(getApplesFromStock('Mary')).toBeUndefined()
-  })
-  ```
+test('mary doesn\'t have a stock', () => {
+  expect(getApplesFromStock('Mary')).toBeUndefined()
+})
+```
 
 ## toBeTruthy
 
 - **Type:** `() => Awaitable<void>`
 
-  `toBeTruthy` asserts that the value is true when converted to boolean. Useful if you don't care for the value, but just want to know it can be converted to `true`.
+`toBeTruthy` asserts that the value is true when converted to boolean. Useful if you don't care for the value, but just want to know it can be converted to `true`.
 
-  For example, having this code you don't care for the return value of `stocks.getInfo` - it maybe a complex object, a string, or anything else. The code will still work.
+For example, having this code you don't care for the return value of `stocks.getInfo` - it maybe a complex object, a string, or anything else. The code will still work.
 
-  ```ts
-  import { Stocks } from './stocks.js'
+```ts
+import { Stocks } from './stocks.js'
 
-  const stocks = new Stocks()
+const stocks = new Stocks()
+stocks.sync('Bill')
+if (stocks.getInfo('Bill'))
+  stocks.sell('apples', 'Bill')
+```
+
+So if you want to test that `stocks.getInfo` will be truthy, you could write:
+
+```ts
+import { expect, test } from 'vitest'
+import { Stocks } from './stocks.js'
+
+const stocks = new Stocks()
+
+test('if we know Bill stock, sell apples to him', () => {
   stocks.sync('Bill')
-  if (stocks.getInfo('Bill'))
-    stocks.sell('apples', 'Bill')
-  ```
+  expect(stocks.getInfo('Bill')).toBeTruthy()
+})
+```
 
-  So if you want to test that `stocks.getInfo` will be truthy, you could write:
-
-  ```ts
-  import { expect, test } from 'vitest'
-  import { Stocks } from './stocks.js'
-
-  const stocks = new Stocks()
-
-  test('if we know Bill stock, sell apples to him', () => {
-    stocks.sync('Bill')
-    expect(stocks.getInfo('Bill')).toBeTruthy()
-  })
-  ```
-
-  Everything in JavaScript is truthy, except `false`, `null`, `undefined`, `NaN`, `0`, `-0`, `0n`, `""` and `document.all`.
+Everything in JavaScript is truthy, except `false`, `null`, `undefined`, `NaN`, `0`, `-0`, `0n`, `""` and `document.all`.
 
 ## toBeFalsy
 
 - **Type:** `() => Awaitable<void>`
 
-  `toBeFalsy` asserts that the value is false when converted to boolean. Useful if you don't care for the value, but just want to know if it can be converted to `false`.
+`toBeFalsy` asserts that the value is false when converted to boolean. Useful if you don't care for the value, but just want to know if it can be converted to `false`.
 
-  For example, having this code you don't care for the return value of `stocks.stockFailed` - it may return any falsy value, but the code will still work.
+For example, having this code you don't care for the return value of `stocks.stockFailed` - it may return any falsy value, but the code will still work.
 
-  ```ts
-  import { Stocks } from './stocks.js'
+```ts
+import { Stocks } from './stocks.js'
 
-  const stocks = new Stocks()
-  stocks.sync('Bill')
-  if (!stocks.stockFailed('Bill'))
-    stocks.sell('apples', 'Bill')
-  ```
+const stocks = new Stocks()
+stocks.sync('Bill')
+if (!stocks.stockFailed('Bill'))
+  stocks.sell('apples', 'Bill')
+```
 
-  So if you want to test that `stocks.stockFailed` will be falsy, you could write:
+So if you want to test that `stocks.stockFailed` will be falsy, you could write:
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { Stocks } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { Stocks } from './stocks.js'
 
-  const stocks = new Stocks()
+const stocks = new Stocks()
 
-  test('if Bill stock hasn\'t failed, sell apples to him', () => {
-    stocks.syncStocks('Bill')
-    expect(stocks.stockFailed('Bill')).toBeFalsy()
-  })
-  ```
+test('if Bill stock hasn\'t failed, sell apples to him', () => {
+  stocks.syncStocks('Bill')
+  expect(stocks.stockFailed('Bill')).toBeFalsy()
+})
+```
 
-  Everything in JavaScript is truthy, except `false`, `null`, `undefined`, `NaN`, `0`, `-0`, `0n`, `""` and `document.all`.
+Everything in JavaScript is truthy, except `false`, `null`, `undefined`, `NaN`, `0`, `-0`, `0n`, `""` and `document.all`.
 
 ## toBeNull
 
 - **Type:** `() => Awaitable<void>`
 
-  `toBeNull` simply asserts if something is `null`. Alias for `.toBe(null)`.
+`toBeNull` simply asserts if something is `null`. Alias for `.toBe(null)`.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  function apples() {
-    return null
-  }
+function apples() {
+  return null
+}
 
-  test('we don\'t have apples', () => {
-    expect(apples()).toBeNull()
-  })
-  ```
+test('we don\'t have apples', () => {
+  expect(apples()).toBeNull()
+})
+```
 
 ## toBeNaN
 
 - **Type:** `() => Awaitable<void>`
 
-  `toBeNaN` simply asserts if something is `NaN`. Alias for `.toBe(NaN)`.
+`toBeNaN` simply asserts if something is `NaN`. Alias for `.toBe(NaN)`.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  let i = 0
+let i = 0
 
-  function getApplesCount() {
-    i++
-    return i > 1 ? Number.NaN : i
-  }
+function getApplesCount() {
+  i++
+  return i > 1 ? Number.NaN : i
+}
 
-  test('getApplesCount has some unusual side effects...', () => {
-    expect(getApplesCount()).not.toBeNaN()
-    expect(getApplesCount()).toBeNaN()
-  })
-  ```
+test('getApplesCount has some unusual side effects...', () => {
+  expect(getApplesCount()).not.toBeNaN()
+  expect(getApplesCount()).toBeNaN()
+})
+```
 
 ## toBeTypeOf
 
 - **Type:** `(c: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined') => Awaitable<void>`
 
-  `toBeTypeOf` asserts if an actual value is of type of received type.
+`toBeTypeOf` asserts if an actual value is of type of received type.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const actual = 'stock'
+const actual = 'stock'
 
-  test('stock is type of string', () => {
-    expect(actual).toBeTypeOf('string')
-  })
-  ```
+test('stock is type of string', () => {
+  expect(actual).toBeTypeOf('string')
+})
+```
 
 ## toBeInstanceOf
 
 - **Type:** `(c: any) => Awaitable<void>`
 
-  `toBeInstanceOf` asserts if an actual value is instance of received class.
+`toBeInstanceOf` asserts if an actual value is instance of received class.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { Stocks } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { Stocks } from './stocks.js'
 
-  const stocks = new Stocks()
+const stocks = new Stocks()
 
-  test('stocks are instance of Stocks', () => {
-    expect(stocks).toBeInstanceOf(Stocks)
-  })
-  ```
+test('stocks are instance of Stocks', () => {
+  expect(stocks).toBeInstanceOf(Stocks)
+})
+```
 
 ## toBeGreaterThan
 
 - **Type:** `(n: number | bigint) => Awaitable<void>`
 
-  `toBeGreaterThan` asserts if actual value is greater than received one. Equal values will fail the test.
+`toBeGreaterThan` asserts if actual value is greater than received one. Equal values will fail the test.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { getApples } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { getApples } from './stocks.js'
 
-  test('have more then 10 apples', () => {
-    expect(getApples()).toBeGreaterThan(10)
-  })
-  ```
+test('have more then 10 apples', () => {
+  expect(getApples()).toBeGreaterThan(10)
+})
+```
 
 ## toBeGreaterThanOrEqual
 
 - **Type:** `(n: number | bigint) => Awaitable<void>`
 
-  `toBeGreaterThanOrEqual` asserts if actual value is greater than received one or equal to it.
+`toBeGreaterThanOrEqual` asserts if actual value is greater than received one or equal to it.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { getApples } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { getApples } from './stocks.js'
 
-  test('have 11 apples or more', () => {
-    expect(getApples()).toBeGreaterThanOrEqual(11)
-  })
-  ```
+test('have 11 apples or more', () => {
+  expect(getApples()).toBeGreaterThanOrEqual(11)
+})
+```
 
 ## toBeLessThan
 
 - **Type:** `(n: number | bigint) => Awaitable<void>`
 
-  `toBeLessThan` asserts if actual value is less than received one. Equal values will fail the test.
+`toBeLessThan` asserts if actual value is less than received one. Equal values will fail the test.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { getApples } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { getApples } from './stocks.js'
 
-  test('have less then 20 apples', () => {
-    expect(getApples()).toBeLessThan(20)
-  })
-  ```
+test('have less then 20 apples', () => {
+  expect(getApples()).toBeLessThan(20)
+})
+```
 
 ## toBeLessThanOrEqual
 
 - **Type:** `(n: number | bigint) => Awaitable<void>`
 
-  `toBeLessThanOrEqual` asserts if actual value is less than received one or equal to it.
+`toBeLessThanOrEqual` asserts if actual value is less than received one or equal to it.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { getApples } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { getApples } from './stocks.js'
 
-  test('have 11 apples or less', () => {
-    expect(getApples()).toBeLessThanOrEqual(11)
-  })
-  ```
+test('have 11 apples or less', () => {
+  expect(getApples()).toBeLessThanOrEqual(11)
+})
+```
 
 ## toEqual
 
 - **Type:** `(received: any) => Awaitable<void>`
 
-  `toEqual` asserts if actual value is equal to received one or has the same structure, if it is an object (compares them recursively). You can see the difference between `toEqual` and [`toBe`](#tobe) in this example:
+`toEqual` asserts if actual value is equal to received one or has the same structure, if it is an object (compares them recursively). You can see the difference between `toEqual` and [`toBe`](#tobe) in this example:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const stockBill = {
-    type: 'apples',
-    count: 13,
-  }
+const stockBill = {
+  type: 'apples',
+  count: 13,
+}
 
-  const stockMary = {
-    type: 'apples',
-    count: 13,
-  }
+const stockMary = {
+  type: 'apples',
+  count: 13,
+}
 
-  test('stocks have the same properties', () => {
-    expect(stockBill).toEqual(stockMary)
-  })
+test('stocks have the same properties', () => {
+  expect(stockBill).toEqual(stockMary)
+})
 
-  test('stocks are not the same', () => {
-    expect(stockBill).not.toBe(stockMary)
-  })
-  ```
+test('stocks are not the same', () => {
+  expect(stockBill).not.toBe(stockMary)
+})
+```
 
-  :::warning
-  A _deep equality_ will not be performed for `Error` objects. To test if something was thrown, use [`toThrowError`](#tothrowerror) assertion.
-  :::
+:::warning
+A _deep equality_ will not be performed for `Error` objects. To test if something was thrown, use [`toThrowError`](#tothrowerror) assertion.
+:::
 
 ## toStrictEqual
 
 - **Type:** `(received: any) => Awaitable<void>`
 
-  `toStrictEqual` asserts if the actual value is equal to the received one or has the same structure if it is an object (compares them recursively), and of the same type.
+`toStrictEqual` asserts if the actual value is equal to the received one or has the same structure if it is an object (compares them recursively), and of the same type.
 
-  Differences from [`.toEqual`](#toequal):
+Differences from [`.toEqual`](#toequal):
 
-  -  Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-  -  Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-  -  Object types are checked to be equal. e.g. A class instance with fields `a` and` b` will not equal a literal object with fields `a` and `b`.
+-  Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
+-  Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
+-  Object types are checked to be equal. e.g. A class instance with fields `a` and` b` will not equal a literal object with fields `a` and `b`.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  class Stock {
-    constructor(type) {
-      this.type = type
-    }
+class Stock {
+  constructor(type) {
+    this.type = type
   }
+}
 
-  test('structurally the same, but semantically different', () => {
-    expect(new Stock('apples')).toEqual({ type: 'apples' })
-    expect(new Stock('apples')).not.toStrictEqual({ type: 'apples' })
-  })
-  ```
+test('structurally the same, but semantically different', () => {
+  expect(new Stock('apples')).toEqual({ type: 'apples' })
+  expect(new Stock('apples')).not.toStrictEqual({ type: 'apples' })
+})
+```
 
 ## toContain
 
 - **Type:** `(received: string) => Awaitable<void>`
 
-  `toContain` asserts if the actual value is in an array. `toContain` can also check whether a string is a substring of another string.
+`toContain` asserts if the actual value is in an array. `toContain` can also check whether a string is a substring of another string.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { getAllFruits } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { getAllFruits } from './stocks.js'
 
-  test('the fruit list contains orange', () => {
-    expect(getAllFruits()).toContain('orange')
-  })
-  ```
+test('the fruit list contains orange', () => {
+  expect(getAllFruits()).toContain('orange')
+})
+```
 
 ## toContainEqual
 
 - **Type:** `(received: any) => Awaitable<void>`
 
-  `toContainEqual` asserts if an item with a specific structure and values is contained in an array.
-  It works like [`toEqual`](#toequal) inside for each element.
+`toContainEqual` asserts if an item with a specific structure and values is contained in an array.
+It works like [`toEqual`](#toequal) inside for each element.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { getFruitStock } from './stocks.js'
+```ts
+import { expect, test } from 'vitest'
+import { getFruitStock } from './stocks.js'
 
-  test('apple available', () => {
-    expect(getFruitStock()).toContainEqual({ fruit: 'apple', count: 5 })
-  })
-  ```
+test('apple available', () => {
+  expect(getFruitStock()).toContainEqual({ fruit: 'apple', count: 5 })
+})
+```
 
 ## toHaveLength
 
 - **Type:** `(received: number) => Awaitable<void>`
 
-  `toHaveLength` asserts if an object has a `.length` property and it is set to a certain numeric value.
+`toHaveLength` asserts if an object has a `.length` property and it is set to a certain numeric value.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('toHaveLength', () => {
-    expect('abc').toHaveLength(3)
-    expect([1, 2, 3]).toHaveLength(3)
+test('toHaveLength', () => {
+  expect('abc').toHaveLength(3)
+  expect([1, 2, 3]).toHaveLength(3)
 
-    expect('').not.toHaveLength(3) // doesn't have .length of 3
-    expect({ length: 3 }).toHaveLength(3)
-  })
-  ```
+  expect('').not.toHaveLength(3) // doesn't have .length of 3
+  expect({ length: 3 }).toHaveLength(3)
+})
+```
 
 ## toHaveProperty
 
 - **Type:** `(key: any, received?: any) => Awaitable<void>`
 
-  `toHaveProperty` asserts if a property at provided reference `key` exists for an object.
+`toHaveProperty` asserts if a property at provided reference `key` exists for an object.
 
-  You can provide an optional value argument also known as deep equality, like the `toEqual` matcher to compare the received property value.
+You can provide an optional value argument also known as deep equality, like the `toEqual` matcher to compare the received property value.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const invoice = {
-    'isActive': true,
-    'P.O': '12345',
-    'customer': {
-      first_name: 'John',
-      last_name: 'Doe',
-      location: 'China',
+const invoice = {
+  'isActive': true,
+  'P.O': '12345',
+  'customer': {
+    first_name: 'John',
+    last_name: 'Doe',
+    location: 'China',
+  },
+  'total_amount': 5000,
+  'items': [
+    {
+      type: 'apples',
+      quantity: 10,
     },
-    'total_amount': 5000,
-    'items': [
-      {
-        type: 'apples',
-        quantity: 10,
-      },
-      {
-        type: 'oranges',
-        quantity: 5,
-      },
-    ],
-  }
+    {
+      type: 'oranges',
+      quantity: 5,
+    },
+  ],
+}
 
-  test('John Doe Invoice', () => {
-    expect(invoice).toHaveProperty('isActive') // assert that the key exists
-    expect(invoice).toHaveProperty('total_amount', 5000) // assert that the key exists and the value is equal
+test('John Doe Invoice', () => {
+  expect(invoice).toHaveProperty('isActive') // assert that the key exists
+  expect(invoice).toHaveProperty('total_amount', 5000) // assert that the key exists and the value is equal
 
-    expect(invoice).not.toHaveProperty('account') // assert that this key does not exist
+  expect(invoice).not.toHaveProperty('account') // assert that this key does not exist
 
-    // Deep referencing using dot notation
-    expect(invoice).toHaveProperty('customer.first_name')
-    expect(invoice).toHaveProperty('customer.last_name', 'Doe')
-    expect(invoice).not.toHaveProperty('customer.location', 'India')
+  // Deep referencing using dot notation
+  expect(invoice).toHaveProperty('customer.first_name')
+  expect(invoice).toHaveProperty('customer.last_name', 'Doe')
+  expect(invoice).not.toHaveProperty('customer.location', 'India')
 
-    // Deep referencing using an array containing the key
-    expect(invoice).toHaveProperty('items[0].type', 'apples')
-    expect(invoice).toHaveProperty('items.0.type', 'apples') // dot notation also works
+  // Deep referencing using an array containing the key
+  expect(invoice).toHaveProperty('items[0].type', 'apples')
+  expect(invoice).toHaveProperty('items.0.type', 'apples') // dot notation also works
 
-    // Deep referencing using an array containing the keyPath
-    expect(invoice).toHaveProperty(['items', 0, 'type'], 'apples')
-    expect(invoice).toHaveProperty(['items', '0', 'type'], 'apples') // string notation also works
+  // Deep referencing using an array containing the keyPath
+  expect(invoice).toHaveProperty(['items', 0, 'type'], 'apples')
+  expect(invoice).toHaveProperty(['items', '0', 'type'], 'apples') // string notation also works
 
-    // Wrap your key in an array to avoid the key from being parsed as a deep reference
-    expect(invoice).toHaveProperty(['P.O'], '12345')
-  })
-  ```
+  // Wrap your key in an array to avoid the key from being parsed as a deep reference
+  expect(invoice).toHaveProperty(['P.O'], '12345')
+})
+```
 
 ## toMatch
 
 - **Type:** `(received: string | regexp) => Awaitable<void>`
 
-  `toMatch` asserts if a string matches a regular expression or a string.
+`toMatch` asserts if a string matches a regular expression or a string.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('top fruits', () => {
-    expect('top fruits include apple, orange and grape').toMatch(/apple/)
-    expect('applefruits').toMatch('fruit') // toMatch also accepts a string
-  })
-  ```
+test('top fruits', () => {
+  expect('top fruits include apple, orange and grape').toMatch(/apple/)
+  expect('applefruits').toMatch('fruit') // toMatch also accepts a string
+})
+```
 
 ::: tip
 If the value in the error message is too truncated, you can increase [chaiConfig.truncateThreshold](/config/#chaiconfig-truncatethreshold) in your config file.
@@ -546,53 +546,53 @@ If the value in the error message is too truncated, you can increase [chaiConfig
 
 - **Type:** `(received: object | array) => Awaitable<void>`
 
-  `toMatchObject` asserts if an object matches a subset of the properties of an object.
+`toMatchObject` asserts if an object matches a subset of the properties of an object.
 
-  You can also pass an array of objects. This is useful if you want to check that two arrays match in their number of elements, as opposed to `arrayContaining`, which allows for extra elements in the received array.
+You can also pass an array of objects. This is useful if you want to check that two arrays match in their number of elements, as opposed to `arrayContaining`, which allows for extra elements in the received array.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const johnInvoice = {
-    isActive: true,
-    customer: {
-      first_name: 'John',
-      last_name: 'Doe',
-      location: 'China',
+const johnInvoice = {
+  isActive: true,
+  customer: {
+    first_name: 'John',
+    last_name: 'Doe',
+    location: 'China',
+  },
+  total_amount: 5000,
+  items: [
+    {
+      type: 'apples',
+      quantity: 10,
     },
-    total_amount: 5000,
-    items: [
-      {
-        type: 'apples',
-        quantity: 10,
-      },
-      {
-        type: 'oranges',
-        quantity: 5,
-      },
-    ],
-  }
-
-  const johnDetails = {
-    customer: {
-      first_name: 'John',
-      last_name: 'Doe',
-      location: 'China',
+    {
+      type: 'oranges',
+      quantity: 5,
     },
-  }
+  ],
+}
 
-  test('invoice has john personal details', () => {
-    expect(johnInvoice).toMatchObject(johnDetails)
-  })
+const johnDetails = {
+  customer: {
+    first_name: 'John',
+    last_name: 'Doe',
+    location: 'China',
+  },
+}
 
-  test('the number of elements must match exactly', () => {
-    // Assert that an array of object matches
-    expect([{ foo: 'bar' }, { baz: 1 }]).toMatchObject([
-      { foo: 'bar' },
-      { baz: 1 },
-    ])
-  })
-  ```
+test('invoice has john personal details', () => {
+  expect(johnInvoice).toMatchObject(johnDetails)
+})
+
+test('the number of elements must match exactly', () => {
+  // Assert that an array of object matches
+  expect([{ foo: 'bar' }, { baz: 1 }]).toMatchObject([
+    { foo: 'bar' },
+    { baz: 1 },
+  ])
+})
+```
 
 ## toThrowError
 
@@ -600,615 +600,612 @@ If the value in the error message is too truncated, you can increase [chaiConfig
 
 - **Alias:** `toThrow`
 
-  `toThrowError` asserts if a function throws an error when it is called.
+`toThrowError` asserts if a function throws an error when it is called.
 
-  You can provide an optional argument to test that a specific error is thrown:
+You can provide an optional argument to test that a specific error is thrown:
 
-  - regular expression: error message matches the pattern
-  - string: error message includes the substring
+- regular expression: error message matches the pattern
+- string: error message includes the substring
 
-  :::tip
-  You must wrap the code in a function, otherwise the error will not be caught, and test will fail.
-  :::
+:::tip
+You must wrap the code in a function, otherwise the error will not be caught, and test will fail.
+:::
 
-  For example, if we want to test that `getFruitStock('pineapples')` throws, we could write:
+For example, if we want to test that `getFruitStock('pineapples')` throws, we could write:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  function getFruitStock(type) {
-    if (type === 'pineapples')
-      throw new DiabetesError('Pineapples are not good for people with diabetes')
+function getFruitStock(type) {
+  if (type === 'pineapples')
+    throw new DiabetesError('Pineapples are not good for people with diabetes')
 
-    // Do some other stuff
-  }
+  // Do some other stuff
+}
 
-  test('throws on pineapples', () => {
-    // Test that the error message says "diabetes" somewhere: these are equivalent
-    expect(() => getFruitStock('pineapples')).toThrowError(/diabetes/)
-    expect(() => getFruitStock('pineapples')).toThrowError('diabetes')
+test('throws on pineapples', () => {
+  // Test that the error message says "diabetes" somewhere: these are equivalent
+  expect(() => getFruitStock('pineapples')).toThrowError(/diabetes/)
+  expect(() => getFruitStock('pineapples')).toThrowError('diabetes')
 
-    // Test the exact error message
-    expect(() => getFruitStock('pineapples')).toThrowError(
-      /^Pineapples are not good for people with diabetes$/,
-    )
-  })
-  ```
+  // Test the exact error message
+  expect(() => getFruitStock('pineapples')).toThrowError(
+    /^Pineapples are not good for people with diabetes$/,
+  )
+})
+```
 
-  :::tip
-  To test async functions, use in combination with [rejects](#rejects).
+:::tip
+To test async functions, use in combination with [rejects](#rejects).
 
-  ```js
-  function getAsyncFruitStock() {
-    return Promise.reject(new Error('empty'))
-  }
+```js
+function getAsyncFruitStock() {
+  return Promise.reject(new Error('empty'))
+}
 
-  test('throws on pineapples', async () => {
-    await expect(() => getAsyncFruitStock()).rejects.toThrowError('empty')
-  })
-  ```
-  :::
+test('throws on pineapples', async () => {
+  await expect(() => getAsyncFruitStock()).rejects.toThrowError('empty')
+})
+```
+:::
 
 ## toMatchSnapshot
 
 - **Type:** `<T>(shape?: Partial<T> | string, message?: string) => void`
 
-  This ensures that a value matches the most recent snapshot.
+This ensures that a value matches the most recent snapshot.
 
-  You can provide an optional `hint` string argument that is appended to the test name. Although Vitest always appends a number at the end of a snapshot name, short descriptive hints might be more useful than numbers to differentiate multiple snapshots in a single it or test block. Vitest sorts snapshots by name in the corresponding `.snap` file.
+You can provide an optional `hint` string argument that is appended to the test name. Although Vitest always appends a number at the end of a snapshot name, short descriptive hints might be more useful than numbers to differentiate multiple snapshots in a single it or test block. Vitest sorts snapshots by name in the corresponding `.snap` file.
 
-  :::tip
-    When snapshot mismatch and causing the test failing, if the mismatch is expected, you can press `u` key to update the snapshot for once. Or you can pass `-u` or `--update` CLI options to make Vitest always update the tests.
-  :::
+:::tip
+  When snapshot mismatch and causing the test failing, if the mismatch is expected, you can press `u` key to update the snapshot for once. Or you can pass `-u` or `--update` CLI options to make Vitest always update the tests.
+:::
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('matches snapshot', () => {
-    const data = { foo: new Set(['bar', 'snapshot']) }
-    expect(data).toMatchSnapshot()
-  })
-  ```
+test('matches snapshot', () => {
+  const data = { foo: new Set(['bar', 'snapshot']) }
+  expect(data).toMatchSnapshot()
+})
+```
 
-  You can also provide a shape of an object, if you are testing just a shape of an object, and don't need it to be 100% compatible:
+You can also provide a shape of an object, if you are testing just a shape of an object, and don't need it to be 100% compatible:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('matches snapshot', () => {
-    const data = { foo: new Set(['bar', 'snapshot']) }
-    expect(data).toMatchSnapshot({ foo: expect.any(Set) })
-  })
-  ```
+test('matches snapshot', () => {
+  const data = { foo: new Set(['bar', 'snapshot']) }
+  expect(data).toMatchSnapshot({ foo: expect.any(Set) })
+})
+```
 
 ## toMatchInlineSnapshot
 
 - **Type:** `<T>(shape?: Partial<T> | string, snapshot?: string, message?: string) => void`
 
-  This ensures that a value matches the most recent snapshot.
+This ensures that a value matches the most recent snapshot.
 
-  Vitest adds and updates the inlineSnapshot string argument to the matcher in the test file (instead of an external `.snap` file).
+Vitest adds and updates the inlineSnapshot string argument to the matcher in the test file (instead of an external `.snap` file).
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('matches inline snapshot', () => {
-    const data = { foo: new Set(['bar', 'snapshot']) }
-    // Vitest will update following content when updating the snapshot
-    expect(data).toMatchInlineSnapshot(`
-      {
-        "foo": Set {
-          "bar",
-          "snapshot",
-        },
-      }
-    `)
-  })
-  ```
+test('matches inline snapshot', () => {
+  const data = { foo: new Set(['bar', 'snapshot']) }
+  // Vitest will update following content when updating the snapshot
+  expect(data).toMatchInlineSnapshot(`
+    {
+      "foo": Set {
+        "bar",
+        "snapshot",
+      },
+    }
+  `)
+})
+```
 
-  You can also provide a shape of an object, if you are testing just a shape of an object, and don't need it to be 100% compatible:
+You can also provide a shape of an object, if you are testing just a shape of an object, and don't need it to be 100% compatible:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('matches snapshot', () => {
-    const data = { foo: new Set(['bar', 'snapshot']) }
-    expect(data).toMatchInlineSnapshot(
-      { foo: expect.any(Set) },
-      `
-      {
-        "foo": Any<Set>,
-      }
+test('matches snapshot', () => {
+  const data = { foo: new Set(['bar', 'snapshot']) }
+  expect(data).toMatchInlineSnapshot(
+    { foo: expect.any(Set) },
     `
-    )
-  })
-  ```
+    {
+      "foo": Any<Set>,
+    }
+  `
+  )
+})
+```
 
 ## toMatchFileSnapshot
 
 - **Type:** `<T>(filepath: string, message?: string) => Promise<void>`
 - **Version:** Since Vitest 0.30.0
 
-  Compare or update the snapshot with the content of a file explicitly specified (instead of the `.snap` file).
+Compare or update the snapshot with the content of a file explicitly specified (instead of the `.snap` file).
 
-  ```ts
-  import { expect, it } from 'vitest'
+```ts
+import { expect, it } from 'vitest'
 
-  it('render basic', async () => {
-    const result = renderHTML(h('div', { class: 'foo' }))
-    await expect(result).toMatchFileSnapshot('./test/basic.output.html')
-  })
-  ```
+it('render basic', async () => {
+  const result = renderHTML(h('div', { class: 'foo' }))
+  await expect(result).toMatchFileSnapshot('./test/basic.output.html')
+})
+```
 
-  Note that since file system operation is async, you need to use `await` with `toMatchFileSnapshot()`.
+Note that since file system operation is async, you need to use `await` with `toMatchFileSnapshot()`.
 
 ## toThrowErrorMatchingSnapshot
 
 - **Type:** `(message?: string) => void`
 
-  The same as [`toMatchSnapshot`](#tomatchsnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
+The same as [`toMatchSnapshot`](#tomatchsnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
 
-  If the function throws an `Error`, the snapshot will be the error message. Otherwise, snapshot will be the value thrown by the function.
+If the function throws an `Error`, the snapshot will be the error message. Otherwise, snapshot will be the value thrown by the function.
 
 ## toThrowErrorMatchingInlineSnapshot
 
 - **Type:** `(snapshot?: string, message?: string) => void`
 
-  The same as [`toMatchInlineSnapshot`](#tomatchinlinesnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
+The same as [`toMatchInlineSnapshot`](#tomatchinlinesnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
 
-  If the function throws an `Error`, the snapshot will be the error message. Otherwise, snapshot will be the value thrown by the function.
+If the function throws an `Error`, the snapshot will be the error message. Otherwise, snapshot will be the value thrown by the function.
 
 ## toHaveBeenCalled
 
 - **Type:** `() => Awaitable<void>`
 
-  This assertion is useful for testing that a function has been called. Requires a spy function to be passed to `expect`.
+This assertion is useful for testing that a function has been called. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  const market = {
-    buy(subject: string, amount: number) {
-      // ...
-    },
-  }
+const market = {
+  buy(subject: string, amount: number) {
+    // ...
+  },
+}
 
-  test('spy function', () => {
-    const buySpy = vi.spyOn(market, 'buy')
+test('spy function', () => {
+  const buySpy = vi.spyOn(market, 'buy')
 
-    expect(buySpy).not.toHaveBeenCalled()
+  expect(buySpy).not.toHaveBeenCalled()
 
-    market.buy('apples', 10)
+  market.buy('apples', 10)
 
-    expect(buySpy).toHaveBeenCalled()
-  })
-  ```
+  expect(buySpy).toHaveBeenCalled()
+})
+```
 
 ## toHaveBeenCalledTimes
 
- - **Type**: `(amount: number) => Awaitable<void>`
+- **Type**: `(amount: number) => Awaitable<void>`
 
-  This assertion checks if a function was called a certain amount of times. Requires a spy function to be passed to `expect`.
+This assertion checks if a function was called a certain amount of times. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  const market = {
-    buy(subject: string, amount: number) {
-      // ...
-    },
-  }
+const market = {
+  buy(subject: string, amount: number) {
+    // ...
+  },
+}
 
-  test('spy function called two times', () => {
-    const buySpy = vi.spyOn(market, 'buy')
+test('spy function called two times', () => {
+  const buySpy = vi.spyOn(market, 'buy')
 
-    market.buy('apples', 10)
-    market.buy('apples', 20)
+  market.buy('apples', 10)
+  market.buy('apples', 20)
 
-    expect(buySpy).toHaveBeenCalledTimes(2)
-  })
-  ```
+  expect(buySpy).toHaveBeenCalledTimes(2)
+})
+```
 
 ## toHaveBeenCalledWith
 
- - **Type**: `(...args: any[]) => Awaitable<void>`
+- **Type**: `(...args: any[]) => Awaitable<void>`
 
-  This assertion checks if a function was called at least once with certain parameters. Requires a spy function to be passed to `expect`.
+This assertion checks if a function was called at least once with certain parameters. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  const market = {
-    buy(subject: string, amount: number) {
-      // ...
-    },
-  }
+const market = {
+  buy(subject: string, amount: number) {
+    // ...
+  },
+}
 
-  test('spy function', () => {
-    const buySpy = vi.spyOn(market, 'buy')
+test('spy function', () => {
+  const buySpy = vi.spyOn(market, 'buy')
 
-    market.buy('apples', 10)
-    market.buy('apples', 20)
+  market.buy('apples', 10)
+  market.buy('apples', 20)
 
-    expect(buySpy).toHaveBeenCalledWith('apples', 10)
-    expect(buySpy).toHaveBeenCalledWith('apples', 20)
-  })
-  ```
+  expect(buySpy).toHaveBeenCalledWith('apples', 10)
+  expect(buySpy).toHaveBeenCalledWith('apples', 20)
+})
+```
 
 ## toHaveBeenLastCalledWith
 
- - **Type**: `(...args: any[]) => Awaitable<void>`
+- **Type**: `(...args: any[]) => Awaitable<void>`
 
-  This assertion checks if a function was called with certain parameters at it's last invocation. Requires a spy function to be passed to `expect`.
+This assertion checks if a function was called with certain parameters at it's last invocation. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  const market = {
-    buy(subject: string, amount: number) {
-      // ...
-    },
-  }
+const market = {
+  buy(subject: string, amount: number) {
+    // ...
+  },
+}
 
-  test('spy function', () => {
-    const buySpy = vi.spyOn(market, 'buy')
+test('spy function', () => {
+  const buySpy = vi.spyOn(market, 'buy')
 
-    market.buy('apples', 10)
-    market.buy('apples', 20)
+  market.buy('apples', 10)
+  market.buy('apples', 20)
 
-    expect(buySpy).not.toHaveBeenLastCalledWith('apples', 10)
-    expect(buySpy).toHaveBeenLastCalledWith('apples', 20)
-  })
-  ```
+  expect(buySpy).not.toHaveBeenLastCalledWith('apples', 10)
+  expect(buySpy).toHaveBeenLastCalledWith('apples', 20)
+})
+```
 
 ## toHaveBeenNthCalledWith
 
- - **Type**: `(time: number, ...args: any[]) => Awaitable<void>`
+- **Type**: `(time: number, ...args: any[]) => Awaitable<void>`
 
-  This assertion checks if a function was called with certain parameters at the certain time. The count starts at 1. So, to check the second entry, you would write `.toHaveBeenNthCalledWith(2, ...)`.
+This assertion checks if a function was called with certain parameters at the certain time. The count starts at 1. So, to check the second entry, you would write `.toHaveBeenNthCalledWith(2, ...)`.
 
-  Requires a spy function to be passed to `expect`.
+Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  const market = {
-    buy(subject: string, amount: number) {
-      // ...
-    },
-  }
+const market = {
+  buy(subject: string, amount: number) {
+    // ...
+  },
+}
 
-  test('first call of spy function called with right params', () => {
-    const buySpy = vi.spyOn(market, 'buy')
+test('first call of spy function called with right params', () => {
+  const buySpy = vi.spyOn(market, 'buy')
 
-    market.buy('apples', 10)
-    market.buy('apples', 20)
+  market.buy('apples', 10)
+  market.buy('apples', 20)
 
-    expect(buySpy).toHaveBeenNthCalledWith(1, 'apples', 10)
-  })
-  ```
+  expect(buySpy).toHaveBeenNthCalledWith(1, 'apples', 10)
+})
+```
 
 ## toHaveReturned
 
-  - **Type**: `() => Awaitable<void>`
+- **Type**: `() => Awaitable<void>`
 
-  This assertion checks if a function has successfully returned a value at least once (i.e., did not throw an error). Requires a spy function to be passed to `expect`.
+This assertion checks if a function has successfully returned a value at least once (i.e., did not throw an error). Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  function getApplesPrice(amount: number) {
-    const PRICE = 10
-    return amount * PRICE
-  }
+function getApplesPrice(amount: number) {
+  const PRICE = 10
+  return amount * PRICE
+}
 
-  test('spy function returned a value', () => {
-    const getPriceSpy = vi.fn(getApplesPrice)
+test('spy function returned a value', () => {
+  const getPriceSpy = vi.fn(getApplesPrice)
 
-    const price = getPriceSpy(10)
+  const price = getPriceSpy(10)
 
-    expect(price).toBe(100)
-    expect(getPriceSpy).toHaveReturned()
-  })
-  ```
+  expect(price).toBe(100)
+  expect(getPriceSpy).toHaveReturned()
+})
+```
 
 ## toHaveReturnedTimes
 
-  - **Type**: `(amount: number) => Awaitable<void>`
+- **Type**: `(amount: number) => Awaitable<void>`
 
-  This assertion checks if a function has successfully returned a value exact amount of times (i.e., did not throw an error). Requires a spy function to be passed to `expect`.
+This assertion checks if a function has successfully returned a value exact amount of times (i.e., did not throw an error). Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  test('spy function returns a value two times', () => {
-    const sell = vi.fn((product: string) => ({ product }))
+test('spy function returns a value two times', () => {
+  const sell = vi.fn((product: string) => ({ product }))
 
-    sell('apples')
-    sell('bananas')
+  sell('apples')
+  sell('bananas')
 
-    expect(sell).toHaveReturnedTimes(2)
-  })
-  ```
+  expect(sell).toHaveReturnedTimes(2)
+})
+```
 
 ## toHaveReturnedWith
 
-  - **Type**: `(returnValue: any) => Awaitable<void>`
+- **Type**: `(returnValue: any) => Awaitable<void>`
 
-  You can call this assertion to check if a function has successfully returned a value with certain parameters at least once. Requires a spy function to be passed to `expect`.
+You can call this assertion to check if a function has successfully returned a value with certain parameters at least once. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  test('spy function returns a product', () => {
-    const sell = vi.fn((product: string) => ({ product }))
+test('spy function returns a product', () => {
+  const sell = vi.fn((product: string) => ({ product }))
 
-    sell('apples')
+  sell('apples')
 
-    expect(sell).toHaveReturnedWith({ product: 'apples' })
-  })
-  ```
+  expect(sell).toHaveReturnedWith({ product: 'apples' })
+})
+```
 
 ## toHaveLastReturnedWith
 
-  - **Type**: `(returnValue: any) => Awaitable<void>`
+- **Type**: `(returnValue: any) => Awaitable<void>`
 
-  You can call this assertion to check if a function has successfully returned a value with certain parameters on it's last invoking. Requires a spy function to be passed to `expect`.
+You can call this assertion to check if a function has successfully returned a value with certain parameters on it's last invoking. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  test('spy function returns bananas on a last call', () => {
-    const sell = vi.fn((product: string) => ({ product }))
+test('spy function returns bananas on a last call', () => {
+  const sell = vi.fn((product: string) => ({ product }))
 
-    sell('apples')
-    sell('bananas')
+  sell('apples')
+  sell('bananas')
 
-    expect(sell).toHaveLastReturnedWith({ product: 'bananas' })
-  })
-  ```
+  expect(sell).toHaveLastReturnedWith({ product: 'bananas' })
+})
+```
 
 ## toHaveNthReturnedWith
 
-  - **Type**: `(time: number, returnValue: any) => Awaitable<void>`
+- **Type**: `(time: number, returnValue: any) => Awaitable<void>`
 
-  You can call this assertion to check if a function has successfully returned a value with certain parameters on a certain call. Requires a spy function to be passed to `expect`.
+You can call this assertion to check if a function has successfully returned a value with certain parameters on a certain call. Requires a spy function to be passed to `expect`.
 
-  ```ts
-  import { expect, test, vi } from 'vitest'
+```ts
+import { expect, test, vi } from 'vitest'
 
-  test('spy function returns bananas on second call', () => {
-    const sell = vi.fn((product: string) => ({ product }))
+test('spy function returns bananas on second call', () => {
+  const sell = vi.fn((product: string) => ({ product }))
 
-    sell('apples')
-    sell('bananas')
+  sell('apples')
+  sell('bananas')
 
-    expect(sell).toHaveNthReturnedWith(2, { product: 'bananas' })
-  })
-  ```
+  expect(sell).toHaveNthReturnedWith(2, { product: 'bananas' })
+})
+```
 
 ## toSatisfy
 
-  - **Type:** `(predicate: (value: any) => boolean) => Awaitable<void>`
+- **Type:** `(predicate: (value: any) => boolean) => Awaitable<void>`
 
-  This assertion checks if a value satisfies a certain predicate.
+This assertion checks if a value satisfies a certain predicate.
 
-  ```ts
-  describe('toSatisfy()', () => {
-    const isOdd = (value: number) => value % 2 !== 0
+```ts
+describe('toSatisfy()', () => {
+  const isOdd = (value: number) => value % 2 !== 0
 
-    it('pass with 0', () => {
-      expect(1).toSatisfy(isOdd)
-    })
-
-    it('pass with negotiation', () => {
-      expect(2).not.toSatisfy(isOdd)
-    })
+  it('pass with 0', () => {
+    expect(1).toSatisfy(isOdd)
   })
-  ```
+
+  it('pass with negotiation', () => {
+    expect(2).not.toSatisfy(isOdd)
+  })
+})
+```
 
 ## resolves
 
 - **Type:** `Promisify<Assertions>`
 
-  `resolves` is intended to remove boilerplate when asserting asynchronous code. Use it to unwrap value from the pending promise and assert its value with usual assertions. If the promise rejects, the assertion will fail.
+`resolves` is intended to remove boilerplate when asserting asynchronous code. Use it to unwrap value from the pending promise and assert its value with usual assertions. If the promise rejects, the assertion will fail.
 
-  It returns the same `Assertions` object, but all matchers now return `Promise`, so you would need to `await` it. Also works with `chai` assertions.
+It returns the same `Assertions` object, but all matchers now return `Promise`, so you would need to `await` it. Also works with `chai` assertions.
 
-  For example, if you have a function, that makes an API call and returns some data, you may use this code to assert its return value:
+For example, if you have a function, that makes an API call and returns some data, you may use this code to assert its return value:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  async function buyApples() {
-    return fetch('/buy/apples').then(r => r.json())
-  }
+async function buyApples() {
+  return fetch('/buy/apples').then(r => r.json())
+}
 
-  test('buyApples returns new stock id', async () => {
-    // toEqual returns a promise now, so you HAVE to await it
-    await expect(buyApples()).resolves.toEqual({ id: 1 }) // jest API
-    await expect(buyApples()).resolves.to.equal({ id: 1 }) // chai API
-  })
-  ```
+test('buyApples returns new stock id', async () => {
+  // toEqual returns a promise now, so you HAVE to await it
+  await expect(buyApples()).resolves.toEqual({ id: 1 }) // jest API
+  await expect(buyApples()).resolves.to.equal({ id: 1 }) // chai API
+})
+```
 
-  :::warning
-  If the assertion is not awaited, then you will have a false-positive test that will pass every time. To make sure that assertions are actually called, you may use [`expect.assertions(number)`](#expect-assertions).
-  :::
+:::warning
+If the assertion is not awaited, then you will have a false-positive test that will pass every time. To make sure that assertions are actually called, you may use [`expect.assertions(number)`](#expect-assertions).
+:::
 
 ## rejects
 
 - **Type:** `Promisify<Assertions>`
 
-  `rejects` is intended to remove boilerplate when asserting asynchronous code. Use it to unwrap reason why the promise was rejected, and assert its value with usual assertions. If the promise successfully resolves, the assertion will fail.
+`rejects` is intended to remove boilerplate when asserting asynchronous code. Use it to unwrap reason why the promise was rejected, and assert its value with usual assertions. If the promise successfully resolves, the assertion will fail.
 
-  It returns the same `Assertions` object, but all matchers now return `Promise`, so you would need to `await` it. Also works with `chai` assertions.
+It returns the same `Assertions` object, but all matchers now return `Promise`, so you would need to `await` it. Also works with `chai` assertions.
 
-  For example, if you have a function that fails when you call it, you may use this code to assert the reason:
+For example, if you have a function that fails when you call it, you may use this code to assert the reason:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  async function buyApples(id) {
-    if (!id)
-      throw new Error('no id')
-  }
+async function buyApples(id) {
+  if (!id)
+    throw new Error('no id')
+}
 
-  test('buyApples throws an error when no id provided', async () => {
-    // toThrow returns a promise now, so you HAVE to await it
-    await expect(buyApples()).rejects.toThrow('no id')
-  })
-  ```
+test('buyApples throws an error when no id provided', async () => {
+  // toThrow returns a promise now, so you HAVE to await it
+  await expect(buyApples()).rejects.toThrow('no id')
+})
+```
 
-  :::warning
-  If the assertion is not awaited, then you will have a false-positive test that will pass every time. To make sure that assertions were actually called, you can use [`expect.assertions(number)`](#expect-assertions).
-  :::
+:::warning
+If the assertion is not awaited, then you will have a false-positive test that will pass every time. To make sure that assertions were actually called, you can use [`expect.assertions(number)`](#expect-assertions).
+:::
 
 ## expect.assertions
 
 - **Type:** `(count: number) => void`
 
-  After the test has passed or failed verify that a certain number of assertions was called during a test. A useful case would be to check if an asynchronous code was called.
+After the test has passed or failed verify that a certain number of assertions was called during a test. A useful case would be to check if an asynchronous code was called.
 
-  For example, if we have a function that asynchronously calls two matchers, we can assert that they were actually called.
+For example, if we have a function that asynchronously calls two matchers, we can assert that they were actually called.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  async function doAsync(...cbs) {
-    await Promise.all(
-      cbs.map((cb, index) => cb({ index })),
-    )
+async function doAsync(...cbs) {
+  await Promise.all(
+    cbs.map((cb, index) => cb({ index })),
+  )
+}
+
+test('all assertions are called', async () => {
+  expect.assertions(2)
+  function callback1(data) {
+    expect(data).toBeTruthy()
+  }
+  function callback2(data) {
+    expect(data).toBeTruthy()
   }
 
-  test('all assertions are called', async () => {
-    expect.assertions(2)
-    function callback1(data) {
-      expect(data).toBeTruthy()
-    }
-    function callback2(data) {
-      expect(data).toBeTruthy()
-    }
-
-    await doAsync(callback1, callback2)
-  })
-  ```
-  ::: warning
-  When using `assertions` with async concurrent tests, `expect` from the local [Test Context](/guide/test-context.md) must be used to ensure the right test is detected.
-  :::
-
+  await doAsync(callback1, callback2)
+})
+```
+::: warning
+When using `assertions` with async concurrent tests, `expect` from the local [Test Context](/guide/test-context.md) must be used to ensure the right test is detected.
+:::
 
 ## expect.hasAssertions
 
 - **Type:** `() => void`
 
-  After the test has passed or failed verify that at least one assertion was called during a test. A useful case would be to check if an asynchronous code was called.
+After the test has passed or failed verify that at least one assertion was called during a test. A useful case would be to check if an asynchronous code was called.
 
-  For example, if you have a code that calls a callback, we can make an assertion inside a callback, but the test will always pass if we don't check if an assertion was called.
+For example, if you have a code that calls a callback, we can make an assertion inside a callback, but the test will always pass if we don't check if an assertion was called.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { db } from './db.js'
+```ts
+import { expect, test } from 'vitest'
+import { db } from './db.js'
 
-  const cbs = []
+const cbs = []
 
-  function onSelect(cb) {
-    cbs.push(cb)
-  }
+function onSelect(cb) {
+  cbs.push(cb)
+}
 
-  // after selecting from db, we call all callbacks
-  function select(id) {
-    return db.select({ id }).then((data) => {
-      return Promise.all(
-        cbs.map(cb => cb(data)),
-      )
-    })
-  }
-
-  test('callback was called', async () => {
-    expect.hasAssertions()
-    onSelect((data) => {
-      // should be called on select
-      expect(data).toBeTruthy()
-    })
-    // if not awaited, test will fail
-    // if you don't have expect.hasAssertions(), test will pass
-    await select(3)
+// after selecting from db, we call all callbacks
+function select(id) {
+  return db.select({ id }).then((data) => {
+    return Promise.all(
+      cbs.map(cb => cb(data)),
+    )
   })
-  ```
+}
+
+test('callback was called', async () => {
+  expect.hasAssertions()
+  onSelect((data) => {
+    // should be called on select
+    expect(data).toBeTruthy()
+  })
+  // if not awaited, test will fail
+  // if you don't have expect.hasAssertions(), test will pass
+  await select(3)
+})
+```
 
 ## expect.unreachable
 
 - **Type:** `(message?: string) => never`
 
-  This method is used to asserting that a line should never be reached.
+This method is used to asserting that a line should never be reached.
 
-  For example, if we want to test that `build()` throws due to receiving directories having no `src` folder, and also handle each error separately, we could do this:
+For example, if we want to test that `build()` throws due to receiving directories having no `src` folder, and also handle each error separately, we could do this:
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  async function build(dir) {
-    if (dir.includes('no-src'))
-      throw new Error(`${dir}/src does not exist`)
+async function build(dir) {
+  if (dir.includes('no-src'))
+    throw new Error(`${dir}/src does not exist`)
+}
+
+const errorDirs = [
+  'no-src-folder',
+  // ...
+]
+
+test.each(errorDirs)('build fails with "%s"', async (dir) => {
+  try {
+    await build(dir)
+    expect.unreachable('Should not pass build')
   }
+  catch (err: any) {
+    expect(err).toBeInstanceOf(Error)
+    expect(err.stack).toContain('build')
 
-  const errorDirs = [
-    'no-src-folder',
-    // ...
-  ]
-
-  test.each(errorDirs)('build fails with "%s"', async (dir) => {
-    try {
-      await build(dir)
-      expect.unreachable('Should not pass build')
+    switch (dir) {
+      case 'no-src-folder':
+        expect(err.message).toBe(`${dir}/src does not exist`)
+        break
+      default:
+        // to exhaust all error tests
+        expect.unreachable('All error test must be handled')
+        break
     }
-    catch (err: any) {
-      expect(err).toBeInstanceOf(Error)
-      expect(err.stack).toContain('build')
-
-      switch (dir) {
-        case 'no-src-folder':
-          expect(err.message).toBe(`${dir}/src does not exist`)
-          break
-        default:
-          // to exhaust all error tests
-          expect.unreachable('All error test must be handled')
-          break
-      }
-    }
-  })
-  ```
-
-<!-- asymmetric matchers -->
+  }
+})
+```
 
 ## expect.anything
 
 - **Type:** `() => any`
 
-  This asymmetric matcher, when used with equality check, will always return `true`. Useful, if you just want to be sure that the property exist.
+This asymmetric matcher, when used with equality check, will always return `true`. Useful, if you just want to be sure that the property exist.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('object has "apples" key', () => {
-    expect({ apples: 22 }).toEqual({ apples: expect.anything() })
-  })
-  ```
+test('object has "apples" key', () => {
+  expect({ apples: 22 }).toEqual({ apples: expect.anything() })
+})
+```
 
 ## expect.any
 
 - **Type:** `(constructor: unknown) => any`
 
-  This asymmetric matcher, when used with an equality check, will return `true` only if the value is an instance of a specified constructor. Useful, if you have a value that is generated each time, and you only want to know that it exists with a proper type.
+This asymmetric matcher, when used with an equality check, will return `true` only if the value is an instance of a specified constructor. Useful, if you have a value that is generated each time, and you only want to know that it exists with a proper type.
 
-  ```ts
-  import { expect, test } from 'vitest'
-  import { generateId } from './generators.js'
+```ts
+import { expect, test } from 'vitest'
+import { generateId } from './generators.js'
 
-  test('"id" is a number', () => {
-    expect({ id: generateId() }).toEqual({ id: expect.any(Number) })
-  })
-  ```
+test('"id" is a number', () => {
+  expect({ id: generateId() }).toEqual({ id: expect.any(Number) })
+})
+```
 
 ## expect.closeTo
 
@@ -1237,174 +1234,174 @@ test('compare float in object properties', () => {
 
 - **Type:** `<T>(expected: T[]) => any`
 
-  When used with an equality check, this asymmetric matcher will return `true` if the value is an array and contains specified items.
+When used with an equality check, this asymmetric matcher will return `true` if the value is an array and contains specified items.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('basket includes fuji', () => {
-    const basket = {
-      varieties: [
-        'Empire',
-        'Fuji',
-        'Gala',
-      ],
-      count: 3
-    }
-    expect(basket).toEqual({
-      count: 3,
-      varieties: expect.arrayContaining(['Fuji'])
-    })
+test('basket includes fuji', () => {
+  const basket = {
+    varieties: [
+      'Empire',
+      'Fuji',
+      'Gala',
+    ],
+    count: 3
+  }
+  expect(basket).toEqual({
+    count: 3,
+    varieties: expect.arrayContaining(['Fuji'])
   })
-  ```
+})
+```
 
-  :::tip
-  You can use `expect.not` with this matcher to negate the expected value.
-  :::
+:::tip
+You can use `expect.not` with this matcher to negate the expected value.
+:::
 
 ## expect.objectContaining
 
 - **Type:** `(expected: any) => any`
 
-  When used with an equality check, this asymmetric matcher will return `true` if the value has a similar shape.
+When used with an equality check, this asymmetric matcher will return `true` if the value has a similar shape.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('basket has empire apples', () => {
-    const basket = {
-      varieties: [
-        {
-          name: 'Empire',
-          count: 1,
-        }
-      ],
-    }
-    expect(basket).toEqual({
-      varieties: [
-        expect.objectContaining({ name: 'Empire' }),
-      ]
-    })
+test('basket has empire apples', () => {
+  const basket = {
+    varieties: [
+      {
+        name: 'Empire',
+        count: 1,
+      }
+    ],
+  }
+  expect(basket).toEqual({
+    varieties: [
+      expect.objectContaining({ name: 'Empire' }),
+    ]
   })
-  ```
+})
+```
 
-  :::tip
-  You can use `expect.not` with this matcher to negate the expected value.
-  :::
+:::tip
+You can use `expect.not` with this matcher to negate the expected value.
+:::
 
 ## expect.stringContaining
 
 - **Type:** `(expected: any) => any`
 
-  When used with an equality check, this asymmetric matcher will return `true` if the value is a string and contains a specified substring.
+When used with an equality check, this asymmetric matcher will return `true` if the value is a string and contains a specified substring.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('variety has "Emp" in its name', () => {
-    const variety = {
-      name: 'Empire',
-      count: 1,
-    }
-    expect(variety).toEqual({
-      name: expect.stringContaining('Emp'),
-      count: 1,
-    })
+test('variety has "Emp" in its name', () => {
+  const variety = {
+    name: 'Empire',
+    count: 1,
+  }
+  expect(variety).toEqual({
+    name: expect.stringContaining('Emp'),
+    count: 1,
   })
-  ```
+})
+```
 
-  :::tip
-  You can use `expect.not` with this matcher to negate the expected value.
-  :::
+:::tip
+You can use `expect.not` with this matcher to negate the expected value.
+:::
 
 ## expect.stringMatching
 
 - **Type:** `(expected: any) => any`
 
-  When used with an equality check, this asymmetric matcher will return `true` if the value is a string and contains a specified substring or if the string matches a regular expression.
+When used with an equality check, this asymmetric matcher will return `true` if the value is a string and contains a specified substring or if the string matches a regular expression.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('variety ends with "re"', () => {
-    const variety = {
-      name: 'Empire',
-      count: 1,
-    }
-    expect(variety).toEqual({
-      name: expect.stringMatching(/re$/),
-      count: 1,
-    })
+test('variety ends with "re"', () => {
+  const variety = {
+    name: 'Empire',
+    count: 1,
+  }
+  expect(variety).toEqual({
+    name: expect.stringMatching(/re$/),
+    count: 1,
   })
-  ```
+})
+```
 
-  :::tip
-  You can use `expect.not` with this matcher to negate the expected value.
-  :::
+:::tip
+You can use `expect.not` with this matcher to negate the expected value.
+:::
 
 ## expect.addSnapshotSerializer
 
 - **Type:** `(plugin: PrettyFormatPlugin) => void`
 
-  This method adds custom serializers that are called when creating a snapshot. This is an advanced feature - if you want to know more, please read a [guide on custom serializers](/guide/snapshot#custom-serializer).
+This method adds custom serializers that are called when creating a snapshot. This is an advanced feature - if you want to know more, please read a [guide on custom serializers](/guide/snapshot#custom-serializer).
 
-  If you are adding custom serializers, you should call this method inside [`setupFiles`](/config/#setupfiles). This will affect every snapshot.
+If you are adding custom serializers, you should call this method inside [`setupFiles`](/config/#setupfiles). This will affect every snapshot.
 
-  :::tip
-  If you previously used Vue CLI with Jest, you might want to install [jest-serializer-vue](https://www.npmjs.com/package/jest-serializer-vue). Otherwise, your snapshots will be wrapped in a string, which cases `"` to be escaped.
-  :::
+:::tip
+If you previously used Vue CLI with Jest, you might want to install [jest-serializer-vue](https://www.npmjs.com/package/jest-serializer-vue). Otherwise, your snapshots will be wrapped in a string, which cases `"` to be escaped.
+:::
 
 ## expect.extend
 
 - **Type:** `(matchers: MatchersObject) => void`
 
-  You can extend default matchers with your own. This function is used to extend the matchers object with custom matchers.
+You can extend default matchers with your own. This function is used to extend the matchers object with custom matchers.
 
-  When you define matchers that way, you also create asymmetric matchers that can be used like `expect.stringContaining`.
+When you define matchers that way, you also create asymmetric matchers that can be used like `expect.stringContaining`.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('custom matchers', () => {
-    expect.extend({
-      toBeFoo: (received, expected) => {
-        if (received !== 'foo') {
-          return {
-            message: () => `expected ${received} to be foo`,
-            pass: false,
-          }
+test('custom matchers', () => {
+  expect.extend({
+    toBeFoo: (received, expected) => {
+      if (received !== 'foo') {
+        return {
+          message: () => `expected ${received} to be foo`,
+          pass: false,
         }
-      },
-    })
-
-    expect('foo').toBeFoo()
-    expect({ foo: 'foo' }).toEqual({ foo: expect.toBeFoo() })
+      }
+    },
   })
-  ```
 
-  ::: tip
-  If you want your matchers to appear in every test, you should call this method inside [`setupFiles`](/config/#setupFiles).
-  :::
+  expect('foo').toBeFoo()
+  expect({ foo: 'foo' }).toEqual({ foo: expect.toBeFoo() })
+})
+```
 
-  This function is compatible with Jest's `expect.extend`, so any library that uses it to create custom matchers will work with Vitest.
+::: tip
+If you want your matchers to appear in every test, you should call this method inside [`setupFiles`](/config/#setupFiles).
+:::
 
-  If you are using TypeScript, since Vitest 0.31.0 you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
+This function is compatible with Jest's `expect.extend`, so any library that uses it to create custom matchers will work with Vitest.
 
-  ```ts
-  interface CustomMatchers<R = unknown> {
-    toBeFoo(): R
-  }
+If you are using TypeScript, since Vitest 0.31.0 you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
-  declare module 'vitest' {
-    interface Assertion<T = any> extends CustomMatchers<T> {}
-    interface AsymmetricMatchersContaining extends CustomMatchers {}
-  }
-  ```
+```ts
+interface CustomMatchers<R = unknown> {
+  toBeFoo(): R
+}
 
-  ::: warning
-  Don't forget to include the ambient declaration file in your `tsconfig.json`.
-  :::
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}
+```
 
-  :::tip
-  If you want to know more, checkout [guide on extending matchers](/guide/extending-matchers).
-  :::
+::: warning
+Don't forget to include the ambient declaration file in your `tsconfig.json`.
+:::
+
+:::tip
+If you want to know more, checkout [guide on extending matchers](/guide/extending-matchers).
+:::

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -43,17 +43,17 @@ In Jest, `TestFunction` can also be of type `(done: DoneCallback) => void`. If t
 - **Type:** `(name: string | Function, fn: TestFunction, timeout?: number | TestOptions) => void`
 - **Alias:** `it`
 
-  `test` defines a set of related expectations. It receives the test name and a function that holds the expectations to test.
+`test` defines a set of related expectations. It receives the test name and a function that holds the expectations to test.
 
-  Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds, and can be configured globally with [testTimeout](/config/#testtimeout)
+Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds, and can be configured globally with [testTimeout](/config/#testtimeout)
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  test('should work as expected', () => {
-    expect(Math.sqrt(4)).toBe(2)
-  })
-  ```
+test('should work as expected', () => {
+  expect(Math.sqrt(4)).toBe(2)
+})
+```
 
 ### test.extend
 
@@ -61,75 +61,75 @@ In Jest, `TestFunction` can also be of type `(done: DoneCallback) => void`. If t
 - **Alias:** `it.extend`
 - **Version:** Vitest 0.32.3
 
-  Use `test.extend` to extend the test context with custom fixtures. This will return a new `test` and it's also extendable, so you can compose more fixtures or override existing ones by extending it as you need. See [Extend Test Context](/guide/test-context.html#test-extend) for more information.
+Use `test.extend` to extend the test context with custom fixtures. This will return a new `test` and it's also extendable, so you can compose more fixtures or override existing ones by extending it as you need. See [Extend Test Context](/guide/test-context.html#test-extend) for more information.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  const todos = []
-  const archive = []
+const todos = []
+const archive = []
 
-  const myTest = test.extend({
-    todos: async ({ task }, use) => {
-      todos.push(1, 2, 3)
-      await use(todos)
-      todos.length = 0
-    },
-    archive
-  })
+const myTest = test.extend({
+  todos: async ({ task }, use) => {
+    todos.push(1, 2, 3)
+    await use(todos)
+    todos.length = 0
+  },
+  archive
+})
 
-  myTest('add item', ({ todos }) => {
-    expect(todos.length).toBe(3)
+myTest('add item', ({ todos }) => {
+  expect(todos.length).toBe(3)
 
-    todos.push(4)
-    expect(todos.length).toBe(4)
-  })
-  ```
+  todos.push(4)
+  expect(todos.length).toBe(4)
+})
+```
 
 ### test.skip
 
 - **Type:** `(name: string | Function, fn: TestFunction, timeout?: number | TestOptions) => void`
 - **Alias:** `it.skip`
 
-  If you want to skip running certain tests, but you don't want to delete the code due to any reason, you can use `test.skip` to avoid running them.
+If you want to skip running certain tests, but you don't want to delete the code due to any reason, you can use `test.skip` to avoid running them.
 
-  ```ts
-  import { assert, test } from 'vitest'
+```ts
+import { assert, test } from 'vitest'
 
-  test.skip('skipped test', () => {
-    // Test skipped, no error
-    assert.equal(Math.sqrt(4), 3)
-  })
-  ```
+test.skip('skipped test', () => {
+  // Test skipped, no error
+  assert.equal(Math.sqrt(4), 3)
+})
+```
 
-  You can also skip test by calling `skip` on its [context](/guide/test-context) dynamically:
+You can also skip test by calling `skip` on its [context](/guide/test-context) dynamically:
 
-  ```ts
-  import { assert, test } from 'vitest'
+```ts
+import { assert, test } from 'vitest'
 
-  test('skipped test', (context) => {
-    context.skip()
-    // Test skipped, no error
-    assert.equal(Math.sqrt(4), 3)
-  })
-  ```
+test('skipped test', (context) => {
+  context.skip()
+  // Test skipped, no error
+  assert.equal(Math.sqrt(4), 3)
+})
+```
 
 ### test.skipIf
 
 - **Type:** `(condition: any) => Test`
 - **Alias:** `it.skipIf`
 
-  In some cases you might run tests multiple times with different environments, and some of the tests might be environment-specific. Instead of wrapping the test code with `if`, you can use `test.skipIf` to skip the test whenever the condition is truthy.
+In some cases you might run tests multiple times with different environments, and some of the tests might be environment-specific. Instead of wrapping the test code with `if`, you can use `test.skipIf` to skip the test whenever the condition is truthy.
 
-  ```ts
-  import { assert, test } from 'vitest'
+```ts
+import { assert, test } from 'vitest'
 
-  const isDev = process.env.NODE_ENV === 'development'
+const isDev = process.env.NODE_ENV === 'development'
 
-  test.skipIf(isDev)('prod only test', () => {
-    // this test only runs in production
-  })
-  ```
+test.skipIf(isDev)('prod only test', () => {
+  // this test only runs in production
+})
+```
 
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
@@ -140,17 +140,17 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 - **Type:** `(condition: any) => Test`
 - **Alias:** `it.runIf`
 
-  Opposite of [test.skipIf](#test-skipif).
+Opposite of [test.skipIf](#test-skipif).
 
-  ```ts
-  import { assert, test } from 'vitest'
+```ts
+import { assert, test } from 'vitest'
 
-  const isDev = process.env.NODE_ENV === 'development'
+const isDev = process.env.NODE_ENV === 'development'
 
-  test.runIf(isDev)('dev only test', () => {
-    // this test only runs in development
-  })
-  ```
+test.runIf(isDev)('dev only test', () => {
+  // this test only runs in development
+})
+```
 
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
@@ -161,64 +161,64 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 - **Type:** `(name: string | Function, fn: TestFunction, timeout?: number) => void`
 - **Alias:** `it.only`
 
-  Use `test.only` to only run certain tests in a given suite. This is useful when debugging.
+Use `test.only` to only run certain tests in a given suite. This is useful when debugging.
 
-  Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds, and can be configured globally with [testTimeout](/config/#testtimeout).
+Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds, and can be configured globally with [testTimeout](/config/#testtimeout).
 
-  ```ts
-  import { assert, test } from 'vitest'
+```ts
+import { assert, test } from 'vitest'
 
-  test.only('test', () => {
-    // Only this test (and others marked with only) are run
-    assert.equal(Math.sqrt(4), 2)
-  })
-  ```
+test.only('test', () => {
+  // Only this test (and others marked with only) are run
+  assert.equal(Math.sqrt(4), 2)
+})
+```
 
-  Sometimes it is very useful to run `only` tests in a certain file, ignoring all other tests from the whole test suite, which pollute the output.
+Sometimes it is very useful to run `only` tests in a certain file, ignoring all other tests from the whole test suite, which pollute the output.
 
-  In order to do that run `vitest` with specific file containing the tests in question.
-  ```
-  # vitest interesting.test.ts
-  ```
+In order to do that run `vitest` with specific file containing the tests in question.
+```
+# vitest interesting.test.ts
+```
 
 ### test.concurrent
 
 - **Type:** `(name: string | Function, fn: TestFunction, timeout?: number) => void`
 - **Alias:** `it.concurrent`
 
-  `test.concurrent` marks consecutive tests to be run in parallel. It receives the test name, an async function with the tests to collect, and an optional timeout (in milliseconds).
+`test.concurrent` marks consecutive tests to be run in parallel. It receives the test name, an async function with the tests to collect, and an optional timeout (in milliseconds).
 
-  ```ts
-  import { describe, test } from 'vitest'
+```ts
+import { describe, test } from 'vitest'
 
-  // The two tests marked with concurrent will be run in parallel
-  describe('suite', () => {
-    test('serial test', async () => { /* ... */ })
-    test.concurrent('concurrent test 1', async () => { /* ... */ })
-    test.concurrent('concurrent test 2', async () => { /* ... */ })
-  })
-  ```
+// The two tests marked with concurrent will be run in parallel
+describe('suite', () => {
+  test('serial test', async () => { /* ... */ })
+  test.concurrent('concurrent test 1', async () => { /* ... */ })
+  test.concurrent('concurrent test 2', async () => { /* ... */ })
+})
+```
 
-  `test.skip`, `test.only`, and `test.todo` works with concurrent tests. All the following combinations are valid:
+`test.skip`, `test.only`, and `test.todo` works with concurrent tests. All the following combinations are valid:
 
-  ```ts
-  test.concurrent(/* ... */)
-  test.skip.concurrent(/* ... */) // or test.concurrent.skip(/* ... */)
-  test.only.concurrent(/* ... */) // or test.concurrent.only(/* ... */)
-  test.todo.concurrent(/* ... */) // or test.concurrent.todo(/* ... */)
-  ```
+```ts
+test.concurrent(/* ... */)
+test.skip.concurrent(/* ... */) // or test.concurrent.skip(/* ... */)
+test.only.concurrent(/* ... */) // or test.concurrent.only(/* ... */)
+test.todo.concurrent(/* ... */) // or test.concurrent.todo(/* ... */)
+```
 
-  When running concurrent tests, Snapshots and Assertions must use `expect` from the local [Test Context](/guide/test-context.md) to ensure the right test is detected.
+When running concurrent tests, Snapshots and Assertions must use `expect` from the local [Test Context](/guide/test-context.md) to ensure the right test is detected.
 
 
-  ```ts
-  test.concurrent('test 1', async ({ expect }) => {
-    expect(foo).toMatchSnapshot()
-  })
-  test.concurrent('test 2', async ({ expect }) => {
-    expect(foo).toMatchSnapshot()
-  })
-  ```
+```ts
+test.concurrent('test 1', async ({ expect }) => {
+  expect(foo).toMatchSnapshot()
+})
+test.concurrent('test 2', async ({ expect }) => {
+  expect(foo).toMatchSnapshot()
+})
+```
 
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
@@ -229,30 +229,30 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 - **Type:** `(name: string | Function) => void`
 - **Alias:** `it.todo`
 
-  Use `test.todo` to stub tests to be implemented later. An entry will be shown in the report for the tests so you know how many tests you still need to implement.
+Use `test.todo` to stub tests to be implemented later. An entry will be shown in the report for the tests so you know how many tests you still need to implement.
 
-  ```ts
-  // An entry will be shown in the report for this test
-  test.todo('unimplemented test')
-  ```
+```ts
+// An entry will be shown in the report for this test
+test.todo('unimplemented test')
+```
 
 ### test.fails
 
 - **Type:** `(name: string | Function, fn: TestFunction, timeout?: number) => void`
 - **Alias:** `it.fails`
 
-  Use `test.fails` to indicate that an assertion will fail explicitly.
+Use `test.fails` to indicate that an assertion will fail explicitly.
 
-  ```ts
-  import { expect, test } from 'vitest'
+```ts
+import { expect, test } from 'vitest'
 
-  function myAsyncFunc() {
-    return new Promise(resolve => resolve(1))
-  }
-  test.fails('fail test', async () => {
-    await expect(myAsyncFunc()).rejects.toBe(1)
-  })
-  ```
+function myAsyncFunc() {
+  return new Promise(resolve => resolve(1))
+}
+test.fails('fail test', async () => {
+  await expect(myAsyncFunc()).rejects.toBe(1)
+})
+```
 
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
@@ -263,88 +263,87 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 - **Type:** `(cases: ReadonlyArray<T>, ...args: any[]) => void`
 - **Alias:** `it.each`
 
-  Use `test.each` when you need to run the same test with different variables.
-  You can inject parameters with [printf formatting](https://nodejs.org/api/util.html#util_util_format_format_args) in the test name in the order of the test function parameters.
+Use `test.each` when you need to run the same test with different variables.
+You can inject parameters with [printf formatting](https://nodejs.org/api/util.html#util_util_format_format_args) in the test name in the order of the test function parameters.
 
-  - `%s`: string
-  - `%d`: number
-  - `%i`: integer
-  - `%f`: floating point value
-  - `%j`: json
-  - `%o`: object
-  - `%#`: index of the test case
-  - `%%`: single percent sign ('%')
+- `%s`: string
+- `%d`: number
+- `%i`: integer
+- `%f`: floating point value
+- `%j`: json
+- `%o`: object
+- `%#`: index of the test case
+- `%%`: single percent sign ('%')
+
+```ts
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add(%i, %i) -> %i', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})
+
+// this will return
+// ✓ add(1, 1) -> 2
+// ✓ add(1, 2) -> 3
+// ✓ add(2, 1) -> 3
+```
+
+You can also access object properties with `$` prefix, if you are using objects as arguments:
 
   ```ts
   test.each([
-    [1, 1, 2],
-    [1, 2, 3],
-    [2, 1, 3],
-  ])('add(%i, %i) -> %i', (a, b, expected) => {
+    { a: 1, b: 1, expected: 2 },
+    { a: 1, b: 2, expected: 3 },
+    { a: 2, b: 1, expected: 3 },
+  ])('add($a, $b) -> $expected', ({ a, b, expected }) => {
     expect(a + b).toBe(expected)
   })
 
-  // this will return
-  // ✓ add(1, 1) -> 2
-  // ✓ add(1, 2) -> 3
-  // ✓ add(2, 1) -> 3
-  ```
+// this will return
+// ✓ add(1, 1) -> 2
+// ✓ add(1, 2) -> 3
+// ✓ add(2, 1) -> 3
+```
 
-  You can also access object properties with `$` prefix, if you are using objects as arguments:
-
-    ```ts
-    test.each([
-      { a: 1, b: 1, expected: 2 },
-      { a: 1, b: 2, expected: 3 },
-      { a: 2, b: 1, expected: 3 },
-    ])('add($a, $b) -> $expected', ({ a, b, expected }) => {
-      expect(a + b).toBe(expected)
-    })
-
-  // this will return
-  // ✓ add(1, 1) -> 2
-  // ✓ add(1, 2) -> 3
-  // ✓ add(2, 1) -> 3
-  ```
-
-  You can also access Object attributes with `.`, if you are using objects as arguments:
-
-    ```ts
-    test.each`
-    a               | b      | expected
-    ${{ val: 1 }}   | ${'b'} | ${'1b'}
-    ${{ val: 2 }}   | ${'b'} | ${'2b'}
-    ${{ val: 3 }}   | ${'b'} | ${'3b'}
-    `('add($a.val, $b) -> $expected', ({ a, b, expected }) => {
-      expect(a.val + b).toBe(expected)
-    })
-
-    // this will return
-    // ✓ add(1, b) -> 1b
-    // ✓ add(2, b) -> 2b
-    // ✓ add(3, b) -> 3b
-    ```
-
-
-  Starting from Vitest 0.25.3, you can also use template string table.
-
-  * First row should be column names, separated by `|`;
-  * One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
+You can also access Object attributes with `.`, if you are using objects as arguments:
 
   ```ts
   test.each`
-    a               | b      | expected
-    ${1}            | ${1}   | ${2}
-    ${'a'}          | ${'b'} | ${'ab'}
-    ${[]}           | ${'b'} | ${'b'}
-    ${{}}           | ${'b'} | ${'[object Object]b'}
-    ${{ asd: 1 }}   | ${'b'} | ${'[object Object]b'}
-  `('returns $expected when $a is added $b', ({ a, b, expected }) => {
-    expect(a + b).toBe(expected)
+  a               | b      | expected
+  ${{ val: 1 }}   | ${'b'} | ${'1b'}
+  ${{ val: 2 }}   | ${'b'} | ${'2b'}
+  ${{ val: 3 }}   | ${'b'} | ${'3b'}
+  `('add($a.val, $b) -> $expected', ({ a, b, expected }) => {
+    expect(a.val + b).toBe(expected)
   })
+
+  // this will return
+  // ✓ add(1, b) -> 1b
+  // ✓ add(2, b) -> 2b
+  // ✓ add(3, b) -> 3b
   ```
 
-  If you want to have access to `TestContext`, use `describe.each` with a single test.
+Starting from Vitest 0.25.3, you can also use template string table.
+
+* First row should be column names, separated by `|`;
+* One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
+
+```ts
+test.each`
+  a               | b      | expected
+  ${1}            | ${1}   | ${2}
+  ${'a'}          | ${'b'} | ${'ab'}
+  ${[]}           | ${'b'} | ${'b'}
+  ${{}}           | ${'b'} | ${'[object Object]b'}
+  ${{ asd: 1 }}   | ${'b'} | ${'[object Object]b'}
+`('returns $expected when $a is added $b', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected)
+})
+```
+
+If you want to have access to `TestContext`, use `describe.each` with a single test.
 
 ::: tip
 Vitest processes `$values` with chai `format` method. If the value is too truncated, you can increase [chaiConfig.truncateThreshold](/config/#chaiconfig-truncatethreshold) in your config file.
@@ -362,64 +361,64 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 
 Vitest uses [`tinybench`](https://github.com/tinylibs/tinybench) library under the hood, inheriting all its options that can be used as a third argument.
 
-  ```ts
-  import { bench } from 'vitest'
+```ts
+import { bench } from 'vitest'
 
-  bench('normal sorting', () => {
-    const x = [1, 5, 4, 2, 3]
-    x.sort((a, b) => {
-      return a - b
-    })
-  }, { time: 1000 })
-  ```
+bench('normal sorting', () => {
+  const x = [1, 5, 4, 2, 3]
+  x.sort((a, b) => {
+    return a - b
+  })
+}, { time: 1000 })
+```
 
-  ```ts
-  export interface Options {
-    /**
-     * time needed for running a benchmark task (milliseconds)
-     * @default 500
-     */
-    time?: number
+```ts
+export interface Options {
+  /**
+   * time needed for running a benchmark task (milliseconds)
+   * @default 500
+   */
+  time?: number
 
-    /**
-     * number of times that a task should run if even the time option is finished
-     * @default 10
-     */
-    iterations?: number
+  /**
+   * number of times that a task should run if even the time option is finished
+   * @default 10
+   */
+  iterations?: number
 
-    /**
-     * function to get the current timestamp in milliseconds
-     */
-    now?: () => number
+  /**
+   * function to get the current timestamp in milliseconds
+   */
+  now?: () => number
 
-    /**
-     * An AbortSignal for aborting the benchmark
-     */
-    signal?: AbortSignal
+  /**
+   * An AbortSignal for aborting the benchmark
+   */
+  signal?: AbortSignal
 
-    /**
-     * warmup time (milliseconds)
-     * @default 100ms
-     */
-    warmupTime?: number
+  /**
+   * warmup time (milliseconds)
+   * @default 100ms
+   */
+  warmupTime?: number
 
-    /**
-     * warmup iterations
-     * @default 5
-     */
-    warmupIterations?: number
+  /**
+   * warmup iterations
+   * @default 5
+   */
+  warmupIterations?: number
 
-    /**
-     * setup function to run before each benchmark task (cycle)
-     */
-    setup?: Hook
+  /**
+   * setup function to run before each benchmark task (cycle)
+   */
+  setup?: Hook
 
-    /**
-     * teardown function to run after each benchmark task (cycle)
-     */
-    teardown?: Hook
-  }
-  ```
+  /**
+   * teardown function to run after each benchmark task (cycle)
+   */
+  teardown?: Hook
+}
+```
 
 ### bench.skip
 
@@ -427,16 +426,16 @@ Vitest uses [`tinybench`](https://github.com/tinylibs/tinybench) library under t
 
 You can use `bench.skip` syntax to skip running certain benchmarks.
 
-  ```ts
-  import { bench } from 'vitest'
+```ts
+import { bench } from 'vitest'
 
-  bench.skip('normal sorting', () => {
-    const x = [1, 5, 4, 2, 3]
-    x.sort((a, b) => {
-      return a - b
-    })
+bench.skip('normal sorting', () => {
+  const x = [1, 5, 4, 2, 3]
+  x.sort((a, b) => {
+    return a - b
   })
-  ```
+})
+```
 
 ### bench.only
 
@@ -444,16 +443,16 @@ You can use `bench.skip` syntax to skip running certain benchmarks.
 
 Use `bench.only` to only run certain benchmarks in a given suite. This is useful when debugging.
 
-  ```ts
-  import { bench } from 'vitest'
+```ts
+import { bench } from 'vitest'
 
-  bench.only('normal sorting', () => {
-    const x = [1, 5, 4, 2, 3]
-    x.sort((a, b) => {
-      return a - b
-    })
+bench.only('normal sorting', () => {
+  const x = [1, 5, 4, 2, 3]
+  x.sort((a, b) => {
+    return a - b
   })
-  ```
+})
+```
 
 ### bench.todo
 
@@ -461,124 +460,124 @@ Use `bench.only` to only run certain benchmarks in a given suite. This is useful
 
 Use `bench.todo` to stub benchmarks to be implemented later.
 
-  ```ts
-  import { bench } from 'vitest'
+```ts
+import { bench } from 'vitest'
 
-  bench.todo('unimplemented test')
-  ```
+bench.todo('unimplemented test')
+```
 
 ## describe
 
 When you use `test` or `bench` in the top level of file, they are collected as part of the implicit suite for it. Using `describe` you can define a new suite in the current context, as a set of related tests or benchmarks and other nested suites. A suite lets you organize your tests and benchmarks so reports are more clear.
 
-  ```ts
-  // basic.spec.ts
-  // organizing tests
+```ts
+// basic.spec.ts
+// organizing tests
 
-  import { describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
-  const person = {
-    isActive: true,
-    age: 32,
-  }
+const person = {
+  isActive: true,
+  age: 32,
+}
 
-  describe('person', () => {
-    test('person is defined', () => {
-      expect(person).toBeDefined()
-    })
+describe('person', () => {
+  test('person is defined', () => {
+    expect(person).toBeDefined()
+  })
 
-    test('is active', () => {
-      expect(person.isActive).toBeTruthy()
-    })
+  test('is active', () => {
+    expect(person.isActive).toBeTruthy()
+  })
 
-    test('age limit', () => {
-      expect(person.age).toBeLessThanOrEqual(32)
+  test('age limit', () => {
+    expect(person.age).toBeLessThanOrEqual(32)
+  })
+})
+```
+
+```ts
+// basic.bench.ts
+// organizing benchmarks
+
+import { bench, describe } from 'vitest'
+
+describe('sort', () => {
+  bench('normal', () => {
+    const x = [1, 5, 4, 2, 3]
+    x.sort((a, b) => {
+      return a - b
     })
   })
-  ```
 
-  ```ts
-  // basic.bench.ts
-  // organizing benchmarks
-
-  import { bench, describe } from 'vitest'
-
-  describe('sort', () => {
-    bench('normal', () => {
-      const x = [1, 5, 4, 2, 3]
-      x.sort((a, b) => {
-        return a - b
-      })
-    })
-
-    bench('reverse', () => {
-      const x = [1, 5, 4, 2, 3]
-      x.reverse().sort((a, b) => {
-        return a - b
-      })
+  bench('reverse', () => {
+    const x = [1, 5, 4, 2, 3]
+    x.reverse().sort((a, b) => {
+      return a - b
     })
   })
-  ```
+})
+```
 
-  You can also nest describe blocks if you have a hierarchy of tests or benchmarks:
+You can also nest describe blocks if you have a hierarchy of tests or benchmarks:
 
-  ```ts
-  import { describe, expect, test } from 'vitest'
+```ts
+import { describe, expect, test } from 'vitest'
 
-  function numberToCurrency(value) {
-    if (typeof value !== 'number')
-      throw new Error('Value must be a number')
+function numberToCurrency(value) {
+  if (typeof value !== 'number')
+    throw new Error('Value must be a number')
 
-    return value.toFixed(2).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-  }
+  return value.toFixed(2).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
 
-  describe('numberToCurrency', () => {
-    describe('given an invalid number', () => {
-      test('composed of non-numbers to throw error', () => {
-        expect(() => numberToCurrency('abc')).toThrowError()
-      })
-    })
-
-    describe('given a valid number', () => {
-      test('returns the correct currency format', () => {
-        expect(numberToCurrency(10000)).toBe('10,000.00')
-      })
+describe('numberToCurrency', () => {
+  describe('given an invalid number', () => {
+    test('composed of non-numbers to throw error', () => {
+      expect(() => numberToCurrency('abc')).toThrowError()
     })
   })
-  ```
+
+  describe('given a valid number', () => {
+    test('returns the correct currency format', () => {
+      expect(numberToCurrency(10000)).toBe('10,000.00')
+    })
+  })
+})
+```
 
 ### describe.skip
 
 - **Type:** `(name: string | Function, fn: TestFunction, options?: number | TestOptions) => void`
 
-  Use `describe.skip` in a suite to avoid running a particular describe block.
+Use `describe.skip` in a suite to avoid running a particular describe block.
 
-  ```ts
-  import { assert, describe, test } from 'vitest'
+```ts
+import { assert, describe, test } from 'vitest'
 
-  describe.skip('skipped suite', () => {
-    test('sqrt', () => {
-      // Suite skipped, no error
-      assert.equal(Math.sqrt(4), 3)
-    })
+describe.skip('skipped suite', () => {
+  test('sqrt', () => {
+    // Suite skipped, no error
+    assert.equal(Math.sqrt(4), 3)
   })
-  ```
+})
+```
 
 ### describe.skipIf
 
 - **Type:** `(condition: any) => void`
 
-  In some cases, you might run suites multiple times with different environments, and some of the suites might be environment-specific. Instead of wrapping the suite with `if`, you can use `describe.skipIf` to skip the suite whenever the condition is truthy.
+In some cases, you might run suites multiple times with different environments, and some of the suites might be environment-specific. Instead of wrapping the suite with `if`, you can use `describe.skipIf` to skip the suite whenever the condition is truthy.
 
-  ```ts
-  import { describe, test } from 'vitest'
+```ts
+import { describe, test } from 'vitest'
 
-  const isDev = process.env.NODE_ENV === 'development'
+const isDev = process.env.NODE_ENV === 'development'
 
-  describe.skipIf(isDev)('prod only test', () => {
-    // this test only runs in production
-  })
-  ```
+describe.skipIf(isDev)('prod only test', () => {
+  // this test only runs in production
+})
+```
 
 ::: warning
 You cannot use this syntax when using Vitest as [type checker](/guide/testing-types).
@@ -588,65 +587,65 @@ You cannot use this syntax when using Vitest as [type checker](/guide/testing-ty
 
 - **Type:** `(name: string | Function, fn: TestFunction, options?: number | TestOptions) => void`
 
-  Use `describe.only` to only run certain suites
+Use `describe.only` to only run certain suites
 
-  ```ts
-  // Only this suite (and others marked with only) are run
-  describe.only('suite', () => {
-    test('sqrt', () => {
-      assert.equal(Math.sqrt(4), 3)
-    })
+```ts
+// Only this suite (and others marked with only) are run
+describe.only('suite', () => {
+  test('sqrt', () => {
+    assert.equal(Math.sqrt(4), 3)
   })
+})
 
-  describe('other suite', () => {
-    // ... will be skipped
-  })
-  ```
+describe('other suite', () => {
+  // ... will be skipped
+})
+```
 
-  Sometimes it is very useful to run `only` tests in a certain file, ignoring all other tests from the whole test suite, which pollute the output.
+Sometimes it is very useful to run `only` tests in a certain file, ignoring all other tests from the whole test suite, which pollute the output.
 
-  In order to do that run `vitest` with specific file containing the tests in question.
-  ```
-  # vitest interesting.test.ts
-  ```
+In order to do that run `vitest` with specific file containing the tests in question.
+```
+# vitest interesting.test.ts
+```
 
 ### describe.concurrent
 
 - **Type:** `(name: string | Function, fn: TestFunction, options?: number | TestOptions) => void`
 
-  `describe.concurrent` in a suite marks every tests as concurrent
+`describe.concurrent` in a suite marks every tests as concurrent
 
-  ```ts
-  // All tests within this suite will be run in parallel
-  describe.concurrent('suite', () => {
-    test('concurrent test 1', async () => { /* ... */ })
-    test('concurrent test 2', async () => { /* ... */ })
-    test.concurrent('concurrent test 3', async () => { /* ... */ })
-  })
-  ```
+```ts
+// All tests within this suite will be run in parallel
+describe.concurrent('suite', () => {
+  test('concurrent test 1', async () => { /* ... */ })
+  test('concurrent test 2', async () => { /* ... */ })
+  test.concurrent('concurrent test 3', async () => { /* ... */ })
+})
+```
 
-  `.skip`, `.only`, and `.todo` works with concurrent suites. All the following combinations are valid:
+`.skip`, `.only`, and `.todo` works with concurrent suites. All the following combinations are valid:
 
-  ```ts
-  describe.concurrent(/* ... */)
-  describe.skip.concurrent(/* ... */) // or describe.concurrent.skip(/* ... */)
-  describe.only.concurrent(/* ... */) // or describe.concurrent.only(/* ... */)
-  describe.todo.concurrent(/* ... */) // or describe.concurrent.todo(/* ... */)
-  ```
+```ts
+describe.concurrent(/* ... */)
+describe.skip.concurrent(/* ... */) // or describe.concurrent.skip(/* ... */)
+describe.only.concurrent(/* ... */) // or describe.concurrent.only(/* ... */)
+describe.todo.concurrent(/* ... */) // or describe.concurrent.todo(/* ... */)
+```
 
 When running concurrent tests, Snapshots and Assertions must use `expect` from the local [Test Context](/guide/test-context.md) to ensure the right test is detected.
 
-
-  ```ts
-  describe.concurrent('suite', () => {
-    test('concurrent test 1', async ({ expect }) => {
-      expect(foo).toMatchSnapshot()
-    })
-    test('concurrent test 2', async ({ expect }) => {
-      expect(foo).toMatchSnapshot()
-    })
+```ts
+describe.concurrent('suite', () => {
+  test('concurrent test 1', async ({ expect }) => {
+    expect(foo).toMatchSnapshot()
   })
-  ```
+  test('concurrent test 2', async ({ expect }) => {
+    expect(foo).toMatchSnapshot()
+  })
+})
+```
+
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
 :::
@@ -655,34 +654,34 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 
 - **Type:** `(name: string | Function, fn: TestFunction, options?: number | TestOptions) => void`
 
-  `describe.sequential` in a suite marks every test as sequential. This is useful if you want to run tests in sequential within `describe.concurrent` or with the `--sequence.concurrent` command option.
+`describe.sequential` in a suite marks every test as sequential. This is useful if you want to run tests in sequential within `describe.concurrent` or with the `--sequence.concurrent` command option.
 
-  ```ts
-  describe.concurrent('suite', () => {
-    test('concurrent test 1', async () => { /* ... */ })
-    test('concurrent test 2', async () => { /* ... */ })
+```ts
+describe.concurrent('suite', () => {
+  test('concurrent test 1', async () => { /* ... */ })
+  test('concurrent test 2', async () => { /* ... */ })
 
-    describe.sequential('', () => {
-      test('sequential test 1', async () => { /* ... */ })
-      test('sequential test 2', async () => { /* ... */ })
-    })
+  describe.sequential('', () => {
+    test('sequential test 1', async () => { /* ... */ })
+    test('sequential test 2', async () => { /* ... */ })
   })
-  ```
+})
+```
 
 ### describe.shuffle
 
 - **Type:** `(name: string | Function, fn: TestFunction, options?: number | TestOptions) => void`
 
-  Vitest provides a way to run all tests in random order via CLI flag [`--sequence.shuffle`](/guide/cli) or config option [`sequence.shuffle`](/config/#sequence-shuffle), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
+Vitest provides a way to run all tests in random order via CLI flag [`--sequence.shuffle`](/guide/cli) or config option [`sequence.shuffle`](/config/#sequence-shuffle), but if you want to have only part of your test suite to run tests in random order, you can mark it with this flag.
 
-  ```ts
-  describe.shuffle('suite', () => {
-    test('random test 1', async () => { /* ... */ })
-    test('random test 2', async () => { /* ... */ })
-    test('random test 3', async () => { /* ... */ })
-  })
-  // order depends on sequence.seed option in config (Date.now() by default)
-  ```
+```ts
+describe.shuffle('suite', () => {
+  test('random test 1', async () => { /* ... */ })
+  test('random test 2', async () => { /* ... */ })
+  test('random test 3', async () => { /* ... */ })
+})
+// order depends on sequence.seed option in config (Date.now() by default)
+```
 
 `.skip`, `.only`, and `.todo` works with random suites.
 
@@ -694,58 +693,58 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 
 - **Type:** `(name: string | Function) => void`
 
-  Use `describe.todo` to stub suites to be implemented later. An entry will be shown in the report for the tests so you know how many tests you still need to implement.
+Use `describe.todo` to stub suites to be implemented later. An entry will be shown in the report for the tests so you know how many tests you still need to implement.
 
-  ```ts
-  // An entry will be shown in the report for this suite
-  describe.todo('unimplemented suite')
-  ```
+```ts
+// An entry will be shown in the report for this suite
+describe.todo('unimplemented suite')
+```
 
 ### describe.each
 
 - **Type:** `(cases: ReadonlyArray<T>, ...args: any[]): (name: string | Function, fn: (...args: T[]) => void, options?: number | TestOptions) => void`
 
-  Use `describe.each` if you have more than one test that depends on the same data.
+Use `describe.each` if you have more than one test that depends on the same data.
 
-  ```ts
-  describe.each([
-    { a: 1, b: 1, expected: 2 },
-    { a: 1, b: 2, expected: 3 },
-    { a: 2, b: 1, expected: 3 },
-  ])('describe object add($a, $b)', ({ a, b, expected }) => {
-    test(`returns ${expected}`, () => {
-      expect(a + b).toBe(expected)
-    })
-
-    test(`returned value not be greater than ${expected}`, () => {
-      expect(a + b).not.toBeGreaterThan(expected)
-    })
-
-    test(`returned value not be less than ${expected}`, () => {
-      expect(a + b).not.toBeLessThan(expected)
-    })
+```ts
+describe.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('describe object add($a, $b)', ({ a, b, expected }) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected)
   })
-  ```
 
-  Starting from Vitest 0.25.3, you can also use template string table.
-
-  * First row should be column names, separated by `|`;
-  * One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
-
-  ```ts
-  describe.each`
-    a               | b      | expected
-    ${1}            | ${1}   | ${2}
-    ${'a'}          | ${'b'} | ${'ab'}
-    ${[]}           | ${'b'} | ${'b'}
-    ${{}}           | ${'b'} | ${'[object Object]b'}
-    ${{ asd: 1 }}   | ${'b'} | ${'[object Object]b'}
-  `('describe template string add($a, $b)', ({ a, b, expected }) => {
-    test(`returns ${expected}`, () => {
-      expect(a + b).toBe(expected)
-    })
+  test(`returned value not be greater than ${expected}`, () => {
+    expect(a + b).not.toBeGreaterThan(expected)
   })
-  ```
+
+  test(`returned value not be less than ${expected}`, () => {
+    expect(a + b).not.toBeLessThan(expected)
+  })
+})
+```
+
+Starting from Vitest 0.25.3, you can also use template string table.
+
+* First row should be column names, separated by `|`;
+* One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
+
+```ts
+describe.each`
+  a               | b      | expected
+  ${1}            | ${1}   | ${2}
+  ${'a'}          | ${'b'} | ${'ab'}
+  ${[]}           | ${'b'} | ${'b'}
+  ${{}}           | ${'b'} | ${'[object Object]b'}
+  ${{ asd: 1 }}   | ${'b'} | ${'[object Object]b'}
+`('describe template string add($a, $b)', ({ a, b, expected }) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected)
+  })
+})
+```
 
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
@@ -759,107 +758,108 @@ These functions allow you to hook into the life cycle of tests to avoid repeatin
 
 - **Type:** `beforeEach(fn: () => Awaitable<void>, timeout?: number)`
 
-  Register a callback to be called before each of the tests in the current context runs.
-  If the function returns a promise, Vitest waits until the promise resolve before running the test.
+Register a callback to be called before each of the tests in the current context runs.
+If the function returns a promise, Vitest waits until the promise resolve before running the test.
 
-  Optionally, you can pass a timeout (in milliseconds) defining how long to wait before terminating. The default is 5 seconds.
+Optionally, you can pass a timeout (in milliseconds) defining how long to wait before terminating. The default is 5 seconds.
 
-  ```ts
-  import { beforeEach } from 'vitest'
+```ts
+import { beforeEach } from 'vitest'
 
-  beforeEach(async () => {
-    // Clear mocks and add some testing data after before each test run
-    await stopMocking()
-    await addUser({ name: 'John' })
-  })
-  ```
+beforeEach(async () => {
+  // Clear mocks and add some testing data after before each test run
+  await stopMocking()
+  await addUser({ name: 'John' })
+})
+```
 
-  Here, the `beforeEach` ensures that user is added for each test.
+Here, the `beforeEach` ensures that user is added for each test.
 
-  Since Vitest v0.10.0, `beforeEach` also accepts an optional cleanup function (equivalent to `afterEach`).
+Since Vitest v0.10.0, `beforeEach` also accepts an optional cleanup function (equivalent to `afterEach`).
 
-  ```ts
-  import { beforeEach } from 'vitest'
+```ts
+import { beforeEach } from 'vitest'
 
-  beforeEach(async () => {
-    // called once before each test run
-    await prepareSomething()
+beforeEach(async () => {
+  // called once before each test run
+  await prepareSomething()
 
-    // clean up function, called once after each test run
-    return async () => {
-      await resetSomething()
-    }
-  })
-  ```
+  // clean up function, called once after each test run
+  return async () => {
+    await resetSomething()
+  }
+})
+```
 
 ### afterEach
 
 - **Type:** `afterEach(fn: () => Awaitable<void>, timeout?: number)`
 
-  Register a callback to be called after each one of the tests in the current context completes.
-  If the function returns a promise, Vitest waits until the promise resolve before continuing.
+Register a callback to be called after each one of the tests in the current context completes.
+If the function returns a promise, Vitest waits until the promise resolve before continuing.
 
-  Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds.
+Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds.
 
-  ```ts
-  import { afterEach } from 'vitest'
+```ts
+import { afterEach } from 'vitest'
 
-  afterEach(async () => {
-    await clearTestingData() // clear testing data after each test run
-  })
-  ```
-  Here, the `afterEach` ensures that testing data is cleared after each test runs.
+afterEach(async () => {
+  await clearTestingData() // clear testing data after each test run
+})
+```
+
+Here, the `afterEach` ensures that testing data is cleared after each test runs.
 
 ### beforeAll
 
 - **Type:** `beforeAll(fn: () => Awaitable<void>, timeout?: number)`
 
-  Register a callback to be called once before starting to run all tests in the current context.
-  If the function returns a promise, Vitest waits until the promise resolve before running tests.
+Register a callback to be called once before starting to run all tests in the current context.
+If the function returns a promise, Vitest waits until the promise resolve before running tests.
 
-  Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds.
+Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds.
 
-  ```ts
-  import { beforeAll } from 'vitest'
+```ts
+import { beforeAll } from 'vitest'
 
-  beforeAll(async () => {
-    await startMocking() // called once before all tests run
-  })
-  ```
+beforeAll(async () => {
+  await startMocking() // called once before all tests run
+})
+```
 
-  Here the `beforeAll` ensures that the mock data is set up before tests run.
+Here the `beforeAll` ensures that the mock data is set up before tests run.
 
-  Since Vitest v0.10.0, `beforeAll` also accepts an optional cleanup function (equivalent to `afterAll`).
+Since Vitest v0.10.0, `beforeAll` also accepts an optional cleanup function (equivalent to `afterAll`).
 
-  ```ts
-  import { beforeAll } from 'vitest'
+```ts
+import { beforeAll } from 'vitest'
 
-  beforeAll(async () => {
-    // called once before all tests run
-    await startMocking()
+beforeAll(async () => {
+  // called once before all tests run
+  await startMocking()
 
-    // clean up function, called once after all tests run
-    return async () => {
-      await stopMocking()
-    }
-  })
-  ```
+  // clean up function, called once after all tests run
+  return async () => {
+    await stopMocking()
+  }
+})
+```
 
 ### afterAll
 
 - **Type:** `afterAll(fn: () => Awaitable<void>, timeout?: number)`
 
-  Register a callback to be called once after all tests have run in the current context.
-  If the function returns a promise, Vitest waits until the promise resolve before continuing.
+Register a callback to be called once after all tests have run in the current context.
+If the function returns a promise, Vitest waits until the promise resolve before continuing.
 
-  Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds.
+Optionally, you can provide a timeout (in milliseconds) for specifying how long to wait before terminating. The default is 5 seconds.
 
-  ```ts
-  import { afterAll } from 'vitest'
+```ts
+import { afterAll } from 'vitest'
 
-  afterAll(async () => {
-    await stopMocking() // this method is called after all tests run
-  })
-  ```
+afterAll(async () => {
+  await stopMocking() // this method is called after all tests run
+})
+```
 
-  Here the `afterAll` ensures that `stopMocking` method is called after all tests run.
+Here the `afterAll` ensures that `stopMocking` method is called after all tests run.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -84,7 +84,7 @@ export default defineConfig({
 
 ### Types
 
-Vitest doesn't expose a lot of types on `Vi` namespace, it exists mainly for compatibility with matchers, so you might need to import types directly from `vitest` instead of relying on `Vi` namespace:
+Vitest doesn't have an equivalent to `jest` namespace, so you will need to import types directly from `vitest`:
 
 ```ts
 let fn: jest.Mock<string, [string]> // [!code --]


### PR DESCRIPTION
### Description

This PR makes every page in documentation consistent by removing extra spaces before _some_ paragraphs. This PR doesn't have any other changes (except removing one comment in the docs).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
