### PR TITLE
docs: correct oder to order (fix #5830[,#5830])

### DIFF
--- a/docs/guide/cli-table.md
+++ b/docs/guide/cli-table.md
@@ -89,7 +89,7 @@
 | `--shard <shards>` | Test suite shard to execute in a format of `<index>/<count>` |
 | `--changed [since]` | Run tests that are affected by the changed files (default: `false`) |
 | `--sequence.shuffle.files` | Run files in a random order. Long running tests will not start earlier if you enable this option. (default: `false`) |
-| `--sequence.shuffle.tests` | Run tests in a random oder (default: `false`) |
+| `--sequence.shuffle.tests` | Run tests in a random order (default: `false`) |
 | `--sequence.concurrent` | Make tests run in parallel (default: `false`) |
 | `--sequence.seed <seed>` | Set the randomization seed. This option will have no effect if --sequence.shuffle is falsy. Visit ["Random Seed" page](https://en.wikipedia.org/wiki/Random_seed) for more information |
 | `--sequence.hooks <order>` | Changes the order in which hooks are executed. Accepted values are: "stack", "list" and "parallel". Visit [`sequence.hooks`](https://vitest.dev/config/#sequence-hooks) for more information (default: `"parallel"`) |

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -446,7 +446,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
             description: 'Run files in a random order. Long running tests will not start earlier if you enable this option. (default: `false`)',
           },
           tests: {
-            description: 'Run tests in a random oder (default: `false`)',
+            description: 'Run tests in a random order (default: `false`)',
           },
         },
       },


### PR DESCRIPTION
### Description

Correct spelling mistake from oder to order.

Fixes https://github.com/vitest-dev/vitest/issues/5830

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
