### PR TITLE
chore: add setup-overrides script

### DIFF
--- a/scripts/setup-overrides.ts
+++ b/scripts/setup-overrides.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert'
+import fs from 'node:fs'
+import { dirname } from 'node:path'
+import fg from 'fast-glob'
+
+// usage:
+// npx tsx scripts/setup-overrides.ts <target-package.json>
+
+async function main() {
+  const [targetPath] = process.argv.slice(2)
+  assert.ok(fs.existsSync(targetPath))
+
+  const pkgPaths = await fg('./packages/*/package.json', { absolute: true })
+  const overrides: Record<string, string> = {}
+  for (const pkgPath of pkgPaths) {
+    const pkg = await readJson(pkgPath)
+    overrides[pkg.name] = `file:${dirname(pkgPath)}`
+  }
+
+  await editJson(targetPath, (data) => {
+    Object.assign((data.pnpm ??= {}).overrides ??= {}, overrides)
+    return data
+  })
+}
+
+async function readJson(file: string) {
+  return JSON.parse(await fs.promises.readFile(file, 'utf-8'))
+}
+
+async function editJson(file: string, edit: (data: any) => any) {
+  const data = await readJson(file)
+  await fs.promises.writeFile(file, JSON.stringify(edit(data), null, 2))
+}
+
+main()


### PR DESCRIPTION
### Description

This script could be useful to setup ecosystem-ci like environment locally.

Example:

By running the script from Vitest repo root,

```sh
npx tsx scripts/setup-overrides.ts /home/hiroshi/code/others/vitest-vscode/package.json
```

it will setup `pnpm.overrides` for all Vitest packages with `file:...` protocol.


```ts
  ...
  "pnpm": {
    "overrides": {
      "@vitest/browser": "file:/home/hiroshi/code/others/vitest/packages/browser",
      "@vitest/coverage-istanbul": "file:/home/hiroshi/code/others/vitest/packages/coverage-istanbul",
      "@vitest/coverage-v8": "file:/home/hiroshi/code/others/vitest/packages/coverage-v8",
      "@vitest/expect": "file:/home/hiroshi/code/others/vitest/packages/expect",
      "@vitest/runner": "file:/home/hiroshi/code/others/vitest/packages/runner",
      "@vitest/spy": "file:/home/hiroshi/code/others/vitest/packages/spy",
      "@vitest/snapshot": "file:/home/hiroshi/code/others/vitest/packages/snapshot",
      "@vitest/ui": "file:/home/hiroshi/code/others/vitest/packages/ui",
      "@vitest/utils": "file:/home/hiroshi/code/others/vitest/packages/utils",
      "vite-node": "file:/home/hiroshi/code/others/vitest/packages/vite-node",
      "vitest": "file:/home/hiroshi/code/others/vitest/packages/vitest",
      "@vitest/web-worker": "file:/home/hiroshi/code/others/vitest/packages/web-worker",
      "@vitest/ws-client": "file:/home/hiroshi/code/others/vitest/packages/ws-client"
    }
  }
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
