### PR TITLE
fix(coverage): improve memory usage by writing temporary files on file system

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1323,6 +1323,15 @@ See [istanbul documentation](https://github.com/istanbuljs/nyc#ignoring-methods)
 
 Watermarks for statements, lines, branches and functions. See [istanbul documentation](https://github.com/istanbuljs/nyc#high-and-low-watermarks) for more information.
 
+#### coverage.processingConcurrency
+
+- **Type:** `boolean`
+- **Default:** `Math.min(20, os.cpu().length)`
+- **Available for providers:** `'v8' | 'istanbul'`
+- **CLI:** `--coverage.processingConcurrency=<number>`
+
+Concurrency limit used when processing the coverage results.
+
 #### coverage.customProviderModule
 
 - **Type:** `string`

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -45,6 +45,7 @@
     "vitest": "^1.0.0-0"
   },
   "dependencies": {
+    "debug": "^4.3.4",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.1",
     "istanbul-lib-report": "^3.0.1",
@@ -55,6 +56,7 @@
     "test-exclude": "^6.0.0"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/istanbul-lib-coverage": "^2.0.6",
     "@types/istanbul-lib-instrument": "^1.7.7",
     "@types/istanbul-lib-report": "^3.0.3",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@ampproject/remapping": "^2.2.1",
     "@bcoe/v8-coverage": "^0.2.3",
+    "debug": "^4.3.4",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-lib-source-maps": "^4.0.1",
@@ -59,6 +60,7 @@
     "v8-to-istanbul": "^9.2.0"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/istanbul-lib-coverage": "^2.0.6",
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/istanbul-lib-source-maps": "^4.0.4",

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -1,3 +1,4 @@
+import { cpus } from 'node:os'
 import type { BenchmarkUserOptions, CoverageV8Options, ResolvedCoverageOptions, UserConfig } from './types'
 import { isCI } from './utils/env'
 
@@ -42,6 +43,7 @@ export const coverageConfigDefaults: ResolvedCoverageOptions = {
   reporter: [['text', {}], ['html', {}], ['clover', {}], ['json', {}]],
   extension: ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.vue', '.svelte', '.marko'],
   allowExternal: false,
+  processingConcurrency: Math.min(20, cpus().length),
 }
 
 export const fakeTimersDefaults = {

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -79,6 +79,7 @@ type FieldsWithDefaultValues =
   | 'extension'
   | 'reportOnFailure'
   | 'allowExternal'
+  | 'processingConcurrency'
 
 export type ResolvedCoverageOptions<T extends Provider = Provider> =
   & CoverageOptions<T>
@@ -204,6 +205,12 @@ export interface BaseCoverageOptions {
    * @default false
    */
   allowExternal?: boolean
+
+  /**
+   * Concurrency limit used when processing the coverage results.
+   * Defaults to `Math.min(20, os.cpu().length)`
+   */
+  processingConcurrency?: number
 }
 
 export interface CoverageIstanbulOptions extends BaseCoverageOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,6 +914,9 @@ importers:
 
   packages/coverage-istanbul:
     dependencies:
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage:
         specifier: ^3.2.2
         version: 3.2.2
@@ -939,6 +942,9 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/istanbul-lib-coverage':
         specifier: ^2.0.6
         version: 2.0.6
@@ -969,6 +975,9 @@ importers:
       '@bcoe/v8-coverage':
         specifier: ^0.2.3
         version: 0.2.3
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage:
         specifier: ^3.2.2
         version: 3.2.2
@@ -1000,6 +1009,9 @@ importers:
         specifier: ^9.2.0
         version: 9.2.0
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/istanbul-lib-coverage':
         specifier: ^2.0.6
         version: 2.0.6
@@ -8946,12 +8958,6 @@ packages:
 
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
-    dependencies:
-      '@types/ms': 0.7.31
-    dev: true
-
-  /@types/debug@4.1.8:
-    resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
     dependencies:
       '@types/ms': 0.7.31
     dev: true
@@ -25695,7 +25701,7 @@ packages:
       '@vue/compiler-sfc':
         optional: true
     dependencies:
-      '@types/debug': 4.1.8
+      '@types/debug': 4.1.12
       debug: 4.3.4(supports-color@8.1.1)
       deep-equal: 2.2.1
       extract-comments: 1.1.0

--- a/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
@@ -462,12 +462,23 @@ exports[`istanbul json report 1`] = `
     "s": {
       "0": 1,
       "1": 1,
-      "2": 3,
-      "3": 1,
-      "4": 2,
+      "2": 1,
+      "3": 3,
+      "4": 1,
+      "5": 2,
     },
     "statementMap": {
       "0": {
+        "end": {
+          "column": null,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "1": {
         "end": {
           "column": null,
           "line": 6,
@@ -477,7 +488,7 @@ exports[`istanbul json report 1`] = `
           "line": 6,
         },
       },
-      "1": {
+      "2": {
         "end": {
           "column": null,
           "line": 7,
@@ -487,7 +498,7 @@ exports[`istanbul json report 1`] = `
           "line": 7,
         },
       },
-      "2": {
+      "3": {
         "end": {
           "column": 55,
           "line": 7,
@@ -497,7 +508,7 @@ exports[`istanbul json report 1`] = `
           "line": 7,
         },
       },
-      "3": {
+      "4": {
         "end": {
           "column": null,
           "line": 9,
@@ -507,7 +518,7 @@ exports[`istanbul json report 1`] = `
           "line": 9,
         },
       },
-      "4": {
+      "5": {
         "end": {
           "column": 30,
           "line": 14,

--- a/test/coverage-test/coverage-report-tests/__snapshots__/v8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/v8.report.test.ts.snap
@@ -3315,7 +3315,7 @@ exports[`v8 json report 1`] = `
         0,
       ],
       "10": [
-        2,
+        1,
       ],
       "2": [
         0,
@@ -3324,7 +3324,7 @@ exports[`v8 json report 1`] = `
         1,
       ],
       "4": [
-        3,
+        1,
       ],
       "5": [
         0,
@@ -3336,10 +3336,10 @@ exports[`v8 json report 1`] = `
         1,
       ],
       "8": [
-        1,
+        2,
       ],
       "9": [
-        1,
+        3,
       ],
     },
     "branchMap": {
@@ -3399,8 +3399,8 @@ exports[`v8 json report 1`] = `
         "line": 24,
         "loc": {
           "end": {
-            "column": 1,
-            "line": 31,
+            "column": 3,
+            "line": 27,
           },
           "start": {
             "column": 33,
@@ -3410,8 +3410,8 @@ exports[`v8 json report 1`] = `
         "locations": [
           {
             "end": {
-              "column": 1,
-              "line": 31,
+              "column": 3,
+              "line": 27,
             },
             "start": {
               "column": 33,
@@ -3477,8 +3477,8 @@ exports[`v8 json report 1`] = `
         "line": 16,
         "loc": {
           "end": {
-            "column": 1,
-            "line": 31,
+            "column": 3,
+            "line": 19,
           },
           "start": {
             "column": 31,
@@ -3488,8 +3488,8 @@ exports[`v8 json report 1`] = `
         "locations": [
           {
             "end": {
-              "column": 1,
-              "line": 31,
+              "column": 3,
+              "line": 19,
             },
             "start": {
               "column": 31,
@@ -3581,8 +3581,8 @@ exports[`v8 json report 1`] = `
         "line": 24,
         "loc": {
           "end": {
-            "column": 3,
-            "line": 27,
+            "column": 1,
+            "line": 31,
           },
           "start": {
             "column": 33,
@@ -3592,8 +3592,8 @@ exports[`v8 json report 1`] = `
         "locations": [
           {
             "end": {
-              "column": 3,
-              "line": 27,
+              "column": 1,
+              "line": 31,
             },
             "start": {
               "column": 33,
@@ -3607,8 +3607,8 @@ exports[`v8 json report 1`] = `
         "line": 16,
         "loc": {
           "end": {
-            "column": 3,
-            "line": 19,
+            "column": 1,
+            "line": 31,
           },
           "start": {
             "column": 31,
@@ -3618,8 +3618,8 @@ exports[`v8 json report 1`] = `
         "locations": [
           {
             "end": {
-              "column": 3,
-              "line": 19,
+              "column": 1,
+              "line": 31,
             },
             "start": {
               "column": 31,

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -117,6 +117,7 @@ test('provider module', () => {
             reportsDirectory: 'string',
             reportOnFailure: true,
             allowExternal: true,
+            processingConcurrency: 1,
           }
         },
         clean(_: boolean) {},


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes https://github.com/vitest-dev/vitest/issues/4476
- Adds new option `coverage.processingConcurrency` for controlling concurrency limit of coverage file processing. Default value is likely good for most users. This option is only exposed for issues like [nyc#1424](https://github.com/istanbuljs/nyc/issues/1424) and [nyc#1309](https://github.com/istanbuljs/nyc/issues/1309).
- Adds support for debugging coverage report processing by using `DEBUG=vitest:coverage` environment variable. This is useful when debugging slow coverage generation, e.g. cases where `coverage.all: true` picked minified Javascript files. This will also help maintainers when debugging bug reports.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
  - Let's add test case to ecosystem so whole Vitest pipeline won't slow down https://github.com/vitest-dev/vitest-ecosystem-ci/pull/7
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

### Manual testing

Using [`vitest-tests/coverage-large`](https://github.com/vitest-tests/coverage-large) as reference with [options](https://github.com/vitest-tests/coverage-large/blob/ed8f06265e4fb6f5fe2efa61a1a48015dc7083d7/generate-files.mjs#L4-L6) `500, 500, 200`.

- `vitest@0.34.6`  https://github.com/vitest-tests/coverage-large/actions/runs/6961311750
  - Test run 715.68s
  - Crashed with out-of-memory error while generating coverage report after 33m56s :x:
- `vitest@1.0.0-beta.5`  https://github.com/vitest-tests/coverage-large/actions/runs/7009553693
  - Test run 688.40s
  - Crashed with out-of-memory error while generating coverage report after 39m41s :x:
- `vitest@1.0.0-beta.5` + changes from `main` branch, https://github.com/vitest-tests/coverage-large/actions/runs/7009888719
  - Test run 695.61s
  - Crashed with out-of-memory error while generating coverage report after 26m38s :x:
- `vitest@1.0.0-beta.5` + this PR, https://github.com/vitest-tests/coverage-large/actions/runs/7009560641
  - Test run 637.15s
  - Whole `vitest --run` took 21m25s - this includes tests and coverage report generation ✅ 
  - Also runs with higher amount of files pass without crashing ✅
