### PR TITLE
fix(vitest): show `beforeAll/afterAll` errors in junit reporter

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -4,6 +4,7 @@ import { dirname, relative, resolve } from 'pathe'
 
 import type { Task } from '@vitest/runner'
 import type { ErrorWithDiff } from '@vitest/utils'
+import { getSuites } from '@vitest/runner/utils'
 import type { Vitest } from '../../node'
 import type { Reporter } from '../../types/reporter'
 import { parseErrorStacktrace } from '../../utils/source-map'
@@ -218,6 +219,15 @@ export class JUnitReporter implements Reporter {
           failures: 0,
           skipped: 0,
         })
+
+        // inject failed suites to surface errors during beforeAll/afterAll
+        const suites = getSuites(file)
+        for (const suite of suites) {
+          if (suite.result?.errors) {
+            tasks.push(suite)
+            stats.failures += 1
+          }
+        }
 
         // If there are no tests, but the file failed to load, we still want to report it as a failure
         if (tasks.length === 0 && file.result?.state === 'fail') {

--- a/test/reporters/fixtures/suite-hook-failure/basic.test.ts
+++ b/test/reporters/fixtures/suite-hook-failure/basic.test.ts
@@ -1,0 +1,26 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+} from 'vitest';
+
+describe('suite with beforeAll', () => {
+  beforeAll(() => {
+    throw new Error('beforeAll error');
+  });
+
+  it('ok 1', () => {});
+  it('ok 2', () => {});
+  it.skip('skip 1', () => {});
+});
+
+describe('suite with afterAll', () => {
+  afterAll(() => {
+    throw new Error('afterAll error');
+  });
+
+  it('ok 1', () => {});
+  it('ok 2', () => {});
+  it.skip('skip 1', () => {});
+});

--- a/test/reporters/fixtures/suite-hook-failure/vitest.config.ts
+++ b/test/reporters/fixtures/suite-hook-failure/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/test/reporters/tests/__snapshots__/junit.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/junit.test.ts.snap
@@ -1,0 +1,36 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emits <failure> when beforeAll/afterAll failed 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="8" failures="2" errors="0" time="...">
+    <testsuite name="basic.test.ts" timestamp="..." hostname="..." tests="8" failures="2" errors="0" skipped="2" time="...">
+        <testcase classname="basic.test.ts" name="suite with beforeAll &gt; ok 1" time="...">
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with beforeAll &gt; ok 2" time="...">
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with beforeAll &gt; skip 1" time="...">
+            <skipped/>
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with afterAll &gt; ok 1" time="...">
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with afterAll &gt; ok 2" time="...">
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with afterAll &gt; skip 1" time="...">
+            <skipped/>
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with beforeAll" time="...">
+            <failure message="beforeAll error" type="Error">
+Error: beforeAll error
+ ❯ basic.test.ts:10:11
+            </failure>
+        </testcase>
+        <testcase classname="basic.test.ts" name="suite with afterAll" time="...">
+            <failure message="afterAll error" type="Error">
+Error: afterAll error
+ ❯ basic.test.ts:20:11
+            </failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;

--- a/test/reporters/tests/junit.test.ts
+++ b/test/reporters/tests/junit.test.ts
@@ -52,3 +52,10 @@ test('emits <failure> if a test has a syntax error', async () => {
   expect(xml).toContain('<testsuite name="with-syntax-error.test.js" timestamp="TIMESTAMP" hostname="HOSTNAME" tests="1" failures="1" errors="0" skipped="0" time="0">')
   expect(xml).toContain('<failure')
 })
+
+test('emits <failure> when beforeAll/afterAll failed', async () => {
+  let { stdout } = await runVitest({ reporters: 'junit', root: './fixtures/suite-hook-failure' })
+  // reduct non-deterministic output
+  stdout = stdout.replaceAll(/(timestamp|hostname|time)=".*?"/g, '$1="..."')
+  expect(stdout).toMatchSnapshot()
+})


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4516

This PR is an alternative of https://github.com/vitest-dev/vitest/pull/4799 to surface beforeAll/afterAll errors in junit reporter.

This approach might not be the most sound one since it "mutates" test counts when beforeAll/afterAll failed, but this will ensure such suite-level errors will be recorded in the report.

The idea came from how default reporters shows "Failed Suites" separately from "Failed Tests":

https://github.com/vitest-dev/vitest/blob/5ee041d84f1ac94c8455a31b5732391246b12771/packages/vitest/src/node/reporters/base.ts#L290-L302

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
