### PR TITLE
fix!: change default `pool` to `'forks'`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -586,7 +586,7 @@ By providing an object instead of a string you can define individual outputs whe
 ### pool<NonProjectOption /> <Badge type="info">1.0.0+</Badge> {#pool}
 
 - **Type:** `'threads' | 'forks' | 'vmThreads' | 'vmForks'`
-- **Default:** `'threads'`
+- **Default:** `'forks'` (in v1 `'threads'`)
 - **CLI:** `--pool=threads`
 
 Pool used to run tests in.

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -65,9 +65,8 @@ This error can happen when NodeJS's `fetch` is used with default [`pool: 'thread
 
 As work-around you can switch to [`pool: 'forks'`](/config/#forks) or [`pool: 'vmForks'`](/config/#vmforks).
 
-Specify `pool` in your configuration file:
-
-```ts
+::: code-group
+```ts [vitest.config.js]
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -76,12 +75,33 @@ export default defineConfig({
   },
 })
 ```
-
-Or in your `package.json` scripts:
-
-```diff
-scripts: {
--  "test": "vitest"
-+  "test": "vitest --pool=forks"
-}
+```bash [CLI]
+vitest --pool=forks
 ```
+:::
+
+## Segfaults and native code errors
+
+Running [native NodeJS modules](https://nodejs.org/api/addons.html) in `pool: 'threads'` can run into cryptic errors coming from the native code.
+
+- `Segmentation fault (core dumped)`
+- `thread '<unnamed>' panicked at 'assertion failed`
+- `Abort trap: 6`
+- `internal error: entered unreachable code`
+
+In these cases the native module is likely not built to be multi-thread safe. As work-around, you can switch to `pool: 'forks'` which runs the test cases in multiple `node:child_process` instead of multiple `node:worker_threads`.
+
+::: code-group
+```ts [vitest.config.js]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    pool: 'forks',
+  },
+})
+```
+```bash [CLI]
+vitest --pool=forks
+```
+:::

--- a/docs/guide/improving-performance.md
+++ b/docs/guide/improving-performance.md
@@ -1,5 +1,7 @@
 # Improving Performance
 
+## Test isolation
+
 By default Vitest runs every test file in an isolated environment based on the [pool](/config/#pool):
 
 - `threads` pool runs every test file in a separate [`Worker`](https://nodejs.org/api/worker_threads.html#class-worker)
@@ -45,6 +47,27 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     fileParallelism: false,
+  },
+})
+```
+:::
+
+## Pool
+
+By default Vitest runs tests in `pool: 'forks'`. While `'forks'` pool is better for compatibility issues ([hanging process](/guide/common-errors.html#failed-to-terminate-worker) and [segfaults](/guide/common-errors.html#segfaults-and-native-code-errors)), it may be slightly slower than `pool: 'threads'` in larger projects.
+
+You can try to improve test run time by switching `pool` option in configuration:
+
+::: code-group
+```bash [CLI]
+vitest --pool=threads
+```
+```ts [vitest.config.js]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    pool: 'threads',
   },
 })
 ```

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -67,7 +67,7 @@ const config = {
   watch: !isCI,
   globals: false,
   environment: 'node' as const,
-  pool: 'threads' as const,
+  pool: 'forks' as const,
   clearMocks: false,
   restoreMocks: false,
   mockReset: false,

--- a/test/browser/vitest.config.unit.mts
+++ b/test/browser/vitest.config.unit.mts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     include: ['specs/**/*.{spec,test}.ts'],
     poolOptions: {
-      threads: {
-        singleThread: true,
+      forks: {
+        singleFork: true,
       },
     },
     hookTimeout: process.env.CI ? 120_000 : 10_000,

--- a/test/config/test/chai-config.test.ts
+++ b/test/config/test/chai-config.test.ts
@@ -18,8 +18,7 @@ describe('truncateThreshold', () => {
       ok 6 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four', …(1) ]
       ok 7 - test-each-title.test.ts > { one: 1, two: 2, three: 3 }
       ok 8 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4 }
-      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, …(2) }
-      "
+      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, …(2) }"
     `)
     expect(result.exitCode).toBe(0)
   })
@@ -43,8 +42,7 @@ describe('truncateThreshold', () => {
       ok 6 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four', …(1) ]
       ok 7 - test-each-title.test.ts > { one: 1, two: 2, three: 3 }
       ok 8 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4 }
-      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, …(2) }
-      "
+      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, …(2) }"
     `)
     expect(result.exitCode).toBe(0)
   })
@@ -68,8 +66,7 @@ describe('truncateThreshold', () => {
       ok 6 - test-each-title.test.ts > [ 'one', 'two', 'three', 'four', 'five' ]
       ok 7 - test-each-title.test.ts > { one: 1, two: 2, three: 3 }
       ok 8 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4 }
-      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4, five: 5 }
-      "
+      ok 9 - test-each-title.test.ts > { one: 1, two: 2, three: 3, four: 4, five: 5 }"
     `)
     expect(result.exitCode).toBe(0)
   })
@@ -77,5 +74,5 @@ describe('truncateThreshold', () => {
 
 function cleanOutput(output: string) {
   // remove non-deterministic output
-  return output.replaceAll(/\s*# time=.*/g, '')
+  return output.replaceAll(/\s*# time=.*/g, '').trim()
 }

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -144,7 +144,6 @@ test('boolean flag 100 should not crash CLI', async () => {
 
 test('nextTick cannot be mocked inside child_process', async () => {
   const { stderr } = await runVitest({
-    pool: 'forks',
     fakeTimers: { toFake: ['nextTick'] },
     include: ['./fake-timers.test.ts'],
   })
@@ -154,6 +153,7 @@ test('nextTick cannot be mocked inside child_process', async () => {
 
 test('nextTick can be mocked inside worker_threads', async () => {
   const { stderr } = await runVitest({
+    pool: 'threads',
     fakeTimers: { toFake: ['nextTick'] },
     include: ['./fixtures/test/fake-timers.test.ts'],
   })

--- a/test/watch/vitest.config.ts
+++ b/test/watch/vitest.config.ts
@@ -13,13 +13,10 @@ export default defineConfig({
     testTimeout: process.env.CI ? 60_000 : 10_000,
 
     // Test cases may have side effects, e.g. files under fixtures/ are modified on the fly to trigger file watchers
-    poolOptions: {
-      forks: { singleFork: true },
-      threads: { singleThread: true },
-      vmThreads: { singleThread: true },
-    },
+    fileParallelism: false,
 
     // TODO: Fix flakiness and remove
     allowOnly: true,
+    bail: 1,
   },
 })


### PR DESCRIPTION
### Description

Switches defaut `pool` option from `'threads'` to `'forks'`. Adds new documentation pages describing common errors with `pool: 'threads'`: segfaults and process hangs.

- Closes https://github.com/vitest-dev/vitest/issues/2008
- Closes https://github.com/vitest-dev/vitest/issues/3077
- Closes https://github.com/vitest-dev/vitest/issues/4956


#### Motivation

Main goal is to provide stability over _small performance boosts_.

The `pool: 'threads'` runs code in `node:worker_threads`, `pool: 'forks'` runs code in `node:child_process`. While threads may be slightly faster than forks, it has been causing bugs that are very difficult to debug. Typically these errors are coming when users' test code contains native node module (e.g. Node packages that utilize C++, Go, Rust via [Node-API](https://nodejs.org/api/addons.html)). 

There are also some NodeJS bugs in `node:worker_threads` that can lead to `Worker`'s being stuck. So far I've been able to reproduce these issues by using [Node's native `fetch`](https://github.com/nodejs/undici/issues/2026), [`dompurify`](https://github.com/vitest-dev/vitest/issues/3077#issuecomment-1867306736) and [`fastify`](https://github.com/vitest-dev/vitest/issues/4956#issuecomment-1908312966).

All the cases mentioned above and links below work fine when using `pool: 'forks'`.

Segfaults and other native module crashes:
- https://github.com/vitest-dev/vitest/issues/2091
- https://github.com/vitest-dev/vitest/issues/2261
- https://github.com/vitest-dev/vitest/issues/3106
- https://github.com/vitest-dev/vitest/issues/3143
- https://github.com/vitest-dev/vitest/issues/3816
- https://github.com/vitest-dev/vitest/issues/2972
- https://github.com/vitest-dev/vitest/issues/2175
- https://github.com/vitest-dev/vitest/issues/5576

Process hangs:
- https://github.com/vitest-dev/vitest/issues/2008
- https://github.com/vitest-dev/vitest/issues/3077
- https://github.com/vitest-dev/vitest/issues/4956

Related issues:
- https://github.com/nodejs/undici/issues/2026
- https://github.com/getsentry/profiling-node/issues/228
- https://github.com/prisma/prisma/issues/18577
- https://github.com/vitest-dev/vitest/discussions/4914


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
