### PR TITLE
fix: use `toJSON` for error serialization

### DIFF
--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -44,6 +44,8 @@ export function serializeError(val: any, seen = new WeakMap()): any {
     return val.tagName
   if (typeof val.asymmetricMatch === 'function')
     return `${val.toString()} ${format(val.sample)}`
+  if (typeof val.toJSON === 'function')
+    return val.toJSON()
 
   if (seen.has(val))
     return seen.get(val)

--- a/test/reporters/fixtures/error-to-json.test.ts
+++ b/test/reporters/fixtures/error-to-json.test.ts
@@ -1,0 +1,5 @@
+import { test } from "vitest";
+
+test("error serialization with toJSON", () => {
+  throw Object.assign(new Error("hello"), { date: new Date(0) })
+})

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest"
   },
   "devDependencies": {
     "flatted": "^3.2.9",

--- a/test/reporters/tests/__snapshots__/html.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/html.test.ts.snap
@@ -45,7 +45,6 @@ exports[`html reporter > resolves to "failing" status for test file "json-fail" 
             "errors": [
               {
                 "actual": "2",
-                "constructor": "Function<AssertionError>",
                 "diff": "- Expected
 + Received
 
@@ -59,8 +58,6 @@ exports[`html reporter > resolves to "failing" status for test file "json-fail" 
                 "showDiff": true,
                 "stack": "AssertionError: expected 2 to deeply equal 1",
                 "stackStr": "AssertionError: expected 2 to deeply equal 1",
-                "toJSON": "Function<anonymous>",
-                "toString": "Function<toString>",
               },
             ],
             "hooks": {

--- a/test/reporters/tests/error-to-json.test.ts
+++ b/test/reporters/tests/error-to-json.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+test('should print logs correctly', async () => {
+  const result = await runVitest({ root: './fixtures' }, ['error-to-json.test.ts'])
+  expect(result.stderr).toContain(`Serialized Error: { date: '1970-01-01T00:00:00.000Z' }`)
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5487

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
