### PR TITLE
fix(utils): fix object diff with getter only property

### DIFF
--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -111,7 +111,15 @@ export function clone<T>(
       if (!descriptor)
         continue
       const cloned = clone((val as any)[k], seen, options)
-      if ('get' in descriptor) {
+      if (options.forceWritable) {
+        Object.defineProperty(out, k, {
+          enumerable: descriptor.enumerable,
+          configurable: true,
+          writable: true,
+          value: cloned,
+        })
+      }
+      else if ('get' in descriptor) {
         Object.defineProperty(out, k, {
           ...descriptor,
           get() {
@@ -122,7 +130,6 @@ export function clone<T>(
       else {
         Object.defineProperty(out, k, {
           ...descriptor,
-          writable: options.forceWritable ? true : descriptor.writable,
           value: cloned,
         })
       }

--- a/test/core/test/diff.test.ts
+++ b/test/core/test/diff.test.ts
@@ -115,6 +115,34 @@ test('asymmetric matcher in nested', () => {
   `)
 })
 
+test('getter only property', () => {
+  setupColors(getDefaultColors())
+  const x = { normalProp: 1 }
+  const y = { normalProp: 2 }
+  Object.defineProperty(x, 'getOnlyProp', {
+    enumerable: true,
+    get: () => ({ a: 'b' }),
+  })
+  Object.defineProperty(y, 'getOnlyProp', {
+    enumerable: true,
+    get: () => ({ a: 'b' }),
+  })
+  expect(
+    getErrorDiff(x, y),
+  ).toMatchInlineSnapshot(`
+    "- Expected
+    + Received
+
+      Object {
+        "getOnlyProp": Object {
+          "a": "b",
+        },
+    -   "normalProp": 2,
+    +   "normalProp": 1,
+      }"
+  `)
+})
+
 function getErrorDiff(actual: unknown, expected: unknown) {
   try {
     expect(actual).toEqual(expected)


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5406

It looks like similar issues are handled in
- https://github.com/vitest-dev/vitest/pull/3422

but, it wasn't handling when this getter only property case for `forceOverwrite`.

I checked Jest and they seem to have simpler code to do this writable clone, so I borrowed these lines for this PR's fix.

https://github.com/jestjs/jest/blob/1d682f21c7a35da4d3ab3a1436a357b980ebd0fa/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts#L101-L111


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
