### PR TITLE
test(browser): reproduce webkit flakiness

### DIFF
--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -13,6 +13,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
+    force: true,
     include: ['@vitest/cjs-lib'],
   },
   test: {


### PR DESCRIPTION
### Description

Following up https://github.com/vitest-dev/vitest/pull/4879, I made a simpler repro to show flakiness on webkit by forcing pre-bundling for each test run.

I'm not sure where to go from this repro since I might not be able to reproduce this error outside Vitest (some quick attempt https://github.com/hi-ogawa/repro-vitest-playwright-webkit-flaky), but I made a PR here just in case when someone encounters a similar issue.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
