### PR TITLE
fix(cli): `--coverage.all=false` resolved incorrectly

### DIFF
--- a/packages/vitest/src/node/cli.ts
+++ b/packages/vitest/src/node/cli.ts
@@ -26,6 +26,7 @@ cli
   .option('--reporter <name>', 'Specify reporters')
   .option('--outputFile <filename/-s>', 'Write test results to a file when supporter reporter is also specified, use cac\'s dot notation for individual outputs of multiple reporters')
   .option('--coverage', 'Enable coverage report')
+  .option('--coverage.all', 'Whether to include all files, including the untested ones into report', { default: true })
   .option('--run', 'Disable watch mode')
   .option('--mode <name>', 'Override Vite mode (default: test)')
   .option('--globals', 'Inject apis globally')

--- a/test/config/fixtures/test/log-output.test.ts
+++ b/test/config/fixtures/test/log-output.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+/* eslint-disable no-console, unused-imports/no-unused-vars */
+
+test('logs resolved configuration', async () => {
+  // @ts-expect-error -- internal
+  const { snapshotOptions, ...config }: UserConfig['test'] = globalThis.__vitest_worker__.config
+
+  // Log options that are tested
+  log('coverage.enabled', config.coverage?.enabled)
+
+  if(config.coverage?.provider === "istanbul" || config.coverage?.provider === "v8")
+    log('coverage.all', config.coverage?.all)
+})
+
+function log(label: string, value: unknown) {
+  console.log(label, value, typeof value)
+}

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -92,7 +92,7 @@ test('coverage.autoUpdate cannot update thresholds when configuration file doesn
     },
   })
 
-  expect(stderr).toMatch('Error: Unable to parse thresholds from configuration file: Cannot read properties of undefined')
+  expect(stderr).toMatch('Error: Unable to parse thresholds from configuration file: Expected config.test.coverage.thresholds to be an object')
 })
 
 test('boolean flag 100 should not crash CLI', async () => {

--- a/test/config/test/options.test.ts
+++ b/test/config/test/options.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest'
+
+import * as testUtils from '../../test-utils'
+
+function runVitestCli(...cliArgs: string[]) {
+  return testUtils.runVitestCli('--root', 'fixtures', 'run', 'test/log-output.test.ts', ...cliArgs)
+}
+
+test('--coverage', async () => {
+  const { stdout } = await runVitestCli('--coverage')
+
+  expect(stdout).toMatch('coverage.enabled true boolean')
+})
+
+test('--coverage.all=false', async () => {
+  const { stdout } = await runVitestCli('--coverage.enabled', '--coverage.all=false')
+
+  expect(stdout).toMatch('coverage.all false boolean')
+})
+
+test('--coverage.all', async () => {
+  const { stdout } = await runVitestCli('--coverage.enabled', '--coverage.all')
+
+  expect(stdout).toMatch('coverage.all true boolean')
+})

--- a/test/config/vitest.config.ts
+++ b/test/config/vitest.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
     chaiConfig: {
       truncateThreshold: 999,
     },
+    coverage: {
+      reporter: [],
+    },
   },
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/4694

Hopefully this is last time this boolean flag breaks. `cac` is not my favorite library. 


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
