### PR TITLE
docs: make definition clearer in workspace guide

### DIFF
--- a/docs/guide/workspace.md
+++ b/docs/guide/workspace.md
@@ -10,7 +10,7 @@ Vitest provides built-in support for monorepos through a workspace configuration
 
 A workspace should have a `vitest.workspace` or `vitest.projects` file in its root (in the same folder as your config file if you have one). Vitest supports `ts`/`js`/`json` extensions for this file.
 
-Workspace configuration file should have a default export with a list of files or glob patterns referencing your projects. For example, if you have a folder with your projects named `packages`, you can define a workspace with this config file:
+Workspace configuration file should have a default export with a list of files or glob patterns referencing your projects. For example, if you have a folder named `packages` that contains your projects, you can define a workspace with this config file:
 
 :::code-group
 ```ts [vitest.workspace.ts]


### PR DESCRIPTION
### Description

*if you have a folder with your projects named `packages`* is easy to confuse with the actual package name being "packages". 

Even though it's not impossible to understand with some thinking, we can make it clearer with this commit.

No testing required, this is just a docs commit.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] ~Ideally, include a test that fails without this PR but passes with it.~
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- ~[ ] Run the tests with `pnpm test:ci`.~

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
