### PR TITLE
docs(expect): fix soft example error

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -50,8 +50,8 @@ import { expect, test } from 'vitest'
 
 test('expect.soft test', () => {
   expect.soft(1 + 1).toBe(3) // mark the test as fail and continue
-  expect(1 + 2).toBe(3) // failed and terminate the test, all previous errors will be output
-  expect.soft(1 + 2).toBe(4) // do not run
+  expect(1 + 2).toBe(4) // failed and terminate the test, all previous errors will be output
+  expect.soft(1 + 3).toBe(5) // do not run
 })
 ```
 


### PR DESCRIPTION
### Description

https://github.com/vitest-dev/vitest/blob/3413518b3a33bcbb05e5135b5f8f515fd8d15076/docs/api/expect.md?plain=1#L53

I think the intention here is that the assertion fails, but in fact the assertion passes.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
