### PR TITLE
docs: use same pattern in examples

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -228,7 +228,7 @@ import * as mod from './foobar.js'
 vi.spyOn(mod, 'foo')
 vi.mock('./foobar.js', async (importOriginal) => {
   return {
-    ...await importOriginal(),
+    ...await importOriginal<typeof import('./foobar.js')>(),
     // this will only affect "foo" outside of the original module
     foo: () => 'mocked'
   }
@@ -610,7 +610,7 @@ expect(obj.method).toHaveBeenCalled()
 import { mocked, original } from './some-path.js'
 
 vi.mock('./some-path.js', async (importOriginal) => {
-  const mod = await importOriginal()
+  const mod = await importOriginal<typeof import('./some-path.js')>()
   return {
     ...mod,
     mocked: vi.fn()

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -609,8 +609,8 @@ expect(obj.method).toHaveBeenCalled()
 ```ts
 import { mocked, original } from './some-path.js'
 
-vi.mock('./some-path.js', async () => {
-  const mod = await vi.importActual<typeof import('./some-path.js')>('./some-path.js')
+vi.mock('./some-path.js', async (importOriginal) => {
+  const mod = await importOriginal()
   return {
     ...mod,
     mocked: vi.fn()


### PR DESCRIPTION
### Description
Mocking guide already shows off example with `originalModule` inside of `vi.mock` so use the same pattern for the second example.

- make code examples with `vi.mock` consistent
- add types for imported modules to the examples

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
