### PR TITLE
fix(vitest): json reporter location should include file

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -12,7 +12,7 @@ import { parseErrorStacktrace } from '../../utils/source-map'
 
 type Status = 'passed' | 'failed' | 'skipped' | 'pending' | 'todo' | 'disabled'
 type Milliseconds = number
-interface Callsite { line: number; column: number }
+interface Callsite { line: number; column: number; file: string }
 const StatusMap: Record<TaskState, Status> = {
   fail: 'failed',
   only: 'pending',
@@ -193,6 +193,9 @@ export class JsonReporter implements Reporter {
     if (!frame)
       return
 
-    return { line: frame.line, column: frame.column }
+    let file = ''
+    if (error.stacks && error.stacks.length)
+      file = error.stacks[0].file
+    return { line: frame.line, column: frame.column, file }
   }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
JSON reporter returns location of error, but there are multiple files. What is origin of line, column? What file?
So I decided to fix that

NOTE. I don't know how to fix test snapshots, so they will run on each machine. File returns absolute path, so matching with snapshot is not possible, I guess
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
