### PR TITLE
fix: set process name for idle workers

### DIFF
--- a/packages/vitest/src/runtime/child.ts
+++ b/packages/vitest/src/runtime/child.ts
@@ -13,16 +13,16 @@ import { mockMap, moduleCache, startViteNode } from './execute'
 import { createSafeRpc, rpcDone } from './rpc'
 import { setupInspect } from './inspector'
 
+try {
+  process.title = `node (vitest ${poolId})`
+}
+catch {}
+
 async function init(ctx: ChildContext) {
   const { config, workerId, providedContext } = ctx
 
   process.env.VITEST_WORKER_ID = String(workerId)
   process.env.VITEST_POOL_ID = String(poolId)
-
-  try {
-    process.title = `node (vitest ${poolId})`
-  }
-  catch {}
 
   let setCancel = (_reason: CancelReason) => {}
   const onCancel = new Promise<CancelReason>((resolve) => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Ref. https://github.com/vitest-dev/vitest/pull/4191

The `init()` of `runtime/child.ts` is called only once tasks are started. However Tinypool imports the handler of workers when preparing them. In practice, without this change there can be Vitest forks running idle, but process name is not set for them. By moving the `process.title` override to module level it will be set as soon as Tinypool imports the worker entrypoint.

Tested manually by running Vitest in watch mode and checking running processes once tests had succeeded and Vitest was waiting for re-runs. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
