### PR TITLE
fix(browser): don't fail when calling vi.useFakeTimers

### DIFF
--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -138,10 +138,20 @@ export class FakeTimers {
       if (this._userConfig?.toFake?.includes('nextTick') && isChildProcess())
         throw new Error('process.nextTick cannot be mocked inside child_process')
 
+      const existingFakedMethods = (this._userConfig?.toFake || toFake).filter((method) => {
+        switch (method) {
+          case 'hrtime':
+          case 'nextTick':
+            return typeof process !== 'undefined' && method in process && process[method]
+          default:
+            return method in globalThis && globalThis[method]
+        }
+      })
+
       this._clock = this._fakeTimers.install({
         now: Date.now(),
-        toFake,
         ...this._userConfig,
+        toFake: existingFakedMethods,
       })
 
       this._fakingTime = true

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -151,7 +151,7 @@ class AggregateErrorPonyfill extends Error {
 export { AggregateErrorPonyfill as AggregateError }
 
 export function isChildProcess(): boolean {
-  return !!process?.send
+  return typeof process !== 'undefined' && !!process.send
 }
 
 export function setProcessTitle(title: string) {

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -11,8 +11,8 @@ const {
 } = await runVitest()
 
 await test('tests are actually running', async () => {
-  assert.ok(browserResultJson.testResults.length === 11, 'Not all the tests have been run')
-  assert.ok(passedTests.length === 9, 'Some tests failed')
+  assert.ok(browserResultJson.testResults.length === 12, 'Not all the tests have been run')
+  assert.ok(passedTests.length === 10, 'Some tests failed')
   assert.ok(failedTests.length === 2, 'Some tests have passed but should fail')
 
   assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')

--- a/test/browser/test/timers.test.ts
+++ b/test/browser/test/timers.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it('only runs a setTimeout callback once (ever)', () => {
+  vi.useFakeTimers()
+
+  const fn = vi.fn()
+  setTimeout(fn, 0)
+  expect(fn).toHaveBeenCalledTimes(0)
+
+  vi.runAllTimers()
+  expect(fn).toHaveBeenCalledTimes(1)
+
+  vi.runAllTimers()
+  expect(fn).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
### Description

Closes #4984

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
