### PR TITLE
fix(benchmark): table reporter for non TTY output

### DIFF
--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -43,7 +43,10 @@ export class TableReporter extends BaseReporter {
         // render static table when all benches inside single suite are finished
         const benches = task.tasks.filter(t => t.meta.benchmark)
         if (benches.length > 0 && benches.every(t => t.result?.state !== 'run')) {
-          this.ctx.logger.log(` ${getStateSymbol(task)} ${getFullName(task, c.dim(' > '))}`)
+          let title = ` ${getStateSymbol(task)} ${getFullName(task, c.dim(' > '))}`
+          if (task.result.duration != null && task.result.duration > this.ctx.config.slowTestThreshold)
+            title += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
+          this.ctx.logger.log(title)
           this.ctx.logger.log(renderTree(benches, this.rendererOptions, 1))
         }
       }

--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -21,11 +21,10 @@ export class TableReporter extends BaseReporter {
   }
 
   onCollected() {
-    this.rendererOptions.logger = this.ctx.logger
-    this.rendererOptions.showHeap = this.ctx.config.logHeapUsage
-    this.rendererOptions.slowTestThreshold = this.ctx.config.slowTestThreshold
-    this.rendererOptions.recurse = this.isTTY
     if (this.isTTY) {
+      this.rendererOptions.logger = this.ctx.logger
+      this.rendererOptions.showHeap = this.ctx.config.logHeapUsage
+      this.rendererOptions.slowTestThreshold = this.ctx.config.slowTestThreshold
       const files = this.ctx.state.getFiles(this.watchFilters)
       if (!this.renderer)
         this.renderer = createTableRenderer(files, this.rendererOptions).start()
@@ -47,7 +46,7 @@ export class TableReporter extends BaseReporter {
           if (task.result.duration != null && task.result.duration > this.ctx.config.slowTestThreshold)
             title += c.yellow(` ${Math.round(task.result.duration)}${c.dim('ms')}`)
           this.ctx.logger.log(title)
-          this.ctx.logger.log(renderTree(benches, this.rendererOptions, 1))
+          this.ctx.logger.log(renderTree(benches, this.rendererOptions, 1, true))
         }
       }
     }

--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -1,8 +1,8 @@
 import c from 'picocolors'
+import type { TaskResultPack } from '@vitest/runner'
 import type { UserConsoleLog } from '../../../../types/general'
 import { BaseReporter } from '../../base'
 import { getFullName } from '../../../../utils'
-import type { TaskResultPack } from '../../../../types'
 import { getStateSymbol } from '../../renderers/utils'
 import { type TableRendererOptions, createTableRenderer, renderTree } from './tableRender'
 

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -12,6 +12,7 @@ export interface TableRendererOptions {
   logger: Logger
   showHeap: boolean
   slowTestThreshold: number
+  recurse: boolean
 }
 
 const outputMap = new WeakMap<Task, string>()
@@ -100,7 +101,7 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('  ')
 }
 
-function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): string {
+export function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): string {
   const output: string[] = []
 
   let idx = 0
@@ -151,7 +152,7 @@ function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): st
       }
     }
 
-    if (task.type === 'suite' && task.tasks.length > 0) {
+    if (options.recurse && task.type === 'suite' && task.tasks.length > 0) {
       if (task.result?.state)
         output.push(renderTree(task.tasks, options, level + 1))
     }

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -12,7 +12,6 @@ export interface TableRendererOptions {
   logger: Logger
   showHeap: boolean
   slowTestThreshold: number
-  recurse: boolean
 }
 
 const outputMap = new WeakMap<Task, string>()
@@ -101,7 +100,7 @@ function renderBenchmark(task: Benchmark, tasks: Task[]): string {
   ].join('  ')
 }
 
-export function renderTree(tasks: Task[], options: TableRendererOptions, level = 0): string {
+export function renderTree(tasks: Task[], options: TableRendererOptions, level = 0, shallow = false): string {
   const output: string[] = []
 
   let idx = 0
@@ -152,7 +151,7 @@ export function renderTree(tasks: Task[], options: TableRendererOptions, level =
       }
     }
 
-    if (options.recurse && task.type === 'suite' && task.tasks.length > 0) {
+    if (!shallow && task.type === 'suite' && task.tasks.length > 0) {
       if (task.result?.state)
         output.push(renderTree(task.tasks, options, level + 1))
     }

--- a/test/benchmark/fixtures/basic/base.bench.ts
+++ b/test/benchmark/fixtures/basic/base.bench.ts
@@ -38,22 +38,30 @@ describe('timeout', () => {
     teardown() {
 
     },
+    ...benchOptions
   })
 
   bench('timeout75', async () => {
     await timeout(75)
-  })
+  }, benchOptions)
 
   bench('timeout50', async () => {
     await timeout(50)
-  })
+  }, benchOptions)
 
   bench('timeout25', async () => {
     await timeout(25)
-  })
+  }, benchOptions)
 
   // TODO: move to failed tests
   // test('reduce', () => {
   //   expect(1 - 1).toBe(2)
   // })
 })
+
+const benchOptions = {
+  time: 0,
+  iterations: 3,
+  warmupIterations: 0,
+  warmupTime: 0,
+}

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from 'vitest'
+import * as pathe from 'pathe'
+import { runVitest } from '../../test-utils'
+
+it('non-tty', async () => {
+  const root = pathe.join(import.meta.dirname, '../fixtures/basic')
+  const result = await runVitest({ root }, ['base.bench.ts'], 'benchmark')
+  const lines = result.stdout.split('\n').slice(3).slice(0, 10)
+  expect(lines).toMatchObject([
+    ' ✓ base.bench.ts > sort',
+    '     name',
+    '   · normal',
+    '   · reverse',
+    ' ✓ base.bench.ts > timeout',
+    '     name',
+    '   · timeout100',
+    '   · timeout75',
+    '   · timeout50',
+    '   · timeout25',
+  ].map(s => expect.stringContaining(s)))
+})

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -6,16 +6,17 @@ it('non-tty', async () => {
   const root = pathe.join(import.meta.dirname, '../fixtures/basic')
   const result = await runVitest({ root }, ['base.bench.ts'], 'benchmark')
   const lines = result.stdout.split('\n').slice(3).slice(0, 10)
-  expect(lines).toMatchObject([
-    ' ✓ base.bench.ts > sort',
-    '     name',
-    '   · normal',
-    '   · reverse',
-    ' ✓ base.bench.ts > timeout',
-    '     name',
-    '   · timeout100',
-    '   · timeout75',
-    '   · timeout50',
-    '   · timeout25',
-  ].map(s => expect.stringContaining(s)))
+  const expected = `\
+ ✓ base.bench.ts > sort
+     name
+   · normal
+   · reverse
+ ✓ base.bench.ts > timeout
+     name
+   · timeout100
+   · timeout75
+   · timeout50
+   · timeout25
+`
+  expect(lines).toMatchObject(expected.trim().split('\n').map(s => expect.stringContaining(s)))
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5475

This PR implements "non incremental" table output for non TTY case by reusing benchmark `renderTree`.

The idea is similar to `verbose` test reporter, which uses `onTaskUpdate` and waits until status is ready `task.result?.state !== 'run'` then print a full result:

https://github.com/vitest-dev/vitest/blob/48f762a9865ba6c4d5bd34cab405ddc61a1c8ab6/packages/vitest/src/node/reporters/verbose.ts#L14-L20

<details><summary>Reveal screenshots</summary>

- tty

![image](https://github.com/vitest-dev/vitest/assets/4232207/212d2b8d-cbdc-4da8-9363-1f9a7aaef0f2)

- no tty

![image](https://github.com/vitest-dev/vitest/assets/4232207/87e2e660-e04d-4f70-beff-8e09f3970030)

</details>


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
