### PR TITLE
fix(expect): improve `toThrow(asymmetricMatcher)` failure message

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -581,7 +581,6 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         `expected error not to be instance of ${name}`,
         expected,
         thrown,
-        false,
       )
     }
 

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -599,9 +599,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const matcher = expected as any as AsymmetricMatcher<any>
       return this.assert(
         thrown && matcher.asymmetricMatch(thrown),
-        'expected error to match asymmetric matcher',
-        'expected error not to match asymmetric matcher',
-        matcher.toString(),
+        'expected thrown value #{act} to match asymmetric matcher: #{exp}',
+        'expected thrown value #{act} not to match asymmetric matcher: #{exp}',
+        matcher,
         thrown,
         false,
       )

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -599,11 +599,10 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const matcher = expected as any as AsymmetricMatcher<any>
       return this.assert(
         thrown && matcher.asymmetricMatch(thrown),
-        'expected thrown value #{act} to match asymmetric matcher: #{exp}',
-        'expected thrown value #{act} not to match asymmetric matcher: #{exp}',
+        'expected error to match asymmetric matcher',
+        'expected error not to match asymmetric matcher',
         matcher,
         thrown,
-        false,
       )
     }
 

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -227,3 +227,39 @@ exports[`asymmetric matcher error 16`] = `
   "message": "expected 'hello' to deeply equal StringContaining{…}",
 }
 `;
+
+exports[`asymmetric matcher error 17`] = `
+{
+  "actual": "hello",
+  "diff": undefined,
+  "expected": "StringContaining "xx"",
+  "message": "expected thrown value 'hello' to match asymmetric matcher: StringContaining "xx"",
+}
+`;
+
+exports[`asymmetric matcher error 18`] = `
+{
+  "actual": "hello",
+  "diff": undefined,
+  "expected": "stringContainingCustom<xx>",
+  "message": "expected thrown value 'hello' to match asymmetric matcher: stringContainingCustom<xx>",
+}
+`;
+
+exports[`asymmetric matcher error 19`] = `
+{
+  "actual": "hello",
+  "diff": undefined,
+  "expected": "StringContaining "ll"",
+  "message": "expected thrown value 'hello' not to match asymmetric matcher: StringContaining "ll"",
+}
+`;
+
+exports[`asymmetric matcher error 20`] = `
+{
+  "actual": "hello",
+  "diff": undefined,
+  "expected": "stringContainingCustom<ll>",
+  "message": "expected thrown value 'hello' not to match asymmetric matcher: stringContainingCustom<ll>",
+}
+`;

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -297,3 +297,16 @@ stringContainingCustom<ll>
   "message": "expected error to match asymmetric matcher",
 }
 `;
+
+exports[`asymmetric matcher error 23`] = `
+{
+  "actual": "[Error: hello]",
+  "diff": "- Expected: 
+[Function MyError1]
+
++ Received: 
+[Error: hello]",
+  "expected": "[Function MyError1]",
+  "message": "expected error to be instance of MyError1",
+}
+`;

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -231,35 +231,69 @@ exports[`asymmetric matcher error 16`] = `
 exports[`asymmetric matcher error 17`] = `
 {
   "actual": "hello",
-  "diff": undefined,
+  "diff": null,
   "expected": "StringContaining "xx"",
-  "message": "expected thrown value 'hello' to match asymmetric matcher: StringContaining "xx"",
+  "message": "expected error to match asymmetric matcher",
 }
 `;
 
 exports[`asymmetric matcher error 18`] = `
 {
   "actual": "hello",
-  "diff": undefined,
+  "diff": "- Expected: 
+stringContainingCustom<xx>
+
++ Received: 
+"hello"",
   "expected": "stringContainingCustom<xx>",
-  "message": "expected thrown value 'hello' to match asymmetric matcher: stringContainingCustom<xx>",
+  "message": "expected error to match asymmetric matcher",
 }
 `;
 
 exports[`asymmetric matcher error 19`] = `
 {
   "actual": "hello",
-  "diff": undefined,
+  "diff": null,
   "expected": "StringContaining "ll"",
-  "message": "expected thrown value 'hello' not to match asymmetric matcher: StringContaining "ll"",
+  "message": "expected error not to match asymmetric matcher",
 }
 `;
 
 exports[`asymmetric matcher error 20`] = `
 {
   "actual": "hello",
-  "diff": undefined,
+  "diff": "- Expected: 
+stringContainingCustom<ll>
+
++ Received: 
+"hello"",
   "expected": "stringContainingCustom<ll>",
-  "message": "expected thrown value 'hello' not to match asymmetric matcher: stringContainingCustom<ll>",
+  "message": "expected error not to match asymmetric matcher",
+}
+`;
+
+exports[`asymmetric matcher error 21`] = `
+{
+  "actual": "[Error: hello]",
+  "diff": "- Expected: 
+StringContaining "ll"
+
++ Received: 
+[Error: hello]",
+  "expected": "StringContaining "ll"",
+  "message": "expected error to match asymmetric matcher",
+}
+`;
+
+exports[`asymmetric matcher error 22`] = `
+{
+  "actual": "[Error: hello]",
+  "diff": "- Expected: 
+stringContainingCustom<ll>
+
++ Received: 
+[Error: hello]",
+  "expected": "stringContainingCustom<ll>",
+  "message": "expected error to match asymmetric matcher",
 }
 `;

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1057,6 +1057,16 @@ it('asymmetric matcher error', () => {
 
   // simple truncation if pretty-format is too long
   snapshotError(() => expect('hello').toEqual(expect.stringContaining('a'.repeat(40))))
+
+  // error message on `toThrow(asymmetricMatcher)` failure
+  function throwError() {
+    // eslint-disable-next-line no-throw-literal
+    throw 'hello'
+  }
+  snapshotError(() => expect(throwError).toThrow(expect.stringContaining('xx')))
+  snapshotError(() => expect(throwError).toThrow((expect as any).stringContainingCustom('xx')))
+  snapshotError(() => expect(throwError).not.toThrow(expect.stringContaining('ll')))
+  snapshotError(() => expect(throwError).not.toThrow((expect as any).stringContainingCustom('ll')))
 })
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, 500)))

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1067,6 +1067,13 @@ it('asymmetric matcher error', () => {
   snapshotError(() => expect(throwError).toThrow((expect as any).stringContainingCustom('xx')))
   snapshotError(() => expect(throwError).not.toThrow(expect.stringContaining('ll')))
   snapshotError(() => expect(throwError).not.toThrow((expect as any).stringContainingCustom('ll')))
+
+  snapshotError(() => expect(() => {
+    throw new Error('hello')
+  }).toThrow(expect.stringContaining('ll')))
+  snapshotError(() => expect(() => {
+    throw new Error('hello')
+  }).toThrow((expect as any).stringContainingCustom('ll')))
 })
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, 500)))

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1074,6 +1074,14 @@ it('asymmetric matcher error', () => {
   snapshotError(() => expect(() => {
     throw new Error('hello')
   }).toThrow((expect as any).stringContainingCustom('ll')))
+
+  // error constructor
+  class MyError1 extends Error {}
+  class MyError2 extends Error {}
+
+  snapshotError(() => expect(() => {
+    throw new MyError2('hello')
+  }).toThrow(MyError1))
 })
 
 it('timeout', () => new Promise(resolve => setTimeout(resolve, 500)))


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4093
- Follow up https://github.com/vitest-dev/vitest/pull/4942

Tiny improvement for rather minor use case, but I wanted to finish off that issue.

Jest example is in the same repro as the last PR:
- https://stackblitz.com/edit/github-o6sfsk?file=tests%2Fjest.test.cjs

```
    Message:
      expect(received).toThrow(expected)
    
    Expected asymmetric matcher: StringNotContaining "ll"
    
    Thrown value: "hello"
    

    Difference:

    Compared values have no visual difference.Error:

      67 |
      68 | test("throw error 4", () => {
    > 69 |   expect(() => { throw "hello" }).toThrow(expect.not.stringContaining("ll"))
         |                                   ^
      70 | })
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
