### PR TITLE
fix: match jest json output by reporting location of error in test file

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -188,7 +188,7 @@ export class JsonReporter implements Reporter {
       getSourceMap: file => project.getBrowserSourceMapModuleById(file),
       frameFilter: this.ctx.config.onStackTrace,
     })
-    const frame = stack[0]
+    const frame = stack[stack.length - 1]
     if (!frame)
       return
 


### PR DESCRIPTION
### Description

This change improves compatibility of the JSON reporter with Jest's `--json` output by pointing to the last stack frame (where the error surfaced in the test) instead of the first. 

#### Repro

```sh
$ git clone https://github.com/bard/vitest-json-reporter-bugs-repros && cd vitest-json-reporter-bugs-repros && pnpm i
$ pnpm run repro-lineindex-bug

$ pnpm repro-location-bug

> repro@1.0.0 repro-location-bug /tmp/vitest-json-reporter-bugs-repros
> echo '### WITH JEST:'; pnpm run location-bug-jest; echo; echo '### WITH VITEST:'; pnpm run location-bug-vitest

### WITH JEST:

> repro@1.0.0 location-bug-jest /tmp/vitest-json-reporter-bugs-repros
> jest --json --testLocationInResults src/location-bug/jest.test.ts 2>/dev/null | jq .testResults[0].assertionResults[0].location

{
  "column": 5,
  "line": 4
}

### WITH VITEST:

> repro@1.0.0 location-bug-vitest /tmp/vitest-json-reporter-bugs-repros
> vitest run --reporter=json src/location-bug/vitest.test.ts | jq .testResults[0].assertionResults[0].location

{
  "line": 1,
  "column": 8
}
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
