### PR TITLE
docs: fix incorrect instructions for avoiding in-source tests in production builds

### DIFF
--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -52,19 +52,18 @@ $ npx vitest
 
 ## Production build
 
-For the production build, you will need to set the `define` options in your config file, letting the bundler do the dead code elimination. For example, in Vite
+For the production build, you will need to set the `define` options in your _main_ config file, letting the bundler do the dead code elimination. For example, in Vite
 
 ```ts
-// vitest.config.ts
-import { defineConfig } from 'vitest/config'
+// vite.config.ts
+import { defineConfig } from 'vite';
 
-export default defineConfig({
-  define: { // [!code ++]
-    'import.meta.vitest': 'undefined', // [!code ++]
-  }, // [!code ++]
-  test: {
-    includeSource: ['src/**/*.{js,ts}']
-  },
+export default defineConfig(({ command, mode }) => {
+  return {
+    define: { // [!code ++]
+      'import.meta.vitest': 'undefined', // [!code ++]
+    }, // [!code ++]
+  }
 })
 ```
 

--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -34,12 +34,13 @@ if (import.meta.vitest) {
 Update the `includeSource` config for Vitest to grab the files under `src/`:
 
 ```ts
-// vitest.config.ts
-import { defineConfig } from 'vitest/config'
+// vite.config.ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
 
 export default defineConfig({
   test: {
-    includeSource: ['src/**/*.{js,ts}'],
+    includeSource: ['src/**/*.{js,ts}'], // [!code ++]
   },
 })
 ```
@@ -52,18 +53,20 @@ $ npx vitest
 
 ## Production build
 
-For the production build, you will need to set the `define` options in your _main_ config file, letting the bundler do the dead code elimination. For example, in Vite
+For the production build, you will need to set the `define` options in your config file, letting the bundler do the dead code elimination. For example, in Vite
 
 ```ts
 // vite.config.ts
-import { defineConfig } from 'vite';
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
 
-export default defineConfig(({ command, mode }) => {
-  return {
-    define: { // [!code ++]
-      'import.meta.vitest': 'undefined', // [!code ++]
-    }, // [!code ++]
-  }
+export default defineConfig({
+  test: {
+    includeSource: ['src/**/*.{js,ts}'],
+  },
+  define: { // [!code ++]
+    'import.meta.vitest': 'undefined', // [!code ++]
+  }, // [!code ++]
 })
 ```
 


### PR DESCRIPTION
### Description

The following configuration needs to be in `vite.config.ts` instead of `vitest.config.ts`, otherwise it has no effect and the in-source unit tests are included in the production build.

```ts
define: {
  'import.meta.vitest': 'undefined', // prevent unit tests from being included in other builds
},
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
