### PR TITLE
fix(vitest): test deep dependencies change detection

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -389,6 +389,8 @@ export class Vitest {
     const addImports = async ([project, filepath]: WorkspaceSpec) => {
       if (deps.has(filepath))
         return
+      deps.add(filepath)
+
       const mod = project.server.moduleGraph.getModuleById(filepath)
       const transformed = mod?.ssrTransformResult || await project.vitenode.transformRequest(filepath)
       if (!transformed)
@@ -397,15 +399,13 @@ export class Vitest {
       await Promise.all(dependencies.map(async (dep) => {
         const path = await project.server.pluginContainer.resolveId(dep, filepath, { ssr: true })
         const fsPath = path && !path.external && path.id.split('?')[0]
-        if (fsPath && !fsPath.includes('node_modules') && !deps.has(fsPath) && existsSync(fsPath)) {
-          deps.add(fsPath)
-
+        if (fsPath && !fsPath.includes('node_modules') && !deps.has(fsPath) && existsSync(fsPath))
           await addImports([project, fsPath])
-        }
       }))
     }
 
     await addImports(filepath)
+    deps.delete(filepath[1])
 
     return deps
   }

--- a/test/changed/fixtures/related/deep-related-exports.test.ts
+++ b/test/changed/fixtures/related/deep-related-exports.test.ts
@@ -1,0 +1,11 @@
+import { access } from 'node:fs'
+import { sep } from 'pathe'
+import { expect, test } from 'vitest'
+import { A } from './src/sourceC'
+
+test('values', () => {
+  expect(A).toBe('A')
+  expect(typeof sep).toBe('string')
+  // doesn't throw
+  expect(typeof access).toBe('function')
+})

--- a/test/changed/fixtures/related/deep-related-imports.test.ts
+++ b/test/changed/fixtures/related/deep-related-imports.test.ts
@@ -1,0 +1,11 @@
+import { access } from 'node:fs'
+import { sep } from 'pathe'
+import { expect, test } from 'vitest'
+import { A } from './src/sourceD'
+
+test('values', () => {
+  expect(A).toBe('A')
+  expect(typeof sep).toBe('string')
+  // doesn't throw
+  expect(typeof access).toBe('function')
+})

--- a/test/changed/fixtures/related/src/sourceC.ts
+++ b/test/changed/fixtures/related/src/sourceC.ts
@@ -1,0 +1,2 @@
+// re-exporting for deep changed detection
+export { A } from './sourceA'

--- a/test/changed/fixtures/related/src/sourceD.ts
+++ b/test/changed/fixtures/related/src/sourceD.ts
@@ -1,0 +1,4 @@
+// import and re-exporting for deep changed detection
+import { A as sourceA } from './sourceA'
+
+export const A = sourceA

--- a/test/changed/tests/related.test.ts
+++ b/test/changed/tests/related.test.ts
@@ -6,7 +6,9 @@ import { runVitestCli } from '../../test-utils'
 it('related correctly runs only related tests', async () => {
   const { stdout, stderr } = await runVitestCli('related', join(process.cwd(), 'fixtures/related/src/sourceA.ts'), '--root', join(process.cwd(), './fixtures/related'), '--globals', '--no-watch')
   expect(stderr).toBe('')
-  expect(stdout).toContain('1 passed')
+  expect(stdout).toContain('3 passed')
   expect(stdout).toContain('related.test.ts')
+  expect(stdout).toContain('deep-related-imports.test.ts')
+  expect(stdout).toContain('deep-related-exports.test.ts')
   expect(stdout).not.toContain('not-related.test.ts')
 })


### PR DESCRIPTION
`--changed` flag is not correctly looking up deep dependencies, as such the changed flag does not trigger specs if a sub dependency is changed.

Alters the logic to add the collected dependency after recursive `addImports` is called, otherwise the logic returns early because that dependency has already been added to the collected deps set. So it will not look deeply.

Resolves #4933 
(Also Resolves https://github.com/vitest-dev/vitest/issues/5009)