### PR TITLE
feat!: remove watchExclude

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1036,14 +1036,6 @@ inject('wsPort') === 3000
 ```
 :::
 
-### watchExclude<NonProjectOption />
-
-- **Type:** `string[]`
-- **Default:** `['**/node_modules/**', '**/dist/**']`
-- **Deprecated** use [`server.watch.ignored`](https://vitejs.dev/config/server-options.html#server-watch)
-
-Glob pattern of file paths to be ignored from triggering watch rerun.
-
 ### forceRerunTriggers<NonProjectOption />
 
 - **Type**: `string[]`
@@ -1061,7 +1053,7 @@ test('execute a script', async () => {
 ```
 
 ::: tip
-Make sure that your files are not excluded by `watchExclude`.
+Make sure that your files are not excluded by [`server.watch.ignored`](https://vitejs.dev/config/server-options.html#server-watch).
 :::
 
 ### coverage<NonProjectOption />

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -76,7 +76,6 @@ const config = {
   testTimeout: 5000,
   hookTimeout: 10000,
   teardownTimeout: 10000,
-  watchExclude: ['**/node_modules/**', '**/dist/**'],
   forceRerunTriggers: [
     '**/package.json/**',
     '**/{vitest,vite}.config.*/**',

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -615,7 +615,6 @@ export const cliOptionsConfig: VitestCLIOptions = {
   snapshotFormat: null,
   snapshotSerializers: null,
   includeSource: null,
-  watchExclude: null,
   alias: null,
   env: null,
   environmentMatchGlobs: null,

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -810,8 +810,6 @@ export class Vitest {
     if (this.config.forceRerunTriggers.length)
       watcher.add(this.config.forceRerunTriggers)
 
-    watcher.unwatch(this.config.watchExclude)
-
     watcher.on('change', onChange)
     watcher.on('unlink', onUnlink)
     watcher.on('add', onAdd)

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -135,8 +135,6 @@ export class Logger {
         this.console.error(c.dim('typecheck exclude: ') + c.yellow(config.typecheck.exclude.join(comma)))
       }
     })
-    if (config.watchExclude)
-      this.console.error(c.dim('watch exclude:  ') + c.yellow(config.watchExclude.join(comma)))
 
     if (config.watch && (config.changed || config.related?.length)) {
       this.log(`No affected ${config.mode} files found\n`)

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -80,9 +80,6 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
           },
           server: {
             ...testConfig.api,
-            watch: {
-              ignored: testConfig.watchExclude,
-            },
             open,
             hmr: false,
             preTransformRequests: false,

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -444,12 +444,6 @@ export interface InlineConfig {
   globalSetup?: string | string[]
 
   /**
-   * Glob pattern of file paths to be ignore from triggering watch rerun
-   * @deprecated Use server.watch.ignored instead
-   */
-  watchExclude?: string[]
-
-  /**
    * Glob patter of file paths that will trigger the whole suite rerun
    *
    * Useful if you are testing calling CLI commands
@@ -938,7 +932,6 @@ export type ProjectConfig = Omit<
   | 'poolOptions'
   | 'teardownTimeout'
   | 'silent'
-  | 'watchExclude'
   | 'forceRerunTriggers'
   | 'testNamePattern'
   | 'ui'


### PR DESCRIPTION
### Description

PR to remove `watchExclude`, in favor of `server.watch.ignored`. The option should be first deprecated by https://github.com/vitest-dev/vitest/pull/5171. And this PR can be merged in the next major.