### PR TITLE
fix: .mockRestore() should restore original implementation when calling getMockImplementation()

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -424,7 +424,7 @@ function enhanceSpy<TArgs extends any[], TReturns>(
   stub.mockRestore = () => {
     stub.mockReset()
     state.restore()
-    implementation = undefined
+    implementation = state.getOriginal()
     return stub
   }
 

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -129,9 +129,10 @@ describe('jest mock compat layer', () => {
 
     spy.mockRestore()
 
-    expect(spy.getMockImplementation()).toBe(undefined)
-
     expect(spy.mock.results).toEqual([])
+
+    expect(spy.getMockImplementation()).toBe(originalFn)
+    expect(spy()).toEqual('original')
   })
 
   it('implementation async fn', async () => {
@@ -257,7 +258,7 @@ describe('jest mock compat layer', () => {
 
     obj.setter = 'last'
 
-    expect(spy.getMockImplementation()).toBe(undefined)
+    expect(spy.getMockImplementation()).toBe(Object.getOwnPropertyDescriptor(obj, 'setter')?.set)
 
     expect(setValue).toBe('last')
   })
@@ -346,11 +347,15 @@ describe('jest mock compat layer', () => {
   it('.mockRestore() should restore initial implementation', () => {
     const testFn = vi.fn(() => true)
     expect(testFn()).toBe(true)
+    expect(testFn.getMockImplementation()).toBeDefined()
+    expect(testFn.getMockImplementation()?.()).toBe(true)
 
     testFn.mockReturnValue(false)
     expect(testFn()).toBe(false)
 
     testFn.mockRestore()
     expect(testFn()).toBe(true)
+    expect(testFn.getMockImplementation()).toBeDefined()
+    expect(testFn.getMockImplementation()?.()).toBe(true)
   })
 })


### PR DESCRIPTION
### Description

We do some shady stuff in storybook, trying to automatically showing vitest spy in the storybook action panel:

https://github.com/storybookjs/storybook/blob/1d765656e8d3657baaf1b025c2571be48078171f/code/addons/actions/src/loaders.ts#L20-L29

```ts
  const previous = value.getMockImplementation();
  if (previous?._actionAttached !== true && previous?.isAction !== true) {
    const implementation = (...params: unknown[]) => {
      action(key)(...params);
      return previous?.(...params);
    };
    implementation._actionAttached = true;
    value.mockImplementation(implementation);
  }
```

However, this does not work after a spy is restored. As value.getMockImplementation() won't the original implementation, which I believe it should after restoring (not resetting) a mock. I think this is a bug in @vitest/spy.

There is a workaround though, that I implemented in this PR:
https://github.com/storybookjs/storybook/pull/26364

But it seems weird that the `getMockImplementation()` value is out of sync with what is actually being "implemented" after restoring the spy. So feels like a bug to me, especially given the documentation:

```
  mockReset: () => this
  /**
   * Does what `mockReset` does and restores inner implementation to the original function.
   *
   * Note that restoring mock from `vi.fn()` will set implementation to an empty function that returns `undefined`. Restoring a `vi.fn(impl)` will restore implementation to `impl`.
   */
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
