### PR TITLE
test(browser): add test case for cjs import

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1479,6 +1479,9 @@ importers:
       '@vitest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
+      '@vitest/cjs-lib':
+        specifier: link:./cjs-lib
+        version: link:cjs-lib
       execa:
         specifier: ^7.1.1
         version: 7.1.1

--- a/test/browser/cjs-lib/index.js
+++ b/test/browser/cjs-lib/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  a: 'a',
+  b: 'b',
+  object: {
+    h: 'h',
+  },
+}

--- a/test/browser/cjs-lib/package.json
+++ b/test/browser/cjs-lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitest/cjs-lib",
+  "type": "commonjs",
+	"exports": {
+		"default": "./index.js"
+	}
+}

--- a/test/browser/cjs-lib/package.json
+++ b/test/browser/cjs-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vitest/cjs-lib",
   "type": "commonjs",
-	"exports": {
-		"default": "./index.js"
-	}
+  "exports": {
+    "default": "./index.js"
+  }
 }

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -9,6 +9,7 @@
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes"
   },
   "devDependencies": {
+    "@vitest/cjs-lib": "link:./cjs-lib",
     "@vitest/browser": "workspace:*",
     "execa": "^7.1.1",
     "safaridriver": "^0.0.4",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -9,8 +9,8 @@
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes"
   },
   "devDependencies": {
-    "@vitest/cjs-lib": "link:./cjs-lib",
     "@vitest/browser": "workspace:*",
+    "@vitest/cjs-lib": "link:./cjs-lib",
     "execa": "^7.1.1",
     "safaridriver": "^0.0.4",
     "vitest": "workspace:*"

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -24,8 +24,8 @@ const passedTests = getPassed(browserResultJson.testResults)
 const failedTests = getFailed(browserResultJson.testResults)
 
 await test('tests are actually running', async () => {
-  assert.ok(browserResultJson.testResults.length === 8, 'Not all the tests have been run')
-  assert.ok(passedTests.length === 7, 'Some tests failed')
+  assert.ok(browserResultJson.testResults.length === 9, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 8, 'Some tests failed')
   assert.ok(failedTests.length === 1, 'Some tests have passed but should fail')
 
   assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')

--- a/test/browser/test/cjs-lib.test.ts
+++ b/test/browser/test/cjs-lib.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import cjsDefault from '@vitest/cjs-lib'
+import * as cjsNamespace from '@vitest/cjs-lib'
+
+test('cjs namespace import', () => {
+  expect(cjsNamespace).toEqual({
+    a: 'a',
+    b: 'b',
+    object: {
+      h: 'h',
+    },
+  })
+})
+
+test('cjs default import not supported when slowHijackESM', () => {
+  expect(cjsDefault).toBeUndefined()
+})

--- a/test/browser/test/cjs-lib.test.ts
+++ b/test/browser/test/cjs-lib.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import cjsDefault from '@vitest/cjs-lib'
+import cjsDefault, { a as cjsNamed } from '@vitest/cjs-lib'
 import * as cjsNamespace from '@vitest/cjs-lib'
 
 test('cjs namespace import', () => {
@@ -10,6 +10,10 @@ test('cjs namespace import', () => {
       h: 'h',
     },
   })
+})
+
+test('cjs named import', () => {
+  expect(cjsNamed).toEqual('a')
 })
 
 test('cjs default import not supported when slowHijackESM', () => {

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -7,6 +7,9 @@ const dir = dirname(fileURLToPath(import.meta.url))
 function noop() {}
 
 export default defineConfig({
+  optimizeDeps: {
+    include: ["@vitest/cjs-lib"]
+  },
   test: {
     include: ['test/**.test.{ts,js}'],
     browser: {

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -8,7 +8,7 @@ function noop() {}
 
 export default defineConfig({
   optimizeDeps: {
-    include: ["@vitest/cjs-lib"]
+    include: ['@vitest/cjs-lib'],
   },
   test: {
     include: ['test/**.test.{ts,js}'],


### PR DESCRIPTION
### Description

I'm currently investigating cjs default import issue with `browser.slowHijackESM` (cf. https://github.com/vitest-dev/vitest/issues/4264).
I wasn't sure the future plan of supporting this use case, but I thought it might still make sense to have a test case to demonstrate the current behavior. This would also help debugging this scenario in the future.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
