### PR TITLE
fix(vite-node): dedupe -v flag

### DIFF
--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -19,8 +19,8 @@ cli
   .option('-w, --watch', 'Restart on file changes, similar to "nodemon"')
   .option('--script', 'Use vite-node as a script runner')
   .option('--options <options>', 'Use specified Vite server options')
-  .option('-v, --version', 'Output the version number')
   .option('-h, --help', 'Display help for command')
+  .version(version)
 
 cli
   .command('[...files]')
@@ -61,18 +61,13 @@ async function run(files: string[], options: CliOptions = {}) {
     process.argv = [...process.argv.slice(0, 2), ...(options['--'] || [])]
   }
 
-  if (options.version) {
-    cli.version(version)
-    cli.outputVersion()
-    process.exit(0)
-  }
   if (options.help) {
-    cli.version(version).outputHelp()
+    cli.outputHelp()
     process.exit(0)
   }
   if (!files.length) {
     console.error(c.red('No files specified.'))
-    cli.version(version).outputHelp()
+    cli.outputHelp()
     process.exit(1)
   }
 

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -46,7 +46,6 @@ export interface CliOptions {
   mode?: string
   watch?: boolean
   options?: ViteNodeServerOptionsCLI
-  version?: boolean
   help?: boolean
   '--'?: string[]
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Current `vite-node -h` output includes `-v, --version` twice, as `cac` [will add one for us](https://www.npmjs.com/package/cac#cliversionversion-customflags)

```
Options:
  -r, --root <path>    Use specified root directory 
  -c, --config <path>  Use specified config file 
  -m, --mode <mode>    Set env mode 
  -w, --watch          Restart on file changes, similar to "nodemon" 
  --script             Use vite-node as a script runner 
  --options <options>  Use specified Vite server options 
  -v, --version        Output the version number 
  -h, --help           Display help for command 
  -v, --version        Display version number 
```

I removed custom version handling and let `cac` do all the work

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
