### PR TITLE
fix(vitest): don't hang when mocking files with cyclic dependencies

### DIFF
--- a/examples/mocks/src/cyclic-deps/module-1.mjs
+++ b/examples/mocks/src/cyclic-deps/module-1.mjs
@@ -1,0 +1,1 @@
+import './module-2'

--- a/examples/mocks/src/cyclic-deps/module-2.mjs
+++ b/examples/mocks/src/cyclic-deps/module-2.mjs
@@ -1,0 +1,1 @@
+import './module-3'

--- a/examples/mocks/src/cyclic-deps/module-3.mjs
+++ b/examples/mocks/src/cyclic-deps/module-3.mjs
@@ -1,0 +1,1 @@
+import './module-4'

--- a/examples/mocks/src/cyclic-deps/module-4.mjs
+++ b/examples/mocks/src/cyclic-deps/module-4.mjs
@@ -1,0 +1,1 @@
+import './module-1'

--- a/examples/mocks/test/cyclic-import-actual.spec.ts
+++ b/examples/mocks/test/cyclic-import-actual.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test, vi } from 'vitest'
+
+import '../src/cyclic-deps/module-1'
+
+vi.mock('../src/cyclic-deps/module-2', async (importOriginal) => {
+  await importOriginal()
+
+  return { default: () => {} }
+})
+
+test('some test', () => {
+  expect(1 + 1).toBe(2)
+})

--- a/examples/mocks/test/cyclic-import-original.spec.ts
+++ b/examples/mocks/test/cyclic-import-original.spec.ts
@@ -2,8 +2,8 @@ import { expect, test, vi } from 'vitest'
 
 import '../src/cyclic-deps/module-1'
 
-vi.mock('../src/cyclic-deps/module-2', async () => {
-  await vi.importActual('../src/cyclic-deps/module-2')
+vi.mock('../src/cyclic-deps/module-2', async (importOriginal) => {
+  await importOriginal()
 
   return { default: () => {} }
 })

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -482,7 +482,7 @@ function createVitest(): VitestUtils {
       _mocker.queueMock(
         path,
         importer,
-        factory ? () => factory(() => _mocker.importActual(path, importer)) : undefined,
+        factory ? () => factory(() => _mocker.importActual(path, importer, _mocker.getMockContext().callstack)) : undefined,
       )
     },
 
@@ -495,7 +495,7 @@ function createVitest(): VitestUtils {
       _mocker.queueMock(
         path,
         importer,
-        factory ? () => factory(() => _mocker.importActual(path, importer)) : undefined,
+        factory ? () => factory(() => _mocker.importActual(path, importer, _mocker.getMockContext().callstack)) : undefined,
       )
     },
 
@@ -504,7 +504,11 @@ function createVitest(): VitestUtils {
     },
 
     async importActual<T = unknown>(path: string): Promise<T> {
-      return _mocker.importActual<T>(path, getImporter())
+      return _mocker.importActual<T>(
+        path,
+        getImporter(),
+        _mocker.getMockContext().callstack,
+      )
     },
 
     async importMock<T>(path: string): Promise<MaybeMockedDeep<T>> {

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -176,7 +176,6 @@ export class VitestMocker {
     const cached = this.moduleCache.get(dep)?.exports
     if (cached)
       return cached
-    // TODO: set this.moduleCache before calling handler
     let exports: any
     try {
       exports = await mock()

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -212,9 +212,9 @@ export class VitestMocker {
           throw this.createError(
             `[vitest] No "${String(prop)}" export is defined on the "${mockpath}" mock. `
             + 'Did you forget to return it from "vi.mock"?'
-            + '\nIf you need to partially mock a module, you can use "vi.importActual" inside:\n\n'
-            + `${c.green(`vi.mock("${mockpath}", async () => {
-  const actual = await vi.importActual("${mockpath}")
+            + '\nIf you need to partially mock a module, you can use "importOriginal" helper inside:\n\n'
+            + `${c.green(`vi.mock("${mockpath}", async (importOriginal) => {
+  const actual = await importOriginal()
   return {
     ...actual,
     // your mocked methods


### PR DESCRIPTION
### Description

Fixes #4373

The problem was that the call stack didn't contain the file that triggered the mock factory execution - in this case `importActual` should behave the same way as a dynamic `import`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
