### PR TITLE
refactor(coverage): move common parts to `vitest` package

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -4,7 +4,6 @@ import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, Repo
 import { coverageConfigDefaults, defaultExclude, defaultInclude } from 'vitest/config'
 import { BaseCoverageProvider } from 'vitest/coverage'
 import c from 'picocolors'
-import type { ProxifiedModule } from 'magicast'
 import { parseModule } from 'magicast'
 import createDebug from 'debug'
 import libReport from 'istanbul-lib-report'
@@ -172,7 +171,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       for (const filenames of [coveragePerProject.ssr, coveragePerProject.web]) {
         const coverageMapByTransformMode = libCoverage.createCoverageMap({})
 
-        for (const chunk of toSlices(filenames, this.options.processingConcurrency)) {
+        for (const chunk of this.toSlices(filenames, this.options.processingConcurrency)) {
           if (debug.enabled) {
             index += chunk.length
             debug('Covered files %d/%d', index, total)
@@ -206,7 +205,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
       watermarks: this.options.watermarks,
     })
 
-    if (hasTerminalReporter(this.options.reporter))
+    if (this.hasTerminalReporter(this.options.reporter))
       this.ctx.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.name))
 
     for (const reporter of this.options.reporter) {
@@ -240,10 +239,8 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
         this.updateThresholds({
           thresholds: resolvedThresholds,
           perFile: this.options.thresholds.perFile,
-          configurationFile: {
-            write: () => writeFileSync(configFilePath, configModule.generate().code, 'utf-8'),
-            read: () => resolveConfig(configModule),
-          },
+          configurationFile: configModule,
+          onUpdate: () => writeFileSync(configFilePath, configModule.generate().code, 'utf-8'),
         })
       }
     }
@@ -337,54 +334,4 @@ function isEmptyCoverageRange(range: libCoverage.Range) {
     || range.end.line === undefined
     || range.end.column === undefined
   )
-}
-
-function hasTerminalReporter(reporters: Options['reporter']) {
-  return reporters.some(([reporter]) =>
-    reporter === 'text'
-    || reporter === 'text-summary'
-    || reporter === 'text-lcov'
-    || reporter === 'teamcity')
-}
-
-function toSlices<T>(array: T[], size: number): T[][] {
-  return array.reduce<T[][]>((chunks, item) => {
-    const index = Math.max(0, chunks.length - 1)
-    const lastChunk = chunks[index] || []
-    chunks[index] = lastChunk
-
-    if (lastChunk.length >= size)
-      chunks.push([item])
-
-    else
-      lastChunk.push(item)
-
-    return chunks
-  }, [])
-}
-
-function resolveConfig(configModule: ProxifiedModule<any>) {
-  const mod = configModule.exports.default
-
-  try {
-    // Check for "export default { test: {...} }"
-    if (mod.$type === 'object')
-      return mod
-
-    if (mod.$type === 'function-call') {
-      // "export default defineConfig({ test: {...} })"
-      if (mod.$args[0].$type === 'object')
-        return mod.$args[0]
-
-      // "export default defineConfig(() => ({ test: {...} }))"
-      if (mod.$args[0].$type === 'arrow-function-expression' && mod.$args[0].$body.$type === 'object')
-        return mod.$args[0].$body
-    }
-  }
-  catch (error) {
-    // Reduce magicast's verbose errors to readable ones
-    throw new Error(error instanceof Error ? error.message : String(error))
-  }
-
-  throw new Error('Failed to update coverage thresholds. Configuration file is too complex.')
 }

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -9,7 +9,6 @@ import type { CoverageMap } from 'istanbul-lib-coverage'
 import libCoverage from 'istanbul-lib-coverage'
 import libSourceMaps from 'istanbul-lib-source-maps'
 import MagicString from 'magic-string'
-import type { ProxifiedModule } from 'magicast'
 import { parseModule } from 'magicast'
 import remapping from '@ampproject/remapping'
 import { normalize, resolve } from 'pathe'
@@ -162,7 +161,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       for (const [transformMode, filenames] of Object.entries(coveragePerProject) as [AfterSuiteRunMeta['transformMode'], Filename[]][]) {
         let merged: RawCoverage = { result: [] }
 
-        for (const chunk of toSlices(filenames, this.options.processingConcurrency)) {
+        for (const chunk of this.toSlices(filenames, this.options.processingConcurrency)) {
           if (debug.enabled) {
             index += chunk.length
             debug('Covered files %d/%d', index, total)
@@ -198,7 +197,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       watermarks: this.options.watermarks,
     })
 
-    if (hasTerminalReporter(this.options.reporter))
+    if (this.hasTerminalReporter(this.options.reporter))
       this.ctx.logger.log(c.blue(' % ') + c.dim('Coverage report from ') + c.yellow(this.name))
 
     for (const reporter of this.options.reporter) {
@@ -232,10 +231,8 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
         this.updateThresholds({
           thresholds: resolvedThresholds,
           perFile: this.options.thresholds.perFile,
-          configurationFile: {
-            write: () => writeFileSync(configFilePath, configModule.generate().code, 'utf-8'),
-            read: () => resolveConfig(configModule),
-          },
+          configurationFile: configModule,
+          onUpdate: () => writeFileSync(configFilePath, configModule.generate().code, 'utf-8'),
         })
       }
     }
@@ -255,7 +252,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
     let merged: RawCoverage = { result: [] }
     let index = 0
 
-    for (const chunk of toSlices(uncoveredFiles, this.options.processingConcurrency)) {
+    for (const chunk of this.toSlices(uncoveredFiles, this.options.processingConcurrency)) {
       if (debug.enabled) {
         index += chunk.length
         debug('Uncovered files %d/%d', index, uncoveredFiles.length)
@@ -334,7 +331,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
     const coverageMap = libCoverage.createCoverageMap({})
     let index = 0
 
-    for (const chunk of toSlices(scriptCoverages, this.options.processingConcurrency)) {
+    for (const chunk of this.toSlices(scriptCoverages, this.options.processingConcurrency)) {
       if (debug.enabled) {
         index += chunk.length
         debug('Converting %d/%d', index, scriptCoverages.length)
@@ -409,54 +406,4 @@ function normalizeTransformResults(fetchCache: Map<string, { result: FetchResult
   }
 
   return normalized
-}
-
-function hasTerminalReporter(reporters: Options['reporter']) {
-  return reporters.some(([reporter]) =>
-    reporter === 'text'
-    || reporter === 'text-summary'
-    || reporter === 'text-lcov'
-    || reporter === 'teamcity')
-}
-
-function toSlices<T>(array: T[], size: number): T[][] {
-  return array.reduce<T[][]>((chunks, item) => {
-    const index = Math.max(0, chunks.length - 1)
-    const lastChunk = chunks[index] || []
-    chunks[index] = lastChunk
-
-    if (lastChunk.length >= size)
-      chunks.push([item])
-
-    else
-      lastChunk.push(item)
-
-    return chunks
-  }, [])
-}
-
-function resolveConfig(configModule: ProxifiedModule<any>) {
-  const mod = configModule.exports.default
-
-  try {
-    // Check for "export default { test: {...} }"
-    if (mod.$type === 'object')
-      return mod
-
-    if (mod.$type === 'function-call') {
-      // "export default defineConfig({ test: {...} })"
-      if (mod.$args[0].$type === 'object')
-        return mod.$args[0]
-
-      // "export default defineConfig(() => ({ test: {...} }))"
-      if (mod.$args[0].$type === 'arrow-function-expression' && mod.$args[0].$body.$type === 'object')
-        return mod.$args[0].$body
-    }
-  }
-  catch (error) {
-    // Reduce magicast's verbose errors to readable ones
-    throw new Error(error instanceof Error ? error.message : String(error))
-  }
-
-  throw new Error('Failed to update coverage thresholds. Configuration file is too complex.')
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Now that coverages packages don't have to maintain compatibility with previous `vitest` versions in same major (https://github.com/vitest-dev/vitest/pull/5208), we can move more reusable code into `vitest` package. This is only refactoring to reduce duplication.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
