### PR TITLE
fix(vitest): check unhighlighted code for code frame line limit

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -290,7 +290,7 @@ export function generateCodeFrame(
 
         const lineLength = lines[j].length
 
-        // to long, maybe it's a minified file, skip for codeframe
+        // too long, maybe it's a minified file, skip for codeframe
         if (stripAnsi(lines[j]).length > 200)
           return ''
 

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -5,6 +5,7 @@ import c from 'picocolors'
 import cliTruncate from 'cli-truncate'
 import type { StackTraceParserOptions } from '@vitest/utils/source-map'
 import { inspect } from '@vitest/utils'
+import stripAnsi from 'strip-ansi'
 import type { ErrorWithDiff, ParsedStack } from '../types'
 import { lineSplitRE, parseErrorStacktrace, positionToOffset } from '../utils/source-map'
 import { F_POINTER } from '../utils/figures'
@@ -290,7 +291,7 @@ export function generateCodeFrame(
         const lineLength = lines[j].length
 
         // to long, maybe it's a minified file, skip for codeframe
-        if (lineLength > 200)
+        if (stripAnsi(lines[j]).length > 200)
           return ''
 
         res.push(lineNo(j + 1) + cliTruncate(lines[j].replace(/\t/g, ' '), columns - 5 - indent))

--- a/test/reporters/fixtures/code-frame-line-limit.test.ts
+++ b/test/reporters/fixtures/code-frame-line-limit.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "vitest"
+
+test("basic", () => {
+  // line length is 85 but highlight makes this line 245 chars
+  expect([{ prop: 7 }, { prop: 7 }, { prop: 7 }, { prop: 7 }]).toBe([{ another: 8 }])
+})

--- a/test/reporters/tests/code-frame-line-limit.test.ts
+++ b/test/reporters/tests/code-frame-line-limit.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+import { resolve } from 'pathe'
+import { runVitest } from '../../test-utils'
+
+test('show code frame', async () => {
+  const filename = resolve('./fixtures/code-frame-line-limit.test.ts')
+  const { stderr } = await runVitest({ root: './fixtures' }, [filename])
+  expect(stderr).toContain('5|   expect([{ prop: 7 },')
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5431

ANSI-code length adds up a lot, so I think we should use un-highlighted code for this limit check.

For example, this simple line exceeds 200 chars when highlighted:

```ts
// without highlight: 76 chars
// with highlight: 236 chars
expect([{prop: 7}, {prop: 7}, {prop: 7}, {prop: 7}]).toBe([{another: 8} ])
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
