### PR TITLE
docs: correction to configuration parameter

### DIFF
--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -171,7 +171,7 @@ Since Vitest 0.31.0, you can check your coverage report in [Vitest UI](./ui).
 
 Vitest UI will enable coverage report when it is enabled explicitly and the html coverage reporter is present, otherwise it will not be available:
 - enable `coverage.enabled=true` in your configuration or run Vitest with `--coverage.enabled=true` flag
-- add `html` to the `coverage.reporters` list: you can also enable `subdir` option to put coverage report in a subdirectory
+- add `html` to the `coverage.reporter` list: you can also enable `subdir` option to put coverage report in a subdirectory
 
 <img alt="html coverage activation in Vitest UI" img-light src="/vitest-ui-show-coverage-light.png">
 <img alt="html coverage activation in Vitest UI" img-dark src="/vitest-ui-show-coverage-dark.png">


### PR DESCRIPTION
### Description

Small correction of the docs. The vitest config parameter should be `test.coverage.reporter` not `reporters`. This may be confusing because there is also a `test.reporters` parameter.

Appreciate your checklist, but given this is a docs-only change and only 1 character, I'm unable to link an issue or write a new test for this. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
