### PR TITLE
fix(runner): fix fixture cleanup freeze when test times out

### DIFF
--- a/test/fails/fixtures/test-extend/fixture-error.test.ts
+++ b/test/fails/fixtures/test-extend/fixture-error.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expectTypeOf, test } from 'vitest'
+import { afterEach, beforeEach, describe, expectTypeOf, test, expect } from 'vitest'
 
 describe('error thrown in beforeEach fixtures', () => {
   const myTest = test.extend<{ a: never }>({
@@ -37,4 +37,16 @@ describe('error thrown in test fixtures', () => {
 
   // eslint-disable-next-line unused-imports/no-unused-vars
   myTest('fixture errors', ({ a }) => {})
+})
+
+describe('correctly fails when test times out', () => {
+  const myTest = test.extend<{ a: number }>({
+    a: async ({}, use) => {
+      await use(2)
+    },
+  })
+  myTest('test times out', async ({ a }) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    expect(a).toBe(2)
+  }, 20)
 })

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -43,7 +43,8 @@ TypeError: failure"
 exports[`should fail test-extend/circular-dependency.test.ts > test-extend/circular-dependency.test.ts 1`] = `"Error: circular fixture dependency"`;
 
 exports[`should fail test-extend/fixture-error.test.ts > test-extend/fixture-error.test.ts 1`] = `
-"Error: Error thrown in test fixture
+"Error: Test timed out in 20ms.
+Error: Error thrown in test fixture
 Error: Error thrown in afterEach fixture
 Error: Error thrown in beforeEach fixture"
 `;


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4669

The issue seems to be one of `cleanup` promise in `callFixtureCleanup` is kept unresolved when test times out.

While thinking about a fix, the recursive nature of `use/next` in `withFixtures` was a little hard for me to understand, so I attempted to rewrite it with for-loop iteration. This seems to fix the issue and also no regression of existing tests.

I don't know if this refactoring would make sense to everyone and also I'm not completely sure if the implementation is equivalent except fixing the reported bug.
I would like to know what others think. Thanks!

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] (NA) If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
