### PR TITLE
fix(browser): fix chai and loupe deps and silence `util.inspect` warning

### DIFF
--- a/packages/browser/src/client/logger.ts
+++ b/packages/browser/src/client/logger.ts
@@ -31,6 +31,11 @@ export async function setupConsoleLogSpy() {
     return base(...args)
   }
   const stderr = (base: (...args: unknown[]) => void) => (...args: unknown[]) => {
+    // silence warning from loupe's node util.inspect with deps optimization
+    // https://github.com/vitejs/vite/blob/0c0aeaeb3f12d2cdc3c47557da209416c8d48fb7/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L227
+    if (typeof args[0] === 'string' && args[0].startsWith('Module "util" has been externalized for browser compatibility. Cannot access "util.inspect" in client code.'))
+      return base(...args)
+
     sendLog('stderr', processLog(args))
     return base(...args)
   }

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -142,9 +142,6 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
               'vitest/browser',
               'vitest/runners',
               '@vitest/utils',
-
-              // loupe is manually transformed
-              'loupe',
             ],
             include: [
               'vitest > @vitest/utils > pretty-format',
@@ -153,16 +150,11 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
               'vitest > pretty-format',
               'vitest > pretty-format > ansi-styles',
               'vitest > pretty-format > ansi-regex',
+              'vitest > @vitest/utils > loupe',
+              'vitest > @vitest/expect > chai',
               'vitest > chai',
             ],
           },
-        }
-      },
-      transform(code, id) {
-        if (id.includes('loupe/loupe.js')) {
-          const exportsList = ['custom', 'inspect', 'registerConstructor', 'registerStringTag']
-          const codeAppend = exportsList.map(i => `export const ${i} = globalThis.loupe.${i}`).join('\n')
-          return `${code}\n${codeAppend}\nexport default globalThis.loupe`
         }
       },
       async resolveId(id) {


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5332
- related https://github.com/vitest-dev/vitest/pull/5082#issuecomment-1918578246

This is an another idea I had for https://github.com/vitest-dev/vitest/pull/5082, but it might not be fool-proof...

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
