### PR TITLE
test: fix flaky `slowTestThreshold` test

### DIFF
--- a/test/reporters/fixtures/duration/basic.test.ts
+++ b/test/reporters/fixtures/duration/basic.test.ts
@@ -1,11 +1,10 @@
 import { test } from 'vitest';
 
-test('fast', async () => {
-  await sleep(10)
+test('fast', () => {
 });
 
 test('slow', async () => {
-  await sleep(200)
+  await sleep(300)
 });
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))

--- a/test/reporters/fixtures/duration/vitest.config.ts
+++ b/test/reporters/fixtures/duration/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    slowTestThreshold: 100
+    slowTestThreshold: 290
   }
 })


### PR DESCRIPTION
### Description

On CI, it sometimes happens that the "fast" one (10 ms) is taking over `slowTestThreshold` (100 ms) possibly due to a heavy cpu load.

https://github.com/vitest-dev/vitest/actions/runs/7808613959/job/21299124920?pr=5093#step:8:811

I tweaked some numbers so that hopefully it will be less flaky.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
