### PR TITLE
types: use satisfies for defaults

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -100,6 +100,6 @@ const config = {
     exclude: defaultExclude,
   },
   slowTestThreshold: 300,
-}
+} satisfies UserConfig
 
-export const configDefaults: Required<Pick<UserConfig, keyof typeof config>> = Object.freeze(config)
+export const configDefaults = Object.freeze(config)


### PR DESCRIPTION
### Description

Use `satisfies` to type the defaults and remove some verbose types

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
