### PR TITLE
fix(coverage): fix bundling of `v8-to-istanbul`

### DIFF
--- a/patches/v8-to-istanbul@9.2.0.patch
+++ b/patches/v8-to-istanbul@9.2.0.patch
@@ -96,7 +96,7 @@ index d8ebc215f6ad83d472abafe976935acfe5c61b04..021fd2aed1f73ebb4adc449ce6e96f2d
  
  // this implementation is pulled over from istanbul-lib-sourcemap:
 diff --git a/lib/v8-to-istanbul.js b/lib/v8-to-istanbul.js
-index 3616437b00658861dc5a8910c64d1449e9fdf467..c1e0c0ae19984480e408713d1691fa174a7c4c1f 100644
+index 3616437b00658861dc5a8910c64d1449e9fdf467..4642ca4818ce982e2f186abe4289793768e7cdf9 100644
 --- a/lib/v8-to-istanbul.js
 +++ b/lib/v8-to-istanbul.js
 @@ -1,3 +1,4 @@
@@ -104,7 +104,25 @@ index 3616437b00658861dc5a8910c64d1449e9fdf467..c1e0c0ae19984480e408713d1691fa17
  const assert = require('assert')
  const convertSourceMap = require('convert-source-map')
  const util = require('util')
-@@ -25,12 +26,13 @@ const isNode8 = /^v8\./.test(process.version)
+@@ -8,14 +9,9 @@ const CovBranch = require('./branch')
+ const CovFunction = require('./function')
+ const CovSource = require('./source')
+ const { sliceRange } = require('./range')
+-const compatError = Error(`requires Node.js ${require('../package.json').engines.node}`)
+-const { readFileSync } = require('fs')
+-let readFile = () => { throw compatError }
+-try {
+-  readFile = require('fs').promises.readFile
+-} catch (_err) {
+-  // most likely we're on an older version of Node.js.
+-}
++const { readFileSync, promises } = require('fs')
++const readFile = promises.readFile
++
+ const { TraceMap } = require('@jridgewell/trace-mapping')
+ const isOlderNode10 = /^v10\.(([0-9]\.)|(1[0-5]\.))/u.test(process.version)
+ const isNode8 = /^v8\./.test(process.version)
+@@ -25,12 +21,13 @@ const isNode8 = /^v8\./.test(process.version)
  const cjsWrapperLength = isOlderNode10 ? require('module').wrapper[0].length : 0
  
  module.exports = class V8ToIstanbul {
@@ -119,7 +137,7 @@ index 3616437b00658861dc5a8910c64d1449e9fdf467..c1e0c0ae19984480e408713d1691fa17
      this.sources = sources || {}
      this.generatedLines = []
      this.branches = {}
-@@ -58,8 +60,8 @@ module.exports = class V8ToIstanbul {
+@@ -58,8 +55,8 @@ module.exports = class V8ToIstanbul {
          if (!this.sourceMap.sourcesContent) {
            this.sourceMap.sourcesContent = await this.sourcesContentFromSources()
          }
@@ -130,7 +148,7 @@ index 3616437b00658861dc5a8910c64d1449e9fdf467..c1e0c0ae19984480e408713d1691fa17
        } else {
          const candidatePath = this.rawSourceMap.sourcemap.sources.length >= 1 ? this.rawSourceMap.sourcemap.sources[0] : this.rawSourceMap.sourcemap.file
          this.path = this._resolveSource(this.rawSourceMap, candidatePath || this.path)
-@@ -82,8 +84,8 @@ module.exports = class V8ToIstanbul {
+@@ -82,8 +79,8 @@ module.exports = class V8ToIstanbul {
            // We fallback to reading the original source from disk.
            originalRawSource = await readFile(this.path, 'utf8')
          }
@@ -141,7 +159,7 @@ index 3616437b00658861dc5a8910c64d1449e9fdf467..c1e0c0ae19984480e408713d1691fa17
        }
      } else {
        this.covSources = [{ source: new CovSource(rawSource, this.wrapperLength), path: this.path }]
-@@ -281,8 +283,10 @@ module.exports = class V8ToIstanbul {
+@@ -281,8 +278,10 @@ module.exports = class V8ToIstanbul {
        s: {}
      }
      source.lines.forEach((line, index) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ patchedDependencies:
     hash: slh3cigivjjjktoa42g2agwaem
     path: patches/cac@6.7.14.patch
   v8-to-istanbul@9.2.0:
-    hash: zm2cjmgndzbmnuve7zu5emyu7i
+    hash: 5pdyrbs4i7bdmssok6uzfxxdia
     path: patches/v8-to-istanbul@9.2.0.patch
 
 importers:
@@ -1090,7 +1090,7 @@ importers:
         version: 1.1.1
       v8-to-istanbul:
         specifier: ^9.2.0
-        version: 9.2.0(patch_hash=zm2cjmgndzbmnuve7zu5emyu7i)
+        version: 9.2.0(patch_hash=5pdyrbs4i7bdmssok6uzfxxdia)
       vite-node:
         specifier: workspace:*
         version: link:../vite-node
@@ -6076,7 +6076,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -6097,7 +6097,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -6134,7 +6134,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       jest-mock: 27.5.1
     dev: true
 
@@ -6151,7 +6151,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -6180,7 +6180,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -6311,7 +6311,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       '@types/yargs': 16.0.7
       chalk: 4.1.2
     dev: true
@@ -9696,7 +9696,7 @@ packages:
     resolution: {integrity: sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==}
     dependencies:
       '@types/connect': 3.4.37
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/braces@3.0.1:
@@ -9717,7 +9717,7 @@ packages:
   /@types/connect@3.4.37:
     resolution: {integrity: sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/cookie@0.4.1:
@@ -9784,7 +9784,7 @@ packages:
   /@types/express-serve-static-core@4.17.39:
     resolution: {integrity: sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       '@types/qs': 6.9.9
       '@types/range-parser': 1.2.6
       '@types/send': 0.17.3
@@ -9808,7 +9808,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
     optional: true
 
@@ -9835,19 +9835,19 @@ packages:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/graceful-fs@4.1.8:
     resolution: {integrity: sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/hast@2.3.4:
@@ -9947,7 +9947,7 @@ packages:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
     optional: true
 
@@ -10018,7 +10018,7 @@ packages:
   /@types/node-fetch@2.6.7:
     resolution: {integrity: sha512-lX17GZVpJ/fuCjguZ5b3TjEbSENxmEk1B2z02yoXSK9WMEWRivhdSY73wWMn6bpcCDAOh6qAdktpKHIlkDk2lg==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       form-data: 4.0.0
     dev: true
 
@@ -10052,6 +10052,12 @@ packages:
 
   /@types/node@20.12.5:
     resolution: {integrity: sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /@types/node@20.12.7:
+    resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -10206,7 +10212,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/resolve@1.20.2:
@@ -10224,7 +10230,7 @@ packages:
     resolution: {integrity: sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==}
     dependencies:
       '@types/mime': 1.3.4
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/serve-static@1.15.4:
@@ -10232,7 +10238,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
@@ -10387,7 +10393,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
     optional: true
 
@@ -13325,7 +13331,7 @@ packages:
       istanbul-reports: 3.1.6
       rimraf: 3.0.2
       test-exclude: 6.0.0
-      v8-to-istanbul: 9.2.0(patch_hash=zm2cjmgndzbmnuve7zu5emyu7i)
+      v8-to-istanbul: 9.2.0(patch_hash=5pdyrbs4i7bdmssok6uzfxxdia)
       yargs: 16.2.0
       yargs-parser: 20.2.9
     dev: true
@@ -19419,7 +19425,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -19554,7 +19560,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -19572,7 +19578,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -19616,7 +19622,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.8
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -19656,7 +19662,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -19736,7 +19742,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -19797,7 +19803,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -19854,7 +19860,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       graceful-fs: 4.2.11
     dev: true
 
@@ -19862,7 +19868,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       graceful-fs: 4.2.11
     dev: true
 
@@ -19913,7 +19919,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19950,7 +19956,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -19961,7 +19967,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -27290,7 +27296,7 @@ packages:
       source-map: 0.7.4
     dev: true
 
-  /v8-to-istanbul@9.2.0(patch_hash=zm2cjmgndzbmnuve7zu5emyu7i):
+  /v8-to-istanbul@9.2.0(patch_hash=5pdyrbs4i7bdmssok6uzfxxdia):
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
     dependencies:
@@ -28835,7 +28841,7 @@ packages:
     hasBin: true
     optionalDependencies:
       '@types/fs-extra': 11.0.4
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
     dev: true
 
   file:test/config/fixtures/conditions-subpackage:


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes https://github.com/vitest-dev/vitest/issues/5532

Looks like Rollup doesn't transpile `require('fs').promises`. 

Changes in bundle:

```diff
-const compatError = Error(`requires Node.js ${require$$9.engines.node}`);
-const { readFileSync } = require$$10;
-let readFile = () => { throw compatError };
-try {
-  readFile = require('fs').promises.readFile;
-} catch (_err) {
-  // most likely we're on an older version of Node.js.
-}
+import require$$9 from 'fs';
...
+const { readFileSync, promises } = require$$9;
+const readFile = promises.readFile;
```


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
