### PR TITLE
test: use `startVitest` instead of `execa`

### DIFF
--- a/test/changed/tests/related.test.ts
+++ b/test/changed/tests/related.test.ts
@@ -1,10 +1,14 @@
-import { join } from 'node:path'
 import { expect, it } from 'vitest'
 
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 it('related correctly runs only related tests', async () => {
-  const { stdout, stderr } = await runVitestCli('related', join(process.cwd(), 'fixtures/related/src/sourceA.ts'), '--root', join(process.cwd(), './fixtures/related'), '--globals', '--no-watch')
+  const { stdout, stderr } = await runVitest({
+    related: 'src/sourceA.ts',
+    root: './fixtures/related',
+    globals: true,
+  })
+
   expect(stderr).toBe('')
   expect(stdout).toContain('3 passed')
   expect(stdout).toContain('related.test.ts')

--- a/test/changed/tests/workspaceRelated.test.ts
+++ b/test/changed/tests/workspaceRelated.test.ts
@@ -1,17 +1,25 @@
-import { join } from 'node:path'
 import { expect, it } from 'vitest'
 
-import { editFile, resolvePath, runVitestCli } from '../../test-utils'
+import { editFile, resolvePath, runVitest } from '../../test-utils'
 
 it('doesn\'t run any test in a workspace because there are no changes', async () => {
-  const { stdout } = await runVitestCli('--root', join(process.cwd(), './fixtures/workspace'), '--no-watch', '--changed')
+  const { stdout } = await runVitest({
+    changed: true,
+    root: './fixtures/workspace',
+  })
+
   expect(stdout).toContain('No test files found, exiting with code 0')
 })
 
 // Fixes #4674
 it('related correctly runs only related tests inside a workspace', async () => {
   editFile(resolvePath(import.meta.url, '../fixtures/workspace/packages/packageA/index.js'), content => `${content}\n`)
-  const { stdout, stderr } = await runVitestCli('--root', join(process.cwd(), './fixtures/workspace'), '--no-watch', '--changed')
+
+  const { stdout, stderr } = await runVitest({
+    changed: true,
+    root: './fixtures/workspace',
+  })
+
   expect(stderr).toBe('')
   expect(stdout).toContain('1 passed')
   expect(stdout).toContain('packageA')

--- a/test/cli/test/exclude.test.ts
+++ b/test/cli/test/exclude.test.ts
@@ -1,15 +1,12 @@
 import { expect, test } from 'vitest'
 
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 test('should still test math.test.ts', async () => {
-  const { stderr, stdout } = await runVitestCli(
-    'run',
-    '--config',
-    'fixtures/exclude/vitest.exclude.config.ts',
-    '--exclude',
-    'fixtures/exclude/string.test.ts',
-  )
+  const { stderr, stdout } = await runVitest({
+    config: 'fixtures/exclude/vitest.exclude.config.ts',
+    exclude: ['fixtures/exclude/string.test.ts'],
+  })
 
   expect(stdout).toContain(`✓ fixtures/exclude/math.test.ts`)
   expect(stdout).not.toContain(`string.test.ts`)

--- a/test/cli/test/project.test.ts
+++ b/test/cli/test/project.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 test.each([
   { pattern: 'project_1', expected: ['project_1'] },
@@ -8,13 +8,11 @@ test.each([
   { pattern: 'project*', expected: ['project_1', 'project_2'] },
   { pattern: 'space*', expected: ['space_1'] },
 ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
-  const { stdout, stderr } = await runVitestCli(
-    'run',
-    '--root',
-    'fixtures/project',
-    '--project',
-    pattern,
-  )
+  const { stdout, stderr } = await runVitest({
+    root: 'fixtures/project',
+    reporters: ['basic'],
+    project: pattern,
+  })
 
   expect(stderr).toBeFalsy()
   expect(stdout).toBeTruthy()

--- a/test/config/test/retry.test.ts
+++ b/test/config/test/retry.test.ts
@@ -1,18 +1,25 @@
 import { describe, expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 function run(testNamePattern: string) {
-  return runVitestCli('run', 'fixtures/retry/retry.test.ts', '-c', 'fixtures/retry/vitest.config.ts', '-t', testNamePattern)
+  return runVitest({
+    include: ['fixtures/retry/retry.test.ts'],
+    config: 'fixtures/retry/vitest.config.ts',
+    reporters: ['basic'],
+    testNamePattern,
+  })
 }
 
 describe('retry', () => {
   test('should passed', async () => {
     const { stdout } = await run('should passed')
+
     expect(stdout).toContain('1 passed')
   })
 
   test('retry but still failed', async () => {
     const { stdout } = await run('retry but still failed')
+
     expect(stdout).toContain('expected 1 to be 4')
     expect(stdout).toContain('expected 2 to be 4')
     expect(stdout).toContain('expected 3 to be 4')

--- a/test/config/test/workspace.test.ts
+++ b/test/config/test/workspace.test.ts
@@ -1,8 +1,11 @@
 import { expect, it } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 it('correctly runs workspace tests when workspace config path is specified', async () => {
-  const { stderr, stdout } = await runVitestCli('run', '--root', 'fixtures/workspace', '--workspace', './nested/e2e.projects.js')
+  const { stderr, stdout } = await runVitest({
+    root: 'fixtures/workspace',
+    workspace: 'nested/e2e.projects.js',
+  })
   expect(stderr).toBe('')
   expect(stdout).toContain('1 + 1 = 2')
   expect(stdout).not.toContain('2 + 2 = 4')

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "NO_COLOR=1 GITHUB_ACTIONS=false vitest run"
+    "test": "vitest run"
   },
   "devDependencies": {
     "flatted": "^3.2.9",

--- a/test/reporters/tests/console.test.ts
+++ b/test/reporters/tests/console.test.ts
@@ -9,7 +9,7 @@ test('should print logs correctly', async () => {
   expect(stdout).toBeTruthy()
   expect(stderr).toBeTruthy()
 
-  expect(stdout).toContain(
+  expect(stdout.replace('\n ✓ console.test.ts > suite > snested suite > test', '')).toContain(
 `
 stdout | console.test.ts > suite > nested suite
 beforeAll

--- a/test/reporters/tests/custom-reporter.spec.ts
+++ b/test/reporters/tests/custom-reporter.spec.ts
@@ -8,18 +8,13 @@ const customTsReporterPath = resolve(__dirname, '../src/custom-reporter.ts')
 const customJSReporterPath = resolve(__dirname, '../src/custom-reporter.js')
 const root = resolve(__dirname, '..')
 
-async function run(...runOptions: string[]): Promise<string> {
-  const vitest = await runVitestCli({ cwd: root, windowsHide: false }, 'run', ...runOptions)
-
-  return vitest.stdout
-}
-
 async function runWithRetry(...runOptions: string[]) {
   const count = 3
 
   for (let i = count; i >= 0; i--) {
     try {
-      return await run(...runOptions)
+      const vitest = await runVitestCli({ cwd: root, windowsHide: false }, 'run', ...runOptions)
+      return vitest.stdout
     }
     catch (e) {
       if (i <= 0)
@@ -41,7 +36,8 @@ describe('custom reporters', () => {
   }, TIMEOUT)
 
   test('load no base on root custom reporter instances defined in configuration works', async () => {
-    const stdout = await runWithRetry('--config', './reportTest2/custom-reporter-path.vitest.config.ts')
+    const { stdout, stderr } = await runVitest({ reporters: 'none', config: './reportTest2/custom-reporter-path.vitest.config.ts' })
+    expect(stderr).toBe('')
     expect(stdout).includes('hello from custom reporter')
   }, TIMEOUT)
 

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -1,28 +1,26 @@
-import path from 'pathe'
 import { describe, expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
-
-const resolve = (id = '') => path.resolve(__dirname, '../fixtures/default', id)
-async function run(fileFilter: string[], watch = false, ...args: string[]) {
-  return runVitestCli(
-    ...fileFilter,
-    '--root',
-    resolve(),
-    watch ? '--watch' : '--run',
-    ...args,
-  )
-}
+import { runVitest, runVitestCli } from '../../test-utils'
 
 describe('default reporter', async () => {
   test('normal', async () => {
-    const { stdout } = await run(['b1.test.ts', 'b2.test.ts'])
+    const { stdout } = await runVitest({
+      include: ['b1.test.ts', 'b2.test.ts'],
+      root: 'fixtures/default',
+      reporters: 'none',
+    })
+
     expect(stdout).contain('✓ b2 test')
     expect(stdout).not.contain('✓ nested b1 test')
     expect(stdout).contain('× b failed test')
   })
 
   test('show full test suite when only one file', async () => {
-    const { stdout } = await run(['a.test.ts'])
+    const { stdout } = await runVitest({
+      include: ['a.test.ts'],
+      root: 'fixtures/default',
+      reporters: 'none',
+    })
+
     expect(stdout).contain('✓ a1 test')
     expect(stdout).contain('✓ nested a3 test')
     expect(stdout).contain('× a failed test')
@@ -30,8 +28,13 @@ describe('default reporter', async () => {
   })
 
   test('rerun should undo', async () => {
-    const vitest = await run([], true, '-t', 'passed')
-
+    const vitest = await runVitestCli(
+      '--root',
+      'fixtures/default',
+      '--watch',
+      '-t',
+      'passed',
+    )
     vitest.resetOutput()
 
     // one file

--- a/test/reporters/tests/html.test.ts
+++ b/test/reporters/tests/html.test.ts
@@ -14,7 +14,7 @@ describe('html reporter', async () => {
   it('resolves to "passing" status for test file "all-passing-or-skipped"', async () => {
     const [expected, testFile, basePath] = ['passing', 'all-passing-or-skipped', 'html/all-passing-or-skipped']
 
-    await runVitest({ reporters: 'html', outputFile: `${basePath}/index.html`, root }, [testFile])
+    await runVitest({ reporters: 'html', outputFile: `${basePath}/index.html`, root, env: { NO_COLOR: '1' } }, [testFile])
 
     const metaJsonGzipeed = fs.readFileSync(resolve(root, `${basePath}/html.meta.json.gz`))
     const metaJson = zlib.gunzipSync(metaJsonGzipeed).toString('utf-8')
@@ -42,7 +42,7 @@ describe('html reporter', async () => {
   it('resolves to "failing" status for test file "json-fail"', async () => {
     const [expected, testFile, basePath] = ['failing', 'json-fail.test', 'html/fail']
 
-    await runVitest({ reporters: 'html', outputFile: `${basePath}/index.html`, root }, [testFile])
+    await runVitest({ reporters: 'html', outputFile: `${basePath}/index.html`, root, env: { NO_COLOR: '1' } }, [testFile])
 
     const metaJsonGzipped = fs.readFileSync(resolve(root, `${basePath}/html.meta.json.gz`))
     const metaJson = zlib.gunzipSync(metaJsonGzipped).toString('utf-8')

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 test('duration', async () => {
-  const result = await runVitestCli({ env: { CI: '1' } }, '--root=fixtures/duration', '--reporter=verbose')
+  const result = await runVitest({
+    root: 'fixtures/duration',
+    reporters: 'verbose',
+    env: { CI: '1' },
+  })
+
   const output = result.stdout.replaceAll(/\d+ms/g, '[...]ms')
   expect(output).toContain(`
  ✓ basic.test.ts > fast

--- a/test/reporters/vitest.config.ts
+++ b/test/reporters/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     exclude: ['node_modules', 'fixtures', 'dist'],
+    reporters: ['verbose'],
     testTimeout: 100000,
     chaiConfig: {
       truncateThreshold: 0,

--- a/test/run/test/custom-pool.test.ts
+++ b/test/run/test/custom-pool.test.ts
@@ -1,8 +1,11 @@
 import { expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 test('can run custom pools with Vitest', async () => {
-  const vitest = await runVitestCli('--run', '--root', 'pool-custom-fixtures')
+  const vitest = await runVitest({
+    root: 'pool-custom-fixtures',
+    reporters: ['basic'],
+  })
 
   expect(vitest.stderr).toMatchInlineSnapshot(`
     "[pool] printing: options are respected

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -23,10 +23,13 @@ export async function runVitest(config: UserConfig, cliFilters: string[] = [], m
 
   let vitest: Vitest | undefined
   try {
+    const { reporters, ...rest } = config
+
     vitest = await startVitest(mode, cliFilters, {
       watch: false,
-      reporters: ['verbose'],
-      ...config,
+      // "none" can be used to disable passing "reporter" option so that default value is used (it's not same as reporters: ["default"])
+      ...(reporters === 'none' ? {} : reporters ? { reporters } : { reporters: ['verbose'] }),
+      ...rest,
     }, viteOverrides)
   }
   catch (e: any) {

--- a/test/ws-api/tests/server-url.test.ts
+++ b/test/ws-api/tests/server-url.test.ts
@@ -1,18 +1,17 @@
-import { join } from 'node:path'
 import { expect, it } from 'vitest'
 
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
 it('api server-url http', async () => {
   delete process.env.TEST_HTTPS
-  const { stdout } = await runVitestCli('run', '--root', join(process.cwd(), './fixtures/server-url'), '--api')
+  const { stdout } = await runVitest({ root: 'fixtures/server-url', api: true })
   expect(stdout).toContain('API started at http://localhost:51204/')
   expect(stdout).toContain('Test Files  1 passed')
 })
 
 it('api server-url https', async () => {
   process.env.TEST_HTTPS = '1'
-  const { stdout } = await runVitestCli('run', '--root', join(process.cwd(), './fixtures/server-url'), '--api')
+  const { stdout } = await runVitest({ root: 'fixtures/server-url', api: true })
   expect(stdout).toContain('API started at https://localhost:51204/')
   expect(stdout).toContain('Test Files  1 passed')
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Attempts to fix flaky CI. Replaces usage of `runVitestCli()` with lighter `runVitest()` utility. This reduces the amount of `node:child_process` launched during tests (via `execa`). The `runVitestCli()` should only be used when tests require interactive watch mode or are explicitly testing CLI options. 
 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
