### PR TITLE
docs: fix rendering error and typo

### DIFF
--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -8,7 +8,7 @@ title: Snapshot | Guide
 
 Snapshot tests are a very useful tool whenever you want to make sure the output of your functions does not change unexpectedly.
 
-When using snapshot, Vitest will take a snapshot of the given value, then compares it to a reference snapshot file stored alongside the test. The test will fail if the two snapshots do not match: either the change is unexpected, or the reference snapshot needs to be updated to the new version of the result.
+When using snapshot, Vitest will take a snapshot of the given value, then compare it to a reference snapshot file stored alongside the test. The test will fail if the two snapshots do not match: either the change is unexpected, or the reference snapshot needs to be updated to the new version of the result.
 
 ## Use Snapshots
 
@@ -81,7 +81,7 @@ vitest -u
 
 ## File Snapshots
 
-When calling `toMatchSnapshot()`, we store all snapshots in a formatted snap file. That means we need to escape some characters (namely the double-quote `"` and backtick `\``) in the snapshot string. Meanwhile, you might lose the syntax highlighting for the snapshot content (if they are in some language).
+When calling `toMatchSnapshot()`, we store all snapshots in a formatted snap file. That means we need to escape some characters (namely the double-quote `"` and backtick `` ` ``) in the snapshot string. Meanwhile, you might lose the syntax highlighting for the snapshot content (if they are in some language).
 
 To improve this case, we introduce [`toMatchFileSnapshot()`](/api/expect#tomatchfilesnapshot) to explicitly snapshot in a file. This allows you to assign any file extension to the snapshot file, and making them more readable.
 


### PR DESCRIPTION
### Description

Fix rendering error:

<img width="700" alt="image" src="https://github.com/vitest-dev/vitest/assets/60599231/2cab08e1-a959-40b3-9069-05332bbc6ef8">

Preview: https://deploy-preview-5403--fastidious-cascaron-4ded94.netlify.app/guide/snapshot.html#file-snapshots

<img width="730" alt="image" src="https://github.com/vitest-dev/vitest/assets/60599231/07adc8ac-9d8a-44ab-91df-7efa97aa59bd">


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
