### PR TITLE
fix(vitest): loosen `onConsoleLog` return type

### DIFF
--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -580,7 +580,7 @@ export interface InlineConfig {
    *
    * Return `false` to ignore the log.
    */
-  onConsoleLog?: (log: string, type: 'stdout' | 'stderr') => false | void
+  onConsoleLog?: (log: string, type: 'stdout' | 'stderr') => boolean | void
 
   /**
    * Enable stack trace filtering. If absent, all stack trace frames

--- a/test/web-worker/vitest.config.ts
+++ b/test/web-worker/vitest.config.ts
@@ -13,8 +13,7 @@ export default defineConfig({
       },
     },
     onConsoleLog(log) {
-      if (log.includes('Failed to load'))
-        return false
+      return !log.includes('Failed to load')
     },
   },
 })


### PR DESCRIPTION
### Description

- close https://github.com/vitest-dev/vitest/issues/5317

I think this is a minor paper cut and loosening it makes sense to allow something like:

```ts
onConsoleLog(type) {
  return type !== 'stderr';
}
```

Currently users need to rewrite it into a following, which seems unnecessary restriction. Also it seems some eslint rule doesn't like this form.

```ts
onConsoleLog(type) {
  if (type === 'stderr') {
    return false;
  }
}
```

I don't know about `void` vs `undefined`, so I kept `void` here.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
