### PR TITLE
fix(coverage): `thresholds` to compare files relative to root

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -225,6 +225,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
         coverageMap,
         thresholds: this.options.thresholds,
         createCoverageMap: () => libCoverage.createCoverageMap({}),
+        root: this.ctx.config.root,
       })
 
       this.checkThresholds({

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -216,6 +216,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
         coverageMap,
         thresholds: this.options.thresholds,
         createCoverageMap: () => libCoverage.createCoverageMap({}),
+        root: this.ctx.config.root,
       })
 
       this.checkThresholds({

--- a/packages/vitest/src/utils/coverage.ts
+++ b/packages/vitest/src/utils/coverage.ts
@@ -125,10 +125,11 @@ export class BaseCoverageProvider {
    * where each threshold set holds their own coverage maps. Threshold set is either
    * for specific files defined by glob pattern or global for all other files.
    */
-  resolveThresholds({ coverageMap, thresholds, createCoverageMap }: {
+  resolveThresholds({ coverageMap, thresholds, createCoverageMap, root }: {
     coverageMap: CoverageMap
     thresholds: NonNullable<BaseCoverageOptions['thresholds']>
     createCoverageMap: () => CoverageMap
+    root: string
   }): ResolvedThreshold[] {
     const resolvedThresholds: ResolvedThreshold[] = []
     const files = coverageMap.files()
@@ -143,7 +144,7 @@ export class BaseCoverageProvider {
       const globThresholds = resolveGlobThresholds(thresholds[glob])
       const globCoverageMap = createCoverageMap()
 
-      const matchingFiles = files.filter(file => mm.isMatch(file, glob))
+      const matchingFiles = files.filter(file => mm.isMatch(relative(root, file), glob))
       filesMatchedByGlobs.push(...matchingFiles)
 
       for (const file of matchingFiles) {

--- a/test/coverage-test/option-tests/thresholds.test.ts
+++ b/test/coverage-test/option-tests/thresholds.test.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest'
+import { add } from '../src/utils'
+
+test('cover some lines, but not too much', () => {
+  add(1, 2)
+})

--- a/test/coverage-test/testing-options.mjs
+++ b/test/coverage-test/testing-options.mjs
@@ -106,6 +106,31 @@ const testCases = [
       include: ['coverage-report-tests/empty-lines.test.ts'],
     },
   },
+  {
+    testConfig: {
+      name: 'failing thresholds',
+      include: ['option-tests/thresholds.test.ts'],
+      coverage: {
+        reporter: 'text',
+        all: false,
+        include: ['src/utils.ts'],
+        thresholds: {
+          'src/utils.ts': {
+            branches: 100,
+            functions: 100,
+            lines: 100,
+            statements: 100,
+          },
+        },
+      },
+    },
+    after() {
+      if (process.exitCode !== 1)
+        throw new Error('Expected test to fail as thresholds are not met')
+
+      process.exitCode = 0
+    },
+  },
 ]
 
 for (const provider of ['v8', 'istanbul']) {
@@ -149,6 +174,8 @@ for (const provider of ['v8', 'istanbul']) {
 }
 
 function checkExit() {
-  if (process.exitCode)
+  if (process.exitCode) {
+    console.error(`Exit code was set to ${process.exitCode}. Failing tests`)
     process.exit(process.exitCode)
+  }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/5545

In following project:
```
<root>
|
├── package.json
├── vitest.config.ts
├── src
|  └── utils.ts
└── test
   └── utils.test.ts
```

... users no longer need to define `**/src/utils.ts` in `coverage.thresholds[<glob>]`. A simple `src/utils.ts` works now.

```diff
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    coverage: {
      thresholds: {
-       '**/src/utils.ts': {
+       'src/utils.ts': {
          functions: 100,
        },
      },
    },
  },
});
```

Documentation is already using this pattern:

https://github.com/vitest-dev/vitest/blob/413ec5e6fc0addb2216db6104228138f8027f392/docs/config/index.md?plain=1#L1322-L1328

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
