### PR TITLE
fix(browser): handle config.base (#4686)

### DIFF
--- a/packages/browser/src/client/logger.ts
+++ b/packages/browser/src/client/logger.ts
@@ -3,8 +3,8 @@ import { importId } from './utils'
 
 const { Date, console } = globalThis
 
-export async function setupConsoleLogSpy() {
-  const { stringify, format, inspect } = await importId('vitest/utils') as typeof import('vitest/utils')
+export async function setupConsoleLogSpy(basePath: string) {
+  const { stringify, format, inspect } = await importId('vitest/utils', basePath) as typeof import('vitest/utils')
   const { log, info, error, dir, dirxml, trace, time, timeEnd, timeLog, warn, debug, count, countReset } = console
   const formatInput = (input: unknown) => {
     if (input instanceof Node)

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -3,7 +3,7 @@ import type { ResolvedConfig } from 'vitest'
 import type { CancelReason, VitestRunner } from '@vitest/runner'
 import type { VitestExecutor } from '../../../vitest/src/runtime/execute'
 import { createBrowserRunner } from './runner'
-import { importId as importIdImpl } from './utils'
+import { importId as _importId } from './utils'
 import { setupConsoleLogSpy } from './logger'
 import { createSafeRpc, rpc, rpcDone } from './rpc'
 import { setupDialogsSpy } from './dialog'
@@ -24,8 +24,8 @@ const url = new URL(location.href)
 const testId = url.searchParams.get('id') || 'unknown'
 const reloadTries = Number(url.searchParams.get('reloadTries') || '0')
 
-const basePath = () => config!.base! || '/'
-const importId = (id: string) => importIdImpl(id, basePath())
+const basePath = () => config?.base || '/'
+const importId = (id: string) => _importId(id, basePath())
 const viteClientPath = () => `${basePath()}@vite/client`
 
 function getQueryPaths() {
@@ -207,7 +207,7 @@ async function prepareTestEnvironment(config: ResolvedConfig) {
 
   if (!runner) {
     const { VitestTestRunner } = await importId('vitest/runners') as typeof import('vitest/runners')
-    const BrowserRunner = createBrowserRunner(VitestTestRunner, { takeCoverage: () => takeCoverageInsideWorker(config.coverage, executor) }, basePath())
+    const BrowserRunner = createBrowserRunner(VitestTestRunner, { takeCoverage: () => takeCoverageInsideWorker(config.coverage, executor) })
     runner = new BrowserRunner({ config, browserHashMap })
   }
 

--- a/packages/browser/src/client/runner.ts
+++ b/packages/browser/src/client/runner.ts
@@ -14,6 +14,7 @@ interface CoverageHandler {
 export function createBrowserRunner(
   original: { new(config: ResolvedConfig): VitestRunner },
   coverageModule: CoverageHandler | null,
+  basePath: string,
 ): { new(options: BrowserRunnerOptions): VitestRunner } {
   return class BrowserTestRunner extends original {
     public config: ResolvedConfig
@@ -71,9 +72,9 @@ export function createBrowserRunner(
       }
 
       // on Windows we need the unit to resolve the test file
-      const importpath = /^\w:/.test(filepath)
-        ? `/@fs/${filepath}?${test ? 'browserv' : 'v'}=${hash}`
-        : `${filepath}?${test ? 'browserv' : 'v'}=${hash}`
+      const prefix = `${basePath}${/^\w:/.test(filepath) ? '@fs/' : ''}`
+      const query = `${test ? 'browserv' : 'v'}=${hash}`
+      const importpath = `${prefix}${filepath}?${query}`.replace(/\/+/g, '/')
       await import(importpath)
     }
   }

--- a/packages/browser/src/client/runner.ts
+++ b/packages/browser/src/client/runner.ts
@@ -12,11 +12,10 @@ interface CoverageHandler {
 }
 
 export function createBrowserRunner(
-  original: { new(config: ResolvedConfig): VitestRunner },
+  VitestRunner: { new(config: ResolvedConfig): VitestRunner },
   coverageModule: CoverageHandler | null,
-  basePath: string,
 ): { new(options: BrowserRunnerOptions): VitestRunner } {
-  return class BrowserTestRunner extends original {
+  return class BrowserTestRunner extends VitestRunner {
     public config: ResolvedConfig
     hashMap = new Map<string, [test: boolean, timstamp: string]>()
 
@@ -70,9 +69,10 @@ export function createBrowserRunner(
         hash = Date.now().toString()
         this.hashMap.set(filepath, [false, hash])
       }
+      const base = this.config.base || '/'
 
       // on Windows we need the unit to resolve the test file
-      const prefix = `${basePath}${/^\w:/.test(filepath) ? '@fs/' : ''}`
+      const prefix = `${base}${/^\w:/.test(filepath) ? '@fs/' : ''}`
       const query = `${test ? 'browserv' : 'v'}=${hash}`
       const importpath = `${prefix}${filepath}?${query}`.replace(/\/+/g, '/')
       await import(importpath)

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -1,5 +1,5 @@
-export async function importId(id: string) {
-  const name = `/@id/${id}`
+export async function importId(id: string, basePath: string) {
+  const name = `${basePath}@id/${id}`
   // @ts-expect-error mocking vitest apis
   return __vi_wrap_module__(import(name))
 }

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "test": "pnpm run test:webdriverio && pnpm run test:playwright",
-    "test:webdriverio": "PROVIDER=webdriverio node --test specs/",
-    "test:playwright": "PROVIDER=playwright node --test specs/",
-    "test:safaridriver": "PROVIDER=webdriverio BROWSER=safari node --test specs/",
+    "test:webdriverio": "PROVIDER=webdriverio node --test --test-concurrency=1 specs/",
+    "test:playwright": "PROVIDER=playwright node --test --test-concurrency=1 specs/",
+    "test:safaridriver": "PROVIDER=webdriverio BROWSER=safari node --test --test-concurrency=1 specs/",
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes"
   },
   "devDependencies": {

--- a/test/browser/specs/fix-4686.test.mjs
+++ b/test/browser/specs/fix-4686.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert'
+import test from 'node:test'
+import runVitest from './run-vitest.mjs'
+
+const {
+  stderr,
+  browserResultJson,
+  passedTests,
+  failedTests,
+} = await runVitest(['--config', 'vitest.config-basepath.mts'])
+
+await test('tests run in presence of config.base', async () => {
+  assert.ok(browserResultJson.testResults.length === 8, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 7, 'Some tests failed')
+  assert.ok(failedTests.length === 1, 'Some tests have passed but should fail')
+
+  assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')
+})

--- a/test/browser/specs/fix-4686.test.mjs
+++ b/test/browser/specs/fix-4686.test.mjs
@@ -1,3 +1,5 @@
+// fix #4686
+
 import assert from 'node:assert'
 import test from 'node:test'
 import runVitest from './run-vitest.mjs'
@@ -7,12 +9,12 @@ const {
   browserResultJson,
   passedTests,
   failedTests,
-} = await runVitest(['--config', 'vitest.config-basepath.mts'])
+} = await runVitest(['--config', 'vitest.config-basepath.mts', 'basic.test.ts'])
 
 await test('tests run in presence of config.base', async () => {
-  assert.ok(browserResultJson.testResults.length === 8, 'Not all the tests have been run')
-  assert.ok(passedTests.length === 7, 'Some tests failed')
-  assert.ok(failedTests.length === 1, 'Some tests have passed but should fail')
+  assert.ok(browserResultJson.testResults.length === 1, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 1, 'Some tests failed')
+  assert.ok(failedTests.length === 0, 'Some tests have passed but should fail')
 
   assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')
 })

--- a/test/browser/specs/run-vitest.mjs
+++ b/test/browser/specs/run-vitest.mjs
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises'
+import { execa } from 'execa'
+
+const browser = process.env.BROWSER || (process.env.PROVIDER === 'playwright' ? 'chromium' : 'chrome')
+
+export default async function runVitest(moreArgs = []) {
+  const argv = ['vitest', '--run', `--browser.name=${browser}`]
+
+  if (browser !== 'safari')
+    argv.push('--browser.headless')
+
+  const { stderr, stdout } = await execa('npx', argv.concat(moreArgs), {
+    env: {
+      ...process.env,
+      CI: 'true',
+      NO_COLOR: 'true',
+    },
+    reject: false,
+  })
+  const browserResult = await readFile('./browser.json', 'utf-8')
+  const browserResultJson = JSON.parse(browserResult)
+
+  const getPassed = results => results.filter(result => result.status === 'passed')
+  const getFailed = results => results.filter(result => result.status === 'failed')
+
+  const passedTests = getPassed(browserResultJson.testResults)
+  const failedTests = getFailed(browserResultJson.testResults)
+
+  return { stderr, stdout, browserResultJson, passedTests, failedTests }
+}

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -1,31 +1,14 @@
 import assert from 'node:assert'
-import { readFile } from 'node:fs/promises'
 import test from 'node:test'
-import { execa } from 'execa'
+import runVitest from './run-vitest.mjs'
 
-const browser = process.env.BROWSER || (process.env.PROVIDER === 'playwright' ? 'chromium' : 'chrome')
-const argv = ['vitest', '--run', `--browser.name=${browser}`]
-
-if (browser !== 'safari')
-  argv.push('--browser.headless')
-
-const { stderr, stdout } = await execa('npx', argv, {
-  env: {
-    ...process.env,
-    CI: 'true',
-    NO_COLOR: 'true',
-  },
-  reject: false,
-})
-
-const browserResult = await readFile('./browser.json', 'utf-8')
-const browserResultJson = JSON.parse(browserResult)
-
-const getPassed = results => results.filter(result => result.status === 'passed')
-const getFailed = results => results.filter(result => result.status === 'failed')
-
-const passedTests = getPassed(browserResultJson.testResults)
-const failedTests = getFailed(browserResultJson.testResults)
+const {
+  stderr,
+  stdout,
+  browserResultJson,
+  passedTests,
+  failedTests,
+} = await runVitest()
 
 await test('tests are actually running', async () => {
   assert.ok(browserResultJson.testResults.length === 10, 'Not all the tests have been run')

--- a/test/browser/vitest.config-basepath.mts
+++ b/test/browser/vitest.config-basepath.mts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import baseConfig from './vitest.config.mts'
+
+export default mergeConfig(baseConfig, defineConfig({ base: '/fix-4686' }))

--- a/test/browser/vitest.config-basepath.mts
+++ b/test/browser/vitest.config-basepath.mts
@@ -1,4 +1,4 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
-import baseConfig from './vitest.config.mts'
+import baseConfig from './vitest.config.mjs'
 
 export default mergeConfig(baseConfig, defineConfig({ base: '/fix-4686' }))


### PR DESCRIPTION
### Description

Closes #4686.

Ensures that every import() is properly prefixed with either config.base or '/'.

Also extracted a `runVitest()` test helper to eliminate duplication in the new test. (Except that the new test file copies the first of the existing test cases.)

cc: @alexdulin

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.

`pnpm test` passes locally on macOS; will try Linux and Windows 11 shortly. However, `pnpm test:ci` mostly passes, but eventually fails with:

```text
test/vm-threads test:  ✓ test/module.test.js  (1 test) 3ms
test/vm-threads test: Failed
/Users/msb/src/mbland/vitest/test/vm-threads:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @vitest/test-vm-threads@ test: `vitest "--allowOnly"`
Exit status 129
test/workspaces test$ pnpm test:workspace && pnpm test:coverage "--allowOnly"
 ELIFECYCLE  Command failed with exit code 1.
```

I wonder if this might be due to the fact that I'm running on Apple Silicon, however. Any insight would be appreciated.

### Documentation
- [X] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
