### PR TITLE
fix(browser): dispose tester iframe on done

### DIFF
--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -69,6 +69,10 @@ client.ws.addEventListener('open', async () => {
         const filenames = e.data.filenames
         filenames.forEach(filename => runningFiles.delete(filename))
 
+        const iframeId = filenames.length > 1 ? ID_ALL : filenames[0]
+        iframes.get(iframeId)?.remove()
+        iframes.delete(iframeId)
+
         if (!runningFiles.size)
           await done()
         break


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5382

Currently iframes are not disposed and that seems to make browser mode get stuck.
We might not want to always dispose the iframe, for example, if users are expecting to view the actual browser render (cf. https://github.com/vitest-dev/vitest/issues/5568), but I think that can be implemented as a dedicated option (like `browser.retainWindow` or something) and disposing them by default for stability seems right.

_Test plan_

I tested a same patch on https://github.com/underoot/vitest-large-file-list-issue with 300 test files and it's working fine at least with `fileParallelism: false`: 

![image](https://github.com/vitest-dev/vitest/assets/4232207/1e46dfcc-8bec-4e70-96ab-7cba0a7f719b)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
