### PR TITLE
fix(cli): prompted packages fail to install

### DIFF
--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1085,23 +1085,6 @@ Repository: sindresorhus/p-locate
 
 ---------------------------------------
 
-## path-exists
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/path-exists
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
 ## picomatch
 License: MIT
 By: Jon Schlinkert

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -161,7 +161,7 @@
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.2.1",
-    "@antfu/install-pkg": "^0.1.1",
+    "@antfu/install-pkg": "^0.3.1",
     "@edge-runtime/vm": "^3.1.7",
     "@sinonjs/fake-timers": "11.1.0",
     "@types/estree": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,8 +1331,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       '@antfu/install-pkg':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.3.1
+        version: 0.3.1
       '@edge-runtime/vm':
         specifier: ^3.1.7
         version: 3.1.7
@@ -2226,6 +2226,12 @@ packages:
     dependencies:
       execa: 5.1.1
       find-up: 5.0.0
+    dev: true
+
+  /@antfu/install-pkg@0.3.1:
+    resolution: {integrity: sha512-A3zWY9VeTPnxlMiZtsGHw2lSd3ghwvL8s9RiGOtqvDxhhFfZ781ynsGBa/iUnDJ5zBrmTFQrJDud3TGgRISaxw==}
+    dependencies:
+      execa: 8.0.1
     dev: true
 
   /@antfu/ni@0.21.12:


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes https://github.com/vitest-dev/vitest/issues/4589

After updating `@antfu/install-pkg@0.2.0` the Rollup build fails to resolve `find-up > unicorn-magic`. There is `node` condition in its exports: https://github.com/sindresorhus/unicorn-magic/blob/67bb2fd1da1eecb252ba14284df14c0d234a8cfa/package.json#L16

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
