### PR TITLE
fix: always run `onTestFinished` in reverse order

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1010,6 +1010,10 @@ test('performs an organization query', async () => {
 })
 ```
 
+::: tip
+This hook is always called in reverse order and is not affected by [`sequence.hooks`](/config/#sequence-hooks) option.
+:::
+
 ### onTestFailed
 
 This hook is called only after the test has failed. It is called after `afterEach` hooks since they can influence the test result. It receives a `TaskResult` object with the current test result. This hook is useful for debugging.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1865,6 +1865,10 @@ Changes the order in which hooks are executed.
 - `list` will order all hooks in the order they are defined
 - `parallel` will run hooks in a single group in parallel (hooks in parent suites will still run before the current suite's hooks)
 
+::: tip
+This option doesn't affect [`onTestFinished`](/api/#ontestfinished). It is always called in reverse order.
+:::
+
 #### sequence.setupFiles <Badge type="info">0.29.3+</Badge> {#sequence-setupfiles}
 
 - **Type**: `'list' | 'parallel'`

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -1,4 +1,5 @@
 import limit from 'p-limit'
+import type { Awaitable } from '@vitest/utils'
 import { getSafeTimers, shuffle } from '@vitest/utils'
 import { processError } from '@vitest/utils/error'
 import type { DiffOptions } from '@vitest/utils/diff'
@@ -31,6 +32,19 @@ function getSuiteHooks(suite: Suite, name: keyof SuiteHooks, sequence: SequenceH
   if (sequence === 'stack' && (name === 'afterAll' || name === 'afterEach'))
     return hooks.slice().reverse()
   return hooks
+}
+
+async function callTaskHooks(task: Task, hooks: ((result: TaskResult) => Awaitable<void>)[], sequence: SequenceHooks) {
+  if (sequence === 'stack')
+    hooks = hooks.slice().reverse()
+
+  if (sequence === 'parallel') {
+    await Promise.all(hooks.map(fn => fn(task.result!)))
+  }
+  else {
+    for (const fn of hooks)
+      await fn(task.result!)
+  }
 }
 
 export async function callSuiteHook<T extends keyof SuiteHooks>(
@@ -211,7 +225,7 @@ export async function runTest(test: Test | Custom, runner: VitestRunner) {
   }
 
   try {
-    await Promise.all(test.onFinished?.map(fn => fn(test.result!)) || [])
+    await callTaskHooks(test, test.onFinished || [], 'stack')
   }
   catch (e) {
     failTask(test.result, e, runner.config.diffOptions)
@@ -219,7 +233,7 @@ export async function runTest(test: Test | Custom, runner: VitestRunner) {
 
   if (test.result.state === 'fail') {
     try {
-      await Promise.all(test.onFailed?.map(fn => fn(test.result!)) || [])
+      await callTaskHooks(test, test.onFailed || [], runner.config.sequence.hooks)
     }
     catch (e) {
       failTask(test.result, e, runner.config.diffOptions)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10923,19 +10923,12 @@ packages:
   /@types/eslint-scope@3.7.6:
     resolution: {integrity: sha512-zfM4ipmxVKWdxtDaJ3MP3pBurDXOCoyjvlpE3u6Qzrmw4BPbfm4/ambIeTk/r/J0iq/+2/xp0Fmt+gFvXJY2PQ==}
     dependencies:
-      '@types/eslint': 8.44.6
+      '@types/eslint': 8.56.10
       '@types/estree': 1.0.5
     dev: true
 
   /@types/eslint@8.4.6:
     resolution: {integrity: sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==}
-    dependencies:
-      '@types/estree': 1.0.5
-      '@types/json-schema': 7.0.14
-    dev: true
-
-  /@types/eslint@8.44.6:
-    resolution: {integrity: sha512-P6bY56TVmX8y9J87jHNgQh43h6VVU+6H7oN7hgvivV81K2XY8qJZ5vqPy/HdUoVIelii2kChYVzQanlswPWVFw==}
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.14
@@ -11727,7 +11720,7 @@ packages:
     resolution: {integrity: sha512-LKGAXMPQs8U/zMRFXDZOzmMKgFv3COlxUQ+2NMPhbqgVm6R1w+nU1i4836Pmxu9jZAuIeyySNrN/6Rc657ggig==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      eslint: ^8.56.0 || ^9.0.0
+      eslint: ^8.56.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.1.0)
       '@types/json-schema': 7.0.15
@@ -26239,7 +26232,7 @@ packages:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.14
+      '@types/json-schema': 7.0.15
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: true

--- a/test/core/test/on-finished.test.ts
+++ b/test/core/test/on-finished.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, onTestFinished } from 'vitest'
 
 const collected: any[] = []
+const multiple: any[] = []
 
 it('on-finished regular', () => {
   collected.push(1)
@@ -38,6 +39,23 @@ it.fails('failed finish context', (t) => {
   collected.push(null)
 })
 
+it('multiple on-finished', () => {
+  onTestFinished(() => {
+    multiple.push(1)
+  })
+  onTestFinished(() => {
+    multiple.push(2)
+  })
+  onTestFinished(async () => {
+    await new Promise(r => setTimeout(r, 100))
+    multiple.push(3)
+  })
+  onTestFinished(() => {
+    multiple.push(4)
+  })
+})
+
 it('after', () => {
   expect(collected).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+  expect(multiple).toEqual([4, 3, 2, 1])
 })


### PR DESCRIPTION
### Description

Fixes #5529

TODO:
- [x] Test

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
