### PR TITLE
fix(reporter): use default error formatter for JUnit

### DIFF
--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -65,7 +65,7 @@ export class GithubActionsReporter implements Reporter {
 
 // use Logger with custom Console to extract messgage from `processError` util
 // TODO: maybe refactor `processError` to require single function `(message: string) => void` instead of full Logger?
-async function printErrorWrapper(error: unknown, ctx: Vitest, project: WorkspaceProject) {
+export async function printErrorWrapper(error: unknown, ctx: Vitest, project: WorkspaceProject) {
   let output = ''
   const writable = new Writable({
     write(chunk, _encoding, callback) {

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -212,7 +212,7 @@ export class JUnitReporter implements Reporter {
                 this.ctx,
                 this.ctx.getProjectByTaskId(task.id),
               )
-              await this.baseLog(escapeXML(stripAnsi(result.output)))
+              await this.baseLog(escapeXML(stripAnsi(result.output.trim())))
             })
           }
         }

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -11,6 +11,7 @@ import { parseErrorStacktrace } from '../../utils/source-map'
 import { F_POINTER } from '../../utils/figures'
 import { getOutputFile } from '../../utils/config-helpers'
 import { IndentedLogger } from './renderers/indented-logger'
+import { printErrorWrapper } from './github-actions'
 
 export interface JUnitOptions {
   outputFile?: string
@@ -205,7 +206,13 @@ export class JUnitReporter implements Reporter {
               if (!error)
                 return
 
-              await this.writeErrorDetails(task, error)
+              const result = await printErrorWrapper(
+                error,
+                this.ctx,
+                this.ctx.getProjectByTaskId(task.id),
+              )
+              // TODO: should strip color?
+              await this.baseLog(escapeXML(result.output))
             })
           }
         }

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -5,6 +5,7 @@ import { dirname, relative, resolve } from 'pathe'
 import type { Task } from '@vitest/runner'
 import type { ErrorWithDiff } from '@vitest/utils'
 import { getSuites } from '@vitest/runner/utils'
+import stripAnsi from 'strip-ansi'
 import type { Vitest } from '../../node'
 import type { Reporter } from '../../types/reporter'
 import { parseErrorStacktrace } from '../../utils/source-map'
@@ -211,8 +212,7 @@ export class JUnitReporter implements Reporter {
                 this.ctx,
                 this.ctx.getProjectByTaskId(task.id),
               )
-              // TODO: should strip color?
-              await this.baseLog(escapeXML(result.output))
+              await this.baseLog(escapeXML(stripAnsi(result.output)))
             })
           }
         }

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -3,13 +3,10 @@ import { hostname } from 'node:os'
 import { dirname, relative, resolve } from 'pathe'
 
 import type { Task } from '@vitest/runner'
-import type { ErrorWithDiff } from '@vitest/utils'
 import { getSuites } from '@vitest/runner/utils'
 import stripAnsi from 'strip-ansi'
 import type { Vitest } from '../../node'
 import type { Reporter } from '../../types/reporter'
-import { parseErrorStacktrace } from '../../utils/source-map'
-import { F_POINTER } from '../../utils/figures'
 import { getOutputFile } from '../../utils/config-helpers'
 import { IndentedLogger } from './renderers/indented-logger'
 import { printErrorWrapper } from './github-actions'
@@ -140,31 +137,6 @@ export class JUnitReporter implements Reporter {
     this.logger.unindent()
 
     await this.logger.log(`</${name}>`)
-  }
-
-  async writeErrorDetails(task: Task, error: ErrorWithDiff): Promise<void> {
-    const errorName = error.name ?? error.nameStr ?? 'Unknown Error'
-    const errorDetails = `${errorName}: ${error.message}`
-
-    // Be sure to escape any XML in the error Details
-    await this.baseLog(escapeXML(errorDetails))
-
-    const project = this.ctx.getProjectByTaskId(task.id)
-    const stack = parseErrorStacktrace(error, {
-      getSourceMap: file => project.getBrowserSourceMapModuleById(file),
-      frameFilter: this.ctx.config.onStackTrace,
-    })
-
-    // TODO: This is same as printStack but without colors. Find a way to reuse code.
-    for (const frame of stack) {
-      const path = relative(this.ctx.config.root, frame.file)
-
-      await this.baseLog(escapeXML(` ${F_POINTER} ${[frame.method, `${path}:${frame.line}:${frame.column}`].filter(Boolean).join(' ')}`))
-
-      // reached at test file, skip the follow stack
-      if (frame.file in this.ctx.state.filesMap)
-        break
-    }
   }
 
   async writeLogs(task: Task, type: 'err' | 'out'): Promise<void> {


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5603

Since we now have reusable `printErrorWrapper` (introduced for github actions reporter https://github.com/vitest-dev/vitest/pull/5093) to generate the default error formatting, probably using it for Junit would make sense.

This wrapper supports all the good things automatically:
- expected/actual diff
- stack
- formatting of `throw {somePlainObject}` (which is what OP mentioned)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
