### PR TITLE
fix(ui): escape html in error diff

### DIFF
--- a/packages/ui/client/components/views/ViewReportError.vue
+++ b/packages/ui/client/components/views/ViewReportError.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ErrorWithDiff } from 'vitest'
 import { openInEditor, shouldOpenInEditor } from '~/composables/error'
+import { escapeHtml } from '~/utils/escape';
 
 const props = defineProps<{
   root: string
@@ -20,7 +21,7 @@ const isDiffShowable = computed(() => {
   return !!props.error?.diff
 })
 
-const diff = computed(() => props.error.diff ? filter.value.toHtml(props.error.diff) : undefined)
+const diff = computed(() => props.error.diff ? filter.value.toHtml(escapeHtml(props.error.diff)) : undefined)
 </script>
 
 <template>


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5321

<details>

- before

![image](https://github.com/vitest-dev/vitest/assets/4232207/cbbe46a9-6bf0-4ff1-9916-07e0a01f22f0)

- after

![image](https://github.com/vitest-dev/vitest/assets/4232207/cee97dea-916f-4ccc-b8e7-a0c61af8aaff)

</details>

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
