### PR TITLE
perf: improve performance of forks pool

### DIFF
--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -149,8 +149,15 @@ export class ViteNodeServer {
   }
 
   async fetchModule(id: string, transformMode?: 'web' | 'ssr'): Promise<FetchResult> {
-    const moduleId = normalizeModuleId(id)
     const mode = transformMode || this.getTransformMode(id)
+    return this.fetchResult(id, mode)
+      .then((r) => {
+        return this.options.sourcemap !== true ? { ...r, map: undefined } : r
+      })
+  }
+
+  async fetchResult(id: string, mode: 'web' | 'ssr') {
+    const moduleId = normalizeModuleId(id)
     this.assertMode(mode)
     const promiseMap = this.fetchPromiseMap[mode]
     // reuse transform for concurrent requests
@@ -267,7 +274,7 @@ export class ViteNodeServer {
       const start = performance.now()
       const r = await this._transformRequest(id, filePath, transformMode)
       duration = performance.now() - start
-      result = { code: r?.code, map: this.options.sourcemap ? r?.map as any : undefined }
+      result = { code: r?.code, map: r?.map as any }
     }
 
     const cacheEntry = {

--- a/packages/vitest/src/integrations/env/loader.ts
+++ b/packages/vitest/src/integrations/env/loader.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { normalize, resolve } from 'pathe'
 import { ViteNodeRunner } from 'vite-node/client'
 import type { ViteNodeRunnerOptions } from 'vite-node'
@@ -26,7 +27,12 @@ export async function loadEnvironment(ctx: ContextRPC, rpc: WorkerRPC): Promise<
     return environments[name]
   const loader = await createEnvironmentLoader({
     root: ctx.config.root,
-    fetchModule: id => rpc.fetch(id, 'ssr'),
+    fetchModule: async (id) => {
+      const result = await rpc.fetch(id, 'ssr')
+      if (result.id)
+        return { code: readFileSync(result.id, 'utf-8') }
+      return result
+    },
     resolveId: (id, importer) => rpc.resolveId(id, importer, 'ssr'),
   })
   const root = loader.root

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -39,7 +39,7 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       }
       const code = result.code
       const dir = join(tmpdir(), transformMode)
-      const tmp = join(dir, id.replace(/[/\\?%*:|"<>]/g, '_'))
+      const tmp = join(dir, id.replace(/[/\\?%*:|"<>]/g, '_').replace('\0', '__x00__'))
       if (promises.has(tmp)) {
         await promises.get(tmp)
         return { id: tmp }

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -27,12 +27,13 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
     },
     async fetch(id, transformMode) {
       const result = await project.vitenode.fetchResult(id, transformMode)
+      const code = result.code
       if (result.externalize)
         return result
-      if (!result.code && 'id' in result)
+      if ('id' in result)
         return { id: result.id as string }
 
-      if (!result.code)
+      if (!code)
         throw new Error(`Failed to fetch module ${id}`)
 
       const dir = join(project.tmpDir, transformMode)
@@ -45,10 +46,8 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
         await mkdir(dir, { recursive: true })
         created.add(dir)
       }
-      const code = result.code
       promises.set(tmp, writeFile(tmp, code, 'utf-8').finally(() => promises.delete(tmp)))
       await promises.get(tmp)
-      result.code = undefined
       Object.assign(result, { id: tmp })
       return { id: tmp }
     },

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -39,7 +39,7 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       }
       const code = result.code
       const dir = join(tmpdir(), transformMode)
-      const tmp = join(dir, id.replace(/[\s/\\]/g, '_'))
+      const tmp = join(dir, id.replace(/[/\\?%*:|"<>]/g, '_'))
       if (promises.has(tmp)) {
         await promises.get(tmp)
         return { id: tmp }

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -33,12 +33,11 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       if (!result.code && 'id' in result)
         return result
 
-      if (!result.code) {
-        console.error(result)
-        return { code: `throw new Error('What is going on?')` }
-      }
+      if (!result.code)
+        throw new Error(`Failed to fetch module ${id}`)
+
       const code = result.code
-      const dir = join(tmpdir(), transformMode)
+      const dir = join(tmpdir(), project.id, transformMode)
       const tmp = join(dir, id.replace(/[/\\?%*:|"<>]/g, '_').replace('\0', '__x00__'))
       if (promises.has(tmp)) {
         await promises.get(tmp)

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -1,6 +1,12 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import type { RawSourceMap } from 'vite-node'
+import { join } from 'pathe'
 import type { RuntimeRPC } from '../../types'
 import type { WorkspaceProject } from '../workspace'
+
+const created = new Set()
+const promises = new Map<string, Promise<void>>()
 
 export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
   const ctx = project.ctx
@@ -20,8 +26,33 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       const r = await project.vitenode.transformRequest(id)
       return r?.map as RawSourceMap | undefined
     },
-    fetch(id, transformMode) {
-      return project.vitenode.fetchModule(id, transformMode)
+    async fetch(id, transformMode) {
+      const result = await project.vitenode.fetchModule(id, transformMode)
+      if (result.externalize)
+        return result
+      if (!result.code && 'id' in result)
+        return result
+
+      if (!result.code) {
+        console.error(result)
+        return { code: `throw new Error('What is going on?')` }
+      }
+      const code = result.code
+      const dir = join(tmpdir(), transformMode)
+      const tmp = join(dir, id.replace(/[\s/\\]/g, '_'))
+      if (promises.has(tmp)) {
+        await promises.get(tmp)
+        return { id: tmp }
+      }
+      if (!created.has(dir)) {
+        await mkdir(dir, { recursive: true })
+        created.add(dir)
+      }
+      promises.set(tmp, writeFile(tmp, code, 'utf-8').finally(() => promises.delete(tmp)))
+      await promises.get(tmp)
+      result.code = undefined
+      Object.assign(result, { id: tmp })
+      return { id: tmp }
     },
     resolveId(id, importer, transformMode) {
       return project.vitenode.resolveId(id, importer, transformMode)

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -27,7 +27,7 @@ export function createMethodsRPC(project: WorkspaceProject): RuntimeRPC {
       return r?.map as RawSourceMap | undefined
     },
     async fetch(id, transformMode) {
-      const result = await project.vitenode.fetchModule(id, transformMode)
+      const result = await project.vitenode.fetchResult(id, transformMode)
       if (result.externalize)
         return result
       if (!result.code && 'id' in result)

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -232,7 +232,7 @@ export abstract class BaseReporter implements Reporter {
     const setupTime = files.reduce((acc, test) => acc + Math.max(0, test.setupDuration || 0), 0)
     const testsTime = files.reduce((acc, test) => acc + Math.max(0, test.result?.duration || 0), 0)
     const transformTime = this.ctx.projects
-      .flatMap(w => Array.from(w.vitenode.fetchCache.values()).map(i => i.duration || 0))
+      .flatMap(w => w.vitenode.getTotalDuration())
       .reduce((a, b) => a + b, 0)
     const environmentTime = files.reduce((acc, file) => acc + Math.max(0, file.environmentLoad || 0), 0)
     const prepareTime = files.reduce((acc, file) => acc + Math.max(0, file.prepareDuration || 0), 0)

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -8,10 +8,10 @@ import { ViteNodeServer } from 'vite-node/server'
 import c from 'picocolors'
 import { createBrowserServer } from '../integrations/browser/server'
 import type { ProvidedContext, ResolvedConfig, UserConfig, UserWorkspaceConfig, Vitest } from '../types'
-import { deepMerge } from '../utils'
 import type { Typechecker } from '../typecheck/typechecker'
 import type { BrowserProvider } from '../types/browser'
 import { getBrowserProvider } from '../integrations/browser'
+import { deepMerge, nanoid } from '../utils/base'
 import { isBrowserEnabled, resolveConfig } from './config'
 import { WorkspaceVitestPlugin } from './plugins/workspace'
 import { createViteServer } from './vite'
@@ -77,6 +77,8 @@ export class WorkspaceProject {
   } | undefined
 
   testFilesList: string[] | null = null
+
+  public readonly id = nanoid()
 
   private _globalSetups: GlobalSetupFile[] | undefined
   private _provided: ProvidedContext = {} as any

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -1,5 +1,6 @@
 import vm from 'node:vm'
 import { pathToFileURL } from 'node:url'
+import { readFileSync } from 'node:fs'
 import type { ModuleCacheMap } from 'vite-node/client'
 import { DEFAULT_REQUEST_STUBS, ViteNodeRunner } from 'vite-node/client'
 import { isInternalRequest, isNodeBuiltin, isPrimitive, toFilePath } from 'vite-node/utils'
@@ -104,7 +105,12 @@ export async function startVitestExecutor(options: ContextExecutorOptions) {
         return { externalize: id }
       }
 
-      return rpc().fetch(id, getTransformMode())
+      const result = await rpc().fetch(id, getTransformMode())
+      if (result.id && !result.externalize) {
+        const code = readFileSync(result.id, 'utf-8')
+        return { code }
+      }
+      return result
     },
     resolveId(id, importer) {
       return rpc().resolveId(id, importer, getTransformMode())

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -1,6 +1,6 @@
 import vm from 'node:vm'
 import { pathToFileURL } from 'node:url'
-import { readFile } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
 import type { ModuleCacheMap } from 'vite-node/client'
 import { DEFAULT_REQUEST_STUBS, ViteNodeRunner } from 'vite-node/client'
 import { isInternalRequest, isNodeBuiltin, isPrimitive, toFilePath } from 'vite-node/utils'
@@ -107,7 +107,7 @@ export async function startVitestExecutor(options: ContextExecutorOptions) {
 
       const result = await rpc().fetch(id, getTransformMode())
       if (result.id && !result.externalize) {
-        const code = await readFile(result.id, 'utf-8')
+        const code = readFileSync(result.id, 'utf-8')
         return { code }
       }
       return result

--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -1,6 +1,6 @@
 import vm from 'node:vm'
 import { pathToFileURL } from 'node:url'
-import { readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import type { ModuleCacheMap } from 'vite-node/client'
 import { DEFAULT_REQUEST_STUBS, ViteNodeRunner } from 'vite-node/client'
 import { isInternalRequest, isNodeBuiltin, isPrimitive, toFilePath } from 'vite-node/utils'
@@ -107,7 +107,7 @@ export async function startVitestExecutor(options: ContextExecutorOptions) {
 
       const result = await rpc().fetch(id, getTransformMode())
       if (result.id && !result.externalize) {
-        const code = readFileSync(result.id, 'utf-8')
+        const code = await readFile(result.id, 'utf-8')
         return { code }
       }
       return result

--- a/packages/vitest/src/types/rpc.ts
+++ b/packages/vitest/src/types/rpc.ts
@@ -9,7 +9,10 @@ import type { AfterSuiteRunMeta } from './worker'
 type TransformMode = 'web' | 'ssr'
 
 export interface RuntimeRPC {
-  fetch: (id: string, environment: TransformMode) => Promise<FetchResult>
+  fetch: (id: string, environment: TransformMode) => Promise<{
+    externalize?: string
+    id?: string
+  }>
   transform: (id: string, environment: TransformMode) => Promise<FetchResult>
   resolveId: (id: string, importer: string | undefined, environment: TransformMode) => Promise<ViteNodeResolveId | null>
   getSourceMap: (id: string, force?: boolean) => Promise<RawSourceMap | undefined>

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -169,3 +169,14 @@ export function escapeRegExp(s: string) {
 export function wildcardPatternToRegExp(pattern: string): RegExp {
   return new RegExp(`^${pattern.split('*').map(escapeRegExp).join('.*')}$`, 'i')
 }
+
+// port from nanoid
+// https://github.com/ai/nanoid
+const urlAlphabet
+  = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
+export function nanoid(size = 21) {
+  let id = ''
+  let i = size
+  while (i--) id += urlAlphabet[(Math.random() * 64) | 0]
+  return id
+}

--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import type { WorkerGlobalState } from 'vitest'
 import ponyfillStructuredClone from '@ungap/structured-clone'
 import createDebug from 'debug'
@@ -65,8 +66,13 @@ export function getRunnerOptions(): any {
   const { config, rpc, mockMap, moduleCache } = state
 
   return {
-    fetchModule(id: string) {
-      return rpc.fetch(id, 'web')
+    async fetchModule(id: string) {
+      const result = await rpc.fetch(id, 'web')
+      if (result.id && !result.externalize) {
+        const code = await readFile(result.id, 'utf-8')
+        return { code }
+      }
+      return result
     },
     resolveId(id: string, importer?: string) {
       return rpc.resolveId(id, importer, 'web')

--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
 import type { WorkerGlobalState } from 'vitest'
 import ponyfillStructuredClone from '@ungap/structured-clone'
 import createDebug from 'debug'
@@ -69,7 +69,7 @@ export function getRunnerOptions(): any {
     async fetchModule(id: string) {
       const result = await rpc.fetch(id, 'web')
       if (result.id && !result.externalize) {
-        const code = await readFile(result.id, 'utf-8')
+        const code = readFileSync(result.id, 'utf-8')
         return { code }
       }
       return result

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -879,7 +879,7 @@ importers:
         version: 4.3.10
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       execa:
         specifier: ^8.0.1
         version: 8.0.1
@@ -7064,7 +7064,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8569,6 +8569,17 @@ packages:
       ms: 2.1.3
       supports-color: 8.1.1
     dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10855,7 +10866,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10906,7 +10917,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
### Description

This PR makes forks pool 2 times faster on https://github.com/vuejs/core monorepo (using M1 Air):

Before:

```
threads:
Duration  16.17s (transform 5.28s, setup 740ms, collect 54.54s, tests 7.42s, environment 14.06s, prepare 13.76s)

forks:
Duration  28.68s (transform 6.17s, setup 1.30s, collect 138.67s, tests 5.53s, environment 11.92s, prepare 11.67s)
```

After:

```
threads:
Duration  16.29s (transform 6.79s, setup 1.81s, collect 55.58s, tests 6.79s, environment 12.41s, prepare 14.32s)

forks:
Duration  18.89s (transform 7.70s, setup 811ms, collect 65.05s, tests 7.40s, environment 14.14s, prepare 14.98s)
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
