### PR TITLE
fix(vitest): handle single `await vi.hoisted`

### DIFF
--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -59,7 +59,7 @@ export function getBetterEnd(code: string, node: Node) {
   return end
 }
 
-const regexpHoistable = /[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/m
+const regexpHoistable = /[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/
 const hashbangRE = /^#!.*\n/
 
 export function hoistMocks(code: string, id: string, parse: PluginContext['parse']) {

--- a/packages/vitest/src/node/hoistMocks.ts
+++ b/packages/vitest/src/node/hoistMocks.ts
@@ -59,12 +59,11 @@ export function getBetterEnd(code: string, node: Node) {
   return end
 }
 
-const regexpHoistable = /^[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/m
-const regexpAssignedHoisted = /=[ \t]*(\bawait|)[ \t]*\b(vi|vitest)\s*\.\s*hoisted\(/
+const regexpHoistable = /[ \t]*\b(vi|vitest)\s*\.\s*(mock|unmock|hoisted)\(/m
 const hashbangRE = /^#!.*\n/
 
 export function hoistMocks(code: string, id: string, parse: PluginContext['parse']) {
-  const needHoisting = regexpHoistable.test(code) || regexpAssignedHoisted.test(code)
+  const needHoisting = regexpHoistable.test(code)
 
   if (!needHoisting)
     return

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -1188,11 +1188,13 @@ console.log(foo + 2)
       hoistSimpleCode(`
 import { vi } from 'vitest';
 1234;
-await vi.hoisted(() => {});
+await vi
+  .hoisted(() => {});
     `),
     ).toMatchInlineSnapshot(`
       "const { vi } = await import('vitest')
-      await vi.hoisted(() => {});
+      await vi
+        .hoisted(() => {});
 
 
       1234;"

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -1182,6 +1182,22 @@ console.log(foo + 2)
       console.log(__vi_import_0__.foo + 2)"
     `)
   })
+
+  test('handle single "await vi.hoisted"', async () => {
+    expect(
+      hoistSimpleCode(`
+import { vi } from 'vitest';
+1234;
+await vi.hoisted(() => {});
+    `),
+    ).toMatchInlineSnapshot(`
+      "const { vi } = await import('vitest')
+      await vi.hoisted(() => {});
+
+
+      1234;"
+    `)
+  })
 })
 
 describe('throws an error when nodes are incompatible', () => {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4941

I loosened regex to match `(vi|vitest).(mock|unmock|hoisted)` anywhere in the code (not necessary assignment nor beginning of line).

Btw, it looks like currently tests are failing locally when color is enabled probably because of code frame offset not taking account highlight:

https://github.com/vitest-dev/vitest/blob/0b28f30153bce95e26cd343ad7a6a6f0c22518a2/packages/vitest/src/node/hoistMocks.ts#L259

So, for now I verified it by running with `NO_COLOR=1`.
(I tried to reproduced it but it doesn't look like highlight is enabled in user's tests https://stackblitz.com/edit/vitest-dev-vitest-nanulr?file=test%2Frepro.test.ts)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
