### PR TITLE
docs(browser): fix jsdoc default value of `slowHijackESM`

### DIFF
--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -72,7 +72,7 @@ export interface BrowserConfigOptions {
    * Update ESM imports so they can be spied/stubbed with vi.spyOn.
    * Enabled by default when running in browser.
    *
-   * @default true
+   * @default false
    * @experimental
    */
   slowHijackESM?: boolean


### PR DESCRIPTION
### Description

Related PR https://github.com/vitest-dev/vitest/pull/4414

While investigating https://github.com/vitest-dev/vitest/issues/4505, I noticed that the jsdoc default value was still `true`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
