### PR TITLE
browser mode - puppeteer basic support

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -30,6 +30,9 @@
     "./providers/playwright": {
       "types": "./dist/providers/playwright.d.ts"
     },
+    "./providers/puppeteer": {
+      "types": "./dist/providers/puppeteer.d.ts"
+    },
     "./*": "./*"
   },
   "main": "./dist/index.js",
@@ -50,6 +53,7 @@
   },
   "peerDependencies": {
     "playwright": "*",
+    "puppeteer": "*",
     "safaridriver": "*",
     "vitest": "^1.0.0-0",
     "webdriverio": "*"
@@ -62,6 +66,9 @@
       "optional": true
     },
     "playwright": {
+      "optional": true
+    },
+    "puppeteer": {
       "optional": true
     }
   },
@@ -80,6 +87,7 @@
     "periscopic": "^4.0.2",
     "playwright": "^1.40.0",
     "playwright-core": "^1.40.0",
+    "puppeteer": "^21.5.2",
     "safaridriver": "^0.1.0",
     "vitest": "workspace:*",
     "webdriverio": "^8.22.1"

--- a/packages/browser/providers.d.ts
+++ b/packages/browser/providers.d.ts
@@ -2,6 +2,7 @@ import type { BrowserProvider } from 'vitest/nide'
 
 declare const webdriverio: BrowserProvider
 declare const playwright: BrowserProvider
+declare const puppeteer: BrowserProvider
 declare const none: BrowserProvider
 
-export { webdriverio, playwright, none }
+export { webdriverio, playwright, puppeteer, none }

--- a/packages/browser/providers/puppeteer.d.ts
+++ b/packages/browser/providers/puppeteer.d.ts
@@ -1,0 +1,7 @@
+import type { LaunchOptions } from 'puppeteer'
+
+declare module 'vitest/node' {
+  interface BrowserProviderOptions {
+    launch?: LaunchOptions
+  }
+}

--- a/packages/browser/src/node/providers/index.ts
+++ b/packages/browser/src/node/providers/index.ts
@@ -1,7 +1,9 @@
 import { PlaywrightBrowserProvider } from './playwright'
+import { PuppeteerBrowserProvider } from './puppeteer'
 import { WebdriverBrowserProvider } from './webdriver'
 import { NoneBrowserProvider } from './none'
 
 export const webdriverio = WebdriverBrowserProvider
 export const playwright = PlaywrightBrowserProvider
+export const puppeteer = PuppeteerBrowserProvider
 export const none = NoneBrowserProvider

--- a/packages/browser/src/node/providers/puppeteer.ts
+++ b/packages/browser/src/node/providers/puppeteer.ts
@@ -1,0 +1,75 @@
+import type { Browser, LaunchOptions, Page } from 'puppeteer'
+import type { BrowserProvider, BrowserProviderInitializationOptions, WorkspaceProject } from 'vitest/node'
+
+type Awaitable<T> = T | PromiseLike<T>
+
+export const puppeteerBrowsers = ['chrome', 'firefox'] as const
+export type PuppeteerBrowser = typeof puppeteerBrowsers[number]
+
+export interface PuppeteerProviderOptions extends BrowserProviderInitializationOptions {
+  browser: PuppeteerBrowser
+}
+
+export class PuppeteerBrowserProvider implements BrowserProvider {
+  public name = 'puppeteer'
+
+  private cachedBrowser: Browser | null = null
+  private cachedPage: Page | null = null
+  private browser!: PuppeteerBrowser
+  private ctx!: WorkspaceProject
+
+  private options?: {
+    launch?: LaunchOptions
+  }
+
+  getSupportedBrowsers() {
+    return puppeteerBrowsers
+  }
+
+  async initialize(ctx: WorkspaceProject, { browser, options }: PuppeteerProviderOptions) {
+    this.ctx = ctx
+    this.browser = browser || 'chrome'
+    this.options = options as any
+  }
+
+  private async openBrowserPage() {
+    if (this.cachedPage)
+      return this.cachedPage
+
+    const options = this.ctx.config.browser
+
+    const puppeteer = await import('puppeteer')
+
+    const headless = options.headless == null ? 'new' : (options.headless ? 'new' : false)
+    const browser = await puppeteer.launch({
+      ...this.options?.launch,
+      headless,
+      product: this.browser,
+    })
+    this.cachedBrowser = browser
+    this.cachedPage = await browser.newPage()
+
+    this.cachedPage.on('close', () => {
+      browser.close()
+    })
+
+    return this.cachedPage
+  }
+
+  catchError(cb: (error: Error) => Awaitable<void>) {
+    this.cachedPage?.on('pageerror', cb)
+    return () => {
+      this.cachedPage?.off('pageerror', cb)
+    }
+  }
+
+  async openPage(url: string) {
+    const browserPage = await this.openBrowserPage()
+    await browserPage.goto(url)
+  }
+
+  async close() {
+    await this.cachedPage?.close()
+    await this.cachedBrowser?.close()
+  }
+}

--- a/packages/vitest/src/integrations/browser.ts
+++ b/packages/vitest/src/integrations/browser.ts
@@ -6,7 +6,7 @@ interface Loader {
   executeId: (id: string) => any
 }
 
-const builtinProviders = ['webdriverio', 'playwright', 'none']
+const builtinProviders = ['webdriverio', 'playwright', 'puppeteer', 'none']
 
 export async function getBrowserProvider(options: ResolvedBrowserOptions, loader: Loader): Promise<BrowserProviderModule> {
   if (options.provider == null || builtinProviders.includes(options.provider)) {
@@ -14,9 +14,10 @@ export async function getBrowserProvider(options: ResolvedBrowserOptions, loader
     const providers = await loader.executeId('@vitest/browser/providers') as {
       webdriverio: BrowserProviderModule
       playwright: BrowserProviderModule
+      puppeteer: BrowserProviderModule
       none: BrowserProviderModule
     }
-    const provider = (options.provider || 'webdriverio') as 'webdriverio' | 'playwright' | 'none'
+    const provider = (options.provider || 'webdriverio') as 'webdriverio' | 'puppeteer' | 'playwright' | 'none'
     return providers[provider]
   }
 

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -40,7 +40,7 @@ export interface BrowserConfigOptions {
    *
    * @default 'webdriverio'
    */
-  provider?: 'webdriverio' | 'playwright' | 'none' | (string & {})
+  provider?: 'webdriverio' | 'playwright' | 'puppetee' | 'none' | (string & {})
 
   /**
    * Options that are passed down to a browser provider.
@@ -48,6 +48,7 @@ export interface BrowserConfigOptions {
    *
    * - for webdriverio: `@vitest/browser/providers/webdriverio`
    * - for playwright: `@vitest/browser/providers/playwright`
+   * - for puppeteer: `@vitest/browser/providers/puppeteer`
    *
    * @example
    * { playwright: { launch: { devtools: true } }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,6 +902,9 @@ importers:
       playwright-core:
         specifier: ^1.40.0
         version: 1.40.0
+      puppeteer:
+        specifier: ^21.5.2
+        version: 21.5.2(typescript@5.2.2)
       safaridriver:
         specifier: ^0.1.0
         version: 0.1.0
@@ -5801,7 +5804,7 @@ packages:
     resolution: {integrity: sha512-ezL7SU//1OV4Oyt/zQ3CsX8uLujVEYUHuULkqgcW6wOuQfRnvgkn99HZtLWwS257GmZVwszGQzhL7VE3PbMAYw==}
     peerDependencies:
       typescript: '>= 4.3.x'
-      vite: '>2.0.0-0'
+      vite: ^5.0.0-beta.19
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
@@ -5964,7 +5967,7 @@ packages:
     resolution: {integrity: sha512-3cixhQvMOzeWx1YvpW9N4KzwccEHmrFPhfuGDQFi53BBh0ccgBRmb2/Aly7oCDFEP8qwZZkuDJX3278nB7KmdQ==}
     peerDependencies:
       '@marko/compiler': ^5
-      vite: 4 - 5
+      vite: ^5.0.0-beta.19
     dependencies:
       '@marko/compiler': 5.34.1
       anymatch: 3.1.3
@@ -6614,7 +6617,7 @@ packages:
     resolution: {integrity: sha512-5nztNzXbCpqyVum/K94nB2YQ5PTnvWdz4u7/X0jc8+kLyskSSpkNUxLQJeI90zfGSFIX1Ibj2G2JIS/mySHWYQ==}
     peerDependencies:
       '@babel/core': 7.x
-      vite: 2.x || 3.x || 4.x
+      vite: ^5.0.0-beta.19
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.3)
@@ -6651,7 +6654,7 @@ packages:
     resolution: {integrity: sha512-vthWmEqu8TZFeyrBNc9YE5SiC3DVSzPgsOCp/WQ7FqdHpOIJi7Z8XvCK06rBPOtG4914S52MjG9Ls22eVAiuqQ==}
     peerDependencies:
       preact: ^10.4.0
-      vite: '>=2.0.0'
+      vite: ^5.0.0-beta.19
     dependencies:
       '@babel/core': 7.23.3
       '@prefresh/babel-plugin': 0.5.0
@@ -6686,18 +6689,18 @@ packages:
       - supports-color
     dev: true
 
-  /@puppeteer/browsers@1.7.0:
-    resolution: {integrity: sha512-sl7zI0IkbQGak/+IE3VEEZab5SSOlI5F6558WvzWGC1n3+C722rfewC1ZIkcF9dsoGSsxhsONoseVlNQG4wWvQ==}
+  /@puppeteer/browsers@1.8.0:
+    resolution: {integrity: sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==}
     engines: {node: '>=16.3.0'}
     hasBin: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 2.0.1(supports-color@8.1.1)
       progress: 2.0.3
-      proxy-agent: 6.3.0
+      proxy-agent: 6.3.1
       tar-fs: 3.0.4
       unbzip2-stream: 1.4.3
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7414,7 +7417,7 @@ packages:
       '@storybook/mdx2-csf': ^0.0.3
       '@storybook/node-logger': '>=6.4.3 || >=6.5.0-alpha.0'
       '@storybook/source-loader': '>=6.4.3 || >=6.5.0-alpha.0'
-      vite: '>=2.6.7'
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       '@storybook/mdx2-csf':
         optional: true
@@ -8403,7 +8406,7 @@ packages:
     resolution: {integrity: sha512-ZcMSaqFNx1E+G00nRDUi8kKL7gxJVlnCvbKLNj3V85guy4DkIYAZr31yDqze07gDWbjvKoHIp3tKpgE+2i8upQ==}
     dependencies:
       '@storybook/channels': 7.5.1
-      '@types/babel__core': 7.20.3
+      '@types/babel__core': 7.20.5
       '@types/express': 4.17.20
       file-system-cache: 2.3.0
     dev: true
@@ -8502,7 +8505,7 @@ packages:
     requiresBuild: true
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0-next.0
-      vite: ^4.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.59.1)(vite@5.0.0-beta.19)
       '@types/cookie': 0.5.1
@@ -8529,7 +8532,7 @@ packages:
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^2.2.0
       svelte: ^3.54.0 || ^4.0.0
-      vite: ^4.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.59.1)(vite@5.0.0-beta.19)
       debug: 4.3.4(supports-color@8.1.1)
@@ -8545,7 +8548,7 @@ packages:
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^3.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.0.0-beta.19)
       debug: 4.3.4(supports-color@8.1.1)
@@ -8560,7 +8563,7 @@ packages:
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0
-      vite: ^4.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.59.1)(vite@5.0.0-beta.19)
       debug: 4.3.4(supports-color@8.1.1)
@@ -8580,7 +8583,7 @@ packages:
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.0-beta.19)
       debug: 4.3.4(supports-color@8.1.1)
@@ -8691,7 +8694,7 @@ packages:
       '@jest/globals': '>= 28'
       '@types/jest': '>= 28'
       jest: '>= 28'
-      vitest: '>= 0.32'
+      vitest: workspace:*
     peerDependenciesMeta:
       '@jest/globals':
         optional: true
@@ -9693,7 +9696,7 @@ packages:
   /@unocss/astro@0.57.4(rollup@2.79.1)(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-BP7+X/AlUFFMzr5s8bUpbO4HsWBESzIcPUE9VMA4bpSJIbXxi9GyJRU3Av72nbQp4BBeDjYiDT0qRa5gS0oPxw==}
     peerDependencies:
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       vite:
         optional: true
@@ -9709,7 +9712,7 @@ packages:
   /@unocss/astro@0.57.4(rollup@4.4.0)(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-BP7+X/AlUFFMzr5s8bUpbO4HsWBESzIcPUE9VMA4bpSJIbXxi9GyJRU3Av72nbQp4BBeDjYiDT0qRa5gS0oPxw==}
     peerDependencies:
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       vite:
         optional: true
@@ -9920,7 +9923,7 @@ packages:
   /@unocss/vite@0.57.4(rollup@2.79.1)(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-bVMftC1hzdlfRQOfllDuJ+bd5Z0/TOvPthNk8LyoHsnjAEH7FqspdCyPM3nQpnfqfYRocXiuLJv+KdQ2DLQWOQ==}
     peerDependencies:
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@rollup/pluginutils': 5.0.5(rollup@2.79.1)
@@ -9940,7 +9943,7 @@ packages:
   /@unocss/vite@0.57.4(rollup@4.4.0)(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-bVMftC1hzdlfRQOfllDuJ+bd5Z0/TOvPthNk8LyoHsnjAEH7FqspdCyPM3nQpnfqfYRocXiuLJv+KdQ2DLQWOQ==}
     peerDependencies:
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@rollup/pluginutils': 5.0.5(rollup@4.4.0)
@@ -9998,7 +10001,7 @@ packages:
     resolution: {integrity: sha512-Jie2HERK+uh27e+ORXXwEP5h0Y2lS9T2PRGbfebiHGlwzDO0dEnd2aNtOR/qjBlPb1YgxwAONeblL1xqLikLag==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.23.3)
@@ -10014,7 +10017,7 @@ packages:
     resolution: {integrity: sha512-+MHTH/e6H12kRp5HUkzOGqPMksezRMmW+TNzlh/QXfI8rRf6l2Z2yH/v12no1UvTwhZgEDMuQ7g7rrfMseU6FQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.3)
@@ -10030,7 +10033,7 @@ packages:
     resolution: {integrity: sha512-+MHTH/e6H12kRp5HUkzOGqPMksezRMmW+TNzlh/QXfI8rRf6l2Z2yH/v12no1UvTwhZgEDMuQ7g7rrfMseU6FQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.3)
@@ -10046,7 +10049,7 @@ packages:
     resolution: {integrity: sha512-obF26P2Z4Ogy3cPp07B4VaW6rpiu0ue4OT2Y15UxT5BZZ76haUY9guOsZV3uWh/I6xc+VeiW+ZVabRE82FyzWw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.0.0
+      vite: ^5.0.0-beta.19
       vue: ^3.0.0
     dependencies:
       '@babel/core': 7.23.3
@@ -10062,7 +10065,7 @@ packages:
     resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.0.0 || ^5.0.0
+      vite: ^5.0.0-beta.19
       vue: ^3.0.0
     dependencies:
       '@babel/core': 7.23.3
@@ -10078,7 +10081,7 @@ packages:
     resolution: {integrity: sha512-HCQG8VDFDM7YDAdcj5QI5DvUi+r6xvo9LgvYdk7LSkUNwdpempdB5horkMSZsbdey9Ywsf5aaU8kEPw9M5kREA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.0.0
+      vite: ^5.0.0-beta.19
       vue: ^3.2.25
     dependencies:
       vite: 5.0.0-beta.19(@types/node@18.18.9)(less@4.1.3)
@@ -10089,7 +10092,7 @@ packages:
     resolution: {integrity: sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.0.0 || ^5.0.0
+      vite: ^5.0.0-beta.19
       vue: ^3.2.25
     dependencies:
       vite: 5.0.0-beta.19(@types/node@18.18.9)(less@4.1.3)
@@ -10505,7 +10508,7 @@ packages:
     resolution: {integrity: sha512-n09ZLfe6NADQ7XyeO45nPBtNHi8nwu1RpOI18c94SrRS7gmO0CQWpjSilJCoHvu10ekUPJE7Oh/1Nw28w7ceVg==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@puppeteer/browsers': 1.7.0
+      '@puppeteer/browsers': 1.8.0
       '@wdio/logger': 8.16.17
       '@wdio/types': 8.21.0
       decamelize: 6.0.0
@@ -10527,7 +10530,7 @@ packages:
     resolution: {integrity: sha512-m0qsWx2U5ZBTS0vzg1gTBp9mTrcLQlDrOBVR28LJ93a/e0bj+4aQ4c5U2y9gUzV+lKH0wUJSZTLnhebQwapURQ==}
     engines: {node: ^16.13 || >=18}
     dependencies:
-      '@puppeteer/browsers': 1.7.0
+      '@puppeteer/browsers': 1.8.0
       '@wdio/logger': 8.16.17
       '@wdio/types': 8.24.0
       decamelize: 6.0.0
@@ -11644,7 +11647,7 @@ packages:
       '@babel/core': 7.23.3
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/babel__core': 7.20.3
+      '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.5.1(@babel/core@7.23.3)
       chalk: 4.1.2
@@ -11729,7 +11732,7 @@ packages:
     dependencies:
       '@babel/template': 7.22.15
       '@babel/types': 7.23.3
-      '@types/babel__core': 7.20.3
+      '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.3
     dev: true
 
@@ -12682,6 +12685,16 @@ packages:
       mitt: 3.0.0
     dev: true
 
+  /chromium-bidi@0.4.33(devtools-protocol@0.0.1203626):
+    resolution: {integrity: sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==}
+    peerDependencies:
+      devtools-protocol: '*'
+    dependencies:
+      devtools-protocol: 0.0.1203626
+      mitt: 3.0.1
+      urlpattern-polyfill: 9.0.0
+    dev: true
+
   /ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
     dev: true
@@ -13192,6 +13205,22 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  /cosmiconfig@8.3.6(typescript@5.2.2):
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      typescript: 5.2.2
+    dev: true
 
   /cp-file@7.0.0:
     resolution: {integrity: sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==}
@@ -13991,6 +14020,10 @@ packages:
 
   /devtools-protocol@0.0.1147663:
     resolution: {integrity: sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==}
+    dev: true
+
+  /devtools-protocol@0.0.1203626:
+    resolution: {integrity: sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g==}
     dev: true
 
   /devtools-protocol@0.0.1213968:
@@ -15097,7 +15130,7 @@ packages:
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '*'
       eslint: '>=8.0.0'
-      vitest: '*'
+      vitest: workspace:*
     peerDependenciesMeta:
       '@typescript-eslint/eslint-plugin':
         optional: true
@@ -18616,7 +18649,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/generator': 7.23.3
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.3)
+      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.3)
       '@babel/traverse': 7.23.3
       '@babel/types': 7.23.3
       '@jest/transform': 27.5.1
@@ -20058,6 +20091,10 @@ packages:
 
   /mitt@3.0.0:
     resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
+    dev: true
+
+  /mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
     dev: true
 
   /mixin-deep@1.3.2:
@@ -21736,6 +21773,22 @@ packages:
       - supports-color
     dev: true
 
+  /proxy-agent@6.3.1:
+    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4(supports-color@8.1.1)
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.0.1
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /proxy-from-env@1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
     dev: true
@@ -21818,6 +21871,39 @@ packages:
       - bufferutil
       - encoding
       - supports-color
+      - utf-8-validate
+    dev: true
+
+  /puppeteer-core@21.5.2:
+    resolution: {integrity: sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==}
+    engines: {node: '>=16.13.2'}
+    dependencies:
+      '@puppeteer/browsers': 1.8.0
+      chromium-bidi: 0.4.33(devtools-protocol@0.0.1203626)
+      cross-fetch: 4.0.0
+      debug: 4.3.4(supports-color@8.1.1)
+      devtools-protocol: 0.0.1203626
+      ws: 8.14.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /puppeteer@21.5.2(typescript@5.2.2):
+    resolution: {integrity: sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==}
+    engines: {node: '>=16.13.2'}
+    requiresBuild: true
+    dependencies:
+      '@puppeteer/browsers': 1.8.0
+      cosmiconfig: 8.3.6(typescript@5.2.2)
+      puppeteer-core: 21.5.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
       - utf-8-validate
     dev: true
 
@@ -25250,7 +25336,7 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.57.4
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
@@ -25289,7 +25375,7 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.57.4
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
@@ -25529,6 +25615,10 @@ packages:
       querystring: 0.2.0
     dev: true
 
+  /urlpattern-polyfill@9.0.0:
+    resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
+    dev: true
+
   /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
@@ -25683,7 +25773,7 @@ packages:
     resolution: {integrity: sha512-fw3onBfVTXQI7rOzAbSZhmfwvk50+3qNnGZpERjmD93c8nEjrGLyd53eFXYMxcJV4KA1vzi4qIHt2+6tS4dEMw==}
     peerDependencies:
       '@vue/compiler-sfc': ^2.7.0 || ^3.0.0
-      vite: ^2.0.0 || ^3.0.0-0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       '@vue/compiler-sfc':
         optional: true
@@ -25706,7 +25796,7 @@ packages:
     resolution: {integrity: sha512-4WMA5unuKlHs+koNoykeuCfTcqEGbiTRr8sVYUQMhc6tWxZpSRnv9Ojk4LKmqVhoPGHfBVCdGaMo8t9Qidkc1Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0
+      vite: ^5.0.0-beta.19
       workbox-build: ^7.0.0
       workbox-window: ^7.0.0
     dependencies:
@@ -25723,7 +25813,7 @@ packages:
   /vite-plugin-ruby@3.2.2(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-cuHG1MajRWPR8YdfF6lvgsQRnKFEBRwZF//asFbRiI1psacxB5aPlHSvYZYxAu5IflrAa0MdR0HxEq+g98M3iQ==}
     peerDependencies:
-      vite: '>=4.0.0'
+      vite: ^5.0.0-beta.19
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.2
@@ -25736,7 +25826,7 @@ packages:
     resolution: {integrity: sha512-GV2SMLAibOoXe76i02AsjAg7sbm/0lngBlERvJKVN67HOrJsHcWgkt0R6sfGLDJuFkv2aBe14Zm4vJcNME+7zw==}
     peerDependencies:
       solid-js: ^1.7.2
-      vite: ^3.0.0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     dependencies:
       '@babel/core': 7.23.3
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.3)
@@ -25862,7 +25952,7 @@ packages:
   /vitefu@0.2.4(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       vite:
         optional: true
@@ -25873,7 +25963,7 @@ packages:
   /vitefu@0.2.5(vite@5.0.0-beta.19):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+      vite: ^5.0.0-beta.19
     peerDependenciesMeta:
       vite:
         optional: true
@@ -25939,7 +26029,7 @@ packages:
     resolution: {integrity: sha512-754xxoEe5h8QO8jFlNd/aLm9nUYwgu708KAiatdNH0DVwbS4LI9Mm2tBjKMPYbPVaD8UjQUO+/mGa+WTExzygQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      vitest: '>=0.18.0'
+      vitest: workspace:*
     dependencies:
       vitest: link:packages/vitest
     dev: true

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -3,9 +3,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "pnpm run test:webdriverio && pnpm run test:playwright",
+    "test": "pnpm run test:webdriverio && pnpm run test:playwright && pnpm run test:puppeteer",
     "test:webdriverio": "PROVIDER=webdriverio node --test specs/",
     "test:playwright": "PROVIDER=playwright node --test specs/",
+    "test:puppeteer": "PROVIDER=puppeteer node --test specs/",
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Support for `puppeteer` provider to **browser mode**.

**Ideally this PR shouldn't be needed and I still investigating if adding a new provider, is a good idea**. 

The issue is that `@playwight/test` doesn't play well with `playwright` package installed, so it forces me to use `webdriverio`. The issues is that in workspaces with lots of packages that use **browser mode** with `webdriverio`, I got to very unstable CI. All e2e tests with Playwright are stable, so I thought using `puppeteer` which is essentially the same as `playwright` without the limitation of using it with `@playwight/test` in the same module would improve the stability. **I still need more testing in the CI with it to make sure it adds stability (I hope to update result in recent days)**.

**Anyway, I'm adding this PR as a reference until I finish to see if it worth it**

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

**I also tested it manually with Chrome and Firefox**

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
