### PR TITLE
refactor: replace `os.cpus` with `availableParallelism`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1326,7 +1326,7 @@ Watermarks for statements, lines, branches and functions. See [istanbul document
 #### coverage.processingConcurrency
 
 - **Type:** `boolean`
-- **Default:** `Math.min(20, os.cpus().length)`
+- **Default:** `Math.min(20, os.availableParallelism?.() ?? os.cpus().length)`
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.processingConcurrency=<number>`
 

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -1,4 +1,4 @@
-import { cpus } from 'node:os'
+import os from 'node:os'
 import type { BenchmarkUserOptions, CoverageV8Options, ResolvedCoverageOptions, UserConfig } from './types'
 import { isCI } from './utils/env'
 
@@ -43,7 +43,7 @@ export const coverageConfigDefaults: ResolvedCoverageOptions = {
   reporter: [['text', {}], ['html', {}], ['clover', {}], ['json', {}]],
   extension: ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.vue', '.svelte', '.marko'],
   allowExternal: false,
-  processingConcurrency: Math.min(20, cpus().length),
+  processingConcurrency: Math.min(20, os.availableParallelism?.() ?? os.cpus().length),
 }
 
 export const fakeTimersDefaults = {

--- a/packages/vitest/src/types/coverage.ts
+++ b/packages/vitest/src/types/coverage.ts
@@ -208,7 +208,7 @@ export interface BaseCoverageOptions {
 
   /**
    * Concurrency limit used when processing the coverage results.
-   * Defaults to `Math.min(20, os.cpus().length)`
+   * Defaults to `Math.min(20, os.availableParallelism?.() ?? os.cpus().length)`
    */
   processingConcurrency?: number
 }


### PR DESCRIPTION
### Description
Used to replace `os.cpus` when `availableParallelism` is available.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
