### PR TITLE
chore(bench): extract ChainableBenchmarkAPI type

### DIFF
--- a/packages/vitest/src/types/benchmark.ts
+++ b/packages/vitest/src/types/benchmark.ts
@@ -52,13 +52,14 @@ export interface BenchmarkResult extends TinybenchResult {
 }
 
 export type BenchFunction = (this: BenchFactory) => Promise<void> | void
-export type BenchmarkAPI = ChainableFunction<
-'skip' | 'only' | 'todo',
-[name: string | Function, fn?: BenchFunction, options?: BenchOptions],
-void
-> & {
-  skipIf(condition: any): BenchmarkAPI
-  runIf(condition: any): BenchmarkAPI
+type ChainableBenchmarkAPI = ChainableFunction<
+  'skip' | 'only' | 'todo',
+  [name: string | Function, fn?: BenchFunction, options?: BenchOptions],
+  void
+>
+export type BenchmarkAPI = ChainableBenchmarkAPI & {
+  skipIf(condition: any): ChainableBenchmarkAPI
+  runIf(condition: any): ChainableBenchmarkAPI
 }
 
 export {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR extracts a new type `ChainableBenchmarkAPI` from `BenchmarkAPI`. This prevents display of incorrect type hints for `bench.runIf.runIf`, `bench.runIf.skipIf`, `bench.skipIf.runIf` and `bench.skipIf.skipIf`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
