### PR TITLE
fix: call `resolveId('vitest')` after `buildStart`

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -381,11 +381,6 @@ export class Vitest {
   async start(filters?: string[]) {
     this._onClose = []
 
-    // if Vitest is running globally, then we should still import local vitest if possible
-    const projectVitestPath = await this.vitenode.resolveId('vitest')
-    const vitestDir = projectVitestPath ? resolve(projectVitestPath.id, '../..') : rootDir
-    this.distPath = join(vitestDir, 'dist')
-
     try {
       await this.initCoverageProvider()
       await this.coverageProvider?.clean(this.config.coverage.clean)
@@ -508,7 +503,19 @@ export class Vitest {
       await project.initializeGlobalSetup()
   }
 
+  private async initializeDistPath() {
+    if (this.distPath)
+      return
+
+    // if Vitest is running globally, then we should still import local vitest if possible
+    const projectVitestPath = await this.vitenode.resolveId('vitest')
+    const vitestDir = projectVitestPath ? resolve(projectVitestPath.id, '../..') : rootDir
+    this.distPath = join(vitestDir, 'dist')
+  }
+
   async runFiles(paths: WorkspaceSpec[], allTestsRun: boolean) {
+    await this.initializeDistPath()
+
     const filepaths = paths.map(([, file]) => file)
     this.state.collectPaths(filepaths)
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -95,6 +95,7 @@ export class Vitest {
     this.pool = undefined
     this.coverageProvider = undefined
     this.runningPromise = undefined
+    this.distPath = undefined!
     this.projectsTestFiles.clear()
 
     const resolved = resolveConfig(this.mode, options, server.config, this.logger)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1,6 +1,7 @@
 import { existsSync, promises as fs } from 'node:fs'
 import type { Writable } from 'node:stream'
 import { isMainThread } from 'node:worker_threads'
+import { createRequire } from 'node:module'
 import type { ViteDevServer } from 'vite'
 import { mergeConfig } from 'vite'
 import { basename, dirname, join, normalize, relative, resolve } from 'pathe'
@@ -111,8 +112,16 @@ export class Vitest {
     this.vitenode = new ViteNodeServer(server, this.config.server)
 
     // if Vitest is running globally, then we should still import local vitest if possible
-    const projectVitestPath = await this.vitenode.resolveId('vitest')
-    const vitestDir = projectVitestPath ? resolve(projectVitestPath.id, '../..') : rootDir
+    function getVitestDir(configRoot: string) {
+      const require = createRequire(import.meta.url)
+      try {
+        const vitestCjsPath = require.resolve('vitest', { paths: [configRoot, rootDir] })
+        return resolve(vitestCjsPath, '..')
+      }
+      catch {}
+      return rootDir
+    }
+    const vitestDir = getVitestDir(resolved.root)
     this.distPath = join(vitestDir, 'dist')
 
     const node = this.vitenode

--- a/test/cli/fixtures/create-vitest/basic.test.ts
+++ b/test/cli/fixtures/create-vitest/basic.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+test("basic", () => {
+  expect(1).toBe(1);
+})

--- a/test/cli/fixtures/create-vitest/vitest.config.ts
+++ b/test/cli/fixtures/create-vitest/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/test/cli/fixtures/plugin/basic.test.ts
+++ b/test/cli/fixtures/plugin/basic.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+test("basic", () => {
+  expect(1).toBe(1);
+})

--- a/test/cli/fixtures/plugin/vitest.config.ts
+++ b/test/cli/fixtures/plugin/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "test-default",
+      configureServer() {
+        console.log("##test## configureServer(default)")
+      },
+      buildStart() {
+        console.log("##test## buildStart(default)")
+      },
+      resolveId(source) {
+        console.log("##test## resolveId(default)")
+        console.log({ source })
+      },
+      transform(_code, id) {
+        console.log("##test## transform(default)")
+        console.log({ id })
+      },
+    },
+    {
+      name: "test-pre",
+      enforce: "pre",
+      configureServer() {
+        console.log("##test## configureServer(pre)")
+      },
+      buildStart() {
+        console.log("##test## buildStart(pre)")
+      },
+      resolveId(source) {
+        console.log("##test## resolveId(pre)")
+        console.log({ source })
+      },
+      transform(_code, id) {
+        console.log("##test## transform(pre)")
+        console.log({ id })
+      },
+    }
+  ]
+})

--- a/test/cli/fixtures/plugin/vitest.config.ts
+++ b/test/cli/fixtures/plugin/vitest.config.ts
@@ -1,40 +1,46 @@
 import { defineConfig } from 'vitest/config'
 
+const testHooks: string[] = (globalThis as any).__testHooks ??= [];
+
 export default defineConfig({
   plugins: [
     {
       name: "test-default",
       configureServer() {
-        console.log("##test## configureServer(default)")
+        testHooks.push("configureServer(default)")
+        console.log("configureServer(default)")
       },
       buildStart() {
-        console.log("##test## buildStart(default)")
+        testHooks.push("buildStart(default)")
+        console.log("buildStart(default)")
       },
       resolveId(source) {
-        console.log("##test## resolveId(default)")
-        console.log({ source })
+        testHooks.push("resolveId(default)")
+        console.log("resolveId(default)", source)
       },
       transform(_code, id) {
-        console.log("##test## transform(default)")
-        console.log({ id })
+        testHooks.push("transform(default)")
+        console.log("transform(default)", id)
       },
     },
     {
       name: "test-pre",
       enforce: "pre",
       configureServer() {
-        console.log("##test## configureServer(pre)")
+        testHooks.push("configureServer(pre)")
+        console.log("configureServer(pre)")
       },
       buildStart() {
-        console.log("##test## buildStart(pre)")
+        testHooks.push("buildStart(pre)")
+        console.log("buildStart(pre)")
       },
       resolveId(source) {
-        console.log("##test## resolveId(pre)")
-        console.log({ source })
+        testHooks.push("resolveId(pre)")
+        console.log("resolveId(pre)", source)
       },
       transform(_code, id) {
-        console.log("##test## transform(pre)")
-        console.log({ id })
+        testHooks.push("transform(pre)")
+        console.log("transform(pre)", id)
       },
     }
   ]

--- a/test/cli/fixtures/plugin/vitest.config.ts
+++ b/test/cli/fixtures/plugin/vitest.config.ts
@@ -1,46 +1,44 @@
 import { defineConfig } from 'vitest/config'
 
-const testHooks: string[] = (globalThis as any).__testHooks ??= [];
+function logHook(...args: unknown[]) {
+  ((globalThis as any).__testHooks ??= []).push(args[0]);
+
+  if (process.env["LOG_HOOK"]) {
+    console.log(...args);
+  }
+}
 
 export default defineConfig({
   plugins: [
     {
       name: "test-default",
       configureServer() {
-        testHooks.push("configureServer(default)")
-        console.log("configureServer(default)")
+        logHook("configureServer(default)")
       },
       buildStart() {
-        testHooks.push("buildStart(default)")
-        console.log("buildStart(default)")
+        logHook("buildStart(default)")
       },
       resolveId(source) {
-        testHooks.push("resolveId(default)")
-        console.log("resolveId(default)", source)
+        logHook("resolveId(default)", source)
       },
       transform(_code, id) {
-        testHooks.push("transform(default)")
-        console.log("transform(default)", id)
+        logHook("transform(default)", id)
       },
     },
     {
       name: "test-pre",
       enforce: "pre",
       configureServer() {
-        testHooks.push("configureServer(pre)")
-        console.log("configureServer(pre)")
+        logHook("configureServer(pre)")
       },
       buildStart() {
-        testHooks.push("buildStart(pre)")
-        console.log("buildStart(pre)")
+        logHook("buildStart(pre)")
       },
       resolveId(source) {
-        testHooks.push("resolveId(pre)")
-        console.log("resolveId(pre)", source)
+        logHook("resolveId(pre)", source)
       },
       transform(_code, id) {
-        testHooks.push("transform(pre)")
-        console.log("transform(pre)", id)
+        logHook("transform(pre)", id)
       },
     }
   ]

--- a/test/cli/test/create-vitest.test.ts
+++ b/test/cli/test/create-vitest.test.ts
@@ -1,0 +1,28 @@
+import { expect, it, vi } from 'vitest'
+import { createVitest } from 'vitest/node'
+
+it(createVitest, async () => {
+  const onFinished = vi.fn()
+  const ctx = await createVitest('test', {
+    watch: false,
+    root: 'fixtures/create-vitest',
+    reporters: [
+      {
+        onFinished,
+      },
+    ],
+  })
+  const testFiles = await ctx.globTestFiles()
+  await ctx.runFiles(testFiles, false)
+  expect(onFinished.mock.calls[0]).toMatchObject([
+    [
+      {
+        name: 'basic.test.ts',
+        result: {
+          state: 'pass',
+        },
+      },
+    ],
+    [],
+  ])
+})

--- a/test/cli/test/plugin.test.ts
+++ b/test/cli/test/plugin.test.ts
@@ -1,28 +1,15 @@
-import { Console } from 'node:console'
-import { Writable } from 'node:stream'
-import { expect, it, vi } from 'vitest'
+import { expect, it } from 'vitest'
 import { runVitest } from '../../test-utils'
 
 it('plugin hooks', async () => {
-  // capture console on main process
-  let stdout = ''
-  vi.stubGlobal('console', new Console({
-    stdout: new Writable({
-      write: (data, _, callback) => {
-        stdout += String(data)
-        callback()
-      },
-    }),
-  }))
   await runVitest({ root: './fixtures/plugin' })
-  vi.unstubAllGlobals()
-
-  const lines = stdout.split('\n').filter(line => line.startsWith('##test##'))
-  expect(lines.slice(0, 5)).toEqual([
-    '##test## configureServer(pre)',
-    '##test## configureServer(default)',
-    '##test## buildStart(pre)',
-    '##test## buildStart(default)',
-    '##test## resolveId(pre)',
-  ])
+  expect((globalThis as any).__testHooks.slice(0, 5)).toEqual(
+    [
+      'configureServer(pre)',
+      'configureServer(default)',
+      'buildStart(pre)',
+      'buildStart(default)',
+      'resolveId(pre)',
+    ],
+  )
 })

--- a/test/cli/test/plugin.test.ts
+++ b/test/cli/test/plugin.test.ts
@@ -1,0 +1,28 @@
+import { Console } from 'node:console'
+import { Writable } from 'node:stream'
+import { expect, it, vi } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+it('plugin hooks', async () => {
+  // capture console on main process
+  let stdout = ''
+  vi.stubGlobal('console', new Console({
+    stdout: new Writable({
+      write: (data, _, callback) => {
+        stdout += String(data)
+        callback()
+      },
+    }),
+  }))
+  await runVitest({ root: './fixtures/plugin' })
+  vi.unstubAllGlobals()
+
+  const lines = stdout.split('\n').filter(line => line.startsWith('##test##'))
+  expect(lines.slice(0, 5)).toEqual([
+    '##test## configureServer(pre)',
+    '##test## configureServer(default)',
+    '##test## buildStart(pre)',
+    '##test## buildStart(default)',
+    '##test## resolveId(pre)',
+  ])
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5616

`ctx.distPath` is only used by pool `runTests`, so we can move `resolveId` from `ctx.setServer` to `ctx.start`.

_todo_

- [x] test with vscode extension
  - verified locally with `pnpm.overrides`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
