### PR TITLE
perf: unnecessary rpc call when coverage is disabled

### DIFF
--- a/packages/vitest/src/runtime/runners/index.ts
+++ b/packages/vitest/src/runtime/runners/index.ts
@@ -70,11 +70,14 @@ export async function resolveTestRunner(config: ResolvedConfig, executor: Vitest
   testRunner.onAfterRunFiles = async (files) => {
     const state = getWorkerState()
     const coverage = await takeCoverageInsideWorker(config.coverage, executor)
-    rpc().onAfterSuiteRun({
-      coverage,
-      transformMode: state.environment.transformMode,
-      projectName: state.ctx.projectName,
-    })
+
+    if (coverage) {
+      rpc().onAfterSuiteRun({
+        coverage,
+        transformMode: state.environment.transformMode,
+        projectName: state.ctx.projectName,
+      })
+    }
 
     await originalOnAfterRun?.call(testRunner, files)
   }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Small improvement to reduce rpc calls when we know they are unnecessary

Browser runner already does this:

https://github.com/vitest-dev/vitest/blob/bdce0a29db1b5a2766d583cef40277a2b3857659/packages/browser/src/client/runner.ts#L45-L56

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
