### PR TITLE
fix!: don't exit process if config failed

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -193,15 +193,9 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
             console.log('[debug] watcher is ready')
           })
         }
-        try {
-          await ctx.setServer(options, server, userConfig)
-          if (options.api && options.watch)
-            (await import('../../api/setup')).setup(ctx)
-        }
-        catch (err) {
-          ctx.logger.printError(err, { fullStack: true })
-          process.exit(1)
-        }
+        await ctx.setServer(options, server, userConfig)
+        if (options.api && options.watch)
+          (await import('../../api/setup')).setup(ctx)
 
         // #415, in run mode we don't need the watcher, close it would improve the performance
         if (!options.watch)

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -16,49 +16,49 @@ function runVitestCli(...cliArgs: string[]) {
 test('shard cannot be used with watch mode', async () => {
   const { stderr } = await runVitest({ watch: true, shard: '1/2' })
 
-  expect(stderr).toMatch('Error: You cannot use --shard option with enabled watch')
+  expect(stderr).toMatch('You cannot use --shard option with enabled watch')
 })
 
 test('shard must be positive number', async () => {
   const { stderr } = await runVitest({ shard: '-1' })
 
-  expect(stderr).toMatch('Error: --shard <count> must be a positive number')
+  expect(stderr).toMatch('--shard <count> must be a positive number')
 })
 
 test('shard index must be smaller than count', async () => {
   const { stderr } = await runVitest({ shard: '2/1' })
 
-  expect(stderr).toMatch('Error: --shard <index> must be a positive number less then <count>')
+  expect(stderr).toMatch('--shard <index> must be a positive number less then <count>')
 })
 
 test('inspect requires changing pool and singleThread/singleFork', async () => {
   const { stderr } = await runVitest({ inspect: true })
 
-  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('inspect cannot be used with multi-threading', async () => {
   const { stderr } = await runVitest({ inspect: true, pool: 'threads', poolOptions: { threads: { singleThread: false } } })
 
-  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('inspect-brk cannot be used with multi processing', async () => {
   const { stderr } = await runVitest({ inspect: true, pool: 'forks', poolOptions: { forks: { singleFork: false } } })
 
-  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('v8 coverage provider cannot be used with browser', async () => {
   const { stderr } = await runVitest({ coverage: { enabled: true }, browser: { enabled: true, name: 'chrome' } })
 
-  expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+  expect(stderr).toMatch('@vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
 })
 
 test('v8 coverage provider cannot be used with browser in workspace', async () => {
   const { stderr } = await runVitest({ coverage: { enabled: true }, workspace: './fixtures/workspace/browser/workspace-with-browser.ts' })
 
-  expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+  expect(stderr).toMatch('@vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
 })
 
 test('coverage reportsDirectory cannot be current working directory', async () => {
@@ -77,7 +77,7 @@ test('coverage reportsDirectory cannot be current working directory', async () =
   })
 
   const directory = normalize(resolve('./'))
-  expect(stderr).toMatch(`Error: You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
+  expect(stderr).toMatch(`You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
 })
 
 test('coverage reportsDirectory cannot be root', async () => {
@@ -96,7 +96,7 @@ test('coverage reportsDirectory cannot be root', async () => {
   })
 
   const directory = normalize(resolve('./fixtures/test'))
-  expect(stderr).toMatch(`Error: You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
+  expect(stderr).toMatch(`You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
 })
 
 test('version number is printed when coverage provider fails to load', async () => {
@@ -109,7 +109,7 @@ test('version number is printed when coverage provider fails to load', async () 
   })
 
   expect(stdout).toMatch(`RUN  v${version}`)
-  expect(stderr).toMatch('Error: Failed to load custom CoverageProviderModule from ./non-existing-module.ts')
+  expect(stderr).toMatch('Failed to load custom CoverageProviderModule from ./non-existing-module.ts')
 })
 
 test('coverage.autoUpdate cannot update thresholds when configuration file doesnt define them', async () => {
@@ -123,16 +123,16 @@ test('coverage.autoUpdate cannot update thresholds when configuration file doesn
     },
   })
 
-  expect(stderr).toMatch('Error: Unable to parse thresholds from configuration file: Expected config.test.coverage.thresholds to be an object')
+  expect(stderr).toMatch('Unable to parse thresholds from configuration file: Expected config.test.coverage.thresholds to be an object')
 })
 
 test('boolean flag 100 should not crash CLI', async () => {
   const { stderr } = await runVitestCli('--coverage.enabled', '--coverage.thresholds.100')
 
-  expect(stderr).toMatch('ERROR: Coverage for lines (0%) does not meet global threshold (100%)')
-  expect(stderr).toMatch('ERROR: Coverage for functions (0%) does not meet global threshold (100%)')
-  expect(stderr).toMatch('ERROR: Coverage for statements (0%) does not meet global threshold (100%)')
-  expect(stderr).toMatch('ERROR: Coverage for branches (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('Coverage for lines (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('Coverage for functions (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('Coverage for statements (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('Coverage for branches (0%) does not meet global threshold (100%)')
 })
 
 test('nextTick cannot be mocked inside child_process', async () => {
@@ -141,7 +141,7 @@ test('nextTick cannot be mocked inside child_process', async () => {
     include: ['./fake-timers.test.ts'],
   })
 
-  expect(stderr).toMatch('Error: vi.useFakeTimers({ toFake: ["nextTick"] }) is not supported in node:child_process. Use --pool=threads if mocking nextTick is required.')
+  expect(stderr).toMatch('vi.useFakeTimers({ toFake: ["nextTick"] }) is not supported in node:child_process. Use --pool=threads if mocking nextTick is required.')
 })
 
 test('nextTick can be mocked inside worker_threads', async () => {

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -16,49 +16,49 @@ function runVitestCli(...cliArgs: string[]) {
 test('shard cannot be used with watch mode', async () => {
   const { stderr } = await runVitest({ watch: true, shard: '1/2' })
 
-  expect(stderr).toMatch('You cannot use --shard option with enabled watch')
+  expect(stderr).toMatch('Error: You cannot use --shard option with enabled watch')
 })
 
 test('shard must be positive number', async () => {
   const { stderr } = await runVitest({ shard: '-1' })
 
-  expect(stderr).toMatch('--shard <count> must be a positive number')
+  expect(stderr).toMatch('Error: --shard <count> must be a positive number')
 })
 
 test('shard index must be smaller than count', async () => {
   const { stderr } = await runVitest({ shard: '2/1' })
 
-  expect(stderr).toMatch('--shard <index> must be a positive number less then <count>')
+  expect(stderr).toMatch('Error: --shard <index> must be a positive number less then <count>')
 })
 
 test('inspect requires changing pool and singleThread/singleFork', async () => {
   const { stderr } = await runVitest({ inspect: true })
 
-  expect(stderr).toMatch('You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('inspect cannot be used with multi-threading', async () => {
   const { stderr } = await runVitest({ inspect: true, pool: 'threads', poolOptions: { threads: { singleThread: false } } })
 
-  expect(stderr).toMatch('You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('inspect-brk cannot be used with multi processing', async () => {
   const { stderr } = await runVitest({ inspect: true, pool: 'forks', poolOptions: { forks: { singleFork: false } } })
 
-  expect(stderr).toMatch('You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
+  expect(stderr).toMatch('Error: You cannot use --inspect without "--no-file-parallelism", "poolOptions.threads.singleThread" or "poolOptions.forks.singleFork"')
 })
 
 test('v8 coverage provider cannot be used with browser', async () => {
   const { stderr } = await runVitest({ coverage: { enabled: true }, browser: { enabled: true, name: 'chrome' } })
 
-  expect(stderr).toMatch('@vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+  expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
 })
 
 test('v8 coverage provider cannot be used with browser in workspace', async () => {
   const { stderr } = await runVitest({ coverage: { enabled: true }, workspace: './fixtures/workspace/browser/workspace-with-browser.ts' })
 
-  expect(stderr).toMatch('@vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
+  expect(stderr).toMatch('Error: @vitest/coverage-v8 does not work with --browser. Use @vitest/coverage-istanbul instead')
 })
 
 test('coverage reportsDirectory cannot be current working directory', async () => {
@@ -77,7 +77,7 @@ test('coverage reportsDirectory cannot be current working directory', async () =
   })
 
   const directory = normalize(resolve('./'))
-  expect(stderr).toMatch(`You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
+  expect(stderr).toMatch(`Error: You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
 })
 
 test('coverage reportsDirectory cannot be root', async () => {
@@ -96,7 +96,7 @@ test('coverage reportsDirectory cannot be root', async () => {
   })
 
   const directory = normalize(resolve('./fixtures/test'))
-  expect(stderr).toMatch(`You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
+  expect(stderr).toMatch(`Error: You cannot set "coverage.reportsDirectory" as ${directory}. Vitest needs to be able to remove this directory before test run`)
 })
 
 test('version number is printed when coverage provider fails to load', async () => {
@@ -109,7 +109,7 @@ test('version number is printed when coverage provider fails to load', async () 
   })
 
   expect(stdout).toMatch(`RUN  v${version}`)
-  expect(stderr).toMatch('Failed to load custom CoverageProviderModule from ./non-existing-module.ts')
+  expect(stderr).toMatch('Error: Failed to load custom CoverageProviderModule from ./non-existing-module.ts')
 })
 
 test('coverage.autoUpdate cannot update thresholds when configuration file doesnt define them', async () => {
@@ -123,16 +123,16 @@ test('coverage.autoUpdate cannot update thresholds when configuration file doesn
     },
   })
 
-  expect(stderr).toMatch('Unable to parse thresholds from configuration file: Expected config.test.coverage.thresholds to be an object')
+  expect(stderr).toMatch('Error: Unable to parse thresholds from configuration file: Expected config.test.coverage.thresholds to be an object')
 })
 
 test('boolean flag 100 should not crash CLI', async () => {
   const { stderr } = await runVitestCli('--coverage.enabled', '--coverage.thresholds.100')
 
-  expect(stderr).toMatch('Coverage for lines (0%) does not meet global threshold (100%)')
-  expect(stderr).toMatch('Coverage for functions (0%) does not meet global threshold (100%)')
-  expect(stderr).toMatch('Coverage for statements (0%) does not meet global threshold (100%)')
-  expect(stderr).toMatch('Coverage for branches (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('ERROR: Coverage for lines (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('ERROR: Coverage for functions (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('ERROR: Coverage for statements (0%) does not meet global threshold (100%)')
+  expect(stderr).toMatch('ERROR: Coverage for branches (0%) does not meet global threshold (100%)')
 })
 
 test('nextTick cannot be mocked inside child_process', async () => {
@@ -141,7 +141,7 @@ test('nextTick cannot be mocked inside child_process', async () => {
     include: ['./fake-timers.test.ts'],
   })
 
-  expect(stderr).toMatch('vi.useFakeTimers({ toFake: ["nextTick"] }) is not supported in node:child_process. Use --pool=threads if mocking nextTick is required.')
+  expect(stderr).toMatch('Error: vi.useFakeTimers({ toFake: ["nextTick"] }) is not supported in node:child_process. Use --pool=threads if mocking nextTick is required.')
 })
 
 test('nextTick can be mocked inside worker_threads', async () => {

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -1,4 +1,3 @@
-import { Writable } from 'node:stream'
 import type { UserConfig } from 'vitest'
 import type { UserConfig as ViteUserConfig } from 'vite'
 import { describe, expect, it } from 'vitest'
@@ -291,7 +290,7 @@ describe.each([
       waitForDebugger: inspectFlagName === '--inspect-brk' && inspect.enabled,
     })
   })
-  it('cannot use a URL', async () => {
+  it('cannot use URL', async () => {
     const url = 'https://www.remote.com:1002'
     const rawConfig = parseCLI([
       'vitest',
@@ -299,19 +298,8 @@ describe.each([
       inspectFlagName,
       url,
     ])
-    const errors: string[] = []
-    const stderr = new Writable({
-      write(chunk, _encoding, callback) {
-        errors.push(chunk.toString())
-        callback()
-      },
-    })
     await expect(async () => {
-      await config(rawConfig.options, {}, {}, { stderr })
-    }).rejects.toThrowError()
-
-    expect(errors[0]).toEqual(
-      expect.stringContaining(`Inspector host cannot be a URL. Use "host:port" instead of "${url}"`),
-    )
+      await config(rawConfig.options)
+    }).rejects.toThrowError(`Inspector host cannot be a URL. Use "host:port" instead of "${url}"`)
   })
 })

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -43,8 +43,8 @@ export async function runVitest(config: UserConfig, cliFilters: string[] = [], m
     })
   }
   catch (e: any) {
-    console.error(e.message)
-    cli.stderr += e.message
+    console.error(e)
+    cli.stderr += e.stack
   }
   finally {
     exitCode = process.exitCode


### PR DESCRIPTION
### Description

An error in this function already triggers error handling here:

https://github.com/vitest-dev/vitest/blob/6a0778d09dd430e7cb0ba7cbba9def26bd76b039/packages/vitest/src/node/cli/cac.ts#L247

This affects public API - it's no longer needed to overwrite `process.exit` when initiating Vitest because there was no way to intercept this error.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
