### PR TITLE
fix: match jest json output by providing full stack trace

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -109,7 +109,7 @@ export class JsonReporter implements Reporter {
           status: StatusMap[t.result?.state || t.mode] || 'skipped',
           title: t.name,
           duration: t.result?.duration,
-          failureMessages: t.result?.errors?.map(e => e.message) || [],
+          failureMessages: t.result?.errors?.map(e => e.stack) || [],
           location: await this.getFailureLocation(t),
         } as FormattedAssertionResult
       }))

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "NO_COLOR=1 vitest run"
+    "test": "NO_COLOR=1 vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "flatted": "^3.2.9",

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -3,8 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "NO_COLOR=1 vitest run",
-    "test:watch": "vitest"
+    "test": "NO_COLOR=1 vitest run"
   },
   "devDependencies": {
     "flatted": "^3.2.9",

--- a/test/reporters/tests/__snapshots__/json.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/json.test.ts.snap
@@ -6,7 +6,17 @@ exports[`json reporter > generates correct report 1`] = `
     "",
   ],
   "failureMessages": [
-    "expected 2 to deeply equal 1",
+    "AssertionError: expected 2 to deeply equal 1
+    at /home/bard/projects/vitest/test/reporters/fixtures/json-fail.test.ts:8:13
+    at file:///home/bard/projects/vitest/packages/runner/dist/index.js:127:14
+    at file:///home/bard/projects/vitest/packages/runner/dist/index.js:59:26
+    at runTest (file:///home/bard/projects/vitest/packages/runner/dist/index.js:671:17)
+    at runSuite (file:///home/bard/projects/vitest/packages/runner/dist/index.js:789:15)
+    at runFiles (file:///home/bard/projects/vitest/packages/runner/dist/index.js:838:5)
+    at startTests (file:///home/bard/projects/vitest/packages/runner/dist/index.js:847:3)
+    at file:///home/bard/projects/vitest/packages/vitest/dist/entry.js:112:7
+    at withEnv (file:///home/bard/projects/vitest/packages/vitest/dist/entry.js:79:5)
+    at run (file:///home/bard/projects/vitest/packages/vitest/dist/entry.js:101:3)",
   ],
   "fullName": " should fail",
   "location": {

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -280,7 +280,17 @@ exports[`json reporter (no outputFile entry) 1`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite inner suite Math.sqrt()",
           "location": {
@@ -402,7 +412,17 @@ exports[`json reporter 1`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite inner suite Math.sqrt()",
           "location": {
@@ -532,7 +552,7 @@ exports[`json reporter with outputFile 2`] = `
           "title": "Math.sqrt()",
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2"
+            "AssertionError: expected 2.23606797749979 to equal 2\\n    at /vitest/test/core/test/basic.test.ts:8:32\\n    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26\\n    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)\\n    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)\\n    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)\\n    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)\\n    at async /vitest/packages/vitest/dist/entry.js:1798:7\\n    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)\\n    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)\\n    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20"
           ],
           "location": {
             "line": 8,
@@ -659,7 +679,7 @@ exports[`json reporter with outputFile in non-existing directory 2`] = `
           "title": "Math.sqrt()",
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2"
+            "AssertionError: expected 2.23606797749979 to equal 2\\n    at /vitest/test/core/test/basic.test.ts:8:32\\n    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26\\n    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)\\n    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)\\n    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)\\n    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)\\n    at async /vitest/packages/vitest/dist/entry.js:1798:7\\n    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)\\n    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)\\n    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20"
           ],
           "location": {
             "line": 8,
@@ -786,7 +806,7 @@ exports[`json reporter with outputFile object 2`] = `
           "title": "Math.sqrt()",
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2"
+            "AssertionError: expected 2.23606797749979 to equal 2\\n    at /vitest/test/core/test/basic.test.ts:8:32\\n    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26\\n    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)\\n    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)\\n    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)\\n    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)\\n    at async /vitest/packages/vitest/dist/entry.js:1798:7\\n    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)\\n    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)\\n    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20"
           ],
           "location": {
             "line": 8,
@@ -913,7 +933,7 @@ exports[`json reporter with outputFile object in non-existing directory 2`] = `
           "title": "Math.sqrt()",
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2"
+            "AssertionError: expected 2.23606797749979 to equal 2\\n    at /vitest/test/core/test/basic.test.ts:8:32\\n    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26\\n    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)\\n    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)\\n    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)\\n    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)\\n    at async /vitest/packages/vitest/dist/entry.js:1798:7\\n    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)\\n    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)\\n    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20"
           ],
           "location": {
             "line": 8,


### PR DESCRIPTION
### Description

Continuation of https://github.com/vitest-dev/vitest/pull/4826.

Jest's JSON output reports the full stack trace in the `failureMessage` field. This PR aligns Vitest's JSON reporter output to Jest's in that regard.

Note: not sure what's causing the conflict on the snapshot, I can't seem to reproduce it locally.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
