### PR TITLE
fix(vitest): fix false positive file filter match with leading slash

### DIFF
--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -284,17 +284,11 @@ export class WorkspaceProject {
       return testFiles.filter((t) => {
         const testFile = relative(dir, t).toLocaleLowerCase()
         return filters.some((f) => {
-          const relativePath = f.endsWith('/') ? join(relative(dir, f), '/') : relative(dir, f)
-
           // if filter is a full file path, we should include it if it's in the same folder
-          if (isAbsolute(f)) {
-            // the file is inside the filter path, so we should always include it,
-            // we don't include ../file because this condition is always true if
-            // the file doens't exist which cause false positives
-            if (relativePath === '..' || relativePath === '../' || relativePath.startsWith('../..'))
-              return true
-          }
+          if (isAbsolute(f) && t.startsWith(f))
+            return true
 
+          const relativePath = f.endsWith('/') ? join(relative(dir, f), '/') : relative(dir, f)
           return testFile.includes(f.toLocaleLowerCase()) || testFile.includes(relativePath.toLocaleLowerCase())
         })
       })

--- a/test/filters/fixtures-slash/test/basic-foo/a.test.ts
+++ b/test/filters/fixtures-slash/test/basic-foo/a.test.ts
@@ -1,0 +1,3 @@
+import { test } from 'vitest'
+
+test('example', () => {})

--- a/test/filters/fixtures-slash/test/basic.test.ts
+++ b/test/filters/fixtures-slash/test/basic.test.ts
@@ -1,0 +1,3 @@
+import { test } from 'vitest'
+
+test('example', () => {})

--- a/test/filters/fixtures-slash/test/basic/a.test.ts
+++ b/test/filters/fixtures-slash/test/basic/a.test.ts
@@ -1,0 +1,3 @@
+import { test } from 'vitest'
+
+test('example', () => {})

--- a/test/filters/fixtures-slash/test/foo-basic/a.test.ts
+++ b/test/filters/fixtures-slash/test/foo-basic/a.test.ts
@@ -1,0 +1,3 @@
+import { test } from 'vitest'
+
+test('example', () => {})

--- a/test/filters/fixtures-slash/vitest.config.ts
+++ b/test/filters/fixtures-slash/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/test/filters/package.json
+++ b/test/filters/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest"
   },
   "devDependencies": {
     "vite": "latest",

--- a/test/filters/test/testname-pattern.test.ts
+++ b/test/filters/test/testname-pattern.test.ts
@@ -46,3 +46,41 @@ test.each([
   expect(stdout).toMatch('× test/dont-run-this.test.ts > this will fail')
   expect(stdout).toMatch('✓ test/example.test.ts > this will pass')
 })
+
+test.each([
+  {
+    filter: 'basic',
+    files: [
+      'test/basic.test.ts',
+      'test/foo-basic/a.test.ts',
+      'test/basic/a.test.ts',
+      'test/basic-foo/a.test.ts',
+    ],
+  },
+  {
+    filter: '/basic',
+    files: [
+      'test/basic.test.ts',
+      'test/basic/a.test.ts',
+      'test/basic-foo/a.test.ts',
+    ],
+  },
+  {
+    filter: 'basic/',
+    files: [
+      'test/foo-basic/a.test.ts',
+      'test/basic/a.test.ts',
+    ],
+  },
+  {
+    filter: '/basic/',
+    files: [
+      'test/basic/a.test.ts',
+    ],
+  },
+])('filter with slash $filter', async ({ filter, files }) => {
+  const { stdout } = await runVitest({ root: './fixtures-slash' }, [filter])
+  expect(stdout).toMatch(`Test Files  ${files.length} passed (${files.length})`)
+  for (const file of files)
+    expect(stdout).toMatch(`✓ ${file}`)
+})

--- a/test/filters/test/testname-pattern.test.ts
+++ b/test/filters/test/testname-pattern.test.ts
@@ -3,8 +3,12 @@ import { expect, test } from 'vitest'
 
 import { runVitest } from '../../test-utils'
 
-test('match by partial pattern', async () => {
-  const { stdout } = await runVitest({ root: './fixtures' }, ['example'])
+test.each([
+  { filter: 'example' },
+  { filter: '/example' },
+  { filter: resolve('./fixtures/test/example') },
+])('match by partial pattern $filter', async ({ filter }) => {
+  const { stdout } = await runVitest({ root: './fixtures' }, [filter])
 
   expect(stdout).toMatch('✓ test/example.test.ts > this will pass')
   expect(stdout).toMatch('Test Files  1 passed (1)')


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5534
- follow up https://github.com/vitest-dev/vitest/pull/5408

With the current filter condition, it makes false positive in a following way

```ts
dir: /home/hiroshi/code/others/vitest/examples/basic
filter: /basic                             // looks like absolute path but users wish to use to match substring
relativePath = ../../../../../../../basic  // starts with '../..' so filter is true regardless of `testFile`
```

I'm not sure supporting a filter like `/basic` has been planned, but I OP's usage makes sense to me.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
