### PR TITLE
fix(coverage): remove `coverage/.tmp` files after run

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -235,10 +235,10 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
           },
         })
       }
-
-      this.coverageFiles = new Map()
-      await fs.rm(this.coverageFilesDirectory, { recursive: true })
     }
+
+    this.coverageFiles = new Map()
+    await fs.rm(this.coverageFilesDirectory, { recursive: true })
   }
 
   private async getUntestedFiles(testedFiles: string[]): Promise<RawCoverage> {

--- a/test/coverage-test/coverage-report-tests/generic.report.test.ts
+++ b/test/coverage-test/coverage-report-tests/generic.report.test.ts
@@ -184,3 +184,10 @@ test('multi environment coverage is merged correctly', async () => {
   // Condition covered by both tests
   expect(lineCoverage[30]).toBe(2)
 })
+
+test('temporary files are removed after test', async () => {
+  const coveragePath = resolve('./coverage')
+  const files = fs.readdirSync(coveragePath)
+
+  expect(files).not.toContain('.tmp')
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes bug where `coverage/.tmp` directory is left on file system after test run
- The `fs.rm` was accidentally inside `coverage.thresholds` check's if-block
- This is only on V8 provider. Istanbul provider does not have this issue
- Bug introduced in https://github.com/vitest-dev/vitest/pull/4603

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
