### PR TITLE
fix(vitest): support network imports in vm pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:run": "vitest run -r test/core",
     "test:all": "CI=true pnpm -r --stream run test --allowOnly",
     "test:ci": "CI=true pnpm -r --stream --filter !test-browser --filter !test-esm --filter !test-browser run test --allowOnly",
-    "test:ci:vm-threads": "CI=true pnpm -r --stream --filter !test-coverage --filter !test-single-thread --filter !test-browser --filter !test-esm --filter !test-network-imports --filter !test-browser --filter !example-react-testing-lib-msw run test --allowOnly --pool vmThreads",
+    "test:ci:vm-threads": "CI=true pnpm -r --stream --filter !test-coverage --filter !test-single-thread --filter !test-browser --filter !test-esm --filter !test-browser --filter !example-react-testing-lib-msw run test --allowOnly --pool vmThreads",
     "test:ci:no-threads": "CI=true pnpm -r --stream --filter !test-vm-threads --filter !test-coverage --filter !test-watch --filter !test-bail --filter !test-esm --filter !test-browser run test --allowOnly --pool forks",
     "typecheck": "tsc -p tsconfig.check.json --noEmit",
     "typecheck:why": "tsc -p tsconfig.check.json --noEmit --explainFiles > explainTypes.txt",

--- a/packages/vitest/src/runtime/external-executor.ts
+++ b/packages/vitest/src/runtime/external-executor.ts
@@ -29,7 +29,7 @@ export interface ExternalModulesExecutorOptions {
 }
 
 interface ModuleInformation {
-  type: 'data' | 'builtin' | 'vite' | 'module' | 'commonjs'
+  type: 'data' | 'network' | 'builtin' | 'vite' | 'module' | 'commonjs'
   url: string
   path: string
 }
@@ -153,6 +153,9 @@ export class ExternalModulesExecutor {
     if (identifier.startsWith('data:'))
       return { type: 'data', url: identifier, path: identifier }
 
+    if (/^(https?:)?\/\//.test(identifier))
+      return { type: 'network', url: identifier, path: identifier }
+
     const extension = extname(identifier)
     if (extension === '.node' || isNodeBuiltin(identifier))
       return { type: 'builtin', url: identifier, path: identifier }
@@ -185,6 +188,8 @@ export class ExternalModulesExecutor {
     switch (type) {
       case 'data':
         return this.esm.createDataModule(identifier)
+      case 'network':
+        return this.esm.createNetworkModule(identifier)
       case 'builtin': {
         const exports = this.require(identifier)
         return this.wrapCoreSynteticModule(identifier, exports)

--- a/packages/vitest/src/runtime/vm/esm-executor.ts
+++ b/packages/vitest/src/runtime/vm/esm-executor.ts
@@ -177,4 +177,22 @@ export class EsmExecutor {
 
     return this.createEsModule(identifier, code)
   }
+
+  // https://nodejs.org/api/esm.html#https-and-http-imports
+  // TODO: find reference implementation (node? deno?)
+  // TODO: default disabled to align with node?
+  // TODO: mime-type (json, wasm)? share code with `createDataModule` above?
+  // TODO: dynamic import?
+  public async createNetworkModule(identifier: string): Promise<VMModule> {
+    const cached = this.moduleCache.get(identifier)
+    if (cached)
+      return cached
+
+    const res = await fetch(identifier)
+    if (!res.ok)
+      throw new Error(`Fetch failed on network import: '${identifier}'`)
+
+    const code = await res.text()
+    return this.createEsModule(identifier, code)
+  }
 }

--- a/test/network-imports/test/basic.test.ts
+++ b/test/network-imports/test/basic.test.ts
@@ -4,7 +4,10 @@ import { expect, test } from 'vitest'
 import slash from 'http://localhost:9602/slash@3.0.0.js'
 
 // test without local server
+// - with internal imports with a relative path '/v135/slash@3.0.0/es2022/slash.mjs'
 // import slash from 'https://esm.sh/slash@3.0.0'
+// - single file
+// import slash from 'https://esm.sh/v135/slash@3.0.0/es2022/slash.mjs'
 
 test('network imports', () => {
   expect(slash('foo\\bar')).toBe('foo/bar')

--- a/test/network-imports/vitest.config.ts
+++ b/test/network-imports/vitest.config.ts
@@ -9,14 +9,6 @@ export default defineConfig({
       forks: {
         execArgv: ['--experimental-network-imports'],
       },
-      // not supported?
-      //   FAIL  test/basic.test.ts [ test/basic.test.ts ]
-      //   Error: ENOENT: no such file or directory, open 'http://localhost:9602/slash@3.0.0.js'
-      //    ❯ Object.openSync node:fs:596:3
-      //    ❯ readFileSync node:fs:464:35
-      vmThreads: {
-        execArgv: ['--experimental-network-imports'],
-      },
     },
     // let vite serve public/slash@3.0.0.js
     api: 9602,


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4995

I had no idea the whole external import is handled by its own implementation with vm, Very cool!

For starter, I added a very rudimentary one for network imports, which seems to be working for the test case. I plan to look up other runtime's implementation since I assume it's important to have somewhat of compatibility with NodeJS at least (but their doc doesn't give much detail https://nodejs.org/api/esm.html#https-and-http-imports).

_references_

- https://github.com/nodejs/node/pull/36328

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
