### PR TITLE
feat(config): add `shuffle.files` and `shuffle.tests` options

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1768,13 +1768,29 @@ Sharding is happening before sorting, and only if `--shard` option is provided.
 
 #### sequence.shuffle
 
-- **Type**: `boolean`
+- **Type**: `boolean | { files?, tests? }`
 - **Default**: `false`
 - **CLI**: `--sequence.shuffle`, `--sequence.shuffle=false`
 
-If you want tests to run randomly, you can enable it with this option, or CLI argument [`--sequence.shuffle`](/guide/cli).
+If you want files and tests to run randomly, you can enable it with this option, or CLI argument [`--sequence.shuffle`](/guide/cli).
 
-Vitest usually uses cache to sort tests, so long running tests start earlier - this makes tests run faster. If your tests will run in random order you will lose this performance improvement, but it may be useful to track tests that accidentally depend on another run previously.
+Vitest usually uses cache to sort tests, so long running tests start earlier - this makes tests run faster. If your files and tests will run in random order you will lose this performance improvement, but it may be useful to track tests that accidentally depend on another run previously.
+
+#### sequence.shuffle.files <Badge type="info">1.4.0+</Badge> {#sequence-shuffle-files}
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **CLI**: `--sequence.shuffle.files`, `--sequence.shuffle.files=false`
+
+Whether to randomize files, be aware that long running tests will not start earlier if you enable this option.
+
+#### sequence.shuffle.tests <Badge type="info">1.4.0+</Badge> {#sequence-shuffle-tests}
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **CLI**: `--sequence.shuffle.tests`, `--sequence.shuffle.tests=false`
+
+Whether to randomize tests.
 
 #### sequence.concurrent <Badge type="info">0.32.2+</Badge> {#sequence-concurrent}
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -436,7 +436,16 @@ export const cliOptionsConfig: VitestCLIOptions = {
     argument: '<options>',
     subcommands: {
       shuffle: {
-        description: 'Run tests in a random order. Enabling this option will impact Vitest\'s cache and have a performance impact. May be useful to find tests that accidentally depend on another run previously (default: false)',
+        description: 'Run files and tests in a random order. Enabling this option will impact Vitest\'s cache and have a performance impact. May be useful to find tests that accidentally depend on another run previously (default: false)',
+        argument: '',
+        subcommands: {
+          files: {
+            description: 'Run files in a random order. Long running tests will not start earlier if you enable this option. (default: false)',
+          },
+          tests: {
+            description: 'Run tests in a random oder (default: false)',
+          },
+        },
       },
       concurrent: {
         description: 'Make tests run in parallel (default: false)',

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -441,6 +441,11 @@ export function resolveConfig(
     resolved.cache.dir = VitestCache.resolveCacheDir(resolved.root, resolved.cache.dir, resolved.name)
 
   resolved.sequence ??= {} as any
+  if (resolved.sequence.shuffle && typeof resolved.sequence.shuffle === 'object') {
+    const { files, tests } = resolved.sequence.shuffle
+    resolved.sequence.sequencer ??= files ? RandomSequencer : BaseSequencer
+    resolved.sequence.shuffle = files || tests
+  }
   if (!resolved.sequence?.sequencer) {
     // CLI flag has higher priority
     resolved.sequence.sequencer = resolved.sequence.shuffle

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -444,7 +444,7 @@ export function resolveConfig(
   if (resolved.sequence.shuffle && typeof resolved.sequence.shuffle === 'object') {
     const { files, tests } = resolved.sequence.shuffle
     resolved.sequence.sequencer ??= files ? RandomSequencer : BaseSequencer
-    resolved.sequence.shuffle = files || tests
+    resolved.sequence.shuffle = tests
   }
   if (!resolved.sequence?.sequencer) {
     // CLI flag has higher priority

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -48,10 +48,22 @@ interface SequenceOptions {
    */
   sequencer?: TestSequencerConstructor
   /**
-   * Should tests run in random order.
+   * Should files and tests run in random order.
    * @default false
    */
-  shuffle?: boolean
+  shuffle?: boolean | {
+    /**
+     * Should files run in random order. Long running tests will not start
+     * earlier if you enable this option.
+     * @default false
+     */
+    files?: boolean
+    /**
+     * Should tests run in random order.
+     * @default false
+     */
+    tests?: boolean
+  }
   /**
    * Should tests run in parallel.
    * @default false

--- a/test/config/test/shuffle-options.test.ts
+++ b/test/config/test/shuffle-options.test.ts
@@ -1,0 +1,49 @@
+import type { InlineConfig } from 'vitest'
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+function run(sequence: InlineConfig['sequence']) {
+  return runVitest({
+    sequence,
+    include: [],
+  })
+}
+
+class CustomSequencer {
+  sort() {
+    return []
+  }
+
+  shard() {
+    return []
+  }
+}
+
+test.each([
+  false,
+  { files: false, tests: false },
+  { files: false, tests: true },
+],
+)('should use BaseSequencer if shuffle is %o', async (shuffle) => {
+  const { vitest } = await run({ shuffle })
+  expect(vitest?.config.sequence.sequencer.name).toBe('BaseSequencer')
+})
+
+test.each([
+  true,
+  { files: true, tests: false },
+  { files: true, tests: true },
+])('should use RandomSequencer if shuffle is %o', async (shuffle) => {
+  const { vitest } = await run({ shuffle })
+  expect(vitest?.config.sequence.sequencer.name).toBe('RandomSequencer')
+})
+
+test.each([
+  false,
+  true,
+  { files: true, tests: false },
+  { files: true, tests: true },
+])('should always use CustomSequencer if passed', async (shuffle) => {
+  const { vitest } = await run({ shuffle, sequencer: CustomSequencer })
+  expect(vitest?.config.sequence.sequencer.name).toBe('CustomSequencer')
+})

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -223,6 +223,13 @@ test('cache is parsed correctly', () => {
   })
 })
 
+test('shuffle is parsed correctly', () => {
+  expect(getCLIOptions('--sequence.shuffle')).toEqual({ sequence: { shuffle: true } })
+  expect(getCLIOptions('--sequence.shuffle=false')).toEqual({ sequence: { shuffle: false } })
+  expect(getCLIOptions('--sequence.shuffle.files --sequence.shuffle.tests')).toEqual({ sequence: { shuffle: { files: true, tests: true } } })
+  expect(getCLIOptions('--sequence.shuffle.files=false --sequence.shuffle.tests=false')).toEqual({ sequence: { shuffle: { files: false, tests: false } } })
+})
+
 test('typecheck correctly passes down arguments', () => {
   const { options, args } = parseArguments('--typecheck some.name.ts')
   expect(options).toEqual({ typecheck: { enabled: true } })
@@ -326,15 +333,6 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space_1', 'space_2'],
-      '--': [],
-      'color': true,
-    },
-  })
-
-  expect(parseCLI('vitest --sequence.shuffle.files --sequence.shuffle.tests=false')).toEqual({
-    filter: [],
-    options: {
-      'sequence': { shuffle: { files: true, tests: false } },
       '--': [],
       'color': true,
     },

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -321,4 +321,13 @@ test('public parseCLI works correctly', () => {
   expect(() => {
     parseCLI('node --test --coverage --browser --typecheck')
   }).toThrowError(`Expected "vitest" as the first argument, received "node"`)
+
+  expect(parseCLI('vitest --sequence.shuffle.files --sequence.shuffle.tests=false')).toEqual({
+    filter: [],
+    options: {
+      'sequence': { shuffle: { files: true, tests: false } },
+      '--': [],
+      'color': true,
+    },
+  })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Add `shuffle.files` and `shuffle.tests` options, allowing users to shuffle tests while leveraging cache to run long-running tests earlier. 
- Closes #3568 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
