### PR TITLE
fix(runner): preserve fixtures when calling runif and skipif (fix #4585)

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -269,8 +269,12 @@ export function createTaskCollector(
     }
   }
 
-  taskFn.skipIf = (condition: any) => (condition ? test.skip : test) as TestAPI
-  taskFn.runIf = (condition: any) => (condition ? test : test.skip) as TestAPI
+  taskFn.skipIf = function (this: TestAPI, condition: any) {
+    return condition ? this.skip : this
+  }
+  taskFn.runIf = function (this: TestAPI, condition: any) {
+    return condition ? this : this.skip
+  }
 
   taskFn.extend = function (fixtures: Fixtures<Record<string, any>>) {
     const _context = mergeContextFixtures(fixtures, context)

--- a/test/core/test/fixture-initialization.test.ts
+++ b/test/core/test/fixture-initialization.test.ts
@@ -82,6 +82,14 @@ describe('fixture initialization', () => {
     })
   })
 
+  myTest.runIf(true)('fixtures work with runIf', ({ a }) => {
+    expect(a).toBe(1)
+  })
+
+  myTest.skipIf(false)('fixtures work with skipIf', ({ a }) => {
+    expect(a).toBe(1)
+  })
+
   describe('fixture dependency', () => {
     myTest2('b => a', ({ b }) => {
       expect(b).toBe('2')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes https://github.com/vitest-dev/vitest/issues/4585

Currently, calling `test.runIf()` and `test.skipIf()` does not propagate the test's context through the method chain. This causes test fixtures to become unavailable after calling `runIf` or `skipIf`. This PR fixes the issue by making the `runIf` and `skipIf` functions return the same instance of the test object instead of returning the base test object, preserving the test context.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
