### PR TITLE
feat: add an option to print console stack trace

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2322,3 +2322,10 @@ Polling interval in milliseconds
 - **Default:** `1000`
 
 Polling timeout in milliseconds
+
+### printConsoleTrace
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Always print console traces when calling any `console` method. This is useful for debugging.

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -618,6 +618,9 @@ export const cliOptionsConfig: VitestCLIOptions = {
       return value
     },
   },
+  printConsoleTrace: {
+    description: 'Always print console stack traces',
+  },
 
   // CLI only options
   run: {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -315,6 +315,7 @@ export class Vitest {
       'passWithNoTests',
       'bail',
       'isolate',
+      'printConsoleTrace',
     ] as const
 
     const cliOverrides = overridesOptions.reduce((acc, name) => {

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -260,7 +260,7 @@ function printErrorMessage(error: ErrorWithDiff, logger: Logger) {
   }
 }
 
-function printStack(
+export function printStack(
   logger: Logger,
   project: WorkspaceProject,
   stack: ParsedStack[],

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -200,7 +200,7 @@ export abstract class BaseReporter implements Reporter {
     const header = c.gray(log.type + c.dim(` | ${task ? getFullName(task, c.dim(' > ')) : log.taskId !== UNKNOWN_TEST_ID ? log.taskId : 'unknown test'}`))
 
     const output = log.type === 'stdout' ? this.ctx.logger.outputStream : this.ctx.logger.errorStream
-    const write = output.write as (str: string) => void
+    const write = output.write.bind(output) as (str: string) => void
 
     write(`${header}\n${log.content}`)
 

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -200,7 +200,7 @@ export abstract class BaseReporter implements Reporter {
     const header = c.gray(log.type + c.dim(` | ${task ? getFullName(task, c.dim(' > ')) : log.taskId !== UNKNOWN_TEST_ID ? log.taskId : 'unknown test'}`))
 
     const output = log.type === 'stdout' ? this.ctx.logger.outputStream : this.ctx.logger.errorStream
-    const write = output.write.bind(output) as (str: string) => void
+    const write = (msg: string) => (output as any).write(msg)
 
     write(`${header}\n${log.content}`)
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -397,6 +397,7 @@ export class WorkspaceProject {
         testerScripts: [],
         commands: {},
       },
+      printConsoleTrace: this.config.printConsoleTrace ?? this.ctx.config.printConsoleTrace,
     }, this.ctx.configOverride || {} as any) as ResolvedConfig
   }
 

--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -74,7 +74,7 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
       })
     }
     else {
-      const content = buffer.map(i => String(i)).join('')
+      const content = buffer.map(i => String(i[0])).join('')
       sendLog(type, taskId, content, buffer.length)
     }
     const timer = timers.get(taskId)!

--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -121,8 +121,9 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
       }
       if (state().config.printConsoleTrace) {
         const limit = Error.stackTraceLimit
-        Error.stackTraceLimit = 20
-        const trace = new Error('STACK_TRACE').stack?.split('\n').slice(7).join('\n')
+        Error.stackTraceLimit = limit + 6
+        const stack = new Error('STACK_TRACE').stack
+        const trace = stack?.split('\n').slice(7).join('\n')
         Error.stackTraceLimit = limit
         buffer.push([data, trace])
       }
@@ -152,10 +153,18 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
       }
       if (state().config.printConsoleTrace) {
         const limit = Error.stackTraceLimit
-        Error.stackTraceLimit = 20
-        const trace = new Error('STACK_TRACE').stack?.split('\n').slice(7).join('\n')
+        Error.stackTraceLimit = limit + 6
+        const stack = new Error('STACK_TRACE').stack?.split('\n')
         Error.stackTraceLimit = limit
-        buffer.push([data, trace])
+        const isTrace = stack?.some(line => line.includes('at Console.trace'))
+        if (isTrace) {
+          buffer.push([data, undefined])
+        }
+        else {
+          const trace = stack?.slice(7).join('\n')
+          Error.stackTraceLimit = limit
+          buffer.push([data, trace])
+        }
       }
       else {
         buffer.push([data, undefined])

--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -57,33 +57,50 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
     const buffer = stdoutBuffer.get(taskId)
     if (!buffer)
       return
-    const content = buffer.map(i => String(i)).join('')
-    const timer = timers.get(taskId)!
-    state().rpc.onUserConsoleLog({
-      type: 'stdout',
-      content: content || '<empty line>',
-      taskId,
-      time: timer.stdoutTime || RealDate.now(),
-      size: buffer.length,
-    })
-    stdoutBuffer.set(taskId, [])
-    timer.stdoutTime = 0
+    sendBuffer(buffer, taskId, 'stdout')
   }
+
   function sendStderr(taskId: string) {
     const buffer = stderrBuffer.get(taskId)
     if (!buffer)
       return
-    const content = buffer.map(i => String(i)).join('')
+    sendBuffer(buffer, taskId, 'stderr')
+  }
+
+  function sendBuffer(buffer: any[], taskId: string, type: 'stdout' | 'stderr') {
+    if (state().config.printConsoleTrace) {
+      buffer.forEach(([buffer, origin]) => {
+        sendLog(type, taskId, String(buffer), buffer.length, origin)
+      })
+    }
+    else {
+      const content = buffer.map(i => String(i)).join('')
+      sendLog(type, taskId, content, buffer.length)
+    }
+    const timer = timers.get(taskId)!
+    stderrBuffer.set(taskId, [])
+    if (type === 'stderr')
+      timer.stderrTime = 0
+    else
+      timer.stdoutTime = 0
+  }
+
+  function sendLog(
+    type: 'stderr' | 'stdout',
+    taskId: string,
+    content: string,
+    size: number,
+    origin?: string,
+  ) {
     const timer = timers.get(taskId)!
     state().rpc.onUserConsoleLog({
-      type: 'stderr',
+      type,
       content: content || '<empty line>',
       taskId,
       time: timer.stderrTime || RealDate.now(),
-      size: buffer.length,
+      size,
+      origin,
     })
-    stderrBuffer.set(taskId, [])
-    timer.stderrTime = 0
   }
 
   const stdout = new Writable({
@@ -103,7 +120,16 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
         buffer = []
         stdoutBuffer.set(id, buffer)
       }
-      buffer.push(data)
+      if (state().config.printConsoleTrace) {
+        const limit = Error.stackTraceLimit
+        Error.stackTraceLimit = 20
+        const trace = new Error('STACK_TRACE').stack?.split('\n').slice(7).join('\n')
+        Error.stackTraceLimit = limit
+        buffer.push([data, trace])
+      }
+      else {
+        buffer.push([data, undefined])
+      }
       schedule(id)
       callback()
     },
@@ -125,7 +151,16 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
         buffer = []
         stderrBuffer.set(id, buffer)
       }
-      buffer.push(data)
+      if (state().config.printConsoleTrace) {
+        const limit = Error.stackTraceLimit
+        Error.stackTraceLimit = 20
+        const trace = new Error('STACK_TRACE').stack?.split('\n').slice(7).join('\n')
+        Error.stackTraceLimit = limit
+        buffer.push([data, trace])
+      }
+      else {
+        buffer.push([data, undefined])
+      }
       schedule(id)
       callback()
     },

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -1007,6 +1007,7 @@ export type RuntimeConfig = Pick<
   | 'fakeTimers'
   | 'maxConcurrency'
   | 'expect'
+  | 'printConsoleTrace'
 > & {
   sequence?: {
     concurrent?: boolean

--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -766,6 +766,13 @@ export interface InlineConfig {
   disableConsoleIntercept?: boolean
 
   /**
+   * Always print console stack traces.
+   *
+   * @default false
+   */
+  printConsoleTrace?: boolean
+
+  /**
    * Include "location" property inside the test definition
    *
    * @default false

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -35,6 +35,7 @@ export interface Environment {
 
 export interface UserConsoleLog {
   content: string
+  origin?: string
   type: 'stdout' | 'stderr'
   taskId?: string
   time: number

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -36,6 +36,7 @@ export interface Environment {
 export interface UserConsoleLog {
   content: string
   origin?: string
+  browser?: boolean
   type: 'stdout' | 'stderr'
   taskId?: string
   time: number

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, onTestFailed, test } from 'vitest'
-import { runBrowserTests } from './utils'
+import { browser, runBrowserTests } from './utils'
 
 describe('running browser tests', async () => {
   let stderr: string
@@ -7,7 +7,6 @@ describe('running browser tests', async () => {
   let browserResultJson: any
   let passedTests: any[]
   let failedTests: any[]
-  let browser: string
 
   beforeAll(async () => {
     ({
@@ -16,7 +15,6 @@ describe('running browser tests', async () => {
       browserResultJson,
       passedTests,
       failedTests,
-      browser,
     } = await runBrowserTests())
   })
 

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -45,8 +45,6 @@ describe('running browser tests', async () => {
     expect(stdout).toContain('hello from console.debug')
     expect(stdout).toContain('{ hello: \'from dir\' }')
     expect(stdout).toContain('{ hello: \'from dirxml\' }')
-    // safari logs the stack files with @https://...
-    expect(stdout).toMatch(/hello from console.trace\s+(\w+|@)/)
     expect(stdout).toContain('dom <div />')
     expect(stdout).toContain('default: 1')
     expect(stdout).toContain('default: 2')
@@ -64,6 +62,21 @@ describe('running browser tests', async () => {
     expect(stderr).toContain('hello from console.warn')
     expect(stderr).toContain('Timer "invalid timeLog" does not exist')
     expect(stderr).toContain('Timer "invalid timeEnd" does not exist')
+    // safari logs the stack files with @https://...
+    expect(stderr).toMatch(/hello from console.trace\s+(\w+|@)/)
+  })
+
+  test(`[${description}] logs have stack traces`, () => {
+    expect(stdout).toMatch(`
+log with a stack
+ ❯ test/logs.test.ts:58:10
+    `.trim())
+    expect(stderr).toMatch(`
+error with a stack
+ ❯ test/logs.test.ts:59:10
+    `.trim())
+    // console.trace doens't add additional stack trace
+    expect(stderr).not.toMatch('test/logs.test.ts:60:10')
   })
 
   test('stack trace points to correct file in every browser', () => {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -68,7 +68,7 @@ describe('running browser tests', async () => {
     expect(stderr).toMatch(/hello from console.trace\s+(\w+|@)/)
   })
 
-  test.runIf(browser !== 'safari')(`logs have stack traces in non-safari`, () => {
+  test.runIf(browser !== 'webkit')(`logs have stack traces in non-safari`, () => {
     expect(stdout).toMatch(`
 log with a stack
  ❯ test/logs.test.ts:58:10
@@ -81,7 +81,7 @@ error with a stack
     expect(stderr).not.toMatch('test/logs.test.ts:60:10')
   })
 
-  test.runIf(browser === 'safari')(`logs have stack traces in safari`, () => {
+  test.runIf(browser === 'webkit')(`logs have stack traces in safari`, () => {
     // safari print stack trace in a different place
     expect(stdout).toMatch(`
 log with a stack

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -7,6 +7,7 @@ describe('running browser tests', async () => {
   let browserResultJson: any
   let passedTests: any[]
   let failedTests: any[]
+  let browser: string
 
   beforeAll(async () => {
     ({
@@ -15,6 +16,7 @@ describe('running browser tests', async () => {
       browserResultJson,
       passedTests,
       failedTests,
+      browser,
     } = await runBrowserTests())
   })
 
@@ -66,7 +68,7 @@ describe('running browser tests', async () => {
     expect(stderr).toMatch(/hello from console.trace\s+(\w+|@)/)
   })
 
-  test(`[${description}] logs have stack traces`, () => {
+  test.runIf(browser !== 'safari')(`logs have stack traces in non-safari`, () => {
     expect(stdout).toMatch(`
 log with a stack
  ❯ test/logs.test.ts:58:10
@@ -79,8 +81,22 @@ error with a stack
     expect(stderr).not.toMatch('test/logs.test.ts:60:10')
   })
 
-  test('stack trace points to correct file in every browser', () => {
-    // dependeing on the browser it references either '.toBe()' or 'expect()'
+  test.runIf(browser === 'safari')(`logs have stack traces in safari`, () => {
+    // safari print stack trace in a different place
+    expect(stdout).toMatch(`
+log with a stack
+ ❯ test/logs.test.ts:58:14
+    `.trim())
+    expect(stderr).toMatch(`
+error with a stack
+ ❯ test/logs.test.ts:59:16
+    `.trim())
+    // console.trace doens't add additional stack trace
+    expect(stderr).not.toMatch('test/logs.test.ts:60:16')
+  })
+
+  test(`stack trace points to correct file in every browser`, () => {
+    // dependeing on the browser it references either `.toBe()` or `expect()`
     expect(stderr).toMatch(/test\/failing.test.ts:4:(12|17)/)
   })
 

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -24,5 +24,5 @@ export async function runBrowserTests(config?: Omit<UserConfig, 'browser'> & { b
   const passedTests = getPassed(browserResultJson.testResults)
   const failedTests = getFailed(browserResultJson.testResults)
 
-  return { ...result, browserResultJson, passedTests, failedTests }
+  return { ...result, browserResultJson, passedTests, failedTests, browser }
 }

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import type { UserConfig } from 'vitest'
 import { runVitest } from '../../test-utils'
 
-const browser = process.env.BROWSER || (process.env.PROVIDER !== 'playwright' ? 'chromium' : 'chrome')
+export const browser = process.env.BROWSER || (process.env.PROVIDER !== 'playwright' ? 'chromium' : 'chrome')
 
 export async function runBrowserTests(config?: Omit<UserConfig, 'browser'> & { browser?: Partial<UserConfig['browser']> }, include?: string[]) {
   const result = await runVitest({

--- a/test/browser/test/logs.test.ts
+++ b/test/browser/test/logs.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
 test('logging to stdout', () => {
   console.log('hello from console.log')
@@ -51,4 +51,11 @@ test('logging custom time', () => {
 test('logging invalid time', () => {
   console.timeLog('invalid timeLog')
   console.timeEnd('invalid timeEnd')
+})
+
+test('logging the stack', () => {
+  vi.setConfig({ printConsoleTrace: true })
+  console.log('log with a stack')
+  console.error('error with a stack')
+  console.trace('trace with a stack')
 })

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -86,5 +86,8 @@ export default defineConfig({
       onServerRestart: noop,
       onUserConsoleLog: noop,
     }, 'default'],
+    env: {
+      BROWSER: browser,
+    },
   },
 })

--- a/test/cli/fixtures/console/trace.test.ts
+++ b/test/cli/fixtures/console/trace.test.ts
@@ -1,0 +1,12 @@
+import { test } from 'vitest';
+
+test('logging to stdout', () => {
+  console.log('log with trace')
+  console.info('info with trace')
+  console.debug('debug with trace')
+  console.dir({ hello: 'from dir with trace' })
+  console.warn('warn with trace')
+  console.assert(false, 'assert with trace')
+  console.error('error with trace')
+  console.trace('trace with trace')
+})

--- a/test/cli/fixtures/console/vitest.config.ts
+++ b/test/cli/fixtures/console/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    printConsoleTrace: true,
+  }
+})

--- a/test/cli/test/console.test.ts
+++ b/test/cli/test/console.test.ts
@@ -64,14 +64,14 @@ test('can run custom pools with Vitest', async () => {
   expect(stackStderr).not.toMatch('❯ ')
   if (process.platform !== 'win32') {
     const root = resolve(process.cwd(), '../..')
-    expect(stackStderr.replace(new RegExp(root, 'g'), '<root>')).toMatchInlineSnapshot(`
+    expect(stackStderr.replace(new RegExp(root, 'g'), '<root>').replace(/\d+:\d+/g, 'ln:cl')).toMatchInlineSnapshot(`
       "stderr | trace.test.ts > logging to stdout
       Trace: trace with trace
-          at <root>/test/cli/fixtures/console/trace.test.ts:11:11
-          at file://<root>/packages/runner/dist/index.js:135:14
-          at file://<root>/packages/runner/dist/index.js:60:26
-          at runTest (file://<root>/packages/runner/dist/index.js:798:17)
-          at processTicksAndRejections (node:internal/process/task_queues:95:5)
+          at <root>/test/cli/fixtures/console/trace.test.ts:ln:cl
+          at file://<root>/packages/runner/dist/index.js:ln:cl
+          at file://<root>/packages/runner/dist/index.js:ln:cl
+          at runTest (file://<root>/packages/runner/dist/index.js:ln:cl)
+          at processTicksAndRejections (node:internal/process/task_queues:ln:cl)
 
       "
     `)

--- a/test/cli/test/console.test.ts
+++ b/test/cli/test/console.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'vitest'
+import { DefaultReporter } from 'vitest/reporters'
+import { resolve } from 'pathe'
+import { runVitest } from '../../test-utils'
+
+test('can run custom pools with Vitest', async () => {
+  const reporter = new DefaultReporter()
+  const vitest = await runVitest({
+    root: './fixtures/console',
+    reporters: [
+      {
+        onInit(ctx) {
+          reporter.onInit(ctx as any)
+        },
+        onUserConsoleLog(ctx) {
+          reporter.onUserConsoleLog(ctx)
+        },
+      },
+    ],
+  })
+  // removed the banner with version and timestamp
+  expect(vitest.stdout.split('\n').slice(2).join('\n')).toMatchInlineSnapshot(`
+    "
+    stdout | trace.test.ts > logging to stdout
+    log with trace
+     ❯ trace.test.ts:4:11
+
+    stdout | trace.test.ts > logging to stdout
+    info with trace
+     ❯ trace.test.ts:5:11
+
+    stdout | trace.test.ts > logging to stdout
+    debug with trace
+     ❯ trace.test.ts:6:11
+
+    stdout | trace.test.ts > logging to stdout
+    { hello: 'from dir with trace' }
+     ❯ trace.test.ts:7:11
+
+    "
+  `)
+  const stderrArray = vitest.stderr.split('\n')
+  // remove stack trace
+  const stderr = stderrArray.slice(0, -9).join('\n')
+  const stackStderr = stderrArray.slice(-9).join('\n')
+  expect(stderr).toMatchInlineSnapshot(`
+    "stderr | trace.test.ts > logging to stdout
+    warn with trace
+     ❯ trace.test.ts:8:11
+
+    stderr | trace.test.ts > logging to stdout
+    Assertion failed: assert with trace
+     ❯ trace.test.ts:9:11
+
+    stderr | trace.test.ts > logging to stdout
+    error with trace
+     ❯ trace.test.ts:10:11
+    "
+  `)
+  // shows built-in stack because we don't intercept it, but doesn't show the new one
+  expect(stackStderr).toMatch('Trace: trace with trace')
+  expect(stackStderr).toMatch('trace.test.ts:11:11')
+  expect(stackStderr).toMatch('   at ')
+  expect(stackStderr).not.toMatch('❯ ')
+  if (process.platform !== 'win32') {
+    const root = resolve(process.cwd(), '../..')
+    expect(stackStderr.replace(new RegExp(root, 'g'), '<root>')).toMatchInlineSnapshot(`
+      "stderr | trace.test.ts > logging to stdout
+      Trace: trace with trace
+          at <root>/test/cli/fixtures/console/trace.test.ts:11:11
+          at file://<root>/packages/runner/dist/index.js:135:14
+          at file://<root>/packages/runner/dist/index.js:60:26
+          at runTest (file://<root>/packages/runner/dist/index.js:798:17)
+          at processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+      "
+    `)
+  }
+})


### PR DESCRIPTION
### Description

This PR add a `--print-console-stack` option to always print every console stack:

<img width="489" alt="Screenshot 2024-05-14 at 15 06 04" src="https://github.com/vitest-dev/vitest/assets/16173870/c7c8b216-8a5c-4f1a-ae9c-6b6bbc52e84d">

I am reusing the `printError` logic to print stack traces and hide internal ones.

TODO

- [x] Docs
- [x] Tests
- [x] Browser Support

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
