### PR TITLE
fix: requires fixed version across the monorepo

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "playwright": "*",
-    "vitest": "^1.0.0",
+    "vitest": "workspace:*",
     "webdriverio": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": "^1.0.0"
+    "vitest": "workspace:*"
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": "^1.0.0"
+    "vitest": "workspace:*"
   },
   "dependencies": {
     "@ampproject/remapping": "^2.2.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "vitest": "^1.0.0"
+    "vitest": "workspace:*"
   },
   "dependencies": {
     "@vitest/utils": "workspace:*",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -118,8 +118,8 @@
   "peerDependencies": {
     "@edge-runtime/vm": "*",
     "@types/node": "^18.0.0 || >=20.0.0",
-    "@vitest/browser": "^1.0.0",
-    "@vitest/ui": "^1.0.0",
+    "@vitest/browser": "workspace:*",
+    "@vitest/ui": "workspace:*",
     "happy-dom": "*",
     "jsdom": "*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1292,7 +1292,7 @@ importers:
   packages/vitest:
     dependencies:
       '@vitest/browser':
-        specifier: ^1.0.0
+        specifier: workspace:*
         version: link:../browser
       '@vitest/expect':
         specifier: workspace:*
@@ -1307,7 +1307,7 @@ importers:
         specifier: workspace:*
         version: link:../spy
       '@vitest/ui':
-        specifier: ^1.0.0
+        specifier: workspace:*
         version: link:../ui
       '@vitest/utils':
         specifier: workspace:*
@@ -5753,7 +5753,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -5774,7 +5774,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -5811,7 +5811,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       jest-mock: 27.5.1
     dev: true
 
@@ -5828,7 +5828,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -5857,7 +5857,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -5988,7 +5988,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       '@types/yargs': 16.0.7
       chalk: 4.1.2
     dev: true
@@ -9104,7 +9104,7 @@ packages:
     resolution: {integrity: sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==}
     dependencies:
       '@types/connect': 3.4.37
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /@types/braces@3.0.1:
@@ -9125,7 +9125,7 @@ packages:
   /@types/connect@3.4.37:
     resolution: {integrity: sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /@types/cookie@0.4.1:
@@ -9192,7 +9192,7 @@ packages:
   /@types/express-serve-static-core@4.17.39:
     resolution: {integrity: sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       '@types/qs': 6.9.9
       '@types/range-parser': 1.2.6
       '@types/send': 0.17.3
@@ -9246,7 +9246,7 @@ packages:
   /@types/graceful-fs@4.1.8:
     resolution: {integrity: sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /@types/hast@2.3.4:
@@ -9396,7 +9396,7 @@ packages:
   /@types/node-fetch@2.6.7:
     resolution: {integrity: sha512-lX17GZVpJ/fuCjguZ5b3TjEbSENxmEk1B2z02yoXSK9WMEWRivhdSY73wWMn6bpcCDAOh6qAdktpKHIlkDk2lg==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       form-data: 4.0.0
     dev: true
 
@@ -9413,6 +9413,12 @@ packages:
 
   /@types/node@20.11.17:
     resolution: {integrity: sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /@types/node@20.11.18:
+    resolution: {integrity: sha512-ABT5VWnnYneSBcNWYSCuR05M826RoMyMSGiFivXGx6ZUIsXb9vn4643IEwkg2zbEOSgAiSogtapN2fgc4mAPlw==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -9572,7 +9578,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /@types/resolve@1.20.2:
@@ -9590,7 +9596,7 @@ packages:
     resolution: {integrity: sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==}
     dependencies:
       '@types/mime': 1.3.4
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /@types/serve-static@1.15.4:
@@ -9598,7 +9604,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
@@ -18556,7 +18562,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -18691,7 +18697,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -18709,7 +18715,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -18753,7 +18759,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.8
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18793,7 +18799,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -18873,7 +18879,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -18934,7 +18940,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -18999,7 +19005,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       graceful-fs: 4.2.11
     dev: true
 
@@ -19050,7 +19056,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19087,7 +19093,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1


### PR DESCRIPTION
### Description

This PR makes `vitest` in `peerDependencies` as the fixed version. This enforces users to have a single version across the monorepo to have a stable and predictable behavior.

fix #4985 fix #4983