### PR TITLE
fix!: add correct location and snapshot fields in json reporter

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -110,9 +110,6 @@ export class JsonReporter implements Reporter {
         const ancestorTitles: string[] = []
         let iter: Suite | undefined = t.suite
         while (iter) {
-          // the root suite should not be reported
-          if (iter.id === '')
-            break
           ancestorTitles.push(iter.name)
           iter = iter.suite
         }
@@ -125,7 +122,7 @@ export class JsonReporter implements Reporter {
           title: t.name,
           duration: t.result?.duration,
           failureMessages: t.result?.errors?.map(e => e.stack || e.message) || [],
-          location: t.location || null,
+          location: t.location,
         } satisfies JsonAssertionResult
       })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16870,7 +16870,6 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
-    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0

--- a/test/reporters/src/context.ts
+++ b/test/reporters/src/context.ts
@@ -33,6 +33,9 @@ export function getContext(): Context {
     config: config as ResolvedConfig,
     server: server as ViteDevServer,
     getProjectByTaskId: () => ({ getBrowserSourceMapModuleById: () => undefined }) as any,
+    snapshot: {
+      summary: { added: 100, _test: true },
+    } as any,
   }
 
   context.logger = {

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -16,7 +16,7 @@ const file: File = {
 file.file = file
 
 const suite: Suite = {
-  id: '',
+  id: '1223128da3_0',
   type: 'suite',
   name: 'suite',
   mode: 'run',
@@ -47,7 +47,7 @@ error.stack = 'AssertionError: expected 2.23606797749979 to equal 2\n'
 
 const tasks: Task[] = [
   {
-    id: '1223128da3_0',
+    id: '1223128da3_0_0',
     type: 'test',
     name: 'Math.sqrt()',
     mode: 'run',
@@ -60,10 +60,14 @@ const tasks: Task[] = [
       errors: [error],
       duration: 1.4422860145568848,
     },
+    location: {
+      column: 32,
+      line: 8,
+    },
     context: null as any,
   },
   {
-    id: '1223128da3_1',
+    id: '1223128da3_0_1',
     type: 'test',
     name: 'JSON',
     mode: 'run',
@@ -75,7 +79,7 @@ const tasks: Task[] = [
     context: null as any,
   },
   {
-    id: '1223128da3_3',
+    id: '1223128da3_0_3',
     type: 'test',
     name: 'async with timeout',
     mode: 'skip',
@@ -87,7 +91,7 @@ const tasks: Task[] = [
     context: null as any,
   },
   {
-    id: '1223128da3_4',
+    id: '1223128da3_0_4',
     type: 'test',
     name: 'timeout',
     mode: 'run',
@@ -99,7 +103,7 @@ const tasks: Task[] = [
     context: null as any,
   },
   {
-    id: '1223128da3_5',
+    id: '1223128da3_0_5',
     type: 'test',
     name: 'callback setup success ',
     mode: 'run',
@@ -111,7 +115,7 @@ const tasks: Task[] = [
     context: null as any,
   },
   {
-    id: '1223128da3_6',
+    id: '1223128da3_0_6',
     type: 'test',
     name: 'callback test success ',
     mode: 'run',
@@ -123,7 +127,7 @@ const tasks: Task[] = [
     context: null as any,
   },
   {
-    id: '1223128da3_7',
+    id: '1223128da3_0_7',
     type: 'test',
     name: 'callback setup success done(false)',
     mode: 'run',
@@ -135,7 +139,7 @@ const tasks: Task[] = [
     context: null as any,
   },
   {
-    id: '1223128da3_8',
+    id: '1223128da3_0_8',
     type: 'test',
     name: 'callback test success done(false)',
     mode: 'run',
@@ -155,7 +159,7 @@ const tasks: Task[] = [
     ],
   },
   {
-    id: '1223128da3_9',
+    id: '1223128da3_0_9',
     type: 'test',
     name: 'todo test',
     mode: 'todo',

--- a/test/reporters/tests/__snapshots__/json.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/json.test.ts.snap
@@ -4,12 +4,22 @@ exports[`json reporter > generates correct report 1`] = `
 {
   "ancestorTitles": [],
   "failureMessages": [
-    "expected 2 to deeply equal 1",
+    "AssertionError: expected 2 to deeply equal 1
+    at <root>/test/reporters/fixtures/json-fail.test.ts:8:13
+    at file://<root>/packages/runner/dist/index.js:135:14
+    at file://<root>/packages/runner/dist/index.js:60:26
+    at runTest (file://<root>/packages/runner/dist/index.js:767:17)
+    at runSuite (file://<root>/packages/runner/dist/index.js:895:15)
+    at runFiles (file://<root>/packages/runner/dist/index.js:944:5)
+    at startTests (file://<root>/packages/runner/dist/index.js:953:3)
+    at file://<root>/packages/vitest/src/runtime/runBaseTests.ts:43:7
+    at withEnv (file://<root>/packages/vitest/src/runtime/setup-node.ts:80:5)
+    at run (file://<root>/packages/vitest/src/runtime/runBaseTests.ts:29:9)",
   ],
   "fullName": "should fail",
   "location": {
-    "column": 13,
-    "line": 8,
+    "column": 1,
+    "line": 5,
   },
   "status": "failed",
   "title": "should fail",

--- a/test/reporters/tests/__snapshots__/json.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/json.test.ts.snap
@@ -5,16 +5,7 @@ exports[`json reporter > generates correct report 1`] = `
   "ancestorTitles": [],
   "failureMessages": [
     "AssertionError: expected 2 to deeply equal 1
-    at <root>/test/reporters/fixtures/json-fail.test.ts:8:13
-    at file://<root>/packages/runner/dist/index.js:135:14
-    at file://<root>/packages/runner/dist/index.js:60:26
-    at runTest (file://<root>/packages/runner/dist/index.js:767:17)
-    at runSuite (file://<root>/packages/runner/dist/index.js:895:15)
-    at runFiles (file://<root>/packages/runner/dist/index.js:944:5)
-    at startTests (file://<root>/packages/runner/dist/index.js:953:3)
-    at file://<root>/packages/vitest/src/runtime/runBaseTests.ts:43:7
-    at withEnv (file://<root>/packages/vitest/src/runtime/setup-node.ts:80:5)
-    at run (file://<root>/packages/vitest/src/runtime/runBaseTests.ts:29:9)",
+    at <root>/test/reporters/fixtures/json-fail.test.ts:8:13",
   ],
   "fullName": "should fail",
   "location": {

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -73,6 +73,10 @@ exports[`json reporter (no outputFile entry) 1`] = `
   "numTodoTests": 1,
   "numTotalTestSuites": 2,
   "numTotalTests": 9,
+  "snapshot": {
+    "_test": true,
+    "added": 100,
+  },
   "startTime": 1642587001759,
   "success": false,
   "testResults": [
@@ -84,7 +88,17 @@ exports[`json reporter (no outputFile entry) 1`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite Math.sqrt()",
           "location": {
@@ -194,6 +208,10 @@ exports[`json reporter 1`] = `
   "numTodoTests": 1,
   "numTotalTestSuites": 2,
   "numTotalTests": 9,
+  "snapshot": {
+    "_test": true,
+    "added": 100,
+  },
   "startTime": 1642587001759,
   "success": false,
   "testResults": [
@@ -205,7 +223,17 @@ exports[`json reporter 1`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite Math.sqrt()",
           "location": {
@@ -320,6 +348,10 @@ exports[`json reporter with outputFile 2`] = `
   "numTodoTests": 1,
   "numTotalTestSuites": 2,
   "numTotalTests": 9,
+  "snapshot": {
+    "_test": true,
+    "added": 100,
+  },
   "startTime": 1642587001759,
   "success": false,
   "testResults": [
@@ -331,7 +363,17 @@ exports[`json reporter with outputFile 2`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite Math.sqrt()",
           "location": {
@@ -446,6 +488,10 @@ exports[`json reporter with outputFile in non-existing directory 2`] = `
   "numTodoTests": 1,
   "numTotalTestSuites": 2,
   "numTotalTests": 9,
+  "snapshot": {
+    "_test": true,
+    "added": 100,
+  },
   "startTime": 1642587001759,
   "success": false,
   "testResults": [
@@ -457,7 +503,17 @@ exports[`json reporter with outputFile in non-existing directory 2`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite Math.sqrt()",
           "location": {
@@ -572,6 +628,10 @@ exports[`json reporter with outputFile object 2`] = `
   "numTodoTests": 1,
   "numTotalTestSuites": 2,
   "numTotalTests": 9,
+  "snapshot": {
+    "_test": true,
+    "added": 100,
+  },
   "startTime": 1642587001759,
   "success": false,
   "testResults": [
@@ -583,7 +643,17 @@ exports[`json reporter with outputFile object 2`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite Math.sqrt()",
           "location": {
@@ -698,6 +768,10 @@ exports[`json reporter with outputFile object in non-existing directory 2`] = `
   "numTodoTests": 1,
   "numTotalTestSuites": 2,
   "numTotalTests": 9,
+  "snapshot": {
+    "_test": true,
+    "added": 100,
+  },
   "startTime": 1642587001759,
   "success": false,
   "testResults": [
@@ -709,7 +783,17 @@ exports[`json reporter with outputFile object in non-existing directory 2`] = `
           ],
           "duration": 1.4422860145568848,
           "failureMessages": [
-            "expected 2.23606797749979 to equal 2",
+            "AssertionError: expected 2.23606797749979 to equal 2
+    at /vitest/test/core/test/basic.test.ts:8:32
+    at /vitest/packages/vitest/dist/vi-ac0504aa.js:73:26
+    at runTest (/vitest/packages/vitest/dist/entry.js:1689:40)
+    at async runSuite (/vitest/packages/vitest/dist/entry.js:1741:13)
+    at async runSuites (/vitest/packages/vitest/dist/entry.js:1769:5)
+    at async startTests (/vitest/packages/vitest/dist/entry.js:1774:3)
+    at async /vitest/packages/vitest/dist/entry.js:1798:7
+    at async withEnv (/vitest/packages/vitest/dist/entry.js:1481:5)
+    at async run (/vitest/packages/vitest/dist/entry.js:1797:5)
+    at async file:///vitest/node_modules/.pnpm/tinypool@0.1.1/node_modules/tinypool/dist/esm/worker.js:96:20",
           ],
           "fullName": "suite Math.sqrt()",
           "location": {

--- a/test/reporters/tests/json.test.ts
+++ b/test/reporters/tests/json.test.ts
@@ -1,11 +1,11 @@
-import { resolve } from 'pathe'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { runVitest } from '../../test-utils'
 
 describe('json reporter', async () => {
-  const root = resolve(__dirname, '../fixtures')
-  const projectRoot = resolve(__dirname, '../../..')
+  const root = resolve(__dirname, '..', 'fixtures')
+  const projectRoot = resolve(__dirname, '..', '..', '..')
 
   it('generates correct report', async () => {
     const { stdout } = await runVitest({ reporters: 'json', root, includeTaskLocation: true }, ['json-fail'])

--- a/test/reporters/tests/json.test.ts
+++ b/test/reporters/tests/json.test.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path'
+import { resolve } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
 import { runVitest } from '../../test-utils'
@@ -8,7 +8,11 @@ describe('json reporter', async () => {
   const projectRoot = resolve(__dirname, '..', '..', '..')
 
   it('generates correct report', async () => {
-    const { stdout } = await runVitest({ reporters: 'json', root, includeTaskLocation: true }, ['json-fail'])
+    const { stdout } = await runVitest({
+      reporters: 'json',
+      root,
+      includeTaskLocation: true,
+    }, ['json-fail'])
 
     const data = JSON.parse(stdout)
 
@@ -26,7 +30,11 @@ describe('json reporter', async () => {
     const result = failedTest.assertionResults[0]
     delete result.duration
     const rootRegexp = new RegExp(projectRoot, 'g')
-    result.failureMessages = result.failureMessages.map((m: string) => m.split('\n').slice(0, 2).join('\n').replace(rootRegexp, '<root>'))
+    result.failureMessages = result.failureMessages
+      .map((m: string) => {
+        const errorStack = m.split('\n').slice(0, 2).join('\n')
+        return errorStack.replace(/\\/g, '/').replace(rootRegexp, '<root>')
+      })
     expect(result).toMatchSnapshot()
   }, 40000)
 

--- a/test/reporters/tests/json.test.ts
+++ b/test/reporters/tests/json.test.ts
@@ -5,9 +5,10 @@ import { runVitest } from '../../test-utils'
 
 describe('json reporter', async () => {
   const root = resolve(__dirname, '../fixtures')
+  const projectRoot = resolve(__dirname, '../../..')
 
   it('generates correct report', async () => {
-    const { stdout } = await runVitest({ reporters: 'json', root }, ['json-fail'])
+    const { stdout } = await runVitest({ reporters: 'json', root, includeTaskLocation: true }, ['json-fail'])
 
     const data = JSON.parse(stdout)
 
@@ -24,6 +25,8 @@ describe('json reporter', async () => {
 
     const result = failedTest.assertionResults[0]
     delete result.duration
+    const rootRegexp = new RegExp(projectRoot, 'g')
+    result.failureMessages = result.failureMessages.map((m: string) => m.replace(rootRegexp, '<root>'))
     expect(result).toMatchSnapshot()
   }, 40000)
 

--- a/test/reporters/tests/json.test.ts
+++ b/test/reporters/tests/json.test.ts
@@ -26,7 +26,7 @@ describe('json reporter', async () => {
     const result = failedTest.assertionResults[0]
     delete result.duration
     const rootRegexp = new RegExp(projectRoot, 'g')
-    result.failureMessages = result.failureMessages.map((m: string) => m.replace(rootRegexp, '<root>'))
+    result.failureMessages = result.failureMessages.map((m: string) => m.split('\n').slice(0, 2).join('\n').replace(rootRegexp, '<root>'))
     expect(result).toMatchSnapshot()
   }, 40000)
 

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/test-helpers",
+  "name": "@vitest/internal-testing-helpers",
   "type": "module",
   "private": true,
   "main": "./index.ts",


### PR DESCRIPTION
### Description

JSON reporter incorrectly gets the location from the test error. Vitest 1.4.0 introduced `--includeTaskLocation` flag and we can now reliably take it from there (which actually follows jest behaviour).

This PR adds a missing `snapshot` property to the root of the json reporter.

The `failureMessages` now includes the full stack trace.

Related: https://github.com/vitest-dev/vitest/discussions/5350
Follow-up #5435

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
