### PR TITLE
fix(vitest): allow `useFakeTimers` to fake `requestIdleCallback` on non browser

### DIFF
--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -141,7 +141,7 @@ export class FakeTimers {
         throw new Error('process.nextTick cannot be mocked inside child_process')
 
       // setImmediate/clearImmediate is not possible to mock when it's not globally avaiable and it throws an internal error.
-      // this might be sinonjs/fake-timers's bug and inconsistent behavior, but for now, we simply filter out these two for browser testing.
+      // this might be @sinonjs/fake-timers's bug and inconsistent behavior, but for now, we silently filter out these two beforehand for browser testing.
       // https://github.com/sinonjs/fake-timers/issues/277
       // https://github.com/sinonjs/sinon/issues/2085
       const existingFakedMethods = (this._userConfig?.toFake || toFake).filter((method) => {

--- a/test/core/test/fixtures/timers.suite.ts
+++ b/test/core/test/fixtures/timers.suite.ts
@@ -119,6 +119,21 @@ describe('FakeTimers', () => {
       timers.useFakeTimers()
       expect(global.clearImmediate).not.toBe(origClearImmediate)
     })
+
+    it('mocks requestIdleCallback even if not on global', () => {
+      const global = { Date: FakeDate, clearTimeout, setTimeout };
+      const timers = new FakeTimers({ global, config: { toFake: ["requestIdleCallback"] }})
+      timers.useFakeTimers()
+      expect(global.requestIdleCallback).toBeDefined();
+    })
+
+    it('cannot mock setImmediate and clearImmediate if not on global', () => {
+      const global = { Date: FakeDate, clearTimeout, setTimeout };
+      const timers = new FakeTimers({ global, config: { toFake: ["setImmediate", "clearImmediate"] }})
+      timers.useFakeTimers()
+      expect(global.setImmediate).toBeUndefined();
+      expect(global.clearImmediate).toBeUndefined();
+    })
   })
 
   describe('runAllTicks', () => {


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5027

It seems `@sinonjs/fake-timers` (inconsistently) supports faking certain timer API even when not globally available. Strict filtering for `toFake` is added in https://github.com/vitest-dev/vitest/pull/4992 for browser tests, but it looks like only `setImmediate` and `clearImmediate` have odd behavior (probably https://github.com/sinonjs/fake-timers/issues/277) and faking `requestIdleCallback` was still possible on NodeJs where it's not available natively. I found either `jsdom` or `happy-dom` exposes this, so I think it's reasonable to allow faking `requestIdleCallback` for non-browser mode testing.

I couldn't see a strong reason for filtering out except `setImmediate/clearImmediate` on Vitest side. Please let me know if I miss something purposely done in https://github.com/vitest-dev/vitest/pull/4992.

Silently filtering would not be ideal, so maybe it would be better to not include `setImmediate/clearImmediate` as a default when browser tests are running, then throw an error if unsupported `toFake` is explicitly provided by the user. But this seems currently tricky since config defaults are decided quite early to be aware of pool specific behavior.

https://github.com/vitest-dev/vitest/blob/15c354cbd6ef7e8f8beb1bb5283f829fa41e70c1/packages/vitest/src/defaults.ts#L57-L58

_todo_

- does `jsdom/happy-dom` expose `requestIdleCallback`? (no, they don't)
- fix default `toFake` for browser pool? (looks tricky since config defaults is decided quite early. try restructuring it later.)
- check other inconsistency of `@sinonjs/fake-timers` and report upstream
  - https://github.com/sinonjs/fake-timers/issues/490
- discuss whether stricter behavior is desired (i.e. don't allow fake if not available in environment)
  - `@sinonjs/fake-timers` already silently ignores `toFake` in some cases

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
