### PR TITLE
fix: apply `stripSnapshotIndentation` for thrown snapshot

### DIFF
--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -154,6 +154,9 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
       const promise = utils.flag(this, 'promise') as string | undefined
       const errorMessage = utils.flag(this, 'message')
 
+      if (inlineSnapshot)
+        inlineSnapshot = stripSnapshotIndentation(inlineSnapshot)
+
       getSnapshotClient().assert({
         received: getError(expected, promise),
         message,

--- a/test/core/test/snapshot-inline.test.ts
+++ b/test/core/test/snapshot-inline.test.ts
@@ -100,6 +100,15 @@ test('throwing inline snapshots', async () => {
     newlines"
   `)
 
+  expect(() => {
+    throw new Error(['Inline', 'snapshot', 'with', 'newlines'].join('\n'))
+  }).toThrowErrorMatchingInlineSnapshot(`
+    [Error: Inline
+    snapshot
+    with
+    newlines]
+  `)
+
   await expect(async () => {
     throw new Error('omega')
   }).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: omega]`)

--- a/test/core/test/snapshot-inline.test.ts
+++ b/test/core/test/snapshot-inline.test.ts
@@ -109,6 +109,13 @@ test('throwing inline snapshots', async () => {
     newlines]
   `)
 
+  expect(new Error(['Inline', 'snapshot', 'with', 'newlines'].join('\n'))).toMatchInlineSnapshot(`
+    [Error: Inline
+    snapshot
+    with
+    newlines]
+  `)
+
   await expect(async () => {
     throw new Error('omega')
   }).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: omega]`)


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4662

I think the difference between `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` was due to the lack of `stripSnapshotIndentation`. It seems to work fine after adding it to `toThrowErrorMatchingInlineSnapshot`.

Actually I'm a little puzzled by why the following case was working fine without this change. I might be still missing something ...

https://github.com/vitest-dev/vitest/blob/4a8714e00c83adba1f509861f031f5489e82dfb0/test/core/test/snapshot-inline.test.ts#L94-L101

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] (N/A) If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
