### PR TITLE
feat(expect): compare URL objects by href

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -96,6 +96,9 @@ function eq(
   if (a instanceof Error && b instanceof Error)
     return a.message === b.message
 
+  if (a instanceof URL && b instanceof URL)
+    return a.href === b.href
+
   if (Object.is(a, b))
     return true
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -58,6 +58,10 @@ describe('jest-expect', () => {
     expect(new URL('https://example.org')).not.toEqual(new URL('https://different-example.org'))
     expect(new URL('https://example.org?query=value')).toEqual(new URL('https://example.org?query=value'))
     expect(new URL('https://example.org?query=one')).not.toEqual(new URL('https://example.org?query=two'))
+    expect(new URL('https://subdomain.example.org/path?query=value#fragment-identifier')).toEqual(new URL('https://subdomain.example.org/path?query=value#fragment-identifier'))
+    expect(new URL('https://subdomain.example.org/path?query=value#fragment-identifier')).not.toEqual(new URL('https://subdomain.example.org/path?query=value#different-fragment-identifier'))
+    expect(new URL('https://example.org/path')).toEqual(new URL('/path', 'https://example.org'))
+    expect(new URL('https://example.org/path')).not.toEqual(new URL('/path', 'https://example.com'))
 
     expect(BigInt(1)).toBeGreaterThan(BigInt(0))
     expect(1).toBeGreaterThan(BigInt(0))

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -51,6 +51,12 @@ describe('jest-expect', () => {
     expect(new Date(0)).toEqual(new Date(0))
     expect(new Date('inValId')).toEqual(new Date('inValId'))
 
+    expect(new Error('message')).toEqual(new Error('message'))
+    expect(new Error('message')).not.toEqual(new Error('different message'))
+
+    expect(new URL('https://example.org')).toEqual(new URL('https://example.org'))
+    expect(new URL('https://example.org')).not.toEqual(new URL('https://different-example.org'))
+
     expect(BigInt(1)).toBeGreaterThan(BigInt(0))
     expect(1).toBeGreaterThan(BigInt(0))
     expect(BigInt(1)).toBeGreaterThan(0)

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -56,6 +56,8 @@ describe('jest-expect', () => {
 
     expect(new URL('https://example.org')).toEqual(new URL('https://example.org'))
     expect(new URL('https://example.org')).not.toEqual(new URL('https://different-example.org'))
+    expect(new URL('https://example.org?query=value')).toEqual(new URL('https://example.org?query=value'))
+    expect(new URL('https://example.org?query=one')).not.toEqual(new URL('https://example.org?query=two'))
 
     expect(BigInt(1)).toBeGreaterThan(BigInt(0))
     expect(1).toBeGreaterThan(BigInt(0))


### PR DESCRIPTION
### Description

Change the "equal comparison" logic (as used by `toEqual`, `toStrictEqual`, etc.) to compare `URL` objects by their `href` property.

Closes #4614.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
