### PR TITLE
fix(forks): resolve `poolOptions.<name>.isolate` from `forks` options

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -102,7 +102,7 @@ export async function VitestPlugin(options: UserConfig = {}, ctx = new Vitest('t
                 isolate: options.poolOptions?.threads?.isolate ?? options.isolate ?? testConfig.poolOptions?.threads?.isolate ?? viteConfig.test?.isolate,
               },
               forks: {
-                isolate: options.poolOptions?.threads?.isolate ?? options.isolate ?? testConfig.poolOptions?.threads?.isolate ?? viteConfig.test?.isolate,
+                isolate: options.poolOptions?.forks?.isolate ?? options.isolate ?? testConfig.poolOptions?.forks?.isolate ?? viteConfig.test?.isolate,
               },
             },
           },

--- a/test/config/fixtures/pool-isolation/isolated.test.ts
+++ b/test/config/fixtures/pool-isolation/isolated.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+const pool = process.env.TESTED_POOL as "forks" | "threads";
+
+test('is isolated', () => {
+  // @ts-expect-error -- internal
+  const config: NonNullable<UserConfig['test']> = globalThis.__vitest_worker__.config
+
+  if (pool === 'forks') {
+    expect(config.poolOptions?.forks?.isolate).toBe(true)
+  }
+  else {
+    expect(pool).toBe('threads')
+    expect(config.poolOptions?.threads?.isolate).toBe(true)
+  }
+})

--- a/test/config/fixtures/pool-isolation/non-isolated.test.ts
+++ b/test/config/fixtures/pool-isolation/non-isolated.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/config'
+
+const pool = process.env.TESTED_POOL as "forks" | "threads";
+
+test('is isolated', () => {
+  // @ts-expect-error -- internal
+  const config: NonNullable<UserConfig['test']> = globalThis.__vitest_worker__.config
+
+  if (pool === 'forks') {
+    expect(config.poolOptions?.forks?.isolate).toBe(false)
+  }
+  else {
+    expect(pool).toBe('threads')
+    expect(config.poolOptions?.threads?.isolate).toBe(false)
+  }
+})

--- a/test/config/test/pool-isolation.test.ts
+++ b/test/config/test/pool-isolation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+describe.each(['forks', 'threads'] as const)('%s', async (pool) => {
+  test('is isolated', async () => {
+    const { stderr, exitCode } = await runVitest({
+      root: './fixtures/pool-isolation',
+      include: ['isolated.test.ts'],
+      pool,
+      poolOptions: {
+        // Use default value on the tested pool and disable on the other one
+        [invertPool(pool)]: { isolate: false },
+      },
+      env: { TESTED_POOL: pool },
+    })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  test('is isolated + poolMatchGlobs', async () => {
+    const { stderr, exitCode } = await runVitest({
+      root: './fixtures/pool-isolation',
+      include: ['isolated.test.ts'],
+      pool,
+      poolMatchGlobs: [['**', pool]],
+      poolOptions: {
+        // Use default value on the tested pool and disable on the other one
+        [invertPool(pool)]: { isolate: false },
+      },
+      env: { TESTED_POOL: pool },
+    })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  test('is not isolated', async () => {
+    const { stderr, exitCode } = await runVitest({
+      root: './fixtures/pool-isolation',
+      include: ['non-isolated.test.ts'],
+      pool,
+      poolOptions: {
+        [pool]: { isolate: false },
+      },
+      env: { TESTED_POOL: pool },
+    })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+
+  test('is not isolated + poolMatchGlobs', async () => {
+    const { stderr, exitCode } = await runVitest({
+      root: './fixtures/pool-isolation',
+      include: ['non-isolated.test.ts'],
+      pool: invertPool(pool),
+      poolMatchGlobs: [['**/**.test.ts', pool]],
+      poolOptions: {
+        [pool]: { isolate: false },
+      },
+      env: { TESTED_POOL: pool },
+    })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  })
+})
+
+function invertPool(pool: 'threads' | 'forks') {
+  return pool === 'threads' ? 'forks' : 'threads'
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes issue where `poolOptions.forks.isolate` is not resolved correctly
- Minimal reproduction at https://stackblitz.com/edit/vitejs-vite-pchfh4?file=vite.config.ts

This is working fine when using workspaces:

https://github.com/vitest-dev/vitest/blob/c79b3f1f9a591c48935b0beda5aa924ea392f02f/packages/vitest/src/node/workspace.ts#L344-L348

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
