### PR TITLE
chore(deps): update `tinypool`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -160,7 +160,7 @@
     "picocolors": "^1.0.0",
     "std-env": "^3.7.0",
     "tinybench": "^2.8.0",
-    "tinypool": "^0.8.4",
+    "tinypool": "^0.9.0",
     "vite": "^5.0.0",
     "vite-node": "workspace:*",
     "why-is-node-running": "^2.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,8 +900,8 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0
       tinypool:
-        specifier: ^0.8.4
-        version: 0.8.4
+        specifier: ^0.9.0
+        version: 0.9.0
       vite:
         specifier: ^5.2.6
         version: 5.2.6(@types/node@20.12.11)
@@ -15269,9 +15269,9 @@ packages:
       js-tokens: 8.0.2
     dev: true
 
-  /tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
+  /tinypool@0.9.0:
+    resolution: {integrity: sha512-/aMLccuigz3ZZV8pv/LvOVkOzOfcKkz0V2d5JfHhXUSlp0JJ8h2lAjveUZFTKqII9L4iJh4jod5bfZxx3mditw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     dev: false
 
   /tinyspy@1.0.2:


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Updates Tinypool to the latest breaking change release
- Adds ability to run CI manually. This is useful for forks that are not pushing to their `main` and still want to run CIs before opening PR to upstream.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
