### PR TITLE
chore(test): restore trailing new line in `coverage-test/vitest.config.ts`

### DIFF
--- a/test/coverage-test/coverage-report-tests/generic.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/generic.report.test.ts
@@ -112,7 +112,7 @@ test('thresholds.autoUpdate updates thresholds', async () => {
   thresholds['**/function-count.ts'].functions = 59
   thresholds['**/function-count.ts'].lines = 50
 
-  fs.writeFileSync(configFilename, mod.generate().code, 'utf-8')
+  fs.writeFileSync(configFilename, `${mod.generate().code}\n`, 'utf-8')
 })
 
 test('function count is correct', async () => {


### PR DESCRIPTION
### Description

I'm not sure if this is only my local issue, but when I run `pnpm test:ci`, there is always new diff left in `test/coverage-test/vitest.config.ts` and `examples/vitesse/src/auto-import.d.ts`.

For the first issue, restoring the trailing new line seems to helps, so I put that in this PR. I tested with `pnpm -C test/coverage-test test:v8`.

For the 2nd issue, maybe `auto-import.d.ts` is meant to be updated, but I'm not familiar with vue nor auto-import, so I'll leave it there for now. FYI, this is the diff I see after running `pnpm -C examples/vitesse test`:

<details><summary>Reveal git diff</summary>

```diff
diff --git a/examples/vitesse/src/auto-import.d.ts b/examples/vitesse/src/auto-import.d.ts
index 9959df65..5eb5ac52 100644
--- a/examples/vitesse/src/auto-import.d.ts
+++ b/examples/vitesse/src/auto-import.d.ts
@@ -61,5 +61,5 @@ declare global {
 // for type re-export
 declare global {
   // @ts-ignore
-  export type { Component, ComponentPublicInstance, ComputedRef, InjectionKey, PropType, Ref, VNode } from 'vue'
+  export type { Component, ComponentPublicInstance, ComputedRef, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, VNode, WritableComputedRef } from 'vue'
 }
```

</details>

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
