### PR TITLE
fix(vitest): apply `slowTestThreshold` to all reporters

### DIFF
--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -1,12 +1,11 @@
 import c from 'picocolors'
 import type { UserConsoleLog } from '../../../../types/general'
 import { BaseReporter } from '../../base'
-import type { ListRendererOptions } from '../../renderers/listRenderer'
-import { createTableRenderer } from './tableRender'
+import { type TableRendererOptions, createTableRenderer } from './tableRender'
 
 export class TableReporter extends BaseReporter {
   renderer?: ReturnType<typeof createTableRenderer>
-  rendererOptions: ListRendererOptions = {} as any
+  rendererOptions: TableRendererOptions = {} as any
 
   async onTestRemoved(trigger?: string) {
     await this.stopListRender()

--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -21,6 +21,7 @@ export class TableReporter extends BaseReporter {
     if (this.isTTY) {
       this.rendererOptions.logger = this.ctx.logger
       this.rendererOptions.showHeap = this.ctx.config.logHeapUsage
+      this.rendererOptions.slowTestThreshold = this.ctx.config.slowTestThreshold
       const files = this.ctx.state.getFiles(this.watchFilters)
       if (!this.renderer)
         this.renderer = createTableRenderer(files, this.rendererOptions).start()

--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -1,11 +1,12 @@
 import c from 'picocolors'
 import type { UserConsoleLog } from '../../../../types/general'
 import { BaseReporter } from '../../base'
-import { type TableRendererOptions, createTableRenderer } from './tableRender'
+import type { ListRendererOptions } from '../../renderers/listRenderer'
+import { createTableRenderer } from './tableRender'
 
 export class TableReporter extends BaseReporter {
   renderer?: ReturnType<typeof createTableRenderer>
-  rendererOptions: TableRendererOptions = {} as any
+  rendererOptions: ListRendererOptions = {} as any
 
   async onTestRemoved(trigger?: string) {
     await this.stopListRender()

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -7,7 +7,7 @@ import { F_RIGHT } from '../../../../utils/figures'
 import type { Logger } from '../../../logger'
 import { getCols, getStateSymbol } from '../../renderers/utils'
 
-export interface ListRendererOptions {
+export interface TableRendererOptions {
   renderSucceed?: boolean
   logger: Logger
   showHeap: boolean
@@ -101,7 +101,7 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('  ')
 }
 
-export function renderTree(tasks: Task[], options: ListRendererOptions, level = 0): string {
+function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): string {
   const output: string[] = []
 
   let idx = 0
@@ -162,7 +162,7 @@ export function renderTree(tasks: Task[], options: ListRendererOptions, level = 
   return output.filter(Boolean).join('\n')
 }
 
-export function createTableRenderer(_tasks: Task[], options: ListRendererOptions) {
+export function createTableRenderer(_tasks: Task[], options: TableRendererOptions) {
   let tasks = _tasks
   let timer: any
 

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -11,9 +11,8 @@ export interface TableRendererOptions {
   renderSucceed?: boolean
   logger: Logger
   showHeap: boolean
+  slowTestThreshold: number
 }
-
-const DURATION_LONG = 300
 
 const outputMap = new WeakMap<Task, string>()
 
@@ -121,7 +120,7 @@ function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): st
       suffix += ` ${c.dim(c.gray('[skipped]'))}`
 
     if (task.result?.duration != null) {
-      if (task.result.duration > DURATION_LONG)
+      if (task.result.duration > options.slowTestThreshold)
         suffix += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
     }
 

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -7,7 +7,7 @@ import { F_RIGHT } from '../../../../utils/figures'
 import type { Logger } from '../../../logger'
 import { getCols, getStateSymbol } from '../../renderers/utils'
 
-export interface TableRendererOptions {
+export interface ListRendererOptions {
   renderSucceed?: boolean
   logger: Logger
   showHeap: boolean
@@ -100,7 +100,7 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('  ')
 }
 
-function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): string {
+export function renderTree(tasks: Task[], options: ListRendererOptions, level = 0): string {
   const output: string[] = []
 
   let idx = 0
@@ -161,7 +161,7 @@ function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): st
   return output.filter(Boolean).join('\n')
 }
 
-export function createTableRenderer(_tasks: Task[], options: TableRendererOptions) {
+export function createTableRenderer(_tasks: Task[], options: ListRendererOptions) {
   let tasks = _tasks
   let timer: any
 

--- a/packages/vitest/src/node/reporters/default.ts
+++ b/packages/vitest/src/node/reporters/default.ts
@@ -33,6 +33,7 @@ export class DefaultReporter extends BaseReporter {
     if (this.isTTY) {
       this.rendererOptions.logger = this.ctx.logger
       this.rendererOptions.showHeap = this.ctx.config.logHeapUsage
+      this.rendererOptions.slowTestThreshold = this.ctx.config.slowTestThreshold
       this.rendererOptions.mode = this.mode
       const files = this.ctx.state.getFiles(this.watchFilters)
       if (!this.renderer)

--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -1,10 +1,9 @@
 import type { UserConsoleLog } from '../../types/general'
 import { BaseReporter } from './base'
 import { createDotRenderer } from './renderers/dotRenderer'
-import type { createListRenderer } from './renderers/listRenderer'
 
 export class DotReporter extends BaseReporter {
-  renderer?: ReturnType<typeof createListRenderer>
+  renderer?: ReturnType<typeof createDotRenderer>
 
   onCollected() {
     if (this.isTTY) {

--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -1,9 +1,10 @@
 import type { UserConsoleLog } from '../../types/general'
 import { BaseReporter } from './base'
 import { createDotRenderer } from './renderers/dotRenderer'
+import type { createListRenderer } from './renderers/listRenderer'
 
 export class DotReporter extends BaseReporter {
-  renderer?: ReturnType<typeof createDotRenderer>
+  renderer?: ReturnType<typeof createListRenderer>
 
   onCollected() {
     if (this.isTTY) {

--- a/packages/vitest/src/node/reporters/renderers/listRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/listRenderer.ts
@@ -85,7 +85,7 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('')
 }
 
-function renderTree(tasks: Task[], options: ListRendererOptions, level = 0, maxRows?: number): string {
+export function renderTree(tasks: Task[], options: ListRendererOptions, level = 0, maxRows?: number): string {
   const output: string[] = []
   let currentRowCount = 0
 

--- a/packages/vitest/src/node/reporters/renderers/listRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/listRenderer.ts
@@ -86,7 +86,7 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('')
 }
 
-export function renderTree(tasks: Task[], options: ListRendererOptions, level = 0, maxRows?: number): string {
+function renderTree(tasks: Task[], options: ListRendererOptions, level = 0, maxRows?: number): string {
   const output: string[] = []
   let currentRowCount = 0
 

--- a/packages/vitest/src/node/reporters/renderers/listRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/listRenderer.ts
@@ -11,10 +11,9 @@ export interface ListRendererOptions {
   renderSucceed?: boolean
   logger: Logger
   showHeap: boolean
+  slowTestThreshold: number
   mode: VitestRunMode
 }
-
-const DURATION_LONG = 300
 
 const outputMap = new WeakMap<Task, string>()
 
@@ -115,7 +114,7 @@ function renderTree(tasks: Task[], options: ListRendererOptions, level = 0, maxR
       suffix += c.yellow(` (repeat x${task.result.repeatCount})`)
 
     if (task.result?.duration != null) {
-      if (task.result.duration > DURATION_LONG)
+      if (task.result.duration > options.slowTestThreshold)
         suffix += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
     }
 


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4869

There were two more `const DURATION_LONG = 300` hard-coded in list/table renders. This PR does the same for these two as done in https://github.com/vitest-dev/vitest/pull/2396.

I didn't attempt to add a test yet since list renderer requires non CI environment, so I suspect it might be too difficult and also overkill to setup this scenario.

The fix can be verified locally using existing core test, which coincidentally takes 400ms and has `slowTestThreshold: 1000`:

- before (400ms > hard-coded 300ms)

```
$ pnpm -C test/core test run test-extend.test.ts 
...

 ✓ |core| test/test-extend.test.ts (18) 411ms

...

   ✓ asynchonous setup/teardown (1) 401ms
     ✓ quick test 401ms
```

- after (400ms < slowTestThreshold 1000ms)

```
$ pnpm -C test/core test run test-extend.test.ts 
...

 ✓ |core| test/test-extend.test.ts (18)

...

   ✓ asynchonous setup/teardown (1)
     ✓ quick test
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
