### PR TITLE
chore: add vscode extension to issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: VS Code Extension Issues
+    url: https://github.com/vitest-dev/vscode/issues/new/choose
+    about: VS Code extension related issues should be reported on the vitest-dev/vscode repository.
   - name: Discord Chat
     url: https://chat.vitest.dev
     about: Ask questions and discuss with other Vitest users in real time.


### PR DESCRIPTION
### Description

Some people are reporting vscode extension bugs here, but we probably want them to open the issue downstream first, so they go through the checklist.

For the template, I copied what Vite does for react/vue plugins:
https://github.com/vitejs/vite/blob/84299f30a7244e6885e41531ffe5c4b54c8b0ed7/.github/ISSUE_TEMPLATE/config.yml#L3-L8

EDIT: Ah, I thought this issue https://github.com/vitest-dev/vitest/issues/5523 is about vscode extension, but it's actually about vscode debugger without extension. I guess it's still fine to have this link?

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
