### PR TITLE
fix(coverage): clean up empty coverage reports directory

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs, writeFileSync } from 'node:fs'
+import { existsSync, promises as fs, readdirSync, writeFileSync } from 'node:fs'
 import { resolve } from 'pathe'
 import type { AfterSuiteRunMeta, CoverageIstanbulOptions, CoverageProvider, ReportContext, ResolvedCoverageOptions, Vitest } from 'vitest'
 import { coverageConfigDefaults, defaultExclude, defaultInclude } from 'vitest/config'
@@ -255,6 +255,10 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
     if (!keepResults) {
       this.coverageFiles = new Map()
       await fs.rm(this.coverageFilesDirectory, { recursive: true })
+
+      // Remove empty reports directory, e.g. when only text-reporter is used
+      if (readdirSync(this.options.reportsDirectory).length === 0)
+        await fs.rm(this.options.reportsDirectory, { recursive: true })
     }
   }
 

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs, writeFileSync } from 'node:fs'
+import { existsSync, promises as fs, readdirSync, writeFileSync } from 'node:fs'
 import type { Profiler } from 'node:inspector'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import v8ToIstanbul from 'v8-to-istanbul'
@@ -246,6 +246,10 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
     if (!keepResults) {
       this.coverageFiles = new Map()
       await fs.rm(this.coverageFilesDirectory, { recursive: true })
+
+      // Remove empty reports directory, e.g. when only text-reporter is used
+      if (readdirSync(this.options.reportsDirectory).length === 0)
+        await fs.rm(this.options.reportsDirectory, { recursive: true })
     }
   }
 

--- a/test/coverage-test/option-tests/fixture.test.ts
+++ b/test/coverage-test/option-tests/fixture.test.ts
@@ -1,0 +1,8 @@
+// Generic test fixture to generate some coverage
+
+import { test } from 'vitest'
+import { add } from '../src/utils'
+
+test('cover some lines', () => {
+  add(1, 2)
+})

--- a/test/coverage-test/testing-options.mjs
+++ b/test/coverage-test/testing-options.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { startVitest } from 'vitest/node'
 
 /**
@@ -145,6 +145,25 @@ const testCases = [
         throw new Error('Expected test to fail as thresholds are not met')
 
       process.exitCode = 0
+    },
+  },
+  {
+    testConfig: {
+      name: 'remove empty coverages directory',
+      include: ['option-tests/fixture.test.ts'],
+      coverage: {
+        reporter: 'text',
+        all: false,
+        include: ['src/utils.ts'],
+      },
+    },
+    after() {
+      if (existsSync('./coverage')) {
+        if (readdirSync('./coverage').length !== 0)
+          throw new Error('Test case expected coverage directory to be empty')
+
+        throw new Error('Empty coverage directory was not cleaned')
+      }
     },
   },
 ]


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Fixes https://github.com/vitest-dev/vitest/issues/5722

If built-in or third party coverage reporter doesn't emit any files in reports directory, remove that directory after coverage reporting. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
