### PR TITLE
feat(coverage): support `/* v8 ignore...` ignore hints

### DIFF
--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -153,11 +153,11 @@ Beware that these ignore hints may now be included in final production build as 
 if (condition) {
 ```
 
-For `v8` this does not cause any issues. You can use `c8 ignore` comments with Typescript as usual:
+For `v8` this does not cause any issues. You can use `v8 ignore` comments with Typescript as usual:
 
 <!-- eslint-skip -->
 ```ts
-/* c8 ignore next 3 */
+/* v8 ignore next 3 */
 if (condition) {
 ```
 

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -56,7 +56,7 @@
     "picocolors": "^1.0.0",
     "std-env": "^3.4.3",
     "test-exclude": "^6.0.0",
-    "v8-to-istanbul": "^9.1.3"
+    "v8-to-istanbul": "^9.2.0"
   },
   "devDependencies": {
     "@types/istanbul-lib-coverage": "^2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,8 +997,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       v8-to-istanbul:
-        specifier: ^9.1.3
-        version: 9.1.3
+        specifier: ^9.2.0
+        version: 9.2.0
     devDependencies:
       '@types/istanbul-lib-coverage':
         specifier: ^2.0.6
@@ -25989,6 +25989,16 @@ packages:
       '@jridgewell/trace-mapping': 0.3.20
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+    dev: true
+
+  /v8-to-istanbul@9.2.0:
+    resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.20
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+    dev: false
 
   /validate-html-nesting@1.2.2:
     resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}

--- a/test/coverage-test/src/utils.ts
+++ b/test/coverage-test/src/utils.ts
@@ -23,7 +23,7 @@ export function run() {
   divide(1, 1)
 }
 
-/* c8 ignore next 4 */
+/* v8 ignore next 4 */
 /* istanbul ignore next -- @preserve */
 export function ignoredFunction() {
   throw new Error('Test files should not call this function!')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Adds support for ignoring code using `/* v8 ignore...` ignore hints instead of `/* c8 ignore...` ones when using `@vitest/coverage-v8` provider. The old `c8` ignore hints were confusing as Vitest does not use `c8` at all.

- Ref. https://github.com/istanbuljs/v8-to-istanbul/pull/228

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
