### PR TITLE
fix(typecheck): fix suite collection while-loop

### DIFF
--- a/packages/vitest/src/typecheck/collect.ts
+++ b/packages/vitest/src/typecheck/collect.ts
@@ -99,9 +99,8 @@ export async function collectTests(ctx: WorkspaceProject, filepath: string): Pro
   })
   let lastSuite: ParsedSuite = file
   const updateLatestSuite = (index: number) => {
-    const suite = lastSuite
-    while (lastSuite !== file && lastSuite.end < index)
-      lastSuite = suite.suite as ParsedSuite
+    while (lastSuite.suite && lastSuite.end < index)
+      lastSuite = lastSuite.suite as ParsedSuite
     return lastSuite
   }
   definitions.sort((a, b) => a.start - b.start).forEach((definition) => {

--- a/test/typescript/test-d/nested-suite1.test-d.ts
+++ b/test/typescript/test-d/nested-suite1.test-d.ts
@@ -1,0 +1,11 @@
+import { describe, test } from 'vitest'
+
+describe('suite-A', () => {
+  describe('suite-B', () => {
+    test('case-X', () => {
+    })
+  })
+})
+
+test('case-Y', () => {
+})

--- a/test/typescript/test-d/nested-suite2.test-d.ts
+++ b/test/typescript/test-d/nested-suite2.test-d.ts
@@ -1,0 +1,18 @@
+import { describe, test } from 'vitest'
+
+describe('suite-A', () => {
+  describe('suite-B', () => {
+    test('case-X', () => {
+    })
+
+    describe('suite-C', () => {
+      test('case-Y', () => {
+      })
+    })
+  })
+
+  describe('suite-D', () => {
+    test('case-Z', () => {
+    })
+  })
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5021
- closes https://github.com/vitest-dev/vitest/issues/4964

Since `suite` is `const`, while-loop's body `lastSuite = suite.suite` doesn't change when `suite` is twice deep.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
