### PR TITLE
docs(getting started): Add default test name tip 

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -62,6 +62,10 @@ test('adds 1 + 2 to equal 3', () => {
 })
 ```
 
+::: tip
+By default, tests must contain ".test." or ".spec." in their file name.
+:::
+
 Next, in order to execute the test, add the following section to your `package.json`:
 
 ```json


### PR DESCRIPTION
### Description

I'm new to Vite, vitest, and JS in general.
Because I had to follow multiple tutorials, my test name was wrong, and it took me multiple hours to realize.
Coming from multiple other programing languages that works differently, and even having written some small test runners, I expected the include regex to look inside the file rather than only the file name.


I think this small tip in documentation can help neophytes to avoid that basic mistake that they can encounter for multiple reasons.

- [-] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
Only discution to be had is the format of the tip. I think this can be done in the PR directly as it is very small.
- [ - ] Ideally, include a test that fails without this PR but passes with it.
Documentation, no tests impacted
- [ x ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
None

### Tests
- [ - ] Run the tests with `pnpm test:ci`.
None

### Documentation
- [  - ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.
None

### Changesets
- [ - ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.


I hope I followed everything to make this PR viable :)
Have a wonderful day !