### PR TITLE
chore: fix `--watch.include` option of `dev` scripts

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
     "build:client": "vite build src/client",
     "build:node": "rollup -c",
     "dev:client": "vite build src/client --watch",
-    "dev:node": "rollup -c --watch --watch.include src/node/index.ts",
+    "dev:node": "rollup -c --watch --watch.include 'src/node/**'",
     "dev": "rimraf dist && run-p dev:node dev:client",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "build:node": "rollup -c",
     "typecheck": "tsc --noEmit",
     "dev:client": "vite",
-    "dev": "rollup -c --watch --watch.include=node",
+    "dev": "rollup -c --watch --watch.include 'node/**'",
     "dev:ui": "run-p dev dev:client",
     "test:run": "cypress run --component",
     "test:open": "cypress open --component",


### PR DESCRIPTION
### Description

While experimenting with browser package code, I noticed that `pnpm dev` is not picking up the change of some files.

I assumed `--watch.include` hasn't been updated after getting more files there, so I updated the options to align with other places such as:

https://github.com/vitest-dev/vitest/blob/f13fa9c1e7289f6d5988df8e70058b21abd51e60/packages/coverage-istanbul/package.json#L41

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
