### PR TITLE
feat(vite-node): provide `import.meta.resolve`

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -303,6 +303,9 @@ export class ViteNodeRunner {
       env,
       filename: __filename,
       dirname: __dirname,
+      // this requires users to enable "--experimental-import-meta-resolve" even on the latest NodeJS since it uses 2nd argument `parent`.
+      // TODO: how to guard "import.meta" syntax error on vite-node cjs users?
+      resolve: (specifier: string, parent?: string | URL) => import.meta.resolve(specifier, parent ?? href),
     }
     const exports = Object.create(null)
     Object.defineProperty(exports, Symbol.toStringTag, {

--- a/test/import-meta-resolve/package.json
+++ b/test/import-meta-resolve/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitest/test-import-meta-resolve",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "workspace:*"
+  }
+}

--- a/test/import-meta-resolve/test/basic.test.ts
+++ b/test/import-meta-resolve/test/basic.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest'
+
+test('basic', () => {
+  // relative path
+  expect(
+    cleanDir(import.meta.resolve('../package.json')),
+  ).toMatchInlineSnapshot(`"__DIR__/test/import-meta-resolve/package.json"`)
+
+  // not throw in latest NodeJS
+  expect(cleanDir(import.meta.resolve('../no-such-file'))).toMatchInlineSnapshot(
+    `"__DIR__/test/import-meta-resolve/no-such-file"`,
+  )
+
+  // with 2nd argument `parent`
+  expect(
+    cleanDir(
+      import.meta.resolve('./package.json', new URL('..', import.meta.url)),
+    ),
+  ).toMatchInlineSnapshot(`"__DIR__/test/import-meta-resolve/package.json"`)
+
+  // node_module
+  expect(cleanDir(import.meta.resolve('vitest'))).toMatchInlineSnapshot(
+    `"__DIR__/packages/vitest/dist/index.js"`,
+  )
+
+  expect(() =>
+    cleanDir(import.meta.resolve('@vitest/not-such-module')),
+  ).toThrow(
+    expect.objectContaining({
+      message: expect.stringContaining(
+        'Cannot find package \'@vitest/not-such-module\' imported from',
+      ),
+    }),
+  )
+})
+
+// make output deterministic
+function cleanDir(out: string) {
+  const dir = new URL('../../..', import.meta.url).toString()
+  return out.replace(dir, '__DIR__/')
+}

--- a/test/import-meta-resolve/vitest.config.ts
+++ b/test/import-meta-resolve/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    poolOptions: {
+      threads: {
+        execArgv: ['--experimental-import-meta-resolve'],
+      },
+      forks: {
+        execArgv: ['--experimental-import-meta-resolve'],
+      },
+      vmThreads: {
+        execArgv: ['--experimental-import-meta-resolve'],
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Description

_related_

- https://github.com/vitejs/vite/discussions/15871
  - the user is wishing to use `import.meta.resolve` inside vitest
- https://github.com/vitejs/vite/issues/14500
  - So far, Vite side issue is mostly concerned with browser usages. For SSR, eventually this feature would be provided at ViteRuntime level.

I'm not sure if this has been considered before. Assuming `--experimental-import-meta-resolve` is explicitly managed by users (and thus this feature is considered experimental as well on vite-node/vitest), this approach seems to work.

I noticed that a similar approach is already used to implement `import.meta.resolve` for VM external:

https://github.com/vitest-dev/vitest/blob/060a638eb7e4ed630de0d04aba5c8f37a9673c96/packages/vitest/src/runtime/vm/esm-executor.ts#L70-L72

Do you think this is a good addition?
If it's too early to start implementing, then I can create a separate issue on Vitest (or maybe just linking to Vite issue https://github.com/vitejs/vite/issues/14500 is enough).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
