### PR TITLE
fix(coverage): apply `vite-node`'s wrapper only to executed files

### DIFF
--- a/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/istanbul.report.test.ts.snap
@@ -1895,6 +1895,54 @@ exports[`istanbul json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/load-outside-vite.cjs": {
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 30,
+            "line": 1,
+          },
+          "start": {
+            "column": 26,
+            "line": 1,
+          },
+        },
+        "loc": {
+          "end": {
+            "column": 35,
+            "line": 1,
+          },
+          "start": {
+            "column": 33,
+            "line": 1,
+          },
+        },
+        "name": "noop",
+      },
+    },
+    "path": "<process-cwd>/src/load-outside-vite.cjs",
+    "s": {
+      "0": 0,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/multi-environment.ts": {
     "b": {
       "0": [

--- a/test/coverage-test/coverage-report-tests/__snapshots__/v8.report.test.ts.snap
+++ b/test/coverage-test/coverage-report-tests/__snapshots__/v8.report.test.ts.snap
@@ -4345,6 +4345,56 @@ exports[`v8 json report 1`] = `
       },
     },
   },
+  "<process-cwd>/src/load-outside-vite.cjs": {
+    "all": false,
+    "b": {},
+    "branchMap": {},
+    "f": {
+      "0": 0,
+    },
+    "fnMap": {
+      "0": {
+        "decl": {
+          "end": {
+            "column": 35,
+            "line": 1,
+          },
+          "start": {
+            "column": 17,
+            "line": 1,
+          },
+        },
+        "line": 1,
+        "loc": {
+          "end": {
+            "column": 35,
+            "line": 1,
+          },
+          "start": {
+            "column": 17,
+            "line": 1,
+          },
+        },
+        "name": "noop",
+      },
+    },
+    "path": "<process-cwd>/src/load-outside-vite.cjs",
+    "s": {
+      "0": 1,
+    },
+    "statementMap": {
+      "0": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+  },
   "<process-cwd>/src/multi-environment.ts": {
     "all": false,
     "b": {

--- a/test/coverage-test/src/load-outside-vite.cjs
+++ b/test/coverage-test/src/load-outside-vite.cjs
@@ -1,0 +1,1 @@
+module.exports = function noop() {}

--- a/test/coverage-test/test/coverage.test.ts
+++ b/test/coverage-test/test/coverage.test.ts
@@ -84,3 +84,10 @@ test.runIf(provider === 'v8' || provider === 'custom')('pre-transpiled code with
 
   transpiled.hello()
 })
+
+test.runIf(provider === 'v8' || provider === 'custom')('file loaded outside Vite, #5639', async () => {
+  const { Module: { createRequire } } = await import('node:module')
+
+  const noop = createRequire(import.meta.url)('../src/load-outside-vite.cjs')
+  expect(noop).toBeTypeOf('function')
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes #5639 
- This is an edge case that can happen if a file was loaded outside Vitest, e.g. using `require()`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
