### PR TITLE
fix(ui): auto reload coverage iframe after test run

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -28,7 +28,8 @@ export const client = (function createVitestClient() {
         onFinished(_files, errors) {
           testRunState.value = 'idle'
           unhandledErrors.value = (errors || []).map(parseError)
-
+        },
+        onFinishedReportCoverage() {
           // reload coverage iframe
           const iframe = document.querySelector('iframe#vitest-ui-coverage')
           if (iframe instanceof HTMLIFrameElement && iframe.contentWindow)

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -28,6 +28,11 @@ export const client = (function createVitestClient() {
         onFinished(_files, errors) {
           testRunState.value = 'idle'
           unhandledErrors.value = (errors || []).map(parseError)
+
+          // reload coverage iframe
+          const iframe = document.querySelector('iframe#vitest-ui-coverage')
+          if (iframe instanceof HTMLIFrameElement && iframe.contentWindow)
+            iframe.contentWindow.location.reload()
         },
       },
     })

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -162,7 +162,7 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, _server?: Vi
       {
         post: msg => ws.send(msg),
         on: fn => ws.on('message', fn),
-        eventNames: ['onUserConsoleLog', 'onFinished', 'onCollected', 'onCancel'],
+        eventNames: ['onUserConsoleLog', 'onFinished', 'onFinishedReportCoverage', 'onCollected', 'onCancel'],
         serialize: (data: any) => stringify(data, stringifyReplace),
         deserialize: parse,
         onTimeoutError(functionName) {
@@ -223,6 +223,12 @@ class WebSocketReporter implements Reporter {
   onFinished(files?: File[], errors?: unknown[]) {
     this.clients.forEach((client) => {
       client.onFinished?.(files, errors)
+    })
+  }
+
+  onFinishedReportCoverage() {
+    this.clients.forEach((client) => {
+      client.onFinishedReportCoverage?.()
     })
   }
 

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -183,7 +183,7 @@ export function setup(vitestOrWorkspace: Vitest | WorkspaceProject, _server?: Vi
   ctx.reporters.push(new WebSocketReporter(ctx, wss, clients))
 }
 
-class WebSocketReporter implements Reporter {
+export class WebSocketReporter implements Reporter {
   constructor(
     public ctx: Vitest,
     public wss: WebSocketServer,

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -37,6 +37,7 @@ export interface WebSocketHandlers {
   debug: (...args: string[]) => void
 }
 
-export interface WebSocketEvents extends Pick<Reporter, 'onCollected' | 'onFinished' | 'onFinishedReportCoverage' | 'onTaskUpdate' | 'onUserConsoleLog' | 'onPathsCollected'> {
+export interface WebSocketEvents extends Pick<Reporter, 'onCollected' | 'onFinished' | 'onTaskUpdate' | 'onUserConsoleLog' | 'onPathsCollected'> {
   onCancel: (reason: CancelReason) => void
+  onFinishedReportCoverage: () => void
 }

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -37,6 +37,6 @@ export interface WebSocketHandlers {
   debug: (...args: string[]) => void
 }
 
-export interface WebSocketEvents extends Pick<Reporter, 'onCollected' | 'onFinished' | 'onTaskUpdate' | 'onUserConsoleLog' | 'onPathsCollected'> {
+export interface WebSocketEvents extends Pick<Reporter, 'onCollected' | 'onFinished' | 'onFinishedReportCoverage' | 'onTaskUpdate' | 'onUserConsoleLog' | 'onPathsCollected'> {
   onCancel: (reason: CancelReason) => void
 }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -16,6 +16,7 @@ import { getCoverageProvider } from '../integrations/coverage'
 import type { BrowserProvider } from '../types/browser'
 import { CONFIG_NAMES, configFiles, workspacesFiles as workspaceFiles } from '../constants'
 import { rootDir } from '../paths'
+import { WebSocketReporter } from '../api/setup'
 import { createPool } from './pool'
 import type { ProcessPool, WorkspaceSpec } from './pool'
 import { createBenchmarkReporters, createReporters } from './reporters/utils'
@@ -802,7 +803,11 @@ export class Vitest {
 
     if (this.coverageProvider) {
       await this.coverageProvider.reportCoverage({ allTestsRun })
-      await this.report('onFinishedReportCoverage')
+      // notify coverage iframe reload
+      for (const reporter of this.reporters) {
+        if (reporter instanceof WebSocketReporter)
+          reporter.onFinishedReportCoverage()
+      }
     }
   }
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -800,8 +800,10 @@ export class Vitest {
     if (!this.config.coverage.reportOnFailure && this.state.getCountOfFailedTests() > 0)
       return
 
-    if (this.coverageProvider)
+    if (this.coverageProvider) {
       await this.coverageProvider.reportCoverage({ allTestsRun })
+      await this.report('onFinishedReportCoverage')
+    }
   }
 
   async close() {

--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -7,8 +7,6 @@ export interface Reporter {
   onPathsCollected?: (paths?: string[]) => Awaitable<void>
   onCollected?: (files?: File[]) => Awaitable<void>
   onFinished?: (files?: File[], errors?: unknown[]) => Awaitable<void>
-  /** @internal */
-  onFinishedReportCoverage?: () => Awaitable<void>
   onTaskUpdate?: (packs: TaskResultPack[]) => Awaitable<void>
 
   onTestRemoved?: (trigger?: string) => Awaitable<void>

--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -7,6 +7,8 @@ export interface Reporter {
   onPathsCollected?: (paths?: string[]) => Awaitable<void>
   onCollected?: (files?: File[]) => Awaitable<void>
   onFinished?: (files?: File[], errors?: unknown[]) => Awaitable<void>
+  /** @internal */
+  onFinishedReportCoverage?: () => Awaitable<void>
   onTaskUpdate?: (packs: TaskResultPack[]) => Awaitable<void>
 
   onTestRemoved?: (trigger?: string) => Awaitable<void>

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -70,6 +70,9 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
     onFinished(files, errors) {
       handlers.onFinished?.(files, errors)
     },
+    onFinishedReportCoverage() {
+      handlers.onFinishedReportCoverage?.()
+    },
     onCancel(reason: CancelReason) {
       handlers.onCancel?.(reason)
     },


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5057

I tested a simple iframe reloading and tested by `pnpm -C examples/basic test:ui --coverage`:

<details><summary>Show demo</summary>

[스크린캐스트 2024-02-20 13-35-10.webm](https://github.com/vitest-dev/vitest/assets/4232207/d8574554-50f0-4e61-a021-b0c4f49ffa3c)

</details>

But actually I'm worrying that there might be some race condition here:

https://github.com/vitest-dev/vitest/blob/a479115913c6428dd28ed8339b9b80e7ce3ccc06/packages/vitest/src/node/core.ts#L529-L530

If `reportCoverage` takes significant time, then reloading iframe during `onFinished` might end up fetching old coverage html.

To avoid this race condition, it might be necessary to either:
- add new reporter hook (like `onReportCoverageFinished`) just for this, or
- move up `reportCoverage` before `onFinished` (this would likely mess up terminal output for coverage `text` reporter) or
- provide a dedicated "iframe reload" button on UI, so users can at least reload it manually.

I'm leaning towards the 1st option, but what do you think?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
