### PR TITLE
docs: Improve formatting and readability of the Mocking / Cheat Sheet section

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -497,7 +497,10 @@ vi.spyOn(exports, 'getter', 'get').mockReturnValue('mocked')
 
 1. Example with `vi.mock`:
 
-Example with `vi.mock`:
+::: warning
+Don't forget that a `vi.mock` call is hoisted to top of the file. It will always be executed before all imports.
+:::
+
 ```ts
 // ./some-path.js
 export function method() {}
@@ -643,8 +646,11 @@ expect(__VERSION__).toBe('1.0.0')
 
 ### Mock `import.meta.env`
 
-To change environmental variable, you can just assign a new value to it. This value will **not** automatically reset between different tests.
 1. To change environmental variable, you can just assign a new value to it.
+
+::: warning
+The environmental variable value will **_not_** automatically reset between different tests.
+:::
 
 ```ts
 import { beforeEach, expect, it } from 'vitest'

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -474,14 +474,14 @@ describe('delayed execution', () => {
 
 I want to…
 
-- Spy on a `method`
+### Spy on a `method`
 
 ```ts
 const instance = new SomeClass()
 vi.spyOn(instance, 'method')
 ```
 
-- Mock exported variables
+### Mock exported variables
 ```js
 // some-path.js
 export const getter = 'variable'
@@ -493,7 +493,9 @@ import * as exports from './some-path.js'
 vi.spyOn(exports, 'getter', 'get').mockReturnValue('mocked')
 ```
 
-- Mock exported function
+### Mock an exported function
+
+1. Example with `vi.mock`:
 
 Example with `vi.mock`:
 ```ts
@@ -508,20 +510,16 @@ vi.mock('./some-path.js', () => ({
 }))
 ```
 
-::: warning
-Don't forget that `vi.mock` call is hoisted to top of the file. **Do not** put `vi.mock` calls inside `beforeEach`, only one of these will actually mock a module.
-:::
-
-Example with `vi.spyOn`:
+2. Example with `vi.spyOn`:
 ```ts
 import * as exports from './some-path.js'
 
 vi.spyOn(exports, 'method').mockImplementation(() => {})
 ```
 
-- Mock exported class implementation
+### Mock an exported class implementation
 
-Example with `vi.mock` and prototype:
+1. Example with `vi.mock` and `.prototype`:
 ```ts
 // some-path.ts
 export class SomeClass {}
@@ -537,7 +535,7 @@ vi.mock('./some-path.js', () => {
 // SomeClass.mock.instances will have SomeClass
 ```
 
-Example with `vi.mock` and return value:
+2. Example with `vi.mock` and a return value:
 ```ts
 import { SomeClass } from './some-path.js'
 
@@ -550,7 +548,7 @@ vi.mock('./some-path.js', () => {
 // SomeClass.mock.returns will have returned object
 ```
 
-Example with `vi.spyOn`:
+3. Example with `vi.spyOn`:
 
 ```ts
 import * as exports from './some-path.js'
@@ -560,9 +558,9 @@ vi.spyOn(exports, 'SomeClass').mockImplementation(() => {
 })
 ```
 
-- Spy on an object returned from a function
+### Spy on an object returned from a function
 
-Example using cache:
+1. Example using cache:
 
 ```ts
 // some-path.ts
@@ -603,7 +601,7 @@ const obj = useObject()
 expect(obj.method).toHaveBeenCalled()
 ```
 
-- Mock part of a module
+### Mock part of a module
 
 ```ts
 import { mocked, original } from './some-path.js'
@@ -619,7 +617,7 @@ original() // has original behaviour
 mocked() // is a spy function
 ```
 
-- Mock current date
+### Mock the current date
 
 To mock `Date`'s time, you can use `vi.setSystemTime` helper function. This value will **not** automatically reset between different tests.
 
@@ -634,7 +632,7 @@ expect(now.valueOf()).toBe(mockDate.valueOf())
 vi.useRealTimers()
 ```
 
-- Mock global variable
+### Mock a global variable
 
 You can set global variable by assigning a value to `globalThis` or using [`vi.stubGlobal`](/api/vi#vi-stubglobal) helper. When using `vi.stubGlobal`, it will **not** automatically reset between different tests, unless you enable [`unstubGlobals`](/config/#unstubglobals) config option or call [`vi.unstubAllGlobals`](/api/vi#vi-unstuballglobals).
 
@@ -643,9 +641,10 @@ vi.stubGlobal('__VERSION__', '1.0.0')
 expect(__VERSION__).toBe('1.0.0')
 ```
 
-- Mock `import.meta.env`
+### Mock `import.meta.env`
 
 To change environmental variable, you can just assign a new value to it. This value will **not** automatically reset between different tests.
+1. To change environmental variable, you can just assign a new value to it.
 
 ```ts
 import { beforeEach, expect, it } from 'vitest'
@@ -663,7 +662,7 @@ it('changes value', () => {
 })
 ```
 
-If you want to automatically reset value, you can use `vi.stubEnv` helper with [`unstubEnvs`](/config/#unstubenvs) config option enabled (or call [`vi.unstubAllEnvs`](/api/vi#vi-unstuballenvs) manually in `beforeEach` hook):
+2. If you want to automatically reset the value(s), you can use the `vi.stubEnv` helper with the [`unstubEnvs`](/config/#unstubenvs) config option enabled (or call [`vi.unstubAllEnvs`](/api/vi#vi-unstuballenvs) manually in a `beforeEach` hook):
 
 ```ts
 import { expect, it, vi } from 'vitest'


### PR DESCRIPTION
### Description
Addresses #5631 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Problem:
The  [Cheat Sheet](https://vitest.dev/guide/mocking.html#cheat-sheet) section of the *Mocking* guide is hard to read. The section uses bullets (`- `) for each "topic" (item that the user wants to do), but these bullets show up as indented under normal paragraphs, e.g. "Examples", and thus seem to be sub-sections of the examples.


Changes:
1. Each "topic"  is a sub-heading 1 level under the  "Cheat Sheet" heading level. Examples and text are visually (and semantically) "under" the topic.
2. If there is more than 1 example for each topic, they are numbered. This makes them easy to refer to both within the documentation and during any discussion.
3. Moved *warning* sections up so they are more prominent; they are seen _before_ the code examples. (When they're after code examples, they could easily be missed.)
4. Minor grammatical errors fixed (a/an, inserting 'the', etc.)


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
