### PR TITLE
feat: add test.sequential() api

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -224,6 +224,30 @@ test.concurrent('test 2', async ({ expect }) => {
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
 :::
 
+### test.sequential
+
+- **Type:** `(name: string | Function, fn: TestFunction, timeout?: number) => void`
+
+`test.sequential` marks a test as sequential. This is useful if you want to run tests in sequence within `describe.concurrent` or with the `--sequence.concurrent` command option.
+
+```ts
+// with config option { sequence: { concurrent: true } }
+test('concurrent test 1', async () => { /* ... */ })
+test('concurrent test 2', async () => { /* ... */ })
+
+test.sequential('sequential test 1', async () => { /* ... */ })
+test.sequential('sequential test 2', async () => { /* ... */ })
+
+// within concurrent suite
+describe.concurrent('suite', () => {
+  test('concurrent test 1', async () => { /* ... */ })
+  test('concurrent test 2', async () => { /* ... */ })
+
+  test.sequential('sequential test 1', async () => { /* ... */ })
+  test.sequential('sequential test 2', async () => { /* ... */ })
+})
+```
+
 ### test.todo
 
 - **Type:** `(name: string | Function) => void`

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -280,7 +280,7 @@ export function createTaskCollector(
   }
 
   const _test = createChainable(
-    ['concurrent', 'skip', 'only', 'todo', 'fails'],
+    ['concurrent', 'sequential', 'skip', 'only', 'todo', 'fails'],
     taskFn,
   ) as CustomAPI
 

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -150,7 +150,7 @@ interface TestEachFunction {
 }
 
 type ChainableTestAPI<ExtraContext = {}> = ChainableFunction<
-  'concurrent' | 'only' | 'skip' | 'todo' | 'fails',
+  'concurrent' | 'sequential' | 'only' | 'skip' | 'todo' | 'fails',
   [name: string | Function, fn?: TestFunction<ExtraContext>, options?: number | TestOptions],
   void,
   {

--- a/test/core/test/sequential-sequence-concurrent.test.ts
+++ b/test/core/test/sequential-sequence-concurrent.test.ts
@@ -22,3 +22,14 @@ describe.sequential('running sequential suite when sequence.concurrent is true',
     expect(++count).toBe(2)
   })
 })
+
+test.sequential('third test completes third', async ({ task }) => {
+  await delay(50)
+  expect(task.concurrent).toBeFalsy()
+  expect(++count).toBe(3)
+})
+
+test.sequential('fourth test completes fourth', ({ task }) => {
+  expect(task.concurrent).toBeFalsy()
+  expect(++count).toBe(4)
+})

--- a/test/core/test/sequential.test.ts
+++ b/test/core/test/sequential.test.ts
@@ -41,6 +41,17 @@ function assertConcurrent() {
     expect(task.concurrent).toBe(true)
     expect(++count).toBe(1)
   })
+
+  test.sequential('third test completes third', async ({ task }) => {
+    await delay(50)
+    expect(task.concurrent).toBeFalsy()
+    expect(++count).toBe(3)
+  })
+
+  test.sequential('fourth test completes fourth', ({ task }) => {
+    expect(task.concurrent).toBeFalsy()
+    expect(++count).toBe(4)
+  })
 }
 
 assertSequential()


### PR DESCRIPTION
### Description

Implements #4511 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds `.sequential()` to the chainable test API so that individual tests can be marked as sequential within a concurrent suite in the same way that individual tests can be marked as concurrent within a sequential suite.

Usage example:

```ts
// with config option { sequence: { concurrent: true } }
test('concurrent test 1', async () => { /* ... */ })
test('concurrent test 2', async () => { /* ... */ })

test.sequential('sequential test 1', async () => { /* ... */ })
test.sequential('sequential test 2', async () => { /* ... */ })

// within concurrent suite
describe.concurrent('suite', () => {
  test('concurrent test 1', async () => { /* ... */ })
  test('concurrent test 2', async () => { /* ... */ })

  test.sequential('sequential test 1', async () => { /* ... */ })
  test.sequential('sequential test 2', async () => { /* ... */ })
})
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
