### PR TITLE
chore: fix undefined mocked key error suggestion

### DIFF
--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -207,7 +207,7 @@ export class VitestMocker {
   return {
     ...actual,
     // your mocked methods
-  },
+  }
 })`)}\n`,
           )
         }


### PR DESCRIPTION
### Description

This is just a quality of life issue. It was bugging me that when you copy the suggested code when an undefined mock key is accessed, it contains errors. The comma is invalid, because it should be either a semicolon or nothing at all.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
