### PR TITLE
fix(vitest): show correct error when vi.hoisted is used inside vi.mock and the other way around

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -80,7 +80,7 @@ export async function printError(error: unknown, project: WorkspaceProject | und
     printStack(project, stacks, nearest, errorProperties, (s) => {
       if (showCodeFrame && s === nearest && nearest) {
         const sourceCode = readFileSync(nearest.file, 'utf-8')
-        logger.error(generateCodeFrame(sourceCode, 4, s.line, s.column))
+        logger.error(generateCodeFrame(sourceCode, 4, s))
       }
     })
   }
@@ -248,11 +248,10 @@ function printStack(
 export function generateCodeFrame(
   source: string,
   indent = 0,
-  lineNumber: number,
-  columnNumber: number,
+  loc: { line: number; column: number } | number,
   range = 2,
 ): string {
-  const start = positionToOffset(source, lineNumber, columnNumber)
+  const start = typeof loc === 'object' ? positionToOffset(source, loc.line, loc.column) : loc
   const end = start
   const lines = source.split(lineSplitRE)
   const nl = /\r\n/.test(source) ? 2 : 1

--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -231,11 +231,8 @@ export function hoistMocks(code: string, id: string, parse: PluginContext['parse
   }
 
   function getNodeCall(node: Node): Positioned<CallExpression> {
-    if (node.type === 'CallExpression') {
-      const { callee } = node
-      if (callee.type === 'MemberExpression' && isIdentifier(callee.property) && isIdentifier(callee.object))
-        return node
-    }
+    if (node.type === 'CallExpression')
+      return node
     if (node.type === 'VariableDeclaration') {
       const { declarations } = node
       const init = declarations[0].init

--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -3,7 +3,7 @@ import type { AwaitExpression, CallExpression, Identifier, ImportDeclaration, Va
 
 // TODO: should use findNodeBefore, but it's not typed
 import { findNodeAround } from 'acorn-walk'
-import type { PluginContext, TransformPluginContext } from 'rollup'
+import type { PluginContext } from 'rollup'
 import { esmWalker } from '@vitest/utils/ast'
 import { generateCodeFrame } from './error'
 
@@ -246,10 +246,14 @@ export function hoistMocks(code: string, id: string, parse: PluginContext['parse
   function createError(outsideNode: Node, insideNode: Node) {
     const outsideMethod = getNodeName(outsideNode)
     const insideMethod = getNodeName(insideNode)
-    const error = new SyntaxError(`Cannot call ${insideMethod} inside ${outsideMethod}: both methods are hoisted to the top of the file and not actually called inside each other.`)
-    Object.assign(error, {
+    const _error = new SyntaxError(`Cannot call ${insideMethod} inside ${outsideMethod}: both methods are hoisted to the top of the file and not actually called inside each other.`)
+    // throw an object instead of an error so it can be serialized for RPC, TODO: improve error handling in rpc serializer
+    const error = {
+      name: 'SyntaxError',
+      message: _error.message,
+      stack: _error.stack,
       frame: generateCodeFrame(code, 4, insideNode.start + 1),
-    })
+    }
     throw error
   }
 

--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -3,8 +3,9 @@ import type { AwaitExpression, CallExpression, Identifier, ImportDeclaration, Va
 
 // TODO: should use findNodeBefore, but it's not typed
 import { findNodeAround } from 'acorn-walk'
-import type { PluginContext } from 'rollup'
+import type { PluginContext, TransformPluginContext } from 'rollup'
 import { esmWalker } from '@vitest/utils/ast'
+import { generateCodeFrame } from './error'
 
 export type Positioned<T> = T & {
   start: number
@@ -62,9 +63,9 @@ const regexpAssignedHoisted = /=[ \t]*(\bawait|)[ \t]*\b(vi|vitest)\s*\.\s*hoist
 const hashbangRE = /^#!.*\n/
 
 export function hoistMocks(code: string, id: string, parse: PluginContext['parse']) {
-  const hasMocks = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
+  const needHoisting = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
 
-  if (!hasMocks)
+  if (!needHoisting)
     return
 
   const s = new MagicString(code)
@@ -149,7 +150,7 @@ export function hoistMocks(code: string, id: string, parse: PluginContext['parse
   }
 
   const declaredConst = new Set<string>()
-  const hoistedNodes: Node[] = []
+  const hoistedNodes: Positioned<CallExpression | VariableDeclaration | AwaitExpression>[] = []
 
   esmWalker(ast, {
     onIdentifier(id, info, parentStack) {
@@ -221,6 +222,49 @@ export function hoistMocks(code: string, id: string, parse: PluginContext['parse
       }
     },
   })
+
+  function getNodeName(node: Node): string {
+    if (node.type === 'CallExpression') {
+      const { callee } = node
+      if (callee.type === 'MemberExpression' && isIdentifier(callee.property) && isIdentifier(callee.object))
+        return `${callee.object.name}.${callee.property.name}()`
+    }
+    if (node.type === 'VariableDeclaration') {
+      const { declarations } = node
+      const init = declarations[0].init
+      if (init)
+        return getNodeName(init as Node)
+    }
+    if (node.type === 'AwaitExpression') {
+      const { argument } = node
+      if (argument.type === 'CallExpression')
+        return getNodeName(argument as Node)
+    }
+    return '"hoisted method"'
+  }
+
+  function createError(outsideNode: Node, insideNode: Node) {
+    const outsideMethod = getNodeName(outsideNode)
+    const insideMethod = getNodeName(insideNode)
+    const error = new SyntaxError(`Cannot call ${insideMethod} inside ${outsideMethod}: both methods are hoisted to the top of the file and not actually called inside each other.`)
+    Object.assign(error, {
+      frame: generateCodeFrame(code, 4, insideNode.start + 1),
+    })
+    throw error
+  }
+
+  // validate hoistedNodes doesn't have nodes inside other nodes
+  for (let i = 0; i < hoistedNodes.length; i++) {
+    const node = hoistedNodes[i]
+    for (let j = i + 1; j < hoistedNodes.length; j++) {
+      const otherNode = hoistedNodes[j]
+
+      if (node.start >= otherNode.start && node.end <= otherNode.end)
+        throw createError(otherNode, node)
+      if (otherNode.start >= node.start && otherNode.end <= node.end)
+        throw createError(node, otherNode)
+    }
+  }
 
   // Wait for imports to be hoisted and then hoist the mocks
   const hoistedCode = hoistedNodes.map((node) => {

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -1,4 +1,5 @@
 import type { RawSourceMap } from 'vite-node'
+import { processError } from '@vitest/runner'
 import type { RuntimeRPC } from '../../types'
 import type { WorkspaceProject } from '../workspace'
 
@@ -20,8 +21,14 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       const r = await project.vitenode.transformRequest(id)
       return r?.map as RawSourceMap | undefined
     },
-    fetch(id, transformMode) {
-      return project.vitenode.fetchModule(id, transformMode)
+    async fetch(id, transformMode) {
+      try {
+        return await project.vitenode.fetchModule(id, transformMode)
+      }
+      catch (e) {
+        // TODO: improve error serialization between threads
+        throw processError(e)
+      }
     },
     resolveId(id, importer, transformMode) {
       return project.vitenode.resolveId(id, importer, transformMode)

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -1,5 +1,4 @@
 import type { RawSourceMap } from 'vite-node'
-import { processError } from '@vitest/runner'
 import type { RuntimeRPC } from '../../types'
 import type { WorkspaceProject } from '../workspace'
 
@@ -21,14 +20,8 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       const r = await project.vitenode.transformRequest(id)
       return r?.map as RawSourceMap | undefined
     },
-    async fetch(id, transformMode) {
-      try {
-        return await project.vitenode.fetchModule(id, transformMode)
-      }
-      catch (e) {
-        // TODO: improve error serialization between threads
-        throw processError(e)
-      }
+    fetch(id, transformMode) {
+      return project.vitenode.fetchModule(id, transformMode)
     },
     resolveId(id, importer, transformMode) {
       return project.vitenode.resolveId(id, importer, transformMode)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1569,6 +1569,9 @@ importers:
       '@vitest/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
       tinyspy:
         specifier: ^1.0.2
         version: 1.0.2

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -11,6 +11,7 @@
     "@vitest/expect": "workspace:*",
     "@vitest/runner": "workspace:*",
     "@vitest/utils": "workspace:*",
+    "strip-ansi": "^7.1.0",
     "tinyspy": "^1.0.2",
     "url": "^0.11.0",
     "vitest": "workspace:*"

--- a/test/core/test/__snapshots__/injector-mock.test.ts.snap
+++ b/test/core/test/__snapshots__/injector-mock.test.ts.snap
@@ -1,0 +1,78 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 1`] = `"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 2`] = `
+"      3|     
+      4|     vi.mock('./mocked', () => {
+      5|       const variable = vi.hoisted(() => 1)
+       |                        ^
+      6|       console.log(variable)
+      7|     })"
+`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 3`] = `"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 4`] = `
+"      3| 
+      4| vi.mock('./mocked', async () => {
+      5|   await vi.hoisted(() => 1)
+       |         ^
+      6| })
+      7|     "
+`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 5`] = `"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 6`] = `
+"      3| 
+      4| vi.mock('./mocked', async () => {
+      5|   const variable = await vi.hoisted(() => 1)
+       |                          ^
+      6| })
+      7|     "
+`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 7`] = `"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 8`] = `
+"      3| 
+      4| vi.hoisted(() => {
+      5|   vi.mock('./mocked')
+       |   ^
+      6| })
+      7|     "
+`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 9`] = `"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 10`] = `
+"      3| 
+      4| const values = vi.hoisted(() => {
+      5|   vi.mock('./mocked')
+       |   ^
+      6| })
+      7|     "
+`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 11`] = `"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 12`] = `
+"      3| 
+      4| await vi.hoisted(async () => {
+      5|   vi.mock('./mocked')
+       |   ^
+      6| })
+      7|     "
+`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 13`] = `"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
+
+exports[`throws an error when nodes are incompatible > correctly throws an error 14`] = `
+"      3| 
+      4| const values = await vi.hoisted(async () => {
+      5|   vi.mock('./mocked')
+       |   ^
+      6| })
+      7|     "
+`;

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -1,5 +1,6 @@
 import { parseAst } from 'rollup/parseAst'
 import { describe, expect, it, test } from 'vitest'
+import stripAnsi from 'strip-ansi'
 import { hoistMocks } from '../../../packages/vitest/src/node/hoistMocks'
 
 function parse(code: string, options: any) {
@@ -1189,77 +1190,64 @@ describe('throws an error when nodes are incompatible', () => {
       hoistSimpleCode(code)
     }
     catch (err: any) {
-      return err.message
+      return err
     }
   }
 
-  it('throws an error when hoisted is used inside vi.mock', () => {
-    expect(getErrorWhileHoisting(`
-import { vi } from 'vitest'
-
-vi.mock('./mocked', () => {
-  const variable = vi.hoisted(() => 1)
-  console.log(variable)
-})
-    `)).toMatchInlineSnapshot(`"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`)
-  })
-
-  it('throws an error when async hoisted is used inside vi.mock', () => {
-    expect(getErrorWhileHoisting(`
+  it.each([
+    `
+    import { vi } from 'vitest'
+    
+    vi.mock('./mocked', () => {
+      const variable = vi.hoisted(() => 1)
+      console.log(variable)
+    })
+        `,
+        `
 import { vi } from 'vitest'
 
 vi.mock('./mocked', async () => {
   await vi.hoisted(() => 1)
 })
-    `)).toMatchInlineSnapshot(`"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`)
-  })
-
-  it('throws an error when assigned async hoisted is used inside vi.mock', () => {
-    expect(getErrorWhileHoisting(`
+    `,
+    `
 import { vi } from 'vitest'
 
 vi.mock('./mocked', async () => {
   const variable = await vi.hoisted(() => 1)
 })
-    `)).toMatchInlineSnapshot(`"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`)
-  })
-
-  it('throws an error when mock is used inside vi.hoisted', () => {
-    expect(getErrorWhileHoisting(`
+    `,
+    `
 import { vi } from 'vitest'
 
 vi.hoisted(() => {
   vi.mock('./mocked')
 })
-    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
-  })
-
-  it('throws an error when mock is used inside assigned vi.hoisted', () => {
-    expect(getErrorWhileHoisting(`
+    `,
+    `
 import { vi } from 'vitest'
 
 const values = vi.hoisted(() => {
   vi.mock('./mocked')
 })
-    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
-  })
-
-  it('throws an error when mock is used inside async vi.hoisted', () => {
-    expect(getErrorWhileHoisting(`
+    `,
+    `
 import { vi } from 'vitest'
 
 await vi.hoisted(async () => {
   vi.mock('./mocked')
 })
-    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
-  })
-  it('throws an error when mock is used inside async assigned vi.hoisted', () => {
-    expect(getErrorWhileHoisting(`
+    `,
+    `
 import { vi } from 'vitest'
 
 const values = await vi.hoisted(async () => {
   vi.mock('./mocked')
 })
-    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
+    `,
+  ])('correctly throws an error', (code) => {
+    const error = getErrorWhileHoisting(code)
+    expect(error.message).toMatchSnapshot()
+    expect(stripAnsi(error.frame)).toMatchSnapshot()
   })
 })

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -1184,73 +1184,82 @@ console.log(foo + 2)
 })
 
 describe('throws an error when nodes are incompatible', () => {
+  const getErrorWhileHoisting = (code: string) => {
+    try {
+      hoistSimpleCode(code)
+    }
+    catch (err: any) {
+      return err.message
+    }
+  }
+
   it('throws an error when hoisted is used inside vi.mock', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 vi.mock('./mocked', () => {
   const variable = vi.hoisted(() => 1)
   console.log(variable)
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
 
   it('throws an error when async hoisted is used inside vi.mock', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 vi.mock('./mocked', async () => {
   await vi.hoisted(() => 1)
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
 
   it('throws an error when assigned async hoisted is used inside vi.mock', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 vi.mock('./mocked', async () => {
   const variable = await vi.hoisted(() => 1)
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.hoisted() inside vi.mock(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
 
   it('throws an error when mock is used inside vi.hoisted', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 vi.hoisted(() => {
   vi.mock('./mocked')
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
 
   it('throws an error when mock is used inside assigned vi.hoisted', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 const values = vi.hoisted(() => {
   vi.mock('./mocked')
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
 
   it('throws an error when mock is used inside async vi.hoisted', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 await vi.hoisted(async () => {
   vi.mock('./mocked')
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
   it('throws an error when mock is used inside async assigned vi.hoisted', () => {
-    expect(() => hoistSimpleCode(`
+    expect(getErrorWhileHoisting(`
 import { vi } from 'vitest'
 
 const values = await vi.hoisted(async () => {
   vi.mock('./mocked')
 })
-    `)).toThrowErrorMatchingInlineSnapshot(`[SyntaxError: Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other.]`)
+    `)).toMatchInlineSnapshot(`"Cannot call vi.mock() inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`)
   })
 })


### PR DESCRIPTION
### Description

Closes #4907

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
