### PR TITLE
fix: remove browser.fileParallelism

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1536,20 +1536,6 @@ Run the browser in a `headless` mode. If you are running Vitest in CI, it will b
 
 Run every test in a separate iframe.
 
-### browser.fileParallelism {#browser-fileparallelism}
-
-- **Type:** `boolean`
-- **Default:** the same as [`fileParallelism`](#fileparallelism)
-- **CLI:** `--browser.fileParallelism=false`
-
-Create all test iframes at the same time so they are running in parallel.
-
-This makes it impossible to use interactive APIs (like clicking or hovering) because there are several iframes on the screen at the same time, but if your tests don't rely on those APIs, it might be much faster to just run all of them at the same time.
-
-::: tip
-If you disabled isolation via [`browser.isolate=false`](#browser-isolate), your test files will still run one after another because of the nature of the test runner.
-:::
-
 #### browser.api
 
 - **Type:** `number | { port?, strictPort?, host? }`

--- a/docs/guide/cli-table.md
+++ b/docs/guide/cli-table.md
@@ -57,7 +57,6 @@
 | `--browser.providerOptions <options>` | Options that are passed down to a browser provider. Visit [`browser.providerOptions`](https://vitest.dev/config/#browser-provideroptions) for more information |
 | `--browser.slowHijackESM` | Let Vitest use its own module resolution on the browser to enable APIs such as vi.mock and vi.spyOn. Visit [`browser.slowHijackESM`](https://vitest.dev/config/#browser-slowhijackesm) for more information (default: `false`) |
 | `--browser.isolate` | Run every browser test file in isolation. To disable isolation, use `--browser.isolate=false` (default: `true`) |
-| `--browser.fileParallelism` | Should all test files run in parallel. Use `--browser.file-parallelism=false` to disable (default: same as `--file-parallelism`) |
 | `--pool <pool>` | Specify pool, if not running in the browser (default: `threads`) |
 | `--poolOptions.threads.isolate` | Isolate tests in threads pool (default: `true`) |
 | `--poolOptions.threads.singleThread` | Run tests inside a single thread (default: `false`) |

--- a/packages/browser/src/client/main.ts
+++ b/packages/browser/src/client/main.ts
@@ -100,8 +100,6 @@ client.ws.addEventListener('open', async () => {
     }
   })
 
-  const fileParallelism = config.browser.fileParallelism ?? config.fileParallelism
-
   if (config.isolate === false) {
     createIframe(
       container,
@@ -109,33 +107,22 @@ client.ws.addEventListener('open', async () => {
     )
   }
   else {
-    // if fileParallelism is enabled, we can create all iframes at once
-    if (fileParallelism) {
-      for (const file of testFiles) {
-        createIframe(
-          container,
-          file,
-        )
-      }
-    }
-    else {
-      // otherwise, we need to wait for each iframe to finish before creating the next one
-      // this is the most stable way to run tests in the browser
-      for (const file of testFiles) {
-        createIframe(
-          container,
-          file,
-        )
-        await new Promise<void>((resolve) => {
-          channel.addEventListener('message', function handler(e: MessageEvent<IframeChannelEvent>) {
-            // done and error can only be triggered by the previous iframe
-            if (e.data.type === 'done' || e.data.type === 'error') {
-              channel.removeEventListener('message', handler)
-              resolve()
-            }
-          })
+    // otherwise, we need to wait for each iframe to finish before creating the next one
+    // this is the most stable way to run tests in the browser
+    for (const file of testFiles) {
+      createIframe(
+        container,
+        file,
+      )
+      await new Promise<void>((resolve) => {
+        channel.addEventListener('message', function handler(e: MessageEvent<IframeChannelEvent>) {
+          // done and error can only be triggered by the previous iframe
+          if (e.data.type === 'done' || e.data.type === 'error') {
+            channel.removeEventListener('message', handler)
+            resolve()
+          }
         })
-      }
+      })
     }
   }
 })

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -350,9 +350,6 @@ export const cliOptionsConfig: VitestCLIOptions = {
       ui: {
         description: 'Show Vitest UI when running tests',
       },
-      fileParallelism: {
-        description: 'Should all test files run in parallel. Use `--browser.file-parallelism=false` to disable (default: same as `--file-parallelism`)',
-      },
       indexScripts: null,
       testerScripts: null,
       commands: null,

--- a/packages/vitest/src/node/config.ts
+++ b/packages/vitest/src/node/config.ts
@@ -149,7 +149,6 @@ export function resolveConfig(
     resolved.minWorkers = Number(resolved.minWorkers)
 
   resolved.browser ??= {} as any
-  resolved.browser.fileParallelism ??= resolved.fileParallelism ?? false
 
   // run benchmark sequentially by default
   resolved.fileParallelism ??= mode !== 'benchmark'

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -95,13 +95,6 @@ export interface BrowserConfigOptions {
   ui?: boolean
 
   /**
-   * Run test files in parallel. Fallbacks to `test.fileParallelism`.
-   *
-   * @default test.fileParallelism
-   */
-  fileParallelism?: boolean
-
-  /**
    * Scripts injected into the tester iframe.
    */
   testerScripts?: BrowserScript[]

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -72,9 +72,9 @@ describe('running browser tests', async () => {
   })
 
   test('popup apis should log a warning', () => {
-    expect(stderr).toContain(`Vitest encountered a 'alert("test")'`)
-    expect(stderr).toContain(`Vitest encountered a 'confirm("test")'`)
-    expect(stderr).toContain(`Vitest encountered a 'prompt("test")'`)
+    expect(stderr).toContain('Vitest encountered a `alert("test")`')
+    expect(stderr).toContain('Vitest encountered a `confirm("test")`')
+    expect(stderr).toContain('Vitest encountered a `prompt("test")`')
   })
 
   test('snapshot inaccessible file debuggability', () => {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -1,10 +1,7 @@
 import { beforeAll, describe, expect, onTestFailed, test } from 'vitest'
 import { runBrowserTests } from './utils'
 
-describe.each([
-  ['non parallel', false],
-  ['parallel', true],
-])('[%s] running browser tests', async (description, fileParallelism) => {
+describe('running browser tests', async () => {
   let stderr: string
   let stdout: string
   let browserResultJson: any
@@ -18,14 +15,10 @@ describe.each([
       browserResultJson,
       passedTests,
       failedTests,
-    } = await runBrowserTests({
-      browser: {
-        fileParallelism,
-      },
-    }))
+    } = await runBrowserTests())
   })
 
-  test(`[${description}] tests are actually running`, () => {
+  test('tests are actually running', () => {
     onTestFailed(() => {
       console.error(stderr)
     })
@@ -38,14 +31,14 @@ describe.each([
     expect(stderr).not.toContain('Unhandled Error')
   })
 
-  test(`[${description}] correctly prints error`, () => {
+  test('correctly prints error', () => {
     expect(stderr).toContain('expected 1 to be 2')
     expect(stderr).toMatch(/- 2\s+\+ 1/)
     expect(stderr).toContain('Expected to be')
     expect(stderr).toContain('But got')
   })
 
-  test(`[${description}] logs are redirected to stdout`, () => {
+  test('logs are redirected to stdout', () => {
     expect(stdout).toContain('stdout | test/logs.test.ts > logging to stdout')
     expect(stdout).toContain('hello from console.log')
     expect(stdout).toContain('hello from console.info')
@@ -65,7 +58,7 @@ describe.each([
     expect(stdout).toMatch(/time: [\d.]+ ms/)
   })
 
-  test(`[${description}] logs are redirected to stderr`, () => {
+  test('logs are redirected to stderr', () => {
     expect(stderr).toContain('stderr | test/logs.test.ts > logging to stderr')
     expect(stderr).toContain('hello from console.error')
     expect(stderr).toContain('hello from console.warn')
@@ -73,18 +66,18 @@ describe.each([
     expect(stderr).toContain('Timer "invalid timeEnd" does not exist')
   })
 
-  test(`[${description}] stack trace points to correct file in every browser`, () => {
-    // dependeing on the browser it references either `.toBe()` or `expect()`
+  test('stack trace points to correct file in every browser', () => {
+    // dependeing on the browser it references either '.toBe()' or 'expect()'
     expect(stderr).toMatch(/test\/failing.test.ts:4:(12|17)/)
   })
 
-  test(`[${description}] popup apis should log a warning`, () => {
-    expect(stderr).toContain('Vitest encountered a `alert("test")`')
-    expect(stderr).toContain('Vitest encountered a `confirm("test")`')
-    expect(stderr).toContain('Vitest encountered a `prompt("test")`')
+  test('popup apis should log a warning', () => {
+    expect(stderr).toContain(`Vitest encountered a 'alert("test")'`)
+    expect(stderr).toContain(`Vitest encountered a 'confirm("test")'`)
+    expect(stderr).toContain(`Vitest encountered a 'prompt("test")'`)
   })
 
-  test(`[${description}] snapshot inaccessible file debuggability`, () => {
+  test('snapshot inaccessible file debuggability', () => {
     expect(stderr).toContain('Access denied to "/inaccesible/path".')
   })
 })


### PR DESCRIPTION
### Description

This PR removes `browser.fileParallelism` support that was added for a short time to experiment with the concept. The fact that it's impossible to use interactive API and module mocking makes it a large maintenance burden to support this use case so we are removing it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
