### PR TITLE
Add Mastodon to “resources” in docs navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -107,6 +107,10 @@ export default withPwa(defineConfig({
           {
             items: [
               {
+                text: 'Mastodon',
+                link: mastodon,
+              },
+              {
                 text: 'X (formerly Twitter)',
                 link: twitter,
               },


### PR DESCRIPTION
### Description

~~Thou the account is not very active, I have good hope it’ll become better in the future since some Vue/Vitest core team members are active there. Maybe you can wait until you’re more active on Mastodon to merge it.~~

Just noticed the account is actually very active! 🥳 I guess I was confused by the pinned messages and did not properly scrolled down.

(Also if you need some convenience, a friend of mine created [oolatoocs](https://framagit.org/veretcle/oolatoocs), a Mastodon to Twitter bridge.)