### PR TITLE
fix(vitest): fix tap reporter to handle custom error

### DIFF
--- a/packages/vitest/src/node/reporters/tap.ts
+++ b/packages/vitest/src/node/reporters/tap.ts
@@ -38,7 +38,7 @@ export class TapReporter implements Reporter {
 
   private logErrorDetails(error: ErrorWithDiff, stack?: ParsedStack) {
     const errorName = error.name || error.nameStr || 'Unknown Error'
-    this.logger.log(`name: ${yamlString(errorName)}`)
+    this.logger.log(`name: ${yamlString(String(errorName))}`)
     this.logger.log(`message: ${yamlString(String(error.message))}`)
 
     if (stack) {

--- a/packages/vitest/src/node/reporters/tap.ts
+++ b/packages/vitest/src/node/reporters/tap.ts
@@ -1,5 +1,5 @@
 import type { Task } from '@vitest/runner'
-import type { ParsedStack } from '@vitest/utils'
+import type { ErrorWithDiff, ParsedStack } from '@vitest/utils'
 import type { Vitest } from '../../node'
 import type { Reporter } from '../../types/reporter'
 import { parseErrorStacktrace } from '../../utils/source-map'
@@ -36,9 +36,10 @@ export class TapReporter implements Reporter {
       return ''
   }
 
-  private logErrorDetails(error: Error, stack?: ParsedStack) {
-    this.logger.log(`name: ${yamlString(error.name)}`)
-    this.logger.log(`message: ${yamlString(error.message)}`)
+  private logErrorDetails(error: ErrorWithDiff, stack?: ParsedStack) {
+    const errorName = error.name || error.nameStr || 'Unknown Error'
+    this.logger.log(`name: ${yamlString(errorName)}`)
+    this.logger.log(`message: ${yamlString(String(error.message))}`)
 
     if (stack) {
       // For compatibility with tap-mocha-reporter

--- a/test/reporters/fixtures/custom-error/basic.test.ts
+++ b/test/reporters/fixtures/custom-error/basic.test.ts
@@ -11,3 +11,7 @@ test('string', () => {
 test('number', () => {
   throw 1234;
 });
+
+test('number name object', () => {
+  throw { name: 1234 };
+});

--- a/test/reporters/fixtures/custom-error/basic.test.ts
+++ b/test/reporters/fixtures/custom-error/basic.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'vitest';
+
+test('no name object', () => {
+  throw { noName: 'hi' };
+});
+
+test('string', () => {
+  throw "hi";
+});
+
+test('number', () => {
+  throw 1234;
+});

--- a/test/reporters/fixtures/custom-error/vitest.config.ts
+++ b/test/reporters/fixtures/custom-error/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/test/reporters/tests/tap.test.ts
+++ b/test/reporters/tests/tap.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+test('handle custom error without name', async () => {
+  let { stdout, stderr } = await runVitest({ reporters: 'tap-flat', root: './fixtures/custom-error' })
+  stdout = stdout.replaceAll(/time=(\S*)/g, 'time=[...]') // strip non-deterministic output
+  expect(stdout).toMatchInlineSnapshot(`
+    "TAP version 13
+    1..3
+    not ok 1 - basic.test.ts > no name object # time=[...]
+        ---
+        error:
+            name: "Unknown Error"
+            message: "undefined"
+        ...
+    not ok 2 - basic.test.ts > string # time=[...]
+        ---
+        error:
+            name: "Unknown Error"
+            message: "hi"
+        ...
+    not ok 3 - basic.test.ts > number # time=[...]
+        ---
+        error:
+            name: "Unknown Error"
+            message: "1234"
+        ...
+    "
+  `)
+  expect(stderr).toBe('')
+})

--- a/test/reporters/tests/tap.test.ts
+++ b/test/reporters/tests/tap.test.ts
@@ -6,7 +6,7 @@ test('handle custom error without name', async () => {
   stdout = stdout.replaceAll(/time=(\S*)/g, 'time=[...]') // strip non-deterministic output
   expect(stdout).toMatchInlineSnapshot(`
     "TAP version 13
-    1..3
+    1..4
     not ok 1 - basic.test.ts > no name object # time=[...]
         ---
         error:
@@ -24,6 +24,12 @@ test('handle custom error without name', async () => {
         error:
             name: "Unknown Error"
             message: "1234"
+        ...
+    not ok 4 - basic.test.ts > number name object # time=[...]
+        ---
+        error:
+            name: "1234"
+            message: "undefined"
         ...
     "
   `)


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4885

Currently `processError` (from @vitest/utils) returns `any`, but it looks like most of the usages expect it to be `ErrorWithDiff`. `ErrorWithDiff` requires `name: string`, but `processError` doesn't seem to guarantee this when odd things are thrown.

Fixing `processError` might be better in a long run, but for this PR, I just adjusted tap reporter to do something similar as other reporters in `printErrorMessage`:

https://github.com/vitest-dev/vitest/blob/67e321102b8f0b1a6a4cd5f54ab62656b307426c/packages/vitest/src/node/error.ts#L208-L209

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
