### PR TITLE
fix(vitest): support older NodeJS with async `import.meta.resolve`

### DIFF
--- a/packages/vitest/src/runtime/external-executor.ts
+++ b/packages/vitest/src/runtime/external-executor.ts
@@ -71,7 +71,11 @@ export class ExternalModulesExecutor {
   }
 
   public resolveModule = async (specifier: string, referencer: string) => {
-    const identifier = this.resolve(specifier, referencer)
+    let identifier = this.resolve(specifier, referencer) as string | Promise<string>
+
+    if (identifier instanceof Promise)
+      identifier = await identifier
+
     return await this.createModule(identifier)
   }
 
@@ -81,6 +85,8 @@ export class ExternalModulesExecutor {
       if (id)
         return id
     }
+
+    // import.meta.resolve can be asynchronous in older +18 Node versions
     return nativeResolve(specifier, parent)
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- https://github.com/vitest-dev/vitest/pull/5011#discussion_r1466552730

`import.meta.resolve` can be asynchronous in older Node versions like my `18.17.1`:

- https://github.com/nodejs/node/pull/43363
- https://github.com/nodejs/node/pull/43526


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
