### PR TITLE
fix(vitest): disable optimizer by default until it's stable

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -230,7 +230,7 @@ You will not be able to edit your `node_modules` code for debugging, since the c
 #### deps.optimizer.{mode}.enabled
 
 - **Type:** `boolean`
-- **Default:** `true` if using >= Vite 4.3.2, `false` otherwise
+- **Default:** `false` since Vitest 1.3.0
 
 Enable dependency optimization.
 
@@ -702,7 +702,6 @@ Minimum number of threads. You can also use `VITEST_MIN_THREADS` environment var
 
 Run all tests with the same environment inside a single worker thread. This will disable built-in module isolation (your source code or [inlined](#deps-inline) code will still be reevaluated for each test), but can improve test performance.
 
-
 :::warning
 Even though this option will force tests to run one after another, this option is different from Jest's `--runInBand`. Vitest uses workers not only for running tests in parallel, but also to provide isolation. By disabling this option, your tests will run sequentially, but in the same global context, so you must provide isolation yourself.
 
@@ -781,7 +780,6 @@ Isolate environment for each test file.
 - **Default:** `false`
 
 Run all tests with the same environment inside a single child process. This will disable built-in module isolation (your source code or [inlined](#deps-inline) code will still be reevaluated for each test), but can improve test performance.
-
 
 :::warning
 Even though this option will force tests to run one after another, this option is different from Jest's `--runInBand`. Vitest uses child processes not only for running tests in parallel, but also to provide isolation. By disabling this option, your tests will run sequentially, but in the same global context, so you must provide isolation yourself.
@@ -880,7 +878,6 @@ Pass additional arguments to `node` process in the VM context. See [Command-line
 :::warning
 Be careful when using, it as some options may crash worker, e.g. --prof, --title. See https://github.com/nodejs/node/issues/41103.
 :::
-
 
 #### poolOptions.vmForks<NonProjectOption />
 
@@ -1062,7 +1059,6 @@ declare module 'vitest' {
 }
 ```
 :::
-
 
 ### watchExclude<NonProjectOption />
 
@@ -1557,10 +1553,10 @@ Path to a provider that will be used when running browser tests. Vitest provides
 ```ts
 export interface BrowserProvider {
   name: string
-  getSupportedBrowsers(): readonly string[]
-  initialize(ctx: Vitest, options: { browser: string; options?: BrowserProviderOptions }): Awaitable<void>
-  openPage(url: string): Awaitable<void>
-  close(): Awaitable<void>
+  getSupportedBrowsers: () => readonly string[]
+  initialize: (ctx: Vitest, options: { browser: string; options?: BrowserProviderOptions }) => Awaitable<void>
+  openPage: (url: string) => Awaitable<void>
+  close: () => Awaitable<void>
 }
 ```
 

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -14,7 +14,7 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
     console.warn(`Vitest: "deps.optimizer" is only available in Vite >= 4.3.2, current Vite version: ${viteVersion}`)
   else
     // enable by default
-    testOptions.enabled ??= true
+    testOptions.enabled ??= false
   if (!allowed || testOptions?.enabled !== true) {
     newConfig.cacheDir = undefined
     newConfig.optimizeDeps = {


### PR DESCRIPTION
### Description

The optimizer is not stable enough at this point (some packages like `react` don't work with it and if all dependencies are not pre-bundled, there is a high chance users will get a "Cannot find module" error only in CI which is hard to debug). Since Vitest 1.3.0 focuses more on stability, we are disabling this option until we can figure out a good way to enable it without these hazards. If your tests are slower after this PR, you can always enable optimizer manually:

```ts
export default defineConfig({
  test: {
    deps: {
      optimizer: {
        web: {
           enabled: true,
        },
        ssr: {
          enabled: true,
        }
      }
    }
  }
})
```


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
