### PR TITLE
feat(runner): support automatic fixtures

### DIFF
--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -161,6 +161,32 @@ myTest('', ({ todos }) => {})
 When using `test.extend()` with fixtures, you should always use the object destructuring pattern `{ todos }` to access context both in fixture function and test function.
 :::
 
+#### Automatic fixture
+
+::: warning
+This feature is available since Vitest 1.3.0.
+:::
+
+Vitest also supports the tuple syntax for fixtures, allowing you to pass options for each fixture. For example, you can use it to explicitly initialize a fixture, even if it's not being used in tests.
+
+```ts
+import { test as base } from 'vitest'
+
+const test = base.extend({
+  fixture: [
+    async ({}, use) => {
+      // this function will run
+      setup()
+      await use()
+      teardown()
+    },
+    { auto: true } // Mark as an automatic fixture
+  ],
+})
+
+test('', () => {})
+```
+
 #### TypeScript
 
 To provide fixture types for all your custom contexts, you can pass the fixtures type as a generic.

--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -21,9 +21,11 @@ export function mergeContextFixtures(fixtures: Record<string, any>, context: { f
     .map(([prop, value]) => {
       const fixtureItem = { value } as FixtureItem
 
-      if (Array.isArray(value) && value.length >= 2
-      && isObject(value[1])
-      && Object.keys(value[1]).some(key => fixtureOptionKeys.includes(key))) {
+      if (
+        Array.isArray(value) && value.length >= 2
+        && isObject(value[1])
+        && Object.keys(value[1]).some(key => fixtureOptionKeys.includes(key))
+      ) {
         // fixture with options
         Object.assign(fixtureItem, value[1])
         fixtureItem.value = value[0]

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -217,7 +217,7 @@ export interface FixtureOptions {
   auto?: boolean
 }
 
-export type Use<T> = (value?: T) => Promise<void>
+export type Use<T> = (value: T) => Promise<void>
 export type FixtureFn<T, K extends keyof T, ExtraContext> =
   (context: Omit<T, K> & ExtraContext, use: Use<T[K]>) => Promise<void>
 export type Fixture<T, K extends keyof T, ExtraContext = {}> =

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -210,7 +210,14 @@ export type TestAPI<ExtraContext = {}> = ChainableTestAPI<ExtraContext> & Extend
       K extends keyof ExtraContext ? ExtraContext[K] : never }>
 }
 
-export type Use<T> = (value: T) => Promise<void>
+export interface FixtureOptions {
+  /**
+   * Whether to automatically set up current fixture, even though it's not being used in tests.
+   */
+  auto?: boolean
+}
+
+export type Use<T> = (value?: T) => Promise<void>
 export type FixtureFn<T, K extends keyof T, ExtraContext> =
   (context: Omit<T, K> & ExtraContext, use: Use<T[K]>) => Promise<void>
 export type Fixture<T, K extends keyof T, ExtraContext = {}> =
@@ -218,7 +225,7 @@ export type Fixture<T, K extends keyof T, ExtraContext = {}> =
     ? (T[K] extends any ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>> : never)
     : T[K] | (T[K] extends any ? FixtureFn<T, K, Omit<ExtraContext, Exclude<keyof T, K>>> : never)
 export type Fixtures<T extends Record<string, any>, ExtraContext = {}> = {
-  [K in keyof T]: Fixture<T, K, ExtraContext & ExtendedContext<Test>>
+  [K in keyof T]: Fixture<T, K, ExtraContext & ExtendedContext<Test>> | [Fixture<T, K, ExtraContext & ExtendedContext<Test>>, FixtureOptions?]
 }
 
 export type InferFixturesTypes<T> = T extends TestAPI<infer C> ? C : T

--- a/test/core/test/fixture-options.test.ts
+++ b/test/core/test/fixture-options.test.ts
@@ -3,16 +3,18 @@ import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
 const mockServer = { setup: vi.fn(), teardown: vi.fn() }
 const FnA = vi.fn()
 
-const myTest = test.extend({
+const myTest = test.extend<{
+  autoFixture: void
+  normalFixture: any[]
+}>({
   autoFixture: [async ({}, use) => {
     await mockServer.setup()
     await use()
     await mockServer.teardown()
   }, { auto: true }],
 
-  normalFixture: [async ({}, use) => {
+  normalFixture: [async () => {
     await FnA()
-    await use()
   }, {}],
 })
 

--- a/test/core/test/fixture-options.test.ts
+++ b/test/core/test/fixture-options.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mockServer = { setup: vi.fn(), teardown: vi.fn() }
+const FnA = vi.fn()
+
+export const myTest = test.extend({
+  autoFixture: [async ({}, use) => {
+    await mockServer.setup()
+    await use()
+    await mockServer.teardown()
+  }, { auto: true }],
+
+  normalFixture: [async ({}, use) => {
+    await FnA()
+    await use()
+  }, {}],
+})
+
+describe('fixture with options', () => {
+  describe('automatic fixture', () => {
+    beforeEach(() => {
+      expect(mockServer.setup).toBeCalledTimes(1)
+    })
+
+    afterAll(() => {
+      expect(mockServer.setup).toBeCalledTimes(1)
+      expect(mockServer.teardown).toBeCalledTimes(1)
+    })
+
+    myTest('should setup mock server', () => {
+      expect(mockServer.setup).toBeCalledTimes(1)
+    })
+  })
+
+  describe('normal fixture', () => {
+    myTest('it is not a fixture with options', ({ normalFixture }) => {
+      expect(FnA).not.toBeCalled()
+      expect(normalFixture).toBeInstanceOf(Array)
+    })
+  })
+})

--- a/test/core/test/fixture-options.test.ts
+++ b/test/core/test/fixture-options.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
 const mockServer = { setup: vi.fn(), teardown: vi.fn() }
 const FnA = vi.fn()
 
-export const myTest = test.extend({
+const myTest = test.extend({
   autoFixture: [async ({}, use) => {
     await mockServer.setup()
     await use()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
To close #4953, this PR adds the [automatic fixtures](https://playwright.dev/docs/test-fixtures#automatic-fixtures) feature, allowing users to explicitly initialize fixtures even they are not being used in tests.

Like Playwright, users can use the tuple syntax to pass options for each fixture through the second element. And Only if supported options (currently, only the `auto` option) are passed, we consider it as a fixture with options.

So below is an automatic fixture:

```ts
import { test as base } from 'vitest'

const test = base.extend({
  fixture: [
    async ({}, use) => {
     // this function will run automatically
      setup()
      await use()
      teardown()
    },
    { auto: true } // Mark as an automatic fixture
  ],
})

test('', () => {})
``` 

And here are normal fixtures:

```ts
import { test as base, expect } from 'vitest'

const test = base.extend({
  fixture1: [
    async ({}, use) => {
      // this function will not run automatically
      setup()
      await use()
      teardown()
    },
  ],
  fixture2: [
    async ({}, use) => {
      // this function will not run automatically
      setup()
      await use()
      teardown()
    },
   { foo: 1 }
  ],
})

test('', ({ fixture1, fixture2 }) => {
  expect(fixture1).toBeInstanceOf(Array)
  expect(fixture2).toBeInstanceOf(Array)
})
```

Not quite sure if it's the right solution for the tuple syntax, I'm following Playwright's behavior for compatibility, would love to receive some feedback, thanks!

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
