### PR TITLE
chore(deps): update vite to 5.1.1 apply security patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "simple-git-hooks": "^2.9.0",
     "tsx": "^4.6.1",
     "typescript": "^5.2.2",
-    "vite": "^5.0.12",
+    "vite": "^5.1.1",
     "vitest": "workspace:*"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   rollup: ^4.9.6
-  vite: ^5.0.12
+  vite: ^5.1.1
   vitest: workspace:*
 
 patchedDependencies:
@@ -103,8 +103,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:packages/vitest
@@ -135,7 +135,7 @@ importers:
         version: 0.2.3(vite-plugin-pwa@0.16.7)
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.5.0(vite@5.0.12)(vue@3.3.8)
+        version: 4.5.0(vite@5.1.1)(vue@3.3.8)
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -144,16 +144,16 @@ importers:
         version: 4.7.1
       unocss:
         specifier: ^0.57.4
-        version: 0.57.4(postcss@8.4.32)(rollup@4.9.6)(vite@5.0.12)
+        version: 0.57.4(postcss@8.4.32)(rollup@4.9.6)(vite@5.1.1)
       unplugin-vue-components:
         specifier: ^0.25.2
         version: 0.25.2(rollup@4.9.6)(vue@3.3.8)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vite-plugin-pwa:
         specifier: ^0.16.7
-        version: 0.16.7(vite@5.0.12)(workbox-build@7.0.0)(workbox-window@7.0.0)
+        version: 0.16.7(vite@5.1.1)(workbox-build@7.0.0)(workbox-window@7.0.0)
       vitepress:
         specifier: ^1.0.0-rc.35
         version: 1.0.0-rc.35(@types/node@20.11.5)(postcss@8.4.32)(search-insights@2.9.0)(typescript@5.2.2)
@@ -167,8 +167,8 @@ importers:
         specifier: latest
         version: link:../../packages/ui
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -191,8 +191,8 @@ importers:
         specifier: ^3.9.0
         version: 3.9.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -210,8 +210,8 @@ importers:
         specifier: latest
         version: link:../../packages/ui
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -225,8 +225,8 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1(jest@27.5.1)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -247,8 +247,8 @@ importers:
         specifier: latest
         version: 22.1.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -266,7 +266,7 @@ importers:
         version: 6.1.4(marko@5.32.0)
       '@marko/vite':
         specifier: latest
-        version: 4.1.0(@marko/compiler@5.34.1)(vite@5.0.12)
+        version: 4.1.0(@marko/compiler@5.34.1)(vite@5.1.1)
       '@vitest/ui':
         specifier: latest
         version: link:../../packages/ui
@@ -277,8 +277,8 @@ importers:
         specifier: latest
         version: 5.32.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -305,8 +305,8 @@ importers:
         specifier: ^11.6.16
         version: 11.6.16
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -340,7 +340,7 @@ importers:
         version: 18.2.38
       '@vitejs/plugin-react':
         specifier: latest
-        version: 4.2.0(vite@5.0.12)
+        version: 4.2.0(vite@5.1.1)
       jsdom:
         specifier: latest
         version: 22.1.0
@@ -363,8 +363,8 @@ importers:
         specifier: ^1.41.0
         version: 1.41.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -386,7 +386,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.6.0
-        version: 2.6.0(@babel/core@7.23.3)(preact@10.15.1)(vite@5.0.12)
+        version: 2.6.0(@babel/core@7.23.3)(preact@10.15.1)(vite@5.1.1)
       '@testing-library/jest-dom':
         specifier: ^5.16.4
         version: 5.16.5
@@ -403,8 +403,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -423,7 +423,7 @@ importers:
         version: 17.0.2
       '@vitejs/plugin-react':
         specifier: latest
-        version: 4.2.0(vite@5.0.12)
+        version: 4.2.0(vite@5.1.1)
       '@vitest/ui':
         specifier: latest
         version: link:../../packages/ui
@@ -437,8 +437,8 @@ importers:
         specifier: 17.0.2
         version: 17.0.2(react@17.0.2)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -501,8 +501,8 @@ importers:
         specifier: latest
         version: 22.1.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -539,7 +539,7 @@ importers:
         version: 6.5.10(react-dom@17.0.2)(react@17.0.2)
       '@storybook/builder-vite':
         specifier: ^0.1.35
-        version: 0.1.41(@babel/core@7.23.3)(@storybook/core-common@7.5.1)(@storybook/node-logger@7.5.1)(@storybook/source-loader@7.5.1)(react@17.0.2)(typescript@5.2.2)(vite@5.0.12)
+        version: 0.1.41(@babel/core@7.23.3)(@storybook/core-common@7.5.1)(@storybook/node-logger@7.5.1)(@storybook/source-loader@7.5.1)(react@17.0.2)(typescript@5.2.2)(vite@5.1.1)
       '@storybook/client-api':
         specifier: ^6.5.5
         version: 6.5.10(react-dom@17.0.2)(react@17.0.2)
@@ -569,7 +569,7 @@ importers:
         version: 17.0.17
       '@vitejs/plugin-react':
         specifier: ^4.1.0
-        version: 4.1.1(vite@5.0.12)
+        version: 4.1.1(vite@5.1.1)
       '@vitest/ui':
         specifier: latest
         version: link:../../packages/ui
@@ -589,8 +589,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -621,7 +621,7 @@ importers:
         version: 18.0.8
       '@vitejs/plugin-react':
         specifier: latest
-        version: 4.2.0(vite@5.0.12)
+        version: 4.2.0(vite@5.1.1)
       '@vitest/coverage-v8':
         specifier: latest
         version: link:../../packages/coverage-v8
@@ -635,8 +635,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -667,7 +667,7 @@ importers:
         version: 18.2.14
       '@vitejs/plugin-react':
         specifier: latest
-        version: 4.2.0(vite@5.0.12)
+        version: 4.2.0(vite@5.1.1)
       '@vitest/ui':
         specifier: latest
         version: link:../../packages/ui
@@ -678,8 +678,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.2.2)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -688,7 +688,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.5.0(vite@5.0.12)(vue@3.3.8)
+        version: 4.5.0(vite@5.1.1)(vue@3.3.8)
       '@vue/test-utils':
         specifier: latest
         version: 2.4.1(vue@3.3.8)
@@ -696,11 +696,11 @@ importers:
         specifier: latest
         version: 22.1.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vite-plugin-ruby:
         specifier: ^3.2.2
-        version: 3.2.2(vite@5.0.12)
+        version: 3.2.2(vite@5.1.1)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -724,11 +724,11 @@ importers:
         specifier: latest
         version: 22.1.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vite-plugin-solid:
         specifier: ^2.7.2
-        version: 2.7.2(solid-js@1.8.3)(vite@5.0.12)
+        version: 2.7.2(solid-js@1.8.3)(vite@5.1.1)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -737,7 +737,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: latest
-        version: 3.0.1(svelte@4.1.1)(vite@5.0.12)
+        version: 3.0.1(svelte@4.1.1)(vite@5.1.1)
       '@testing-library/svelte':
         specifier: ^4.0.3
         version: 4.0.3(svelte@4.1.1)
@@ -751,8 +751,8 @@ importers:
         specifier: latest
         version: 4.1.1
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -764,7 +764,7 @@ importers:
         version: 2.1.0(@sveltejs/kit@1.20.2)
       '@sveltejs/kit':
         specifier: ^1.20.2
-        version: 1.20.2(svelte@3.59.1)(vite@5.0.12)
+        version: 1.20.2(svelte@3.59.1)(vite@5.1.1)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -784,8 +784,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -802,8 +802,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -816,7 +816,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.5.0(vite@5.0.12)(vue@3.3.8)
+        version: 4.5.0(vite@5.1.1)(vue@3.3.8)
       '@vue/test-utils':
         specifier: ^2.0.2
         version: 2.0.2(vue@3.3.8)
@@ -830,8 +830,8 @@ importers:
         specifier: latest
         version: 0.25.2(rollup@4.9.6)(vue@3.3.8)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -844,7 +844,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.5.0(vite@5.0.12)(vue@3.3.8)
+        version: 4.5.0(vite@5.1.1)(vue@3.3.8)
       '@vue/test-utils':
         specifier: ^2.4.1
         version: 2.4.1(vue@3.3.8)
@@ -852,8 +852,8 @@ importers:
         specifier: latest
         version: 22.1.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -862,10 +862,10 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.5.0(vite@5.0.12)(vue@3.3.8)
+        version: 4.5.0(vite@5.1.1)(vue@3.3.8)
       '@vitejs/plugin-vue-jsx':
         specifier: latest
-        version: 3.1.0(vite@5.0.12)(vue@3.3.8)
+        version: 3.1.0(vite@5.1.1)(vue@3.3.8)
       '@vue/test-utils':
         specifier: latest
         version: 2.4.1(vue@3.3.8)
@@ -873,8 +873,8 @@ importers:
         specifier: latest
         version: 22.1.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -888,8 +888,8 @@ importers:
         specifier: latest
         version: link:../../packages/ui
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1180,10 +1180,10 @@ importers:
         version: 0.57.4
       '@vitejs/plugin-vue':
         specifier: ^5.0.3
-        version: 5.0.3(vite@5.0.12)(vue@3.3.8)
+        version: 5.0.3(vite@5.1.1)(vue@3.3.8)
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.2
-        version: 3.0.2(vite@5.0.12)(vue@3.3.8)
+        version: 3.0.2(vite@5.1.1)(vue@3.3.8)
       '@vitest/runner':
         specifier: workspace:*
         version: link:../runner
@@ -1219,7 +1219,7 @@ importers:
         version: 3.1.5
       unocss:
         specifier: ^0.57.4
-        version: 0.57.4(postcss@8.4.32)(rollup@4.9.6)(vite@5.0.12)
+        version: 0.57.4(postcss@8.4.32)(rollup@4.9.6)(vite@5.1.1)
       unplugin-auto-import:
         specifier: ^0.16.7
         version: 0.16.7(@vueuse/core@10.6.1)(rollup@4.9.6)
@@ -1227,11 +1227,11 @@ importers:
         specifier: ^0.25.2
         version: 0.25.2(rollup@4.9.6)(vue@3.3.8)
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vite-plugin-pages:
         specifier: ^0.31.0
-        version: 0.31.0(@vue/compiler-sfc@3.4.5)(vite@5.0.12)
+        version: 0.31.0(@vue/compiler-sfc@3.4.5)(vite@5.1.1)
       vue:
         specifier: ^3.3.8
         version: 3.3.8(typescript@5.2.2)
@@ -1279,8 +1279,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     devDependencies:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.22
@@ -1349,8 +1349,8 @@ importers:
         specifier: ^0.8.2
         version: 0.8.2
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vite-node:
         specifier: workspace:*
         version: link:../vite-node
@@ -1490,8 +1490,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/browser
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1515,7 +1515,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.0.2
-        version: 1.0.2(vite@5.0.12)
+        version: 1.0.2(vite@5.1.1)
       '@vitest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -1586,8 +1586,8 @@ importers:
   test/cli:
     devDependencies:
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1598,8 +1598,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1647,7 +1647,7 @@ importers:
         version: 3.0.3
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 4.5.0(vite@5.0.12)(vue@3.3.8)
+        version: 4.5.0(vite@5.1.1)(vue@3.3.8)
       '@vitest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -1673,8 +1673,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1757,8 +1757,8 @@ importers:
         specifier: latest
         version: 12.10.3
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1800,8 +1800,8 @@ importers:
   test/filters:
     devDependencies:
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1907,8 +1907,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1958,8 +1958,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vite-node:
         specifier: workspace:*
         version: link:../../packages/vite-node
@@ -2055,8 +2055,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/browser
       vite:
-        specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -6005,18 +6005,18 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.0.4(typescript@5.2.2)(vite@5.0.12):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.0.4(typescript@5.2.2)(vite@5.1.1):
     resolution: {integrity: sha512-ezL7SU//1OV4Oyt/zQ3CsX8uLujVEYUHuULkqgcW6wOuQfRnvgkn99HZtLWwS257GmZVwszGQzhL7VE3PbMAYw==}
     peerDependencies:
       typescript: '>= 4.3.x'
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.26.7
       react-docgen-typescript: 2.2.2(typescript@5.2.2)
       typescript: 5.2.2
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.2:
@@ -6174,11 +6174,11 @@ packages:
       self-closing-tags: 1.0.1
     dev: true
 
-  /@marko/vite@4.1.0(@marko/compiler@5.34.1)(vite@5.0.12):
+  /@marko/vite@4.1.0(@marko/compiler@5.34.1)(vite@5.1.1):
     resolution: {integrity: sha512-3cixhQvMOzeWx1YvpW9N4KzwccEHmrFPhfuGDQFi53BBh0ccgBRmb2/Aly7oCDFEP8qwZZkuDJX3278nB7KmdQ==}
     peerDependencies:
       '@marko/compiler': ^5
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@marko/compiler': 5.34.1
       anymatch: 3.1.3
@@ -6187,7 +6187,7 @@ packages:
       htmlparser2: 9.0.0
       resolve: 1.22.8
       resolve.exports: 2.0.2
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     dev: true
 
   /@mdx-js/mdx@1.6.22:
@@ -6828,22 +6828,22 @@ packages:
       preact: 10.15.1
     dev: false
 
-  /@preact/preset-vite@2.6.0(@babel/core@7.23.3)(preact@10.15.1)(vite@5.0.12):
+  /@preact/preset-vite@2.6.0(@babel/core@7.23.3)(preact@10.15.1)(vite@5.1.1):
     resolution: {integrity: sha512-5nztNzXbCpqyVum/K94nB2YQ5PTnvWdz4u7/X0jc8+kLyskSSpkNUxLQJeI90zfGSFIX1Ibj2G2JIS/mySHWYQ==}
     peerDependencies:
       '@babel/core': 7.x
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.3)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.3)
-      '@prefresh/vite': 2.4.1(preact@10.15.1)(vite@5.0.12)
+      '@prefresh/vite': 2.4.1(preact@10.15.1)(vite@5.1.1)
       '@rollup/pluginutils': 4.2.1
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.23.3)
       debug: 4.3.4(supports-color@8.1.1)
       kolorist: 1.8.0
       resolve: 1.22.8
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -6865,11 +6865,11 @@ packages:
     resolution: {integrity: sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==}
     dev: true
 
-  /@prefresh/vite@2.4.1(preact@10.15.1)(vite@5.0.12):
+  /@prefresh/vite@2.4.1(preact@10.15.1)(vite@5.1.1):
     resolution: {integrity: sha512-vthWmEqu8TZFeyrBNc9YE5SiC3DVSzPgsOCp/WQ7FqdHpOIJi7Z8XvCK06rBPOtG4914S52MjG9Ls22eVAiuqQ==}
     peerDependencies:
       preact: ^10.4.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@babel/core': 7.23.3
       '@prefresh/babel-plugin': 0.5.0
@@ -6877,7 +6877,7 @@ packages:
       '@prefresh/utils': 1.2.0
       '@rollup/pluginutils': 4.2.1
       preact: 10.15.1
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7617,19 +7617,19 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-vite@0.1.41(@babel/core@7.23.3)(@storybook/core-common@7.5.1)(@storybook/node-logger@7.5.1)(@storybook/source-loader@7.5.1)(react@17.0.2)(typescript@5.2.2)(vite@5.0.12):
+  /@storybook/builder-vite@0.1.41(@babel/core@7.23.3)(@storybook/core-common@7.5.1)(@storybook/node-logger@7.5.1)(@storybook/source-loader@7.5.1)(react@17.0.2)(typescript@5.2.2)(vite@5.1.1):
     resolution: {integrity: sha512-h/7AgEUfSuVexTD6LuJ6BCNu+FSo/+IKYBQ1O3TyF2BEgcob5/BGrx9QcwM0LJCF44L1zNKaxkKpCZs9p+LRRA==}
     peerDependencies:
       '@storybook/core-common': '>=6.4.3 || >=6.5.0-alpha.0'
       '@storybook/mdx2-csf': ^0.0.3
       '@storybook/node-logger': '>=6.4.3 || >=6.5.0-alpha.0'
       '@storybook/source-loader': '>=6.4.3 || >=6.5.0-alpha.0'
-      vite: ^5.0.12
+      vite: ^5.1.1
     peerDependenciesMeta:
       '@storybook/mdx2-csf':
         optional: true
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.4(typescript@5.2.2)(vite@5.0.12)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.0.4(typescript@5.2.2)(vite@5.1.1)
       '@storybook/core-common': 7.5.1
       '@storybook/mdx1-csf': 0.0.4(@babel/core@7.23.3)(react@17.0.2)
       '@storybook/node-logger': 7.5.1
@@ -7643,7 +7643,7 @@ packages:
       react-docgen: 6.0.0-alpha.3
       slash: 3.0.0
       sveltedoc-parser: 4.2.1
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - '@babel/core'
       - react
@@ -8723,20 +8723,20 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.20.2(svelte@3.59.1)(vite@5.0.12)
+      '@sveltejs/kit': 1.20.2(svelte@3.59.1)(vite@5.1.1)
       import-meta-resolve: 3.0.0
     dev: true
 
-  /@sveltejs/kit@1.20.2(svelte@3.59.1)(vite@5.0.12):
+  /@sveltejs/kit@1.20.2(svelte@3.59.1)(vite@5.1.1):
     resolution: {integrity: sha512-MtR1i+HtmYWcRgtubw1GQqT/+CWXL/z24PegE0xYAdObbhdr7YtEfmoe705D/JZMtMmoPXrmSk4W0MfL5A3lYw==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0-next.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.59.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.59.1)(vite@5.1.1)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.3.2
@@ -8750,79 +8750,79 @@ packages:
       svelte: 3.59.1
       tiny-glob: 0.2.9
       undici: 5.22.1
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.59.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.59.1)(vite@5.1.1):
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^2.2.0
       svelte: ^3.54.0 || ^4.0.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.59.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@3.59.1)(vite@5.1.1)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 3.59.1
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.1):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       '@sveltejs/vite-plugin-svelte': ^3.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.1.1)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 4.1.1
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.59.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte@2.4.6(svelte@3.59.1)(vite@5.1.1):
     resolution: {integrity: sha512-zO79p0+DZnXPnF0ltIigWDx/ux7Ni+HRaFOw720Qeivc1azFUrJxTl0OryXVibYNx1hCboGia1NRV3x8RNv4cA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.59.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@3.59.1)(vite@5.1.1)
       debug: 4.3.4(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 3.59.1
       svelte-hmr: 0.15.3(svelte@3.59.1)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
-      vitefu: 0.2.4(vite@5.0.12)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
+      vitefu: 0.2.4(vite@5.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.1.1)(vite@5.1.1):
     resolution: {integrity: sha512-CGURX6Ps+TkOovK6xV+Y2rn8JKa8ZPUHPZ/NKgCxAmgBrXReavzFl8aOSCj3kQ1xqT7yGJj53hjcV/gqwDAaWA==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.1)
       debug: 4.3.4(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.1.1
       svelte-hmr: 0.15.3(svelte@4.1.1)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
-      vitefu: 0.2.5(vite@5.0.12)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
+      vitefu: 0.2.5(vite@5.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9888,18 +9888,18 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@unocss/astro@0.57.4(rollup@4.9.6)(vite@5.0.12):
+  /@unocss/astro@0.57.4(rollup@4.9.6)(vite@5.1.1):
     resolution: {integrity: sha512-BP7+X/AlUFFMzr5s8bUpbO4HsWBESzIcPUE9VMA4bpSJIbXxi9GyJRU3Av72nbQp4BBeDjYiDT0qRa5gS0oPxw==}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     peerDependenciesMeta:
       vite:
         optional: true
     dependencies:
       '@unocss/core': 0.57.4
       '@unocss/reset': 0.57.4
-      '@unocss/vite': 0.57.4(rollup@4.9.6)(vite@5.0.12)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      '@unocss/vite': 0.57.4(rollup@4.9.6)(vite@5.1.1)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -10077,10 +10077,10 @@ packages:
       '@unocss/core': 0.57.4
     dev: true
 
-  /@unocss/vite@0.57.4(rollup@4.9.6)(vite@5.0.12):
+  /@unocss/vite@0.57.4(rollup@4.9.6)(vite@5.1.1):
     resolution: {integrity: sha512-bVMftC1hzdlfRQOfllDuJ+bd5Z0/TOvPthNk8LyoHsnjAEH7FqspdCyPM3nQpnfqfYRocXiuLJv+KdQ2DLQWOQ==}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@rollup/pluginutils': 5.0.5(rollup@4.9.6)
@@ -10092,7 +10092,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.2
       magic-string: 0.30.5
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -10115,16 +10115,16 @@ packages:
     peerDependencies:
       vite-plugin-pwa: '>=0.16.5 <1'
     dependencies:
-      vite-plugin-pwa: 0.16.7(vite@5.0.12)(workbox-build@7.0.0)(workbox-window@7.0.0)
+      vite-plugin-pwa: 0.16.7(vite@5.1.1)(workbox-build@7.0.0)(workbox-window@7.0.0)
     dev: true
 
-  /@vitejs/plugin-basic-ssl@1.0.2(vite@5.0.12):
+  /@vitejs/plugin-basic-ssl@1.0.2(vite@5.1.1):
     resolution: {integrity: sha512-DKHKVtpI+eA5fvObVgQ3QtTGU70CcCnedalzqmGSR050AzKZMdUzgC8KmlOneHWH8dF2hJ3wkC9+8FDVAaDRCw==}
     engines: {node: '>=14.6.0'}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     dev: true
 
   /@vitejs/plugin-react@1.3.2:
@@ -10143,100 +10143,100 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-react@4.1.1(vite@5.0.12):
+  /@vitejs/plugin-react@4.1.1(vite@5.1.1):
     resolution: {integrity: sha512-Jie2HERK+uh27e+ORXXwEP5h0Y2lS9T2PRGbfebiHGlwzDO0dEnd2aNtOR/qjBlPb1YgxwAONeblL1xqLikLag==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.23.3)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.3)
       '@types/babel__core': 7.20.3
       react-refresh: 0.14.0
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-react@4.2.0(vite@5.0.12):
+  /@vitejs/plugin-react@4.2.0(vite@5.1.1):
     resolution: {integrity: sha512-+MHTH/e6H12kRp5HUkzOGqPMksezRMmW+TNzlh/QXfI8rRf6l2Z2yH/v12no1UvTwhZgEDMuQ7g7rrfMseU6FQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.3)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.3)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.0.12(@types/node@20.9.5)
+      vite: 5.1.1(@types/node@20.9.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue-jsx@3.0.2(vite@5.0.12)(vue@3.3.8):
+  /@vitejs/plugin-vue-jsx@3.0.2(vite@5.1.1)(vue@3.3.8):
     resolution: {integrity: sha512-obF26P2Z4Ogy3cPp07B4VaW6rpiu0ue4OT2Y15UxT5BZZ76haUY9guOsZV3uWh/I6xc+VeiW+ZVabRE82FyzWw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
       vue: ^3.0.0
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.23.3)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.3)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vue: 3.3.8(typescript@5.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.12)(vue@3.3.8):
+  /@vitejs/plugin-vue-jsx@3.1.0(vite@5.1.1)(vue@3.3.8):
     resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
       vue: ^3.0.0
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-transform-typescript': 7.23.4(@babel/core@7.23.3)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.3)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vue: 3.3.8(typescript@5.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-vue@4.5.0(vite@5.0.12)(vue@3.3.8):
+  /@vitejs/plugin-vue@4.5.0(vite@5.1.1)(vue@3.3.8):
     resolution: {integrity: sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vue: 3.3.8(typescript@5.2.2)
     dev: true
 
-  /@vitejs/plugin-vue@5.0.2(vite@5.0.12)(vue@3.4.5):
+  /@vitejs/plugin-vue@5.0.2(vite@5.1.1)(vue@3.4.5):
     resolution: {integrity: sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vue: 3.4.5(typescript@5.2.2)
     dev: true
 
-  /@vitejs/plugin-vue@5.0.3(vite@5.0.12)(vue@3.3.8):
+  /@vitejs/plugin-vue@5.0.3(vite@5.1.1)(vue@3.3.8):
     resolution: {integrity: sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vue: 3.3.8(typescript@5.2.2)
     dev: true
 
@@ -21903,6 +21903,15 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
 
   /postcss@8.4.5:
     resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
@@ -25639,19 +25648,19 @@ packages:
       detect-node: 2.1.0
     dev: false
 
-  /unocss@0.57.4(postcss@8.4.32)(rollup@4.9.6)(vite@5.0.12):
+  /unocss@0.57.4(postcss@8.4.32)(rollup@4.9.6)(vite@5.1.1):
     resolution: {integrity: sha512-rf5eiCVb8957rqzCyRxLzljeYguVMS70X322/Z1sYhosKhh8SBBMsC/TrZEf5o8LTn/MbFN9fVizEtbUKaFjUg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.57.4
-      vite: ^5.0.12
+      vite: ^5.1.1
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
       vite:
         optional: true
     dependencies:
-      '@unocss/astro': 0.57.4(rollup@4.9.6)(vite@5.0.12)
+      '@unocss/astro': 0.57.4(rollup@4.9.6)(vite@5.1.1)
       '@unocss/cli': 0.57.4(rollup@4.9.6)
       '@unocss/core': 0.57.4
       '@unocss/extractor-arbitrary-variants': 0.57.4
@@ -25670,8 +25679,8 @@ packages:
       '@unocss/transformer-compile-class': 0.57.4
       '@unocss/transformer-directives': 0.57.4
       '@unocss/transformer-variant-group': 0.57.4
-      '@unocss/vite': 0.57.4(rollup@4.9.6)(vite@5.0.12)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      '@unocss/vite': 0.57.4(rollup@4.9.6)(vite@5.1.1)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -26023,11 +26032,11 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /vite-plugin-pages@0.31.0(@vue/compiler-sfc@3.4.5)(vite@5.0.12):
+  /vite-plugin-pages@0.31.0(@vue/compiler-sfc@3.4.5)(vite@5.1.1):
     resolution: {integrity: sha512-fw3onBfVTXQI7rOzAbSZhmfwvk50+3qNnGZpERjmD93c8nEjrGLyd53eFXYMxcJV4KA1vzi4qIHt2+6tS4dEMw==}
     peerDependencies:
       '@vue/compiler-sfc': ^2.7.0 || ^3.0.0
-      vite: ^5.0.12
+      vite: ^5.1.1
     peerDependenciesMeta:
       '@vue/compiler-sfc':
         optional: true
@@ -26041,47 +26050,47 @@ packages:
       json5: 2.2.3
       local-pkg: 0.4.3
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       yaml: 2.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa@0.16.7(vite@5.0.12)(workbox-build@7.0.0)(workbox-window@7.0.0):
+  /vite-plugin-pwa@0.16.7(vite@5.1.1)(workbox-build@7.0.0)(workbox-window@7.0.0):
     resolution: {integrity: sha512-4WMA5unuKlHs+koNoykeuCfTcqEGbiTRr8sVYUQMhc6tWxZpSRnv9Ojk4LKmqVhoPGHfBVCdGaMo8t9Qidkc1Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
       workbox-build: ^7.0.0
       workbox-window: ^7.0.0
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       workbox-build: 7.0.0
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-ruby@3.2.2(vite@5.0.12):
+  /vite-plugin-ruby@3.2.2(vite@5.1.1):
     resolution: {integrity: sha512-cuHG1MajRWPR8YdfF6lvgsQRnKFEBRwZF//asFbRiI1psacxB5aPlHSvYZYxAu5IflrAa0MdR0HxEq+g98M3iQ==}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.2
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite-plugin-solid@2.7.2(solid-js@1.8.3)(vite@5.0.12):
+  /vite-plugin-solid@2.7.2(solid-js@1.8.3)(vite@5.1.1):
     resolution: {integrity: sha512-GV2SMLAibOoXe76i02AsjAg7sbm/0lngBlERvJKVN67HOrJsHcWgkt0R6sfGLDJuFkv2aBe14Zm4vJcNME+7zw==}
     peerDependencies:
       solid-js: ^1.7.2
-      vite: ^5.0.12
+      vite: ^5.1.1
     dependencies:
       '@babel/core': 7.23.3
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.3)
@@ -26090,14 +26099,14 @@ packages:
       merge-anything: 5.1.7
       solid-js: 1.8.3
       solid-refresh: 0.5.3(solid-js@1.8.3)
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
-      vitefu: 0.2.4(vite@5.0.12)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
+      vitefu: 0.2.4(vite@5.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@5.0.12(@types/node@20.11.5)(less@4.1.3):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+  /vite@5.1.1(@types/node@20.11.5)(less@4.1.3):
+    resolution: {integrity: sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -26127,13 +26136,13 @@ packages:
       '@types/node': 20.11.5
       esbuild: 0.19.11
       less: 4.1.3
-      postcss: 8.4.32
+      postcss: 8.4.35
       rollup: 4.9.6
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@5.0.12(@types/node@20.9.5):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+  /vite@5.1.1(@types/node@20.9.5):
+    resolution: {integrity: sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -26162,32 +26171,32 @@ packages:
     dependencies:
       '@types/node': 20.9.5
       esbuild: 0.19.11
-      postcss: 8.4.32
+      postcss: 8.4.35
       rollup: 4.9.6
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vitefu@0.2.4(vite@5.0.12):
+  /vitefu@0.2.4(vite@5.1.1):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     peerDependenciesMeta:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     dev: true
 
-  /vitefu@0.2.5(vite@5.0.12):
+  /vitefu@0.2.5(vite@5.1.1):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
-      vite: ^5.0.12
+      vite: ^5.1.1
     peerDependenciesMeta:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
     dev: true
 
   /vitepress@1.0.0-rc.35(@types/node@20.11.5)(postcss@8.4.32)(search-insights@2.9.0)(typescript@5.2.2):
@@ -26205,7 +26214,7 @@ packages:
       '@docsearch/css': 3.5.2
       '@docsearch/js': 3.5.2(search-insights@2.9.0)
       '@types/markdown-it': 13.0.7
-      '@vitejs/plugin-vue': 5.0.2(vite@5.0.12)(vue@3.4.5)
+      '@vitejs/plugin-vue': 5.0.2(vite@5.1.1)(vue@3.4.5)
       '@vue/devtools-api': 6.5.1
       '@vueuse/core': 10.7.1(vue@3.4.5)
       '@vueuse/integrations': 10.7.1(focus-trap@7.5.4)(vue@3.4.5)
@@ -26216,7 +26225,7 @@ packages:
       shikiji: 0.9.17
       shikiji-core: 0.9.17
       shikiji-transformers: 0.9.17
-      vite: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vite: 5.1.1(@types/node@20.11.5)(less@4.1.3)
       vue: 3.4.5(typescript@5.2.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -27112,6 +27121,7 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0


### PR DESCRIPTION
### Description

It upgrade vite from 5.0.1 to 5.1.1 and apply the security patches which break a lot CI/CD

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
