### PR TITLE
docs: Update incorrect import in request mocking example

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -277,7 +277,7 @@ You can use it like below in your [setup file](/config/#setupfiles)
 ```js
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { setupServer } from 'msw/node'
-import { HttpResponse, graphql, rest } from 'msw'
+import { HttpResponse, graphql, http } from 'msw'
 
 const posts = [
   {


### PR DESCRIPTION
### Description

Minor fix to update an outdated import in the docs. It looks like there are some other changes to this file that have addressed most of the [out of date usage from `msw` on the current site](https://vitest.dev/guide/mocking.html#configuration), however the import itself seems to have been missed.

Note: The other changes to this example from https://github.com/vitest-dev/vitest/pull/4502 should probably be released soon.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
