### PR TITLE
fix: handle errors thrown in fixtures

### DIFF
--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -118,7 +118,7 @@ export function withFixtures(fn: Function, testContext?: TestContext) {
           return isFn ? value(context, use) : use(value)
       }
 
-      const setupFixturePromise = next()
+      const setupFixturePromise = next().catch(reject)
       cleanupFnArray.unshift(() => setupFixturePromise)
     })
   }

--- a/test/fails/fixtures/test-extend/fixture-error.test.ts
+++ b/test/fails/fixtures/test-extend/fixture-error.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expectTypeOf, test } from 'vitest'
+
+describe('error thrown in beforeEach fixtures', () => {
+  const myTest = test.extend<{ a: never }>({
+    a: async () => {
+      throw new Error('Error thrown in beforeEach fixture')
+    },
+  })
+
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  beforeEach<{ a: never }>(({ a }) => {})
+
+  myTest('error is handled', () => {})
+})
+
+describe('error thrown in afterEach fixtures', () => {
+  const myTest = test.extend<{ a: never }>({
+    a: async () => {
+      throw new Error('Error thrown in afterEach fixture')
+    },
+  })
+
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  afterEach<{ a: never }>(({ a }) => {})
+
+  myTest('fixture errors', () => {
+    expectTypeOf(1).toEqualTypeOf<number>()
+  })
+})
+
+describe('error thrown in test fixtures', () => {
+  const myTest = test.extend<{ a: never }>({
+    a: async () => {
+      throw new Error('Error thrown in test fixture')
+    },
+  })
+
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  myTest('fixture errors', ({ a }) => {})
+})

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -42,6 +42,12 @@ TypeError: failure"
 
 exports[`should fail test-extend/circular-dependency.test.ts > test-extend/circular-dependency.test.ts 1`] = `"Error: circular fixture dependency"`;
 
+exports[`should fail test-extend/fixture-error.test.ts > test-extend/fixture-error.test.ts 1`] = `
+"Error: Error thrown in test fixture
+Error: Error thrown in afterEach fixture
+Error: Error thrown in beforeEach fixture"
+`;
+
 exports[`should fail test-extend/fixture-rest-params.test.ts > test-extend/fixture-rest-params.test.ts 1`] = `"Error: the first argument must use object destructuring pattern"`;
 
 exports[`should fail test-extend/fixture-rest-props.test.ts > test-extend/fixture-rest-props.test.ts 1`] = `"Error: Rest parameters are not supported"`;


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes https://github.com/vitest-dev/vitest/issues/4435

When running a test with a fixture function that throws an error, the error is not handled by the test runner and the test times out. (Reproduction: https://stackblitz.com/edit/vitest-dev-vitest-72lr7i?file=test%2Ffixture-error.test.ts)

Example:

```
import { test } from 'vitest';

const myTest = test.extend<{ a: never }>({
  a: async () => {
    throw new Error('Error thrown in test fixture');
  },
});

myTest('error in fixture causes a timeout', ({ a }) => {});
```

Instead of timing out, the test runner should handle the error immediately. This PR amends the `withFixtures` function to catch any rejected fixture promise and forwards the error so that the test fails immediately.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
