### PR TITLE
build: rollup-plugin-esbuild target Node.js v18

### DIFF
--- a/packages/runner/rollup.config.js
+++ b/packages/runner/rollup.config.js
@@ -22,7 +22,7 @@ const entries = {
 
 const plugins = [
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
   json(),
 ]

--- a/packages/snapshot/rollup.config.js
+++ b/packages/snapshot/rollup.config.js
@@ -26,7 +26,7 @@ const plugins = [
   }),
   commonjs(),
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
 ]
 

--- a/packages/spy/rollup.config.js
+++ b/packages/spy/rollup.config.js
@@ -14,7 +14,7 @@ const external = [
 
 const plugins = [
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
 ]
 

--- a/packages/utils/rollup.config.js
+++ b/packages/utils/rollup.config.js
@@ -30,7 +30,7 @@ const plugins = [
   }),
   json(),
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
 ]
 

--- a/packages/vite-node/rollup.config.js
+++ b/packages/vite-node/rollup.config.js
@@ -40,7 +40,7 @@ const plugins = [
   json(),
   commonjs(),
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
 ]
 

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -84,7 +84,7 @@ const plugins = [
   json(),
   commonjs(),
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
 ]
 


### PR DESCRIPTION
### Description

While I was reading the source code of Vitest, notably `vite-node` to investigate how it works, I stumble on the `rollup.config.js` file and found out that it was building for Node.js v14 whereas Vitest requires at least Node.js v18.

By avoiding useless transformations for old runtimes not supported anymore, we can reduce packages sizes.
For example I tried to experiment with the build size of `vite-node`, with Node.js v14 target, the dist folder takes 180.6 kB and with Node.js v18, it takes 176.9 kB.
I haven't checked the other packages, but we should probably get a similar reduction of package size.
It's a minimal difference, but still good to get, I guess, it's always nice to have less to download on `npm` and reduce the size of our `node_modules`. :laughing: 

### Small note

We could maybe improve the "implementation" of this PR, by automatically getting the oldest supported Node.js version thanks to the `package.json`, `"engines"` field, but that might overcomplicate something which is not needed, might be fine to update it manually each time we drop support for a Node.js version (however we should not forget to also update this then).
