### PR TITLE
chore: provide explicit type param to one of the calls

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -320,7 +320,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner) {
               // run describe block independently from tests
               const suites = tasksGroup.filter(group => group.type === 'suite')
               const tests = tasksGroup.filter(group => group.type === 'test')
-              const groups = shuffle([suites, tests], sequence.seed)
+              const groups = shuffle<Task[]>([suites, tests], sequence.seed)
               tasksGroup = groups.flatMap(group => shuffle(group, sequence.seed))
             }
             for (const c of tasksGroup)


### PR DESCRIPTION
This is not needed today but you will have to workaround an improved inference for type predicated in the upcoming TS 5.5. See the failure reported [here](https://github.com/microsoft/TypeScript/issues/58104#issuecomment-2041579302) and the discussion~ [here](https://github.com/microsoft/TypeScript/pull/57952#issuecomment-2023641553)