### PR TITLE
fix: don't crash when memoryLimit is assumed to be a percentage of system memory

### DIFF
--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -167,6 +167,7 @@ function getMemoryLimit(config: ResolvedConfig) {
     )
   }
 
+// If totalmem is not supported we cannot resolve percentage based values like 0.5, "50%"
   if ((typeof limit === 'number' && limit > 1) || (typeof limit === 'string' && limit.at(-1) !== '%'))
     return stringToBytes(limit)
 

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -167,9 +167,9 @@ function getMemoryLimit(config: ResolvedConfig) {
     )
   }
 
-  if (limit && limit > 1)
+  if ((typeof limit === 'number' && limit > 1) || (typeof limit === 'string' && limit.at(-1) !== '%'))
     return stringToBytes(limit)
 
-  // just ignore "experimentalVmWorkerMemoryLimit" value because we cannot detect memory limit
+  // just ignore "memoryLimit" value because we cannot detect memory limit
   return null
 }

--- a/packages/vitest/src/node/pools/vm-threads.ts
+++ b/packages/vitest/src/node/pools/vm-threads.ts
@@ -167,7 +167,7 @@ function getMemoryLimit(config: ResolvedConfig) {
     )
   }
 
-// If totalmem is not supported we cannot resolve percentage based values like 0.5, "50%"
+  // If totalmem is not supported we cannot resolve percentage based values like 0.5, "50%"
   if ((typeof limit === 'number' && limit > 1) || (typeof limit === 'string' && limit.at(-1) !== '%'))
     return stringToBytes(limit)
 

--- a/packages/vitest/src/utils/memory-limit.ts
+++ b/packages/vitest/src/utils/memory-limit.ts
@@ -23,7 +23,7 @@ export function getWorkerMemoryLimit(config: ResolvedConfig) {
   const memoryLimit = config.poolOptions?.vmThreads?.memoryLimit
 
   if (memoryLimit)
-    return stringToBytes(memoryLimit)
+    return memoryLimit
 
   return 1 / (config.poolOptions?.vmThreads?.maxThreads ?? getDefaultThreadsCount(config))
 }
@@ -94,7 +94,7 @@ export function stringToBytes(
       return Math.floor(input)
     }
     else {
-      throw new Error('Unexpected numerical input for "experimentalVmWorkerMemoryLimit"')
+      throw new Error('Unexpected numerical input for "memoryLimit"')
     }
   }
 


### PR DESCRIPTION
### Description

When I upgraded vitest to version 1.1.0 and replaced the original `experimentalVmWorkerMemoryLimit` config with `poolOptions.vmThreads.memoryLimit`, an error occurred when running `pnpm test`: "For a percentage based memory limit, a percentageReference must be provided."

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
