### PR TITLE
perf(coverage-istanbul): `all: true` instruments already instrumented files

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -216,27 +216,13 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       .map(file => resolve(this.ctx.config.root, file))
       .filter(file => !coveredFiles.includes(file))
 
-    const transformResults = await Promise.all(uncoveredFiles.map(async (filename) => {
-      const transformResult = await this.ctx.vitenode.transformRequest(filename)
-      return { transformResult, filename }
-    }))
-
     const coverageMap = libCoverage.createCoverageMap({})
 
-    for (const { transformResult, filename } of transformResults) {
-      const sourceMap = transformResult?.map
+    for (const filename of uncoveredFiles) {
+      await this.ctx.vitenode.transformRequest(filename)
 
-      if (sourceMap) {
-        this.instrumenter.instrumentSync(
-          transformResult.code,
-          filename,
-          sourceMap as any,
-        )
-
-        const lastCoverage = this.instrumenter.lastFileCoverage()
-        if (lastCoverage)
-          coverageMap.addFileCoverage(lastCoverage)
-      }
+      const lastCoverage = this.instrumenter.lastFileCoverage()
+      coverageMap.addFileCoverage(lastCoverage)
     }
 
     return coverageMap.data


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

While looking into https://github.com/vitest-dev/vitest/issues/4476 I noticed that `@vitest/coverage-istanbul` instruments files that are already instrumented when using `coverage.all: true`. In practice it means that once coverage counters are added to source files, we re-run instrumentation and instrument **all** of those coverage counters too. This is really expensive process and leads to out-of-memory errors easily.

`vitenode.transformRequest` runs transforms for the requested file, which includes the `vitest:coverage-transform` Vite plugin.

https://github.com/vitest-dev/vitest/blob/cc19117d303ad0a36721ddee01c14f04812245ae/packages/coverage-istanbul/src/provider.ts#L213

Then we take that transformed + instrumented code and instrument it again:

https://github.com/vitest-dev/vitest/blob/cc19117d303ad0a36721ddee01c14f04812245ae/packages/coverage-istanbul/src/provider.ts#L220-L227

Using https://github.com/vitest-tests/coverage-large as reference with following parameters:

```ts
const COVERED_FILE_COUNT = Array(100).fill(0);
const UNCOVERED_FILE_COUNT = Array(300).fill(0);
const FUNCTION_COUNT = Array(200).fill(0);
```

Before:

Whole run took 5m54.664s

![image](https://github.com/vitest-dev/vitest/assets/14806298/92887bcf-4ffc-4f64-88ec-c588dcbf6845)


After:

Whole run took 3m40.676s

![image](https://github.com/vitest-dev/vitest/assets/14806298/48ac4cb3-82b2-4441-ac98-3ebcee6a22bb)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
