### PR TITLE
fix(browser): apply inlined workspace config to browser mode vite server

### DIFF
--- a/packages/vitest/src/integrations/browser/server.ts
+++ b/packages/vitest/src/integrations/browser/server.ts
@@ -2,11 +2,11 @@ import { createServer } from 'vite'
 import { defaultBrowserPort } from '../../constants'
 import { resolveApiServerConfig } from '../../node/config'
 import { CoverageTransform } from '../../node/plugins/coverageTransform'
-import type { InitializeProjectOptions, WorkspaceProject } from '../../node/workspace'
+import type { WorkspaceProject } from '../../node/workspace'
 import { MocksPlugin } from '../../node/plugins/mocks'
 import { resolveFsAllow } from '../../node/plugins/utils'
 
-export async function createBrowserServer(project: WorkspaceProject, configFile: string | undefined, options?: InitializeProjectOptions) {
+export async function createBrowserServer(project: WorkspaceProject, configFile: string | undefined) {
   const root = project.config.root
 
   await project.ctx.packageInstaller.ensureInstalled('@vitest/browser', root)
@@ -14,7 +14,7 @@ export async function createBrowserServer(project: WorkspaceProject, configFile:
   const configPath = typeof configFile === 'string' ? configFile : false
 
   const server = await createServer({
-    ...options,
+    ...project.options, // spread project config inlined in root workspace config
     logLevel: 'error',
     mode: project.config.mode,
     configFile: configPath,
@@ -26,7 +26,7 @@ export async function createBrowserServer(project: WorkspaceProject, configFile:
       },
     },
     plugins: [
-      ...options?.plugins || [],
+      ...project.options?.plugins || [],
       (await import('@vitest/browser')).default(project, '/'),
       CoverageTransform(project.ctx),
       {

--- a/packages/vitest/src/integrations/browser/server.ts
+++ b/packages/vitest/src/integrations/browser/server.ts
@@ -2,11 +2,11 @@ import { createServer } from 'vite'
 import { defaultBrowserPort } from '../../constants'
 import { resolveApiServerConfig } from '../../node/config'
 import { CoverageTransform } from '../../node/plugins/coverageTransform'
-import type { WorkspaceProject } from '../../node/workspace'
+import type { InitializeProjectOptions, WorkspaceProject } from '../../node/workspace'
 import { MocksPlugin } from '../../node/plugins/mocks'
 import { resolveFsAllow } from '../../node/plugins/utils'
 
-export async function createBrowserServer(project: WorkspaceProject, configFile: string | undefined) {
+export async function createBrowserServer(project: WorkspaceProject, configFile: string | undefined, options?: InitializeProjectOptions) {
   const root = project.config.root
 
   await project.ctx.packageInstaller.ensureInstalled('@vitest/browser', root)
@@ -14,10 +14,9 @@ export async function createBrowserServer(project: WorkspaceProject, configFile:
   const configPath = typeof configFile === 'string' ? configFile : false
 
   const server = await createServer({
+    ...options,
     logLevel: 'error',
     mode: project.config.mode,
-    // test config can be inlined in root workspace config without dedicated vite/vitest configFile for this project
-    test: project.config,
     configFile: configPath,
     // watch is handled by Vitest
     server: {
@@ -27,6 +26,7 @@ export async function createBrowserServer(project: WorkspaceProject, configFile:
       },
     },
     plugins: [
+      ...options?.plugins || [],
       (await import('@vitest/browser')).default(project, '/'),
       CoverageTransform(project.ctx),
       {

--- a/packages/vitest/src/integrations/browser/server.ts
+++ b/packages/vitest/src/integrations/browser/server.ts
@@ -16,6 +16,8 @@ export async function createBrowserServer(project: WorkspaceProject, configFile:
   const server = await createServer({
     logLevel: 'error',
     mode: project.config.mode,
+    // test config can be inlined in root workspace config without dedicated vite/vitest configFile for this project
+    test: project.config,
     configFile: configPath,
     // watch is handled by Vitest
     server: {

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -19,13 +19,13 @@ import type { GlobalSetupFile } from './globalSetup'
 import { loadGlobalSetupFiles } from './globalSetup'
 import { divider } from './reporters/renderers/utils'
 
-interface InitializeProjectOptions extends UserWorkspaceConfig {
+export interface InitializeProjectOptions extends UserWorkspaceConfig {
   workspaceConfigPath: string
   extends?: string
 }
 
 export async function initializeProject(workspacePath: string | number, ctx: Vitest, options: InitializeProjectOptions) {
-  const project = new WorkspaceProject(workspacePath, ctx)
+  const project = new WorkspaceProject(workspacePath, ctx, options)
 
   const configFile = options.extends
     ? resolve(dirname(options.workspaceConfigPath), options.extends)
@@ -78,6 +78,7 @@ export class WorkspaceProject {
   constructor(
     public path: string | number,
     public ctx: Vitest,
+    public options?: InitializeProjectOptions,
   ) { }
 
   getName(): string {
@@ -271,7 +272,7 @@ export class WorkspaceProject {
     if (!this.isBrowserEnabled())
       return
     await this.browser?.close()
-    this.browser = await createBrowserServer(this, configFile)
+    this.browser = await createBrowserServer(this, configFile, this.options)
   }
 
   static createBasicProject(ctx: Vitest) {

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -19,7 +19,7 @@ import type { GlobalSetupFile } from './globalSetup'
 import { loadGlobalSetupFiles } from './globalSetup'
 import { divider } from './reporters/renderers/utils'
 
-export interface InitializeProjectOptions extends UserWorkspaceConfig {
+interface InitializeProjectOptions extends UserWorkspaceConfig {
   workspaceConfigPath: string
   extends?: string
 }
@@ -272,7 +272,7 @@ export class WorkspaceProject {
     if (!this.isBrowserEnabled())
       return
     await this.browser?.close()
-    this.browser = await createBrowserServer(this, configFile, this.options)
+    this.browser = await createBrowserServer(this, configFile)
   }
 
   static createBasicProject(ctx: Vitest) {

--- a/test/workspaces-browser/globalTest.ts
+++ b/test/workspaces-browser/globalTest.ts
@@ -6,9 +6,9 @@ export async function teardown() {
 
   try {
     assert.ok(results.success)
-    assert.equal(results.numTotalTestSuites, 3)
-    assert.equal(results.numTotalTests, 3)
-    assert.equal(results.numPassedTests, 3)
+    assert.equal(results.numTotalTestSuites, 4)
+    assert.equal(results.numTotalTests, 5)
+    assert.equal(results.numPassedTests, 5)
   }
   catch (err) {
     console.error(err)

--- a/test/workspaces-browser/space_browser_inline/test-alias-to.ts
+++ b/test/workspaces-browser/space_browser_inline/test-alias-to.ts
@@ -1,0 +1,1 @@
+export default 'hello'

--- a/test/workspaces-browser/space_browser_inline/test/basic.test.ts
+++ b/test/workspaces-browser/space_browser_inline/test/basic.test.ts
@@ -5,6 +5,6 @@ test('window is defined', () => {
 })
 
 test('"defined" from workspace inline config', () => {
-  // TODO
-  // expect(typeof TEST_DEIFNE).toBe("string")
+  // @ts-expect-error vite define
+  expect(TEST_DEFINE).toBe('hello')
 })

--- a/test/workspaces-browser/space_browser_inline/test/basic.test.ts
+++ b/test/workspaces-browser/space_browser_inline/test/basic.test.ts
@@ -4,7 +4,7 @@ test('window is defined', () => {
   expect(typeof window).toBe('object')
 })
 
-test('"defined" from workspace inline config', () => {
+test('"define" from workspace inline config', () => {
   // @ts-expect-error vite define
   expect(TEST_DEFINE).toBe('hello')
 })

--- a/test/workspaces-browser/space_browser_inline/test/basic.test.ts
+++ b/test/workspaces-browser/space_browser_inline/test/basic.test.ts
@@ -1,12 +1,16 @@
 import { expect, test } from 'vitest'
 
-// @ts-expect-error test vite resolve.alias
-import testAlias from 'test-alias-from'
+// @ts-expect-error alias
+import testAliasVite from 'test-alias-from-vite'
+
+// @ts-expect-error alias
+import testAliasVitest from 'test-alias-from-vitest'
 
 test('window is defined', () => {
   expect(typeof window).toBe('object')
 })
 
 test('alias from workspace inline config', () => {
-  expect(testAlias).toBe('hello')
+  expect(testAliasVite).toBe('hello')
+  expect(testAliasVitest).toBe('hello')
 })

--- a/test/workspaces-browser/space_browser_inline/test/basic.test.ts
+++ b/test/workspaces-browser/space_browser_inline/test/basic.test.ts
@@ -1,10 +1,12 @@
 import { expect, test } from 'vitest'
 
+// @ts-expect-error test vite resolve.alias
+import testAlias from 'test-alias-from'
+
 test('window is defined', () => {
   expect(typeof window).toBe('object')
 })
 
-test('"define" from workspace inline config', () => {
-  // @ts-expect-error vite define
-  expect(TEST_DEFINE).toBe('hello')
+test('alias from workspace inline config', () => {
+  expect(testAlias).toBe('hello')
 })

--- a/test/workspaces-browser/space_browser_inline/test/basic.test.ts
+++ b/test/workspaces-browser/space_browser_inline/test/basic.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+
+test('window is defined', () => {
+  expect(typeof window).toBe('object')
+})
+
+test('"defined" from workspace inline config', () => {
+  // TODO
+  // expect(typeof TEST_DEIFNE).toBe("string")
+})

--- a/test/workspaces-browser/vitest.workspace.ts
+++ b/test/workspaces-browser/vitest.workspace.ts
@@ -12,13 +12,13 @@ export default defineWorkspace([
         headless: true,
         provider: process.env.PROVIDER || 'webdriverio',
       },
+      alias: {
+        'test-alias-from-vitest': new URL('./space_browser_inline/test-alias-to.ts', import.meta.url).pathname,
+      },
     },
     resolve: {
       alias: {
-        'test-alias-from': new URL(
-          './space_browser_inline/test-alias-to.ts',
-          import.meta.url,
-        ).pathname,
+        'test-alias-from-vite': new URL('./space_browser_inline/test-alias-to.ts', import.meta.url).pathname,
       },
     },
   },

--- a/test/workspaces-browser/vitest.workspace.ts
+++ b/test/workspaces-browser/vitest.workspace.ts
@@ -2,4 +2,19 @@ import { defineWorkspace } from 'vitest/config'
 
 export default defineWorkspace([
   './space_*/*.config.ts',
+  {
+    test: {
+      name: 'space_browser_inline',
+      root: './space_browser_inline',
+      browser: {
+        enabled: true,
+        name: process.env.BROWSER || 'chrome',
+        headless: true,
+        provider: process.env.PROVIDER || 'webdriverio',
+      },
+    },
+    define: {
+      TEST_DEIFNE: 'hello',
+    },
+  },
 ])

--- a/test/workspaces-browser/vitest.workspace.ts
+++ b/test/workspaces-browser/vitest.workspace.ts
@@ -13,8 +13,13 @@ export default defineWorkspace([
         provider: process.env.PROVIDER || 'webdriverio',
       },
     },
-    define: {
-      TEST_DEFINE: '"hello"',
+    resolve: {
+      alias: {
+        'test-alias-from': new URL(
+          './space_browser_inline/test-alias-to.ts',
+          import.meta.url,
+        ).pathname,
+      },
     },
   },
 ])

--- a/test/workspaces-browser/vitest.workspace.ts
+++ b/test/workspaces-browser/vitest.workspace.ts
@@ -14,7 +14,7 @@ export default defineWorkspace([
       },
     },
     define: {
-      TEST_DEIFNE: 'hello',
+      TEST_DEFINE: '"hello"',
     },
   },
 ])


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/4744

For non browser project, inlined workspace project config is included into vite server config via spreading during `initializeProject`:

https://github.com/vitest-dev/vitest/blob/c9824cb3890f82e482245c5d2709dc6c6671e28c/packages/vitest/src/node/workspace.ts#L42-L53

However, browser mode's additional vite server instantiation was missing such logic, which leads to an issue when users relies on root workspace config without dedicated vite/vitest config file for the browser test project.

~In this PR, I copied over only `test: ...`, but maybe it should spread everything like `initializeProject` does above since otherwise it would still miss inlined base vite config.~ (EDIT: I did so in https://github.com/vitest-dev/vitest/pull/4947/commits/aff160dad529d6dbbe6978adb5e7ba81a19e3661)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
