### PR TITLE
fix: fix default `import.meta.env.PROD = false`

### DIFF
--- a/packages/vitest/src/runtime/setup-common.ts
+++ b/packages/vitest/src/runtime/setup-common.ts
@@ -30,7 +30,11 @@ function setupDefines(defines: Record<string, any>) {
 function setupEnv(env: Record<string, any>) {
   if (typeof process === 'undefined')
     return
-  for (const key in env)
+  // same boolean-to-string assignment as VitestPlugin.configResolved
+  const { PROD, DEV, ...restEnvs } = env
+  process.env.PROD = PROD ? '1' : ''
+  process.env.DEV = DEV ? '1' : ''
+  for (const key in restEnvs)
     process.env[key] = env[key]
 }
 

--- a/test/core/test/env.test.ts
+++ b/test/core/test/env.test.ts
@@ -55,9 +55,12 @@ test('define process and using import.meta.env together', () => {
 })
 
 test('PROD, DEV, SSR should be boolean', () => {
-  expect(typeof import.meta.env.PROD).toEqual('boolean')
-  expect(typeof import.meta.env.DEV).toEqual('boolean')
-  expect(typeof import.meta.env.SSR).toEqual('boolean')
+  expect(import.meta.env.PROD).toBe(false)
+  expect(import.meta.env.DEV).toBe(true)
+  expect(import.meta.env.SSR).toBe(true)
+  expect(process.env.PROD).toBe('')
+  expect(process.env.DEV).toBe('1')
+  expect(process.env.SSR).toBe('1')
 
   import.meta.env.SSR = false
   expect(import.meta.env.SSR).toEqual(false)


### PR DESCRIPTION
### Description

- a part of https://github.com/vitest-dev/vitest/issues/5525

`setupEnv` added in https://github.com/vitest-dev/vitest/pull/5476 was assigning boolean values in `config.env.PROD` to `process.env`. I fixed it by copying the same `PROD/DEV` specific logic from `VitestPlugin.configResolved`:

https://github.com/vitest-dev/vitest/blob/643bed6ffffaff43415e573b2adf0f92fdcc1f0c/packages/vitest/src/node/plugins/index.ts#L162-L172

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
