### PR TITLE
feat: pretty print diffs coming from cause

### DIFF
--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -124,9 +124,13 @@ export function processError(err: any, diffOptions?: DiffOptions) {
   }
   catch {}
 
-  // Process the cause of the Error in any (recursive)
-  if (typeof err.cause === 'object')
-    processError(err.cause, diffOptions)
+  // some Error implementations may not allow rewriting cause
+  // in most cases, the assignment will lead to "err.cause = err.cause"
+  try {
+    if (typeof err.cause === 'object')
+      err.cause = processError(err.cause, diffOptions)
+  }
+  catch {}
 
   try {
     return serializeError(err)

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -94,7 +94,7 @@ function normalizeErrorMessage(message: string) {
   return message.replace(/__(vite_ssr_import|vi_import)_\d+__\./g, '')
 }
 
-export function processError(err: any, diffOptions?: DiffOptions) {
+export function processError(err: any, diffOptions?: DiffOptions, seen = new WeakSet()) {
   if (!err || typeof err !== 'object')
     return { message: err }
   // stack is not serialized in worker communication
@@ -127,8 +127,10 @@ export function processError(err: any, diffOptions?: DiffOptions) {
   // some Error implementations may not allow rewriting cause
   // in most cases, the assignment will lead to "err.cause = err.cause"
   try {
-    if (typeof err.cause === 'object')
-      err.cause = processError(err.cause, diffOptions)
+    if (!seen.has(err) && typeof err.cause === 'object') {
+      seen.add(err)
+      err.cause = processError(err.cause, diffOptions, seen)
+    }
   }
   catch {}
 

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -121,12 +121,10 @@ export function processError(err: any, diffOptions?: DiffOptions) {
   try {
     if (typeof err.message === 'string')
       err.message = normalizeErrorMessage(err.message)
-
-    if (typeof err.cause === 'object' && typeof err.cause.message === 'string')
-      err.cause.message = normalizeErrorMessage(err.cause.message)
   }
   catch {}
 
+  // Process the cause of the Error in any (recursive)
   if (typeof err.cause === 'object')
     processError(err.cause, diffOptions)
 

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -127,6 +127,9 @@ export function processError(err: any, diffOptions?: DiffOptions) {
   }
   catch {}
 
+  if (typeof err.cause === 'object')
+    processError(err.cause, diffOptions)
+
   try {
     return serializeError(err)
   }

--- a/test/core/test/error.test.ts
+++ b/test/core/test/error.test.ts
@@ -35,3 +35,15 @@ test('Can correctly process error where actual and expected contains non writabl
 
   expect(() => processError(err)).not.toThrow(TypeError)
 })
+
+test('Can correctly process error where cause is a non writable property', () => {
+  const err = new Error('My error')
+
+  Object.defineProperty(err, 'cause', {
+    value: new Error('My cause'),
+    writable: false,
+    enumerable: true,
+  })
+
+  expect(() => processError(err)).not.toThrow(TypeError)
+})

--- a/test/core/test/error.test.ts
+++ b/test/core/test/error.test.ts
@@ -47,3 +47,16 @@ test('Can correctly process error where cause is a non writable property', () =>
 
   expect(() => processError(err)).not.toThrow(TypeError)
 })
+
+test('Can correctly process error where cause leads to an infinite recursion', () => {
+  const err = new Error('My error')
+
+  Object.defineProperty(err, 'cause', {
+    value: err,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+
+  expect(() => processError(err)).not.toThrow()
+})

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -879,6 +879,19 @@ it('correctly prints diff', () => {
   }
 })
 
+it('correctly prints diff for the cause', () => {
+  try {
+    expect({ a: 1 }).toEqual({ a: 2 })
+    expect.unreachable()
+  }
+  catch (err) {
+    setupColors(getDefaultColors())
+    const error = processError(new Error('wrapper', { cause: err }))
+    expect(error.cause.diff).toContain('-   "a": 2')
+    expect(error.cause.diff).toContain('+   "a": 1')
+  }
+})
+
 it('correctly prints diff with asymmetric matchers', () => {
   try {
     expect({ a: 1, b: 'string' }).toEqual({


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This Pull Request adds support for diffs coming nested errors. In the context of Error with cause, if the cause is an Error coming with a diff, the current version of Vitest does not render it in a diff fashion. It tends to make understanding such nested errors complex. The proposal implemented by this PR is to display the diff attached to causes.

Let's consider the following snippet:

```js
import { test, expect } from "vitest";

const value1 = { a: 1, b: 2, c: 3, e: 4, f: 5, g: 6, h: 7, i: 8, j: 9, k: 10 };
const value2 = { a: 1, b: 2, c: 3, e: 4, f: 5, g: 6, h: 7, i: 88, j: 9, k: 10 };

test("rethrown expect as cause", () => {
  try {
    expect(value1).toEqual(value2);
  } catch (err) {
    throw new Error("failed!", { cause: err });
  }
});
```

| Before | After |
|----|---|
| ![image](https://github.com/vitest-dev/vitest/assets/5300235/5151bb22-c444-444f-a18f-f844cb2f3d53) | ![image](https://github.com/vitest-dev/vitest/assets/5300235/f420bdb7-5d2d-4a27-b74b-9d030fe42944) |

Why is rewrapping an Error within a cause a pattern that should be considered? Property Based Testing and Fuzzing frameworks usually rewrap thrown exceptions into their own exception. When leveraging Error with cause mechanisms they may expose the source Error as a cause of their own Error.

<details>
<summary>
Example of fuzzing with fast-check
</summary>

Considered code:
```js
import { test, expect } from "vitest";
import fc from "fast-check";

fc.configureGlobal({ errorWithCause: true });
const value1 = { a: 1, b: 2, c: 3, e: 4, f: 5, g: 6, h: 7, i: 8, j: 9, k: 10 };

test("fuzz", () => {
  fc.assert(
    fc.property(fc.nat(), (i) => {
      expect(value1).toEqual({ ...value1, i });
    })
  );
});
```

| Before | After |
|----|---|
| ![image](https://github.com/vitest-dev/vitest/assets/5300235/0aa052ee-1102-409b-820e-16f9db248ce8) | ![image](https://github.com/vitest-dev/vitest/assets/5300235/dbce06d9-b081-4b53-87a7-e354877e6284) |

_More on fast-check at [fast-check.dev](https://fast-check.dev)_
</details>

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
