### PR TITLE
fix: the value received by toMatch should be a string

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -172,7 +172,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def('toMatch', function (expected: string | RegExp) {
     const actual = this._obj as string
     if (typeof actual !== 'string')
-      throw new TypeError(`.toMatch() expects to received a string, got ${typeof actual}`)
+      throw new TypeError(`.toMatch() expects to receive a string, but got ${typeof actual}`)
 
     return this.assert(
       typeof expected === 'string'

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -171,6 +171,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   })
   def('toMatch', function (expected: string | RegExp) {
     const actual = this._obj as string
+    if (typeof actual !== 'string')
+      throw new TypeError(`.toMatch() expects to received a string, got ${typeof actual}`)
+
     return this.assert(
       typeof expected === 'string'
         ? actual.includes(expected)

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -110,7 +110,7 @@ describe('jest-expect', () => {
     expect(0.2 + 0.1).toBeCloseTo(0.3, 5)
     expect(0.2 + 0.1).not.toBeCloseTo(0.3, 100) // expect.closeTo will fail in chai
 
-    expect(() => expect(1).toMatch(/\d/)).toThrowErrorMatchingInlineSnapshot(`[TypeError: .toMatch() expects to received a string, got number]`)
+    expect(() => expect(1).toMatch(/\d/)).toThrowErrorMatchingInlineSnapshot(`[TypeError: .toMatch() expects to receive a string, but got number]`)
   })
 
   it('asymmetric matchers (jest style)', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -109,6 +109,8 @@ describe('jest-expect', () => {
     expect(0.2 + 0.1).not.toBe(0.3)
     expect(0.2 + 0.1).toBeCloseTo(0.3, 5)
     expect(0.2 + 0.1).not.toBeCloseTo(0.3, 100) // expect.closeTo will fail in chai
+
+    expect(() => expect(1).toMatch(/\d/)).toThrowErrorMatchingInlineSnapshot(`[TypeError: .toMatch() expects to received a string, got number]`)
   })
 
   it('asymmetric matchers (jest style)', () => {


### PR DESCRIPTION
### Description
In earlier versions of vitest, the value received by toMatch supported numbers, like this:
```ts
expect(1).toMatch(/\d/)
```
After I updated to the latest version, the above test case throws the error `TypeError: actual.match is not a function`.
I think it would be more user-friendly to do type checking inside vitest and provide clearer error messages.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
