### PR TITLE
test: faster bench fixture

### DIFF
--- a/test/reporters/fixtures/function-as-name.bench.ts
+++ b/test/reporters/fixtures/function-as-name.bench.ts
@@ -1,8 +1,15 @@
 import { bench } from 'vitest'
 
+const options = {
+  time: 0,
+  iterations: 3,
+  warmupTime: 0,
+  warmupIterations: 0,
+}
+
 function foo() {}
 class Bar {}
 
-bench(foo, () => {})
-bench(Bar, () => {})
-bench(() => {}, () => {})
+bench(foo, () => {}, options)
+bench(Bar, () => {}, options)
+bench(() => {}, () => {}, options)

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest"
   },
   "devDependencies": {
     "flatted": "^3.2.9",


### PR DESCRIPTION
### Description

These empty benchmarks are bad for CPU and memory (due to huge `samples` array), so I set the minimal bench options

```sh
# before
$ pnpm -C test/reporters test function-as-name
...
 ✓ tests/function-as-name.test.ts (2) 17826ms
   ✓ should print function name 494ms
   ✓ should print function name in benchmark 17331ms

# after
$ pnpm -C test/reporters test function-as-name
...
 ✓ tests/function-as-name.test.ts (2) 820ms
   ✓ should print function name 636ms
   ✓ should print function name in benchmark
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
