### PR TITLE
fix(vitest): support more array cli options

### DIFF
--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -176,6 +176,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
       extension: {
         description: 'Extension to be included in coverage. May be specified more than once when using multiple extensions (default: [".js", ".cjs", ".mjs", ".ts", ".mts", ".cts", ".tsx", ".jsx", ".vue", ".svelte"])',
         argument: '<extension>',
+        array: true,
       },
       clean: {
         description: 'Clean coverage results before running tests (default: true)',
@@ -192,6 +193,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
         description: 'Coverage reporters to use. Visit https://vitest.dev/config/#coverage-reporter for more information (default: ["text", "html", "clover", "json"])',
         argument: '<name>',
         subcommands: null, // don't support custom objects
+        array: true,
       },
       reportOnFailure: {
         description: 'Generate coverage report even when tests fail (default: false)',

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -140,6 +140,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
     description: 'Specify reporters',
     argument: '<name>',
     subcommands: null, // don't support custom objects
+    array: true,
   },
   outputFile: {
     argument: '<filename/-s>',

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -119,3 +119,14 @@ test('even if coverage is boolean, don\'t fail', () => {
     provider: 'v8',
   })
 })
+
+test('array options', () => {
+  expect(parseArguments('--reporter json --reporter=default')).toMatchInlineSnapshot(`
+    {
+      "reporter": [
+        "json",
+        "default",
+      ],
+    }
+  `)
+})

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -64,7 +64,7 @@ test('nested coverage options have correct types', async () => {
     --coverage.thresholds.branches 25
   `).coverage).toEqual({
     enabled: true,
-    reporter: 'text',
+    reporter: ['text'],
     all: true,
     provider: 'v8',
     clean: false,
@@ -121,8 +121,34 @@ test('even if coverage is boolean, don\'t fail', () => {
 })
 
 test('array options', () => {
-  expect(parseArguments('--reporter json --reporter=default')).toMatchInlineSnapshot(`
+  expect(parseArguments('--reporter json --coverage.reporter=html --coverage.extension ts')).toMatchInlineSnapshot(`
     {
+      "coverage": {
+        "extension": [
+          "ts",
+        ],
+        "reporter": [
+          "html",
+        ],
+      },
+      "reporter": [
+        "json",
+      ],
+    }
+  `)
+
+  expect(parseArguments('--reporter json --reporter=default --coverage.reporter=json --coverage.reporter html --coverage.extension=ts --coverage.extension=tsx')).toMatchInlineSnapshot(`
+    {
+      "coverage": {
+        "extension": [
+          "ts",
+          "tsx",
+        ],
+        "reporter": [
+          "json",
+          "html",
+        ],
+      },
       "reporter": [
         "json",
         "default",


### PR DESCRIPTION
### Description

Follow up https://github.com/vitest-dev/vitest/pull/5126#discussion_r1484047483

I think there might be more array flags like `coverage.extension` and `coverage.reporter`, but I'm not sure if these were exposed previously. Do we want to make them as `array: true` too?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
