### PR TITLE
chore: check for the presense of files in watch mode

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -832,7 +832,7 @@ export class Vitest {
             return
 
           const heedsRerun = this.handleFileChanged(i.file)
-          if (heedsRerun)
+          if (heedsRerun.length)
             rerun = true
         })
       }
@@ -841,7 +841,7 @@ export class Vitest {
         files.push(filepath)
     }
 
-    return files
+    return Array.from(new Set(files))
   }
 
   private async reportCoverage(allTestsRun: boolean) {


### PR DESCRIPTION
Fixes incorrect checks that could incorrectly lead to a test rerun