### PR TITLE
fix(coverage): `.tmp` directory conflicts with `--shard` option

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -98,7 +98,10 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       relativePath: !this.options.allowExternal,
     })
 
-    this.coverageFilesDirectory = resolve(this.options.reportsDirectory, '.tmp')
+    const shard = this.ctx.config.shard
+    const tempDirectory = `.tmp${shard ? `-${shard.index}-${shard.count}` : ''}`
+
+    this.coverageFilesDirectory = resolve(this.options.reportsDirectory, tempDirectory)
   }
 
   resolveOptions() {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -101,7 +101,10 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       relativePath: !this.options.allowExternal,
     })
 
-    this.coverageFilesDirectory = resolve(this.options.reportsDirectory, '.tmp')
+    const shard = this.ctx.config.shard
+    const tempDirectory = `.tmp${shard ? `-${shard.index}-${shard.count}` : ''}`
+
+    this.coverageFilesDirectory = resolve(this.options.reportsDirectory, tempDirectory)
   }
 
   resolveOptions() {

--- a/test/coverage-test/option-tests/shard.test.ts
+++ b/test/coverage-test/option-tests/shard.test.ts
@@ -1,0 +1,9 @@
+import { readdirSync } from 'node:fs'
+import { expect, test } from 'vitest'
+
+test('temporary directory is postfixed with --shard value', () => {
+  const files = readdirSync('./coverage')
+
+  expect(files).toContain('.tmp-1-4')
+  expect(files).not.toContain('.tmp')
+})

--- a/test/coverage-test/testing-options.mjs
+++ b/test/coverage-test/testing-options.mjs
@@ -43,6 +43,14 @@ const testCases = [
     },
     assertionConfig: null,
   },
+  {
+    testConfig: {
+      name: 'temp directory with shard',
+      include: ['option-tests/shard.test.ts'],
+      shard: '1/4',
+    },
+    assertionConfig: null,
+  },
 ]
 
 for (const provider of ['v8', 'istanbul']) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Related to https://github.com/vitest-dev/vitest/issues/5125 but does not close the issue completely

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
