### PR TITLE
fix(vitest): support new Request('/api') in happy-dom

### DIFF
--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -47,7 +47,11 @@ export default <Environment>({
       },
     })
 
-    const { keys, originals } = populateGlobal(global, win, { bindFunctions: true })
+    const { keys, originals } = populateGlobal(global, win, {
+      bindFunctions: true,
+      // jsdom doesn't support Request and Response, but happy-dom does
+      additionalKeys: ['Request', 'Response'],
+    })
 
     return {
       teardown(global) {

--- a/packages/vitest/src/integrations/env/utils.ts
+++ b/packages/vitest/src/integrations/env/utils.ts
@@ -7,13 +7,14 @@ const skipKeys = [
   'parent',
 ]
 
-export function getWindowKeys(global: any, win: any) {
-  const keys = new Set(KEYS.concat(Object.getOwnPropertyNames(win))
+export function getWindowKeys(global: any, win: any, additionalKeys: string[] = []) {
+  const keysArray = [...additionalKeys, ...KEYS]
+  const keys = new Set(keysArray.concat(Object.getOwnPropertyNames(win))
     .filter((k) => {
       if (skipKeys.includes(k))
         return false
       if (k in global)
-        return KEYS.includes(k)
+        return keysArray.includes(k)
 
       return true
     }))
@@ -31,11 +32,13 @@ interface PopulateOptions {
   // has a priority for getting implementation from symbols
   // (global doesn't have these symbols, but window - does)
   bindFunctions?: boolean
+
+  additionalKeys?: string[]
 }
 
 export function populateGlobal(global: any, win: any, options: PopulateOptions = {}) {
   const { bindFunctions = false } = options
-  const keys = getWindowKeys(global, win)
+  const keys = getWindowKeys(global, win, options.additionalKeys)
 
   const originals = new Map<string | symbol, any>()
 

--- a/test/core/test/environments/happy-dom.spec.ts
+++ b/test/core/test/environments/happy-dom.spec.ts
@@ -20,3 +20,9 @@ test('atob and btoa are available', () => {
   expect(atob('aGVsbG8gd29ybGQ=')).toBe('hello world')
   expect(btoa('hello world')).toBe('aGVsbG8gd29ybGQ=')
 })
+
+test('request doesn\'t fail when using absolute url because it supports it', () => {
+  expect(() => {
+    const _r = new Request('/api', { method: 'GET' })
+  }).not.toThrow()
+})

--- a/test/core/test/environments/jsdom.spec.ts
+++ b/test/core/test/environments/jsdom.spec.ts
@@ -99,3 +99,9 @@ test('toContain correctly handles DOM nodes', () => {
     `)
   }
 })
+
+test('request doesn\'t support absolute URL because jsdom doesn\'t provide compatible Request so Vitest is using Node.js Request', () => {
+  expect(() => {
+    const _r = new Request('/api', { method: 'GET' })
+  }).toThrow(/Failed to parse URL/)
+})


### PR DESCRIPTION
### Description

fixes #4434

This PR doesn't fix the same issue with jsdom because jsdom doesn't provide compatible Request/Response, so Vitest has to use Node.js native Request and Response

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
