### PR TITLE
fix: Prevent merging of `poolOptions`

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -50,13 +50,6 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
         )
         testConfig.api = resolveApiServerConfig(testConfig)
 
-        testConfig.poolOptions ??= {}
-        testConfig.poolOptions.threads ??= {}
-        testConfig.poolOptions.forks ??= {}
-        // prefer --poolOptions.{name}.isolate CLI arguments over --isolate, but still respect config value
-        testConfig.poolOptions.threads.isolate = options.poolOptions?.threads?.isolate ?? options.isolate ?? testConfig.poolOptions.threads.isolate ?? viteConfig.test?.isolate
-        testConfig.poolOptions.forks.isolate = options.poolOptions?.forks?.isolate ?? options.isolate ?? testConfig.poolOptions.forks.isolate ?? viteConfig.test?.isolate
-
         // store defines for globalThis to make them
         // reassignable when running in worker in src/runtime/setup.ts
         const defines: Record<string, any> = deleteDefineConfig(viteConfig)
@@ -95,6 +88,16 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             preTransformRequests: false,
             fs: {
               allow: resolveFsAllow(getRoot(), testConfig.config),
+            },
+          },
+          test: {
+            poolOptions: {
+              threads: {
+                isolate: options.poolOptions?.threads?.isolate ?? options.isolate ?? testConfig.poolOptions?.threads?.isolate ?? viteConfig.test?.isolate,
+              },
+              forks: {
+                isolate: options.poolOptions?.threads?.isolate ?? options.isolate ?? testConfig.poolOptions?.threads?.isolate ?? viteConfig.test?.isolate,
+              },
             },
           },
         }

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -96,7 +96,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             fs: {
               allow: resolveFsAllow(getRoot(), testConfig.config),
             },
-          }
+          },
         }
 
         // we want inline dependencies to be resolved by analyser plugin so module graph is populated correctly

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -96,10 +96,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             fs: {
               allow: resolveFsAllow(getRoot(), testConfig.config),
             },
-          },
-          test: {
-            poolOptions: testConfig.poolOptions,
-          },
+          }
         }
 
         // we want inline dependencies to be resolved by analyser plugin so module graph is populated correctly

--- a/test/config/test/resolution.test.ts
+++ b/test/config/test/resolution.test.ts
@@ -15,7 +15,7 @@ async function config(cliOptions: UserConfig, configValue: UserConfig = {}, vite
 }
 
 describe('correctly defines isolated flags', async () => {
-  it('does not merge poolOptions with itself', async () => {
+  it('does not merge user-defined poolOptions with itself', async () => {
     const c = await config({}, {
       poolOptions: {
         array: [1, 2, 3],

--- a/test/config/test/resolution.test.ts
+++ b/test/config/test/resolution.test.ts
@@ -15,6 +15,22 @@ async function config(cliOptions: UserConfig, configValue: UserConfig = {}, vite
 }
 
 describe('correctly defines isolated flags', async () => {
+  it('does not merge poolOptions with itself', async () => {
+    const c = await config({}, {
+      poolOptions: {
+        array: [1, 2, 3],
+      },
+    })
+    // Ensure poolOptions.array has not been merged with itself
+    // Previously, this would have been [1,2,3,1,2,3]
+    expect(c.poolOptions?.array).toMatchInlineSnapshot(`
+      [
+        1,
+        2,
+        3,
+      ]
+    `)
+  })
   it('prefers CLI poolOptions flags over config', async () => {
     const c = await config({
       isolate: true,

--- a/test/run/pool-custom-fixtures/pool/custom-pool.ts
+++ b/test/run/pool-custom-fixtures/pool/custom-pool.ts
@@ -10,6 +10,7 @@ export default (ctx: Vitest): ProcessPool => {
     name: 'custom',
     async runTests(specs) {
       console.warn('[pool] printing:', options.print)
+      console.warn('[pool] array option', options.array)
       for await (const [project, file] of specs) {
         ctx.state.clearFiles(project)
         const methods = createMethodsRPC(project)

--- a/test/run/pool-custom-fixtures/vitest.config.ts
+++ b/test/run/pool-custom-fixtures/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     poolOptions: {
       custom: {
         print: 'options are respected',
+        array: [1, 2, 3],
       },
     },
     poolMatchGlobs: [

--- a/test/run/test/custom-pool.test.ts
+++ b/test/run/test/custom-pool.test.ts
@@ -6,6 +6,7 @@ test('can run custom pools with Vitest', async () => {
 
   expect(vitest.stderr).toMatchInlineSnapshot(`
     "[pool] printing: options are respected
+    [pool] array option [ 1, 2, 3 ]
     [pool] running tests for custom-pool-test in /pool-custom-fixtures/tests/custom-not-run.spec.ts
     [pool] custom pool is closed!
     "


### PR DESCRIPTION
### Description
Arrays in poolOptions are merged with themselves, resulting in duplicating the entries. This PR fixes that, by ensuring `poolOptions` is not present in the config being merged. Bug repro at https://github.com/penalosa/vitest-custom-pool-repro (just clone and run ./test.sh to see the contents of the array option being duplicated), 

See https://github.com/solidjs/vite-plugin-solid/pull/101 for a similar fix

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] Discussed on Discord
- [x] Tests TBD
- [x] No lock file changes

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] No new functionality, so no docs needed

### Changesets
- [x] TBD
