### PR TITLE
fix(vitest): don't throw SyntaxError when "await vi.hoisted" is used

### DIFF
--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -1,5 +1,7 @@
 import MagicString from 'magic-string'
-import type { CallExpression, Identifier, ImportDeclaration, VariableDeclaration, Node as _Node } from 'estree'
+import type { AwaitExpression, CallExpression, Identifier, ImportDeclaration, VariableDeclaration, Node as _Node } from 'estree'
+
+// TODO: should use findNodeBefore, but it's not typed
 import { findNodeAround } from 'acorn-walk'
 import type { PluginContext } from 'rollup'
 import { esmWalker } from '@vitest/utils/ast'
@@ -211,8 +213,9 @@ export function hoistMocks(code: string, id: string, parse: PluginContext['parse
             hoistedNodes.push(declarationNode)
           }
           else {
-            // hoist "vi.hoisted(() => {})"
-            hoistedNodes.push(node)
+            const awaitedExpression = findNodeAround(ast, node.start, 'AwaitExpression')?.node as Positioned<AwaitExpression> | undefined
+            // hoist "await vi.hoisted(async () => {})" or "vi.hoisted(() => {})"
+            hoistedNodes.push(awaitedExpression?.argument === node ? awaitedExpression : node)
           }
         }
       }

--- a/test/core/test/hoisted-async-simple.test.ts
+++ b/test/core/test/hoisted-async-simple.test.ts
@@ -6,6 +6,8 @@ import { value } from '../src/rely-on-hoisted'
 const globalValue = await vi.hoisted(async () => {
   // @ts-expect-error not typed global
   globalThis.someGlobalValue = 'globalValue'
+  // @ts-expect-error not typed global
+  ;(globalThis._order ??= []).push(1)
   return 'globalValue'
 })
 
@@ -14,6 +16,26 @@ afterAll(() => {
   delete globalThis.someGlobalValue
 })
 
+// _order is set in the hoisted function before tests are collected
+// @ts-expect-error not typed global
+expect(globalThis._order).toEqual([1, 2, 3])
+
 it('imported value is equal to returned from hoisted', () => {
   expect(value).toBe(globalValue)
+})
+
+it('hoists async "vi.hoisted", but leaves the wrapper alone', async () => {
+  expect.assertions(1)
+  await (async () => {
+    expect(1).toBe(1)
+    vi.hoisted(() => {
+      // @ts-expect-error not typed global
+      ;(globalThis._order ??= []).push(2)
+    })
+  })()
+})
+
+await vi.hoisted(async () => {
+  // @ts-expect-error not typed global
+  ;(globalThis._order ??= []).push(3)
 })


### PR DESCRIPTION
### Description

Fixes #4913

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
