### PR TITLE
fix(workspace): support overring `pool` and `poolOptions` on project level

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -655,7 +655,7 @@ Please, be aware of these issues when using this option. Vitest team cannot fix 
 - **Type:** `Record<'threads' | 'forks' | 'vmThreads', {}>`
 - **Default:** `{}`
 
-#### poolOptions.threads<NonProjectOption />
+#### poolOptions.threads
 
 Options for `threads` pool.
 
@@ -687,7 +687,7 @@ Maximum number of threads. You can also use `VITEST_MAX_THREADS` environment var
 
 Minimum number of threads. You can also use `VITEST_MIN_THREADS` environment variable.
 
-##### poolOptions.threads.singleThread<NonProjectOption />
+##### poolOptions.threads.singleThread
 
 - **Type:** `boolean`
 - **Default:** `false`
@@ -710,7 +710,7 @@ Use Atomics to synchronize threads.
 
 This can improve performance in some cases, but might cause segfault in older Node versions.
 
-##### poolOptions.threads.isolate<NonProjectOption />
+##### poolOptions.threads.isolate
 
 - **Type:** `boolean`
 - **Default:** `true`
@@ -728,7 +728,7 @@ Pass additional arguments to `node` in the threads. See [Command-line API | Node
 Be careful when using, it as some options may crash worker, e.g. --prof, --title. See https://github.com/nodejs/node/issues/41103.
 :::
 
-#### poolOptions.forks<NonProjectOption />
+#### poolOptions.forks
 
 Options for `forks` pool.
 
@@ -760,14 +760,14 @@ Maximum number of forks.
 
 Minimum number of forks.
 
-##### poolOptions.forks.isolate<NonProjectOption />
+##### poolOptions.forks.isolate
 
 - **Type:** `boolean`
 - **Default:** `true`
 
 Isolate environment for each test file.
 
-##### poolOptions.forks.singleFork<NonProjectOption />
+##### poolOptions.forks.singleFork
 
 - **Type:** `boolean`
 - **Default:** `false`
@@ -792,7 +792,7 @@ Pass additional arguments to `node` process in the child processes. See [Command
 Be careful when using, it as some options may crash worker, e.g. --prof, --title. See https://github.com/nodejs/node/issues/41103.
 :::
 
-#### poolOptions.vmThreads<NonProjectOption />
+#### poolOptions.vmThreads
 
 Options for `vmThreads` pool.
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -319,12 +319,28 @@ export class WorkspaceProject {
 
   getSerializableConfig() {
     const optimizer = this.config.deps?.optimizer
+    const poolOptions = this.config.poolOptions
+
+    // Resolve from server.config to avoid comparing against default value
+    const isolate = this.server?.config?.test?.isolate
+
     return deepMerge({
       ...this.config,
       coverage: this.ctx.config.coverage,
 
-      pool: this.ctx.config.pool,
-      poolOptions: this.ctx.config.poolOptions,
+      poolOptions: {
+        forks: {
+          singleFork: poolOptions?.forks?.singleFork ?? this.ctx.config.poolOptions?.forks?.singleFork ?? false,
+          isolate: poolOptions?.forks?.isolate ?? isolate ?? this.ctx.config.poolOptions?.forks?.isolate ?? true,
+        },
+        threads: {
+          singleThread: poolOptions?.threads?.singleThread ?? this.ctx.config.poolOptions?.threads?.singleThread ?? false,
+          isolate: poolOptions?.threads?.isolate ?? isolate ?? this.ctx.config.poolOptions?.threads?.isolate ?? true,
+        },
+        vmThreads: {
+          singleThread: poolOptions?.vmThreads?.singleThread ?? this.ctx.config.poolOptions?.vmThreads?.singleThread ?? false,
+        },
+      },
 
       reporters: [],
       deps: {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -817,7 +817,6 @@ export type ProjectConfig = Omit<
   | 'update'
   | 'reporters'
   | 'outputFile'
-  | 'pool'
   | 'poolOptions'
   | 'teardownTimeout'
   | 'silent'
@@ -842,6 +841,11 @@ export type ProjectConfig = Omit<
 > & {
   sequencer?: Omit<SequenceOptions, 'sequencer' | 'seed'>
   deps?: Omit<DepsOptions, 'moduleDirectories'>
+  poolOptions?: {
+    threads?: Pick<NonNullable<PoolOptions['threads']>, 'singleThread' | 'isolate'>
+    vmThreads?: Pick<NonNullable<PoolOptions['vmThreads']>, 'singleThread'>
+    forks?: Pick<NonNullable<PoolOptions['forks']>, 'singleFork' | 'isolate'>
+  }
 }
 
 export type RuntimeConfig = Pick<

--- a/test/config/test/config-types.test-d.ts
+++ b/test/config/test/config-types.test-d.ts
@@ -9,11 +9,16 @@ describe('define project helper', () => {
     expectProjectTestConfig.toHaveProperty('name')
     expectMainTestConfig.toHaveProperty('name')
 
-    expectProjectTestConfig.not.toHaveProperty('pool')
-    expectMainTestConfig.toHaveProperty('pool')
-
     expectProjectTestConfig.not.toHaveProperty('coverage')
     expectMainTestConfig.toHaveProperty('coverage')
+
+    expectProjectTestConfig.not.toHaveProperty('reporters')
+    expectMainTestConfig.toHaveProperty('reporters')
+  })
+
+  test('allows expected project fields on a project config', () => {
+    expectProjectTestConfig.toHaveProperty('pool')
+    expectProjectTestConfig.toHaveProperty('poolOptions')
   })
 })
 

--- a/test/workspaces/space-pools/forks.test.ts
+++ b/test/workspaces/space-pools/forks.test.ts
@@ -1,0 +1,12 @@
+import { isMainThread } from 'node:worker_threads'
+import { expect, test } from 'vitest'
+
+test('is run in "node:child_process"', () => {
+  expect(isChildProcess()).toBe(true)
+  expect(isMainThread).toBe(true)
+})
+
+// TODO: Use from "src/utils/base.ts" after #4441
+function isChildProcess(): boolean {
+  return !!process?.send
+}

--- a/test/workspaces/space-pools/isolate.test.ts
+++ b/test/workspaces/space-pools/isolate.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+test('is isolated', () => {
+  // @ts-expect-error -- internal
+  const config: NonNullable<UserConfig['test']> = globalThis.__vitest_worker__.config
+
+  if (config.pool === 'forks') {
+    expect(config.poolOptions?.forks?.isolate).toBe(true)
+  }
+  else {
+    expect(config.pool).toBe('threads')
+    expect(config.poolOptions?.threads?.isolate).toBe(true)
+  }
+})

--- a/test/workspaces/space-pools/multi-worker.test.ts
+++ b/test/workspaces/space-pools/multi-worker.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+test('is multi worker', () => {
+  // @ts-expect-error -- internal
+  const config: NonNullable<UserConfig['test']> = globalThis.__vitest_worker__.config
+
+  if (config.pool === 'forks') {
+    expect(config.poolOptions?.forks?.singleFork).toBe(false)
+  }
+  else {
+    expect(config.pool).toBe('threads')
+    expect(config.poolOptions?.threads?.singleThread).toBe(false)
+  }
+})

--- a/test/workspaces/space-pools/no-isolate.test.ts
+++ b/test/workspaces/space-pools/no-isolate.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+test('is not isolated', () => {
+  // @ts-expect-error -- internal
+  const config: NonNullable<UserConfig['test']> = globalThis.__vitest_worker__.config
+
+  if (config.pool === 'forks') {
+    expect(config.poolOptions?.forks?.isolate).toBe(false)
+  }
+  else {
+    expect(config.pool).toBe('threads')
+    expect(config.poolOptions?.threads?.isolate).toBe(false)
+  }
+})

--- a/test/workspaces/space-pools/single-worker.test.ts
+++ b/test/workspaces/space-pools/single-worker.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+test('is single worker', () => {
+  // @ts-expect-error -- internal
+  const config: NonNullable<UserConfig['test']> = globalThis.__vitest_worker__.config
+
+  if (config.pool === 'forks') {
+    expect(config.poolOptions?.forks?.singleFork).toBe(true)
+  }
+  else {
+    expect(config.pool).toBe('threads')
+    expect(config.poolOptions?.threads?.singleThread).toBe(true)
+  }
+})

--- a/test/workspaces/space-pools/threads.test.ts
+++ b/test/workspaces/space-pools/threads.test.ts
@@ -1,0 +1,12 @@
+import { isMainThread } from 'node:worker_threads'
+import { expect, test } from 'vitest'
+
+test('is run in "node:worker_threads"', () => {
+  expect(isChildProcess()).toBe(false)
+  expect(isMainThread).toBe(false)
+})
+
+// TODO: Use from "src/utils/base.ts" after #4441
+function isChildProcess(): boolean {
+  return !!process?.send
+}

--- a/test/workspaces/vitest.workspace.ts
+++ b/test/workspaces/vitest.workspace.ts
@@ -23,6 +23,96 @@ export default defineWorkspace([
     },
   },
 
+  // Projects testing pool and poolOptions
+  {
+    test: {
+      name: 'Threads pool',
+      include: [
+        './space-pools/threads.test.ts',
+        './space-pools/multi-worker.test.ts',
+        './space-pools/isolate.test.ts',
+      ],
+      pool: 'threads',
+    },
+  },
+  {
+    test: {
+      name: 'Single thread pool',
+      include: [
+        './space-pools/threads.test.ts',
+        './space-pools/single-worker.test.ts',
+      ],
+      pool: 'threads',
+      poolOptions: { threads: { singleThread: true } },
+    },
+  },
+  {
+    test: {
+      name: 'Non-isolated thread pool #1',
+      include: [
+        './space-pools/threads.test.ts',
+        './space-pools/no-isolate.test.ts',
+      ],
+      pool: 'threads',
+      poolOptions: { threads: { isolate: false } },
+    },
+  },
+  {
+    test: {
+      name: 'Non-isolated thread pool #2',
+      include: [
+        './space-pools/threads.test.ts',
+        './space-pools/no-isolate.test.ts',
+      ],
+      pool: 'threads',
+      isolate: false,
+    },
+  },
+  {
+    test: {
+      name: 'Forks pool',
+      include: [
+        './space-pools/forks.test.ts',
+        './space-pools/multi-worker.test.ts',
+        './space-pools/isolate.test.ts',
+      ],
+      pool: 'forks',
+    },
+  },
+  {
+    test: {
+      name: 'Single fork pool',
+      include: [
+        './space-pools/forks.test.ts',
+        './space-pools/single-worker.test.ts',
+      ],
+      pool: 'forks',
+      poolOptions: { forks: { singleFork: true } },
+    },
+  },
+  {
+    test: {
+      name: 'Non-isolated fork pool #1',
+      include: [
+        './space-pools/forks.test.ts',
+        './space-pools/no-isolate.test.ts',
+      ],
+      pool: 'forks',
+      poolOptions: { forks: { isolate: false } },
+    },
+  },
+  {
+    test: {
+      name: 'Non-isolated fork pool #2',
+      include: [
+        './space-pools/forks.test.ts',
+        './space-pools/no-isolate.test.ts',
+      ],
+      pool: 'forks',
+      isolate: false,
+    },
+  },
+
   // These two projects run on same environment but still transform
   // a single file differently due to Vite plugins
   {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/4731

Adds support for specifying following options in workspace projects configurations:

- `pool`
- `poolOptions.threads.isolate`
- `poolOptions.threads.singleThread`
- `poolOptions.vmThreads.isolate`
- `poolOptions.forks.isolate`
- `poolOptions.forks.singleFork`

Example:

```ts
import { defineWorkspace } from 'vitest/config'

export default defineWorkspace([
  {
    // Tests with side effects - require isolation
    test: {
      name: 'DOM tests',
      include: ['./src/web/**'],
    },
  },
  {
    // Tests that don't have side effects - can be run without isolation
    test: {
      name: 'Side-effect free unit tests',
      include: ['./src/utils/**'],
      poolOptions: { 
        threads: {
          singleThread:  true,
          isolate: false
        }
      },
    },
  },
  {
    // Tests that require forks pool for compatibility reasons
    test: {
      name: 'Database tests',
      include: ['./src/db/**'],
      pool: 'forks',
    },
  },
])
```


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
