### PR TITLE
fix(typecheck): fix `ignoreSourceErrors` in run mode

### DIFF
--- a/packages/vitest/src/node/pools/typecheck.ts
+++ b/packages/vitest/src/node/pools/typecheck.ts
@@ -20,7 +20,7 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
     if (!project.config.typecheck.ignoreSourceErrors)
       sourceErrors.forEach(error => ctx.state.catchError(error, 'Unhandled Source Error'))
 
-    const processError = !hasFailed(files) && checker.getExitCode()
+    const processError = !hasFailed(files) && !sourceErrors.length && checker.getExitCode()
     if (processError) {
       const error = new Error(checker.getOutput())
       error.stack = ''

--- a/test/typescript/fixtures/source-error/src/not-ok.ts
+++ b/test/typescript/fixtures/source-error/src/not-ok.ts
@@ -1,0 +1,1 @@
+thisIsSourceError

--- a/test/typescript/fixtures/source-error/test/ok.test-d.ts
+++ b/test/typescript/fixtures/source-error/test/ok.test-d.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf, test } from 'vitest'
+
+test('ok', () => {
+  expectTypeOf(1).toEqualTypeOf(2)
+})

--- a/test/typescript/fixtures/source-error/tsconfig.json
+++ b/test/typescript/fixtures/source-error/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "es2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
+}

--- a/test/typescript/fixtures/source-error/vite.config.ts
+++ b/test/typescript/fixtures/source-error/vite.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
   test: {
     typecheck: {
       enabled: true,
-      // ignoreSourceErrors: true
     },
   },
 })

--- a/test/typescript/fixtures/source-error/vite.config.ts
+++ b/test/typescript/fixtures/source-error/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    typecheck: {
+      enabled: true,
+      // ignoreSourceErrors: true
+    },
+  },
+})

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -97,3 +97,30 @@ describe('should fail', async () => {
     expect(stderr.replace(resolve(__dirname, '..'), '<root>')).toMatchSnapshot()
   })
 })
+
+describe('ignoreSourceErrors', () => {
+  it('disabled', async () => {
+    const vitest = await runVitestCli(
+      {
+        cwd: resolve(__dirname, '../fixtures/source-error'),
+      },
+      '--run',
+    )
+    expect(vitest.stdout).toContain('Unhandled Errors')
+    expect(vitest.stderr).toContain('Unhandled Source Error')
+    expect(vitest.stderr).toContain('TypeCheckError: Cannot find name \'thisIsSourceError\'')
+  })
+
+  it('enabled', async () => {
+    const vitest = await runVitestCli(
+      {
+        cwd: resolve(__dirname, '../fixtures/source-error'),
+      },
+      '--run',
+      '--typecheck.ignoreSourceErrors',
+    )
+    expect(vitest.stdout).not.toContain('Unhandled Errors')
+    expect(vitest.stderr).not.toContain('Unhandled Source Error')
+    expect(vitest.stderr).not.toContain('TypeCheckError: Cannot find name \'thisIsSourceError\'')
+  })
+})

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "exclude": [
-    "**/dist/**"
+    "**/dist/**",
+    "**/fixtures/**",
   ]
 }

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "exclude": [
     "**/dist/**",
-    "**/fixtures/**",
+    "**/fixtures/**"
   ]
 }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/4981

When surfacing `tsc`'s non zero exit code, it wasn't considering source errors. This is especially the case for run mode, since `tsc`'s exit code exists for this case.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
