### PR TITLE
fix: fix ensurePackageInstalled on Yarn PnP

### DIFF
--- a/packages/vitest/src/node/pkg.ts
+++ b/packages/vitest/src/node/pkg.ts
@@ -1,4 +1,5 @@
 import url from 'node:url'
+import { createRequire } from 'node:module'
 import c from 'picocolors'
 import { isPackageExists } from 'local-pkg'
 import { EXIT_CODE_RESTART } from '../constants'
@@ -10,6 +11,16 @@ export async function ensurePackageInstalled(
   dependency: string,
   root: string,
 ) {
+  if (process.versions.pnp) {
+    const targetRequire = createRequire(__dirname)
+    try {
+      targetRequire.resolve(dependency, { paths: [root, __dirname] })
+      return true
+    }
+    catch (error) {
+    }
+  }
+
   if (isPackageExists(dependency, { paths: [root, __dirname] }))
     return true
 


### PR DESCRIPTION
close #899
close #4575
partially #4413

### Description

This PR adds a special case for Yarn PnP inside ensurePackageInstalled to work around https://github.com/antfu/local-pkg/issues/2, making Vitest possible to use with Yarn PnP again.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
