### PR TITLE
fix(expect): apply `URL` equality check only when `URL` is available

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -96,7 +96,7 @@ function eq(
   if (a instanceof Error && b instanceof Error)
     return a.message === b.message
 
-  if (a instanceof URL && b instanceof URL)
+  if (typeof URL === 'function' && a instanceof URL && b instanceof URL)
     return a.href === b.href
 
   if (Object.is(a, b))

--- a/test/core/test/jest-expect-no-url.test.ts
+++ b/test/core/test/jest-expect-no-url.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest'
+
+// simulate odd environment where URL is monkey-patched or not available
+it('jest-expect-no-url', () => {
+  (globalThis as any).URL = {}
+  expect('hello').toEqual('hello')
+
+  delete (globalThis as any).URL
+  expect('hello').toEqual('hello')
+})


### PR DESCRIPTION
### Description

As per @sheremet-va 's comment https://github.com/vitest-dev/vitest/discussions/4667#discussioncomment-7762415, I added `typeof URL` check to support environment where standard `URL` is not available.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] (NA) If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
