### PR TITLE
fix(vitest): skip processing getter in auto-mocked constructor call

### DIFF
--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -334,7 +334,11 @@ export class VitestMocker {
             // so that mock states between prototype/instances don't affect each other
             // (jest reference https://github.com/jestjs/jest/blob/2c3d2409879952157433de215ae0eee5188a4384/packages/jest-mock/src/index.ts#L678-L691)
             if (this instanceof newContainer[property]) {
-              for (const { key } of getAllMockableProperties(this, false, primitives)) {
+              for (const { key, descriptor } of getAllMockableProperties(this, false, primitives)) {
+                // skip getter since it's not mocked on prototype as well
+                if (descriptor.get)
+                  continue
+
                 const value = this[key]
                 const type = getType(value)
                 const isFunction = type.includes('Function') && typeof value === 'function'

--- a/test/core/src/mockedC.ts
+++ b/test/core/src/mockedC.ts
@@ -20,6 +20,10 @@ export class MockedC {
   }
 
   set getSetProp(_val: number) {}
+
+  get getExpectNotCalled(): number {
+    throw new Error('automocked constructor should not call this getter')
+  }
 }
 
 export async function asyncFunc(): Promise<string> {


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4676
Follow up https://github.com/vitest-dev/vitest/pull/4564

I found a previous discussion regarding getter/setter mocking in https://github.com/vitest-dev/vitest/pull/1903#discussion_r953359135. Based on that, I think just skipping getter entirely is a desired behavior.

Actually I wonder what's the current behavior with setter (setter only case?), but maybe it can be followed up separately since this getter bug could be a huge blocker for many users trying v1.
Please let me know what you think.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] (NA) If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
