### PR TITLE
fix(workspace): throw error when browser mode and `@vitest/coverage-v8` are used

### DIFF
--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -297,7 +297,15 @@ export class WorkspaceProject {
   }
 
   async setServer(options: UserConfig, server: ViteDevServer) {
-    this.config = resolveConfig(this.ctx.mode, options, server.config)
+    this.config = resolveConfig(
+      this.ctx.mode,
+      {
+        ...options,
+        coverage: this.ctx.config.coverage,
+      },
+      server.config,
+    )
+
     this.server = server
 
     this.vitenode = new ViteNodeServer(server, this.config.server)
@@ -329,7 +337,6 @@ export class WorkspaceProject {
 
     return deepMerge({
       ...this.config,
-      coverage: this.ctx.config.coverage,
 
       poolOptions: {
         forks: {

--- a/test/config/fixtures/workspace/browser/workspace-with-browser.ts
+++ b/test/config/fixtures/workspace/browser/workspace-with-browser.ts
@@ -1,0 +1,13 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace([
+  {
+    test: {
+      name: "Browser project",
+      browser: {
+         enabled: true,
+         name: 'chrome'
+      },
+    }
+  }
+])

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -61,6 +61,12 @@ test('v8 coverage provider cannot be used with browser', async () => {
   expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
 })
 
+test('v8 coverage provider cannot be used with browser in workspace', async () => {
+  const { stderr } = await runVitest({ coverage: { enabled: true }, workspace: './fixtures/workspace/browser/workspace-with-browser.ts' })
+
+  expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+})
+
 test('version number is printed when coverage provider fails to load', async () => {
   const { stderr, stdout } = await runVitest({
     coverage: {


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

This error is not thrown when browser mode is used with `@vitest/coverage-v8`. Browser tests start and show errors related `node:inspector` usage outside Node.

https://github.com/vitest-dev/vitest/blob/4ff7159049e4dd63501cdf512aea3366b55691cf/packages/vitest/src/node/config.ts#L142-L143

The reason is that resolved configuration is for root configuration, not the workspace configuration. Coverage options are in root config, browser config in workspace config. At this scope we don't have access to those both I think. 

```ts
// vitest.config.ts
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    coverage: {
      enabled: true,
    },
  },
});

// vitest.workspace.ts
import { defineWorkspace } from "vitest/config";

export default defineWorkspace([
  {
    test: {
      name: "Browser project",
      browser: {
        headless: true,
        enabled: true,
        name: "chrome",
      },
    },
  },
]);
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
