### PR TITLE
fix: backport jest iterable equality within object

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -411,6 +411,11 @@ export function iterableEquality(a: any, b: any, customTesters: Array<Tester> = 
   if (!bIterator.next().done)
     return false
 
+  const aEntries = Object.entries(a)
+  const bEntries = Object.entries(b)
+  if (!equals(aEntries, bEntries))
+    return false
+
   // Remove the first value from the stack of traversed values.
   aStack.pop()
   bStack.pop()

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -391,3 +391,48 @@ describe('Error equality', () => {
     }
   })
 })
+
+describe('iterator', () => {
+  test('returns true when given iterator within equal objects', () => {
+    const a = {
+      [Symbol.iterator]: () => ({ next: () => ({ done: true }) }),
+      a: [],
+    }
+    const b = {
+      [Symbol.iterator]: () => ({ next: () => ({ done: true }) }),
+      a: [],
+    }
+
+    expect(a).toStrictEqual(b)
+  })
+
+  test('returns false when given iterator within inequal objects', () => {
+    const a = {
+      [Symbol.iterator]: () => ({ next: () => ({ done: true }) }),
+      a: [1],
+    }
+    const b = {
+      [Symbol.iterator]: () => ({ next: () => ({ done: true }) }),
+      a: [],
+    }
+
+    expect(a).not.toStrictEqual(b)
+  })
+
+  test('returns false when given iterator within inequal nested objects', () => {
+    const a = {
+      [Symbol.iterator]: () => ({ next: () => ({ done: true }) }),
+      a: {
+        b: [1],
+      },
+    }
+    const b = {
+      [Symbol.iterator]: () => ({ next: () => ({ done: true }) }),
+      a: {
+        b: [],
+      },
+    }
+
+    expect(a).not.toStrictEqual(b)
+  })
+})


### PR DESCRIPTION
https://github.com/vitest-dev/vitest/issues/5620