### PR TITLE
fix: keep order of arguments for .each in custom task collectors

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -299,11 +299,20 @@ function createSuite() {
         fnOrOptions,
       )
 
+      const fnFirst = typeof optionsOrFn === 'function'
+
       cases.forEach((i, idx) => {
         const items = Array.isArray(i) ? i : [i]
-        arrayOnlyCases
-          ? suite(formatTitle(_name, items, idx), options, () => handler(...items))
-          : suite(formatTitle(_name, items, idx), options, () => handler(i))
+        if (fnFirst) {
+          arrayOnlyCases
+            ? suite(formatTitle(_name, items, idx), () => handler(...items), options)
+            : suite(formatTitle(_name, items, idx), () => handler(i), options)
+        }
+        else {
+          arrayOnlyCases
+            ? suite(formatTitle(_name, items, idx), options, () => handler(...items))
+            : suite(formatTitle(_name, items, idx), options, () => handler(i))
+        }
       })
 
       this.setContext('each', undefined)
@@ -341,12 +350,21 @@ export function createTaskCollector(
         fnOrOptions,
       )
 
+      const fnFirst = typeof optionsOrFn === 'function'
+
       cases.forEach((i, idx) => {
         const items = Array.isArray(i) ? i : [i]
 
-        arrayOnlyCases
-          ? test(formatTitle(_name, items, idx), options, () => handler(...items))
-          : test(formatTitle(_name, items, idx), options, () => handler(i))
+        if (fnFirst) {
+          arrayOnlyCases
+            ? test(formatTitle(_name, items, idx), () => handler(...items), options)
+            : test(formatTitle(_name, items, idx), () => handler(i), options)
+        }
+        else {
+          arrayOnlyCases
+            ? test(formatTitle(_name, items, idx), options, () => handler(...items))
+            : test(formatTitle(_name, items, idx), options, () => handler(i))
+        }
       })
 
       this.setContext('each', undefined)

--- a/test/core/test/task-collector.test.ts
+++ b/test/core/test/task-collector.test.ts
@@ -1,0 +1,25 @@
+import { expect, test, vi } from 'vitest'
+import { createTaskCollector } from 'vitest/suite'
+
+test('collector keeps the order of arguments', () => {
+  const fn = vi.fn()
+  const collector = createTaskCollector(fn)
+  const cb = vi.fn()
+  const options = {}
+
+  collector('a', cb, options)
+
+  expect(fn).toHaveBeenNthCalledWith(1, 'a', cb, options)
+
+  collector('a', options, cb)
+
+  expect(fn).toHaveBeenNthCalledWith(2, 'a', options, cb)
+
+  collector.each([1])('a', cb, options)
+
+  expect(fn).toHaveBeenNthCalledWith(3, 'a', expect.any(Function), options)
+
+  collector.each([1])('a', options, cb)
+
+  expect(fn).toHaveBeenNthCalledWith(4, 'a', options, expect.any(Function))
+})


### PR DESCRIPTION
### Description

Fixes #5231

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
