### PR TITLE
feat(reporters): support custom options

### DIFF
--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -26,6 +26,23 @@ export default defineConfig({
 })
 ```
 
+Some reporters can be customized by passing additional options to them. Reporter specific options are described in sections below.
+
+:::tip
+Since Vitest v1.3.0
+:::
+
+```ts
+export default defineConfig({
+  test: {
+    reporters: [
+      'default',
+      ['junit', { suiteName: 'UI tests' }]
+    ],
+  },
+})
+```
+
 ## Reporter Output
 
 By default, Vitest's reporters will print their output to the terminal. When using the `json`, `html` or `junit` reporters, you can instead write your tests' output to a file by including an `outputFile` [configuration option](/config/#outputfile) either in your Vite configuration file or via CLI.
@@ -234,7 +251,18 @@ AssertionError: expected 5 to be 4 // Object.is equality
     </testsuite>
 </testsuites>
 ```
-The outputted XML contains nested `testsuites` and `testcase` tags. You can use the environment variables `VITEST_JUNIT_SUITE_NAME` and `VITEST_JUNIT_CLASSNAME` to configure their `name` and `classname` attributes, respectively.
+
+The outputted XML contains nested `testsuites` and `testcase` tags. You can use the environment variables `VITEST_JUNIT_SUITE_NAME` and `VITEST_JUNIT_CLASSNAME` to configure their `name` and `classname` attributes, respectively. These can also be customized via reporter options:
+
+```ts
+export default defineConfig({
+  test: {
+    reporters: [
+      ['junit', { suiteName: 'custom suite name', classname: 'custom-classname' }]
+    ]
+  },
+})
+```
 
 ### JSON Reporter
 

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -9,6 +9,10 @@ import { stringify } from 'flatted'
 import type { File, ModuleGraphData, Reporter, ResolvedConfig, Vitest } from 'vitest'
 import { getModuleGraph } from '../../vitest/src/utils/graph'
 
+export interface HTMLOptions {
+  outputFile?: string
+}
+
 interface PotentialConfig {
   outputFile?: string | Partial<Record<string, string>>
 }
@@ -37,6 +41,11 @@ export default class HTMLReporter implements Reporter {
   start = 0
   ctx!: Vitest
   reportUIPath!: string
+  options: HTMLOptions
+
+  constructor(options: HTMLOptions) {
+    this.options = options
+  }
 
   async onInit(ctx: Vitest) {
     this.ctx = ctx
@@ -60,7 +69,7 @@ export default class HTMLReporter implements Reporter {
   }
 
   async writeReport(report: string) {
-    const htmlFile = getOutputFile(this.ctx.config) || 'html/index.html'
+    const htmlFile = this.options.outputFile || getOutputFile(this.ctx.config) || 'html/index.html'
     const htmlFileName = basename(htmlFile)
     const htmlDir = resolve(this.ctx.config.root, dirname(htmlFile))
 

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -2,10 +2,10 @@ import type { Reporter } from '../../types'
 import { BasicReporter } from './basic'
 import { DefaultReporter } from './default'
 import { DotReporter } from './dot'
-import { JsonReporter } from './json'
+import { type JsonOptions, JsonReporter } from './json'
 import { VerboseReporter } from './verbose'
 import { TapReporter } from './tap'
-import { JUnitReporter } from './junit'
+import { type JUnitOptions, JUnitReporter } from './junit'
 import { TapFlatReporter } from './tap-flat'
 import { HangingProcessReporter } from './hanging-process'
 import type { BaseReporter } from './base'
@@ -38,5 +38,18 @@ export const ReportersMap = {
 }
 
 export type BuiltinReporters = keyof typeof ReportersMap
+
+export interface BuiltinReporterOptions {
+  default: never
+  basic: never
+  verbose: never
+  dot: never
+  json: JsonOptions
+  tap: never
+  'tap-flat': never
+  junit: JUnitOptions
+  'hanging-process': never
+  html: { outputFile?: string } // TODO: Any better place for defining this UI package's reporter options?
+}
 
 export * from './benchmark'

--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -62,9 +62,18 @@ export interface JsonTestResults {
   // wasInterrupted: boolean
 }
 
+export interface JsonOptions {
+  outputFile?: string
+}
+
 export class JsonReporter implements Reporter {
   start = 0
   ctx!: Vitest
+  options: JsonOptions
+
+  constructor(options: JsonOptions) {
+    this.options = options
+  }
 
   onInit(ctx: Vitest): void {
     this.ctx = ctx
@@ -162,7 +171,7 @@ export class JsonReporter implements Reporter {
    * @param report
    */
   async writeReport(report: string) {
-    const outputFile = getOutputFile(this.ctx.config, 'json')
+    const outputFile = this.options.outputFile ?? getOutputFile(this.ctx.config, 'json')
 
     if (outputFile) {
       const reportFile = resolve(this.ctx.config.root, outputFile)

--- a/packages/vitest/src/node/reporters/utils.ts
+++ b/packages/vitest/src/node/reporters/utils.ts
@@ -1,9 +1,9 @@
 import type { ViteNodeRunner } from 'vite-node/client'
-import type { Reporter, Vitest } from '../../types'
+import type { Reporter, ResolvedConfig, Vitest } from '../../types'
 import { BenchmarkReportsMap, ReportersMap } from './index'
 import type { BenchmarkBuiltinReporters, BuiltinReporters } from './index'
 
-async function loadCustomReporterModule<C extends Reporter>(path: string, runner: ViteNodeRunner): Promise<new () => C> {
+async function loadCustomReporterModule<C extends Reporter>(path: string, runner: ViteNodeRunner): Promise<new (options?: unknown) => C> {
   let customReporterModule: { default: new () => C }
   try {
     customReporterModule = await runner.executeId(path)
@@ -18,24 +18,27 @@ async function loadCustomReporterModule<C extends Reporter>(path: string, runner
   return customReporterModule.default
 }
 
-function createReporters(reporterReferences: Array<string | Reporter | BuiltinReporters>, ctx: Vitest) {
+function createReporters(reporterReferences: ResolvedConfig['reporters'], ctx: Vitest) {
   const runner = ctx.runner
   const promisedReporters = reporterReferences.map(async (referenceOrInstance) => {
-    if (typeof referenceOrInstance === 'string') {
-      if (referenceOrInstance === 'html') {
+    if (Array.isArray(referenceOrInstance)) {
+      const [reporterName, reporterOptions] = referenceOrInstance
+
+      if (reporterName === 'html') {
         await ctx.packageInstaller.ensureInstalled('@vitest/ui', runner.root)
         const CustomReporter = await loadCustomReporterModule('@vitest/ui/reporter', runner)
-        return new CustomReporter()
+        return new CustomReporter(reporterOptions)
       }
-      else if (referenceOrInstance in ReportersMap) {
-        const BuiltinReporter = ReportersMap[referenceOrInstance as BuiltinReporters]
-        return new BuiltinReporter()
+      else if (reporterName in ReportersMap) {
+        const BuiltinReporter = ReportersMap[reporterName as BuiltinReporters]
+        return new BuiltinReporter(reporterOptions)
       }
       else {
-        const CustomReporter = await loadCustomReporterModule(referenceOrInstance, runner)
-        return new CustomReporter()
+        const CustomReporter = await loadCustomReporterModule(reporterName, runner)
+        return new CustomReporter(reporterOptions)
       }
     }
+
     return referenceOrInstance
   })
   return Promise.all(promisedReporters)

--- a/test/reporters/src/custom-reporter.ts
+++ b/test/reporters/src/custom-reporter.ts
@@ -2,6 +2,11 @@ import type { Reporter, Vitest } from 'vitest'
 
 export default class TestReporter implements Reporter {
   ctx!: Vitest
+  options?: unknown
+
+  constructor(options?: unknown) {
+    this.options = options
+  }
 
   onInit(ctx: Vitest) {
     this.ctx = ctx
@@ -9,5 +14,8 @@ export default class TestReporter implements Reporter {
 
   onFinished() {
     this.ctx.logger.log('hello from custom reporter')
+
+    if (this.options)
+      this.ctx.logger.log(`custom reporter options ${JSON.stringify(this.options)}`)
   }
 }

--- a/test/reporters/tests/configuration-options.test-d.ts
+++ b/test/reporters/tests/configuration-options.test-d.ts
@@ -1,0 +1,61 @@
+import { assertType, test } from 'vitest'
+import type { defineConfig } from 'vitest/config'
+
+type NarrowToTestConfig<T> = T extends { test?: any } ? NonNullable<T['test']> : never
+type Configuration = NonNullable<NarrowToTestConfig<(Parameters<typeof defineConfig>[0])>>
+
+test('reporters, single', () => {
+  assertType<Configuration>({ reporters: 'basic' })
+  assertType<Configuration>({ reporters: 'default' })
+  assertType<Configuration>({ reporters: 'dot' })
+  assertType<Configuration>({ reporters: 'hanging-process' })
+  assertType<Configuration>({ reporters: 'html' })
+  assertType<Configuration>({ reporters: 'json' })
+  assertType<Configuration>({ reporters: 'junit' })
+  assertType<Configuration>({ reporters: 'tap' })
+  assertType<Configuration>({ reporters: 'tap-flat' })
+  assertType<Configuration>({ reporters: 'verbose' })
+
+  assertType<Configuration>({ reporters: 'custom-reporter' })
+  assertType<Configuration>({ reporters: './reporter.mjs' })
+  assertType<Configuration>({ reporters: { onFinished() {} } })
+})
+
+test('reporters, multiple', () => {
+  assertType<Configuration>({
+    reporters: [
+      'basic',
+      'default',
+      'dot',
+      'hanging-process',
+      'html',
+      'json',
+      'junit',
+      'tap',
+      'tap-flat',
+      'verbose',
+    ],
+  })
+  assertType<Configuration>({ reporters: ['custom-reporter'] })
+  assertType<Configuration>({ reporters: ['html', 'json', 'custom-reporter'] })
+})
+
+test('reporters, with options', () => {
+  assertType<Configuration>({
+    reporters: [
+      ['json', { outputFile: 'test.json' }],
+      ['junit', { classname: 'something', suiteName: 'Suite name', outputFile: 'test.json' }],
+      ['vitest-sonar-reporter', { outputFile: 'report.xml' }],
+    ],
+  })
+})
+
+test('reporters, mixed variations', () => {
+  assertType<Configuration>({
+    reporters: [
+      'default',
+      ['verbose'],
+      ['json', { outputFile: 'test.json' }],
+    ],
+  })
+})

--- a/test/reporters/tests/custom-reporter.spec.ts
+++ b/test/reporters/tests/custom-reporter.spec.ts
@@ -75,4 +75,10 @@ describe('custom reporters', () => {
     expect(stdout).not.includes('hello from package reporter')
     expect(stdout).includes('hello from custom reporter')
   }, TIMEOUT)
+
+  test('custom reporter with options', async () => {
+    const { stdout } = await runVitest({ root, reporters: [[customTsReporterPath, { some: { custom: 'option here' } }]], include: ['tests/reporters.spec.ts'] })
+    expect(stdout).includes('hello from custom reporter')
+    expect(stdout).includes('custom reporter options {"some":{"custom":"option here"}}')
+  }, TIMEOUT)
 })

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -41,7 +41,7 @@ test('tap-flat reporter', async () => {
 
 test('JUnit reporter', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const context = getContext()
 
   vi.mock('os', () => ({
@@ -60,7 +60,7 @@ test('JUnit reporter', async () => {
 
 test('JUnit reporter (no outputFile entry)', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const context = getContext()
   context.vitest.config.outputFile = {}
 
@@ -80,7 +80,7 @@ test('JUnit reporter (no outputFile entry)', async () => {
 
 test('JUnit reporter with outputFile', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const outputFile = resolve('report.xml')
   const context = getContext()
   context.vitest.config.outputFile = outputFile
@@ -106,7 +106,7 @@ test('JUnit reporter with outputFile', async () => {
 
 test('JUnit reporter with outputFile with XML in error message', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const outputFile = resolve('report_escape_msg_xml.xml')
   const context = getContext()
   context.vitest.config.outputFile = outputFile
@@ -135,7 +135,7 @@ test('JUnit reporter with outputFile with XML in error message', async () => {
 
 test('JUnit reporter with outputFile object', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const outputFile = resolve('report_object.xml')
   const context = getContext()
   context.vitest.config.outputFile = {
@@ -163,7 +163,7 @@ test('JUnit reporter with outputFile object', async () => {
 
 test('JUnit reporter with outputFile in non-existing directory', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const rootDirectory = resolve('junitReportDirectory')
   const outputFile = `${rootDirectory}/deeply/nested/report.xml`
   const context = getContext()
@@ -190,7 +190,7 @@ test('JUnit reporter with outputFile in non-existing directory', async () => {
 
 test('JUnit reporter with outputFile object in non-existing directory', async () => {
   // Arrange
-  const reporter = new JUnitReporter()
+  const reporter = new JUnitReporter({})
   const rootDirectory = resolve('junitReportDirectory_object')
   const outputFile = `${rootDirectory}/deeply/nested/report.xml`
   const context = getContext()
@@ -219,7 +219,7 @@ test('JUnit reporter with outputFile object in non-existing directory', async ()
 
 test('json reporter', async () => {
   // Arrange
-  const reporter = new JsonReporter()
+  const reporter = new JsonReporter({})
   const context = getContext()
 
   vi.setSystemTime(1642587001759)
@@ -234,7 +234,7 @@ test('json reporter', async () => {
 
 test('json reporter (no outputFile entry)', async () => {
   // Arrange
-  const reporter = new JsonReporter()
+  const reporter = new JsonReporter({})
   const context = getContext()
   context.vitest.config.outputFile = {}
 
@@ -250,7 +250,7 @@ test('json reporter (no outputFile entry)', async () => {
 
 test('json reporter with outputFile', async () => {
   // Arrange
-  const reporter = new JsonReporter()
+  const reporter = new JsonReporter({})
   const outputFile = resolve('report.json')
   const context = getContext()
   context.vitest.config.outputFile = outputFile
@@ -272,7 +272,7 @@ test('json reporter with outputFile', async () => {
 
 test('json reporter with outputFile object', async () => {
   // Arrange
-  const reporter = new JsonReporter()
+  const reporter = new JsonReporter({})
   const outputFile = resolve('report_object.json')
   const context = getContext()
   context.vitest.config.outputFile = {
@@ -296,7 +296,7 @@ test('json reporter with outputFile object', async () => {
 
 test('json reporter with outputFile in non-existing directory', async () => {
   // Arrange
-  const reporter = new JsonReporter()
+  const reporter = new JsonReporter({})
   const rootDirectory = resolve('jsonReportDirectory')
   const outputFile = `${rootDirectory}/deeply/nested/report.json`
   const context = getContext()
@@ -319,7 +319,7 @@ test('json reporter with outputFile in non-existing directory', async () => {
 
 test('json reporter with outputFile object in non-existing directory', async () => {
   // Arrange
-  const reporter = new JsonReporter()
+  const reporter = new JsonReporter({})
   const rootDirectory = resolve('jsonReportDirectory_object')
   const outputFile = `${rootDirectory}/deeply/nested/report.json`
   const context = getContext()

--- a/test/reporters/tests/utils.test.ts
+++ b/test/reporters/tests/utils.test.ts
@@ -24,21 +24,21 @@ describe('Reporter Utils', () => {
   })
 
   test('passing the name of a single built-in reporter returns a new instance', async () => {
-    const promisedReporters = await createReporters(['default'], ctx)
+    const promisedReporters = await createReporters([['default', {}]], ctx)
     expect(promisedReporters).toHaveLength(1)
     const reporter = promisedReporters[0]
     expect(reporter).toBeInstanceOf(DefaultReporter)
   })
 
   test('passing in the path to a custom reporter returns a new instance', async () => {
-    const promisedReporters = await createReporters(([customReporterPath]), ctx)
+    const promisedReporters = await createReporters(([[customReporterPath, {}]]), ctx)
     expect(promisedReporters).toHaveLength(1)
     const customReporter = promisedReporters[0]
     expect(customReporter).toBeInstanceOf(TestReporter)
   })
 
   test('passing in a mix of built-in and custom reporters works', async () => {
-    const promisedReporters = await createReporters(['default', customReporterPath], ctx)
+    const promisedReporters = await createReporters([['default', {}], [customReporterPath, {}]], ctx)
     expect(promisedReporters).toHaveLength(2)
     const defaultReporter = promisedReporters[0]
     expect(defaultReporter).toBeInstanceOf(DefaultReporter)

--- a/test/reporters/vitest.config.ts
+++ b/test/reporters/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
     chaiConfig: {
       truncateThreshold: 0,
     },
+    typecheck: {
+      enabled: true,
+      include: ['./tests/configuration-options.test-d.ts'],
+    },
   },
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Closes https://github.com/vitest-dev/vitest/issues/5042
- Tested custom reporter with options: https://github.com/AriPerkkio/vitest-sonar-reporter/pull/154

There are now multiple different ways how to define reporters in configuration. This is similar shape as `coverage.reporters` has.

```ts
// A single reporter by name
{ reporters: "junit" },

// Inline reporter
{ reporters: { onFinished() { method(); } } },

// A single reporter with options - new option style 
{ reporters: [["junit", { classname: "some-junit-thing", outputFile: "report.xml" }]] },

// Multiple reporters - can combine any of the above
{ 
  reporters: [
    "verbose",
    ["json"],
    ["junit", { classname: "some-junit-thing" } ],
    { onFinished() { method(); } },
    "vitest-github-actions-reporter", // Third party reporter by package name
    "/path/to/local/reporter.js", // Local reporter by path
    ["vitest-sonar-reporter", { silent: true }], // Third party reporter by with options
  ]
},
```

- `junit` reporter's `process.env.VITEST_JUNIT_CLASSNAME` and `process.env.VITEST_JUNIT_SUITE_NAME` can now be passed via reporter options: `["junit", { classname: "..." suiteName: "..." }]`. In 2.0.0 we should drop support for the environment variables.
- `test.outputFile` can now be passed as reporter option, e.g. `["json", { outputFile: "report.json" }]`. I think in 2.0.0 we should drop support for `test.outputFile` completely. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
