### PR TITLE
chore: include `.mts` and `.mjs` in lint-staged pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "pre-commit": "npx lint-staged"
   },
   "lint-staged": {
-    "*.{[jt]s?(x),vue,md}": [
+    "*.{?([cm])[jt]s?(x),vue,md}": [
       "eslint --cache --fix"
     ]
   }


### PR DESCRIPTION
### Description

I recently got eslint failing on CI with files such as `test/browser/vitest.config.mts` and `test/browser/specs/runner.test.mjs`. I updated lint-staged pattern to catch these in git hook.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
