### PR TITLE
fix(vm-threads): tests not cancelled on key press, cancelled tests shown twice

### DIFF
--- a/packages/vitest/src/node/pools/browser.ts
+++ b/packages/vitest/src/node/pools/browser.ts
@@ -44,7 +44,7 @@ export function createBrowserPool(ctx: Vitest): ProcessPool {
     if (project.config.browser.isolate) {
       for (const path of paths) {
         if (isCancelled) {
-          ctx.state.cancelFiles(files.slice(paths.indexOf(path)), ctx.config.root, project.getName())
+          ctx.state.cancelFiles(files.slice(paths.indexOf(path)), ctx.config.root, project.config.name)
           break
         }
 

--- a/packages/vitest/src/node/pools/child.ts
+++ b/packages/vitest/src/node/pools/child.ts
@@ -118,7 +118,7 @@ export function createChildProcessPool(ctx: Vitest, { execArgv, env, forksPath }
 
         // Intentionally cancelled
         else if (ctx.isCancelling && error instanceof Error && /The task has been cancelled/.test(error.message))
-          ctx.state.cancelFiles(files, ctx.config.root, project.getName())
+          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
 
         else
           throw error

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -106,7 +106,7 @@ export function createThreadsPool(ctx: Vitest, { execArgv, env, workerPath }: Po
 
         // Intentionally cancelled
         else if (ctx.isCancelling && error instanceof Error && /The task has been cancelled/.test(error.message))
-          ctx.state.cancelFiles(files, ctx.config.root, project.getName())
+          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
 
         else
           throw error

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -123,6 +123,9 @@ export function createVmThreadsPool(ctx: Vitest, { execArgv, env, vmPath }: Pool
     }
 
     return async (specs, invalidates) => {
+      // Cancel pending tasks from pool when possible
+      ctx.onCancel(() => pool.cancelPendingTasks())
+
       const configs = new Map<WorkspaceProject, ResolvedConfig>()
       const getConfig = (project: WorkspaceProject): ResolvedConfig => {
         if (configs.has(project))

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -111,7 +111,7 @@ export function createVmThreadsPool(ctx: Vitest, { execArgv, env, vmPath }: Pool
 
         // Intentionally cancelled
         else if (ctx.isCancelling && error instanceof Error && /The task has been cancelled/.test(error.message))
-          ctx.state.cancelFiles(files, ctx.config.root, project.getName())
+          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
 
         else
           throw error


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes bug where test run is not cancelled when one of the registered keys is pressed. This is only present on `pool: 'vmThreads'`.
- Fixes bug where cancelled tests were shown twice by reporters

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
