### PR TITLE
feat: allow custom host for --inspect and --inspect-brk

### DIFF
--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -308,7 +308,9 @@ export const cliOptionsConfig: VitestCLIOptions = {
       if (typeof browser === 'boolean')
         return { enabled: browser }
       if (browser === 'true' || browser === 'false')
-        return { enabled: browser !== 'false' }
+        return { enabled: browser === 'true' }
+      if (browser === 'yes' || browser === 'no')
+        return { enabled: browser === 'yes' }
       if (typeof browser === 'string')
         return { enabled: true, name: browser }
       return browser
@@ -465,11 +467,28 @@ export const cliOptionsConfig: VitestCLIOptions = {
     },
   },
   inspect: {
-    description: 'Enable Node.js inspector',
+    description: 'Enable Node.js inspector (default: 127.0.0.1:9229)',
+    argument: '[[host:]port]',
+    transform(portOrEnabled) {
+      if (portOrEnabled === 'true' || portOrEnabled === 'yes')
+        return true
+      if (portOrEnabled === 'false' || portOrEnabled === 'no')
+        return false
+      return portOrEnabled
+    },
   },
   inspectBrk: {
-    description: 'Enable Node.js inspector with break',
+    description: 'Enable Node.js inspector and break before the test starts',
+    argument: '[[host:]port]',
+    transform(portOrEnabled) {
+      if (portOrEnabled === 'true' || portOrEnabled === 'yes')
+        return true
+      if (portOrEnabled === 'false' || portOrEnabled === 'no')
+        return false
+      return portOrEnabled
+    },
   },
+  inspector: null,
   testTimeout: {
     description: 'Default timeout of a test in milliseconds (default: 5000)',
     argument: '<timeout>',

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -20,6 +20,14 @@ function resolvePath(path: string, root: string) {
   )
 }
 
+function parseInspector(inspect: string | undefined | boolean) {
+  if (typeof inspect === 'boolean' || inspect === undefined)
+    return {}
+
+  const [host, port] = inspect.split(':')
+  return { host, port: port ? Number(port) : undefined }
+}
+
 export function resolveApiServerConfig<Options extends ApiConfig & UserConfig>(
   options: Options,
 ): ApiConfig | undefined {
@@ -88,8 +96,14 @@ export function resolveConfig(
     mode,
   } as any as ResolvedConfig
 
-  resolved.inspect = Boolean(resolved.inspect)
-  resolved.inspectBrk = Boolean(resolved.inspectBrk)
+  const inspector = resolved.inspect || resolved.inspectBrk
+
+  resolved.inspector = {
+    ...resolved.inspector,
+    ...parseInspector(inspector),
+    enabled: !!inspector,
+    waitForDebugger: resolved.inspector.waitForDebugger ?? !!resolved.inspectBrk,
+  }
 
   if (viteConfig.base !== '/')
     resolved.base = viteConfig.base

--- a/packages/vitest/src/runtime/inspector.ts
+++ b/packages/vitest/src/runtime/inspector.ts
@@ -12,7 +12,7 @@ let session: InstanceType<typeof inspector.Session>
  */
 export function setupInspect(ctx: ContextRPC) {
   const config = ctx.config
-  const isEnabled = config.inspect || config.inspectBrk
+  const isEnabled = config.inspector.enabled
 
   if (isEnabled) {
     inspector = __require('node:inspector')
@@ -20,10 +20,13 @@ export function setupInspect(ctx: ContextRPC) {
     const isOpen = inspector.url() !== undefined
 
     if (!isOpen) {
-      inspector.open()
+      inspector.open(
+        config.inspector.port,
+        config.inspector.host,
+        config.inspector.waitForDebugger,
+      )
 
       if (config.inspectBrk) {
-        inspector.waitForDebugger()
         const firstTestFile = ctx.files[0]
 
         // Stop at first test file

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -675,7 +675,7 @@ export interface InlineConfig {
    *
    * Requires `poolOptions.threads.singleThread: true` OR `poolOptions.forks.singleFork: true`.
    */
-  inspect?: boolean
+  inspect?: boolean | string
 
   /**
    * Debug tests by opening `node:inspector` in worker / child process and wait for debugger to connect.
@@ -683,7 +683,29 @@ export interface InlineConfig {
    *
    * Requires `poolOptions.threads.singleThread: true` OR `poolOptions.forks.singleFork: true`.
    */
-  inspectBrk?: boolean
+  inspectBrk?: boolean | string
+
+  /**
+   * Inspector options. If `--inspect` or `--inspect-brk` is enabled, these options will be passed to the inspector.
+   */
+  inspector?: {
+    /**
+     * Enable inspector
+     */
+    enabled?: boolean
+    /**
+     * Port to run inspector on
+     */
+    port?: number
+    /**
+     * Host to run inspector on
+     */
+    host?: string
+    /**
+     * Wait for debugger to connect before running tests
+     */
+    waitForDebugger?: boolean
+  }
 
   /**
    * Modify default Chai config. Vitest uses Chai for `expect` and `assert` matches.


### PR DESCRIPTION
### Description

This PR allows passing down a string to `--inspect` and `--inspect-brk`:

```
vitest --inspect=3000
vitest --inspect=www.remove-host.com:3000
```

TODO: 

- [ ] Test
- [ ] Docs

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
