### PR TITLE
fix: default --open to !process.env.CI

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -84,7 +84,7 @@ const config = {
   api: false,
   ui: false,
   uiBase: '/__vitest__/',
-  open: true,
+  open: !isCI,
   css: {
     include: [],
   },


### PR DESCRIPTION
### Description

When running in CI, `vitest` will try to open the UI if you pass `-ui` because `--open` is defaulting to `true` even though it says it should default to `!process.env.CI`.

https://github.com/vitest-dev/vitest/blob/cc19117d303ad0a36721ddee01c14f04812245ae/packages/vitest/src/node/cli.ts#L22

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
