### PR TITLE
fix: add proxyHijackESM for better spyOn in browser

### DIFF
--- a/examples/react/test/basic.test.tsx
+++ b/examples/react/test/basic.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import Link from '../components/Link.jsx'
+import * as linkModule from '../components/Link.jsx'
 
 function toJson(component: renderer.ReactTestRenderer) {
   const result = component.toJSON()
@@ -28,4 +29,20 @@ test('Link changes the class when hovered', () => {
   // re-rendering
   tree = toJson(component)
   expect(tree).toMatchSnapshot()
+})
+
+test('Link can be spied', () => {
+  vi.spyOn(linkModule, 'default').mockImplementation(() => {
+    return <div>Hello</div>
+  })
+
+  const component = renderer.create(
+    <Link page="http://antfu.me">Anthony Fu</Link>,
+  )
+
+  const tree = toJson(component)
+  console.warn('tree', tree)
+
+  expect(tree.type).toBe('div')
+  expect(tree.children).toStrictEqual(['Hello'])
 })

--- a/examples/react/vitest.config.ts
+++ b/examples/react/vitest.config.ts
@@ -6,5 +6,14 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    browser: {
+      enabled: true,
+      name: process.env.BROWSER || 'chrome',
+      headless: false,
+      provider: process.env.PROVIDER || 'webdriverio',
+      isolate: false,
+      proxyHijackESM: true,
+    },
+
   },
 })

--- a/packages/browser/src/client/fakeModule.ts
+++ b/packages/browser/src/client/fakeModule.ts
@@ -3,85 +3,56 @@ function neverFunctionForProxy() {
   throw new Error(`should not get here`)
 }
 
-const originalSymbol = Symbol('orig')
-
 // allows replacing 'function' types on this module: passes through to the 'current value'
-function prepareFakeModuleForSpy(module: any) {
-  for (const key in module) {
-    let value: Function = module[key]
-    if (typeof value !== 'function')
-      continue
-
-    try {
-      delete module[key]
-    }
-    catch {
+function prepareFakeModuleForSpy(fakeModule: any, contents: any) {
+  for (const key in contents) {
+    if (typeof contents[key] !== 'function') {
+      fakeModule[key] = contents[key]
       continue
     }
 
     // uses Reflect to implement Proxy, but use 'current value' and not the original target
+    // this is a Proxy pointing _to_ Reflect, which means it "supports all operations" but on the dynamic target
     const currentValueReflect = new Proxy(Reflect, {
       get(_reflect, reflectKey) {
-        // TODO: does this support ctor mocking (new.target)
-        return (...args: any[]) => (Reflect as any)[reflectKey](value, ...args.slice(1))
+        return (...args: any[]) => (Reflect as any)[reflectKey](contents[key], ...args.slice(1))
       },
     })
-    const p = new Proxy(neverFunctionForProxy, currentValueReflect)
-
-    const get = () => p
-    get[originalSymbol] = true
-
-    const set = (v: any) => value = v
-    set[originalSymbol] = true
-
-    Object.defineProperty(module, key, {
-      get,
-      set,
-      enumerable: true,
-      configurable: true,
-    })
+    fakeModule[key] = new Proxy(neverFunctionForProxy, currentValueReflect)
   }
 }
 
 // this enables bound-like named imports with the import rewriting scheme
-export function buildFakeModule<T extends Record<string | symbol, any>>(contents: T): T {
-  const out: Record<string | symbol, any> = { [Symbol.toStringTag]: 'Module', ...contents }
+export function buildFakeModule<T extends Record<string | symbol, any>>(module: T): T {
+  const fakeModule: Record<string | symbol, any> = { [Symbol.toStringTag]: 'Module' }
+  const contents: Record<string | symbol, any> = { ...module }
 
-  prepareFakeModuleForSpy(out)
+  prepareFakeModuleForSpy(fakeModule, contents)
 
   // this intercepts tinyspy which uses Object.defineProperty to rewrite an object (even a "module")
   return new Proxy({}, {
     ownKeys(_target) {
-      return Reflect.ownKeys(out)
+      return Reflect.ownKeys(fakeModule)
     },
 
-    get(_target, p) {
-      return out[p]
+    set(_target, _property) {
+      return false
+    },
+
+    get(_target, property) {
+      return fakeModule[property]
     },
 
     getOwnPropertyDescriptor(_target, p) {
-      return Reflect.getOwnPropertyDescriptor(out, p)
+      return Reflect.getOwnPropertyDescriptor(contents, p)
     },
 
     defineProperty(_target, property, attributes) {
-      // detect original & restore, otherwise this causes recursive call to self
-      if ((attributes.get as any)?.[originalSymbol]) {
-        out[property] = contents[property]
-        return true
-      }
+      if (attributes.get || attributes.set)
+        throw new Error(`can't defineProperty with get/set on fake module`)
 
       if ('value' in attributes) {
-        out[property] = attributes.value
-        return true
-      }
-
-      if ('get' in attributes) {
-        if (!(attributes.set as any)?.[originalSymbol]) {
-          // tinyspy passes back the same setter from attributes
-          throw new Error(`setter must be original`)
-        }
-        // TODO: this predisposes a setter, which we could skip (different indirection)
-        out[property] = attributes.get!()
+        contents[property] = attributes.value
         return true
       }
 

--- a/packages/browser/src/client/fakeModule.ts
+++ b/packages/browser/src/client/fakeModule.ts
@@ -1,0 +1,91 @@
+// this is just here so Proxy knows we're wrapping a function
+function neverFunctionForProxy() {
+  throw new Error(`should not get here`)
+}
+
+const originalSymbol = Symbol('orig')
+
+// allows replacing 'function' types on this module: passes through to the 'current value'
+function prepareFakeModuleForSpy(module: any) {
+  for (const key in module) {
+    let value: Function = module[key]
+    if (typeof value !== 'function')
+      continue
+
+    try {
+      delete module[key]
+    }
+    catch {
+      continue
+    }
+
+    // uses Reflect to implement Proxy, but use 'current value' and not the original target
+    const currentValueReflect = new Proxy(Reflect, {
+      get(_reflect, reflectKey) {
+        // TODO: does this support ctor mocking (new.target)
+        return (...args: any[]) => (Reflect as any)[reflectKey](value, ...args.slice(1))
+      },
+    })
+    const p = new Proxy(neverFunctionForProxy, currentValueReflect)
+
+    const get = () => p
+    get[originalSymbol] = true
+
+    const set = (v: any) => value = v
+    set[originalSymbol] = true
+
+    Object.defineProperty(module, key, {
+      get,
+      set,
+      enumerable: true,
+      configurable: true,
+    })
+  }
+}
+
+// this enables bound-like named imports with the import rewriting scheme
+export function buildFakeModule<T extends Record<string | symbol, any>>(contents: T): T {
+  const out: Record<string | symbol, any> = { [Symbol.toStringTag]: 'Module', ...contents }
+
+  prepareFakeModuleForSpy(out)
+
+  // this intercepts tinyspy which uses Object.defineProperty to rewrite an object (even a "module")
+  return new Proxy({}, {
+    ownKeys(_target) {
+      return Reflect.ownKeys(out)
+    },
+
+    get(_target, p) {
+      return out[p]
+    },
+
+    getOwnPropertyDescriptor(_target, p) {
+      return Reflect.getOwnPropertyDescriptor(out, p)
+    },
+
+    defineProperty(_target, property, attributes) {
+      // detect original & restore, otherwise this causes recursive call to self
+      if ((attributes.get as any)?.[originalSymbol]) {
+        out[property] = contents[property]
+        return true
+      }
+
+      if ('value' in attributes) {
+        out[property] = attributes.value
+        return true
+      }
+
+      if ('get' in attributes) {
+        if (!(attributes.set as any)?.[originalSymbol]) {
+          // tinyspy passes back the same setter from attributes
+          throw new Error(`setter must be original`)
+        }
+        // TODO: this predisposes a setter, which we could skip (different indirection)
+        out[property] = attributes.get!()
+        return true
+      }
+
+      return false
+    },
+  }) as T
+}

--- a/packages/browser/src/client/index.html
+++ b/packages/browser/src/client/index.html
@@ -63,6 +63,14 @@
         }
       }
 
+      // blindly load all code before mocker arrives
+      window.__vitest_mocker__ = {
+        import: async (src) => {
+          const out = await import(src)
+          return out?.default?.__esModule ? out?.default : out
+        }
+      }
+
       window.__vi_export_all__ = exportAll
 
       // TODO: allow easier rewriting of import.meta.env

--- a/packages/browser/src/client/index.html
+++ b/packages/browser/src/client/index.html
@@ -65,10 +65,7 @@
 
       // blindly load all code before mocker arrives
       window.__vitest_mocker__ = {
-        import: async (src) => {
-          const out = await import(src)
-          return out?.default?.__esModule ? out?.default : out
-        }
+        wrap: (fn) => fn(),
       }
 
       window.__vi_export_all__ = exportAll

--- a/packages/browser/src/client/mocker.ts
+++ b/packages/browser/src/client/mocker.ts
@@ -1,8 +1,67 @@
+import type { ResolvedConfig } from 'vitest'
+import { buildFakeModule } from './fakeModule'
+
 function throwNotImplemented(name: string) {
   throw new Error(`[vitest] ${name} is not implemented in browser environment yet.`)
 }
 
+async function fixEsmExport<T extends Record<string | symbol, any>>(contentsPromise: Promise<T>): Promise<T> {
+  const contents = await contentsPromise
+
+  if (!('default' in contents))
+    return contents
+
+  if (contents.default.__esModule)
+    return contents.default
+
+  for (const key in contents) {
+    if (key !== 'default')
+      return contents
+  }
+
+  if (!['object', 'function'].includes(typeof contents.default))
+    return contents
+
+  // vitest/vite doesn't import React (possibly others) via CJS correctly when imports are rewritten
+  // where there's only a 'default' property, expand its properties to the top-level
+  return {
+    ...contents.default,
+    default: contents.default,
+  }
+}
+
 export class VitestBrowserClientMocker {
+  constructor(public config: ResolvedConfig) {}
+
+  private cachedImports = new Map<string, Promise<any>>()
+
+  /**
+   * Browser tests don't run in parallel. This clears all mocks after each run.
+   */
+  public resetAfterFile() {
+    this.resetModules()
+  }
+
+  public resetModules() {
+    this.cachedImports.clear()
+  }
+
+  public async import(resolved: string, _id: string, _importee: string) {
+    if (!this.config.browser.proxyHijackESM)
+      throw new Error(`hijackESM disabled but mocker invoked`)
+
+    const prev = this.cachedImports.get(resolved)
+    if (prev !== undefined)
+      return prev
+
+    const task = (async () => {
+      const contents = await fixEsmExport(import(resolved))
+      return buildFakeModule(contents)
+    })()
+    this.cachedImports.set(resolved, task)
+    return task
+  }
+
   public importActual() {
     throwNotImplemented('importActual')
   }

--- a/packages/browser/src/node/esmProxy.ts
+++ b/packages/browser/src/node/esmProxy.ts
@@ -1,21 +1,13 @@
 import MagicString from 'magic-string'
 import type { PluginContext } from 'rollup'
 import type { Expression } from 'estree'
-import { isAbsolute } from 'pathe'
 import type { Positioned } from './esmWalker'
 import { esmWalker } from './esmWalker'
-
-// filter this out so getImporter() picks the right index
-const skipImports = [
-  '^vitest$',
-  '^@vitest/',
-]
 
 export async function insertEsmProxy(
   code: string,
   id: string,
   parse: PluginContext['parse'],
-  rollupResolve: PluginContext['resolve'],
 ) {
   const s = new MagicString(code)
 
@@ -28,61 +20,11 @@ export async function insertEsmProxy(
     return
   }
 
-  const importsToResolve = new Set<string>()
-
-  // find all literal imports so we can resolve them in an async step before re-running the sync walker
   esmWalker(ast, {
     onDynamicImport(node) {
-      const expression = (node.source as Positioned<Expression>)
-      if (!(expression.type === 'Literal' && typeof expression.value === 'string'))
-        return
-
-      const { value } = expression
-      if (skipImports.some(i => value.match(i)))
-        return
-
-      importsToResolve.add(value)
-    },
-    onIdentifier() {},
-    onImportMeta() {},
-  })
-
-  // resolve all imports in an async step
-  const resolveToId = async (importName: string) => {
-    const out = await rollupResolve(importName, id)
-    if (!out?.id)
-      return undefined
-    const resolved = out.id
-
-    if (!isAbsolute(resolved))
-      return undefined
-
-    return `/@fs${resolved}`
-  }
-
-  const resolvedImports = Object.fromEntries(
-    await Promise.all([...importsToResolve].map(
-      async (importName): Promise<[string, string | undefined]> => {
-        return [importName, await resolveToId(importName)]
-      },
-    )),
-  )
-
-  // insert matched imports with the import rewrite
-  esmWalker(ast, {
-    onDynamicImport(node) {
-      const expression = (node.source as Positioned<Expression>)
-      if (!(expression.type === 'Literal' && typeof expression.value === 'string')) {
-        // this is import(not-a-literal), ignore: can't mock this for now
-        return
-      }
-
-      const { value } = expression
-      const resolved = resolvedImports[value]
-      if (!resolved)
-        return
-
-      s.overwrite(node.start, node.end, `__vitest_mocker__.import(${JSON.stringify(resolved)}, ${JSON.stringify(value)}, import.meta.url)`)
+      const replace = '__vitest_mocker__.wrap(() => import('
+      s.overwrite(node.start, (node.source as Positioned<Expression>).start, replace)
+      s.overwrite(node.end - 1, node.end, '))')
     },
     onIdentifier() {},
     onImportMeta() {},

--- a/packages/browser/src/node/esmProxy.ts
+++ b/packages/browser/src/node/esmProxy.ts
@@ -1,0 +1,96 @@
+import MagicString from 'magic-string'
+import type { PluginContext } from 'rollup'
+import type { Expression } from 'estree'
+import { isAbsolute } from 'pathe'
+import type { Positioned } from './esmWalker'
+import { esmWalker } from './esmWalker'
+
+// filter this out so getImporter() picks the right index
+const skipImports = [
+  '^vitest$',
+  '^@vitest/',
+]
+
+export async function insertEsmProxy(
+  code: string,
+  id: string,
+  parse: PluginContext['parse'],
+  rollupResolve: PluginContext['resolve'],
+) {
+  const s = new MagicString(code)
+
+  let ast: any
+  try {
+    ast = parse(code)
+  }
+  catch (err) {
+    console.error(`Cannot parse ${id}:\n${(err as any).message}`)
+    return
+  }
+
+  const importsToResolve = new Set<string>()
+
+  // find all literal imports so we can resolve them in an async step before re-running the sync walker
+  esmWalker(ast, {
+    onDynamicImport(node) {
+      const expression = (node.source as Positioned<Expression>)
+      if (!(expression.type === 'Literal' && typeof expression.value === 'string'))
+        return
+
+      const { value } = expression
+      if (skipImports.some(i => value.match(i)))
+        return
+
+      importsToResolve.add(value)
+    },
+    onIdentifier() {},
+    onImportMeta() {},
+  })
+
+  // resolve all imports in an async step
+  const resolveToId = async (importName: string) => {
+    const out = await rollupResolve(importName, id)
+    if (!out?.id)
+      return undefined
+    const resolved = out.id
+
+    if (!isAbsolute(resolved))
+      return undefined
+
+    return `/@fs${resolved}`
+  }
+
+  const resolvedImports = Object.fromEntries(
+    await Promise.all([...importsToResolve].map(
+      async (importName): Promise<[string, string | undefined]> => {
+        return [importName, await resolveToId(importName)]
+      },
+    )),
+  )
+
+  // insert matched imports with the import rewrite
+  esmWalker(ast, {
+    onDynamicImport(node) {
+      const expression = (node.source as Positioned<Expression>)
+      if (!(expression.type === 'Literal' && typeof expression.value === 'string')) {
+        // this is import(not-a-literal), ignore: can't mock this for now
+        return
+      }
+
+      const { value } = expression
+      const resolved = resolvedImports[value]
+      if (!resolved)
+        return
+
+      s.overwrite(node.start, node.end, `__vitest_mocker__.import(${JSON.stringify(resolved)}, ${JSON.stringify(value)}, import.meta.url)`)
+    },
+    onIdentifier() {},
+    onImportMeta() {},
+  })
+
+  return {
+    ast,
+    code: s.toString(),
+    map: s.generateMap({ hires: 'boundary', source: id }),
+  }
+}

--- a/packages/browser/src/node/esmProxy.ts
+++ b/packages/browser/src/node/esmProxy.ts
@@ -4,6 +4,13 @@ import type { Expression } from 'estree'
 import type { Positioned } from './esmWalker'
 import { esmWalker } from './esmWalker'
 
+// don't allow mocking vitest itself
+// (this *also* changes the position of user code in the getImporter() helper)
+const skipImports = [
+  '^vitest$',
+  '^@vitest/',
+]
+
 export async function insertEsmProxy(
   code: string,
   id: string,
@@ -22,9 +29,18 @@ export async function insertEsmProxy(
 
   esmWalker(ast, {
     onDynamicImport(node) {
-      const replace = '__vitest_mocker__.wrap(() => import('
-      s.overwrite(node.start, (node.source as Positioned<Expression>).start, replace)
-      s.overwrite(node.end - 1, node.end, '))')
+      const expression = (node.source as Positioned<Expression>)
+      if (!(expression.type === 'Literal' && typeof expression.value === 'string'))
+        // this is a non-string import so vite won't change it anyway
+        return
+
+      const value = expression.value as string
+
+      if (skipImports.some(i => value.match(i)))
+        return
+
+      const replace = `__vitest_mocker__.wrap(() => import(${JSON.stringify(value)}))`
+      s.overwrite(node.start, node.end, replace)
     },
     onIdentifier() {},
     onImportMeta() {},

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -110,7 +110,7 @@ export default (existingPlugins: Plugin[], project: WorkspaceProject, base = '/'
         const proxyHijackESM = project.config.browser.proxyHijackESM ?? false
         if (!proxyHijackESM)
           return
-        return insertEsmProxy(source, id, this.parse, this.resolve.bind(this))
+        return insertEsmProxy(source, id, this.parse)
       },
     },
   ]

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -89,47 +89,6 @@ export default (existingPlugins: Plugin[], project: WorkspaceProject, base = '/'
         return useId
       },
     },
-    // {
-    //   name: 'vitest:browser:isolate-tests',
-    //   enforce: 'pre',
-    //   async resolveId(id, importer, options) {
-    //     if (importer?.startsWith('/@test/')) {
-    //       console.debug('got importer', { id, importer })
-    //       // TODO
-
-    //       const testId = importer.slice(7).split('~', 1)[0]
-    //       return `/@test/${testId}~${id}`
-    //     }
-
-    //     if (!id.startsWith('/@test/'))
-    //       return
-
-    //     // match /@test/<testId>~<import>
-    //     let useId = id.slice(7)
-    //     const testId = useId.split('~', 1)[0]
-    //     useId = useId.slice(testId.length + 1)
-
-    //     console.debug('got @test prefixed', { testId, useId, id, importer, options })
-
-    //     return id // still use this to load
-    //   },
-    //   // async load(id) {
-    //   //   if (!id.startsWith('/@test/'))
-    //   //     return undefined
-
-    //   //   let useId = id.slice(7)
-    //   //   const testId = useId.split('~', 1)[0]
-    //   //   useId = useId.slice(testId.length + 1)
-    //   //   console.debug('load direct', { id, useId })
-
-    //   //   const internalLoad = await this.load({ id: useId })
-    //   //   console.debug('got load', internalLoad)
-    //   //   return { ast: internalLoad.ast!, code: '' }
-    //   //   // return {
-    //   //   //   code: internalLoad.code,
-    //   //   // }
-    //   // },
-    // },
     {
       name: 'vitest:browser:esm-injector',
       enforce: 'post',

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1092,23 +1092,6 @@ Repository: sindresorhus/p-locate
 
 ---------------------------------------
 
-## path-exists
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/path-exists
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
 ## picomatch
 License: MIT
 By: Jon Schlinkert

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1092,6 +1092,23 @@ Repository: sindresorhus/p-locate
 
 ---------------------------------------
 
+## path-exists
+License: MIT
+By: Sindre Sorhus
+Repository: sindresorhus/path-exists
+
+> MIT License
+>
+> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------
+
 ## picomatch
 License: MIT
 By: Jon Schlinkert

--- a/packages/vitest/src/integrations/browser/server.ts
+++ b/packages/vitest/src/integrations/browser/server.ts
@@ -1,4 +1,5 @@
 import { createServer } from 'vite'
+import type { Plugin } from 'vite'
 import { defaultBrowserPort } from '../../constants'
 import { ensurePackageInstalled } from '../../node/pkg'
 import { resolveApiServerConfig } from '../../node/config'
@@ -8,11 +9,54 @@ import { MocksPlugin } from '../../node/plugins/mocks'
 import { resolveFsAllow } from '../../node/plugins/utils'
 
 export async function createBrowserServer(project: WorkspaceProject, configFile: string | undefined) {
+  if (project.config.browser.proxyHijackESM && project.config.browser.slowHijackESM)
+    throw new Error(`cannot set both proxyHijackESM and slowHijackESM`)
+
   const root = project.config.root
 
   await ensurePackageInstalled('@vitest/browser', root)
 
   const configPath = typeof configFile === 'string' ? configFile : false
+  const alwaysMock = Boolean(project.config.browser.proxyHijackESM)
+
+  const existingPlugins: Plugin[] = [
+    CoverageTransform(project.ctx),
+    {
+      enforce: 'post',
+      name: 'vitest:browser:config',
+      async config(config) {
+        const server = resolveApiServerConfig(config.test?.browser || {}) || {
+          port: defaultBrowserPort,
+        }
+
+        // browser never runs in middleware mode
+        server.middlewareMode = false
+
+        config.server = {
+          ...config.server,
+          ...server,
+        }
+        config.server.fs ??= {}
+        config.server.fs.allow = config.server.fs.allow || []
+        config.server.fs.allow.push(
+          ...resolveFsAllow(
+            project.ctx.config.root,
+            project.ctx.server.config.configFile,
+          ),
+        )
+
+        return {
+          resolve: {
+            alias: config.test?.alias,
+          },
+          server: {
+            watch: null,
+          },
+        }
+      },
+    },
+    MocksPlugin({ always: alwaysMock }),
+  ]
 
   const server = await createServer({
     logLevel: 'error',
@@ -25,45 +69,7 @@ export async function createBrowserServer(project: WorkspaceProject, configFile:
         ignored: ['**/**'],
       },
     },
-    plugins: [
-      (await import('@vitest/browser')).default(project, '/'),
-      CoverageTransform(project.ctx),
-      {
-        enforce: 'post',
-        name: 'vitest:browser:config',
-        async config(config) {
-          const server = resolveApiServerConfig(config.test?.browser || {}) || {
-            port: defaultBrowserPort,
-          }
-
-          // browser never runs in middleware mode
-          server.middlewareMode = false
-
-          config.server = {
-            ...config.server,
-            ...server,
-          }
-          config.server.fs ??= {}
-          config.server.fs.allow = config.server.fs.allow || []
-          config.server.fs.allow.push(
-            ...resolveFsAllow(
-              project.ctx.config.root,
-              project.ctx.server.config.configFile,
-            ),
-          )
-
-          return {
-            resolve: {
-              alias: config.test?.alias,
-            },
-            server: {
-              watch: null,
-            },
-          }
-        },
-      },
-      MocksPlugin(),
-    ],
+    plugins: (await import('@vitest/browser')).default(existingPlugins, project, '/'),
   })
 
   await server.listen()

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -576,6 +576,7 @@ function createVitest(): VitestUtils {
     },
 
     resetModules() {
+      _mocker.resetModules()
       resetModules(workerState.moduleCache)
       return utils
     },

--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -49,7 +49,7 @@ const regexpHoistable = /^[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/m
 const regexpAssignedHoisted = /=[ \t]*(\bawait|)[ \t]*\b(vi|vitest)\s*\.\s*hoisted\(/
 const hashbangRE = /^#!.*\n/
 
-export function hoistMocks(code: string, id: string, parse: PluginContext['parse'], always: boolean) {
+export function hoistMocks(code: string, id: string, parse: PluginContext['parse'], always?: boolean) {
   if (!always) {
     const hasMocks = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
 

--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -49,11 +49,13 @@ const regexpHoistable = /^[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/m
 const regexpAssignedHoisted = /=[ \t]*(\bawait|)[ \t]*\b(vi|vitest)\s*\.\s*hoisted\(/
 const hashbangRE = /^#!.*\n/
 
-export function hoistMocks(code: string, id: string, parse: PluginContext['parse']) {
-  const hasMocks = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
+export function hoistMocks(code: string, id: string, parse: PluginContext['parse'], always: boolean) {
+  if (!always) {
+    const hasMocks = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
 
-  if (!hasMocks)
-    return
+    if (!hasMocks)
+      return
+  }
 
   const s = new MagicString(code)
 

--- a/packages/vitest/src/node/plugins/coverageTransform.ts
+++ b/packages/vitest/src/node/plugins/coverageTransform.ts
@@ -3,7 +3,7 @@ import { normalizeRequestId } from 'vite-node/utils'
 
 import type { Vitest } from '../core'
 
-export function CoverageTransform(ctx: Vitest): VitePlugin | null {
+export function CoverageTransform(ctx: Vitest): VitePlugin {
   return {
     name: 'vitest:coverage-transform',
     transform(srcCode, id) {

--- a/packages/vitest/src/node/plugins/mocks.ts
+++ b/packages/vitest/src/node/plugins/mocks.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from 'vite'
 import { hoistMocks } from '../hoistMocks'
 
-export function MocksPlugin(): Plugin {
+export function MocksPlugin(arg?: { always?: boolean }): Plugin {
   return {
     name: 'vitest:mocks',
     enforce: 'post',
     transform(code, id) {
-      return hoistMocks(code, id, this.parse)
+      return hoistMocks(code, id, this.parse, arg?.always ?? false)
     },
   }
 }

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -88,6 +88,8 @@ export class VitestMocker {
     this.spyModule = await this.executor.executeId(spyModulePath)
   }
 
+  public resetModules() {}
+
   private deleteCachedItem(id: string) {
     const mockId = this.getMockPath(id)
     if (this.moduleCache.has(mockId))

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -78,6 +78,16 @@ export interface BrowserConfigOptions {
   slowHijackESM?: boolean
 
   /**
+   * Update ESM imports with a Proxy so they can be spied/stubbed with vi.spyOn.
+   *
+   * This is an alternative design to `slowHijackESM` and should not be set at the same time.
+   *
+   * @default false
+   * @experimental
+   */
+  proxyHijackESM?: boolean
+
+  /**
    * Isolate test environment after each test
    *
    * @default true

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -18,7 +18,7 @@ export default defineConfig({
       headless: false,
       provider: process.env.PROVIDER || 'webdriverio',
       isolate: false,
-      slowHijackESM: true,
+      proxyHijackESM: true,
     },
     alias: {
       '#src': resolve(dir, './src'),


### PR DESCRIPTION
### Description

Changes the way `vi.spyOn` works in the browser via a new experimental flag `proxyHijackESM` that's intended to replace `slowHijackESM`.
(I'm not making promises about the speed of this approach, just that it works via a `Proxy`)

Refixes #4264 (which wasn't "fixed", it was just disabled) - importing `React` now works, the React sample included now uses this 👍 

The approach is vaguely:
 - Always convert static imports to dynamic ones (using `HoistMocks`)
 - dedups these dynamic imports inside `__vitest_mocker__.wrap`, so matching imports can be modified in a central location
 - instead of modifying modules that might be spied on (`slowHijackESM`), wraps these imports in a `Proxy`, which lets `tinyspy` work on it
   - the functions/callables of a module are further wrapped in a `Proxy`, so code like `import { callable } from 'foo'` continues to work — `callable` is itself now a "bound" callable `Proxy`, even though it looks like an orphan var

For more context, this is the start of an approach to #3046. This makes every module's import be wrapped so it can be piggybacked by `vi.mock` in a follow-up PR. (A complete version [is here](https://github.com/vitest-dev/vitest/compare/main...samthor:vitest:sam-test-update?expand=1) but it's not good enough for review)

**Alternatives**: Using iframes-per-test might make some things simpler, but I think this PR still helps — because `spyOn` is something we allow on any module - the `HoistMocks`/`Proxy` combination needs to run on anything a user might spy.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
