### PR TITLE
chore: default exclude `eslint.config` and `prettier.config`

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -3,7 +3,7 @@ import type { BenchmarkUserOptions, CoverageV8Options, ResolvedCoverageOptions, 
 import { isCI } from './utils/env'
 
 export const defaultInclude = ['**/*.{test,spec}.?(c|m)[jt]s?(x)']
-export const defaultExclude = ['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*']
+export const defaultExclude = ['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*']
 export const benchmarkConfigDefaults: Required<Omit<BenchmarkUserOptions, 'outputFile'>> = {
   include: ['**/*.{bench,benchmark}.?(c|m)[jt]s?(x)'],
   exclude: defaultExclude,


### PR DESCRIPTION
### Description

Exclude `eslint.config` and `prettier.config` by default to avoid impacting coverage

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] ~~It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.~~
- [ ] ~~Ideally, include a test that fails without this PR but passes with it.~~
This change is too small to require this, I will add it if requested.
- [ ] ~~Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.~~

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] ~~If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.~~

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
