### PR TITLE
fix(vitest): delegate snapshot options to workspace from root config

### DIFF
--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -359,9 +359,7 @@ export class WorkspaceProject {
       },
       snapshotOptions: {
         ...this.ctx.config.snapshotOptions,
-        expand:
-          this.config.snapshotOptions.expand
-          ?? this.ctx.config.snapshotOptions.expand,
+        expand: this.config.snapshotOptions.expand ?? this.ctx.config.snapshotOptions.expand,
         resolveSnapshotPath: undefined,
       },
       onConsoleLog: undefined!,

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -357,7 +357,10 @@ export class WorkspaceProject {
           },
         },
       },
-      snapshotOptions: this.ctx.config.snapshotOptions,
+      snapshotOptions: {
+        ...this.ctx.config.snapshotOptions,
+        resolveSnapshotPath: undefined,
+      },
       onConsoleLog: undefined!,
       onStackTrace: undefined!,
       sequence: {

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -359,6 +359,9 @@ export class WorkspaceProject {
       },
       snapshotOptions: {
         ...this.ctx.config.snapshotOptions,
+        expand:
+          this.config.snapshotOptions.expand
+          ?? this.ctx.config.snapshotOptions.expand,
         resolveSnapshotPath: undefined,
       },
       onConsoleLog: undefined!,

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -357,10 +357,7 @@ export class WorkspaceProject {
           },
         },
       },
-      snapshotOptions: {
-        ...this.config.snapshotOptions,
-        resolveSnapshotPath: undefined,
-      },
+      snapshotOptions: this.ctx.config.snapshotOptions,
       onConsoleLog: undefined!,
       onStackTrace: undefined!,
       sequence: {

--- a/test/snapshots/test/fixtures/workspace/packages/space/test/__snapshots__/basic.test.ts.snap
+++ b/test/snapshots/test/fixtures/workspace/packages/space/test/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`basic 1`] = `1`;

--- a/test/snapshots/test/fixtures/workspace/packages/space/test/basic.test.ts
+++ b/test/snapshots/test/fixtures/workspace/packages/space/test/basic.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "vitest"
+
+test("basic", () => {
+  expect(1).toMatchSnapshot()
+})

--- a/test/snapshots/test/fixtures/workspace/packages/space/vite.config.ts
+++ b/test/snapshots/test/fixtures/workspace/packages/space/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {},
+})

--- a/test/snapshots/test/fixtures/workspace/vitest.workspace.ts
+++ b/test/snapshots/test/fixtures/workspace/vitest.workspace.ts
@@ -1,0 +1,5 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  'packages/*',
+])

--- a/test/snapshots/test/workspace.test.ts
+++ b/test/snapshots/test/workspace.test.ts
@@ -3,8 +3,10 @@ import { editFile, runVitest } from '../../test-utils'
 
 test('--update works for workspace project', async () => {
   // setup wrong snapshot value
-  const snapshotPath = 'test/fixtures/workspace/packages/space/test/__snapshots__/basic.test.ts.snap'
-  editFile(snapshotPath, data => data.replace('`1`', '`2`'))
+  editFile(
+    'test/fixtures/workspace/packages/space/test/__snapshots__/basic.test.ts.snap',
+    data => data.replace('`1`', '`2`'),
+  )
 
   // run with --update
   const { stdout, exitCode } = await runVitest({

--- a/test/snapshots/test/workspace.test.ts
+++ b/test/snapshots/test/workspace.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { editFile, runVitest } from '../../test-utils'
+
+test('--update works for workspace project', async () => {
+  // setup wrong snapshot value
+  const snapshotPath = 'test/fixtures/workspace/packages/space/test/__snapshots__/basic.test.ts.snap'
+  editFile(snapshotPath, data => data.replace('`1`', '`2`'))
+
+  // run with --update
+  const { stdout, exitCode } = await runVitest({
+    update: true,
+    root: 'test/fixtures/workspace',
+  })
+  expect(stdout).include('Snapshots  1 updated')
+  expect(exitCode).toBe(0)
+})

--- a/test/snapshots/test/workspace.test.ts
+++ b/test/snapshots/test/workspace.test.ts
@@ -10,7 +10,8 @@ test('--update works for workspace project', async () => {
   const { stdout, exitCode } = await runVitest({
     update: true,
     root: 'test/fixtures/workspace',
+    workspace: 'vitest.workspace.ts',
   })
-  expect(stdout).include('Snapshots  1 updated')
-  expect(exitCode).toBe(0)
+  expect.soft(stdout).include('Snapshots  1 updated')
+  expect.soft(exitCode).toBe(0)
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5194

Since `SnapshotManager` is a singleton managed by main `Vitest` instance, I think `WorkspaceProject.getSerializableConfig` needs to use the same options as:

https://github.com/vitest-dev/vitest/blob/ec55fddef66fe820c570f01b3e7be920a6d566d4/packages/vitest/src/node/core.ts#L101

I expect snapshot options to do something similar to coverage options, which is also root config only options:

https://github.com/vitest-dev/vitest/blob/ec55fddef66fe820c570f01b3e7be920a6d566d4/packages/vitest/src/node/workspace.ts#L332

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
