### PR TITLE
test: fix `stdin.test.ts` pattern

### DIFF
--- a/test/watch/test/stdin.test.ts
+++ b/test/watch/test/stdin.test.ts
@@ -47,7 +47,7 @@ test('filter by filename', async () => {
 
   vitest.write('math')
 
-  await vitest.waitForStdout('Pattern matches 1 results')
+  await vitest.waitForStdout('Pattern matches 1 result')
   await vitest.waitForStdout('› math.test.ts')
 
   vitest.write('\n')
@@ -64,7 +64,7 @@ test('filter by test name', async () => {
   await vitest.waitForStdout('Input test name pattern')
 
   vitest.write('sum')
-  await vitest.waitForStdout('Pattern matches 1 results')
+  await vitest.waitForStdout('Pattern matches 1 result')
   await vitest.waitForStdout('› sum')
 
   vitest.write('\n')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

This test keeps failing locally. 

https://github.com/vitest-dev/vitest/blob/6421c2766c364a9dd37dabac432f792ff1ecc556/packages/vitest/src/node/watch-filter.ts#L106

Likely related to https://github.com/vitest-dev/vitest/pull/4733/files#diff-0f89ba66a3f72adafc990980fd1ac9deadff8da24502087c72ef11545fdcd08bR106.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
