### PR TITLE
fix(runner): mark tests as failed when `beforeAll/afterAll` failed

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -251,6 +251,17 @@ function failTask(result: TaskResult, err: unknown, diffOptions?: DiffOptions) {
   }
 }
 
+function markTasksAsFailed(suite: Suite, runner: VitestRunner) {
+  suite.tasks.forEach((t) => {
+    if (t.mode === 'run') {
+      t.result = { ...t.result, state: 'fail' }
+      updateTask(t, runner)
+      if (t.type === 'suite')
+        markTasksAsFailed(t, runner)
+    }
+  })
+}
+
 function markTasksAsSkipped(suite: Suite, runner: VitestRunner) {
   suite.tasks.forEach((t) => {
     t.mode = 'skip'
@@ -317,6 +328,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
     }
     catch (e) {
       failTask(suite.result, e, runner.config.diffOptions)
+      markTasksAsFailed(suite, runner)
     }
 
     try {
@@ -325,6 +337,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
     }
     catch (e) {
       failTask(suite.result, e, runner.config.diffOptions)
+      markTasksAsFailed(suite, runner)
     }
 
     if (suite.mode === 'run') {

--- a/test/fails/test/__snapshots__/runner.test.ts.snap
+++ b/test/fails/test/__snapshots__/runner.test.ts.snap
@@ -16,6 +16,8 @@ exports[`should fail hook-timeout.test.ts > hook-timeout.test.ts 1`] = `"Error: 
 
 exports[`should fail hooks-called.test.ts > hooks-called.test.ts 1`] = `
 "Error: after all
+Error: before all
+Error: after all
 Error: before all"
 `;
 

--- a/test/reporters/fixtures/suite-hook-failure/basic.test.ts
+++ b/test/reporters/fixtures/suite-hook-failure/basic.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest'
+
+describe("fail beforeEach", () => {
+  beforeEach(() => {
+    throw new Error("fail");
+  });
+
+  it("run", () => {});
+  it.skip("skip", () => {});
+})
+
+describe("fail beforeAll", () => {
+  beforeAll(() => {
+    throw new Error("fail");
+  });
+
+  it("run", () => {});
+  it.skip("skip", () => {});
+})
+
+describe("fail afterEach", () => {
+  afterEach(() => {
+    throw new Error("fail");
+  });
+
+  it("run", () => {});
+  it.skip("skip", () => {});
+})
+
+describe("fail afterAll", () => {
+  afterAll(() => {
+    throw new Error("fail");
+  });
+
+  it("run", () => {});
+  it.skip("skip", () => {});
+})
+
+it("ok", () => {});

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -1,6 +1,6 @@
 import path from 'pathe'
 import { describe, expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest, runVitestCli } from '../../test-utils'
 
 const resolve = (id = '') => path.resolve(__dirname, '../fixtures/default', id)
 async function run(fileFilter: string[], watch = false, ...args: string[]) {
@@ -53,5 +53,17 @@ describe('default reporter', async () => {
     expect(vitest.stdout).not.toContain('✓ nested b1 test')
     expect(vitest.stdout).not.toContain('✓ b1 test')
     expect(vitest.stdout).not.toContain('✓ b2 test')
+  })
+
+  test('suite hook failure', async () => {
+    const vitest = await runVitest({
+      root: 'fixtures/suite-hook-failure',
+    })
+    expect(vitest.stdout).toContain('× basic.test.ts > fail beforeEach > run')
+    expect(vitest.stdout).toContain('× basic.test.ts > fail beforeAll > run')
+    expect(vitest.stdout).toContain('× basic.test.ts > fail afterEach > run')
+    expect(vitest.stdout).toContain('× basic.test.ts > fail afterAll > run')
+    expect(vitest.stdout).toContain('✓ basic.test.ts > ok')
+    expect(vitest.stdout).toContain('4 failed | 1 passed | 4 skipped')
   })
 }, 120000)

--- a/test/reporters/tests/junit.test.ts
+++ b/test/reporters/tests/junit.test.ts
@@ -52,3 +52,60 @@ test('emits <failure> if a test has a syntax error', async () => {
   expect(xml).toContain('<testsuite name="with-syntax-error.test.js" timestamp="TIMESTAMP" hostname="HOSTNAME" tests="1" failures="1" errors="0" skipped="0" time="0">')
   expect(xml).toContain('<failure')
 })
+
+test('suite hook failure', async () => {
+  const vitest = await runVitest({
+    root: 'fixtures/suite-hook-failure',
+    reporters: 'junit',
+  })
+  let xml = vitest.stdout
+  xml = xml.replaceAll(/time=".*?"/g, 'time="..."')
+  xml = xml.replaceAll(/timestamp=".*?"/g, 'timestamp="..."')
+  xml = xml.replaceAll(/hostname=".*?"/g, 'hostname="..."')
+  expect(xml).toMatchInlineSnapshot(`
+    "<?xml version="1.0" encoding="UTF-8" ?>
+    <testsuites name="vitest tests" tests="9" failures="4" errors="0" time="...">
+        <testsuite name="basic.test.ts" timestamp="..." hostname="..." tests="9" failures="4" errors="0" skipped="4" time="...">
+            <testcase classname="basic.test.ts" name="fail beforeEach &gt; run" time="...">
+                <failure message="fail" type="Error">
+    Error: fail
+     ❯ basic.test.ts:5:11
+                </failure>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail beforeEach &gt; skip" time="...">
+                <skipped/>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail beforeAll &gt; run" time="...">
+                <failure message="fail" type="Error">
+    Error: fail
+     ❯ basic.test.ts:14:11
+                </failure>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail beforeAll &gt; skip" time="...">
+                <skipped/>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail afterEach &gt; run" time="...">
+                <failure message="fail" type="Error">
+    Error: fail
+     ❯ basic.test.ts:23:11
+                </failure>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail afterEach &gt; skip" time="...">
+                <skipped/>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail afterAll &gt; run" time="...">
+                <failure message="fail" type="Error">
+    Error: fail
+     ❯ basic.test.ts:32:11
+                </failure>
+            </testcase>
+            <testcase classname="basic.test.ts" name="fail afterAll &gt; skip" time="...">
+                <skipped/>
+            </testcase>
+            <testcase classname="basic.test.ts" name="ok" time="...">
+            </testcase>
+        </testsuite>
+    </testsuites>
+    "
+  `)
+})


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4516

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
