### PR TITLE
docs(mocking): fix broken msw links

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -360,7 +360,7 @@ describe('get a list of todo items', () => {
 
 Because Vitest runs in Node, mocking network requests is tricky; web APIs are not available, so we need something that will mimic network behavior for us. We recommend [Mock Service Worker](https://mswjs.io/) to accomplish this. It will let you mock both `REST` and `GraphQL` network requests, and is framework agnostic.
 
-Mock Service Worker (MSW) works by intercepting the requests your tests make, allowing you to use it without changing any of your application code. In-browser, this uses the [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). In Node.js, and for Vitest, it uses [node-request-interceptor](https://mswjs.io/docs/api/setup-server#operation). To learn more about MSW, read their [introduction](https://mswjs.io/docs/)
+Mock Service Worker (MSW) works by intercepting the requests your tests make, allowing you to use it without changing any of your application code. In-browser, this uses the [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). In Node.js, and for Vitest, it uses the [`@mswjs/interceptors`](https://github.com/mswjs/interceptors) library. To learn more about MSW, read their [introduction](https://mswjs.io/docs/)
 
 
 ### Configuration
@@ -388,7 +388,7 @@ export const restHandlers = [
 ]
 
 const graphqlHandlers = [
-  graphql.query('https://graphql-endpoint.example/api/v1/posts', () => {
+  graphql.query('ListPosts', () => {
     return HttpResponse.json(
       {
         data: { posts },
@@ -416,7 +416,7 @@ afterEach(() => server.resetHandlers())
 We have a full working example which uses MSW: [React Testing with MSW](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw).
 
 ### More
-There is much more to MSW. You can access cookies and query parameters, define mock error responses, and much more! To see all you can do with MSW, read [their documentation](https://mswjs.io/docs/recipes).
+There is much more to MSW. You can access cookies and query parameters, define mock error responses, and much more! To see all you can do with MSW, read [their documentation](https://mswjs.io/docs).
 
 ## Timers
 


### PR DESCRIPTION
Hey! Thank you so much for recommending MSW in the Vitest docs! 

I was reading through the docs and found a few issues/outdated links so I opened this pull request. 

- Changes `node-request-interceptor` mention to `@mswjs/interceptors`. That mention references a rather old library name. Let's stay up-to-date!
- Updates the link to learn more about MSW to point to the `/docs` instead of `/docs/recipes` (which doesn't exist anymore).
- Updates the `graphql.query()` example because that request handler expects an _operation name_, not the endpoint. Now it's correct.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
