### PR TITLE
fix: match jest json output by making locations zero-based in json report

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -192,6 +192,7 @@ export class JsonReporter implements Reporter {
     if (!frame)
       return
 
-    return { line: frame.line, column: frame.column }
+    // Jest produces zero-based line and column numbers
+    return { line: frame.line - 1, column: frame.column - 1 }
   }
 }

--- a/test/reporters/tests/__snapshots__/json.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/json.test.ts.snap
@@ -10,8 +10,8 @@ exports[`json reporter > generates correct report 1`] = `
   ],
   "fullName": " should fail",
   "location": {
-    "column": 13,
-    "line": 8,
+    "column": 12,
+    "line": 7,
   },
   "status": "failed",
   "title": "should fail",

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -284,8 +284,8 @@ exports[`json reporter (no outputFile entry) 1`] = `
           ],
           "fullName": "suite inner suite Math.sqrt()",
           "location": {
-            "column": 32,
-            "line": 8,
+            "column": 31,
+            "line": 7,
           },
           "status": "failed",
           "title": "Math.sqrt()",
@@ -406,8 +406,8 @@ exports[`json reporter 1`] = `
           ],
           "fullName": "suite inner suite Math.sqrt()",
           "location": {
-            "column": 32,
-            "line": 8,
+            "column": 31,
+            "line": 7,
           },
           "status": "failed",
           "title": "Math.sqrt()",
@@ -535,8 +535,8 @@ exports[`json reporter with outputFile 2`] = `
             "expected 2.23606797749979 to equal 2"
           ],
           "location": {
-            "line": 8,
-            "column": 32
+            "line": 7,
+            "column": 31
           }
         },
         {
@@ -662,8 +662,8 @@ exports[`json reporter with outputFile in non-existing directory 2`] = `
             "expected 2.23606797749979 to equal 2"
           ],
           "location": {
-            "line": 8,
-            "column": 32
+            "line": 7,
+            "column": 31
           }
         },
         {
@@ -789,8 +789,8 @@ exports[`json reporter with outputFile object 2`] = `
             "expected 2.23606797749979 to equal 2"
           ],
           "location": {
-            "line": 8,
-            "column": 32
+            "line": 7,
+            "column": 31
           }
         },
         {
@@ -916,8 +916,8 @@ exports[`json reporter with outputFile object in non-existing directory 2`] = `
             "expected 2.23606797749979 to equal 2"
           ],
           "location": {
-            "line": 8,
-            "column": 32
+            "line": 7,
+            "column": 31
           }
         },
         {


### PR DESCRIPTION
### Description

~~This change improves compatibility of the JSON reporter with Jest's `--json` output by making locations zero-based.~~

#### Repro


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
