### PR TITLE
test(browser): unskipped https test for browser

### DIFF
--- a/test/browser/fixtures/server-url/vitest.config.ts
+++ b/test/browser/fixtures/server-url/vitest.config.ts
@@ -9,6 +9,16 @@ import basicSsl from '@vitejs/plugin-basic-ssl'
 const provider = process.env.PROVIDER || 'webdriverio';
 const browser = process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome');
 
+// ignore https errors due to self-signed certificate from plugin-basic-ssl
+// https://playwright.dev/docs/api/class-browser#browser-new-context-option-ignore-https-errors
+// https://webdriver.io/docs/configuration/#strictssl and acceptInsecureCerts in https://webdriver.io/docs/api/browser/#properties
+const providerOptions = (function () {
+  switch (provider) {
+    case 'playwright': return { page: { ignoreHTTPSErrors: true } }
+    case 'webdriverio': return { strictSSL: false, capabilities: { acceptInsecureCerts: true } }
+  }
+})()
+
 export default defineConfig({
   plugins: [
     !!process.env.TEST_HTTPS && basicSsl(),
@@ -18,6 +28,7 @@ export default defineConfig({
       enabled: true,
       provider,
       name: browser,
+      providerOptions,
     },
   },
   // separate cacheDir from test/browser/vite.config.ts

--- a/test/browser/specs/server-url.test.mjs
+++ b/test/browser/specs/server-url.test.mjs
@@ -13,11 +13,10 @@ test('server-url http', async () => {
   assert.match(result.stdout, /Test Files {2}1 passed/)
 })
 
-// this test is skipped since browser warns self-signed https and it requires manual interaction.
-// you can toggle "skip" to verify it locally.
-test('server-url https', { skip: true }, async () => {
-  const result = await execa('npx', ['vitest', 'run', '--root=./fixtures/server-url'], {
+test('server-url https', async () => {
+  const result = await execa('npx', ['vitest', 'run', '--root=./fixtures/server-url', '--browser.headless'], {
     env: {
+      CI: '1',
       NO_COLOR: '1',
       TEST_HTTPS: '1',
     },


### PR DESCRIPTION
### Description

In #4855 https tests for browser module were introduced, but they were skipped due to self-signed certificate that basic-ssl-plugin produces. Browser automation tools usually provide a way to disable ssl protection and playwright and webdriverio are no exceptions (well, you'll see about that). I unskipped https test by configuring it via `providerOptions`

Playwright way: https://playwright.dev/docs/api/class-browser#browser-new-context-option-ignore-https-errors
WebdriverIO way: https://webdriver.io/docs/configuration/#strictssl and `acceptInsecureCerts` in `capabilities` https://webdriver.io/docs/api/browser/#properties

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
