### PR TITLE
Revert "docs: add ant-design-web3 using vitest"

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -246,7 +246,6 @@ Learn more about [IDE Integrations](./ide.md)
 - [iconify](https://github.com/iconify/iconify)
 - [tdesign-vue-next](https://github.com/Tencent/tdesign-vue-next)
 - [cz-git](https://github.com/Zhengqbbb/cz-git)
-- [ant-design-web3](https://github.com/ant-design/ant-design-web3)
 
 <!--
 For contributors:


### PR DESCRIPTION
Reverts vitest-dev/vitest#5066

We don't add new projects there anymore. See: https://github.com/vitest-dev/vitest/pull/3207#issuecomment-1516081471