### PR TITLE
fix: run tests in sequential suite sequentially with sequence.concurrent

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -654,7 +654,7 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 
 - **Type:** `(name: string | Function, fn: TestFunction, options?: number | TestOptions) => void`
 
-`describe.sequential` in a suite marks every test as sequential. This is useful if you want to run tests in sequential within `describe.concurrent` or with the `--sequence.concurrent` command option.
+`describe.sequential` in a suite marks every test as sequential. This is useful if you want to run tests in sequence within `describe.concurrent` or with the `--sequence.concurrent` command option.
 
 ```ts
 describe.concurrent('suite', () => {

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -199,7 +199,7 @@ function createSuite() {
     if (currentSuite?.options)
       options = { ...currentSuite.options, ...options }
 
-    return createSuiteCollector(formatName(name), factory, mode, this.concurrent, this.sequence, this.shuffle, this.each, options)
+    return createSuiteCollector(formatName(name), factory, mode, this.concurrent, this.sequential, this.shuffle, this.each, options)
   }
 
   suiteFn.each = function<T>(this: { withContext: () => SuiteAPI; setContext: (key: string, value: boolean | undefined) => SuiteAPI }, cases: ReadonlyArray<T>, ...args: any[]) {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -813,6 +813,11 @@ export type RuntimeConfig = Pick<
   | 'restoreMocks'
   | 'fakeTimers'
   | 'maxConcurrency'
-> & { sequence?: { hooks?: SequenceHooks } }
+> & {
+  sequence?: {
+    concurrent?: boolean
+    hooks?: SequenceHooks
+  }
+}
 
 export type { UserWorkspaceConfig } from '../config'

--- a/test/core/test/sequential-sequence-concurrent.test.ts
+++ b/test/core/test/sequential-sequence-concurrent.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.setConfig({
+  sequence: {
+    concurrent: true,
+  },
+})
+
+const delay = (timeout: number) => new Promise(resolve => setTimeout(resolve, timeout))
+
+let count = 0
+
+describe.sequential('running sequential suite when sequence.concurrent is true', () => {
+  test('first test completes first', async ({ task }) => {
+    await delay(50)
+    expect(task.concurrent).toBeFalsy()
+    expect(++count).toBe(1)
+  })
+
+  test('second test completes second', ({ task }) => {
+    expect(task.concurrent).toBeFalsy()
+    expect(++count).toBe(2)
+  })
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #4473 

Currently, when running Vitest with the `--sequence.concurrent` CLI option or with the `sequence.concurrent` config option set to true, `describe.sequential` has no effect and tests run concurrently.

This PR fixes the issue by correcting a typo causing the sequential option to not be passed to the task collector.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
