### PR TITLE
fix: fix crash when using happy-dom or jsdom environment on Yarn PnP workspaces

### DIFF
--- a/packages/vitest/src/integrations/env/edge-runtime.ts
+++ b/packages/vitest/src/integrations/env/edge-runtime.ts
@@ -6,7 +6,7 @@ export default <Environment>({
   name: 'edge-runtime',
   transformMode: 'ssr',
   async setupVM() {
-    const { EdgeVM } = await import('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
+    const { EdgeVM } = await import('@edge-runtime/vm')
     const vm = new EdgeVM({
       extend: (context) => {
         context.global = context
@@ -24,7 +24,7 @@ export default <Environment>({
     }
   },
   async setup(global) {
-    const { EdgeVM } = await import('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
+    const { EdgeVM } = await import('@edge-runtime/vm')
     const vm = new EdgeVM({
       extend: (context) => {
         context.global = context

--- a/packages/vitest/src/integrations/env/edge-runtime.ts
+++ b/packages/vitest/src/integrations/env/edge-runtime.ts
@@ -1,4 +1,3 @@
-import { importModule } from 'local-pkg'
 import type { Environment } from '../../types'
 import { populateGlobal } from './utils'
 import { KEYS } from './jsdom-keys'
@@ -7,7 +6,7 @@ export default <Environment>({
   name: 'edge-runtime',
   transformMode: 'ssr',
   async setupVM() {
-    const { EdgeVM } = await importModule('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
+    const { EdgeVM } = await import('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
     const vm = new EdgeVM({
       extend: (context) => {
         context.global = context
@@ -25,7 +24,7 @@ export default <Environment>({
     }
   },
   async setup(global) {
-    const { EdgeVM } = await importModule('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
+    const { EdgeVM } = await import('@edge-runtime/vm') as typeof import('@edge-runtime/vm')
     const vm = new EdgeVM({
       extend: (context) => {
         context.global = context

--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -1,4 +1,3 @@
-import { importModule } from 'local-pkg'
 import type { Environment } from '../../types'
 import { populateGlobal } from './utils'
 
@@ -6,7 +5,7 @@ export default <Environment>({
   name: 'happy-dom',
   transformMode: 'web',
   async setupVM({ happyDOM = {} }) {
-    const { Window } = await importModule('happy-dom') as typeof import('happy-dom')
+    const { Window } = await import('happy-dom') as typeof import('happy-dom')
     const win = new Window({
       ...happyDOM,
       console: (console && globalThis.console) ? globalThis.console : undefined,
@@ -36,7 +35,7 @@ export default <Environment>({
   async setup(global, { happyDOM = {} }) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
-    const { Window, GlobalWindow } = await importModule('happy-dom') as typeof import('happy-dom')
+    const { Window, GlobalWindow } = await import('happy-dom') as typeof import('happy-dom')
     const win = new (GlobalWindow || Window)({
       ...happyDOM,
       console: (console && global.console) ? global.console : undefined,

--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -5,7 +5,7 @@ export default <Environment>({
   name: 'happy-dom',
   transformMode: 'web',
   async setupVM({ happyDOM = {} }) {
-    const { Window } = await import('happy-dom') as typeof import('happy-dom')
+    const { Window } = await import('happy-dom')
     const win = new Window({
       ...happyDOM,
       console: (console && globalThis.console) ? globalThis.console : undefined,
@@ -35,7 +35,7 @@ export default <Environment>({
   async setup(global, { happyDOM = {} }) {
     // happy-dom v3 introduced a breaking change to Window, but
     // provides GlobalWindow as a way to use previous behaviour
-    const { Window, GlobalWindow } = await import('happy-dom') as typeof import('happy-dom')
+    const { Window, GlobalWindow } = await import('happy-dom')
     const win = new (GlobalWindow || Window)({
       ...happyDOM,
       console: (console && global.console) ? global.console : undefined,

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -34,7 +34,7 @@ export default <Environment>({
       JSDOM,
       ResourceLoader,
       VirtualConsole,
-    } = await import('jsdom') as typeof import('jsdom')
+    } = await import('jsdom')
     const {
       html = '<!DOCTYPE html>',
       userAgent,
@@ -106,7 +106,7 @@ export default <Environment>({
       JSDOM,
       ResourceLoader,
       VirtualConsole,
-    } = await import('jsdom') as typeof import('jsdom')
+    } = await import('jsdom')
     const {
       html = '<!DOCTYPE html>',
       userAgent,

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -1,4 +1,3 @@
-import { importModule } from 'local-pkg'
 import type { Environment } from '../../types'
 import { populateGlobal } from './utils'
 
@@ -35,7 +34,7 @@ export default <Environment>({
       JSDOM,
       ResourceLoader,
       VirtualConsole,
-    } = await importModule('jsdom') as typeof import('jsdom')
+    } = await import('jsdom') as typeof import('jsdom')
     const {
       html = '<!DOCTYPE html>',
       userAgent,
@@ -107,7 +106,7 @@ export default <Environment>({
       JSDOM,
       ResourceLoader,
       VirtualConsole,
-    } = await importModule('jsdom') as typeof import('jsdom')
+    } = await import('jsdom') as typeof import('jsdom')
     const {
       html = '<!DOCTYPE html>',
       userAgent,


### PR DESCRIPTION
close #4413

### Description

Fixes an issue with Vitest crashing with cryptic error:

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

```

when using happy-dom or jsdom environment on Yarn PnP workspaces (note: this is NOT happening in "just" Yarn PnP).

Similarly to #4657, this "lifts" the logic up from local-pkg in order for PnP not to complain about local-pkg accessing packages that are not declared as its dependencies or peerDependencies.

I was unsure what to do `pnpm-lock.yaml` because this PR technically adds a direct dependency (in reality, it "lifts" it, since it's already used in `local-pkg`), so lockfile had to be modified...

How I tested it:

1. Ran unit tests in my workspace using vitest + happy-dom, expecting failures, after removing [workaround mentioned in #4413](https://github.com/vitest-dev/vitest/issues/4413#issuecomment-1790347687):

```
wmaj@MacBook-Air-2 react-ui % yarn unit

 RUN  v1.0.2 /packages/packages/react-ui


⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 9 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
{ type: 'Unhandled Error', stacks: [] }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 Test Files  no tests
      Tests  no tests
     Errors  9 errors
   Start at  22:13:08
   Duration  775ms (transform 3ms, setup 0ms, collect 0ms, tests 0ms, environment 0ms, prepare 0ms)
```

2. Built vitest from source; copied `dist` directory to `.yarn/unplugged/vitest-virtual-64d4633324/node_modules/vitest/dist`; reinstalled repo:

```
wmaj@MacBook-Air-2 react-ui % yarn     
➤ YN0000: · Yarn 4.0.2
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 0s 206ms
➤ YN0000: ┌ Link step
➤ YN0000: │ ESM support for PnP uses the experimental loader API and is therefore experimental
➤ YN0000: └ Completed
➤ YN0000: · Done with warnings in 0s 408ms
```

3. Re-ran tests:

```
wmaj@MacBook-Air-2 react-ui % yarn unit

 RUN  v1.0.2 /packages/packages/react-ui

 ✓ textarea_field/index.spec.tsx (1)
 ✓ button_link/index.spec.tsx (1)
 ✓ radio_field/index.spec.tsx (6)
 ✓ input_field/index.spec.tsx (5)
 ✓ toggle/index.spec.tsx (7)
 ✓ checkbox_field/index.spec.tsx (8)
 ✓ select_field/index.spec.tsx (2)
 ✓ link_button/index.spec.tsx (1)
 ✓ button/index.spec.tsx (1)

 Test Files  9 passed (9)
      Tests  32 passed (32)
   Start at  22:16:27
   Duration  3.69s (transform 470ms, setup 2.74s, collect 2.79s, tests 503ms, environment 6.15s, prepare 2.86s)
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
