### PR TITLE
chore: add `.svelte-kit` to eslint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default antfu(
       'test/reporters/fixtures/with-syntax-error.test.js',
       'test/network-imports/public/slash@3.0.0.js',
       'examples/**/mockServiceWorker.js',
+      'examples/sveltekit/.svelte-kit',
     ],
   },
   {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When I ran the lint command in the Vitest codebase, got the following result. The directory `.svelte-kit` was generated after runing `pnpm test:ci`, I thought it might be better to add it to eslint ignore list.

<img width="883" alt="image" src="https://github.com/vitest-dev/vitest/assets/59411875/4f7d039e-59ca-4540-9755-190a0c3d5510">

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
