### PR TITLE
fix(utils): fix `objDisplay` default truncate option for `test.each` title

### DIFF
--- a/packages/utils/src/display.ts
+++ b/packages/utils/src/display.ts
@@ -98,18 +98,19 @@ export function format(...args: unknown[]) {
   return str
 }
 
-export function inspect(obj: unknown, options: LoupeOptions = {}) {
+export function inspect(obj: unknown, options: LoupeOptions = {}): string {
   if (options.truncate === 0)
     options.truncate = Number.POSITIVE_INFINITY
   return loupe(obj, options)
 }
 
 export function objDisplay(obj: unknown, options: LoupeOptions = {}): string {
-  const truncateThreshold = options.truncate ?? 40
+  if (typeof options.truncate === 'undefined')
+    options.truncate = 40
   const str = inspect(obj, options)
   const type = Object.prototype.toString.call(obj)
 
-  if (truncateThreshold && str.length >= truncateThreshold) {
+  if (options.truncate && str.length >= options.truncate) {
     if (type === '[object Function]') {
       const fn = obj as () => void
       return (!fn.name || fn.name === '')

--- a/test/config/fixtures/chai-config/test-each-title.test.ts
+++ b/test/config/fixtures/chai-config/test-each-title.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+
+test.each`
+  length | param
+  ${30}  | ${'0123456789'.repeat(3)}
+  ${40}  | ${'0123456789'.repeat(4)}
+  ${50}  | ${'0123456789'.repeat(5)}
+`('$param (length = $length)', () => {});
+
+test.each`
+  param
+  ${['one', 'two', 'three']}
+  ${['one', 'two', 'three', 'four']}
+  ${['one', 'two', 'three', 'four', 'five']}
+`('$param', () => {});
+
+test.each`
+  param
+  ${{ one: 1, two: 2, three: 3 }}
+  ${{ one: 1, two: 2, three: 3, four: 4 }}
+  ${{ one: 1, two: 2, three: 3, four: 4, five: 5 }}
+`('$param', () => {});

--- a/test/config/fixtures/chai-config/vitest.config.ts
+++ b/test/config/fixtures/chai-config/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/test/config/test/chai-config.test.ts
+++ b/test/config/test/chai-config.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+describe('truncateThreshold', () => {
+  it('default', async () => {
+    const result = await runVitest({
+      root: 'fixtures/chai-config',
+      reporters: ['tap-flat'],
+    })
+    expect(cleanOutput(result.stdout)).toMatchInlineSnapshot(`
+      "TAP version 13
+      1..9
+      ok 1 - test-each-title.test.ts > '012345678901234567890123456789' (length = 30)
+      ok 2 - test-each-title.test.ts > '0123456789012345678901234567890123456…' (length = 40)
+      ok 3 - test-each-title.test.ts > '0123456789012345678901234567890123456…' (length = 50)
+      ok 4 - test-each-title.test.ts > [ 'one', 'two', 'three' ]
+      ok 5 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four' ]
+      ok 6 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four', …(1) ]
+      ok 7 - test-each-title.test.ts > { one: 1, two: 2, three: 3 }
+      ok 8 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4 }
+      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, …(2) }
+      "
+    `)
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('40', async () => {
+    const result = await runVitest({
+      root: 'fixtures/chai-config',
+      reporters: ['tap-flat'],
+      chaiConfig: {
+        truncateThreshold: 40,
+      },
+    })
+    expect(cleanOutput(result.stdout)).toMatchInlineSnapshot(`
+      "TAP version 13
+      1..9
+      ok 1 - test-each-title.test.ts > '012345678901234567890123456789' (length = 30)
+      ok 2 - test-each-title.test.ts > '0123456789012345678901234567890123456…' (length = 40)
+      ok 3 - test-each-title.test.ts > '0123456789012345678901234567890123456…' (length = 50)
+      ok 4 - test-each-title.test.ts > [ 'one', 'two', 'three' ]
+      ok 5 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four' ]
+      ok 6 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four', …(1) ]
+      ok 7 - test-each-title.test.ts > { one: 1, two: 2, three: 3 }
+      ok 8 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4 }
+      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, …(2) }
+      "
+    `)
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('0', async () => {
+    const result = await runVitest({
+      root: 'fixtures/chai-config',
+      reporters: ['tap-flat'],
+      chaiConfig: {
+        truncateThreshold: 0,
+      },
+    })
+    expect(cleanOutput(result.stdout)).toMatchInlineSnapshot(`
+      "TAP version 13
+      1..9
+      ok 1 - test-each-title.test.ts > '012345678901234567890123456789' (length = 30)
+      ok 2 - test-each-title.test.ts > '0123456789012345678901234567890123456789' (length = 40)
+      ok 3 - test-each-title.test.ts > '01234567890123456789012345678901234567890123456789' (length = 50)
+      ok 4 - test-each-title.test.ts > [ 'one', 'two', 'three' ]
+      ok 5 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four' ]
+      ok 6 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four', 'five' ]
+      ok 7 - test-each-title.test.ts > { one: 1, two: 2, three: 3 }
+      ok 8 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4 }
+      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4, five: 5 }
+      "
+    `)
+    expect(result.exitCode).toBe(0)
+  })
+})
+
+function cleanOutput(output: string) {
+  return output.replaceAll(/\s*# time=.*/g, '')
+}

--- a/test/config/test/chai-config.test.ts
+++ b/test/config/test/chai-config.test.ts
@@ -76,5 +76,6 @@ describe('truncateThreshold', () => {
 })
 
 function cleanOutput(output: string) {
+  // remove non-deterministic output
   return output.replaceAll(/\s*# time=.*/g, '')
 }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/3955

Currently `objDisplay` from `@vitest/utils` with `truncate` option are only used for test title formatting. So the effect of this change would be minimal and probably only breaking file snapshot back to what it was before.

One more note, there is another usage of `objDisplay` but I think this one is calling into chai utils, so this change doesn't affect here:

https://github.com/vitest-dev/vitest/blob/926e633c9f61a57d70441438e37da6988cfcbf08/packages/expect/src/jest-expect.ts#L344

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
