### PR TITLE
fix(runner): reset "current test" state on dynamic `skip`

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -183,6 +183,7 @@ export async function runTest(test: Test | Custom, runner: VitestRunner) {
         test.mode = 'skip'
         test.result = { state: 'skip' }
         updateTask(test, runner)
+        setCurrentTest(undefined)
         return
       }
 

--- a/test/core/test/skip-reset-state.test.ts
+++ b/test/core/test/skip-reset-state.test.ts
@@ -1,0 +1,11 @@
+import { getCurrentTest } from '@vitest/runner'
+import { afterAll, expect, test } from 'vitest'
+
+afterAll(() => {
+  // verify "current test" resets after "skip"
+  expect(getCurrentTest()).toBeUndefined()
+})
+
+test('single skipped test', ({ skip }) => {
+  skip()
+})


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4812

The tests I added are not a repro of the referenced issue, but I think this test demonstrates the fix more concisely.

I also locally verified the issue's repro is fixed. If it's desired to add such tests, then I can do that, but I felt it's a little overkill since it would probably requires a dedicated test directory and singleThread option to reproduce.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
