### PR TITLE
test: `msw` to use `--pool=forks`

### DIFF
--- a/examples/react-testing-lib-msw/vite.config.ts
+++ b/examples/react-testing-lib-msw/vite.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/setup.ts'],
+    pool: 'forks',
   },
 })

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:run": "vitest run -r test/core",
     "test:all": "CI=true pnpm -r --stream run test --allowOnly",
     "test:ci": "CI=true pnpm -r --stream --filter !test-fails --filter !test-browser --filter !test-esm --filter !test-browser run test --allowOnly",
-    "test:ci:vm-threads": "CI=true pnpm -r --stream --filter !test-fails --filter !test-coverage --filter !test-single-thread --filter !test-browser --filter !test-esm --filter !test-browser run test --allowOnly --pool vmThreads",
+    "test:ci:vm-threads": "CI=true pnpm -r --stream --filter !test-fails --filter !test-coverage --filter !test-single-thread --filter !test-browser --filter !test-esm --filter !test-browser --filter !example-react-testing-lib-msw run test --allowOnly --pool vmThreads",
     "test:ci:no-threads": "CI=true pnpm -r --stream --filter !test-fails --filter !test-vm-threads --filter !test-coverage --filter !test-watch --filter !test-bail --filter !test-esm --filter !test-browser run test --allowOnly --pool forks",
     "typecheck": "tsc -p tsconfig.check.json --noEmit",
     "typecheck:why": "tsc -p tsconfig.check.json --noEmit --explainFiles > explainTypes.txt",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

The `msw` tests use `fetch` which is unstable on `node:worker_threads`. Example failure on `main` CI: https://github.com/vitest-dev/vitest/actions/runs/6926748073/job/18839404982

Worker seems to get completely stuck. When CI terminates the job following error is shown.

```
vitest "--allowOnly" "--pool" "vmThreads"
 RUN  v1.0.0-beta.5 /home/runner/work/vitest/vitest/examples/react-testing-lib-msw
 ✓ src/App.test.tsx  (2 tests) 301ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  07:22:36
   Duration  3.59s (transform 779ms, setup 253ms, collect 1.43s, tests 301ms, environment 662ms, prepare 831ms)
file:///home/runner/work/vitest/vitest/node_modules/.pnpm/tinypool@0.8.1/node_modules/tinypool/dist/esm/index.js:532
    const timer = timeout ? setTimeout(() => reject(new Error("Failed to terminate worker")), timeout) : null;
                                                    ^
Error: Failed to terminate worker
    at Timeout._onTimeout (file:///home/runner/work/vitest/vitest/node_modules/.pnpm/tinypool@0.8.1/node_modules/tinypool/dist/esm/index.js:532:53)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7)
Node.js v18.18.2
```

`msw@2` does not support polyfilling `fetch` so the only thing to do is switch the runtime to `forks`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
