### PR TITLE
fix: mistyped option name(--no-parallelism)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -73,7 +73,7 @@ Run only [benchmark](https://vitest.dev/guide/features.html#benchmarking-experim
 | `--poolOptions <options>` | Specify pool options |
 | `--poolOptions.threads.isolate` | Isolate tests in threads pool (default: `true`)  |
 | `--poolOptions.forks.isolate` | Isolate tests in forks pool (default: `true`)  |
-| `--fileParallelism` | Should all test files run in parallel. Use --no-parallelism to disable (default: true) |
+| `--fileParallelism` | Should all test files run in parallel. Use --no-file-parallelism to disable (default: true) |
 | `--maxWorkers` | Maximum number of workers to run tests in |
 | `--minWorkers` | Minimum number of workers to run tests in |
 | `--silent` | Silent console output from tests |

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -62,7 +62,7 @@ vitest --inspect-brk --pool threads --poolOptions.threads.singleThread
 vitest --inspect-brk --pool forks --poolOptions.forks.singleFork
 ```
 
-If you are using Vitest 1.1 or higher, you can also just provide `--no-parallelism` flag:
+If you are using Vitest 1.1 or higher, you can also just provide `--no-file-parallelism` flag:
 
 ```sh
 # If pool is unknown

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -134,7 +134,7 @@ export function resolveConfig(
 
     if (resolved.fileParallelism && !isSingleThread && !isSingleFork) {
       const inspectOption = `--inspect${resolved.inspectBrk ? '-brk' : ''}`
-      throw new Error(`You cannot use ${inspectOption} without "--no-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"`)
+      throw new Error(`You cannot use ${inspectOption} without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"`)
     }
   }
 

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -33,19 +33,19 @@ test('shard index must be smaller than count', async () => {
 test('inspect requires changing pool and singleThread/singleFork', async () => {
   const { stderr } = await runVitest({ inspect: true })
 
-  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('inspect cannot be used with multi-threading', async () => {
   const { stderr } = await runVitest({ inspect: true, pool: 'threads', poolOptions: { threads: { singleThread: false } } })
 
-  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('inspect-brk cannot be used with multi processing', async () => {
   const { stderr } = await runVitest({ inspect: true, pool: 'forks', poolOptions: { forks: { singleFork: false } } })
 
-  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('c8 coverage provider is not supported', async () => {


### PR DESCRIPTION
### Description
- closes #4830 

In certain sections of the documentation and error messages, the option `--no-file-parallelism` is incorrectly referred to as `--no-parallelism`. 
This Pull Request corrects these inconsistencies to ensure that the correct option name, `--no-file-parallelism`, is used throughout.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
