### PR TITLE
fix(browser): disable `fileParallelism` by default on browser pool

### DIFF
--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -140,6 +140,9 @@ export function resolveConfig(
   if (resolved.minWorkers)
     resolved.minWorkers = Number(resolved.minWorkers)
 
+  resolved.browser ??= {} as any
+  resolved.browser.fileParallelism ??= resolved.fileParallelism ?? false
+
   // run benchmark sequentially by default
   resolved.fileParallelism ??= mode !== 'benchmark'
 

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -140,8 +140,8 @@ export function resolveConfig(
   if (resolved.minWorkers)
     resolved.minWorkers = Number(resolved.minWorkers)
 
-  // browser pool and benchmark are sequential by default
-  resolved.fileParallelism ??= resolved.pool !== 'browser' && mode !== 'benchmark'
+  // run benchmark sequentially by default
+  resolved.fileParallelism ??= mode !== 'benchmark'
 
   if (!resolved.fileParallelism) {
     // ignore user config, parallelism cannot be implemented without limiting workers

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -140,8 +140,8 @@ export function resolveConfig(
   if (resolved.minWorkers)
     resolved.minWorkers = Number(resolved.minWorkers)
 
-  // run benchmark sequentially by default
-  resolved.fileParallelism ??= mode !== 'benchmark'
+  // browser pool and benchmark are sequential by default
+  resolved.fileParallelism ??= resolved.pool !== 'browser' && mode !== 'benchmark'
 
   if (!resolved.fileParallelism) {
     // ignore user config, parallelism cannot be implemented without limiting workers


### PR DESCRIPTION
### Description

- related to https://github.com/vitest-dev/vitest/issues/5382

It looks like `fileParallelism` becomes true by default since it's inherited in this way:

https://github.com/vitest-dev/vitest/blob/c44a15fb9027e4e9b78f2e6e2b506a83d2348762/packages/browser/src/client/main.ts#L99

I'm not sure how to test the fix. For now, I manually verified by putting `console.log` above and checking browser devtools.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
