### PR TITLE
fix(vitest): add inlined deps to ssr.noExternal so they are added to the module graph

### DIFF
--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -65,7 +65,8 @@ export class ViteNodeServer {
       }
       else if (options.deps.inline !== true) {
         options.deps.inline ??= []
-        options.deps.inline.push(...toArray(ssrOptions.noExternal))
+        const inline = options.deps.inline
+        options.deps.inline.push(...toArray(ssrOptions.noExternal).filter(dep => !inline.includes(dep)))
       }
     }
     if (process.env.VITE_NODE_DEBUG_DUMP) {

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -8,6 +8,7 @@ export interface UserWorkspaceConfig extends ViteUserConfig {
 // will import vitest declare test in module 'vite'
 export { configDefaults, defaultInclude, defaultExclude, coverageConfigDefaults } from './defaults'
 export { mergeConfig } from 'vite'
+export { extraInlineDeps } from './constants'
 
 export type { ConfigEnv, ViteUserConfig as UserConfig }
 export type UserConfigFnObject = (env: ConfigEnv) => ViteUserConfig

--- a/packages/vitest/src/constants.ts
+++ b/packages/vitest/src/constants.ts
@@ -6,6 +6,15 @@ export const EXIT_CODE_RESTART = 43
 
 export const API_PATH = '/__vitest_api__'
 
+export const extraInlineDeps = [
+  /^(?!.*(?:node_modules)).*\.mjs$/,
+  /^(?!.*(?:node_modules)).*\.cjs\.js$/,
+  // Vite client
+  /vite\w*\/dist\/client\/env.mjs/,
+  // Nuxt
+  '@nuxt/test-utils',
+]
+
 export const CONFIG_NAMES = [
   'vitest.config',
   'vite.config',

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -13,7 +13,7 @@ import { RandomSequencer } from './sequencers/RandomSequencer'
 import type { BenchmarkBuiltinReporters } from './reporters'
 import { builtinPools } from './pool'
 
-const extraInlineDeps = [
+export const extraInlineDeps = [
   /^(?!.*(?:node_modules)).*\.mjs$/,
   /^(?!.*(?:node_modules)).*\.cjs\.js$/,
   // Vite client

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -3,7 +3,7 @@ import { normalize, relative, resolve } from 'pathe'
 import c from 'picocolors'
 import type { ResolvedConfig as ResolvedViteConfig } from 'vite'
 import type { ApiConfig, ResolvedConfig, UserConfig, VitestRunMode } from '../types'
-import { defaultBrowserPort, defaultPort } from '../constants'
+import { defaultBrowserPort, defaultPort, extraInlineDeps } from '../constants'
 import { benchmarkConfigDefaults, configDefaults } from '../defaults'
 import { isCI, stdProvider, toArray } from '../utils'
 import type { BuiltinPool } from '../types/pool-options'
@@ -12,15 +12,6 @@ import { BaseSequencer } from './sequencers/BaseSequencer'
 import { RandomSequencer } from './sequencers/RandomSequencer'
 import type { BenchmarkBuiltinReporters } from './reporters'
 import { builtinPools } from './pool'
-
-export const extraInlineDeps = [
-  /^(?!.*(?:node_modules)).*\.mjs$/,
-  /^(?!.*(?:node_modules)).*\.cjs\.js$/,
-  // Vite client
-  /vite\w*\/dist\/client\/env.mjs/,
-  // Nuxt
-  '@nuxt/test-utils',
-]
 
 function resolvePath(path: string, root: string) {
   return normalize(

--- a/test/config/test/resolution.test.ts
+++ b/test/config/test/resolution.test.ts
@@ -1,10 +1,17 @@
 import type { UserConfig } from 'vitest'
+import type { UserConfig as ViteUserConfig } from 'vite'
 import { describe, expect, it } from 'vitest'
 import { createVitest } from 'vitest/node'
+import { extraInlineDeps } from '../../../packages/vitest/src/node/config'
 
-async function config(cliOptions: UserConfig, configValue: UserConfig = {}) {
-  const vitest = await createVitest('test', { ...cliOptions, watch: false }, { test: configValue })
-  return vitest.config
+async function vitest(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}) {
+  const vitest = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue })
+  return vitest
+}
+
+async function config(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}) {
+  const v = await vitest(cliOptions, configValue, viteConfig)
+  return v.config
 }
 
 describe('correctly defines isolated flags', async () => {
@@ -100,5 +107,115 @@ describe('correctly defines isolated flags', async () => {
     expect(c.poolOptions?.forks?.isolate).toBe(undefined)
     // set in configDefaults, so it's always defined
     expect(c.isolate).toBe(true)
+  })
+})
+
+describe('correctly defines inline and noExternal flags', async () => {
+  it('both are true if inline is true', async () => {
+    const v = await vitest({}, {
+      server: {
+        deps: {
+          inline: true,
+        },
+      },
+    })
+    expect(v.vitenode.options.deps?.inline).toBe(true)
+    expect(v.vitenode.server.config.ssr.noExternal).toBe(true)
+  })
+
+  it('both are true if noExternal is true', async () => {
+    const v = await vitest({}, {}, {
+      ssr: {
+        noExternal: true,
+      },
+    })
+    expect(v.vitenode.options.deps?.inline).toBe(true)
+    expect(v.vitenode.server.config.ssr.noExternal).toBe(true)
+  })
+
+  it('inline are added to noExternal', async () => {
+    const regexp1 = /dep1/
+    const regexp2 = /dep2/
+
+    const v = await vitest({}, {
+      server: {
+        deps: {
+          inline: ['dep1', 'dep2', regexp1, regexp2],
+        },
+      },
+    })
+
+    expect(v.vitenode.options.deps?.inline).toEqual([
+      'dep1',
+      'dep2',
+      regexp1,
+      regexp2,
+      ...extraInlineDeps,
+    ])
+    expect(v.server.config.ssr.noExternal).toEqual([
+      'dep1',
+      'dep2',
+      regexp1,
+      regexp2,
+      ...extraInlineDeps,
+    ])
+  })
+
+  it('noExternal are added to inline', async () => {
+    const regexp1 = /dep1/
+    const regexp2 = /dep2/
+
+    const v = await vitest({}, {}, {
+      ssr: {
+        noExternal: ['dep1', 'dep2', regexp1, regexp2],
+      },
+    })
+
+    expect(v.vitenode.options.deps?.inline).toEqual([
+      ...extraInlineDeps,
+      'dep1',
+      'dep2',
+      regexp1,
+      regexp2,
+    ])
+    expect(v.server.config.ssr.noExternal).toEqual([
+      'dep1',
+      'dep2',
+      regexp1,
+      regexp2,
+    ])
+  })
+
+  it('noExternal and inline don\'t have duplicates', async () => {
+    const regexp1 = /dep1/
+    const regexp2 = /dep2/
+
+    const v = await vitest({}, {
+      server: {
+        deps: {
+          inline: ['dep2', regexp1, 'dep3'],
+        },
+      },
+    }, {
+      ssr: {
+        noExternal: ['dep1', 'dep2', regexp1, regexp2],
+      },
+    })
+
+    expect(v.vitenode.options.deps?.inline).toEqual([
+      'dep2',
+      regexp1,
+      'dep3',
+      ...extraInlineDeps,
+      'dep1',
+      regexp2,
+    ])
+    expect(v.server.config.ssr.noExternal).toEqual([
+      'dep1',
+      'dep2',
+      regexp1,
+      regexp2,
+      'dep3',
+    ])
   })
 })

--- a/test/config/test/resolution.test.ts
+++ b/test/config/test/resolution.test.ts
@@ -2,10 +2,10 @@ import type { UserConfig } from 'vitest'
 import type { UserConfig as ViteUserConfig } from 'vite'
 import { describe, expect, it } from 'vitest'
 import { createVitest } from 'vitest/node'
-import { extraInlineDeps } from '../../../packages/vitest/src/node/config'
+import { extraInlineDeps } from 'vitest/config'
 
 async function vitest(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}) {
-  const vitest = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue })
+  const vitest = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any })
   return vitest
 }
 


### PR DESCRIPTION
### Description

Fixes #4785

This fixes the first case when changing code in dependencies with `node` environment did not trigger an HMR update.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
