### PR TITLE
fix(api): use resolvedUrls from devserver

### DIFF
--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -171,10 +171,16 @@ export class Logger {
       this.log(c.dim(c.green(`     ${output} Browser runner started at ${new URL('/', origin)}`)))
     })
 
-    if (this.ctx.config.ui)
+    if (this.ctx.config.ui) {
       this.log(c.dim(c.green(`      UI started at http://${this.ctx.config.api?.host || 'localhost'}:${c.bold(`${this.ctx.server.config.server.port}`)}${this.ctx.config.uiBase}`)))
-    else if (this.ctx.config.api?.port)
-      this.log(c.dim(c.green(`      API started at http://${this.ctx.config.api?.host || 'localhost'}:${c.bold(`${this.ctx.config.api.port}`)}`)))
+    }
+    else if (this.ctx.config.api?.port) {
+      const resolvedUrls = this.ctx.server.resolvedUrls
+      // workaround for https://github.com/vitejs/vite/issues/15438, it was fixed in vite 5.1
+      const fallbackUrl = `http://${this.ctx.config.api.host || 'localhost'}:${this.ctx.config.api.port}`
+      const origin = resolvedUrls?.local[0] ?? resolvedUrls?.network[0] ?? fallbackUrl
+      this.log(c.dim(c.green(`      API started at ${new URL('/', origin)}`)))
+    }
 
     if (this.ctx.coverageProvider)
       this.log(c.dim('      Coverage enabled with ') + c.yellow(this.ctx.coverageProvider.name))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2133,6 +2133,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest
 
+  test/ws-api:
+    devDependencies:
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^1.0.2
+        version: 1.0.2(vite@5.0.12)
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -27567,6 +27576,7 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0

--- a/test/ws-api/fixtures/server-url/basic.test.ts
+++ b/test/ws-api/fixtures/server-url/basic.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+test("basic", () => {
+  expect(1).toBe(1);
+})

--- a/test/ws-api/fixtures/server-url/vitest.config.ts
+++ b/test/ws-api/fixtures/server-url/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import basicSsl from '@vitejs/plugin-basic-ssl'
+
+// test https by
+//   TEST_HTTPS=1 pnpm test-fixtures --root fixtures/server-url
+
+export default defineConfig({
+  plugins: [
+    !!process.env.TEST_HTTPS && basicSsl(),
+  ],
+})

--- a/test/ws-api/fixtures/server-url/vitest.config.ts
+++ b/test/ws-api/fixtures/server-url/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 import basicSsl from '@vitejs/plugin-basic-ssl'
 
 // test https by
-//   TEST_HTTPS=1 pnpm test-fixtures --root fixtures/server-url
+//   TEST_HTTPS=1 pnpm test --root fixtures/server-url --api
 
 export default defineConfig({
   plugins: [

--- a/test/ws-api/package.json
+++ b/test/ws-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-ws-api",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-basic-ssl": "^1.0.2",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/ws-api/tests/server-url.test.ts
+++ b/test/ws-api/tests/server-url.test.ts
@@ -1,0 +1,20 @@
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+
+import { runVitestCli } from '../../test-utils'
+
+it('api server-url http', async () => {
+  delete process.env.TEST_HTTPS
+  const { stdout } = await runVitestCli('run', '--root', join(process.cwd(), './fixtures/server-url'), '--api')
+  expect(stdout).toContain('API started at http://localhost:51204/')
+  expect(stdout).toContain('Test Files  1 passed')
+})
+
+it('api server-url https', async () => {
+  process.env.TEST_HTTPS = '1'
+  const { stdout } = await runVitestCli('run', '--root', join(process.cwd(), './fixtures/server-url'), '--api')
+  expect(stdout).toContain('API started at https://localhost:51204/')
+  expect(stdout).toContain('Test Files  1 passed')
+})
+
+it.todo('api server-url fallback if resolvedUrls is null')

--- a/test/ws-api/vitest.config.ts
+++ b/test/ws-api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
### Description

Applied the fix with `resolvedUrls` for ws api logs and provided fallback url in case `resolvedUrls` is null.

<!-- You can also add additional context here -->
This relates to https://github.com/vitest-dev/vscode/issues/226

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
