### PR TITLE
fix: rpc timeout error messages to include caller

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -72,7 +72,7 @@
     "@vitest/ws-client": "workspace:*",
     "@vueuse/core": "^10.6.1",
     "ansi-to-html": "^0.7.2",
-    "birpc": "0.2.14",
+    "birpc": "0.2.15",
     "codemirror": "^5.65.16",
     "codemirror-theme-vars": "^0.1.2",
     "cypress": "^13.6.2",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -176,7 +176,7 @@
     "@types/node": "^20.11.5",
     "@types/prompts": "^2.4.9",
     "@types/sinonjs__fake-timers": "^8.1.5",
-    "birpc": "0.2.14",
+    "birpc": "0.2.15",
     "chai-subset": "^1.6.0",
     "cli-truncate": "^4.0.0",
     "expect-type": "^0.17.3",

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -157,6 +157,9 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, _server?: Vi
         eventNames: ['onUserConsoleLog', 'onFinished', 'onCollected', 'onCancel'],
         serialize: (data: any) => stringify(data, stringifyReplace),
         deserialize: parse,
+        onTimeoutError(functionName) {
+          throw new Error(`[vitest-api]: Timeout calling "${functionName}"`)
+        },
       },
     )
 

--- a/packages/vitest/src/node/pools/forks.ts
+++ b/packages/vitest/src/node/pools/forks.ts
@@ -33,6 +33,9 @@ function createChildProcessChannel(project: WorkspaceProject) {
       on(fn) {
         emitter.on(events.response, fn)
       },
+      onTimeoutError(functionName) {
+        throw new Error(`[vitest-pool]: Timeout calling "${functionName}"`)
+      },
     },
   )
 

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -26,6 +26,9 @@ function createWorkerChannel(project: WorkspaceProject) {
       on(fn) {
         port.on('message', fn)
       },
+      onTimeoutError(functionName) {
+        throw new Error(`[vitest-pool]: Timeout calling "${functionName}"`)
+      },
     },
   )
 

--- a/packages/vitest/src/node/pools/vmForks.ts
+++ b/packages/vitest/src/node/pools/vmForks.ts
@@ -38,6 +38,9 @@ function createChildProcessChannel(project: WorkspaceProject) {
       on(fn) {
         emitter.on(events.response, fn)
       },
+      onTimeoutError(functionName) {
+        throw new Error(`[vitest-pool]: Timeout calling "${functionName}"`)
+      },
     },
   )
 

--- a/packages/vitest/src/node/pools/vmThreads.ts
+++ b/packages/vitest/src/node/pools/vmThreads.ts
@@ -30,6 +30,9 @@ function createWorkerChannel(project: WorkspaceProject) {
       on(fn) {
         port.on('message', fn)
       },
+      onTimeoutError(functionName) {
+        throw new Error(`[vitest-pool]: Timeout calling "${functionName}"`)
+      },
     },
   )
 

--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -67,6 +67,14 @@ export function createRuntimeRpc(options: Pick<BirpcOptions<RuntimeRPC>, 'on' | 
     },
     {
       eventNames: ['onUserConsoleLog', 'onFinished', 'onCollected', 'onCancel'],
+      onTimeoutError(functionName, args) {
+        let message = `[vitest-worker]: Timeout calling "${functionName}"`
+
+        if (functionName === 'fetch' || functionName === 'transform' || functionName === 'resolveId')
+          message += ` with "${JSON.stringify(args)}"`
+
+        throw new Error(message)
+      },
       ...options,
     },
   ))

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -39,7 +39,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "birpc": "0.2.14",
+    "birpc": "0.2.15",
     "flatted": "^3.2.9",
     "ws": "^8.14.2"
   },

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -78,6 +78,9 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
     on: fn => (onMessage = fn),
     serialize: stringify,
     deserialize: parse,
+    onTimeoutError(functionName) {
+      throw new Error(`[vitest-ws-client]: Timeout calling "${functionName}"`)
+    },
   }
 
   ctx.rpc = createBirpc<WebSocketHandlers, WebSocketEvents>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1196,8 +1196,8 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2
       birpc:
-        specifier: 0.2.14
-        version: 0.2.14
+        specifier: 0.2.15
+        version: 0.2.15
       codemirror:
         specifier: ^5.65.16
         version: 5.65.16
@@ -1397,8 +1397,8 @@ importers:
         specifier: ^8.1.5
         version: 8.1.5
       birpc:
-        specifier: 0.2.14
-        version: 0.2.14
+        specifier: 0.2.15
+        version: 0.2.15
       chai-subset:
         specifier: ^1.6.0
         version: 1.6.0
@@ -1470,8 +1470,8 @@ importers:
   packages/ws-client:
     dependencies:
       birpc:
-        specifier: 0.2.14
-        version: 0.2.14
+        specifier: 0.2.15
+        version: 0.2.15
       flatted:
         specifier: ^3.2.9
         version: 3.2.9
@@ -12376,8 +12376,8 @@ packages:
     dev: true
     optional: true
 
-  /birpc@0.2.14:
-    resolution: {integrity: sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==}
+  /birpc@0.2.15:
+    resolution: {integrity: sha512-LuZgWLW6DB1zenkfJuF4/kfSZdazOR2xaMSzeqgvfbNIwECwV1AJso9wpNje79uaRU86Obbujv4qtDnwoOLQww==}
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Ref. https://github.com/antfu/birpc/pull/13

Improves error messages caused by `birpc` timeouts. Currently it can be difficult to track down a `birpc` timeout error as those are used in multiple modules. This PR extends the error message to include the caller in Vitest's context. The test runner's RPC also adds arguments of some known functions.


<img width="480" src="https://github.com/vitest-dev/vitest/assets/14806298/0aa304e5-7e18-4b5b-885c-54131c9ec572" />


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
