### PR TITLE
test(fixture): beforeEach concurrent tests issue reproduction

### DIFF
--- a/test/core/test/fixture-concurrent.test.ts
+++ b/test/core/test/fixture-concurrent.test.ts
@@ -35,7 +35,7 @@ beforeEach<MyFixtures>(({ counter }) => {
  * The issue is that it is invoked (2*N - 1) + M times.
  */
 afterAll(() => {
-  expect(i).toEqual(4)
+  expect(i).toEqual(5)
 })
 
 myTest.concurrent('fixture - concurrent test 1', ({ a, b, counter, task }) => {

--- a/test/core/test/fixture-concurrent.test.ts
+++ b/test/core/test/fixture-concurrent.test.ts
@@ -1,9 +1,14 @@
-import { expect, test } from 'vitest'
+import { afterAll, beforeEach, expect, test } from 'vitest'
 
-export const myTest = test.extend<{
+let i = 0
+
+interface MyFixtures {
   a: string
   b: string
-}>({
+  counter: number
+}
+
+export const myTest = test.extend<MyFixtures>({
   a: async ({ task }: any, use) => {
     await new Promise<void>(resolve => setTimeout(resolve, 200))
     await use(task.id)
@@ -11,14 +16,54 @@ export const myTest = test.extend<{
   b: async ({ a }, use) => {
     await use(a)
   },
+  counter: async ({}, use) => {
+    await use(i++)
+  },
 })
 
-myTest.concurrent('fixture - concurrent test 1', ({ a, b, task }) => {
-  expect(a).toBe(task.id)
-  expect(b).toBe(task.id)
+/**
+ * The `beforeEach` hook causes the issue.
+ */
+beforeEach<MyFixtures>(({ counter }) => {
+  // this is a dummy expectation to make use of the fixture
+  expect(counter).toBeTypeOf('number')
 })
 
-myTest.concurrent('fixture - concurrent test 2', ({ a, b, task }) => {
+/**
+ * Let N be the number of concurrent tests in the suite and M the number of non-concurrent tests.
+ * The fixture should be invoked N+M times.
+ * The issue is that it is invoked (2*N - 1) + M times.
+ */
+afterAll(() => {
+  expect(i).toEqual(4)
+})
+
+myTest.concurrent('fixture - concurrent test 1', ({ a, b, counter, task }) => {
   expect(a).toBe(task.id)
   expect(b).toBe(task.id)
+  expect(counter).toBeTypeOf('number')
+})
+
+myTest.concurrent('fixture - concurrent test 2', ({ a, b, counter, task }) => {
+  expect(a).toBe(task.id)
+  expect(b).toBe(task.id)
+  expect(counter).toBeTypeOf('number')
+})
+
+myTest.concurrent('fixture - concurrent test 3', ({ a, b, counter, task }) => {
+  expect(a).toBe(task.id)
+  expect(b).toBe(task.id)
+  expect(counter).toBeTypeOf('number')
+})
+
+myTest.concurrent('fixture - concurrent test 4', ({ a, b, counter, task }) => {
+  expect(a).toBe(task.id)
+  expect(b).toBe(task.id)
+  expect(counter).toBeTypeOf('number')
+})
+
+myTest('fixture - non-concurrent test', ({ a, b, counter, task }) => {
+  expect(a).toBe(task.id)
+  expect(b).toBe(task.id)
+  expect(counter).toBeTypeOf('number')
 })


### PR DESCRIPTION
### Description

See issue #4749 
This PR contains the tests about the abnormal invocation of fixtures during concurrent tests with a `beforeEach` hook.
I don't expect this to be merged, it's just to illustrate the issue.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
