### PR TITLE
fix(browser): remove `enforce` from `vitest:browser` plugin to simplify custom middleware plugin usage

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -13,7 +13,6 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
 
   return [
     {
-      enforce: 'pre',
       name: 'vitest:browser',
       async config(viteConfig) {
         // Enables using ignore hint for coverage providers with @preserve keyword

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -24,8 +24,8 @@ const passedTests = getPassed(browserResultJson.testResults)
 const failedTests = getFailed(browserResultJson.testResults)
 
 await test('tests are actually running', async () => {
-  assert.ok(browserResultJson.testResults.length === 8, 'Not all the tests have been run')
-  assert.ok(passedTests.length === 7, 'Some tests failed')
+  assert.ok(browserResultJson.testResults.length === 9, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 8, 'Some tests failed')
   assert.ok(failedTests.length === 1, 'Some tests have passed but should fail')
 
   assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -24,8 +24,8 @@ const passedTests = getPassed(browserResultJson.testResults)
 const failedTests = getFailed(browserResultJson.testResults)
 
 await test('tests are actually running', async () => {
-  assert.ok(browserResultJson.testResults.length === 9, 'Not all the tests have been run')
-  assert.ok(passedTests.length === 8, 'Some tests failed')
+  assert.ok(browserResultJson.testResults.length === 10, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 9, 'Some tests failed')
   assert.ok(failedTests.length === 1, 'Some tests have passed but should fail')
 
   assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')

--- a/test/browser/test/cross-origin-isolated.test.ts
+++ b/test/browser/test/cross-origin-isolated.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from 'vitest'
+
+// users can achive cross-origin isolation via custom plugin (see "coop-coep-header-middleware-plugin")
+// https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated
+it('crossOriginIsolated', () => {
+  expect(crossOriginIsolated).toBe(true)
+})

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -38,14 +38,14 @@ export default defineConfig({
   },
   plugins: [
     {
-      name: "test:coop-coep-header-middleware-plugin",
+      name: 'test:coop-coep-header-middleware-plugin',
       configureServer(server) {
         server.middlewares.use((_req, res, next) => {
-          res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
-          res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-          next();
-        });
-      }
-    }
-  ]
+          res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+          res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+          next()
+        })
+      },
+    },
+  ],
 })

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -36,4 +36,16 @@ export default defineConfig({
       onUserConsoleLog: noop,
     }, 'default'],
   },
+  plugins: [
+    {
+      name: "test:coop-coep-header-middleware-plugin",
+      configureServer(server) {
+        server.middlewares.use((_req, res, next) => {
+          res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+          res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+          next();
+        });
+      }
+    }
+  ]
 })


### PR DESCRIPTION
### Description

Close https://github.com/vitest-dev/vitest/issues/3743

I wasn't sure if Vitest side change is worth it for this issue since currently user-side workaround exists, but I created this PR as this demonstrates the reproduction and allows quick experiment.

---

Actually `crossOriginIsolated` might not be working for some browsers on CI. I will look into this further.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
