### PR TITLE
fix(runner): fix fixture cleanup for concurrent tests

### DIFF
--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -76,7 +76,6 @@ export function withFixtures(fn: Function, testContext?: TestContext) {
 
     if (!cleanupFnArrayMap.has(context))
       cleanupFnArrayMap.set(context, [])
-
     const cleanupFnArray = cleanupFnArrayMap.get(context)!
 
     const usedFixtures = fixtures.filter(({ prop }) => usedProps.includes(prop))

--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -46,12 +46,13 @@ export function mergeContextFixtures(fixtures: Record<string, any>, context: { f
 }
 
 const fixtureValueMaps = new Map<TestContext, Map<FixtureItem, any>>()
-let cleanupFnArray = new Array<() => void | Promise<void>>()
+const cleanupFnArrayMap = new Map<TestContext, Array<() => void | Promise<void>>>()
 
-export async function callFixtureCleanup() {
+export async function callFixtureCleanup(context: TestContext) {
+  const cleanupFnArray = cleanupFnArrayMap.get(context) ?? []
   for (const cleanup of cleanupFnArray.reverse())
     await cleanup()
-  cleanupFnArray = []
+  cleanupFnArrayMap.delete(context)
 }
 
 export function withFixtures(fn: Function, testContext?: TestContext) {
@@ -72,6 +73,11 @@ export function withFixtures(fn: Function, testContext?: TestContext) {
     if (!fixtureValueMaps.get(context))
       fixtureValueMaps.set(context, new Map<FixtureItem, any>())
     const fixtureValueMap: Map<FixtureItem, any> = fixtureValueMaps.get(context)!
+
+    if (!cleanupFnArrayMap.has(context))
+      cleanupFnArrayMap.set(context, [])
+
+    const cleanupFnArray = cleanupFnArrayMap.get(context)!
 
     const usedFixtures = fixtures.filter(({ prop }) => usedProps.includes(prop))
     const pendingFixtures = resolveDeps(usedFixtures)

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -190,7 +190,7 @@ export async function runTest(test: Test | Custom, runner: VitestRunner) {
       try {
         await callSuiteHook(test.suite, test, 'afterEach', runner, [test.context, test.suite])
         await callCleanupHooks(beforeEachCleanups)
-        await callFixtureCleanup()
+        await callFixtureCleanup(test.context)
       }
       catch (e) {
         failTask(test.result, e, runner.config.diffOptions)

--- a/test/core/test/fixture-concurrent-beforeEach.test.ts
+++ b/test/core/test/fixture-concurrent-beforeEach.test.ts
@@ -1,0 +1,45 @@
+import { afterAll, beforeEach, expect, test } from 'vitest'
+
+// this test case might look exotic, but a few conditions were required to reproduce the reported bug.
+// such particular conditions are marked with "[repro]" in the comments.
+
+let globalA = 0
+let globalB = 0
+
+interface MyFixtures {
+  a: number
+  b: number
+}
+
+export const myTest = test.extend<MyFixtures>({
+  // [repro] ordered must be { a, b } and not { b, a }
+  a: async ({}, use) => {
+    globalA++
+    await new Promise<void>(resolve => setTimeout(resolve, 200)) // [repro] async fixture
+    await use(globalA)
+  },
+  b: async ({}, use) => {
+    globalB++
+    await use(globalB)
+  },
+})
+
+// [repro] beforeEach uses only "b"
+beforeEach<MyFixtures>(({ b }) => {
+  expect(b).toBeTypeOf('number')
+})
+
+afterAll(() => {
+  expect([globalA, globalB]).toEqual([2, 2])
+})
+
+// [repro] concurrent test uses both "a" and "b"
+myTest.concurrent('test1', async ({ a, b }) => {
+  expect(a).toBeTypeOf('number')
+  expect(b).toBeTypeOf('number')
+})
+
+myTest.concurrent('test2', async ({ a, b }) => {
+  expect(a).toBeTypeOf('number')
+  expect(b).toBeTypeOf('number')
+})

--- a/test/core/test/fixture-concurrent-beforeEach.test.ts
+++ b/test/core/test/fixture-concurrent-beforeEach.test.ts
@@ -12,7 +12,7 @@ interface MyFixtures {
 }
 
 export const myTest = test.extend<MyFixtures>({
-  // [repro] ordered must be { a, b } and not { b, a }
+  // [repro] fixture order must be { a, b } and not { b, a }
   a: async ({}, use) => {
     globalA++
     await new Promise<void>(resolve => setTimeout(resolve, 200)) // [repro] async fixture


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4749

To properly support concurrent test with fixtures, I think "clean up array" has to be aware of "test context".
This fix is along the same line of https://github.com/vitest-dev/vitest/pull/4403 where it made "fixture value" to be aware of "test context".

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
