### PR TITLE
fix(coverage): prevent `reportsDirectory` from removing user's project

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1137,6 +1137,10 @@ Clean coverage report on watch rerun
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.reportsDirectory=<path>`
 
+::: warning
+Vitest will delete this directory before running tests if `coverage.clean` is enabled (default value).
+:::
+
 Directory to write coverage report to.
 
 To preview the coverage report in the output of [HTML reporter](/guide/reporters.html#html-reporter), this option must be set as a sub-directory of the html report directory (for example `./html/coverage`).

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -135,12 +135,20 @@ export function resolveConfig(
     }
   }
 
+  // TODO: V2.0.0 remove
   // @ts-expect-error -- check for removed API option
   if (resolved.coverage.provider === 'c8')
     throw new Error('"coverage.provider: c8" is not supported anymore. Use "coverage.provider: v8" instead')
 
   if (resolved.coverage.provider === 'v8' && resolved.coverage.enabled && isBrowserEnabled(resolved))
     throw new Error('@vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+
+  if (resolved.coverage.enabled && resolved.coverage.reportsDirectory) {
+    const reportsDirectory = resolve(resolved.root, resolved.coverage.reportsDirectory)
+
+    if (reportsDirectory === resolved.root || reportsDirectory === process.cwd())
+      throw new Error(`You cannot set "coverage.reportsDirectory" as ${reportsDirectory}. Vitest needs to be able to remove this directory before test run`)
+  }
 
   resolved.deps ??= {}
   resolved.deps.moduleDirectories ??= []

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import type { UserConfig } from 'vitest/config'
 import { version } from 'vitest/package.json'
 
+import { normalize, resolve } from 'pathe'
 import * as testUtils from '../../test-utils'
 
 function runVitest(config: NonNullable<UserConfig['test']> & { shard?: any }) {
@@ -65,6 +66,43 @@ test('v8 coverage provider cannot be used with browser in workspace', async () =
   const { stderr } = await runVitest({ coverage: { enabled: true }, workspace: './fixtures/workspace/browser/workspace-with-browser.ts' })
 
   expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+})
+
+test('coverage reportsDirectory cannot be current working directory', async () => {
+  const { stderr } = await runVitest({
+    coverage: {
+      enabled: true,
+      reportsDirectory: './',
+
+      // Additional options to make sure this test doesn't accidentally remove whole vitest project
+      clean: false,
+      cleanOnRerun: false,
+      provider: 'custom',
+      customProviderModule: 'non-existing-provider-so-that-reportsDirectory-is-not-removed',
+    },
+  })
+
+  const directory = normalize(resolve('./'))
+  expect(stderr).toMatch(`Error: You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
+})
+
+test('coverage reportsDirectory cannot be root', async () => {
+  const { stderr } = await runVitest({
+    root: './fixtures',
+    coverage: {
+      enabled: true,
+      reportsDirectory: './',
+
+      // Additional options to make sure this test doesn't accidentally remove whole vitest project
+      clean: false,
+      cleanOnRerun: false,
+      provider: 'custom',
+      customProviderModule: 'non-existing-provider-so-that-reportsDirectory-is-not-removed',
+    },
+  })
+
+  const directory = normalize(resolve('./fixtures'))
+  expect(stderr).toMatch(`Error: You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
 })
 
 test('version number is printed when coverage provider fails to load', async () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Configuration below can remove user's whole project including local Git history from `.git`. One could accidentally use that when trying to generate coverage reports in the root of project instead of the default `./coverage`, and find out that their whole project is now wiped (that's me 🙃).

<details>

```ts
// Don't run this
export default defineConfig({
  test: {
    coverage: {
      reportsDirectory: './',
    },
  },
})
```

</details>



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
