### PR TITLE
revert: close pool early in run-mode #4623

### DIFF
--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -68,7 +68,11 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
   }
 
   async close() {
-    await this.cachedPage?.close()
-    await this.cachedBrowser?.close()
+    const page = this.cachedPage
+    this.cachedPage = null
+    const browser = this.cachedBrowser
+    this.cachedBrowser = null
+    await page?.close()
+    await browser?.close()
   }
 }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -10,7 +10,7 @@ import { ViteNodeRunner } from 'vite-node/client'
 import { SnapshotManager } from '@vitest/snapshot/manager'
 import type { CancelReason, File } from '@vitest/runner'
 import { ViteNodeServer } from 'vite-node/server'
-import type { ArgumentsType, Awaitable, CoverageProvider, OnServerRestartHandler, Reporter, ResolvedConfig, UserConfig, UserWorkspaceConfig, VitestRunMode } from '../types'
+import type { ArgumentsType, CoverageProvider, OnServerRestartHandler, Reporter, ResolvedConfig, UserConfig, UserWorkspaceConfig, VitestRunMode } from '../types'
 import { hasFailed, noop, slash, toArray } from '../utils'
 import { getCoverageProvider } from '../integrations/coverage'
 import type { BrowserProvider } from '../types/browser'
@@ -76,7 +76,6 @@ export class Vitest {
   private _onClose: (() => Awaited<unknown>)[] = []
   private _onSetServer: OnServerRestartHandler[] = []
   private _onCancelListeners: ((reason: CancelReason) => Promise<void> | void)[] = []
-  private _poolClosePromise?: Awaitable<void>
 
   async setServer(options: UserConfig, server: ViteDevServer, cliOptions: UserConfig) {
     this.unregisterWatcher?.()
@@ -357,10 +356,6 @@ export class Vitest {
 
       await this.runFiles(files)
     }
-
-    // In run mode close pool as early as possible
-    if (!this.config.watch && this.pool?.close)
-      this._poolClosePromise = this.pool.close()
 
     await this.reportCoverage(true)
 
@@ -785,9 +780,8 @@ export class Vitest {
 
         if (this.pool) {
           closePromises.push((async () => {
-            await (this._poolClosePromise || this.pool?.close?.())
+            await this.pool?.close?.()
 
-            this._poolClosePromise = undefined
             this.pool = undefined
           })())
         }


### PR DESCRIPTION
### Description

Reverting https://github.com/vitest-dev/vitest/pull/4623 because public API can call start/stop at any time.

This PR will be merged non-squashed.

Fixes #4713

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
