### PR TITLE
docs(expect api): fix typo of negation in toSatisfy example

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1002,7 +1002,7 @@ describe('toSatisfy()', () => {
     expect(1).toSatisfy(isOdd)
   })
 
-  it('pass with negotiation', () => {
+  it('pass with negation', () => {
     expect(2).not.toSatisfy(isOdd)
   })
 })


### PR DESCRIPTION
`negotiation` should be `negation`, as the example demonstrates `not.toSatisfy()`

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
small copy change in the `expect().toSatisfy` documentation

on an example showing it's use with `not`, "negation" was typod as "negotiation"

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
