### PR TITLE
Require vitest 1.2.0 to run @vitest/browser >1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm exec playwright install
+        run: pnpm playwright install --with-deps
 
       - name: Build
         run: pnpm run build
@@ -130,7 +130,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpx playwright install chromium
+        run: pnpm playwright install chromium
 
       - name: Build
         run: pnpm run build
@@ -167,7 +167,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm exec playwright install
+        run: pnpm playwright install --with-deps
 
       - name: Build
         run: pnpm run build
@@ -207,7 +207,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm exec playwright install
+        run: pnpm playwright install --with-deps
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpx playwright install --with-deps
+        run: pnpm exec playwright install
 
       - name: Build
         run: pnpm run build
@@ -167,7 +167,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpx playwright install --with-deps
+        run: pnpm exec playwright install
 
       - name: Build
         run: pnpm run build
@@ -207,7 +207,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpx playwright install --with-deps
+        run: pnpm exec playwright install
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm playwright install --with-deps
+        run: pnpx playwright install --with-deps
 
       - name: Build
         run: pnpm run build
@@ -130,7 +130,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm playwright install chromium
+        run: pnpx playwright install chromium
 
       - name: Build
         run: pnpm run build
@@ -167,7 +167,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm playwright install --with-deps
+        run: pnpx playwright install --with-deps
 
       - name: Build
         run: pnpm run build
@@ -207,7 +207,7 @@ jobs:
         run: pnpm i
 
       - name: Install Playwright Dependencies
-        run: pnpm playwright install --with-deps
+        run: pnpx playwright install --with-deps
 
       - name: Build
         run: pnpm run build

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "playwright": "*",
-    "vitest": "^1.0.0",
+    "vitest": "^1.2.0",
     "webdriverio": "*"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### Description

Vitest browser is not compatible with Vitest versions below 1.2.0. See: https://github.com/vitest-dev/vitest/issues/4983
Change peerDependency version.