### PR TITLE
fix(vitest): ensure restoring terminal cursor on close

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -841,6 +841,7 @@ export class Vitest {
           results.filter(r => r.status === 'rejected').forEach((err) => {
             this.logger.error('error during close', (err as PromiseRejectedResult).reason)
           })
+          this.logger.logUpdate.done() // restore terminal cursor
         })
       })()
     }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5247

I couldn't identify the actual cause of cursor not getting back _only_ on typecheck run, so I went with using `logUpdate.done` to explicitly restore the cursor. There could be some deeper bug specific to typecheck run, but I couldn't see anything suspicious.

_additional notes_
- `log-update` is used only for reporters such as `dot` and `default` reporters on TTY, so the bug doesn't occur when using `--reporter=tap` for example.
- `log-update` internally uses [cli-cursor](https://github.com/sindresorhus/cli-cursor/blob/main/index.js), which in turn uses [restore-cursor](https://github.com/sindresorhus/restore-cursor/blob/main/index.js). Since we haven't used `logUpdate.done`, probably we're relying on `restore-cursor`'s automatic restoration, which somehow doesn't work on `typecheck` mode.

_test_

- run `pnpm -C examples/typecheck test:run`
- verify cursor is restored

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
