### PR TITLE
fix(utils): fix color util maximum call stack error

### DIFF
--- a/packages/utils/src/colors.ts
+++ b/packages/utils/src/colors.ts
@@ -74,10 +74,14 @@ export function createColors(isTTY = false): Colors {
     || 'CI' in process.env)
 
   const replaceClose = (string: string, close: string, replace: string, index: number): string => {
-    const start = string.substring(0, index) + replace
-    const end = string.substring(index + close.length)
-    const nextIndex = end.indexOf(close)
-    return ~nextIndex ? start + replaceClose(end, close, replace, nextIndex) : start + end
+    let result = ''
+    let cursor = 0
+    do {
+      result += string.substring(cursor, index) + replace
+      cursor = index + close.length
+      index = string.indexOf(close, cursor)
+    } while (~index)
+    return result + string.substring(cursor)
   }
 
   const formatter = (open: string, close: string, replace = open) => {

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'vitest'
-import { assertTypes, deepClone, objDisplay, objectAttr, toArray } from '@vitest/utils'
+import { assertTypes, createColors, deepClone, objDisplay, objectAttr, toArray } from '@vitest/utils'
 import { deepMerge, resetModules } from '../../../packages/vitest/src/utils'
 import { deepMergeSnapshot } from '../../../packages/snapshot/src/port/utils'
 import type { EncodedSourceMap } from '../../../packages/vite-node/src/types'
@@ -283,5 +283,15 @@ describe('objDisplay', () => {
     // note: our code should not split surrogate pairs, but may split graphemes
     expect(() => encodeURI(objDisplay(value))).not.toThrow()
     expect(objDisplay(value)).toEqual(expected)
+  })
+})
+
+describe(createColors, () => {
+  test('no maximum call stack error', () => {
+    process.env.FORCE_COLOR = '1'
+    delete process.env.GITHUB_ACTIONS
+    const c = createColors()
+    expect(c.isColorSupported).toBe(true)
+    expect(c.blue(c.blue('x').repeat(10000))).toBeTruthy()
   })
 })


### PR DESCRIPTION
### Description

- Related to https://github.com/vitest-dev/vitest/issues/5614

Porting the same fix from https://github.com/alexeyraspopov/picocolors/pull/64 to Vitest's internal color utils.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
