### PR TITLE
fix: close vite servers on all resolved projects

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -868,10 +868,10 @@ export class Vitest {
         for await (const project of teardownProjects.reverse())
           await project.teardownGlobalSetup()
 
-        const closePromises: unknown[] = this.projects.map(w => w.close().then(() => w.server = undefined as any))
+        const closePromises: unknown[] = this.resolvedProjects.map(w => w.close().then(() => w.server = undefined as any))
         // close the core workspace server only once
         // it's possible that it's not initialized at all because it's not running any tests
-        if (!this.projects.includes(this.coreWorkspaceProject))
+        if (!this.resolvedProjects.includes(this.coreWorkspaceProject))
           closePromises.push(this.coreWorkspaceProject.close().then(() => this.server = undefined as any))
 
         if (this.pool) {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -905,7 +905,7 @@ export class Vitest {
         this.state.getProcessTimeoutCauses().forEach(cause => console.warn(cause))
 
         if (!this.pool) {
-          const runningServers = [this.server, ...this.projects.map(p => p.server)].filter(Boolean).length
+          const runningServers = [this.server, ...this.resolvedProjects.map(p => p.server)].filter(Boolean).length
 
           if (runningServers === 1)
             console.warn('Tests closed successfully but something prevents Vite server from exiting')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I've been running into an issue where Vitest would hang after the testing is completed with the following output:

```
close timed out after 10000ms
Tests closed successfully but something prevents the main process from exiting
You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters
```

Luckily, this repo has a reproducible setup at `test/cli/fixtures/project` -- in this directory, running `npx vitest run --project space_1` causes the error above (you may need to try multiple times, but I've been getting it consistently).

The only other report I've found is by this commenter https://github.com/vitest-dev/vitest/issues/2008#issuecomment-1933009750 (the issue itself seems to be about a different time out issue).

I've tracked this down to a Vite web-socket server not being cleaned up at the end of the Vitest session.

This PR edits the `Vitest#close()` method to close the Vite dev servers on ALL resolved projects instead of just the filtered projects.

I tried to write a new test under `test/cli` but it seems that the Vite servers for the fixture projects do not get launched due to a port conflict with the Vitest instance running the actual test. I could not find a way to use a different port.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] **(N/A)** Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] **(N/A)** If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
