### PR TITLE
docs: Fix typo in description of `--typecheck.checker` (tcs -> tsc)

### DIFF
--- a/docs/guide/cli-table.md
+++ b/docs/guide/cli-table.md
@@ -106,7 +106,7 @@
 | `--disableConsoleIntercept` | Disable automatic interception of console logging (default: `false`) |
 | `--typecheck.enabled` | Enable typechecking alongside tests (default: `false`) |
 | `--typecheck.only` | Run only typecheck tests. This automatically enables typecheck (default: `false`) |
-| `--typecheck.checker <name>` | Specify the typechecker to use. Available values are: "tcs" and "vue-tsc" and a path to an executable (default: `"tsc"`) |
+| `--typecheck.checker <name>` | Specify the typechecker to use. Available values are: "tsc" and "vue-tsc" and a path to an executable (default: `"tsc"`) |
 | `--typecheck.allowJs` | Allow JavaScript files to be typechecked. By default takes the value from tsconfig.json |
 | `--typecheck.ignoreSourceErrors` | Ignore type errors from source files |
 | `--typecheck.tsconfig <path>` | Path to a custom tsconfig file |

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -534,7 +534,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
         description: 'Run only typecheck tests. This automatically enables typecheck (default: `false`)',
       },
       checker: {
-        description: 'Specify the typechecker to use. Available values are: "tcs" and "vue-tsc" and a path to an executable (default: `"tsc"`)',
+        description: 'Specify the typechecker to use. Available values are: "tsc" and "vue-tsc" and a path to an executable (default: `"tsc"`)',
         argument: '<name>',
         subcommands: null,
       },


### PR DESCRIPTION
### Description

The documentation for `--typecheck.checker` mentions available values are `tcs` and `vue-tsc`. I think this is typo and should be `tsc` (since that is also the default value).
