### PR TITLE
fix(cli): parse `--browser=<name>` correctly

### DIFF
--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -303,10 +303,12 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   browser: {
     description: 'Run tests in the browser. Equivalent to --browser.enabled (default: false)',
-    argument: '', // allow boolean
+    argument: '<name>',
     transform(browser) {
       if (typeof browser === 'boolean')
         return { enabled: browser }
+      if (browser === 'true' || browser === 'false')
+        return { enabled: browser !== 'false' }
       if (typeof browser === 'string')
         return { enabled: true, name: browser }
       return browser

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -3,9 +3,9 @@ import { createCLI } from '../../../packages/vitest/src/node/cli/cac.js'
 
 const vitestCli = createCLI()
 
-function parseArguments(commands: string, full = false) {
+function parseArguments(commands: string, full = false, includeArgs = false) {
   const cliArgs = commands.trim().replace(/\s+/g, ' ').split(' ')
-  const { options } = vitestCli.parse(['node', '/index.js', ...cliArgs], {
+  const { options, args } = vitestCli.parse(['node', '/index.js', ...cliArgs], {
     run: false,
   })
   // remove -- and color from the options since they are always present
@@ -13,6 +13,10 @@ function parseArguments(commands: string, full = false) {
     delete options['--']
     delete options.color
   }
+
+  if (includeArgs)
+    return { options, args }
+
   return options
 }
 
@@ -149,11 +153,11 @@ test('array options', () => {
   `)
 
   expect(parseArguments(`
-  --reporter json 
-  --reporter=default 
-  --coverage.reporter=json 
-  --coverage.reporter html 
-  --coverage.extension=ts 
+  --reporter json
+  --reporter=default
+  --coverage.reporter=json
+  --coverage.reporter html
+  --coverage.extension=ts
   --coverage.extension=tsx
   `)).toMatchInlineSnapshot(`
     {
@@ -216,4 +220,17 @@ test('cache is parsed correctly', () => {
   expect(parseArguments('--cache.dir .\\test\\cache.json')).toEqual({
     cache: { dir: 'test/cache.json' },
   })
+})
+
+test('browser as boolean', () => {
+  const { options, args } = parseArguments('--browser', false, true)
+  expect(options).toEqual({ browser: { enabled: true } })
+  expect(args).toEqual([])
+})
+
+test('browser as string', () => {
+  const { options, args } = parseArguments('--browser=firefox', false, true)
+
+  expect(args).toEqual([])
+  expect(options).toEqual({ browser: { enabled: true, name: 'firefox' } })
 })

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -222,13 +222,25 @@ test('cache is parsed correctly', () => {
   })
 })
 
-test('browser as boolean', () => {
+test('browser as implicit boolean', () => {
   const { options, args } = parseArguments('--browser', false, true)
   expect(options).toEqual({ browser: { enabled: true } })
   expect(args).toEqual([])
 })
 
-test('browser as string', () => {
+test('browser as explicit boolean', () => {
+  const { options, args } = parseArguments('--browser=true', false, true)
+  expect(options).toEqual({ browser: { enabled: true } })
+  expect(args).toEqual([])
+})
+
+test('browser as explicit boolean with space', () => {
+  const { options, args } = parseArguments('--browser true', false, true)
+  expect(options).toEqual({ browser: { enabled: true } })
+  expect(args).toEqual([])
+})
+
+test('browser by name', () => {
   const { options, args } = parseArguments('--browser=firefox', false, true)
 
   expect(args).toEqual([])


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes https://github.com/vitest-dev/vitest/pull/5126#issuecomment-1937005521

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
