### PR TITLE
fix(browser): browser actions icons colors

### DIFF
--- a/packages/ui/client/components/IconAction.vue
+++ b/packages/ui/client/components/IconAction.vue
@@ -5,11 +5,14 @@ defineProps({
 </script>
 
 <template>
-  <div 
-    bg="gray-200" 
-    rounded-1 
+  <button
+    type="button"
+    dark="op75"
+    bg="gray-200 dark:#111"
+    hover="op100"
+    rounded-1
     p-0.5
   >
-    <div :class="icon" op50></div>
-  </div>
+    <span block :class="icon" op65 class="dark:op85 hover:op100"></span>
+  </button>
 </template>

--- a/packages/ui/client/components/TaskItem.vue
+++ b/packages/ui/client/components/TaskItem.vue
@@ -62,7 +62,7 @@ const duration = computed(() => {
         icon="i-carbon-result-old"
         @click.prevent.stop="emit('fixSnapshot')"
       />
-      <IconAction 
+      <IconAction
         v-tooltip.bottom="'Open test details'"
         data-testid="btn-open-details"
         title="Open test details"
@@ -74,8 +74,8 @@ const duration = computed(() => {
         v-tooltip.bottom="'Run current test'"
         data-testid="btn-run-test"
         title="Run current test"
-        icon="i-carbon-play-filled-alt"
-        text="green-500"
+        icon="i-carbon:play-filled-alt"
+        text-green5
         @click.prevent.stop="emit('run')"
       />
     </div>


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR includes:
- fix new browser ui icons on dark theme: right now with light gray bg color
- add hover on dark and light theme
- use semantic markup in `ActionIcon.vue` (replace `div` with `<button type="button">`)
<!-- You can also add additional context here -->

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/e3f5595a-70d4-49b4-a097-36a3f878e400)

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/a988a08e-6555-48fe-b28a-722e91b28a94)

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/27dae0ff-4e7f-4efd-9bec-8d9d1eb8295f)

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/238a4043-37f3-4872-96f3-66f6ebcc8a38)

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/978c27c9-796b-42cb-a70c-1d404ef5a45c)

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/754c4df1-1e45-4585-8bbd-7163c67294c9)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
