### PR TITLE
fix(vm): handle `disableConsoleIntercept` config

### DIFF
--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -48,7 +48,7 @@ export async function runVmTests(state: WorkerGlobalState) {
   // because browser doesn't provide these globals
   context.process = process
   context.global = context
-  context.console = createCustomConsole(state)
+  context.console = state.config.disableConsoleIntercept ? console : createCustomConsole(state)
   // TODO: don't hardcode setImmediate in fake timers defaults
   context.setImmediate = setImmediate
   context.clearImmediate = clearImmediate

--- a/test/config/test/console.test.ts
+++ b/test/config/test/console.test.ts
@@ -8,10 +8,11 @@ test('default intercept', async () => {
   expect(stderr).toBe('stderr | basic.test.ts > basic\n__test_console__\n\n')
 })
 
-test('disable intercept', async () => {
+test.each(['threads', 'vmThreads'] as const)(`disable intercept pool=%s`, async (pool) => {
   const { stderr } = await runVitest({
     root: './fixtures/console',
     disableConsoleIntercept: true,
+    pool,
   })
   expect(stderr).toBe('__test_console__\n')
 })


### PR DESCRIPTION
### Description

While investigating vm's sourcemap yesterday https://github.com/vitest-dev/vitest/pull/5063, I noticed `--disable-console-intercept` isn't working. I think there's no reason to not allow using global console in vm too?

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
