### PR TITLE
docs: Updating migration guide file (jest -> vitest) for server.deps.inline property

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -186,6 +186,14 @@ const { cloneDeep } = jest.requireActual('lodash/cloneDeep') // [!code --]
 const { cloneDeep } = await vi.importActual('lodash/cloneDeep') // [!code ++]
 ```
 
+### Extends mocking to external libraries
+
+Where Jest does it by default, when mocking a module and wanting this mocking to be extended to other external libraries that use the same module, you should explicitly tell which 3rd-party library you want to be mocked, so the external library would be part of your source code, by using [server.deps.inline](https://vitest.dev/config/#server-deps-inline).
+
+```
+server.deps.inline: ["lib-name"]
+```
+
 ### Accessing the Return Values of a Mocked Promise
 
 Both Jest and Vitest store the results of all mock calls in the [`mock.results`](/api/mock.html#mock-results) array, where the return values of each call are stored in the `value` property.


### PR DESCRIPTION
### Description

This PR aims to add a new small documentation chapter regarding the migration page [located here](https://vitest.dev/guide/migration.html#migrating-from-jest).

It will help future folks who will want to mock modules that are already mocked in their source code that they own but not mocked in external libraries that they use.

For instance, I encountered the case a couple of days ago here:
- https://github.com/vitest-dev/vitest/discussions/5589

The situation is more detailed in the above link.