### PR TITLE
feat(vitest): show slow test duration in verbose reporter on CI

### DIFF
--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -21,6 +21,8 @@ export class VerboseReporter extends DefaultReporter {
         if (task.suite?.projectName)
           title += formatProjectName(task.suite.projectName)
         title += getFullName(task, c.dim(' > '))
+        if (task.result.duration != null && task.result.duration > this.ctx.config.slowTestThreshold)
+          title += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
         if (this.ctx.config.logHeapUsage && task.result.heap != null)
           title += c.magenta(` ${Math.floor(task.result.heap / 1024 / 1024)} MB heap used`)
         this.ctx.logger.log(title)

--- a/test/reporters/fixtures/duration/basic.test.ts
+++ b/test/reporters/fixtures/duration/basic.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'vitest';
+
+test('fast', async () => {
+  await sleep(10)
+});
+
+test('slow', async () => {
+  await sleep(200)
+});
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))

--- a/test/reporters/fixtures/duration/vitest.config.ts
+++ b/test/reporters/fixtures/duration/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    slowTestThreshold: 100
+  }
+})

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+import { runVitestCli } from '../../test-utils'
+
+test('duration', async () => {
+  const result = await runVitestCli({ env: { CI: '1' } }, '--root=fixtures/duration', '--reporter=verbose')
+  const output = result.stdout.replaceAll(/\d+ms/g, '[...]ms')
+  expect(output).toContain(`
+ ✓ basic.test.ts > fast
+ ✓ basic.test.ts > slow [...]ms
+`)
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4900

This will make the output similar to non-CI reporters which use list renderer:

https://github.com/vitest-dev/vitest/blob/883d17ed9a5c32fd1d1eb55ae89a91aaec2c19b5/packages/vitest/src/node/reporters/renderers/listRenderer.ts#L116-L119

Regarding the documentation, currently https://vitest.dev/guide/reporters.html doesn't mention anything about CI mode and the example output https://vitest.dev/guide/reporters.html#verbose-reporter shows non-CI mode output. So, probably documentation change is not necessary.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
