### PR TITLE
fix: `--inspect-brk` to pause before execution

### DIFF
--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -48,6 +48,11 @@ export function withInlineSourcemap(result: TransformResult, options: {
   while (OTHER_SOURCE_MAP_REGEXP.test(code))
     code = code.replace(OTHER_SOURCE_MAP_REGEXP, '')
 
+  // If the first line is not present on source maps, add simple 1:1 mapping ([0,0,0,0], [1,0,0,0])
+  // so that debuggers can be set to break on first line
+  if (map.mappings.startsWith(';'))
+    map.mappings = `AAAA,CAAA${map.mappings}`
+
   const sourceMap = Buffer.from(JSON.stringify(map), 'utf-8').toString('base64')
   result.code = `${code.trimEnd()}\n\n${VITE_NODE_SOURCEMAPPING_SOURCE}\n//# ${VITE_NODE_SOURCEMAPPING_URL};base64,${sourceMap}\n`
 

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -15,7 +15,7 @@ if (isChildProcess())
 export async function run(ctx: ContextRPC) {
   const prepareStart = performance.now()
 
-  const inspectorCleanup = setupInspect(ctx.config)
+  const inspectorCleanup = setupInspect(ctx)
 
   process.env.VITEST_WORKER_ID = String(ctx.workerId)
   process.env.VITEST_POOL_ID = String(poolId)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1854,6 +1854,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest
 
+  test/inspect:
+    devDependencies:
+      vite:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.11.5)(less@4.1.3)
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+      ws:
+        specifier: ^8.14.2
+        version: 8.14.2
+
   test/mixed-pools:
     devDependencies:
       vitest:

--- a/test/inspect/fixtures/math.test.ts
+++ b/test/inspect/fixtures/math.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+test("sum", () => {
+  expect(1 + 1).toBe(2)
+})

--- a/test/inspect/fixtures/vitest.config.ts
+++ b/test/inspect/fixtures/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['./**.test.ts'],
+    watch: false,
+  },
+})

--- a/test/inspect/package.json
+++ b/test/inspect/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vitest/test-inspect",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vite": "latest",
+    "vitest": "workspace:*",
+    "ws": "^8.14.2"
+  }
+}

--- a/test/inspect/test/inspect.test.ts
+++ b/test/inspect/test/inspect.test.ts
@@ -2,11 +2,12 @@ import type { InspectorNotification } from 'node:inspector'
 import { expect, test } from 'vitest'
 import WebSocket from 'ws'
 
+import { isWindows } from '../../../packages/vite-node/src/utils'
 import { runVitestCli } from '../../test-utils'
 
 type Message = Partial<InspectorNotification<any>>
 
-test('--inspect-brk stops at test file', async () => {
+test.skipIf(isWindows)('--inspect-brk stops at test file', async () => {
   const vitest = await runVitestCli('--root', 'fixtures', '--inspect-brk', '--no-file-parallelism')
 
   await vitest.waitForStderr('Debugger listening on ')

--- a/test/inspect/test/inspect.test.ts
+++ b/test/inspect/test/inspect.test.ts
@@ -1,0 +1,85 @@
+import type { InspectorNotification } from 'node:inspector'
+import { expect, test } from 'vitest'
+import WebSocket from 'ws'
+
+import { runVitestCli } from '../../test-utils'
+
+type Message = Partial<InspectorNotification<any>>
+
+test('--inspect-brk stops at test file', async () => {
+  const vitest = await runVitestCli('--root', 'fixtures', '--inspect-brk', '--no-file-parallelism')
+
+  await vitest.waitForStderr('Debugger listening on ')
+  const url = vitest.stderr.split('\n')[0].replace('Debugger listening on ', '')
+
+  const { receive, send } = await createChannel(url)
+
+  send({ method: 'Debugger.enable' })
+  send({ method: 'Runtime.enable' })
+  await receive('Runtime.executionContextCreated')
+
+  const paused = receive('Debugger.paused')
+  send({ method: 'Runtime.runIfWaitingForDebugger' })
+
+  const { params } = await paused
+  const scriptId = params.callFrames[0].functionLocation.scriptId
+
+  // Verify that debugger paused on test file
+  const response = receive()
+  send({ method: 'Debugger.getScriptSource', params: { scriptId } })
+  const { result } = await response as any
+
+  expect(result.scriptSource).toContain('test("sum", () => {')
+  expect(result.scriptSource).toContain('expect(1 + 1).toBe(2)')
+
+  send({ method: 'Debugger.resume' })
+
+  await vitest.waitForStdout('Test Files  1 passed (1)')
+  await vitest.isDone
+})
+
+async function createChannel(url: string) {
+  const ws = new WebSocket(url)
+
+  let id = 1
+  let receiver = defer()
+
+  ws.onerror = receiver.reject
+  ws.onmessage = (message) => {
+    const response = JSON.parse(message.data.toString())
+    receiver.resolve(response)
+  }
+
+  async function receive(filter?: string) {
+    const message = await receiver.promise
+    receiver = defer()
+
+    if (filter && message.method !== filter)
+      return receive(filter)
+
+    return message
+  }
+
+  function send(message: Message) {
+    ws.send(JSON.stringify({ ...message, id: id++ }))
+  }
+
+  await new Promise(r => ws.on('open', r))
+
+  return { receive, send }
+}
+
+function defer(): {
+  promise: Promise<Message>
+  resolve: (response: Message) => void
+  reject: (error: unknown) => void
+} {
+  const pr = {} as ReturnType<typeof defer>
+
+  pr.promise = new Promise((resolve, reject) => {
+    pr.resolve = resolve
+    pr.reject = reject
+  })
+
+  return pr
+}

--- a/test/inspect/vitest.config.ts
+++ b/test/inspect/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['./test/**'],
+  },
+})

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -188,6 +188,9 @@ export async function runCli(command: string, _options?: Options | string, ...ar
     await cli.isDone
   })
 
+  if (args.includes('--inspect') || args.includes('--inspect-brk'))
+    return cli
+
   if (args.includes('--watch')) {
     if (command === 'vitest') // Wait for initial test run to complete
       await cli.waitForStdout('Waiting for file changes')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Pauses code execution similarly as Node's `--inspect-brk` does
- Dev tools will stop on top of the first test file that is being run

<img width="480" src="https://github.com/vitest-dev/vitest/assets/14806298/6f8fab51-6f64-4096-846a-77e5e981f247" />


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
