### PR TITLE
fix(vitest): throw an error if mock was already loaded when vi.mock is called

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -45,9 +45,9 @@ export default defineConfig({
 
 ## Cannot mock "./mocked-file.js" because it is already loaded
 
-This error happens when `vi.mock` or `vi.doMock` methods are called on modules that were already loaded. Vitest throws this error because this call has no effect because cached modules are preferred.
+This error happens when `vi.mock` method is called on a module that was already loaded. Vitest throws this error because this call has no effect since cached modules are preferred.
 
-If you are getting this error for `vi.mock`, remember that `vi.mock` is always hoisted - it means that the module was loaded before the test file started executing - most likely in a setup file. To fix the error, remove the import or clear the cache at the end of a setup file - beware that setup file and your test file will reference different modules in that case.
+Remember that `vi.mock` is always hoisted - it means that the module was loaded before the test file started executing - most likely in a setup file. To fix the error, remove the import or clear the cache at the end of a setup file - beware that setup file and your test file will reference different modules in that case.
 
 ```ts
 // setupFile.js
@@ -57,28 +57,4 @@ import { sideEffect } from './mocked-file.js'
 sideEffect()
 
 vi.resetModules()
-```
-
-If you are getting this error with `vi.doMock`, it means the file was already imported during test file execution or inside the setup file. If it was imported in the setup file, follow instruction from the previous paragraph. Otherwise it is possible that you are testing different module behaviours - so make sure to call `vi.resetModules` before mocking a module:
-
-```ts
-import { beforeEach, it, vi } from 'vitest'
-
-beforeEach(() => {
-  vi.resetModules() // this will reset all modules cache
-})
-
-it('total is big', async () => {
-  vi.doMock('./mocked-file.js', () => ({ total: 100 }))
-
-  const { total } = await import('./mocked-file.js')
-  expect(total).toBe(100)
-})
-
-it('total is bigger', async () => {
-  vi.doMock('./mocked-file.js', () => ({ total: 200 }))
-
-  const { total } = await import('./mocked-file.js')
-  expect(total).toBe(200)
-})
 ```

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -42,3 +42,43 @@ export default defineConfig({
   }
 })
 ```
+
+## Cannot mock "./mocked-file.js" because it is already loaded
+
+This error happens when `vi.mock` or `vi.doMock` methods are called on modules that were already loaded. Vitest throws this error because this call has no effect because cached modules are preferred.
+
+If you are getting this error for `vi.mock`, remember that `vi.mock` is always hoisted - it means that the module was loaded before the test file started executing - most likely in a setup file. To fix the error, remove the import or clear the cache at the end of a setup file - beware that setup file and your test file will reference different modules in that case.
+
+```ts
+// setupFile.js
+import { vi } from 'vitest'
+import { sideEffect } from './mocked-file.js'
+
+sideEffect()
+
+vi.resetModules()
+```
+
+If you are getting this error with `vi.doMock`, it means the file was already imported during test file execution or inside the setup file. If it was imported in the setup file, follow instruction from the previous paragraph. Otherwise it is possible that you are testing different module behaviours - so make sure to call `vi.resetModules` before mocking a module:
+
+```ts
+import { beforeEach, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetModules() // this will reset all modules cache
+})
+
+it('total is big', async () => {
+  vi.doMock('./mocked-file.js', () => ({ total: 100 }))
+
+  const { total } = await import('./mocked-file.js')
+  expect(total).toBe(100)
+})
+
+it('total is bigger', async () => {
+  vi.doMock('./mocked-file.js', () => ({ total: 200 }))
+
+  const { total } = await import('./mocked-file.js')
+  expect(total).toBe(200)
+})
+```

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -483,6 +483,7 @@ function createVitest(): VitestUtils {
         path,
         importer,
         factory ? () => factory(() => _mocker.importActual(path, importer, _mocker.getMockContext().callstack)) : undefined,
+        true,
       )
     },
 
@@ -496,6 +497,7 @@ function createVitest(): VitestUtils {
         path,
         importer,
         factory ? () => factory(() => _mocker.importActual(path, importer, _mocker.getMockContext().callstack)) : undefined,
+        false,
       )
     },
 

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -412,7 +412,7 @@ export class VitestMocker {
     const id = this.normalizePath(path)
 
     if (this.moduleCache.has(id))
-      throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded. Did you import it in a setup file?\n\nPlease, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again.`)
+      throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded. Did you import it in a setup file?\n\nPlease, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again. See: https://vitest.dev/guide/common-errors.html#cannot-mock-mocked-file.js-because-it-is-already-loaded`)
 
     const mocks = this.mockMap.get(suitefile) || {}
     const resolves = this.resolveCache.get(suitefile) || {}

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -166,7 +166,7 @@ export class VitestMocker {
       if (mock.type === 'unmock')
         this.unmockPath(fsPath)
       if (mock.type === 'mock')
-        this.mockPath(mock.id, fsPath, external, mock.factory)
+        this.mockPath(mock.id, fsPath, external, mock.factory, mock.throwIfCached)
     }))
 
     VitestMocker.pendingIds = []
@@ -407,13 +407,13 @@ export class VitestMocker {
     this.deleteCachedItem(id)
   }
 
-  public mockPath(originalId: string, path: string, external: string | null, factory?: MockFactory) {
-    const suitefile = this.getSuiteFilepath()
+  public mockPath(originalId: string, path: string, external: string | null, factory: MockFactory | undefined, throwIfExists: boolean) {
     const id = this.normalizePath(path)
 
-    if (this.moduleCache.has(id))
+    if (throwIfExists && this.moduleCache.has(id))
       throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded. Did you import it in a setup file?\n\nPlease, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again. See: https://vitest.dev/guide/common-errors.html#cannot-mock-mocked-file.js-because-it-is-already-loaded`)
 
+    const suitefile = this.getSuiteFilepath()
     const mocks = this.mockMap.get(suitefile) || {}
     const resolves = this.resolveCache.get(suitefile) || {}
 
@@ -487,11 +487,11 @@ export class VitestMocker {
       return mock
   }
 
-  public queueMock(id: string, importer: string, factory?: MockFactory) {
-    VitestMocker.pendingIds.push({ type: 'mock', id, importer, factory })
+  public queueMock(id: string, importer: string, factory?: MockFactory, throwIfCached = false) {
+    VitestMocker.pendingIds.push({ type: 'mock', id, importer, factory, throwIfCached })
   }
 
-  public queueUnmock(id: string, importer: string) {
-    VitestMocker.pendingIds.push({ type: 'unmock', id, importer })
+  public queueUnmock(id: string, importer: string, throwIfCached = false) {
+    VitestMocker.pendingIds.push({ type: 'unmock', id, importer, throwIfCached })
   }
 }

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -412,7 +412,7 @@ export class VitestMocker {
     const id = this.normalizePath(path)
 
     if (this.moduleCache.has(id))
-      throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded. Did you import it in a setup file?`)
+      throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded. Did you import it in a setup file?\n\nPlease, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again.`)
 
     const mocks = this.mockMap.get(suitefile) || {}
     const resolves = this.resolveCache.get(suitefile) || {}

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -411,6 +411,9 @@ export class VitestMocker {
     const suitefile = this.getSuiteFilepath()
     const id = this.normalizePath(path)
 
+    if (this.moduleCache.has(id))
+      throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded. Did you import it in a setup file?`)
+
     const mocks = this.mockMap.get(suitefile) || {}
     const resolves = this.resolveCache.get(suitefile) || {}
 

--- a/packages/vitest/src/types/mocker.ts
+++ b/packages/vitest/src/types/mocker.ts
@@ -7,5 +7,6 @@ export interface PendingSuiteMock {
   id: string
   importer: string
   type: 'mock' | 'unmock'
+  throwIfCached: boolean
   factory?: MockFactory
 }


### PR DESCRIPTION
### Description

Closes #4759

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
