### PR TITLE
feat(browser): allow injecting scripts

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1612,6 +1612,55 @@ This option has no effect on tests running inside Node.js.
 
 If you rely on spying on ES modules with `vi.spyOn`, you can enable this experimental feature to allow spying on module exports.
 
+#### browser.indexScripts <Version>1.6.0</Version> {#browser-indexscripts}
+
+- **Type:** `BrowserScript[]`
+- **Default:** `[]`
+
+Custom scripts that should be injected into the index HTML before test iframes are initiated. This HTML document only sets up iframes and doesn't actually import your code.
+
+The script `src` and `content` will be processed by Vite plugins. Script should be provided in the following shape:
+
+```ts
+export interface BrowserScript {
+  /**
+   * If "content" is provided and type is "module", this will be its identifier.
+   *
+   * If you are using TypeScript, you can add `.ts` extension here for example.
+   * @default `injected-${index}.js`
+   */
+  id?: string
+  /**
+   * JavaScript content to be injected. This string is processed by Vite plugins if type is "module".
+   *
+   * You can use `id` to give Vite a hint about the file extension.
+   */
+  content?: string
+  /**
+   * Path to the script. This value is resolved by Vite so it can be a node module or a file path.
+   */
+  src?: string
+  /**
+   * If the script should be loaded asynchronously.
+   */
+  async?: boolean
+  /**
+   * Script type.
+   * @default 'module'
+   */
+  type?: string
+}
+```
+
+#### browser.testerScripts <Version>1.6.0</Version> {#browser-testerscripts}
+
+- **Type:** `BrowserScript[]`
+- **Default:** `[]`
+
+Custom scripts that should be injected into the tester HTML before the tests environment is initiated. This is useful to inject polyfills required for Vitest browser implementation. It is recommended to use [`setupFiles`](#setupfiles) in almost all cases instead of this.
+
+The script `src` and `content` will be processed by Vite plugins.
+
 ### clearMocks
 
 - **Type:** `boolean`

--- a/packages/browser/src/client/index.html
+++ b/packages/browser/src/client/index.html
@@ -22,6 +22,7 @@
       }
     </style>
     <script>{__VITEST_INJECTOR__}</script>
+    {__VITEST_SCRIPTS__}
   </head>
   <body>
     <iframe id="vitest-ui" src=""></iframe>

--- a/packages/browser/src/client/tester.html
+++ b/packages/browser/src/client/tester.html
@@ -16,6 +16,7 @@
       }
     </style>
     <script>{__VITEST_INJECTOR__}</script>
+    {__VITEST_SCRIPTS__}
   </head>
   <body>
     <script type="module" src="/tester.ts"></script>

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -252,6 +252,6 @@ function scriptFormatter(scripts: BrowserScript[] | undefined) {
   if (!scripts?.length)
     return ''
   return scripts.map(({ content, src, async }) => {
-    return `<script type="module"${async ? ' async' : ''}${src ? ` src="${src}"` : ''}>${content}</script>`
+    return `<script type="module"${async ? ' async' : ''}${src ? ` src="${src}"` : ''}>${content || ''}</script>`
   }).join('\n')
 }

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -6,6 +6,7 @@ import type { Plugin, ViteDevServer } from 'vite'
 import type { ResolvedConfig } from 'vitest'
 import type { BrowserScript, WorkspaceProject } from 'vitest/node'
 import { coverageConfigDefaults } from 'vitest/config'
+import { slash } from '@vitest/utils'
 import { injectVitestModule } from './esmInjector'
 
 export default (project: WorkspaceProject, base = '/'): Plugin[] => {
@@ -254,7 +255,7 @@ async function formatScripts(scripts: BrowserScript[] | undefined, server: ViteD
     const contentProcessed = content && type === 'module'
       ? (await server.pluginContainer.transform(content, transformId)).code
       : content
-    return `<script type="${type}"${async ? ' async' : ''}${srcLink ? ` src="${srcLink}"` : ''}>${contentProcessed || ''}</script>`
+    return `<script type="${type}"${async ? ' async' : ''}${srcLink ? ` src="${slash(`/@fs/${srcLink}`)}"` : ''}>${contentProcessed || ''}</script>`
   })
   return (await Promise.all(promises)).join('\n')
 }

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -29,8 +29,6 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
         const injectorJs = readFile(resolve(distRoot, 'client/esm-client-injector.js'), 'utf8')
         const favicon = `${base}favicon.svg`
         const testerPrefix = `${base}__vitest_test__/__test__/`
-        let cachedTesterHtml: string | undefined
-        let cachedRunnerHtml: string | undefined
         server.middlewares.use((_req, res, next) => {
           const headers = server.config.server.headers
           if (headers) {
@@ -61,15 +59,10 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
           })
 
           if (url.pathname === base) {
-            if (!cachedRunnerHtml) {
-              cachedRunnerHtml = replacer(await runnerHtml, {
-                __VITEST_SCRIPTS__: scriptFormatter(project.config.browser.indexScripts),
-              })
-            }
-
-            const html = replacer(cachedRunnerHtml, {
+            const html = replacer(await runnerHtml, {
               __VITEST_FAVICON__: favicon,
               __VITEST_TITLE__: 'Vitest Browser Runner',
+              __VITEST_SCRIPTS__: formatScripts(project.config.browser.indexScripts),
               __VITEST_INJECTOR__: injector,
             })
             res.write(html, 'utf-8')
@@ -81,15 +74,10 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
           // if decoded test file is "__vitest_all__" or not in the list of known files, run all tests
           const tests = decodedTestFile === '__vitest_all__' || !files.includes(decodedTestFile) ? '__vitest_browser_runner__.files' : JSON.stringify([decodedTestFile])
 
-          if (!cachedTesterHtml) {
-            cachedTesterHtml = replacer(await testerHtml, {
-              __VITEST_SCRIPTS__: scriptFormatter(project.config.browser.testerScripts),
-            })
-          }
-
-          const html = replacer(cachedTesterHtml, {
+          const html = replacer(await testerHtml, {
             __VITEST_FAVICON__: favicon,
             __VITEST_TITLE__: 'Vitest Browser Tester',
+            __VITEST_SCRIPTS__: formatScripts(project.config.browser.testerScripts),
             __VITEST_INJECTOR__: injector,
             __VITEST_APPEND__:
             // TODO: have only a single global variable to not pollute the global scope
@@ -248,10 +236,10 @@ function replacer(code: string, values: Record<string, string>) {
   return code.replace(/{\s*(\w+)\s*}/g, (_, key) => values[key] ?? '')
 }
 
-function scriptFormatter(scripts: BrowserScript[] | undefined) {
+function formatScripts(scripts: BrowserScript[] | undefined) {
   if (!scripts?.length)
     return ''
-  return scripts.map(({ content, src, async }) => {
-    return `<script type="module"${async ? ' async' : ''}${src ? ` src="${src}"` : ''}>${content || ''}</script>`
+  return scripts.map(({ content, src, async, type = 'module' }) => {
+    return `<script type="${type}"${async ? ' async' : ''}${src ? ` src="${src}"` : ''}>${content || ''}</script>`
   }).join('\n')
 }

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath } from 'node:url'
 import { readFile } from 'node:fs/promises'
-import { basename, resolve } from 'pathe'
+import { basename, join, resolve } from 'pathe'
 import sirv from 'sirv'
-import type { Plugin } from 'vite'
+import type { Plugin, ViteDevServer } from 'vite'
 import type { ResolvedConfig } from 'vitest'
 import type { BrowserScript, WorkspaceProject } from 'vitest/node'
 import { coverageConfigDefaults } from 'vitest/config'
@@ -37,6 +37,8 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
           }
           next()
         })
+        let indexScripts: string | undefined
+        let testerScripts: string | undefined
         server.middlewares.use(async (req, res, next) => {
           if (!req.url)
             return next()
@@ -59,10 +61,13 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
           })
 
           if (url.pathname === base) {
+            if (!indexScripts)
+              indexScripts = await formatScripts(project.config.browser.indexScripts, server)
+
             const html = replacer(await runnerHtml, {
               __VITEST_FAVICON__: favicon,
               __VITEST_TITLE__: 'Vitest Browser Runner',
-              __VITEST_SCRIPTS__: formatScripts(project.config.browser.indexScripts),
+              __VITEST_SCRIPTS__: indexScripts,
               __VITEST_INJECTOR__: injector,
             })
             res.write(html, 'utf-8')
@@ -74,10 +79,13 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
           // if decoded test file is "__vitest_all__" or not in the list of known files, run all tests
           const tests = decodedTestFile === '__vitest_all__' || !files.includes(decodedTestFile) ? '__vitest_browser_runner__.files' : JSON.stringify([decodedTestFile])
 
+          if (!testerScripts)
+            testerScripts = await formatScripts(project.config.browser.testerScripts, server)
+
           const html = replacer(await testerHtml, {
             __VITEST_FAVICON__: favicon,
             __VITEST_TITLE__: 'Vitest Browser Tester',
-            __VITEST_SCRIPTS__: formatScripts(project.config.browser.testerScripts),
+            __VITEST_SCRIPTS__: testerScripts,
             __VITEST_INJECTOR__: injector,
             __VITEST_APPEND__:
             // TODO: have only a single global variable to not pollute the global scope
@@ -236,10 +244,17 @@ function replacer(code: string, values: Record<string, string>) {
   return code.replace(/{\s*(\w+)\s*}/g, (_, key) => values[key] ?? '')
 }
 
-function formatScripts(scripts: BrowserScript[] | undefined) {
+async function formatScripts(scripts: BrowserScript[] | undefined, server: ViteDevServer) {
   if (!scripts?.length)
     return ''
-  return scripts.map(({ content, src, async, type = 'module' }) => {
-    return `<script type="${type}"${async ? ' async' : ''}${src ? ` src="${src}"` : ''}>${content || ''}</script>`
-  }).join('\n')
+  const promises = scripts.map(async ({ content, src, async, id, type = 'module' }, index) => {
+    const srcLink = (src ? (await server.pluginContainer.resolveId(src))?.id : undefined) || src
+    const transformId = srcLink || join(server.config.root, `virtual__${id || `injected-${index}.js`}`)
+    await server.moduleGraph.ensureEntryFromUrl(transformId)
+    const contentProcessed = content && type === 'module'
+      ? (await server.pluginContainer.transform(content, transformId)).code
+      : content
+    return `<script type="${type}"${async ? ' async' : ''}${srcLink ? ` src="${srcLink}"` : ''}>${contentProcessed || ''}</script>`
+  })
+  return (await Promise.all(promises)).join('\n')
 }

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -350,6 +350,8 @@ export const cliOptionsConfig: VitestCLIOptions = {
       fileParallelism: {
         description: 'Should all test files run in parallel. Use `--browser.file-parallelism=false` to disable (default: same as `--file-parallelism`)',
       },
+      indexScripts: null,
+      testerScripts: null,
     },
   },
   pool: {

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -13,4 +13,4 @@ export { VitestPackageInstaller } from './packageInstaller'
 export type { TestSequencer, TestSequencerConstructor } from './sequencers/types'
 export { BaseSequencer } from './sequencers/BaseSequencer'
 
-export type { BrowserProviderInitializationOptions, BrowserProvider, BrowserProviderOptions } from '../types/browser'
+export type { BrowserProviderInitializationOptions, BrowserProvider, BrowserProviderOptions, BrowserScript } from '../types/browser'

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -93,6 +93,22 @@ export interface BrowserConfigOptions {
    * @default test.fileParallelism
    */
   fileParallelism?: boolean
+
+  /**
+   * Scripts injected into the tester iframe.
+   */
+  testerScripts?: BrowserScript[]
+
+  /**
+   * Scripts injected into the main window.
+   */
+  indexScripts?: BrowserScript[]
+}
+
+export interface BrowserScript {
+  content?: string
+  src?: string
+  async?: boolean
 }
 
 export interface ResolvedBrowserOptions extends BrowserConfigOptions {

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -106,10 +106,29 @@ export interface BrowserConfigOptions {
 }
 
 export interface BrowserScript {
+  /**
+   * If "content" is provided and type is "module", this will be its identifier.
+   *
+   * If you are using TypeScript, you can add `.ts` extension here for example.
+   * @default `injected-${index}.js`
+   */
+  id?: string
+  /**
+   * JavaScript content to be injected. This string is processed by Vite plugins if type is "module".
+   *
+   * You can use `id` to give Vite a hint about the file extension.
+   */
   content?: string
+  /**
+   * Path to the script. This value is resolved by Vite so it can be a node module or a file path.
+   */
   src?: string
+  /**
+   * If the script should be loaded asynchronously.
+   */
   async?: boolean
   /**
+   * Script type.
    * @default 'module'
    */
   type?: string

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -109,6 +109,10 @@ export interface BrowserScript {
   content?: string
   src?: string
   async?: boolean
+  /**
+   * @default 'module'
+   */
+  type?: string
 }
 
 export interface ResolvedBrowserOptions extends BrowserConfigOptions {

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -16,6 +16,7 @@ import type { BenchmarkUserOptions } from './benchmark'
 import type { BrowserConfigOptions, ResolvedBrowserOptions } from './browser'
 import type { Pool, PoolOptions } from './pool-options'
 
+export type { BrowserScript, BrowserConfigOptions } from './browser'
 export type { SequenceHooks, SequenceSetupFiles } from '@vitest/runner'
 
 export type BuiltinEnvironment = 'node' | 'jsdom' | 'happy-dom' | 'edge-runtime'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -879,7 +879,7 @@ importers:
         version: 4.3.10
       debug:
         specifier: ^4.3.4
-        version: 4.3.4
+        version: 4.3.4(supports-color@8.1.1)
       execa:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1060,6 +1060,9 @@ importers:
       '@vitest/cjs-lib':
         specifier: link:./cjs-lib
         version: link:cjs-lib
+      '@vitest/injected-lib':
+        specifier: link:./injected-lib
+        version: link:injected-lib
       execa:
         specifier: ^7.1.1
         version: 7.1.1
@@ -7064,7 +7067,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8569,17 +8572,6 @@ packages:
       ms: 2.1.3
       supports-color: 8.1.1
     dev: true
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10866,7 +10858,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10917,7 +10909,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/test/browser/injected-lib/index.js
+++ b/test/browser/injected-lib/index.js
@@ -1,0 +1,1 @@
+__injected.push(4)

--- a/test/browser/injected-lib/package.json
+++ b/test/browser/injected-lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitest/injected-lib",
+  "type": "module",
+  "exports": {
+    "default": "./index.js"
+  }
+}

--- a/test/browser/injected.ts
+++ b/test/browser/injected.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error not typed global
+;(__injected as string[]).push(3)

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -15,6 +15,7 @@
     "@vitejs/plugin-basic-ssl": "^1.0.2",
     "@vitest/browser": "workspace:*",
     "@vitest/cjs-lib": "link:./cjs-lib",
+    "@vitest/injected-lib": "link:./injected-lib",
     "execa": "^7.1.1",
     "playwright": "^1.41.0",
     "url": "^0.11.3",

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from 'vitest'
+import { beforeAll, describe, expect, onTestFailed, test } from 'vitest'
 import { runBrowserTests } from './utils'
 
 describe.each([
@@ -26,6 +26,10 @@ describe.each([
   })
 
   test(`[${description}] tests are actually running`, () => {
+    onTestFailed(() => {
+      console.error(stderr)
+    })
+
     expect(browserResultJson.testResults).toHaveLength(15)
     expect(passedTests).toHaveLength(13)
     expect(failedTests).toHaveLength(2)

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -26,8 +26,8 @@ describe.each([
   })
 
   test(`[${description}] tests are actually running`, () => {
-    expect(browserResultJson.testResults).toHaveLength(14)
-    expect(passedTests).toHaveLength(12)
+    expect(browserResultJson.testResults).toHaveLength(15)
+    expect(passedTests).toHaveLength(13)
     expect(failedTests).toHaveLength(2)
 
     expect(stderr).not.toContain('has been externalized for browser compatibility')

--- a/test/browser/test/injected.test.ts
+++ b/test/browser/test/injected.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+
+test('injected values are correct', () => {
+  expect((globalThis as any).__injected).toEqual([
+    1,
+    2,
+    3,
+    4,
+  ])
+})

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -29,6 +29,37 @@ export default defineConfig({
       provider,
       isolate: false,
       slowHijackESM: true,
+      testerScripts: [
+        {
+          content: 'globalThis.__injected = []',
+          type: 'text/javascript',
+        },
+        {
+          content: '__injected.push(1)',
+        },
+        {
+          id: 'ts.ts',
+          content: '(__injected as string[]).push(2)',
+        },
+        {
+          src: './injected.ts',
+        },
+        {
+          src: '@vitest/injected-lib',
+        },
+      ],
+      indexScripts: [
+        {
+          content: 'console.log("Hello, World");globalThis.__injected = []',
+          type: 'text/javascript',
+        },
+        {
+          content: 'import "./injected.ts"',
+        },
+        {
+          content: 'if(__injected[0] !== 3) throw new Error("injected not working")',
+        },
+      ],
     },
     alias: {
       '#src': resolve(dir, './src'),


### PR DESCRIPTION
### Description

This PR adds an option to inject custom scripts via `browser.testerScripts` and `browser.indexScripts` options.

Closes #5347

TODO:
- [x] Docs
- [x] Tests

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
