### PR TITLE
fix(vitest): fix `optimizeDeps.disabled` warnings on Vite 5.1

### DIFF
--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,4 +1,4 @@
-import { searchForWorkspaceRoot } from 'vite'
+import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
 import type { DepOptimizationOptions, ResolvedConfig, UserConfig as ViteConfig } from 'vite'
 import { dirname } from 'pathe'
 import type { DepsOptimizationOptions, InlineConfig } from '../../types'
@@ -8,15 +8,18 @@ import { rootDir } from '../../paths'
 export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | undefined, viteOptions: DepOptimizationOptions | undefined, testConfig: InlineConfig) {
   const testOptions = _testOptions || {}
   const newConfig: { cacheDir?: string; optimizeDeps: DepOptimizationOptions } = {} as any
-  // disabled by default
-  testOptions.enabled ??= false
-  if (testOptions?.enabled !== true) {
+  const [major, minor, fix] = viteVersion.split('.').map(Number)
+  const allowed = major >= 5 || (major === 4 && minor >= 4) || (major === 4 && minor === 3 && fix >= 2)
+  if (!allowed && testOptions?.enabled === true)
+    console.warn(`Vitest: "deps.optimizer" is only available in Vite >= 4.3.2, current Vite version: ${viteVersion}`)
+  else
+    // disabled by default
+    testOptions.enabled ??= false
+  if (!allowed || testOptions?.enabled !== true) {
     newConfig.cacheDir = undefined
     newConfig.optimizeDeps = {
-      // noDiscovery available since vite@4.3.3
-      // https://github.com/vitejs/vite/discussions/13814
-      noDiscovery: true,
-      include: [],
+      // experimental in Vite >2.9.2, entries remains to help with older versions
+      disabled: true,
       entries: [],
     }
   }
@@ -41,10 +44,21 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
       ...viteOptions,
       ...testOptions,
       noDiscovery: true,
+      disabled: false,
       entries: [],
       exclude,
       include,
     }
+  }
+
+  // `optimizeDeps.disabled` is deprecated since v5.1.0-beta.1
+  // https://github.com/vitejs/vite/pull/15184
+  if (major >= 5 && minor >= 1) {
+    if (newConfig.optimizeDeps.disabled) {
+      newConfig.optimizeDeps.noDiscovery = true
+      newConfig.optimizeDeps.include = []
+    }
+    delete newConfig.optimizeDeps.disabled
   }
 
   return newConfig

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,4 +1,4 @@
-import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
+import { searchForWorkspaceRoot } from 'vite'
 import type { DepOptimizationOptions, ResolvedConfig, UserConfig as ViteConfig } from 'vite'
 import { dirname } from 'pathe'
 import type { DepsOptimizationOptions, InlineConfig } from '../../types'
@@ -8,18 +8,15 @@ import { rootDir } from '../../paths'
 export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | undefined, viteOptions: DepOptimizationOptions | undefined, testConfig: InlineConfig) {
   const testOptions = _testOptions || {}
   const newConfig: { cacheDir?: string; optimizeDeps: DepOptimizationOptions } = {} as any
-  const [major, minor, fix] = viteVersion.split('.').map(Number)
-  const allowed = major >= 5 || (major === 4 && minor >= 4) || (major === 4 && minor === 3 && fix >= 2)
-  if (!allowed && testOptions?.enabled === true)
-    console.warn(`Vitest: "deps.optimizer" is only available in Vite >= 4.3.2, current Vite version: ${viteVersion}`)
-  else
-    // disabled by default
-    testOptions.enabled ??= false
-  if (!allowed || testOptions?.enabled !== true) {
+  // disabled by default
+  testOptions.enabled ??= false
+  if (testOptions?.enabled !== true) {
     newConfig.cacheDir = undefined
     newConfig.optimizeDeps = {
-      // experimental in Vite >2.9.2, entries remains to help with older versions
-      disabled: true,
+      // noDiscovery available since vite@4.3.3
+      // https://github.com/vitejs/vite/discussions/13814
+      noDiscovery: true,
+      include: [],
       entries: [],
     }
   }
@@ -44,21 +41,10 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
       ...viteOptions,
       ...testOptions,
       noDiscovery: true,
-      disabled: false,
       entries: [],
       exclude,
       include,
     }
-  }
-
-  // `optimizeDeps.disabled` is deprecated since v5.1.0-beta.1
-  // https://github.com/vitejs/vite/pull/15184
-  if (major >= 5 && minor >= 1) {
-    if (newConfig.optimizeDeps.disabled) {
-      newConfig.optimizeDeps.noDiscovery = true
-      newConfig.optimizeDeps.include = []
-    }
-    delete newConfig.optimizeDeps.disabled
   }
 
   return newConfig

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,4 +1,4 @@
-import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
+import { searchForWorkspaceRoot } from 'vite'
 import type { DepOptimizationOptions, ResolvedConfig, UserConfig as ViteConfig } from 'vite'
 import { dirname } from 'pathe'
 import type { DepsOptimizationOptions, InlineConfig } from '../../types'
@@ -45,14 +45,6 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
       exclude,
       include,
     }
-
-    // `optimizeDeps.disabled` is deprecated since v5.1.0-beta.1
-    // https://github.com/vitejs/vite/pull/15184
-    // but explicit `disabled: false` is needed for SSR on v5.0
-    // https://github.com/vitejs/vite/discussions/13839#discussioncomment-8078714
-    const [major, minor] = viteVersion.split('.').map(Number)
-    if (major >= 5 && minor < 1)
-      newConfig.optimizeDeps.disabled = false
   }
 
   return newConfig

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -13,7 +13,7 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
   if (!allowed && testOptions?.enabled === true)
     console.warn(`Vitest: "deps.optimizer" is only available in Vite >= 4.3.2, current Vite version: ${viteVersion}`)
   else
-    // enable by default
+    // disabled by default
     testOptions.enabled ??= false
   if (!allowed || testOptions?.enabled !== true) {
     newConfig.cacheDir = undefined
@@ -50,6 +50,17 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
       include,
     }
   }
+
+  // `optimizeDeps.disabled` is deprecated since v5.1.0-beta.1
+  // https://github.com/vitejs/vite/pull/15184
+  if (major >= 5 && minor >= 1) {
+    if (newConfig.optimizeDeps.disabled) {
+      newConfig.optimizeDeps.noDiscovery = true
+      newConfig.optimizeDeps.include = []
+    }
+    delete newConfig.optimizeDeps.disabled
+  }
+
   return newConfig
 }
 

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,4 +1,4 @@
-import { searchForWorkspaceRoot } from 'vite'
+import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
 import type { DepOptimizationOptions, ResolvedConfig, UserConfig as ViteConfig } from 'vite'
 import { dirname } from 'pathe'
 import type { DepsOptimizationOptions, InlineConfig } from '../../types'
@@ -45,6 +45,14 @@ export function resolveOptimizerConfig(_testOptions: DepsOptimizationOptions | u
       exclude,
       include,
     }
+
+    // `optimizeDeps.disabled` is deprecated since v5.1.0-beta.1
+    // https://github.com/vitejs/vite/pull/15184
+    // but explicit `disabled: false` is needed for SSR on v5.0
+    // https://github.com/vitejs/vite/discussions/13839#discussioncomment-8078714
+    const [major, minor] = viteVersion.split('.').map(Number)
+    if (major >= 5 && minor < 1)
+      newConfig.optimizeDeps.disabled = false
   }
 
   return newConfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1836,6 +1836,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest
 
+  test/optimize-deps:
+    devDependencies:
+      '@vitest/test-dep-url':
+        specifier: file:./dep-url
+        version: file:test/optimize-deps/dep-url
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+
   test/path-resolution:
     devDependencies:
       '@edge-runtime/vm':
@@ -5753,7 +5762,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -5774,7 +5783,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -5811,7 +5820,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       jest-mock: 27.5.1
     dev: true
 
@@ -5828,7 +5837,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -5857,7 +5866,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -5988,7 +5997,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       '@types/yargs': 16.0.7
       chalk: 4.1.2
     dev: true
@@ -9104,7 +9113,7 @@ packages:
     resolution: {integrity: sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==}
     dependencies:
       '@types/connect': 3.4.37
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /@types/braces@3.0.1:
@@ -9125,7 +9134,7 @@ packages:
   /@types/connect@3.4.37:
     resolution: {integrity: sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /@types/cookie@0.4.1:
@@ -9192,7 +9201,7 @@ packages:
   /@types/express-serve-static-core@4.17.39:
     resolution: {integrity: sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       '@types/qs': 6.9.9
       '@types/range-parser': 1.2.6
       '@types/send': 0.17.3
@@ -9246,7 +9255,7 @@ packages:
   /@types/graceful-fs@4.1.8:
     resolution: {integrity: sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /@types/hast@2.3.4:
@@ -9396,7 +9405,7 @@ packages:
   /@types/node-fetch@2.6.7:
     resolution: {integrity: sha512-lX17GZVpJ/fuCjguZ5b3TjEbSENxmEk1B2z02yoXSK9WMEWRivhdSY73wWMn6bpcCDAOh6qAdktpKHIlkDk2lg==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       form-data: 4.0.0
     dev: true
 
@@ -9413,6 +9422,12 @@ packages:
 
   /@types/node@20.11.17:
     resolution: {integrity: sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /@types/node@20.11.19:
+    resolution: {integrity: sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -9572,7 +9587,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /@types/resolve@1.20.2:
@@ -9590,7 +9605,7 @@ packages:
     resolution: {integrity: sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==}
     dependencies:
       '@types/mime': 1.3.4
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /@types/serve-static@1.15.4:
@@ -9598,7 +9613,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
@@ -18556,7 +18571,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -18691,7 +18706,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -18709,7 +18724,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -18753,7 +18768,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.8
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18793,7 +18808,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -18873,7 +18888,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -18934,7 +18949,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -18999,7 +19014,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       graceful-fs: 4.2.11
     dev: true
 
@@ -19050,7 +19065,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19087,7 +19102,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.11.17
+      '@types/node': 20.11.19
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -27479,4 +27494,9 @@ packages:
   file:test/env-custom/vitest-environment-custom:
     resolution: {directory: test/env-custom/vitest-environment-custom, type: directory}
     name: vitest-environment-custom
+    dev: true
+
+  file:test/optimize-deps/dep-url:
+    resolution: {directory: test/optimize-deps/dep-url, type: directory}
+    name: '@vitest/test-deps-url'
     dev: true

--- a/test/optimize-deps/dep-url/index.js
+++ b/test/optimize-deps/dep-url/index.js
@@ -1,0 +1,1 @@
+export const importMetaUrl = import.meta.url

--- a/test/optimize-deps/dep-url/package.json
+++ b/test/optimize-deps/dep-url/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@vitest/test-deps-url",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/test/optimize-deps/package.json
+++ b/test/optimize-deps/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-optimize-deps",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@vitest/test-dep-url": "file:./dep-url",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/optimize-deps/test/ssr.test.ts
+++ b/test/optimize-deps/test/ssr.test.ts
@@ -5,6 +5,8 @@ import { expect, test } from 'vitest'
 // @ts-expect-error untyped
 import { importMetaUrl } from '@vitest/test-dep-url'
 
-test('import.meta.url', () => {
+// TODO: flaky on Windows
+// https://github.com/vitest-dev/vitest/pull/5215#discussion_r1492066033
+test.skipIf(process.platform === 'win32')('import.meta.url', () => {
   expect(importMetaUrl).toContain('/node_modules/.vitest/deps_ssr/')
 })

--- a/test/optimize-deps/test/ssr.test.ts
+++ b/test/optimize-deps/test/ssr.test.ts
@@ -1,0 +1,10 @@
+// @vitest-environment node
+
+import { expect, test } from 'vitest'
+
+// @ts-expect-error untyped
+import { importMetaUrl } from '@vitest/test-dep-url'
+
+test('import.meta.url', () => {
+  expect(importMetaUrl).toContain('/node_modules/.vitest/deps_ssr/')
+})

--- a/test/optimize-deps/test/web.test.ts
+++ b/test/optimize-deps/test/web.test.ts
@@ -1,0 +1,10 @@
+// @vitest-environment happy-dom
+
+import { expect, test } from 'vitest'
+
+// @ts-expect-error untyped
+import { importMetaUrl } from '@vitest/test-dep-url'
+
+test('import.meta.url', () => {
+  expect(importMetaUrl).toContain('/node_modules/.vitest/deps/')
+})

--- a/test/optimize-deps/test/web.test.ts
+++ b/test/optimize-deps/test/web.test.ts
@@ -5,8 +5,6 @@ import { expect, test } from 'vitest'
 // @ts-expect-error untyped
 import { importMetaUrl } from '@vitest/test-dep-url'
 
-// TODO: flaky on Windows
-// https://github.com/vitest-dev/vitest/pull/5215#discussion_r1492066033
-test.skipIf(process.platform === 'win32')('import.meta.url', () => {
+test('import.meta.url', () => {
   expect(importMetaUrl).toContain('/node_modules/.vitest/deps/')
 })

--- a/test/optimize-deps/test/web.test.ts
+++ b/test/optimize-deps/test/web.test.ts
@@ -5,6 +5,8 @@ import { expect, test } from 'vitest'
 // @ts-expect-error untyped
 import { importMetaUrl } from '@vitest/test-dep-url'
 
-test('import.meta.url', () => {
+// TODO: flaky on Windows
+// https://github.com/vitest-dev/vitest/pull/5215#discussion_r1492066033
+test.skipIf(process.platform === 'win32')('import.meta.url', () => {
   expect(importMetaUrl).toContain('/node_modules/.vitest/deps/')
 })

--- a/test/optimize-deps/vitest.config.ts
+++ b/test/optimize-deps/vitest.config.ts
@@ -1,8 +1,5 @@
 import { defineConfig } from 'vitest/config'
 
-// cf.
-// https://stackblitz.com/edit/vitest-dev-vitest-8wf26p?file=test%2Fssr.test.ts
-
 export default defineConfig({
   optimizeDeps: {
     include: ['@vitest/test-dep-url'],

--- a/test/optimize-deps/vitest.config.ts
+++ b/test/optimize-deps/vitest.config.ts
@@ -4,7 +4,6 @@ import { defineConfig } from 'vitest/config'
 // https://stackblitz.com/edit/vitest-dev-vitest-8wf26p?file=test%2Fssr.test.ts
 
 export default defineConfig({
-  // customLogger: console as any,
   optimizeDeps: {
     include: ['@vitest/test-dep-url'],
   },

--- a/test/optimize-deps/vitest.config.ts
+++ b/test/optimize-deps/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config'
+
+// cf.
+// https://stackblitz.com/edit/vitest-dev-vitest-8wf26p?file=test%2Fssr.test.ts
+
+export default defineConfig({
+  // customLogger: console as any,
+  optimizeDeps: {
+    include: ['@vitest/test-dep-url'],
+  },
+  ssr: {
+    optimizeDeps: {
+      include: ['@vitest/test-dep-url'],
+    },
+  },
+  test: {
+    deps: {
+      optimizer: {
+        web: {
+          enabled: true,
+        },
+        ssr: {
+          enabled: true,
+        },
+      },
+    },
+  },
+  // use dummy ssrLoadModule to trigger ssr.optimizeDeps.
+  // this will be unnecessary from Vite 5.1
+  // cf. https://github.com/vitejs/vite/pull/15561
+  plugins: [
+    {
+      name: 'force-ssr-optimize-deps',
+      configureServer(server) {
+        return async () => {
+          await server.ssrLoadModule('/package.json')
+        }
+      },
+    },
+  ],
+})

--- a/test/optimize-deps/vitest.config.ts
+++ b/test/optimize-deps/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     },
   },
   test: {
+    chaiConfig: {
+      truncateThreshold: 1000,
+    },
     deps: {
       optimizer: {
         web: {


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5211
- related https://github.com/vitejs/vite/pull/15184

_todo_

- [x] figure out why warning shows up only when `customLogger` (see [comment](https://github.com/vitest-dev/vitest/issues/5211#issuecomment-1947810971))
- [x] add test based on https://github.com/vitest-dev/vitest/issues/4910
- [x] locally test Vite 5.1 + customLogger

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
