### PR TITLE
chore(runner): exporting a few interfaces from tasks.ts

### DIFF
--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -133,14 +133,14 @@ interface EachFunctionReturn<T extends any[]> {
   ): void
 }
 
-interface TestEachFunction {
+export interface TestEachFunction {
   <T extends any[] | [any]>(cases: ReadonlyArray<T>): EachFunctionReturn<T>
   <T extends ReadonlyArray<any>>(cases: ReadonlyArray<T>): EachFunctionReturn<ExtractEachCallbackArgs<T>>
   <T>(cases: ReadonlyArray<T>): EachFunctionReturn<T[]>
   (...args: [TemplateStringsArray, ...any]): EachFunctionReturn<any[]>
 }
 
-interface TestCollectorCallable<C = {}> {
+export interface TestCollectorCallable<C = {}> {
   /**
    * @deprecated Use options as the second argument instead
    */
@@ -204,7 +204,7 @@ export interface TestOptions {
   fails?: boolean
 }
 
-interface ExtendedAPI<ExtraContext> {
+export interface ExtendedAPI<ExtraContext> {
   skipIf: (condition: any) => ChainableTestAPI<ExtraContext>
   runIf: (condition: any) => ChainableTestAPI<ExtraContext>
 }


### PR DESCRIPTION
### Description

Hello!

I would like to extend `it` function like in [here](https://github.com/jpb06/vitest-effect/blob/expect-extend/src/extend/it-effect.extend.ts), to be able to do something like this:

```typescript
import { describe, expect } from 'vitest';
import { it } from '../extend/it-effect.extend';

// just a dumb matcher for the example
const expectErrorWithTag = (tag: string) => Effect.catchAll((e: { _tag: string }) => {
  expect(e._tag).toBe(tag);

  return Effect.succeed(undefined);
});

describe('my cool test suite', () => {
  it.effect('should accept an effect', () => {
    const tag = 'Yolo';
    return pipe(
      Effect.gen(function* (_) {
        yield* _(Effect.fail({ _tag: tag, error: 'Oh no' }));
      }),
      expectErrorWithTag(tag),
    );
  });

  it('should just do classical vitest stuff', () => {
    expect(true).toBe(true);
  });
});

```

Three interfaces are not exported in `packages/runner/src/types/tasks.ts`:
- TestEachFunction
- TestCollectorCallable
- ExtendedAPI

I propose to export these types.

#### Why?

The idea is to simplify testing for [effect](https://effect.website/docs/introduction) lib. 

The change is trivial so I didn't create an issue. Please let me know if there is something I missed.

Thank you for you time 🙇🏻 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
