### PR TITLE
chore: tweak `examples/react` tsconfig

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -15,7 +15,6 @@
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.79",
-    "@vitejs/plugin-react": "^4.2.1",
     "@vitest/ui": "latest",
     "jsdom": "^24.0.0",
     "vite": "latest",

--- a/examples/react/test/basic.test.tsx
+++ b/examples/react/test/basic.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { expect, test } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["esnext", "dom"],
     "module": "node16",
     "moduleResolution": "node16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,9 +320,6 @@ importers:
       '@types/react':
         specifier: ^18.2.79
         version: 18.2.79
-      '@vitejs/plugin-react':
-        specifier: ^4.2.1
-        version: 4.2.1(vite@5.2.6)
       '@vitest/ui':
         specifier: latest
         version: link:../../packages/ui
@@ -6181,22 +6178,6 @@ packages:
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
       vite: 5.2.10(@types/node@20.12.11)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@vitejs/plugin-react@4.2.1(vite@5.2.6):
-    resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^5.2.6
-    dependencies:
-      '@babel/core': 7.24.4
-      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.24.4)
-      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.24.4)
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.14.0
-      vite: 5.2.6(@types/node@20.12.11)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
### Description

I think people now normally use `react-jsx`, which makes esbuild to inject `react/jsx-(dev-)runtime` so `import React` is not necessary.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
