### PR TITLE
Fix: eslint warning in code example from the documentation: void is not valid as a constituent in a union type

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1944,7 +1944,7 @@ Retry the test specific number of times if it fails.
 
 ### onConsoleLog<NonProjectOption />
 
-- **Type**: `(log: string, type: 'stdout' | 'stderr') => false | void`
+- **Type**: `(log: string, type: 'stdout' | 'stderr') => false | undefined`
 
 Custom handler for `console.log` in tests. If you return `false`, Vitest will not print the log to the console.
 
@@ -1955,7 +1955,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    onConsoleLog(log: string, type: 'stdout' | 'stderr'): false | void {
+    onConsoleLog(log: string, type: 'stdout' | 'stderr'): false | undefined {
       if (log === 'message from third party library' && type === 'stdout')
         return false
     },
@@ -1965,7 +1965,7 @@ export default defineConfig({
 
 ### onStackTrace<NonProjectOption /> <Badge type="info">1.0.0+</Badge> {#onstacktrace}
 
-- **Type**: `(error: Error, frame: ParsedStack) => boolean | void`
+- **Type**: `(error: Error, frame: ParsedStack) => boolean | undefined`
 
 Apply a filtering function to each frame of each stack trace when handling errors. The first argument, `error`, is an object with the same properties as a standard `Error`, but it is not an actual instance.
 
@@ -1977,7 +1977,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    onStackTrace(error: Error, { file }: ParsedStack): boolean | void {
+    onStackTrace(error: Error, { file }: ParsedStack): boolean | undefined {
       // If we've encountered a ReferenceError, show the whole stack.
       if (error.name === 'ReferenceError')
         return


### PR DESCRIPTION
eslint@typescript-eslint/no-invalid-void-type

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When I copy the example from the documentation into my project, these warnings appear:

void is not valid as a constituent in a union type eslint[@typescript-eslint/no-invalid-void-type](https://typescript-eslint.io/rules/no-invalid-void-type)

Using `undefined` instead of `void` will fix this problem

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
