### PR TITLE
fix(runner): Ensure test.each print -0 and -NaN properly

### DIFF
--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -216,3 +216,14 @@ export function getCallLastIndex(code: string) {
   }
   return null
 }
+
+export function isNegativeNaN(val: number) {
+  if (!Number.isNaN(val))
+    return false
+  const f64 = new Float64Array(1)
+  f64[0] = val
+  const u32 = new Uint32Array(f64.buffer)
+  const isNegative = u32[1] >>> 31 === 1
+
+  return isNegative
+}

--- a/test/core/test/utils-display.spec.ts
+++ b/test/core/test/utils-display.spec.ts
@@ -60,7 +60,7 @@ describe('format', () => {
     expect(format(formatString, ...args), `failed ${formatString}`).toBe(util.format(formatString, ...args))
   })
 
-  test('cannont serialize some values', () => {
+  test('cannot serialize some values', () => {
     expect(() => format('%j', 100n)).toThrowErrorMatchingInlineSnapshot(`[TypeError: Do not know how to serialize a BigInt]`)
   })
 

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from 'vitest'
-import { assertTypes, createColors, deepClone, objDisplay, objectAttr, toArray } from '@vitest/utils'
+import { assertTypes, createColors, deepClone, isNegativeNaN, objDisplay, objectAttr, toArray } from '@vitest/utils'
 import { deepMerge, resetModules } from '../../../packages/vitest/src/utils'
 import { deepMergeSnapshot } from '../../../packages/snapshot/src/port/utils'
 import type { EncodedSourceMap } from '../../../packages/vite-node/src/types'
@@ -293,5 +293,21 @@ describe(createColors, () => {
     const c = createColors()
     expect(c.isColorSupported).toBe(true)
     expect(c.blue(c.blue('x').repeat(10000))).toBeTruthy()
+  })
+})
+
+describe('isNegativeNaN', () => {
+  test.each`
+  value | expected
+  ${Number.NaN} | ${false}
+  ${-Number.NaN} | ${true}
+  ${0} | ${false}
+  ${-0} | ${false}
+  ${1} | ${false}
+  ${-1} | ${false}
+  ${Number.POSITIVE_INFINITY} | ${false}
+  ${Number.NEGATIVE_INFINITY} | ${false}
+  `('isNegativeNaN($value) -> $expected', ({ value, expected }) => {
+    expect(isNegativeNaN(value)).toBe(expected)
   })
 })


### PR DESCRIPTION
### Description
Fixes [issue #5744](https://github.com/vitest-dev/vitest/issues/5744)
[Prev PR(closed)](https://github.com/vitest-dev/vitest/pull/5775#issuecomment-2141103984)

This bug fix ensures that when using test.each, the descriptive text for `-0` and `-NaN` is correctly printed as `-0` and `-NaN` instead of `0` and `NaN`.

---

### Context

The logic to resolve this issue was moved from format (utils) to the `formatTitle(runner.ts)` function. The function now checks if the value of %f in the template is -0 or -NaN using an ArrayBuffer and formats it appropriately.

However, despite various attempts, it was not possible to write a proper regression test for the formatTitle function in suite.ts without exporting the function. Additionally, no test suite for formatTitle was found.

To get feedback on the test, I am creating this PR with the following considerations:

1. export `formatTitle` for testing purposes (which I believe might be a bit risky).
2. Manually verifying without adding a test suite.
3. Any other alternatives.

+ Below is the screenshot for reference regarding the second approach. (Code Didn't added)

---
### Tests
```ts
  describe('edge cases', () => {
    describe('check for single values', () => {
      test.each([[0], [-0], [Number.NaN], [-Number.NaN], [Number.POSITIVE_INFINITY], [Number.NEGATIVE_INFINITY]] as const)(
        '%f',
        () => {
          throw new Error('test')
        },
      )
    })

    describe('check for multiple values(2)', () => {
      test.each([
        [0, Number.NaN],
        [-0, Number.NaN],
        [Number.NaN, -Number.NaN],
        [-0, -Number.NaN],
      ] as const)('%f %f', () => {
        throw new Error('test')
      })
    })

    describe('check for multiple values(3)', () => {
      test.each([
        [0, Number.NaN, 0],
        [0, -Number.NaN, 0],
        [-0, Number.NaN, 0],
        [-0, -Number.NaN, 0],
        [0, Number.NaN, -0],
        [0, -Number.NaN, -0],
        [-0, Number.NaN, -0],
        [-0, -Number.NaN, -0],
        [Number.NaN, -Number.NaN, 1],
        [-0, -Number.NaN, 1],
      ] as const)('%f %f %f', () => {
        throw new Error('test')
      })
    })

    describe('check for multiple values(4)', () => {
      test.each([
        [0, Number.NaN, 0, 0],
        [0, -Number.NaN, 0, 0],
        [-0, Number.NaN, 0, 0],
        [-0, -Number.NaN, 0, 0],
        [0, Number.NaN, -0, 0],
        [0, -Number.NaN, -0, 0],
        [-0, Number.NaN, -0, 0],
        [-0, -Number.NaN, -0, 0],
        [Number.NaN, -Number.NaN, -Number.NaN, 0],
      ] as const)(' %f %f %f %f', () => {
        throw new Error('test')
      })
    })
  })
  ```

### check for single values: ✓
![image](https://github.com/vitest-dev/vitest/assets/73521518/9719c332-b539-49be-b2ee-ec22c8ece492)

### check for multiple values(2): ✓
![image](https://github.com/vitest-dev/vitest/assets/73521518/929d90e1-e020-4f84-b830-f90bc349ade3)

### check for multiple values(3): ✓
![image](https://github.com/vitest-dev/vitest/assets/73521518/17f24b28-7609-4a2e-aac3-968263ddf083)

### check for multiple values(4): ✓
![image](https://github.com/vitest-dev/vitest/assets/73521518/0451f2f1-d724-4e85-a3d6-1a2b14823d62)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
