### PR TITLE
feat(utils): Produce valid snapshot names

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "diff-sequences": "^29.6.3",
     "estree-walker": "^3.0.3",
-    "loupe": "^3.1.0",
+    "loupe": "^3.1.1",
     "pretty-format": "^29.7.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,8 +805,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       loupe:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1
       pretty-format:
         specifier: ^29.7.0
         version: 29.7.0
@@ -837,7 +837,7 @@ importers:
         version: 1.0.0
       vite:
         specifier: ^5.2.6
-        version: 5.2.6
+        version: 5.2.6(@types/node@20.12.11)
     devDependencies:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.25
@@ -11754,6 +11754,12 @@ packages:
       get-func-name: 2.0.2
     dev: false
 
+  /loupe@3.1.1:
+    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: false
+
   /lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -15681,41 +15687,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
-
-  /vite@5.2.6:
-    resolution: {integrity: sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.17.2
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
 
   /vite@5.2.6(@types/node@20.11.5):
     resolution: {integrity: sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==}

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'vitest'
-import { assertTypes, deepClone, objectAttr, toArray } from '@vitest/utils'
+import { assertTypes, deepClone, objDisplay, objectAttr, toArray } from '@vitest/utils'
 import { deepMerge, resetModules } from '../../../packages/vitest/src/utils'
 import { deepMergeSnapshot } from '../../../packages/snapshot/src/port/utils'
 import type { EncodedSourceMap } from '../../../packages/vite-node/src/types'
@@ -269,5 +269,19 @@ describe('objectAttr', () => {
     ${{ func }}                   | ${'func'}       | ${func}
   `('objectAttr($value, $path) -> $expected', ({ value, path, expected }) => {
     expect(objectAttr(value, path)).toEqual(expected)
+  })
+})
+
+describe('objDisplay', () => {
+  test.each`
+  value | expected
+  ${'a'.repeat(100)} | ${`'${'a'.repeat(37)}…'`}
+  ${'🐱'.repeat(100)} | ${`'${'🐱'.repeat(18)}…'`}
+  ${`a${'🐱'.repeat(100)}…`} | ${`'a${'🐱'.repeat(18)}…'`}
+  `('Do not truncate strings anywhere but produce valid unicode strings for $value', ({ value, expected }) => {
+    // encodeURI can be used to detect invalid strings including invalid code-points
+    // note: our code should not split surrogate pairs, but may split graphemes
+    expect(() => encodeURI(objDisplay(value))).not.toThrow()
+    expect(objDisplay(value)).toEqual(expected)
   })
 })


### PR DESCRIPTION
### Description

The previous version of loupe pulled within Vitest was not properly splitting strings to produce names of snapshots. The proposed PR bumps it and adds the relevant tests.

Fixes #5681

_Note: I feel the lock has changed a bit more than what I would have expected. I updated it with pnpm@8.15.8 from a GitHub Codespace. I don't really get how to properly update it if it's not the right one._

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
