### PR TITLE
docs:Add RiotJS example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@
 | `react-testing-lib-msw` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib-msw?initialPath=__vitest__/) |
 | `react-testing-lib` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react-testing-lib) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react-testing-lib?initialPath=__vitest__/) |
 | `react` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/react) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/react?initialPath=__vitest__/) |
+| `riot` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/riot) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/riot?initialPath=__vitest__/) |
 | `ruby` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/ruby) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/ruby?initialPath=__vitest__/) |
 | `solid` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/solid) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/solid?initialPath=__vitest__/) |
 | `svelte` | [GitHub](https://github.com/vitest-dev/vitest/tree/main/examples/svelte) | [Play Online](https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/svelte?initialPath=__vitest__/) |

--- a/examples/riot/components/Hello.riot
+++ b/examples/riot/components/Hello.riot
@@ -1,0 +1,26 @@
+<hello>
+    <span>
+        <div>{ props.count } x { state.times } = { state.result }</div>
+        <button onclick={ add }>
+            x1
+        </button>
+    </span>
+    <script>
+        export default {
+            state: {
+                times: 2,
+                result: 0
+            },
+            onMounted () {
+                this.compute();
+            },
+            add() {
+                this.update({ times: this.state.times + 1 })
+                this.compute();
+            },
+            compute() {
+                this.update({ result: this.state.times * this.props.count })
+            }
+        }
+    </script>
+</hello>

--- a/examples/riot/package.json
+++ b/examples/riot/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@vitest/example-riot",
+    "private": true,
+    "scripts": {
+      "test": "vitest",
+      "coverage": "vitest --coverage"
+    },
+    "devDependencies": {
+      "jsdom": "latest",
+      "riot": "=9.1.4",
+      "rollup-plugin-riot": "=9.0.2",
+      "vite": "latest",
+      "vitest": "latest"
+    }
+  }
+  

--- a/examples/riot/test/Hello.test.js
+++ b/examples/riot/test/Hello.test.js
@@ -1,0 +1,31 @@
+import { assert, describe, it, expect } from 'vitest'
+import * as riot from 'riot'
+
+import Hello from "../components/Hello.riot"
+
+describe('Hello Component', () => {
+
+    it("should mount the component", () => {
+        expect(Hello).toBeTruthy()
+        riot.register('c-hello', Hello);
+        const [component] = riot.mount(document.createElement('div'), { count : 4 }, 'c-hello');
+        
+        expect(component.root.innerHTML).toContain('4 x 2 = 8')
+        expect(component.root.innerHTML).toMatchSnapshot()
+        riot.unregister('c-hello');
+    })
+
+    it("should updates on button click", () => {
+        riot.register('c-hello', Hello);
+        const [component] = riot.mount(document.createElement('div'), { count : 4 }, 'c-hello');
+
+        console.log()
+        expect(component.root.querySelector('div').innerHTML).toContain('4 x 2 = 8')
+        component.root.querySelector('button').click();
+        expect(component.root.querySelector('div').innerHTML).toContain('4 x 3 = 12')
+        component.root.querySelector('button').click();
+        expect(component.root.querySelector('div').innerHTML).toContain('4 x 4 = 16')
+        riot.unregister('c-hello');
+    })
+
+})

--- a/examples/riot/test/__snapshots__/Hello.test.js.snap
+++ b/examples/riot/test/__snapshots__/Hello.test.js.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Hello Component > should mount the component 1`] = `
+"<span><div>4 x 2 = 8</div><button>
+            x1
+        </button></span>"
+`;

--- a/examples/riot/vite.config.mjs
+++ b/examples/riot/vite.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import riot from 'rollup-plugin-riot'
+
+export default defineConfig({
+  plugins    : [riot()],
+  build: { 
+    minify       : 'esbuild',
+    target       : 'esnext'
+  },
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
### Description

This PR adds an example for setting up Vitest with RiotJS. 
RiotJS lacks visibility and documentation while it's easy to use, that's why I created an example with Vitest.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
