### PR TITLE
fix(browser): support vite config `server.headers`

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -28,6 +28,13 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
           sirv(resolve(distRoot, 'client'), {
             single: false,
             dev: true,
+            setHeaders(res, _pathname, _stats) {
+              const headers = server.config.server.headers
+              if (headers) {
+                for (const name in headers)
+                  res.setHeader(name, headers[name]!)
+              }
+            },
           }),
         )
       },

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -11,8 +11,8 @@ const {
 } = await runVitest()
 
 await test('tests are actually running', async () => {
-  assert.ok(browserResultJson.testResults.length === 10, 'Not all the tests have been run')
-  assert.ok(passedTests.length === 8, 'Some tests failed')
+  assert.ok(browserResultJson.testResults.length === 11, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 9, 'Some tests failed')
   assert.ok(failedTests.length === 2, 'Some tests have passed but should fail')
 
   assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')

--- a/test/browser/test/server-headers.test.ts
+++ b/test/browser/test/server-headers.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from 'vitest'
+
+it('server.headers', async () => {
+  const res = await fetch('/')
+  expect(res.ok)
+  expect(res.headers.get('x-custom')).toBe('hello')
+})

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -9,8 +9,8 @@ function noop() {}
 export default defineConfig({
   server: {
     headers: {
-      "x-custom": "hello",
-    }
+      'x-custom': 'hello',
+    },
   },
   optimizeDeps: {
     include: ['@vitest/cjs-lib'],

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -7,6 +7,11 @@ const dir = dirname(fileURLToPath(import.meta.url))
 function noop() {}
 
 export default defineConfig({
+  server: {
+    headers: {
+      "x-custom": "hello",
+    }
+  },
   optimizeDeps: {
     include: ['@vitest/cjs-lib'],
   },


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4888

This would align with how `server.headers` are applied to Vite's html server, which seems to be targeted for COOP/COEP headers use case. You can find relevant discussions in:
- https://github.com/vitejs/vite/pull/8481

I was wishing to simplify browser mode tests before putting more tests, but I guess adding this one is okay...

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
