### PR TITLE
fix(browser): avoid safaridriver collision

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,6 @@
   },
   "peerDependencies": {
     "playwright": "*",
-    "safaridriver": "*",
     "vitest": "^1.0.0",
     "webdriverio": "*"
   },

--- a/packages/browser/src/node/providers/webdriver.ts
+++ b/packages/browser/src/node/providers/webdriver.ts
@@ -14,7 +14,6 @@ export class WebdriverBrowserProvider implements BrowserProvider {
   public name = 'webdriverio'
 
   private cachedBrowser: WebdriverIO.Browser | null = null
-  private stopSafari: () => void = () => {}
   private browser!: WebdriverBrowser
   private ctx!: WorkspaceProject
 
@@ -39,14 +38,6 @@ export class WebdriverBrowserProvider implements BrowserProvider {
     if (this.browser === 'safari') {
       if (options.headless)
         throw new Error('You\'ve enabled headless mode for Safari but it doesn\'t currently support it.')
-
-      const safaridriver = await import('safaridriver')
-      safaridriver.start({ diagnose: true })
-      this.stopSafari = () => safaridriver.stop()
-
-      process.on('beforeExit', () => {
-        safaridriver.stop()
-      })
     }
 
     const { remote } = await import('webdriverio')
@@ -97,7 +88,6 @@ export class WebdriverBrowserProvider implements BrowserProvider {
 
   async close() {
     await Promise.all([
-      this.stopSafari(),
       this.cachedBrowser?.sessionId ? this.cachedBrowser?.deleteSession?.() : null,
     ])
     // TODO: right now process can only exit with timeout, if we use browser

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -6,6 +6,7 @@
     "test": "pnpm run test:webdriverio && pnpm run test:playwright",
     "test:webdriverio": "PROVIDER=webdriverio node --test specs/",
     "test:playwright": "PROVIDER=playwright node --test specs/",
+    "test:safaridriver": "PROVIDER=webdriverio BROWSER=safari node --test specs/",
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes"
   },
   "devDependencies": {

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -4,8 +4,12 @@ import test from 'node:test'
 import { execa } from 'execa'
 
 const browser = process.env.BROWSER || (process.env.PROVIDER === 'playwright' ? 'chromium' : 'chrome')
+const argv = ['vitest', '--run', `--browser.name=${browser}`]
 
-const { stderr, stdout } = await execa('npx', ['vitest', '--run', `--browser.name=${browser}`, '--browser.headless'], {
+if (browser !== 'safari')
+  argv.push('--browser.headless')
+
+const { stderr, stdout } = await execa('npx', argv, {
   env: {
     ...process.env,
     CI: 'true',


### PR DESCRIPTION
### Description

Fixes #4706.

Removes code from node/providers/webdriver.ts causing the following error when running `vitest --browser.name=safari` on macOS:

```text
  Error: There is already a Safaridriver instance running on port
  undefined!
```

#### Cause

safaridriver.start() maintains a static reference to a safaridriver instance, and will fail with this error if start() is called again before stop().

The original node/providers/webdriver.ts calls safaridriver.start() directly, and then immediately imports and calls webdriverio.remote(). This call also eventually calls safaridriver.start(), producing the error.

The fix is to remove the direct safaridriver access, as webdriverio seems to manage safaridriver successfully now.

#### Testing

Since Safari can't run in headless mode, I couldn't think of a way to add a test that would run in CI. However, I added a new `test:safaridriver` target intended to be run manually as needed, which runs all the existing test/browser tests under Safari.

#### Enabling/documentation

Note that you have to enable automation in Safari via **Developer > Allow remote automation**, or else running with the safaridriver will fail with:

```text
Error: Failed to create session.
Could not create a session: You must enable the 'Allow Remote 
Automation' option in Safari's Develop menu to control Safari via
WebDriver.
```

If it would be helpful to add a doc change for this, or to open a new PR for one, I'm happy to do that.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [X] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
