### PR TITLE
fix: one-line environment options

### DIFF
--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -57,10 +57,13 @@ export async function groupFilesByEnv(
         file,
       )
 
-      const envOptions = JSON.parse(
-        code.match(/@(?:vitest|jest)-environment-options\s+?(.+?)(?=\s*\*\/)/)?.[1]
-        || 'null',
-      )
+      let envOptionsJson = code.match(/@(?:vitest|jest)-environment-options\s+(.+)/)?.[1]
+      if (envOptionsJson?.endsWith('*/')) {
+        // Trim closing Docblock characters the above regex might have captured
+        envOptionsJson = envOptionsJson.slice(0, -2)
+      }
+
+      const envOptions = JSON.parse(envOptionsJson || 'null')
       const envKey = env === 'happy-dom' ? 'happyDOM' : env
       const environment: ContextTestEnvironment = {
         name: env as VitestEnvironment,

--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -58,7 +58,7 @@ export async function groupFilesByEnv(
       )
 
       const envOptions = JSON.parse(
-        code.match(/@(?:vitest|jest)-environment-options\s+?(.+)/)?.[1]
+        code.match(/@(?:vitest|jest)-environment-options\s+?(.+?)(?=\s*\*\/)/)?.[1]
         || 'null',
       )
       const envKey = env === 'happy-dom' ? 'happyDOM' : env

--- a/test/core/test/dom-single-line-options.test.ts
+++ b/test/core/test/dom-single-line-options.test.ts
@@ -1,0 +1,7 @@
+/** @vitest-environment jsdom */
+
+/** @vitest-environment-options { "url": "https://example.com/" } */
+
+import { expect, it } from 'vitest'
+
+it('parse single line environment options', () => expect(location.href).toBe('https://example.com/'))


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/issues/5104

Environment options cannot be parsed when declared like so:

```
/** @vitest-environment-options {"url": "https://vitejs.dev"} */
```

The regexp captures `{"url": "https://vitejs.dev"} */`

I would like to add tests but I get hit with the following error message when trying to run them:

```
examples/graphql test: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/benjamin/projects/vitest/packages/vitest/dist/cli-wrapper.js' imported from /home/benjamin/projects/vitest/packages/vitest/vitest.mjs
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
