### PR TITLE
fix: fix sourcemap in vm pools

### DIFF
--- a/packages/vitest/src/runtime/runVmTests.ts
+++ b/packages/vitest/src/runtime/runVmTests.ts
@@ -19,10 +19,6 @@ import { setupCommonEnv } from './setup-common'
 export async function run(files: string[], config: ResolvedConfig, executor: VitestExecutor): Promise<void> {
   const workerState = getWorkerState()
 
-  installSourcemapsSupport({
-    getSourceMap: source => workerState.moduleCache.getSourceMap(source),
-  })
-
   await setupCommonEnv(config)
 
   Object.defineProperty(globalThis, '__vitest_index__', {
@@ -48,6 +44,10 @@ export async function run(files: string[], config: ResolvedConfig, executor: Vit
     util,
     timers,
   }
+
+  installSourcemapsSupport({
+    getSourceMap: source => workerState.moduleCache.getSourceMap(source),
+  })
 
   await startCoverageInsideWorker(config.coverage, executor)
 

--- a/packages/vitest/src/runtime/runVmTests.ts
+++ b/packages/vitest/src/runtime/runVmTests.ts
@@ -5,6 +5,7 @@ import timers from 'node:timers'
 import { performance } from 'node:perf_hooks'
 import { startTests } from '@vitest/runner'
 import { createColors, setupColors } from '@vitest/utils'
+import { installSourcemapsSupport } from 'vite-node/source-map'
 import { setupChaiConfig } from '../integrations/chai/config'
 import { startCoverageInsideWorker, stopCoverageInsideWorker } from '../integrations/coverage'
 import type { ResolvedConfig } from '../types'
@@ -17,6 +18,10 @@ import { setupCommonEnv } from './setup-common'
 
 export async function run(files: string[], config: ResolvedConfig, executor: VitestExecutor): Promise<void> {
   const workerState = getWorkerState()
+
+  installSourcemapsSupport({
+    getSourceMap: source => workerState.moduleCache.getSourceMap(source),
+  })
 
   await setupCommonEnv(config)
 

--- a/test/stacktraces/test/__snapshots__/runner.test.ts.snap
+++ b/test/stacktraces/test/__snapshots__/runner.test.ts.snap
@@ -21,6 +21,28 @@ Error: Something truly horrible has happened!
 "
 `;
 
+exports[`stacktrace in vmThreads 1`] = `
+"⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  error-with-stack.test.js > error in deps
+Error: Something truly horrible has happened!
+ ❯ d error-with-stack.test.js:20:9
+     18| 
+     19| function d() {
+     20|   throw new Error('Something truly horrible has happened!')
+       |         ^
+     21| }
+     22| 
+ ❯ c error-with-stack.test.js:16:3
+ ❯ b error-with-stack.test.js:12:3
+ ❯ a error-with-stack.test.js:8:3
+ ❯ error-with-stack.test.js:4:3
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+"
+`;
+
 exports[`stacktrace should print error frame source file correctly > error-in-deps > error-in-deps 1`] = `
 "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 

--- a/test/stacktraces/test/runner.test.ts
+++ b/test/stacktraces/test/runner.test.ts
@@ -66,3 +66,14 @@ describe('stacktrace filtering', async () => {
     expect(stderr).toMatchSnapshot('stacktrace-filtering')
   }, 30000)
 })
+
+it('stacktrace in vmThreads', async () => {
+  const root = resolve(__dirname, '../fixtures')
+  const testFile = resolve(root, './error-with-stack.test.js')
+  const { stderr } = await runVitest({
+    root,
+    pool: 'vmThreads',
+  }, [testFile])
+
+  expect(stderr).toMatchSnapshot()
+}, 3000)


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5058

It seems `installSourcemapsSupport` is dropped from vm during the refactoring done in https://github.com/vitest-dev/vitest/pull/4441 so I added back in `runVmTests.ts`. 

For non-vm pool, this happens in `setupGlobalEnv`. The code looks very similar, so it might be possible to refactor around here, but I didn't touch unnecessary code.

https://github.com/vitest-dev/vitest/blob/89d5315d65c5ddd2a797bb959b71ea2750d58ce0/packages/vitest/src/runtime/setup-node.ts#L54-L56

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
