### PR TITLE
fix(coverage): v8 to ignore type-only files

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -55,6 +55,7 @@
     "magicast": "^0.3.3",
     "picocolors": "^1.0.0",
     "std-env": "^3.5.0",
+    "strip-literal": "^2.0.0",
     "test-exclude": "^6.0.0",
     "v8-to-istanbul": "^9.2.0"
   },

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -14,6 +14,7 @@ import remapping from '@ampproject/remapping'
 import { normalize, resolve } from 'pathe'
 import c from 'picocolors'
 import { provider } from 'std-env'
+import { stripLiteral } from 'strip-literal'
 import createDebug from 'debug'
 import { cleanUrl } from 'vite-node/utils'
 import type { EncodedSourceMap, FetchResult } from 'vite-node'
@@ -260,7 +261,13 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       }
 
       const coverages = await Promise.all(chunk.map(async (filename) => {
-        const { source } = await this.getSources(filename.href, transformResults)
+        const transformResult = await this.ctx.vitenode.transformRequest(filename.pathname).catch(() => {})
+
+        // Ignore empty files, e.g. files that contain only typescript types and no runtime code
+        if (transformResult && stripLiteral(transformResult.code).trim() === '')
+          return null
+
+        const { originalSource } = await this.getSources(filename.href, transformResults)
 
         const coverage = {
           url: filename.href,
@@ -269,7 +276,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
           functions: [{
             ranges: [{
               startOffset: 0,
-              endOffset: source.length,
+              endOffset: originalSource.length,
               count: 0,
             }],
             isBlockCoverage: true,
@@ -281,7 +288,10 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
         return { result: [coverage] }
       }))
 
-      merged = mergeProcessCovs([merged, ...coverages])
+      merged = mergeProcessCovs([
+        merged,
+        ...coverages.filter((cov): cov is NonNullable<typeof cov> => cov != null),
+      ])
     }
 
     return merged
@@ -289,7 +299,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
 
   private async getSources(url: string, transformResults: TransformResults, functions: Profiler.FunctionCoverage[] = []): Promise<{
     source: string
-    originalSource?: string
+    originalSource: string
     sourceMap?: { sourcemap: EncodedSourceMap }
   }> {
     const filePath = normalize(fileURLToPath(url))
@@ -306,8 +316,12 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
     })
 
     // These can be uncovered files included by "all: true" or files that are loaded outside vite-node
-    if (!map)
-      return { source: code || sourcesContent }
+    if (!map) {
+      return {
+        source: code || sourcesContent,
+        originalSource: sourcesContent,
+      }
+    }
 
     return {
       originalSource: sourcesContent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1054,6 +1054,9 @@ importers:
       std-env:
         specifier: ^3.5.0
         version: 3.5.0
+      strip-literal:
+        specifier: ^2.0.0
+        version: 2.0.0
       test-exclude:
         specifier: ^6.0.0
         version: 6.0.0

--- a/test/coverage-test/src/types.ts
+++ b/test/coverage-test/src/types.ts
@@ -1,0 +1,3 @@
+export type First = 'This' | 'file' | 'should'
+
+export type Second = 'be' | 'excluded' | 'from' | 'report'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/3605
- The existing test cases that validate `coverage.json` cover this feature. If the fix is removed, the new `types.ts` shows up in snapshot and it fails.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
