### PR TITLE
fix(coverage): exclude files and directories starting with dot by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1043,6 +1043,7 @@ List of files included in coverage as glob patterns
 [
   'coverage/**',
   'dist/**',
+  '**/[.]**',
   'packages/*/test?(s)/**',
   '**/*.d.ts',
   '**/virtual:*',

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -13,6 +13,7 @@ export const benchmarkConfigDefaults: Required<Omit<BenchmarkUserOptions, 'outpu
 const defaultCoverageExcludes = [
   'coverage/**',
   'dist/**',
+  '**/[.]**',
   'packages/*/test?(s)/**',
   '**/*.d.ts',
   '**/virtual:*',

--- a/test/coverage-test/coverage-report-tests/generic.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/generic.report.test.ts
@@ -35,6 +35,11 @@ test('all includes untested files', () => {
   const files = fs.readdirSync(coveragePath)
 
   expect(files).toContain('untested-file.ts.html')
+
+  // Directories starting with dot should be excluded
+  expect(files).not.toContain('.should-be-excluded-from-coverage/excluded-from-coverage.ts.html')
+  expect(files).not.toContain('.should-be-excluded-from-coverage')
+  expect(files).not.toContain('excluded-from-coverage.ts.html')
 })
 
 test('files should not contain query parameters', () => {

--- a/test/coverage-test/src/.should-be-excluded-from-coverage/excluded-from-coverage.ts
+++ b/test/coverage-test/src/.should-be-excluded-from-coverage/excluded-from-coverage.ts
@@ -1,0 +1,5 @@
+// This file should be excluded from coverage report
+
+export function uncoveredFile() {
+  return 0
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
Exclude files and directories that start with `.` from coverage reports by default. 

I just ran into out-of-memory error when using `vite-plugin-inspect` and had `provider: 'istanbul'` enabled. As `coverage.all` picks all included untested files, it picked 4MB JS file `.vite-inspect/assets/index-<hash>.js` and run into OOM while trying to instrument that file. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
