### PR TITLE
fix(vitest): auto-enable "github-actions" only where users didn't configure reporters

### DIFF
--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -447,7 +447,17 @@ export default defineConfig({
 ### Github Actions Reporter <Badge type="info">1.3.0+</Badge>
 
 Output [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)
-to provide annotations for test failures. This reporter is automatically enabled when `process.env.GITHUB_ACTIONS === 'true'`, thus it doesn't require any configuration.
+to provide annotations for test failures. This reporter is automatically enabled with a [`default`](#default-reporter) reporter when `process.env.GITHUB_ACTIONS === 'true'`.
+
+If you configure non-default reporters, you need to explicitly add `github-actions`.
+
+```ts
+export default defineConfig({
+  test: {
+    reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot'],
+  },
+})
+```
 
 <img alt="Github Actions" img-dark src="https://github.com/vitest-dev/vitest/assets/4232207/336cddc2-df6b-4b8a-8e72-4d00010e37f5">
 <img alt="Github Actions" img-light src="https://github.com/vitest-dev/vitest/assets/4232207/ce8447c1-0eab-4fe1-abef-d0d322290dca">

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -419,12 +419,13 @@ export function resolveConfig(
       resolved.reporters = Array.from(new Set(toArray(cliReporters))).filter(Boolean).map(reporter => [reporter, {}])
   }
 
-  if (!resolved.reporters.length)
+  if (!resolved.reporters.length) {
     resolved.reporters.push(['default', {}])
 
-  // automatically enable github-actions reporter
-  if (process.env.GITHUB_ACTIONS === 'true' && !resolved.reporters.some(v => Array.isArray(v) && v[0] === 'github-actions'))
-    resolved.reporters.push(['github-actions', {}])
+    // also enable github-actions reporter as a default
+    if (process.env.GITHUB_ACTIONS === 'true')
+      resolved.reporters.push(['github-actions', {}])
+  }
 
   if (resolved.changed)
     resolved.passWithNoTests ??= true


### PR DESCRIPTION
### Description

- follow up https://github.com/vitest-dev/vitest/pull/5093

Based on the discussion on discord https://discord.com/channels/917386801235247114/1123254125191241868/1205400484530225214, this PR changes `github-actions` to be auto-enabled only when `reporters` are not explicitly provided by users.

Though I think it makes sense, this would potentially make it harder for this feature to reach some people. I still kinda want to see this feature to be enabled automatically for any condition on v1.3.0 and later consider tweaking conditions based on users feedback. So, if doing something is really necessary, then I might prefer introducing yet-another variable like  `VITEST_GITHUB_ACTIONS_REPORTER` 
https://github.com/vitest-dev/vitest/pull/5093#issuecomment-1935419295 to allow opting out. What do you think?


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
