### PR TITLE
docs: `os.cpu()` should be `os.cpus()`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1326,7 +1326,7 @@ Watermarks for statements, lines, branches and functions. See [istanbul document
 #### coverage.processingConcurrency
 
 - **Type:** `boolean`
-- **Default:** `Math.min(20, os.cpu().length)`
+- **Default:** `Math.min(20, os.cpus().length)`
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.processingConcurrency=<number>`
 

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -208,7 +208,7 @@ export interface BaseCoverageOptions {
 
   /**
    * Concurrency limit used when processing the coverage results.
-   * Defaults to `Math.min(20, os.cpu().length)`
+   * Defaults to `Math.min(20, os.cpus().length)`
    */
   processingConcurrency?: number
 }


### PR DESCRIPTION
### Description

`os.cpu()` should be `os.cpus()` in config docs.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
