### PR TITLE
fix(vitest): correctly filter by parent folder

### DIFF
--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -266,6 +266,13 @@ export class WorkspaceProject {
         const testFile = relative(dir, t).toLocaleLowerCase()
         return filters.some((f) => {
           const relativePath = f.endsWith('/') ? join(relative(dir, f), '/') : relative(dir, f)
+
+          // the file is inside the filter path, so we should always include it,
+          // we don't include ../file because this condition is always true if
+          // the file doens't exist which cause false positives
+          if (relativePath === '..' || relativePath === '../' || relativePath.startsWith('../..'))
+            return true
+
           return testFile.includes(f.toLocaleLowerCase()) || testFile.includes(relativePath.toLocaleLowerCase())
         })
       })

--- a/test/filters/test/testname-pattern.test.ts
+++ b/test/filters/test/testname-pattern.test.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'pathe'
+import { join, resolve } from 'pathe'
 import { expect, test } from 'vitest'
 
 import { runVitest } from '../../test-utils'
@@ -29,4 +29,16 @@ test('match by pattern that also matches current working directory', async () =>
   expect(stdout).toMatch('✓ test/filters.test.ts > this will pass')
   expect(stdout).toMatch('Test Files  1 passed (1)')
   expect(stdout).not.toMatch('test/example.test.ts')
+})
+
+test.each([
+  ['the parent of CWD', resolve(process.cwd(), '..')],
+  ['the parent of CWD with slash', join(resolve(process.cwd(), '..'), '/')],
+  ['the parent of a parent of CWD', resolve(process.cwd(), '..', '..')],
+])('match by pattern that also matches %s: %s', async (_, filter) => {
+  const { stdout } = await runVitest({ root: './fixtures' }, [filter])
+
+  expect(stdout).toMatch('✓ test/filters.test.ts > this will pass')
+  expect(stdout).toMatch('× test/dont-run-this.test.ts > this will fail')
+  expect(stdout).toMatch('✓ test/example.test.ts > this will pass')
 })


### PR DESCRIPTION
### Description

Related: https://github.com/vitest-dev/vscode/issues/308

Fixes #5409

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
