### PR TITLE
docs: remove paragraph in Web Test Runner section

### DIFF
--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -42,8 +42,6 @@ WebdriverIO comes with the same advantages as Cypress allowing you to test your 
 
 [@web/test-runner](https://modern-web.dev/docs/test-runner/overview/) runs tests inside a headless browser, providing the same execution environment as your web application without the need for mocking out browser APIs or the DOM. This also makes it possible to debug inside a real browser using the devtools, although there is no UI shown for stepping through the test, as there is in Cypress tests.
 
-There is a watch mode, but it is not as intelligent as that of Vitest, and may not always re-run the tests you want.<sup>[[citation needed](https://en.wikipedia.org/wiki/Wikipedia:Citation_needed)]</sup>
-
 To use @web/test-runner with a Vite project, use [@remcovaes/web-test-runner-vite-plugin](https://github.com/remcovaes/web-test-runner-vite-plugin). @web/test-runner does not include assertion or mocking libraries, so it is up to you to add them.
 
 ## uvu

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -42,7 +42,7 @@ WebdriverIO comes with the same advantages as Cypress allowing you to test your 
 
 [@web/test-runner](https://modern-web.dev/docs/test-runner/overview/) runs tests inside a headless browser, providing the same execution environment as your web application without the need for mocking out browser APIs or the DOM. This also makes it possible to debug inside a real browser using the devtools, although there is no UI shown for stepping through the test, as there is in Cypress tests.
 
-There is a watch mode, but it is not as intelligent as that of Vitest, and may not always re-run the tests you want.
+There is a watch mode, but it is not as intelligent as that of Vitest, and may not always re-run the tests you want.<sup>[[citation needed](https://en.wikipedia.org/wiki/Wikipedia:Citation_needed)]</sup>
 
 To use @web/test-runner with a Vite project, use [@remcovaes/web-test-runner-vite-plugin](https://github.com/remcovaes/web-test-runner-vite-plugin). @web/test-runner does not include assertion or mocking libraries, so it is up to you to add them.
 


### PR DESCRIPTION
### Description

This PR is addressing possible confusion about Web Test Runner by removing a paragraph from it's section.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
