### PR TITLE
fix: print console statements in vmThreads

### DIFF
--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -4,6 +4,7 @@ import { relative } from 'node:path'
 import { getColors, getSafeTimers } from '@vitest/utils'
 import { RealDate } from '../integrations/mock/date'
 import { getWorkerState } from '../utils'
+import type { WorkerGlobalState } from '../types'
 
 export const UNKNOWN_TEST_ID = '__vitest__unknown_test__'
 
@@ -27,14 +28,14 @@ function getTaskIdByStack(root: string) {
   return UNKNOWN_TEST_ID
 }
 
-export function createCustomConsole() {
+export function createCustomConsole(defaultState?: WorkerGlobalState) {
   const stdoutBuffer = new Map<string, any[]>()
   const stderrBuffer = new Map<string, any[]>()
   const timers = new Map<string, { stdoutTime: number; stderrTime: number; timer: any }>()
 
   const { setTimeout, clearTimeout } = getSafeTimers()
 
-  const state = () => getWorkerState()
+  const state = () => defaultState || getWorkerState()
 
   // group sync console.log calls with macro task
   function schedule(taskId: string) {

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -48,7 +48,7 @@ export async function runVmTests(state: WorkerGlobalState) {
   // because browser doesn't provide these globals
   context.process = process
   context.global = context
-  context.console = state.config.disableConsoleIntercept ? console : createCustomConsole()
+  context.console = state.config.disableConsoleIntercept ? console : createCustomConsole(state)
   // TODO: don't hardcode setImmediate in fake timers defaults
   context.setImmediate = setImmediate
   context.clearImmediate = clearImmediate

--- a/test/cli/test/setup-files.test.ts
+++ b/test/cli/test/setup-files.test.ts
@@ -2,11 +2,12 @@ import { promises as fs } from 'node:fs'
 import { describe, expect, it, test } from 'vitest'
 import { editFile, runVitest } from '../../test-utils'
 
-test('print stdout and stderr correctly when called in the setup file', async () => {
+test.each(['threads', 'vmThreads'])('%s: print stdout and stderr correctly when called in the setup file', async (pool) => {
   const { stdout, stderr } = await runVitest({
     root: 'fixtures/setup-files',
     include: ['empty.test.ts'],
     setupFiles: ['./console-setup.ts'],
+    pool,
   })
 
   const filepath = 'console-setup.ts'


### PR DESCRIPTION
### Description

The console was failing due to incorrect access to the worker state, but it didn't print anything because it was overriden.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
