### PR TITLE
docs(environment): add missing expect import

### DIFF
--- a/docs/guide/environment.md
+++ b/docs/guide/environment.md
@@ -16,7 +16,7 @@ When setting `environment` option in your config, it will apply to all the test 
 ```ts
 // @vitest-environment jsdom
 
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 
 test('test', () => {
   expect(typeof window).not.toBe('undefined')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR is a minor docs contribution, adding a missing `expect` import in a `@vitest-environment` code snippet. Without the `expect`, a developer will see the error `ReferenceError: expect is not defined` when running that code sample directly.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
