### PR TITLE
feat(browser): run test files in isolated iframes

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1518,7 +1518,21 @@ Run the browser in a `headless` mode. If you are running Vitest in CI, it will b
 - **Default:** `true`
 - **CLI:** `--browser.isolate`, `--browser.isolate=false`
 
-Isolate test environment after each test.
+Run every test in a separate iframe.
+
+### browser.fileParallelism <Badge type="info">1.3.0+</Badge>
+
+- **Type:** `boolean`
+- **Default:** the same as [`fileParallelism`](#fileparallelism-110)
+- **CLI:** `--browser.fileParallelism=false`
+
+Create all test iframes at the same time so they are running in parallel.
+
+This makes it impossible to use interactive APIs (like clicking or hovering) because there are several iframes on the screen at the same time, but if your tests don't rely on those APIs, it might be much faster to just run all of them at the same time.
+
+::: tip
+If you disabled isolation via [`browser.isolate=false`](#browserisolate), your test files will still run one after another because of the nature of the test runner.
+:::
 
 #### browser.api
 

--- a/packages/browser/src/client/client.ts
+++ b/packages/browser/src/client/client.ts
@@ -1,0 +1,21 @@
+import type { CancelReason } from '@vitest/runner'
+import { createClient } from '@vitest/ws-client'
+
+export const PORT = import.meta.hot ? '51204' : location.port
+export const HOST = [location.hostname, PORT].filter(Boolean).join(':')
+export const ENTRY_URL = `${
+  location.protocol === 'https:' ? 'wss:' : 'ws:'
+}//${HOST}/__vitest_api__`
+
+let setCancel = (_: CancelReason) => {}
+export const onCancel = new Promise<CancelReason>((resolve) => {
+  setCancel = resolve
+})
+
+export const client = createClient(ENTRY_URL, {
+  handlers: {
+    onCancel: setCancel,
+  },
+})
+
+export const channel = new BroadcastChannel('vitest')

--- a/packages/browser/src/client/logger.ts
+++ b/packages/browser/src/client/logger.ts
@@ -3,8 +3,8 @@ import { importId } from './utils'
 
 const { Date, console } = globalThis
 
-export async function setupConsoleLogSpy(basePath: string) {
-  const { stringify, format, inspect } = await importId('vitest/utils', basePath) as typeof import('vitest/utils')
+export async function setupConsoleLogSpy() {
+  const { stringify, format, inspect } = await importId('vitest/utils') as typeof import('vitest/utils')
   const { log, info, error, dir, dirxml, trace, time, timeEnd, timeLog, warn, debug, count, countReset } = console
   const formatInput = (input: unknown) => {
     if (input instanceof Node)

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -1,284 +1,304 @@
-import { createClient } from '@vitest/ws-client'
-import type { ResolvedConfig } from 'vitest'
-import type { CancelReason, VitestRunner } from '@vitest/runner'
-import { parseRegexp } from '@vitest/utils'
-import type { VitestExecutor } from '../../../vitest/src/runtime/execute'
-import { createBrowserRunner } from './runner'
-import { importId as _importId } from './utils'
-import { setupConsoleLogSpy } from './logger'
-import { createSafeRpc, rpc, rpcDone } from './rpc'
-import { setupDialogsSpy } from './dialog'
-import { BrowserSnapshotEnvironment } from './snapshot'
-import { VitestBrowserClientMocker } from './mocker'
-
-export const PORT = import.meta.hot ? '51204' : location.port
-export const HOST = [location.hostname, PORT].filter(Boolean).join(':')
-export const ENTRY_URL = `${
-  location.protocol === 'https:' ? 'wss:' : 'ws:'
-}//${HOST}/__vitest_api__`
-
-let config: ResolvedConfig | undefined
-let runner: VitestRunner | undefined
-const browserHashMap = new Map<string, [test: boolean, timestamp: string]>()
+import { channel, client } from './client'
 
 const url = new URL(location.href)
-const testId = url.searchParams.get('id') || 'unknown'
-const reloadTries = Number(url.searchParams.get('reloadTries') || '0')
+const testId = url.searchParams.get('__vitest_id')!
+const testLength = Number(url.searchParams.get('__vitest_length') || 0)
 
-const basePath = () => config?.base || '/'
-const importId = (id: string) => _importId(id, basePath())
-const viteClientPath = () => `${basePath()}@vite/client`
+const iframes = new Map<number, HTMLIFrameElement>()
 
-function getQueryPaths() {
-  return url.searchParams.getAll('path')
-}
+client.ws.addEventListener('open', async () => {
+  const container = document.querySelector('#vitest-tester') as HTMLDivElement
+  const now = `${new Date().getTime()}`
 
-let setCancel = (_: CancelReason) => {}
-const onCancel = new Promise<CancelReason>((resolve) => {
-  setCancel = resolve
-})
+  const done = new Set<string>()
+  channel.addEventListener('message', async (e) => {
+    if (e.data.type === 'done') {
+      const filename = e.data.filename
+      if (!filename)
+        return
+      done.add(filename)
 
-export const client = createClient(ENTRY_URL, {
-  handlers: {
-    onCancel: setCancel,
-  },
-})
-
-const ws = client.ws
-
-async function loadConfig() {
-  let retries = 5
-  do {
-    try {
-      await new Promise(resolve => setTimeout(resolve, 150))
-      config = await client.rpc.getConfig()
-      config = unwrapConfig(config)
-      return
+      if (done.size === testLength)
+        await client.rpc.onDone(testId)
     }
-    catch (_) {
-      // just ignore
-    }
-  }
-  while (--retries > 0)
-
-  throw new Error('cannot load configuration after 5 retries')
-}
-
-function unwrapConfig(config: ResolvedConfig): ResolvedConfig {
-  return {
-    ...config,
-    // workaround RegExp serialization
-    testNamePattern:
-      config.testNamePattern
-        ? parseRegexp((config.testNamePattern as any as string))
-        : undefined,
-  }
-}
-
-function on(event: string, listener: (...args: any[]) => void) {
-  window.addEventListener(event, listener)
-  return () => window.removeEventListener(event, listener)
-}
-
-function serializeError(unhandledError: any) {
-  return {
-    ...unhandledError,
-    name: unhandledError.name,
-    message: unhandledError.message,
-    stack: String(unhandledError.stack),
-  }
-}
-
-// we can't import "processError" yet because error might've been thrown before the module was loaded
-async function defaultErrorReport(type: string, unhandledError: any) {
-  const error = serializeError(unhandledError)
-  if (testId !== 'no-isolate')
-    error.VITEST_TEST_PATH = testId
-  await client.rpc.onUnhandledError(error, type)
-  await client.rpc.onDone(testId)
-}
-
-function catchWindowErrors(cb: (e: ErrorEvent) => void) {
-  let userErrorListenerCount = 0
-  function throwUnhandlerError(e: ErrorEvent) {
-    if (userErrorListenerCount === 0 && e.error != null)
-      cb(e)
-    else
-      console.error(e.error)
-  }
-  const addEventListener = window.addEventListener.bind(window)
-  const removeEventListener = window.removeEventListener.bind(window)
-  window.addEventListener('error', throwUnhandlerError)
-  window.addEventListener = function (...args: Parameters<typeof addEventListener>) {
-    if (args[0] === 'error')
-      userErrorListenerCount++
-    return addEventListener.apply(this, args)
-  }
-  window.removeEventListener = function (...args: Parameters<typeof removeEventListener>) {
-    if (args[0] === 'error' && userErrorListenerCount)
-      userErrorListenerCount--
-    return removeEventListener.apply(this, args)
-  }
-  return function clearErrorHandlers() {
-    window.removeEventListener('error', throwUnhandlerError)
-  }
-}
-
-const stopErrorHandler = catchWindowErrors(e => defaultErrorReport('Error', e.error))
-const stopRejectionHandler = on('unhandledrejection', e => defaultErrorReport('Unhandled Rejection', e.reason))
-
-let runningTests = false
-
-async function reportUnexpectedError(rpc: typeof client.rpc, type: string, error: any) {
-  const { processError } = await importId('vitest/browser') as typeof import('vitest/browser')
-  const processedError = processError(error)
-  if (testId !== 'no-isolate')
-    error.VITEST_TEST_PATH = testId
-  await rpc.onUnhandledError(processedError, type)
-  if (!runningTests)
-    await rpc.onDone(testId)
-}
-
-ws.addEventListener('open', async () => {
-  await loadConfig()
-
-  let safeRpc: typeof client.rpc
-  try {
-    // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
-    const { getSafeTimers } = await importId('vitest/utils') as typeof import('vitest/utils')
-    safeRpc = createSafeRpc(client, getSafeTimers)
-  }
-  catch (err: any) {
-    if (reloadTries >= 10) {
-      const error = serializeError(new Error('Vitest failed to load "vitest/utils" after 10 retries.'))
-      error.cause = serializeError(err)
-
-      await client.rpc.onUnhandledError(error, 'Reload Error')
-      await client.rpc.onDone(testId)
-      return
-    }
-
-    const tries = reloadTries + 1
-    const newUrl = new URL(location.href)
-    newUrl.searchParams.set('reloadTries', String(tries))
-    location.href = newUrl.href
-    return
-  }
-
-  stopErrorHandler()
-  stopRejectionHandler()
-
-  catchWindowErrors(event => reportUnexpectedError(safeRpc, 'Error', event.error))
-  on('unhandledrejection', event => reportUnexpectedError(safeRpc, 'Unhandled Rejection', event.reason))
-
-  // @ts-expect-error untyped global for internal use
-  globalThis.__vitest_browser__ = true
-  // @ts-expect-error mocking vitest apis
-  globalThis.__vitest_worker__ = {
-    config,
-    browserHashMap,
-    environment: {
-      name: 'browser',
-    },
-    // @ts-expect-error untyped global for internal use
-    moduleCache: globalThis.__vi_module_cache__,
-    rpc: client.rpc,
-    safeRpc,
-    durations: {
-      environment: 0,
-      prepare: 0,
-    },
-    providedContext: await client.rpc.getProvidedContext(),
-  }
-  // @ts-expect-error mocking vitest apis
-  globalThis.__vitest_mocker__ = new VitestBrowserClientMocker()
-
-  const paths = getQueryPaths()
-
-  const iFrame = document.getElementById('vitest-ui') as HTMLIFrameElement
-  iFrame.setAttribute('src', '/__vitest__/')
-
-  await setupConsoleLogSpy(basePath())
-  setupDialogsSpy()
-  await runTests(paths, config!)
-})
-
-async function prepareTestEnvironment(config: ResolvedConfig) {
-  // need to import it before any other import, otherwise Vite optimizer will hang
-  await import(viteClientPath())
-
-  const {
-    startTests,
-    setupCommonEnv,
-    loadDiffConfig,
-    loadSnapshotSerializers,
-    takeCoverageInsideWorker,
-  } = await importId('vitest/browser') as typeof import('vitest/browser')
-
-  const executor = {
-    executeId: (id: string) => importId(id),
-  }
-
-  if (!runner) {
-    const { VitestTestRunner } = await importId('vitest/runners') as typeof import('vitest/runners')
-    const BrowserRunner = createBrowserRunner(VitestTestRunner, { takeCoverage: () => takeCoverageInsideWorker(config.coverage, executor) })
-    runner = new BrowserRunner({ config, browserHashMap })
-  }
-
-  return {
-    startTests,
-    setupCommonEnv,
-    loadDiffConfig,
-    loadSnapshotSerializers,
-    executor,
-    runner,
-  }
-}
-
-async function runTests(paths: string[], config: ResolvedConfig) {
-  let preparedData: Awaited<ReturnType<typeof prepareTestEnvironment>> | undefined
-  // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
-  try {
-    preparedData = await prepareTestEnvironment(config)
-  }
-  catch (err) {
-    location.reload()
-    return
-  }
-
-  const { startTests, setupCommonEnv, loadDiffConfig, loadSnapshotSerializers, executor, runner } = preparedData!
-
-  onCancel.then((reason) => {
-    runner?.onCancel?.(reason)
   })
 
-  if (!config.snapshotOptions.snapshotEnvironment)
-    config.snapshotOptions.snapshotEnvironment = new BrowserSnapshotEnvironment()
+  for (let index = 0; index < testLength; index++) {
+    if (iframes.has(index)) {
+      container.removeChild(iframes.get(index)!)
+      iframes.delete(index)
+    }
 
-  try {
-    const [diffOptions] = await Promise.all([
-      loadDiffConfig(config, executor as VitestExecutor),
-      loadSnapshotSerializers(config, executor as VitestExecutor),
-    ])
-    runner.config.diffOptions = diffOptions
-
-    await setupCommonEnv(config)
-    const files = paths.map((path) => {
-      return (`${config.root}/${path}`).replace(/\/+/g, '/')
-    })
-
-    const now = `${new Date().getTime()}`
-    files.forEach(i => browserHashMap.set(i, [true, now]))
-
-    runningTests = true
-
-    for (const file of files)
-      await startTests([file], runner)
+    const iframe = document.createElement('iframe')
+    iframe.setAttribute('loading', 'eager')
+    iframe.setAttribute('src', `${url.pathname}__vitest_test__/tester.html?__vitest_index=${index}&__vitest_id=${testId}&browserv=${now}`)
+    iframes.set(index, iframe)
+    container.appendChild(iframe)
   }
-  finally {
-    runningTests = false
+})
 
-    await rpcDone()
-    await rpc().onDone(testId)
-  }
-}
+// export const PORT = import.meta.hot ? '51204' : location.port
+// export const HOST = [location.hostname, PORT].filter(Boolean).join(':')
+// export const ENTRY_URL = `${
+//   location.protocol === 'https:' ? 'wss:' : 'ws:'
+// }//${HOST}/__vitest_api__`
+
+// let config: ResolvedConfig | undefined
+// let runner: VitestRunner | undefined
+// const browserHashMap = new Map<string, [test: boolean, timestamp: string]>()
+
+//
+// const testId = url.searchParams.get('id') || 'unknown'
+// const reloadTries = Number(url.searchParams.get('reloadTries') || '0')
+
+// const basePath = () => config?.base || '/'
+// const importId = (id: string) => _importId(id, basePath())
+// const viteClientPath = () => `${basePath()}@vite/client`
+
+// function getQueryPaths() {
+//   return url.searchParams.getAll('path')
+// }
+
+// let setCancel = (_: CancelReason) => {}
+// const onCancel = new Promise<CancelReason>((resolve) => {
+//   setCancel = resolve
+// })
+
+// export const client = createClient(ENTRY_URL, {
+//   handlers: {
+//     onCancel: setCancel,
+//   },
+// })
+
+// const ws = client.ws
+
+// async function loadConfig() {
+//   let retries = 5
+//   do {
+//     try {
+//       await new Promise(resolve => setTimeout(resolve, 150))
+//       config = await client.rpc.getConfig()
+//       config = unwrapConfig(config)
+//       return
+//     }
+//     catch (_) {
+//       // just ignore
+//     }
+//   }
+//   while (--retries > 0)
+
+//   throw new Error('cannot load configuration after 5 retries')
+// }
+
+// function unwrapConfig(config: ResolvedConfig): ResolvedConfig {
+//   return {
+//     ...config,
+//     // workaround RegExp serialization
+//     testNamePattern:
+//       config.testNamePattern
+//         ? parseRegexp((config.testNamePattern as any as string))
+//         : undefined,
+//   }
+// }
+
+// function on(event: string, listener: (...args: any[]) => void) {
+//   window.addEventListener(event, listener)
+//   return () => window.removeEventListener(event, listener)
+// }
+
+// function serializeError(unhandledError: any) {
+//   return {
+//     ...unhandledError,
+//     name: unhandledError.name,
+//     message: unhandledError.message,
+//     stack: String(unhandledError.stack),
+//   }
+// }
+
+// // we can't import "processError" yet because error might've been thrown before the module was loaded
+// async function defaultErrorReport(type: string, unhandledError: any) {
+//   const error = serializeError(unhandledError)
+//   if (testId !== 'no-isolate')
+//     error.VITEST_TEST_PATH = testId
+//   await client.rpc.onUnhandledError(error, type)
+//   await client.rpc.onDone(testId)
+// }
+
+// function catchWindowErrors(cb: (e: ErrorEvent) => void) {
+//   let userErrorListenerCount = 0
+//   function throwUnhandlerError(e: ErrorEvent) {
+//     if (userErrorListenerCount === 0 && e.error != null)
+//       cb(e)
+//     else
+//       console.error(e.error)
+//   }
+//   const addEventListener = window.addEventListener.bind(window)
+//   const removeEventListener = window.removeEventListener.bind(window)
+//   window.addEventListener('error', throwUnhandlerError)
+//   window.addEventListener = function (...args: Parameters<typeof addEventListener>) {
+//     if (args[0] === 'error')
+//       userErrorListenerCount++
+//     return addEventListener.apply(this, args)
+//   }
+//   window.removeEventListener = function (...args: Parameters<typeof removeEventListener>) {
+//     if (args[0] === 'error' && userErrorListenerCount)
+//       userErrorListenerCount--
+//     return removeEventListener.apply(this, args)
+//   }
+//   return function clearErrorHandlers() {
+//     window.removeEventListener('error', throwUnhandlerError)
+//   }
+// }
+
+// const stopErrorHandler = catchWindowErrors(e => defaultErrorReport('Error', e.error))
+// const stopRejectionHandler = on('unhandledrejection', e => defaultErrorReport('Unhandled Rejection', e.reason))
+
+// let runningTests = false
+
+// async function reportUnexpectedError(rpc: typeof client.rpc, type: string, error: any) {
+//   const { processError } = await importId('vitest/browser') as typeof import('vitest/browser')
+//   const processedError = processError(error)
+//   if (testId !== 'no-isolate')
+//     error.VITEST_TEST_PATH = testId
+//   await rpc.onUnhandledError(processedError, type)
+//   if (!runningTests)
+//     await rpc.onDone(testId)
+// }
+
+// ws.addEventListener('open', async () => {
+//   await loadConfig()
+
+//   let safeRpc: typeof client.rpc
+//   try {
+//     // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
+//     const { getSafeTimers } = await importId('vitest/utils') as typeof import('vitest/utils')
+//     safeRpc = createSafeRpc(client, getSafeTimers)
+//   }
+//   catch (err: any) {
+//     if (reloadTries >= 10) {
+//       const error = serializeError(new Error('Vitest failed to load "vitest/utils" after 10 retries.'))
+//       error.cause = serializeError(err)
+
+//       await client.rpc.onUnhandledError(error, 'Reload Error')
+//       await client.rpc.onDone(testId)
+//       return
+//     }
+
+//     const tries = reloadTries + 1
+//     const newUrl = new URL(location.href)
+//     newUrl.searchParams.set('reloadTries', String(tries))
+//     location.href = newUrl.href
+//     return
+//   }
+
+//   stopErrorHandler()
+//   stopRejectionHandler()
+
+// catchWindowErrors(event => reportUnexpectedError(safeRpc, 'Error', event.error))
+// on('unhandledrejection', event => reportUnexpectedError(safeRpc, 'Unhandled Rejection', event.reason))
+
+//   // @ts-expect-error untyped global for internal use
+//   globalThis.__vitest_browser__ = true
+//   // @ts-expect-error mocking vitest apis
+//   globalThis.__vitest_worker__ = {
+//     config,
+//     browserHashMap,
+//     environment: {
+//       name: 'browser',
+//     },
+//     // @ts-expect-error untyped global for internal use
+//     moduleCache: globalThis.__vi_module_cache__,
+//     rpc: client.rpc,
+//     safeRpc,
+//     durations: {
+//       environment: 0,
+//       prepare: 0,
+//     },
+//     providedContext: await client.rpc.getProvidedContext(),
+//   }
+//   // @ts-expect-error mocking vitest apis
+//   globalThis.__vitest_mocker__ = new VitestBrowserClientMocker()
+
+//   const paths = getQueryPaths()
+
+//   const iFrame = document.getElementById('vitest-ui') as HTMLIFrameElement
+//   iFrame.setAttribute('src', '/__vitest__/')
+
+//   await setupConsoleLogSpy(basePath())
+//   setupDialogsSpy()
+//   await runTests(paths, config!)
+// })
+
+// async function prepareTestEnvironment(config: ResolvedConfig) {
+//   // need to import it before any other import, otherwise Vite optimizer will hang
+//   await import(viteClientPath())
+
+//   const {
+//     startTests,
+//     setupCommonEnv,
+//     loadDiffConfig,
+//     takeCoverageInsideWorker,
+//   } = await importId('vitest/browser') as typeof import('vitest/browser')
+
+//   const executor = {
+//     executeId: (id: string) => importId(id),
+//   }
+
+//   if (!runner) {
+//     const { VitestTestRunner } = await importId('vitest/runners') as typeof import('vitest/runners')
+//     const BrowserRunner = createBrowserRunner(VitestTestRunner, { takeCoverage: () => takeCoverageInsideWorker(config.coverage, executor) })
+//     runner = new BrowserRunner({ config, browserHashMap })
+//   }
+
+//   return {
+//     startTests,
+//     setupCommonEnv,
+//     loadDiffConfig,
+//     executor,
+//     runner,
+//   }
+// }
+
+// async function runTests(paths: string[], config: ResolvedConfig) {
+//   let preparedData: Awaited<ReturnType<typeof prepareTestEnvironment>> | undefined
+//   // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
+//   try {
+//     preparedData = await prepareTestEnvironment(config)
+//   }
+//   catch (err) {
+//     location.reload()
+//     return
+//   }
+
+//   const { startTests, setupCommonEnv, loadDiffConfig, executor, runner } = preparedData!
+
+//   onCancel.then((reason) => {
+//     runner?.onCancel?.(reason)
+//   })
+
+//   if (!config.snapshotOptions.snapshotEnvironment)
+//     config.snapshotOptions.snapshotEnvironment = new BrowserSnapshotEnvironment()
+
+//   try {
+//     runner.config.diffOptions = await loadDiffConfig(config, executor as VitestExecutor)
+
+//     await setupCommonEnv(config)
+//     const files = paths.map((path) => {
+//       return (`${config.root}/${path}`).replace(/\/+/g, '/')
+//     })
+
+//     const now = `${new Date().getTime()}`
+//     files.forEach(i => browserHashMap.set(i, [true, now]))
+
+//     runningTests = true
+
+//     for (const file of files)
+//       await startTests([file], runner)
+//   }
+//   finally {
+//     runningTests = false
+
+//     await rpcDone()
+//     await rpc().onDone(testId)
+//   }
+// }

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -1,6 +1,6 @@
 import { channel, client } from './client'
 import { rpcDone } from './rpc'
-import { getConfig } from './utils'
+import { getBrowserState, getConfig } from './utils'
 
 const url = new URL(location.href)
 
@@ -45,18 +45,12 @@ interface IframeErrorEvent {
   files: string[]
 }
 
-interface IframeInvalidEvent {
-  type: 'invalid'
-  id: number
-}
-
-type IframeChannelEvent = IframeDoneEvent | IframeErrorEvent | IframeInvalidEvent
+type IframeChannelEvent = IframeDoneEvent | IframeErrorEvent
 
 client.ws.addEventListener('open', async () => {
   const config = getConfig()
   const container = document.querySelector('#vitest-tester') as HTMLDivElement
-  // @ts-expect-error this is set in injector
-  const testFiles = window.__vi_files__ as string[]
+  const testFiles = getBrowserState().files
 
   debug('test files', testFiles.join(', '))
 

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -1,304 +1,120 @@
 import { channel, client } from './client'
+import { rpcDone } from './rpc'
+import { getConfig } from './utils'
 
 const url = new URL(location.href)
-const testId = url.searchParams.get('__vitest_id')!
-const testLength = Number(url.searchParams.get('__vitest_length') || 0)
 
-const iframes = new Map<number, HTMLIFrameElement>()
+const ID_ALL = '__vitest_all__'
+
+const iframes = new Map<string, HTMLIFrameElement>()
+
+function debug(...args: unknown[]) {
+  const debug = getConfig().env.VITEST_BROWSER_DEBUG
+  if (debug && debug !== 'false')
+    client.rpc.debug(...args.map(String))
+}
+
+function createIframe(container: HTMLDivElement, file: string) {
+  if (iframes.has(file)) {
+    container.removeChild(iframes.get(file)!)
+    iframes.delete(file)
+  }
+
+  const iframe = document.createElement('iframe')
+  iframe.setAttribute('loading', 'eager')
+  iframe.setAttribute('src', `${url.pathname}__vitest_test__/__test__/${encodeURIComponent(file)}`)
+  iframes.set(file, iframe)
+  container.appendChild(iframe)
+  return iframe
+}
+
+async function done() {
+  await rpcDone()
+  await client.rpc.finishBrowserTests()
+}
+
+interface IframeDoneEvent {
+  type: 'done'
+  filenames: string[]
+}
+
+interface IframeErrorEvent {
+  type: 'error'
+  error: any
+  errorType: string
+  files: string[]
+}
+
+interface IframeInvalidEvent {
+  type: 'invalid'
+  id: number
+}
+
+type IframeChannelEvent = IframeDoneEvent | IframeErrorEvent | IframeInvalidEvent
 
 client.ws.addEventListener('open', async () => {
+  const config = getConfig()
   const container = document.querySelector('#vitest-tester') as HTMLDivElement
-  const now = `${new Date().getTime()}`
+  // @ts-expect-error this is set in injector
+  const testFiles = window.__vi_files__ as string[]
 
-  const done = new Set<string>()
-  channel.addEventListener('message', async (e) => {
-    if (e.data.type === 'done') {
-      const filename = e.data.filename
-      if (!filename)
-        return
-      done.add(filename)
+  debug('test files', testFiles.join(', '))
 
-      if (done.size === testLength)
-        await client.rpc.onDone(testId)
+  // TODO: fail tests suite because no tests found?
+  if (!testFiles.length) {
+    await done()
+    return
+  }
+
+  const runningFiles = new Set<string>(testFiles)
+
+  channel.addEventListener('message', async (e: MessageEvent<IframeChannelEvent>): Promise<void> => {
+    debug('channel event', JSON.stringify(e.data))
+    switch (e.data.type) {
+      case 'done': {
+        const filenames = e.data.filenames
+        filenames.forEach(filename => runningFiles.delete(filename))
+
+        if (!runningFiles.size)
+          await done()
+        break
+      }
+      // error happened at the top level, this should never happen in user code, but it can trigger during development
+      case 'error': {
+        const iframeId = e.data.files.length > 1 ? ID_ALL : e.data.files[0]
+        iframes.delete(iframeId)
+        await client.rpc.onUnhandledError(e.data.error, e.data.errorType)
+        if (iframeId === ID_ALL)
+          runningFiles.clear()
+        else
+          runningFiles.delete(iframeId)
+        if (!runningFiles.size)
+          await done()
+        break
+      }
+      default: {
+        await client.rpc.onUnhandledError({
+          name: 'Unexpected Event',
+          message: `Unexpected event: ${(e.data as any).type}`,
+        }, 'Unexpected Event')
+        await done()
+      }
     }
   })
 
-  for (let index = 0; index < testLength; index++) {
-    if (iframes.has(index)) {
-      container.removeChild(iframes.get(index)!)
-      iframes.delete(index)
+  if (config.isolate === false) {
+    createIframe(
+      container,
+      ID_ALL,
+    )
+  }
+  else {
+    // TODO: if cofnig.fileParallelism, then at the same time, otherwise one after another
+    for (const file of testFiles) {
+      createIframe(
+        container,
+        file,
+      )
     }
-
-    const iframe = document.createElement('iframe')
-    iframe.setAttribute('loading', 'eager')
-    iframe.setAttribute('src', `${url.pathname}__vitest_test__/tester.html?__vitest_index=${index}&__vitest_id=${testId}&browserv=${now}`)
-    iframes.set(index, iframe)
-    container.appendChild(iframe)
   }
 })
-
-// export const PORT = import.meta.hot ? '51204' : location.port
-// export const HOST = [location.hostname, PORT].filter(Boolean).join(':')
-// export const ENTRY_URL = `${
-//   location.protocol === 'https:' ? 'wss:' : 'ws:'
-// }//${HOST}/__vitest_api__`
-
-// let config: ResolvedConfig | undefined
-// let runner: VitestRunner | undefined
-// const browserHashMap = new Map<string, [test: boolean, timestamp: string]>()
-
-//
-// const testId = url.searchParams.get('id') || 'unknown'
-// const reloadTries = Number(url.searchParams.get('reloadTries') || '0')
-
-// const basePath = () => config?.base || '/'
-// const importId = (id: string) => _importId(id, basePath())
-// const viteClientPath = () => `${basePath()}@vite/client`
-
-// function getQueryPaths() {
-//   return url.searchParams.getAll('path')
-// }
-
-// let setCancel = (_: CancelReason) => {}
-// const onCancel = new Promise<CancelReason>((resolve) => {
-//   setCancel = resolve
-// })
-
-// export const client = createClient(ENTRY_URL, {
-//   handlers: {
-//     onCancel: setCancel,
-//   },
-// })
-
-// const ws = client.ws
-
-// async function loadConfig() {
-//   let retries = 5
-//   do {
-//     try {
-//       await new Promise(resolve => setTimeout(resolve, 150))
-//       config = await client.rpc.getConfig()
-//       config = unwrapConfig(config)
-//       return
-//     }
-//     catch (_) {
-//       // just ignore
-//     }
-//   }
-//   while (--retries > 0)
-
-//   throw new Error('cannot load configuration after 5 retries')
-// }
-
-// function unwrapConfig(config: ResolvedConfig): ResolvedConfig {
-//   return {
-//     ...config,
-//     // workaround RegExp serialization
-//     testNamePattern:
-//       config.testNamePattern
-//         ? parseRegexp((config.testNamePattern as any as string))
-//         : undefined,
-//   }
-// }
-
-// function on(event: string, listener: (...args: any[]) => void) {
-//   window.addEventListener(event, listener)
-//   return () => window.removeEventListener(event, listener)
-// }
-
-// function serializeError(unhandledError: any) {
-//   return {
-//     ...unhandledError,
-//     name: unhandledError.name,
-//     message: unhandledError.message,
-//     stack: String(unhandledError.stack),
-//   }
-// }
-
-// // we can't import "processError" yet because error might've been thrown before the module was loaded
-// async function defaultErrorReport(type: string, unhandledError: any) {
-//   const error = serializeError(unhandledError)
-//   if (testId !== 'no-isolate')
-//     error.VITEST_TEST_PATH = testId
-//   await client.rpc.onUnhandledError(error, type)
-//   await client.rpc.onDone(testId)
-// }
-
-// function catchWindowErrors(cb: (e: ErrorEvent) => void) {
-//   let userErrorListenerCount = 0
-//   function throwUnhandlerError(e: ErrorEvent) {
-//     if (userErrorListenerCount === 0 && e.error != null)
-//       cb(e)
-//     else
-//       console.error(e.error)
-//   }
-//   const addEventListener = window.addEventListener.bind(window)
-//   const removeEventListener = window.removeEventListener.bind(window)
-//   window.addEventListener('error', throwUnhandlerError)
-//   window.addEventListener = function (...args: Parameters<typeof addEventListener>) {
-//     if (args[0] === 'error')
-//       userErrorListenerCount++
-//     return addEventListener.apply(this, args)
-//   }
-//   window.removeEventListener = function (...args: Parameters<typeof removeEventListener>) {
-//     if (args[0] === 'error' && userErrorListenerCount)
-//       userErrorListenerCount--
-//     return removeEventListener.apply(this, args)
-//   }
-//   return function clearErrorHandlers() {
-//     window.removeEventListener('error', throwUnhandlerError)
-//   }
-// }
-
-// const stopErrorHandler = catchWindowErrors(e => defaultErrorReport('Error', e.error))
-// const stopRejectionHandler = on('unhandledrejection', e => defaultErrorReport('Unhandled Rejection', e.reason))
-
-// let runningTests = false
-
-// async function reportUnexpectedError(rpc: typeof client.rpc, type: string, error: any) {
-//   const { processError } = await importId('vitest/browser') as typeof import('vitest/browser')
-//   const processedError = processError(error)
-//   if (testId !== 'no-isolate')
-//     error.VITEST_TEST_PATH = testId
-//   await rpc.onUnhandledError(processedError, type)
-//   if (!runningTests)
-//     await rpc.onDone(testId)
-// }
-
-// ws.addEventListener('open', async () => {
-//   await loadConfig()
-
-//   let safeRpc: typeof client.rpc
-//   try {
-//     // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
-//     const { getSafeTimers } = await importId('vitest/utils') as typeof import('vitest/utils')
-//     safeRpc = createSafeRpc(client, getSafeTimers)
-//   }
-//   catch (err: any) {
-//     if (reloadTries >= 10) {
-//       const error = serializeError(new Error('Vitest failed to load "vitest/utils" after 10 retries.'))
-//       error.cause = serializeError(err)
-
-//       await client.rpc.onUnhandledError(error, 'Reload Error')
-//       await client.rpc.onDone(testId)
-//       return
-//     }
-
-//     const tries = reloadTries + 1
-//     const newUrl = new URL(location.href)
-//     newUrl.searchParams.set('reloadTries', String(tries))
-//     location.href = newUrl.href
-//     return
-//   }
-
-//   stopErrorHandler()
-//   stopRejectionHandler()
-
-// catchWindowErrors(event => reportUnexpectedError(safeRpc, 'Error', event.error))
-// on('unhandledrejection', event => reportUnexpectedError(safeRpc, 'Unhandled Rejection', event.reason))
-
-//   // @ts-expect-error untyped global for internal use
-//   globalThis.__vitest_browser__ = true
-//   // @ts-expect-error mocking vitest apis
-//   globalThis.__vitest_worker__ = {
-//     config,
-//     browserHashMap,
-//     environment: {
-//       name: 'browser',
-//     },
-//     // @ts-expect-error untyped global for internal use
-//     moduleCache: globalThis.__vi_module_cache__,
-//     rpc: client.rpc,
-//     safeRpc,
-//     durations: {
-//       environment: 0,
-//       prepare: 0,
-//     },
-//     providedContext: await client.rpc.getProvidedContext(),
-//   }
-//   // @ts-expect-error mocking vitest apis
-//   globalThis.__vitest_mocker__ = new VitestBrowserClientMocker()
-
-//   const paths = getQueryPaths()
-
-//   const iFrame = document.getElementById('vitest-ui') as HTMLIFrameElement
-//   iFrame.setAttribute('src', '/__vitest__/')
-
-//   await setupConsoleLogSpy(basePath())
-//   setupDialogsSpy()
-//   await runTests(paths, config!)
-// })
-
-// async function prepareTestEnvironment(config: ResolvedConfig) {
-//   // need to import it before any other import, otherwise Vite optimizer will hang
-//   await import(viteClientPath())
-
-//   const {
-//     startTests,
-//     setupCommonEnv,
-//     loadDiffConfig,
-//     takeCoverageInsideWorker,
-//   } = await importId('vitest/browser') as typeof import('vitest/browser')
-
-//   const executor = {
-//     executeId: (id: string) => importId(id),
-//   }
-
-//   if (!runner) {
-//     const { VitestTestRunner } = await importId('vitest/runners') as typeof import('vitest/runners')
-//     const BrowserRunner = createBrowserRunner(VitestTestRunner, { takeCoverage: () => takeCoverageInsideWorker(config.coverage, executor) })
-//     runner = new BrowserRunner({ config, browserHashMap })
-//   }
-
-//   return {
-//     startTests,
-//     setupCommonEnv,
-//     loadDiffConfig,
-//     executor,
-//     runner,
-//   }
-// }
-
-// async function runTests(paths: string[], config: ResolvedConfig) {
-//   let preparedData: Awaited<ReturnType<typeof prepareTestEnvironment>> | undefined
-//   // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
-//   try {
-//     preparedData = await prepareTestEnvironment(config)
-//   }
-//   catch (err) {
-//     location.reload()
-//     return
-//   }
-
-//   const { startTests, setupCommonEnv, loadDiffConfig, executor, runner } = preparedData!
-
-//   onCancel.then((reason) => {
-//     runner?.onCancel?.(reason)
-//   })
-
-//   if (!config.snapshotOptions.snapshotEnvironment)
-//     config.snapshotOptions.snapshotEnvironment = new BrowserSnapshotEnvironment()
-
-//   try {
-//     runner.config.diffOptions = await loadDiffConfig(config, executor as VitestExecutor)
-
-//     await setupCommonEnv(config)
-//     const files = paths.map((path) => {
-//       return (`${config.root}/${path}`).replace(/\/+/g, '/')
-//     })
-
-//     const now = `${new Date().getTime()}`
-//     files.forEach(i => browserHashMap.set(i, [true, now]))
-
-//     runningTests = true
-
-//     for (const file of files)
-//       await startTests([file], runner)
-//   }
-//   finally {
-//     runningTests = false
-
-//     await rpcDone()
-//     await rpc().onDone(testId)
-//   }
-// }

--- a/packages/browser/src/client/public/esm-client-injector.js
+++ b/packages/browser/src/client/public/esm-client-injector.js
@@ -48,8 +48,9 @@ window.__vi_module_cache__ = moduleCache
 window.__vi_wrap_module__ = wrapModule
 
 window.__vi_config__ = { __VITEST_CONFIG__ }
-if (__vi_config__.testNamePattern)
-  __vi_config__.testNamePattern = parseRegexp(__vi_config__.testNamePattern)
+if (window.__vi_config__.testNamePattern)
+  window.__vi_config__.testNamePattern = parseRegexp(window.__vi_config__.testNamePattern)
+window.__vi_files__ = { __VITEST_FILES__ }
 
 function parseRegexp(input) {
   // Parse input

--- a/packages/browser/src/client/public/esm-client-injector.js
+++ b/packages/browser/src/client/public/esm-client-injector.js
@@ -1,12 +1,9 @@
 const moduleCache = new Map()
 
-// this method receives a module object or "import" promise that it resolves and keeps track of
-// and returns a hijacked module object that can be used to mock module exports
 function wrapModule(module) {
   if (module instanceof Promise) {
     moduleCache.set(module, { promise: module, evaluated: false })
     return module
-      // TODO: add a test
       .then(m => '__vi_inject__' in m ? m.__vi_inject__ : m)
       .finally(() => moduleCache.delete(module))
   }
@@ -14,8 +11,6 @@ function wrapModule(module) {
 }
 
 function exportAll(exports, sourceModule) {
-  // #1120 when a module exports itself it causes
-  // call stack error
   if (exports === sourceModule)
     return
 
@@ -36,21 +31,18 @@ function exportAll(exports, sourceModule) {
   }
 }
 
-window.__vi_export_all__ = exportAll
-
-// TODO: allow easier rewriting of import.meta.env
-window.__vi_import_meta__ = {
-  env: {},
-  url: location.href,
+window.__vitest_browser_runner__ = {
+  exportAll,
+  wrapModule,
+  moduleCache,
+  config: { __VITEST_CONFIG__ },
+  files: { __VITEST_FILES__ },
 }
 
-window.__vi_module_cache__ = moduleCache
-window.__vi_wrap_module__ = wrapModule
+const config = __vitest_browser_runner__.config
 
-window.__vi_config__ = { __VITEST_CONFIG__ }
-if (window.__vi_config__.testNamePattern)
-  window.__vi_config__.testNamePattern = parseRegexp(window.__vi_config__.testNamePattern)
-window.__vi_files__ = { __VITEST_FILES__ }
+if (config.testNamePattern)
+  config.testNamePattern = parseRegexp(config.testNamePattern)
 
 function parseRegexp(input) {
   // Parse input

--- a/packages/browser/src/client/public/esm-client-injector.js
+++ b/packages/browser/src/client/public/esm-client-injector.js
@@ -1,0 +1,68 @@
+const moduleCache = new Map()
+
+// this method receives a module object or "import" promise that it resolves and keeps track of
+// and returns a hijacked module object that can be used to mock module exports
+function wrapModule(module) {
+  if (module instanceof Promise) {
+    moduleCache.set(module, { promise: module, evaluated: false })
+    return module
+      // TODO: add a test
+      .then(m => '__vi_inject__' in m ? m.__vi_inject__ : m)
+      .finally(() => moduleCache.delete(module))
+  }
+  return '__vi_inject__' in module ? module.__vi_inject__ : module
+}
+
+function exportAll(exports, sourceModule) {
+  // #1120 when a module exports itself it causes
+  // call stack error
+  if (exports === sourceModule)
+    return
+
+  if (Object(sourceModule) !== sourceModule || Array.isArray(sourceModule))
+    return
+
+  for (const key in sourceModule) {
+    if (key !== 'default') {
+      try {
+        Object.defineProperty(exports, key, {
+          enumerable: true,
+          configurable: true,
+          get: () => sourceModule[key],
+        })
+      }
+      catch (_err) { }
+    }
+  }
+}
+
+window.__vi_export_all__ = exportAll
+
+// TODO: allow easier rewriting of import.meta.env
+window.__vi_import_meta__ = {
+  env: {},
+  url: location.href,
+}
+
+window.__vi_module_cache__ = moduleCache
+window.__vi_wrap_module__ = wrapModule
+
+window.__vi_config__ = { __VITEST_CONFIG__ }
+if (__vi_config__.testNamePattern)
+  __vi_config__.testNamePattern = parseRegexp(__vi_config__.testNamePattern)
+
+function parseRegexp(input) {
+  // Parse input
+  const m = input.match(/(\/?)(.+)\1([a-z]*)/i)
+
+  // match nothing
+  if (!m)
+    return /$^/
+
+  // Invalid flags
+  if (m[3] && !/^(?!.*?(.).*?\1)[gmixXsuUAJ]+$/.test(m[3]))
+    return RegExp(input)
+
+  // Create the regular expression
+  return new RegExp(m[2], m[3])
+}

--- a/packages/browser/src/client/rpc.ts
+++ b/packages/browser/src/client/rpc.ts
@@ -62,40 +62,10 @@ export function createSafeRpc(client: VitestClient, getTimers: () => any): Vites
   })
 }
 
-function serializeError(unhandledError: any) {
-  return {
-    ...unhandledError,
-    name: unhandledError.name,
-    message: unhandledError.message,
-    stack: String(unhandledError.stack),
-  }
-}
-
-const url = new URL(location.href)
-const reloadTries = Number(url.searchParams.get('reloadTries') || '0')
-
 export async function loadSafeRpc(client: VitestClient) {
-  let safeRpc: typeof client.rpc
-  try {
-    // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
-    const { getSafeTimers } = await importId('vitest/utils') as typeof import('vitest/utils')
-    safeRpc = createSafeRpc(client, getSafeTimers)
-  }
-  catch (err: any) {
-    if (reloadTries >= 10) {
-      const error = serializeError(new Error('Vitest failed to load "vitest/utils" after 10 retries.'))
-      error.cause = serializeError(err)
-
-      throw error
-    }
-
-    const tries = reloadTries + 1
-    const newUrl = new URL(location.href)
-    newUrl.searchParams.set('reloadTries', String(tries))
-    location.href = newUrl.href
-    return
-  }
-  return safeRpc
+  // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
+  const { getSafeTimers } = await importId('vitest/utils') as typeof import('vitest/utils')
+  return createSafeRpc(client, getSafeTimers)
 }
 
 export function rpc(): VitestClient['rpc'] {

--- a/packages/browser/src/client/runner.ts
+++ b/packages/browser/src/client/runner.ts
@@ -86,7 +86,7 @@ export async function initiateRunner() {
   if (cachedRunner)
     return cachedRunner
   const config = getConfig()
-  const [{ VitestTestRunner }, { takeCoverageInsideWorker, loadDiffConfig }] = await Promise.all([
+  const [{ VitestTestRunner }, { takeCoverageInsideWorker, loadDiffConfig, loadSnapshotSerializers }] = await Promise.all([
     importId('vitest/runners') as Promise<typeof import('vitest/runners')>,
     importId('vitest/browser') as Promise<typeof import('vitest/browser')>,
   ])
@@ -98,7 +98,12 @@ export async function initiateRunner() {
   const runner = new BrowserRunner({
     config,
   })
-  runner.config.diffOptions = await loadDiffConfig(config, { executeId: importId } as VitestExecutor)
+  const executor = { executeId: importId } as VitestExecutor
+  const [diffOptions] = await Promise.all([
+    loadDiffConfig(config, executor),
+    loadSnapshotSerializers(config, executor),
+  ])
+  runner.config.diffOptions = diffOptions
   cachedRunner = runner
   return runner
 }

--- a/packages/browser/src/client/tester.html
+++ b/packages/browser/src/client/tester.html
@@ -4,10 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="{__VITEST_FAVICON__}" type="image/svg+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vitest Browser Runner</title>
+    <title>{__VITEST_TITLE__}</title>
     <style>
       html {
-        overflow: hidden;
         padding: 0;
         margin: 0;
       }
@@ -15,17 +14,11 @@
         padding: 0;
         margin: 0;
       }
-      #vitest-ui {
-        width: 100vw;
-        height: 100vh;
-        border: none;
-      }
     </style>
     <script>{__VITEST_INJECTOR__}</script>
   </head>
   <body>
-    <iframe id="vitest-ui" src=""></iframe>
-    <script type="module" src="/main.ts"></script>
-    <div id="vitest-tester"></div>
+    <script type="module" src="/tester.ts"></script>
+    {__VITEST_TESTER__}
   </body>
 </html>

--- a/packages/browser/src/client/tester.html
+++ b/packages/browser/src/client/tester.html
@@ -19,6 +19,6 @@
   </head>
   <body>
     <script type="module" src="/tester.ts"></script>
-    {__VITEST_TESTER__}
+    {__VITEST_APPEND__}
   </body>
 </html>

--- a/packages/browser/src/client/tester.ts
+++ b/packages/browser/src/client/tester.ts
@@ -6,34 +6,57 @@ import { browserHashMap, initiateRunner } from './runner'
 import { getConfig, importId } from './utils'
 import { loadSafeRpc } from './rpc'
 import { VitestBrowserClientMocker } from './mocker'
-import { registerUnexpectedErrors, registerUnhandledErrors } from './unhandled'
+import { registerUnexpectedErrors, registerUnhandledErrors, serializeError } from './unhandled'
 
 const stopErrorHandler = registerUnhandledErrors()
 
 const url = new URL(location.href)
+const reloadStart = url.searchParams.get('__reloadStart')
 
-async function runTest(filename: string) {
-  await client.waitForConnection()
+function debug(...args: unknown[]) {
+  const debug = getConfig().env.VITEST_BROWSER_DEBUG
+  if (debug && debug !== 'false')
+    client.rpc.debug(...args.map(String))
+}
 
+async function tryCall<T>(fn: () => Promise<T>): Promise<T | false | undefined> {
+  try {
+    return await fn()
+  }
+  catch (err: any) {
+    const now = Date.now()
+    // try for 30 seconds
+    const canTry = !reloadStart || (now - Number(reloadStart) < 30_000)
+    debug('failed to resolve runner', err?.message, 'trying again:', canTry, 'time is', now, 'reloadStart is', reloadStart)
+    if (!canTry) {
+      const error = serializeError(new Error('Vitest failed to load its runner after 30 seconds.'))
+      error.cause = serializeError(err)
+
+      await client.rpc.onUnhandledError(error, 'Preload Error')
+      return false
+    }
+
+    if (!reloadStart) {
+      const newUrl = new URL(location.href)
+      newUrl.searchParams.set('__reloadStart', now.toString())
+      debug('set the new url because reload start is not set to', newUrl)
+      location.href = newUrl.toString()
+    }
+    else {
+      debug('reload the iframe because reload start is set', location.href)
+      location.reload()
+    }
+  }
+}
+
+async function prepareTestEnvironment(files: string[]) {
+  debug('trying to resolve runner', `${reloadStart}`)
   const config = getConfig()
 
   const viteClientPath = `${config.base || '/'}@vite/client`
   await import(viteClientPath)
 
-  let rpc: any
-  try {
-    rpc = await loadSafeRpc(client)
-  }
-  catch (error) {
-    await client.rpc.onUnhandledError(error, 'Reload Error')
-    channel.postMessage({ type: 'done', filename })
-    return
-  }
-
-  if (!rpc) {
-    channel.postMessage({ type: 'done', filename })
-    return
-  }
+  const rpc: any = await loadSafeRpc(client)
 
   stopErrorHandler()
   registerUnexpectedErrors(rpc)
@@ -47,7 +70,7 @@ async function runTest(filename: string) {
       workerId: 1,
       config,
       projectName: config.name,
-      files: [filename],
+      files,
       environment: {
         name: 'browser',
         options: null,
@@ -87,32 +110,84 @@ async function runTest(filename: string) {
   const { startTests, setupCommonEnv } = await importId('vitest/browser') as typeof import('vitest/browser')
 
   const version = url.searchParams.get('browserv') || '0'
-  const currentVersion = browserHashMap.get(filename)
-  if (!currentVersion || currentVersion[1] !== version)
-    browserHashMap.set(filename, [true, version])
+  files.forEach((filename) => {
+    const currentVersion = browserHashMap.get(filename)
+    if (!currentVersion || currentVersion[1] !== version)
+      browserHashMap.set(filename, [true, version])
+  })
 
   const runner = await initiateRunner()
-
-  function removeBrowserChannel(event: BroadcastChannelEventMap['message']) {
-    if (event.data.type === 'disconnect' && filename === event.data.filename) {
-      channel.removeEventListener('message', removeBrowserChannel)
-      channel.close()
-    }
-  }
-  channel.addEventListener('message', removeBrowserChannel)
 
   onCancel.then((reason) => {
     runner.onCancel?.(reason)
   })
 
-  try {
-    await setupCommonEnv(config)
-    await startTests([filename], runner)
-  }
-  finally {
-    channel.postMessage({ type: 'done', filename })
+  return {
+    runner,
+    config,
+    state,
+    setupCommonEnv,
+    startTests,
   }
 }
 
-// @ts-expect-error untyped global
-globalThis.__vitest_browser_runner__ = { runTest }
+function done(files: string[]) {
+  channel.postMessage({ type: 'done', filenames: files })
+}
+
+async function runTests(files: string[]) {
+  await client.waitForConnection()
+
+  debug('client is connected to ws server')
+
+  let preparedData: Awaited<ReturnType<typeof prepareTestEnvironment>> | undefined | false
+
+  // if importing /@id/ failed, we reload the page waiting until Vite prebundles it
+  try {
+    preparedData = await tryCall(() => prepareTestEnvironment(files))
+  }
+  catch (error) {
+    debug('data cannot be loaded becuase it threw an error')
+    await client.rpc.onUnhandledError(serializeError(error), 'Preload Error')
+    done(files)
+    return
+  }
+
+  // cannot load data, finish the test
+  if (preparedData === false) {
+    debug('data cannot be loaded, finishing the test')
+    done(files)
+    return
+  }
+
+  // page is reloading
+  if (!preparedData) {
+    debug('page is reloading, waiting for the next run')
+    return
+  }
+
+  debug('runner resolved successfully')
+
+  const { config, runner, state, setupCommonEnv, startTests } = preparedData
+
+  try {
+    await setupCommonEnv(config)
+    for (const file of files)
+      await startTests([file], runner)
+  }
+  finally {
+    state.environmentTeardownRun = true
+    debug('finished running tests')
+    done(files)
+  }
+}
+
+async function invalid(id: string) {
+  channel.postMessage({ type: 'invalid', id })
+}
+
+// @ts-expect-error untyped global for internal use
+window.__vitest_browser_runner__ = {
+  runTests,
+  invalid,
+}

--- a/packages/browser/src/client/tester.ts
+++ b/packages/browser/src/client/tester.ts
@@ -3,7 +3,7 @@ import { channel, client, onCancel } from './client'
 import { setupDialogsSpy } from './dialog'
 import { setupConsoleLogSpy } from './logger'
 import { browserHashMap, initiateRunner } from './runner'
-import { getConfig, importId } from './utils'
+import { getBrowserState, getConfig, importId } from './utils'
 import { loadSafeRpc } from './rpc'
 import { VitestBrowserClientMocker } from './mocker'
 import { registerUnexpectedErrors, registerUnhandledErrors, serializeError } from './unhandled'
@@ -88,8 +88,7 @@ async function prepareTestEnvironment(files: string[]) {
         throw new Error('Not called in the browser')
       },
     },
-    // @ts-expect-error untyped global for internal use
-    moduleCache: globalThis.__vi_module_cache__,
+    moduleCache: getBrowserState().moduleCache,
     rpc,
     durations: {
       environment: 0,
@@ -182,12 +181,5 @@ async function runTests(files: string[]) {
   }
 }
 
-async function invalid(id: string) {
-  channel.postMessage({ type: 'invalid', id })
-}
-
 // @ts-expect-error untyped global for internal use
-window.__vitest_browser_runner__ = {
-  runTests,
-  invalid,
-}
+window.__vitest_browser_runner__.runTests = runTests

--- a/packages/browser/src/client/tester.ts
+++ b/packages/browser/src/client/tester.ts
@@ -1,0 +1,118 @@
+import type { WorkerGlobalState } from 'vitest'
+import { channel, client, onCancel } from './client'
+import { setupDialogsSpy } from './dialog'
+import { setupConsoleLogSpy } from './logger'
+import { browserHashMap, initiateRunner } from './runner'
+import { getConfig, importId } from './utils'
+import { loadSafeRpc } from './rpc'
+import { VitestBrowserClientMocker } from './mocker'
+import { registerUnexpectedErrors, registerUnhandledErrors } from './unhandled'
+
+const stopErrorHandler = registerUnhandledErrors()
+
+const url = new URL(location.href)
+
+async function runTest(filename: string) {
+  await client.waitForConnection()
+
+  const config = getConfig()
+
+  const viteClientPath = `${config.base || '/'}@vite/client`
+  await import(viteClientPath)
+
+  let rpc: any
+  try {
+    rpc = await loadSafeRpc(client)
+  }
+  catch (error) {
+    await client.rpc.onUnhandledError(error, 'Reload Error')
+    channel.postMessage({ type: 'done', filename })
+    return
+  }
+
+  if (!rpc) {
+    channel.postMessage({ type: 'done', filename })
+    return
+  }
+
+  stopErrorHandler()
+  registerUnexpectedErrors(rpc)
+
+  const providedContext = await client.rpc.getProvidedContext()
+
+  const state: WorkerGlobalState = {
+    ctx: {
+      pool: 'browser',
+      worker: './browser.js',
+      workerId: 1,
+      config,
+      projectName: config.name,
+      files: [filename],
+      environment: {
+        name: 'browser',
+        options: null,
+      },
+      providedContext,
+      invalidates: [],
+    },
+    onCancel,
+    mockMap: new Map(),
+    config,
+    environment: {
+      name: 'browser',
+      transformMode: 'web',
+      setup() {
+        throw new Error('Not called in the browser')
+      },
+    },
+    // @ts-expect-error untyped global for internal use
+    moduleCache: globalThis.__vi_module_cache__,
+    rpc,
+    durations: {
+      environment: 0,
+      prepare: 0,
+    },
+    providedContext,
+  }
+  // @ts-expect-error untyped global for internal use
+  globalThis.__vitest_browser__ = true
+  // @ts-expect-error mocking vitest apis
+  globalThis.__vitest_worker__ = state
+  // @ts-expect-error mocking vitest apis
+  globalThis.__vitest_mocker__ = new VitestBrowserClientMocker()
+
+  await setupConsoleLogSpy()
+  setupDialogsSpy()
+
+  const { startTests, setupCommonEnv } = await importId('vitest/browser') as typeof import('vitest/browser')
+
+  const version = url.searchParams.get('browserv') || '0'
+  const currentVersion = browserHashMap.get(filename)
+  if (!currentVersion || currentVersion[1] !== version)
+    browserHashMap.set(filename, [true, version])
+
+  const runner = await initiateRunner()
+
+  function removeBrowserChannel(event: BroadcastChannelEventMap['message']) {
+    if (event.data.type === 'disconnect' && filename === event.data.filename) {
+      channel.removeEventListener('message', removeBrowserChannel)
+      channel.close()
+    }
+  }
+  channel.addEventListener('message', removeBrowserChannel)
+
+  onCancel.then((reason) => {
+    runner.onCancel?.(reason)
+  })
+
+  try {
+    await setupCommonEnv(config)
+    await startTests([filename], runner)
+  }
+  finally {
+    channel.postMessage({ type: 'done', filename })
+  }
+}
+
+// @ts-expect-error untyped global
+globalThis.__vitest_browser_runner__ = { runTest }

--- a/packages/browser/src/client/unhandled.ts
+++ b/packages/browser/src/client/unhandled.ts
@@ -1,6 +1,6 @@
 import type { client } from './client'
 import { channel } from './client'
-import { importId } from './utils'
+import { getBrowserState, importId } from './utils'
 
 function on(event: string, listener: (...args: any[]) => void) {
   window.addEventListener(event, listener)
@@ -16,15 +16,10 @@ export function serializeError(unhandledError: any) {
   }
 }
 
-function getFiles(): string[] {
-  // @ts-expect-error this is set in injector
-  return window.__vi_running_tests__
-}
-
 // we can't import "processError" yet because error might've been thrown before the module was loaded
 async function defaultErrorReport(type: string, unhandledError: any) {
   const error = serializeError(unhandledError)
-  channel.postMessage({ type: 'error', files: getFiles(), error, errorType: type })
+  channel.postMessage({ type: 'error', files: getBrowserState().runningFiles, error, errorType: type })
 }
 
 function catchWindowErrors(cb: (e: ErrorEvent) => void) {

--- a/packages/browser/src/client/unhandled.ts
+++ b/packages/browser/src/client/unhandled.ts
@@ -1,0 +1,73 @@
+import { client } from './client'
+import { importId } from './utils'
+
+const id = new URL(location.href).searchParams.get('__vitest_id')!
+
+function on(event: string, listener: (...args: any[]) => void) {
+  window.addEventListener(event, listener)
+  return () => window.removeEventListener(event, listener)
+}
+
+function serializeError(unhandledError: any) {
+  return {
+    ...unhandledError,
+    name: unhandledError.name,
+    message: unhandledError.message,
+    stack: String(unhandledError.stack),
+  }
+}
+// we can't import "processError" yet because error might've been thrown before the module was loaded
+async function defaultErrorReport(type: string, unhandledError: any) {
+  const error = serializeError(unhandledError)
+  await client.rpc.onUnhandledError(error, type)
+  await client.rpc.onDone(id)
+}
+
+function catchWindowErrors(cb: (e: ErrorEvent) => void) {
+  let userErrorListenerCount = 0
+  function throwUnhandlerError(e: ErrorEvent) {
+    if (userErrorListenerCount === 0 && e.error != null)
+      cb(e)
+    else
+      console.error(e.error)
+  }
+  const addEventListener = window.addEventListener.bind(window)
+  const removeEventListener = window.removeEventListener.bind(window)
+  window.addEventListener('error', throwUnhandlerError)
+  window.addEventListener = function (...args: Parameters<typeof addEventListener>) {
+    if (args[0] === 'error')
+      userErrorListenerCount++
+    return addEventListener.apply(this, args)
+  }
+  window.removeEventListener = function (...args: Parameters<typeof removeEventListener>) {
+    if (args[0] === 'error' && userErrorListenerCount)
+      userErrorListenerCount--
+    return removeEventListener.apply(this, args)
+  }
+  return function clearErrorHandlers() {
+    window.removeEventListener('error', throwUnhandlerError)
+  }
+}
+
+export function registerUnhandledErrors() {
+  const stopErrorHandler = catchWindowErrors(e => defaultErrorReport('Error', e.error))
+  const stopRejectionHandler = on('unhandledrejection', e => defaultErrorReport('Unhandled Rejection', e.reason))
+  return () => {
+    stopErrorHandler()
+    stopRejectionHandler()
+  }
+}
+
+export function registerUnexpectedErrors(rpc: typeof client.rpc) {
+  catchWindowErrors(event => reportUnexpectedError(rpc, 'Error', event.error))
+  on('unhandledrejection', event => reportUnexpectedError(rpc, 'Unhandled Rejection', event.reason))
+}
+
+async function reportUnexpectedError(rpc: typeof client.rpc, type: string, error: any) {
+  const { processError } = await importId('vitest/browser') as typeof import('vitest/browser')
+  const processedError = processError(error)
+  await rpc.onUnhandledError(processedError, type)
+  // TODO: don't fail if test is running
+  // if (!runningTests)
+  await rpc.onDone(id)
+}

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -1,4 +1,4 @@
-import type { ResolvedConfig } from 'vitest'
+import type { ResolvedConfig, WorkerGlobalState } from 'vitest'
 
 export async function importId(id: string) {
   const name = `${getConfig().base || '/'}@id/${id}`
@@ -9,4 +9,9 @@ export async function importId(id: string) {
 export function getConfig(): ResolvedConfig {
   // @ts-expect-error not typed global
   return window.__vi_config__
+}
+
+export function getWorkerState(): WorkerGlobalState {
+  // @ts-expect-error not typed global
+  return window.__vi_worker_state__
 }

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -1,5 +1,12 @@
-export async function importId(id: string, basePath: string) {
-  const name = `${basePath}@id/${id}`
+import type { ResolvedConfig } from 'vitest'
+
+export async function importId(id: string) {
+  const name = `${getConfig().base || '/'}@id/${id}`
   // @ts-expect-error mocking vitest apis
   return __vi_wrap_module__(import(name))
+}
+
+export function getConfig(): ResolvedConfig {
+  // @ts-expect-error not typed global
+  return window.__vi_config__
 }

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -2,16 +2,24 @@ import type { ResolvedConfig, WorkerGlobalState } from 'vitest'
 
 export async function importId(id: string) {
   const name = `${getConfig().base || '/'}@id/${id}`
-  // @ts-expect-error mocking vitest apis
-  return __vi_wrap_module__(import(name))
+  return getBrowserState().wrapModule(import(name))
 }
 
 export function getConfig(): ResolvedConfig {
-  // @ts-expect-error not typed global
-  return window.__vi_config__
+  return getBrowserState().config
 }
 
-export function getWorkerState(): WorkerGlobalState {
+interface BrowserRunnerState {
+  files: string[]
+  runningFiles: string[]
+  moduleCache: WorkerGlobalState['moduleCache']
+  config: ResolvedConfig
+  exportAll(): void
+  wrapModule(module: any): any
+  runTests(tests: string[]): Promise<void>
+}
+
+export function getBrowserState(): BrowserRunnerState {
   // @ts-expect-error not typed global
-  return window.__vi_worker_state__
+  return window.__vitest_browser_runner__
 }

--- a/packages/browser/src/client/vite.config.ts
+++ b/packages/browser/src/client/vite.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
     outDir: '../../dist/client',
     emptyOutDir: false,
     assetsDir: '__vitest_browser__',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, './index.html'),
+        tester: resolve(__dirname, './tester.html'),
+      },
+    },
   },
   plugins: [
     {
@@ -33,7 +39,7 @@ export default defineConfig({
         if (fs.existsSync(browser))
           fs.rmSync(browser, { recursive: true })
 
-        fs.mkdirSync(browser)
+        fs.mkdirSync(browser, { recursive: true })
         fs.mkdirSync(resolve(browser, 'assets'))
 
         files.forEach((f) => {

--- a/packages/browser/src/node/esmInjector.ts
+++ b/packages/browser/src/node/esmInjector.ts
@@ -6,7 +6,7 @@ import type { Expression, ImportDeclaration, Node, Positioned } from '@vitest/ut
 
 const viInjectedKey = '__vi_inject__'
 // const viImportMetaKey = '__vi_import_meta__' // to allow overwrite
-const viExportAllHelper = '__vi_export_all__'
+const viExportAllHelper = '__vitest_browser_runner__.exportAll'
 
 const skipHijack = [
   '/@vite/client',
@@ -230,7 +230,7 @@ export function injectVitestModule(code: string, id: string, parse: PluginContex
       // s.update(node.start, node.end, viImportMetaKey)
     },
     onDynamicImport(node) {
-      const replace = '__vi_wrap_module__(import('
+      const replace = '__vitest_browser_runner__.wrapModule(import('
       s.overwrite(node.start, (node.source as Positioned<Expression>).start, replace)
       s.overwrite(node.end - 1, node.end, '))')
     },

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -75,7 +75,7 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
 
           const decodedTestFile = decodeURIComponent(url.pathname.slice(testerPrefix.length))
           // if decoded test file is "__vitest_all__" or not in the list of known files, run all tests
-          const tests = decodedTestFile === '__vitest_all__' || !files.includes(decodedTestFile) ? 'window.__vi_files__' : JSON.stringify([decodedTestFile])
+          const tests = decodedTestFile === '__vitest_all__' || !files.includes(decodedTestFile) ? '__vitest_browser_runner__.files' : JSON.stringify([decodedTestFile])
 
           const html = replacer(await testerHtml, {
             __VITEST_FAVICON__: favicon,
@@ -84,8 +84,8 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
             __VITEST_APPEND__:
             // TODO: have only a single global variable to not pollute the global scope
 `<script type="module">
-  window.__vi_running_tests__ = ${tests}
-  __vitest_browser_runner__.runTests(window.__vi_running_tests__)
+  __vitest_browser_runner__.runningFiles = ${tests}
+  __vitest_browser_runner__.runTests(__vitest_browser_runner__.runningFiles)
 </script>`,
           })
           res.write(html, 'utf-8')

--- a/packages/browser/src/node/providers/none.ts
+++ b/packages/browser/src/node/providers/none.ts
@@ -22,10 +22,6 @@ export class NoneBrowserProvider implements BrowserProvider {
       throw new Error('You\'ve enabled headless mode for "none" provider but it doesn\'t support it.')
   }
 
-  catchError(_cb: (error: Error) => Awaitable<void>) {
-    return () => {}
-  }
-
   async openPage(_url: string) {
     this.open = true
     if (!this.ctx.browser)

--- a/packages/browser/src/node/providers/none.ts
+++ b/packages/browser/src/node/providers/none.ts
@@ -1,4 +1,3 @@
-import type { Awaitable } from 'vitest'
 import type { BrowserProvider, WorkspaceProject } from 'vitest/node'
 
 export class NoneBrowserProvider implements BrowserProvider {

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -1,8 +1,6 @@
 import type { Browser, LaunchOptions, Page } from 'playwright'
 import type { BrowserProvider, BrowserProviderInitializationOptions, WorkspaceProject } from 'vitest/node'
 
-type Awaitable<T> = T | PromiseLike<T>
-
 export const playwrightBrowsers = ['firefox', 'webkit', 'chromium'] as const
 export type PlaywrightBrowser = typeof playwrightBrowsers[number]
 
@@ -53,13 +51,6 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     })
 
     return this.cachedPage
-  }
-
-  catchError(cb: (error: Error) => Awaitable<void>) {
-    this.cachedPage?.on('pageerror', cb)
-    return () => {
-      this.cachedPage?.off('pageerror', cb)
-    }
   }
 
   async openPage(url: string) {

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -46,10 +46,6 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     this.cachedBrowser = browser
     this.cachedPage = await browser.newPage(this.options?.page)
 
-    this.cachedPage.on('close', () => {
-      browser.close()
-    })
-
     return this.cachedPage
   }
 

--- a/packages/browser/src/node/providers/webdriver.ts
+++ b/packages/browser/src/node/providers/webdriver.ts
@@ -1,8 +1,6 @@
 import type { BrowserProvider, BrowserProviderInitializationOptions, WorkspaceProject } from 'vitest/node'
 import type { RemoteOptions } from 'webdriverio'
 
-type Awaitable<T> = T | PromiseLike<T>
-
 const webdriverBrowsers = ['firefox', 'chrome', 'edge', 'safari'] as const
 type WebdriverBrowser = typeof webdriverBrowsers[number]
 
@@ -79,11 +77,6 @@ export class WebdriverBrowserProvider implements BrowserProvider {
   async openPage(url: string) {
     const browserInstance = await this.openBrowser()
     await browserInstance.url(url)
-  }
-
-  // TODO
-  catchError(_cb: (error: Error) => Awaitable<void>) {
-    return () => {}
   }
 
   async close() {

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -51,9 +51,6 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, _server?: Vi
         async onUnhandledError(error, type) {
           ctx.state.catchError(error, type)
         },
-        async onDone(testId) {
-          return ctx.state.browserTestMap.get(testId)?.resolve(true)
-        },
         async onCollected(files) {
           ctx.state.collectFiles(files)
           await ctx.report('onCollected', files)
@@ -137,15 +134,29 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, _server?: Vi
         onCancel(reason) {
           ctx.cancelCurrentRun(reason)
         },
+        debug(...args) {
+          ctx.logger.console.debug(...args)
+        },
         getCountOfFailedTests() {
           return ctx.state.getCountOfFailedTests()
         },
-        // browser should have a separate RPC in the future, UI doesn't care for provided context
-        getProvidedContext() {
-          return 'ctx' in vitestOrWorkspace ? vitestOrWorkspace.getProvidedContext() : ({} as any)
-        },
         getUnhandledErrors() {
           return ctx.state.getUnhandledErrors()
+        },
+
+        // TODO: have a separate websocket conection for private browser API
+        getBrowserFiles() {
+          if (!('ctx' in vitestOrWorkspace))
+            throw new Error('`getBrowserTestFiles` is only available in the browser API')
+          return vitestOrWorkspace.browserState?.files ?? []
+        },
+        finishBrowserTests() {
+          if (!('ctx' in vitestOrWorkspace))
+            throw new Error('`finishBrowserTests` is only available in the browser API')
+          return vitestOrWorkspace.browserState?.resolve()
+        },
+        getProvidedContext() {
+          return 'ctx' in vitestOrWorkspace ? vitestOrWorkspace.getProvidedContext() : ({} as any)
         },
       },
       {

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -11,7 +11,6 @@ export interface WebSocketHandlers {
   onCollected(files?: File[]): Promise<void>
   onTaskUpdate(packs: TaskResultPack[]): void
   onAfterSuiteRun(meta: AfterSuiteRunMeta): void
-  onDone(name: string): void
   onCancel(reason: CancelReason): void
   getCountOfFailedTests(): number
   sendLog(log: UserConsoleLog): void
@@ -32,6 +31,10 @@ export interface WebSocketHandlers {
   updateSnapshot(file?: File): Promise<void>
   getProvidedContext(): ProvidedContext
   getUnhandledErrors(): unknown[]
+
+  finishBrowserTests(): void
+  getBrowserFiles(): string[]
+  debug(...args: string[]): void
 }
 
 export interface WebSocketEvents extends Pick<Reporter, 'onCollected' | 'onFinished' | 'onTaskUpdate' | 'onUserConsoleLog' | 'onPathsCollected'> {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -17,7 +17,12 @@ export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
 export class StateManager {
   filesMap = new Map<string, File[]>()
   pathsSet: Set<string> = new Set()
-  browserTestPromises = new Map<string, { resolve: (v: unknown) => void; reject: (v: unknown) => void }>()
+  browserTestMap = new Map<string, {
+    paths: string[]
+    resolve: (v: unknown) => void
+    reject: (v: unknown) => void
+  }>()
+
   idMap = new Map<string, Task>()
   taskFileMap = new WeakMap<Task, File>()
   errorsSet = new Set<unknown>()

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -17,12 +17,6 @@ export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
 export class StateManager {
   filesMap = new Map<string, File[]>()
   pathsSet: Set<string> = new Set()
-  browserTestMap = new Map<string, {
-    paths: string[]
-    resolve: (v: unknown) => void
-    reject: (v: unknown) => void
-  }>()
-
   idMap = new Map<string, Task>()
   taskFileMap = new WeakMap<Task, File>()
   errorsSet = new Set<unknown>()

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -70,6 +70,12 @@ export class WorkspaceProject {
   closingPromise: Promise<unknown> | undefined
   browserProvider: BrowserProvider | undefined
 
+  browserState: {
+    files: string[]
+    resolve(): void
+    reject(v: unknown): void
+  } | undefined
+
   testFilesList: string[] | null = null
 
   private _globalSetups: GlobalSetupFile[] | undefined

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -12,7 +12,6 @@ export interface BrowserProvider {
   getSupportedBrowsers(): readonly string[]
   initialize(ctx: WorkspaceProject, options: BrowserProviderInitializationOptions): Awaitable<void>
   openPage(url: string): Awaitable<void>
-  catchError(cb: (error: Error) => Awaitable<void>): () => Awaitable<void>
   close(): Awaitable<void>
 }
 

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -82,6 +82,13 @@ export interface BrowserConfigOptions {
    * @default true
    */
   isolate?: boolean
+
+  /**
+   * Run test files in parallel. Fallbacks to `test.fileParallelism`.
+   *
+   * @default test.fileParallelism
+   */
+  fileParallelism?: boolean
 }
 
 export interface ResolvedBrowserOptions extends BrowserConfigOptions {

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -34,7 +34,7 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
     autoReconnect = true,
     reconnectInterval = 2000,
     reconnectTries = 10,
-    connectTimeout = 5_000,
+    connectTimeout = 60000,
     reactive = v => v,
     WebSocketConstructor = globalThis.WebSocket,
   } = options

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -14,6 +14,7 @@ export interface VitestClientOptions {
   autoReconnect?: boolean
   reconnectInterval?: number
   reconnectTries?: number
+  connectTimeout?: number
   reactive?: <T>(v: T) => T
   ref?: <T>(v: T) => { value: T }
   WebSocketConstructor?: typeof WebSocket
@@ -33,6 +34,7 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
     autoReconnect = true,
     reconnectInterval = 2000,
     reconnectTries = 10,
+    connectTimeout = 5_000,
     reactive = v => v,
     WebSocketConstructor = globalThis.WebSocket,
   } = options
@@ -98,10 +100,17 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
   }
 
   function registerWS() {
-    openPromise = new Promise((resolve) => {
+    openPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Cannot connect to the server in ${connectTimeout / 1000} seconds`))
+      }, connectTimeout)?.unref?.()
+      if (ctx.ws.OPEN === ctx.ws.readyState)
+        resolve()
+      // still have a listener even if it's already open to update tries
       ctx.ws.addEventListener('open', () => {
         tries = reconnectTries
         resolve()
+        clearTimeout(timeout)
       })
     })
     ctx.ws.addEventListener('message', (v) => {

--- a/test/browser/specs/filter.test.mjs
+++ b/test/browser/specs/filter.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test'
 import { execa } from 'execa'
 
 test('filter', async () => {
-  const result = await execa(
+  let result = execa(
     'npx',
     [
       'vitest',
@@ -21,6 +21,15 @@ test('filter', async () => {
       },
     },
   )
+  if (process.env.VITEST_BROWSER_DEBUG) {
+    result.stderr.on('data', (data) => {
+      process.stderr.write(data.toString())
+    })
+    result.stdout.on('data', (data) => {
+      process.stdout.write(data.toString())
+    })
+  }
+  result = await result
   assert.match(result.stdout, /✓ test\/basic.test.ts > basic 2/)
   assert.match(result.stdout, /Test Files {2}1 passed/)
   assert.match(result.stdout, /Tests {2}1 passed | 3 skipped/)

--- a/test/browser/specs/run-vitest.mjs
+++ b/test/browser/specs/run-vitest.mjs
@@ -9,7 +9,7 @@ export default async function runVitest(moreArgs = []) {
   if (browser !== 'safari')
     argv.push('--browser.headless')
 
-  const { stderr, stdout } = await execa('npx', argv.concat(moreArgs), {
+  const result = execa('npx', argv.concat(moreArgs), {
     env: {
       ...process.env,
       CI: 'true',
@@ -17,6 +17,15 @@ export default async function runVitest(moreArgs = []) {
     },
     reject: false,
   })
+  if (process.env.VITEST_BROWSER_DEBUG) {
+    result.stderr.on('data', (data) => {
+      process.stderr.write(data.toString())
+    })
+    result.stdout.on('data', (data) => {
+      process.stdout.write(data.toString())
+    })
+  }
+  const { stderr, stdout } = await result
   const browserResult = await readFile('./browser.json', 'utf-8')
   const browserResultJson = JSON.parse(browserResult)
 

--- a/test/browser/specs/runner.test.mjs
+++ b/test/browser/specs/runner.test.mjs
@@ -2,69 +2,76 @@ import assert from 'node:assert'
 import test from 'node:test'
 import runVitest from './run-vitest.mjs'
 
-const {
-  stderr,
-  stdout,
-  browserResultJson,
-  passedTests,
-  failedTests,
-} = await runVitest()
+const cliArguments = [
+  ['not parallel', ['--no-browser.fileParallelism']],
+  ['parallel', []],
+]
 
-await test('tests are actually running', async () => {
-  assert.equal(browserResultJson.testResults.length, 14, 'Not all the tests have been run')
-  assert.equal(passedTests.length, 12, 'Some tests failed')
-  assert.equal(failedTests.length, 2, 'Some tests have passed but should fail')
+for (const [description, args] of cliArguments) {
+  const {
+    stderr,
+    stdout,
+    browserResultJson,
+    passedTests,
+    failedTests,
+  } = await runVitest(args)
 
-  assert.doesNotMatch(stderr, /has been externalized for browser compatibility/, 'doesn\'t have any externalized modules')
-  assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')
-})
+  await test(`[${description}] tests are actually running`, async () => {
+    assert.equal(browserResultJson.testResults.length, 14, 'Not all the tests have been run')
+    assert.equal(passedTests.length, 12, 'Some tests failed')
+    assert.equal(failedTests.length, 2, 'Some tests have passed but should fail')
 
-await test('correctly prints error', () => {
-  assert.match(stderr, /expected 1 to be 2/, 'prints failing error')
-  assert.match(stderr, /- 2\s+\+ 1/, 'prints failing diff')
-  assert.match(stderr, /Expected to be/, 'prints \`Expected to be\`')
-  assert.match(stderr, /But got/, 'prints \`But got\`')
-})
+    assert.doesNotMatch(stderr, /has been externalized for browser compatibility/, 'doesn\'t have any externalized modules')
+    assert.doesNotMatch(stderr, /Unhandled Error/, 'doesn\'t have any unhandled errors')
+  })
 
-await test('logs are redirected to stdout', async () => {
-  assert.match(stdout, /stdout | test\/logs.test.ts > logging to stdout/)
-  assert.match(stdout, /hello from console.log/, 'prints console.log')
-  assert.match(stdout, /hello from console.info/, 'prints console.info')
-  assert.match(stdout, /hello from console.debug/, 'prints console.debug')
-  assert.match(stdout, /{ hello: 'from dir' }/, 'prints console.dir')
-  assert.match(stdout, /{ hello: 'from dirxml' }/, 'prints console.dixml')
-  // safari logs the stack files with @https://...
-  assert.match(stdout, /hello from console.trace\s+(\w+|@)/, 'prints console.trace')
-  assert.match(stdout, /dom <div \/>/, 'prints dom')
-  assert.match(stdout, /default: 1/, 'prints first default count')
-  assert.match(stdout, /default: 2/, 'prints second default count')
-  assert.match(stdout, /default: 3/, 'prints third default count')
-  assert.match(stdout, /count: 1/, 'prints first custom count')
-  assert.match(stdout, /count: 2/, 'prints second custom count')
-  assert.match(stdout, /count: 3/, 'prints third custom count')
-  assert.match(stdout, /default: [\d.]+ ms/, 'prints default time')
-  assert.match(stdout, /time: [\d.]+ ms/, 'prints custom time')
-})
+  await test(`[${description}] correctly prints error`, () => {
+    assert.match(stderr, /expected 1 to be 2/, 'prints failing error')
+    assert.match(stderr, /- 2\s+\+ 1/, 'prints failing diff')
+    assert.match(stderr, /Expected to be/, 'prints \`Expected to be\`')
+    assert.match(stderr, /But got/, 'prints \`But got\`')
+  })
 
-await test('logs are redirected to stderr', async () => {
-  assert.match(stderr, /stderr | test\/logs.test.ts > logging to stderr/)
-  assert.match(stderr, /hello from console.error/, 'prints console.log')
-  assert.match(stderr, /hello from console.warn/, 'prints console.info')
-  assert.match(stderr, /Timer "invalid timeLog" does not exist/, 'prints errored timeLog')
-  assert.match(stderr, /Timer "invalid timeEnd" does not exist/, 'prints errored timeEnd')
-})
+  await test(`[${description}] logs are redirected to stdout`, async () => {
+    assert.match(stdout, /stdout | test\/logs.test.ts > logging to stdout/)
+    assert.match(stdout, /hello from console.log/, 'prints console.log')
+    assert.match(stdout, /hello from console.info/, 'prints console.info')
+    assert.match(stdout, /hello from console.debug/, 'prints console.debug')
+    assert.match(stdout, /{ hello: 'from dir' }/, 'prints console.dir')
+    assert.match(stdout, /{ hello: 'from dirxml' }/, 'prints console.dixml')
+    // safari logs the stack files with @https://...
+    assert.match(stdout, /hello from console.trace\s+(\w+|@)/, 'prints console.trace')
+    assert.match(stdout, /dom <div \/>/, 'prints dom')
+    assert.match(stdout, /default: 1/, 'prints first default count')
+    assert.match(stdout, /default: 2/, 'prints second default count')
+    assert.match(stdout, /default: 3/, 'prints third default count')
+    assert.match(stdout, /count: 1/, 'prints first custom count')
+    assert.match(stdout, /count: 2/, 'prints second custom count')
+    assert.match(stdout, /count: 3/, 'prints third custom count')
+    assert.match(stdout, /default: [\d.]+ ms/, 'prints default time')
+    assert.match(stdout, /time: [\d.]+ ms/, 'prints custom time')
+  })
 
-await test('stack trace points to correct file in every browser', () => {
-  // dependeing on the browser it references either `.toBe()` or `expect()`
-  assert.match(stderr, /test\/failing.test.ts:4:(12|17)/, 'prints stack trace')
-})
+  await test(`[${description}] logs are redirected to stderr`, async () => {
+    assert.match(stderr, /stderr | test\/logs.test.ts > logging to stderr/)
+    assert.match(stderr, /hello from console.error/, 'prints console.log')
+    assert.match(stderr, /hello from console.warn/, 'prints console.info')
+    assert.match(stderr, /Timer "invalid timeLog" does not exist/, 'prints errored timeLog')
+    assert.match(stderr, /Timer "invalid timeEnd" does not exist/, 'prints errored timeEnd')
+  })
 
-await test('popup apis should log a warning', () => {
-  assert.ok(stderr.includes('Vitest encountered a \`alert\("test"\)\`'), 'prints warning for alert')
-  assert.ok(stderr.includes('Vitest encountered a \`confirm\("test"\)\`'), 'prints warning for confirm')
-  assert.ok(stderr.includes('Vitest encountered a \`prompt\("test"\)\`'), 'prints warning for prompt')
-})
+  await test(`[${description}] stack trace points to correct file in every browser`, () => {
+    // dependeing on the browser it references either `.toBe()` or `expect()`
+    assert.match(stderr, /test\/failing.test.ts:4:(12|17)/, 'prints stack trace')
+  })
 
-await test('snapshot inaccessible file debuggability', () => {
-  assert.ok(stdout.includes('Access denied to "/inaccesible/path".'), 'file security enforcement explained')
-})
+  await test(`[${description}] popup apis should log a warning`, () => {
+    assert.ok(stderr.includes('Vitest encountered a \`alert\("test"\)\`'), 'prints warning for alert')
+    assert.ok(stderr.includes('Vitest encountered a \`confirm\("test"\)\`'), 'prints warning for confirm')
+    assert.ok(stderr.includes('Vitest encountered a \`prompt\("test"\)\`'), 'prints warning for prompt')
+  })
+
+  await test(`[${description}] snapshot inaccessible file debuggability`, () => {
+    assert.ok(stdout.includes('Access denied to "/inaccesible/path".'), 'file security enforcement explained')
+  })
+}

--- a/test/core/test/injector-esm.test.ts
+++ b/test/core/test/injector-esm.test.ts
@@ -126,9 +126,9 @@ test('export * from', async () => {
   ).toMatchInlineSnapshot(`
     "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     const { __vi_inject__: __vi_esm_0__ } = await import("vue");
-    __vi_export_all__(__vi_inject__, __vi_esm_0__);
+    __vitest_browser_runner__.exportAll(__vi_inject__, __vi_esm_0__);
     const { __vi_inject__: __vi_esm_1__ } = await import("react");
-    __vi_export_all__(__vi_inject__, __vi_esm_1__);
+    __vitest_browser_runner__.exportAll(__vi_inject__, __vi_esm_1__);
 
 
     export { __vi_inject__ }"
@@ -167,7 +167,7 @@ test('export then import minified', async () => {
     "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
     import { __vi_inject__ as __vi_esm_0__ } from 'vue'
     const { __vi_inject__: __vi_esm_1__ } = await import("vue");
-    __vi_export_all__(__vi_inject__, __vi_esm_1__);
+    __vitest_browser_runner__.exportAll(__vi_inject__, __vi_esm_1__);
 
     export { __vi_inject__ }"
   `)
@@ -198,7 +198,7 @@ test('dynamic import', async () => {
   )
   expect(result).toMatchInlineSnapshot(`
     "const __vi_inject__ = { [Symbol.toStringTag]: "Module" };
-    const i = () => __vi_wrap_module__(import('./foo'))
+    const i = () => __vitest_browser_runner__.wrapModule(import('./foo'))
     export { __vi_inject__ }"
   `)
 })


### PR DESCRIPTION
### Description

This PR changes how Vitest runs browser tests internally. This is a successor to #3584, but without any visuals.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
