### PR TITLE
fix(vitest): remove excessive listeners when running without isolation, don't reset the state

### DIFF
--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -73,6 +73,10 @@ export function createRuntimeRpc(options: Pick<BirpcOptions<RuntimeRPC>, 'on' | 
         if (functionName === 'fetch' || functionName === 'transform' || functionName === 'resolveId')
           message += ` with "${JSON.stringify(args)}"`
 
+        // JSON.stringify cannot serialize Error instances
+        if (functionName === 'onUnhandledError')
+          message += ` with "${args[0]?.message || args[0]}"`
+
         throw new Error(message)
       },
       ...options,


### PR DESCRIPTION
### Description

We don't reset the state anymore because it doesn't do anything (the state is on the global object, so resetting the reference makes no difference for gc). The same can be said for the environment.

I also noticed Vitest sometimes shows a warning that too many listeners are applied - I think we worked around it by silencing the error with `setMaxListeners` which should never be the solution 😄 

Closes #5071

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
