### PR TITLE
feat: add median to `--output-json`

### DIFF
--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -129,6 +129,7 @@ interface FormattedBenchmarkGroup {
 export type FormattedBenchmarkResult = Omit<BenchmarkResult, 'samples'> & {
   id: string
   sampleCount: number
+  median: number
 }
 
 function createFormattedBenchamrkReport(files: File[]) {
@@ -145,6 +146,9 @@ function createFormattedBenchamrkReport(files: File[]) {
             benchmarks.push({
               id: t.id,
               sampleCount: samples.length,
+              median: samples.length % 2
+                ? samples[Math.floor(samples.length / 2)]
+                : (samples[samples.length / 2] + samples[samples.length / 2 - 1]) / 2,
               ...rest,
             })
           }


### PR DESCRIPTION
### Description
In #5398 the JSON reporter got reworked for the benchmark results. In this rework, the samples array was dropped to prevent huge output files. However, without the samples it's not possible anymore to manually calculate some extra metrics after the bench run. The median is simple enough to calculate when having acces to the samples and can provide some interesting insights (e.g. significant difference between mean and median could indicate outliers).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
