### PR TITLE
fix(runner): Ensure inner suite { sequential: true } correctly overrides outer suite { concurrent: true }

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -286,9 +286,11 @@ function createSuite() {
     if (currentSuite?.options)
       options = { ...currentSuite.options, ...options }
 
-    // inherit concurrent / sequential from current suite
-    options.concurrent = this.concurrent || (!this.sequential && options?.concurrent)
-    options.sequential = this.sequential || (!this.concurrent && options?.sequential)
+    // inherit concurrent / sequential from suite
+    const isConcurrent = options.concurrent || (this.concurrent && !this.sequential)
+    const isSequential = options.sequential || (this.sequential && !this.concurrent)
+    options.concurrent = isConcurrent && !isSequential
+    options.sequential = isSequential && !isConcurrent
 
     return createSuiteCollector(formatName(name), factory, mode, this.shuffle, this.each, options)
   }

--- a/test/core/test/concurrent-suite.test.ts
+++ b/test/core/test/concurrent-suite.test.ts
@@ -119,10 +119,9 @@ describe('override concurrent', { concurrent: true }, () => {
     checkSequentialTests()
   })
 
-  // TODO: not working?
-  // describe('s-x-2', { sequential: true, }, () => {
-  //   checkSequentialTests()
-  // })
+  describe('s-x-2', { sequential: true }, () => {
+    checkSequentialTests()
+  })
 
   describe('s-y', () => {
     checkParallelTests()


### PR DESCRIPTION
### Description
Fixes [issue #5716](https://github.com/vitest-dev/vitest/issues/5716)

 This PR addresses an issue where an inner suite with { sequential: true } does not correctly override an outer suite with { concurrent: true }. Previously, the inheritance logic for options.concurrent and options.sequential led to unexpected behavior where conflicting options were not handled properly. This fix ensures that inner suites with { sequential: true } override outer suites with { concurrent: true }, providing the expected behavior for nested suite configurations.

- Adjust the logic in createSuiteCollector to properly handle conflicting concurrent and sequential options.
- Ensure that options.concurrent and options.sequential are inherited with clear default values, preventing undefined values.
- Update the task context to accurately reflect the intended concurrency behavior.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
