### PR TITLE
fix(vitest): strip ansi code from console output in junit reporter

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -5,6 +5,7 @@ import { dirname, relative, resolve } from 'pathe'
 import type { Task } from '@vitest/runner'
 import type { ErrorWithDiff } from '@vitest/utils'
 import { getSuites } from '@vitest/runner/utils'
+import stripAnsi from 'strip-ansi'
 import type { Vitest } from '../../node'
 import type { Reporter } from '../../types/reporter'
 import { parseErrorStacktrace } from '../../utils/source-map'
@@ -166,7 +167,7 @@ export class JUnitReporter implements Reporter {
 
     await this.writeElement(`system-${type}`, {}, async () => {
       for (const log of logs)
-        await this.baseLog(escapeXML(log.content))
+        await this.baseLog(escapeXML(stripAnsi(log.content)))
     })
   }
 

--- a/test/config/test/console-color.test.ts
+++ b/test/config/test/console-color.test.ts
@@ -26,3 +26,15 @@ test('without color', async () => {
   })
   expect(proc.stdout).toContain('\ntrue\n')
 })
+
+test('junit always strips ansi', async () => {
+  const proc = await execa('vitest', ['run', '--root=./fixtures/console-color', '--reporter', 'junit'], {
+    env: {
+      CI: '1',
+      FORCE_COLOR: '1',
+      NO_COLOR: undefined,
+      GITHUB_ACTIONS: undefined,
+    },
+  })
+  expect(proc.stdout).toMatch(/<system-out>\s*true\s*<\/system-out>/)
+})

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "NO_COLOR=1 vitest run"
+    "test": "vitest"
   },
   "devDependencies": {
     "flatted": "^3.2.9",

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -25,7 +25,7 @@ AssertionError: expected 2.23606797749979 to equal 2
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
-[33merror[39m
+error
             </system-err>
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
@@ -61,7 +61,7 @@ AssertionError: expected 2.23606797749979 to equal 2
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
-[33merror[39m
+error
             </system-err>
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
@@ -102,7 +102,7 @@ AssertionError: expected 2.23606797749979 to equal 2
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
-[33merror[39m
+error
             </system-err>
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
@@ -143,7 +143,7 @@ AssertionError: expected 2.23606797749979 to equal 2
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
-[33merror[39m
+error
             </system-err>
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
@@ -184,7 +184,7 @@ AssertionError: expected 2.23606797749979 to equal 2
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
-[33merror[39m
+error
             </system-err>
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">
@@ -225,7 +225,7 @@ AssertionError: expected 2.23606797749979 to equal 2
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; callback test success done(false)" time="0.0001923509">
             <system-err>
-[33merror[39m
+error
             </system-err>
         </testcase>
         <testcase classname="test/core/test/basic.test.ts" name="suite &gt; todo test" time="0">

--- a/test/reporters/tests/html.test.ts
+++ b/test/reporters/tests/html.test.ts
@@ -47,7 +47,9 @@ describe('html reporter', async () => {
     const metaJsonGzipped = fs.readFileSync(resolve(root, `${basePath}/html.meta.json.gz`))
     const metaJson = zlib.gunzipSync(metaJsonGzipped).toString('utf-8')
     const indexHtml = fs.readFileSync(resolve(root, `${basePath}/index.html`), { encoding: 'utf-8' })
-    const resultJson = parse(metaJson.replace(new RegExp(vitestRoot, 'g'), '<rootDir>'))
+    const resultJson = parse(metaJson.replace(new RegExp(vitestRoot, 'g'), '<rootDir>'), (_key, value) => {
+      return typeof value === 'string' ? stripAnsi(value) : value
+    })
     resultJson.config = {} // doesn't matter for a test
     const file = resultJson.files[0]
     file.id = 0


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4958

I'm not sure the need of preserving color for this logging output, so I propose to always strip it for junit without configuration to toggle color. Please let me know if this makes sense.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
