### PR TITLE
fix(benchmark): fix benchmark summary of single bench suite

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -328,8 +328,10 @@ export abstract class BaseReporter implements Reporter {
       const groupName = getFullName(group, c.dim(' > '))
       logger.log(`  ${bench.name}${c.dim(` - ${groupName}`)}`)
       const siblings = group.tasks
-        .filter(i => i.result?.benchmark && i !== bench)
+        .filter(i => i.meta.benchmark && i.result?.benchmark && i !== bench)
         .sort((a, b) => a.result!.benchmark!.rank - b.result!.benchmark!.rank)
+      if (siblings.length === 0)
+        continue
       for (const sibling of siblings) {
         const number = `${(sibling.result!.benchmark!.mean / bench.result!.benchmark!.mean).toFixed(2)}x`
         logger.log(`    ${c.green(number)} ${c.gray('faster than')} ${sibling.name}`)

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -330,8 +330,10 @@ export abstract class BaseReporter implements Reporter {
       const siblings = group.tasks
         .filter(i => i.meta.benchmark && i.result?.benchmark && i !== bench)
         .sort((a, b) => a.result!.benchmark!.rank - b.result!.benchmark!.rank)
-      if (siblings.length === 0)
+      if (siblings.length === 0) {
+        logger.log('')
         continue
+      }
       for (const sibling of siblings) {
         const number = `${(sibling.result!.benchmark!.mean / bench.result!.benchmark!.mean).toFixed(2)}x`
         logger.log(`    ${c.green(number)} ${c.gray('faster than')} ${sibling.name}`)

--- a/test/benchmark/fixtures/reporter/summary.bench.ts
+++ b/test/benchmark/fixtures/reporter/summary.bench.ts
@@ -1,0 +1,32 @@
+import { bench, describe } from 'vitest'
+
+describe('suite-a', () => {
+  bench('good', async () => {
+    await sleep(25)
+  }, options)
+
+  bench('bad', async () => {
+    await sleep(50)
+  }, options)
+})
+
+describe('suite-b', () => {
+  bench('good', async () => {
+    await sleep(25)
+  }, options)
+
+  describe('suite-b-nested', () => {
+    bench('good', async () => {
+      await sleep(50)
+    }, options)
+  })
+})
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const options = {
+  time: 0,
+  iterations: 3,
+  warmupIterations: 0,
+  warmupTime: 0,
+}

--- a/test/benchmark/fixtures/reporter/vitest.config.ts
+++ b/test/benchmark/fixtures/reporter/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/test/benchmark/test/__snapshots__/reporter.test.ts.snap
+++ b/test/benchmark/test/__snapshots__/reporter.test.ts.snap
@@ -7,6 +7,8 @@ exports[`summary 1`] = `
     ?.??x faster than bad
 
   good - summary.bench.ts > suite-b
+
   good - summary.bench.ts > suite-b > suite-b-nested
+
 "
 `;

--- a/test/benchmark/test/__snapshots__/reporter.test.ts.snap
+++ b/test/benchmark/test/__snapshots__/reporter.test.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`summary 1`] = `
+"
+
+  good - summary.bench.ts > suite-a
+    ?.??x faster than bad
+
+  good - summary.bench.ts > suite-b
+  good - summary.bench.ts > suite-b > suite-b-nested
+"
+`;

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest'
+import * as pathe from 'pathe'
+import { runVitest } from '../../test-utils'
+
+it('summary', async () => {
+  const root = pathe.join(import.meta.dirname, '../fixtures/reporter')
+  const result = await runVitest({ root }, ['summary.bench.ts'], 'benchmark')
+  expect(result.stdout).not.toContain('NaNx')
+  expect(result.stdout.split('BENCH  Summary')[1].replaceAll(/\d/g, '?')).toMatchSnapshot()
+})


### PR DESCRIPTION
### Description

This fixes the summary output `NaNx faster than ...` mentioned in https://github.com/vitest-dev/vitest/issues/5475.

<details><summary>Show example</summary>

```sh
pnpm -C test/benchmark test bench -- --root fixtures/basic only
```

- before

![image](https://github.com/vitest-dev/vitest/assets/4232207/e6a7551c-6786-4123-8956-261f47d47602)


- after

![image](https://github.com/vitest-dev/vitest/assets/4232207/86abd9d5-646d-4a5f-90c9-749bbb75a1aa)

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
