### PR TITLE
fix: don't expand snapshot diff by default

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -96,6 +96,7 @@ Run only [benchmark](https://vitest.dev/guide/features.html#benchmarking-experim
 | `--inspect-brk` | Enables Node.js inspector with break |
 | `--bail <number>` | Stop test execution when given number of tests have failed |
 | `--retry <times>` | Retry the test specific number of times if it fails |
+| `--expand-snapshot-diff` | Show full diff when snapshot fails |
 | `--typecheck [options]` | Custom options for typecheck pool. If passed without options, enables typechecking |
 | `--typecheck.enabled` | Enable typechecking alongside tests (default: `false`) |
 | `--typecheck.only` | Run only typecheck tests. This automatically enables typecheck (default: `false`) |

--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -3,7 +3,7 @@ import SnapshotState from './port/state'
 import type { SnapshotStateOptions } from './types'
 import type { RawSnapshotInfo } from './port/rawSnapshot'
 
-function createMismatchError(message: string, actual: unknown, expected: unknown) {
+function createMismatchError(message: string, expand: boolean | undefined, actual: unknown, expected: unknown) {
   const error = new Error(message)
   Object.defineProperty(error, 'actual', {
     value: actual,
@@ -17,6 +17,7 @@ function createMismatchError(message: string, actual: unknown, expected: unknown
     configurable: true,
     writable: true,
   })
+  Object.defineProperty(error, 'diffOptions', { value: { expand } })
   return error
 }
 
@@ -109,7 +110,7 @@ export class SnapshotClient {
         const pass = this.options.isEqual?.(received, properties) ?? false
         // const pass = equals(received, properties, [iterableEquality, subsetEquality])
         if (!pass)
-          throw createMismatchError('Snapshot properties mismatched', received, properties)
+          throw createMismatchError('Snapshot properties mismatched', this.snapshotState?.expand, received, properties)
         else
           received = deepMergeSnapshot(received, properties)
       }
@@ -136,7 +137,7 @@ export class SnapshotClient {
     })
 
     if (!pass)
-      throw createMismatchError(`Snapshot \`${key || 'unknown'}\` mismatched`, actual?.trim(), expected?.trim())
+      throw createMismatchError(`Snapshot \`${key || 'unknown'}\` mismatched`, this.snapshotState?.expand, actual?.trim(), expected?.trim())
   }
 
   async assertRaw(options: AssertOptions): Promise<void> {

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -106,7 +106,7 @@ export function processError(err: any, diffOptions?: DiffOptions) {
     const clonedExpected = deepClone(err.expected, { forceWritable: true })
 
     const { replacedActual, replacedExpected } = replaceAsymmetricMatcher(clonedActual, clonedExpected)
-    err.diff = diff(replacedExpected, replacedActual, diffOptions)
+    err.diff = diff(replacedExpected, replacedActual, { ...diffOptions, ...err.diffOptions })
   }
 
   if (typeof err.expected !== 'string')

--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -51,6 +51,7 @@ cli
   .option('--bail <number>', 'Stop test execution when given number of tests have failed', { default: 0 })
   .option('--retry <times>', 'Retry the test specific number of times if it fails', { default: 0 })
   .option('--diff <path>', 'Path to a diff config that will be used to generate diff interface')
+  .option('--expand-snapshot-diff', 'Show full diff when snapshot fails')
   .option('--typecheck [options]', 'Custom options for typecheck pool')
   .option('--typecheck.enabled', 'Enable typechecking alongside tests (default: false)')
   .option('--typecheck.only', 'Run only typecheck tests. This automatically enables typecheck (default: false)')

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -209,6 +209,7 @@ export function resolveConfig(
 
   const UPDATE_SNAPSHOT = resolved.update || process.env.UPDATE_SNAPSHOT
   resolved.snapshotOptions = {
+    expand: resolved.expandSnapshotDiff ?? false,
     snapshotFormat: resolved.snapshotFormat || {},
     updateSnapshot: (isCI && !UPDATE_SNAPSHOT)
       ? 'none'

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -711,6 +711,11 @@ export interface UserConfig extends InlineConfig {
    * @example --shard=2/3
    */
   shard?: string
+
+  /**
+   * Show full diff when snapshot fails instead of a patch.
+   */
+  expandSnapshotDiff?: boolean
 }
 
 export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'browser' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'benchmark' | 'shard' | 'cache' | 'sequence' | 'typecheck' | 'runner' | 'poolOptions' | 'pool'> {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -633,6 +633,11 @@ export interface InlineConfig {
    * @default 0
   */
   retry?: number
+
+  /**
+   * Show full diff when snapshot fails instead of a patch.
+   */
+  expandSnapshotDiff?: boolean
 }
 
 export interface TypecheckConfig {
@@ -711,11 +716,6 @@ export interface UserConfig extends InlineConfig {
    * @example --shard=2/3
    */
   shard?: string
-
-  /**
-   * Show full diff when snapshot fails instead of a patch.
-   */
-  expandSnapshotDiff?: boolean
 }
 
 export interface ResolvedConfig extends Omit<Required<UserConfig>, 'config' | 'filters' | 'browser' | 'coverage' | 'testNamePattern' | 'related' | 'api' | 'reporters' | 'resolveSnapshotPath' | 'benchmark' | 'shard' | 'cache' | 'sequence' | 'typecheck' | 'runner' | 'poolOptions' | 'pool'> {


### PR DESCRIPTION
### Description

Currently very long snapshots take a lot of space to display their diff even if there is only one change. This PR makes it so snapshots only show a small patch that actually changed. To allow restoring previous behaviour, the `--expand-snapshot-diff` flag is introduced.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
