### PR TITLE
fix(vitest): don't throw an error if mocked file was already imported

### DIFF
--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -168,7 +168,7 @@ export class VitestMocker {
       if (mock.type === 'unmock')
         this.unmockPath(fsPath)
       if (mock.type === 'mock')
-        this.mockPath(mock.id, fsPath, external, mock.factory, mock.throwIfCached)
+        this.mockPath(mock.id, fsPath, external, mock.factory)
     }))
 
     VitestMocker.pendingIds = []
@@ -408,19 +408,19 @@ export class VitestMocker {
     this.deleteCachedItem(id)
   }
 
-  public mockPath(originalId: string, path: string, external: string | null, factory: MockFactory | undefined, throwIfExists: boolean) {
+  public mockPath(originalId: string, path: string, external: string | null, factory: MockFactory | undefined) {
     const id = this.normalizePath(path)
 
-    const { config } = this.executor.state
-    const isIsolatedThreads = config.pool === 'threads' && (config.poolOptions?.threads?.isolate ?? true)
-    const isIsolatedForks = config.pool === 'forks' && (config.poolOptions?.forks?.isolate ?? true)
+    // const { config } = this.executor.state
+    // const isIsolatedThreads = config.pool === 'threads' && (config.poolOptions?.threads?.isolate ?? true)
+    // const isIsolatedForks = config.pool === 'forks' && (config.poolOptions?.forks?.isolate ?? true)
 
     // TODO: find a good way to throw this error even in non-isolated mode
-    if (throwIfExists && (isIsolatedThreads || isIsolatedForks || config.pool === 'vmThreads')) {
-      const cached = this.moduleCache.has(id) && this.moduleCache.getByModuleId(id)
-      if (cached && cached.importers.size)
-        throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded by "${[...cached.importers.values()].map(i => relative(this.root, i)).join('", "')}".\n\nPlease, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again. See: https://vitest.dev/guide/common-errors.html#cannot-mock-mocked-file-js-because-it-is-already-loaded`)
-    }
+    // if (throwIfExists && (isIsolatedThreads || isIsolatedForks || config.pool === 'vmThreads')) {
+    //   const cached = this.moduleCache.has(id) && this.moduleCache.getByModuleId(id)
+    //   if (cached && cached.importers.size)
+    //     throw new Error(`[vitest] Cannot mock "${originalId}" because it is already loaded by "${[...cached.importers.values()].map(i => relative(this.root, i)).join('", "')}".\n\nPlease, remove the import if you want static imports to be mocked, or clear module cache by calling "vi.resetModules()" before mocking if you are going to import the file again. See: https://vitest.dev/guide/common-errors.html#cannot-mock-mocked-file-js-because-it-is-already-loaded`)
+    // }
 
     const suitefile = this.getSuiteFilepath()
     const mocks = this.mockMap.get(suitefile) || {}

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'node:fs'
 import vm from 'node:vm'
-import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'pathe'
+import { basename, dirname, extname, isAbsolute, join, resolve } from 'pathe'
 import { getType, highlight } from '@vitest/utils'
 import { isNodeBuiltin } from 'vite-node/utils'
 import { distDir } from '../paths'


### PR DESCRIPTION
### Description

Looks like the current condition is not sufficient enough and it catches a lot of false positives. Let's disable it for now until we find a better way to handle it.

Related #4894
Fixes #4970

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
