### PR TITLE
chore: set `package-manager-strict`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ provenance=true
 shell-emulator=true
 registry=https://registry.npmjs.org/
 VITE_NODE_DEPS_MODULE_DIRECTORIES=/node_modules/,/packages/
+package-manager-strict=false


### PR DESCRIPTION
### Description
After pnpm releases version [9.0.3](https://github.com/pnpm/pnpm/releases/tag/v9.0.3), when the local pnpm version and packageManger version do not match, an error message will appear and the process will exit when running `pnpm i`.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
