### PR TITLE
feat: remove deprecated options

### DIFF
--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -7,11 +7,8 @@ import c from 'picocolors'
 import fg from 'fast-glob'
 import { stringify } from 'flatted'
 import type { File, ModuleGraphData, Reporter, ResolvedConfig, Vitest } from 'vitest'
+import type { HTMLOptions } from 'vitest/node'
 import { getModuleGraph } from '../../vitest/src/utils/graph'
-
-export interface HTMLOptions {
-  outputFile?: string
-}
 
 interface PotentialConfig {
   outputFile?: string | Partial<Record<string, string>>

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -17,8 +17,6 @@ export * from './integrations/chai'
 export * from './integrations/vi'
 export * from './integrations/utils'
 export { inject } from './integrations/inject'
-// TODO: remove in 2.0.0, import from vitest/snapshot directly
-export type { SnapshotEnvironment } from '@vitest/snapshot/environment'
 
 export * from './types'
 export * from './api/types'

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -168,13 +168,6 @@ export function createCLI(options: CLIOptions = {}) {
     benchCliOptionsConfig,
   )
 
-  // TODO: remove in Vitest 2.0
-  cli
-    .command('typecheck [...filters]')
-    .action(() => {
-      throw new Error(`Running typecheck via "typecheck" command is removed. Please use "--typecheck" to run your regular tests alongside typechecking, or "--typecheck.only" to run only typecheck tests.`)
-    })
-
   cli
     .command('[...filters]', undefined, options)
     .action((filters, options) => start('test', filters, options))

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -167,11 +167,6 @@ export function resolveConfig(
     }
   }
 
-  // TODO: V2.0.0 remove
-  // @ts-expect-error -- check for removed API option
-  if (resolved.coverage.provider === 'c8')
-    throw new Error('"coverage.provider: c8" is not supported anymore. Use "coverage.provider: v8" instead')
-
   if (resolved.coverage.provider === 'v8' && resolved.coverage.enabled && isBrowserEnabled(resolved))
     throw new Error('@vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
 

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -13,4 +13,12 @@ export { VitestPackageInstaller } from './packageInstaller'
 export type { TestSequencer, TestSequencerConstructor } from './sequencers/types'
 export { BaseSequencer } from './sequencers/BaseSequencer'
 
-export type { BrowserProviderInitializationOptions, BrowserProvider, BrowserProviderOptions, BrowserScript } from '../types/browser'
+export type {
+  BrowserProviderInitializationOptions,
+  BrowserProvider,
+  BrowserProviderOptions,
+  BrowserScript,
+} from '../types/browser'
+export type { JsonOptions } from './reporters/json'
+export type { JUnitOptions } from './reporters/junit'
+export type { HTMLOptions } from './reporters/html'

--- a/packages/vitest/src/node/reporters/html.ts
+++ b/packages/vitest/src/node/reporters/html.ts
@@ -1,0 +1,3 @@
+export interface HTMLOptions {
+  outputFile?: string
+}

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -10,6 +10,7 @@ import { TapFlatReporter } from './tap-flat'
 import { HangingProcessReporter } from './hanging-process'
 import { GithubActionsReporter } from './github-actions'
 import type { BaseReporter } from './base'
+import type { HTMLOptions } from './html'
 
 export {
   DefaultReporter,
@@ -52,7 +53,7 @@ export interface BuiltinReporterOptions {
   'tap-flat': never
   'junit': JUnitOptions
   'hanging-process': never
-  'html': { outputFile?: string } // TODO: Any better place for defining this UI package's reporter options?
+  'html': HTMLOptions
 }
 
 export * from './benchmark'

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -169,8 +169,7 @@ export class JUnitReporter implements Reporter {
   async writeTasks(tasks: Task[], filename: string): Promise<void> {
     for (const task of tasks) {
       await this.writeElement('testcase', {
-        // TODO: v2.0.0 Remove env variable in favor of custom reporter options, e.g. "reporters: [['json', { classname: 'something' }]]"
-        classname: this.options.classname ?? process.env.VITEST_JUNIT_CLASSNAME ?? filename,
+        classname: this.options.classname ?? filename,
         file: this.options.addFileAttribute ? filename : undefined,
         name: task.name,
         time: getDuration(task),
@@ -264,8 +263,7 @@ export class JUnitReporter implements Reporter {
       stats.failures += file.stats.failures
       return stats
     }, {
-      // TODO: v2.0.0 Remove env variable in favor of custom reporter options, e.g. "reporters: [['json', { suiteName: 'something' }]]"
-      name: this.options.suiteName || process.env.VITEST_JUNIT_SUITE_NAME || 'vitest tests',
+      name: this.options.suiteName || 'vitest tests',
       tests: 0,
       failures: 0,
       errors: 0, // we cannot detect those

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -391,7 +391,6 @@ export interface InlineConfig {
    */
   reporters?: Arrayable<ReporterName | InlineReporter> | ((ReporterName | InlineReporter) | [ReporterName] | ReporterWithOptions)[]
 
-  // TODO: v2.0.0 Remove in favor of custom reporter options, e.g. "reporters: [['json', { outputFile: 'some-dir/file.html' }]]"
   /**
    * Write test results to a file when the --reporter=json` or `--reporter=junit` option is also specified.
    * Also definable individually per reporter by using an object instead.

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -49,13 +49,6 @@ test('inspect-brk cannot be used with multi processing', async () => {
   expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
-test('c8 coverage provider is not supported', async () => {
-  // @ts-expect-error -- check for removed API option
-  const { stderr } = await runVitest({ coverage: { enabled: true, provider: 'c8' } })
-
-  expect(stderr).toMatch('Error: "coverage.provider: c8" is not supported anymore. Use "coverage.provider: v8" instead')
-})
-
 test('v8 coverage provider cannot be used with browser', async () => {
   const { stderr } = await runVitest({ coverage: { enabled: true }, browser: { enabled: true, name: 'chrome' } })
 


### PR DESCRIPTION
### Description

This PR removes:

- `vitest typecheck` command - use `vitest --typecheck` instead 
- `VITEST_JUNIT_CLASSNAME` and `VITEST_JUNIT_SUITE_NAME` env variables (use reporter options instead)
- check for `c8` coverage (use coverage-v8 instead)
- export of `SnapshotEnvironment` from `vitest` - import it from `vitest/snapshot` instead

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
