### PR TITLE
test: fix flaky benchmark summary

### DIFF
--- a/test/benchmark/fixtures/reporter/summary.bench.ts
+++ b/test/benchmark/fixtures/reporter/summary.bench.ts
@@ -2,11 +2,11 @@ import { bench, describe } from 'vitest'
 
 describe('suite-a', () => {
   bench('good', async () => {
-    await sleep(25)
+    await sleep(10)
   }, options)
 
   bench('bad', async () => {
-    await sleep(50)
+    await sleep(300)
   }, options)
 })
 
@@ -26,7 +26,7 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const options = {
   time: 0,
-  iterations: 3,
+  iterations: 2,
   warmupIterations: 0,
   warmupTime: 0,
 }

--- a/test/benchmark/test/__snapshots__/reporter.test.ts.snap
+++ b/test/benchmark/test/__snapshots__/reporter.test.ts.snap
@@ -4,7 +4,7 @@ exports[`summary 1`] = `
 "
 
   good - summary.bench.ts > suite-a
-    ?.??x faster than bad
+    (?) faster than bad
 
   good - summary.bench.ts > suite-b
 

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -6,5 +6,5 @@ it('summary', async () => {
   const root = pathe.join(import.meta.dirname, '../fixtures/reporter')
   const result = await runVitest({ root }, ['summary.bench.ts'], 'benchmark')
   expect(result.stdout).not.toContain('NaNx')
-  expect(result.stdout.split('BENCH  Summary')[1].replaceAll(/\d/g, '?')).toMatchSnapshot()
+  expect(result.stdout.split('BENCH  Summary')[1].replaceAll(/[0-9.]+x/g, '(?)')).toMatchSnapshot()
 })


### PR DESCRIPTION
### Description

- follow up to https://github.com/vitest-dev/vitest/pull/5489#discussion_r1554483994

The test added in the above PR had an assertion of `xxx faster than yyy`, but it looks quite unstable on CI.
- https://github.com/vitest-dev/vitest/actions/runs/8568796944/job/23483403713#step:9:322
- https://github.com/vitest-dev/vitest/actions/runs/8577751509/job/23511069656?pr=5311#step:10:341
- https://github.com/vitest-dev/vitest/actions/runs/8577739425/job/23511042842?pr=5484#step:9:316

I updated test case to hopefully fix the flakiness.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
