### PR TITLE
feat(ui): load module graph on tab selection

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -43,13 +43,6 @@ function onDraft(value: boolean) {
   draft.value = value
 }
 
-function relativeToRoot(path?: string) {
-  if (!path) return ''
-  if (path.startsWith(config.value.root))
-    return path.slice(config.value.root.length)
-  return path
-}
-
 async function loadModuleGraph() {
   if (loadingModuleGraph.value || graphData.value?.filepath === currentFilepath.value)
     return
@@ -97,7 +90,7 @@ debouncedWatch(
           [{{ current?.file.projectName || '' }}]
         </div>
         <div flex-1 font-light op-50 ws-nowrap truncate text-sm>
-          {{ relativeToRoot(current?.filepath) }}
+          {{ current?.name }}
         </div>
         <div class="flex text-lg">
           <IconButton

--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -11,8 +11,8 @@ import {
   disableCoverage,
   showCoverage,
   showDashboard,
-} from '../composables/navigation'
-import { client, findById } from '../composables/client'
+} from '~/composables/navigation'
+import { client, findById } from '~/composables/client'
 import { isDark, toggleDark } from '~/composables'
 import { files, isReport, runAll } from '~/composables/client'
 import { activeFileId } from '~/composables/params'
@@ -63,18 +63,18 @@ function expandTests() {
       <img w-6 h-6 src="/favicon.svg" alt="Vitest logo">
       <span font-light text-sm flex-1>Vitest</span>
       <div class="flex text-lg">
-        <IconButton 
+        <IconButton
           v-show="openedTreeItems.length > 0"
           v-tooltip.bottom="'Collapse tests'"
           title="Collapse tests"
-          icon="i-carbon:collapse-all" 
+          icon="i-carbon:collapse-all"
           @click="collapseTests()"
         />
-        <IconButton 
+        <IconButton
           v-show="openedTreeItems.length === 0"
           v-tooltip.bottom="'Expand tests'"
           title="Expand tests"
-          icon="i-carbon:expand-all" 
+          icon="i-carbon:expand-all"
           @click="expandTests()"
         />
         <IconButton

--- a/packages/ui/client/components/ProgressBar.vue
+++ b/packages/ui/client/components/ProgressBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { files } from '../composables/client'
-import { filesFailed, filesSuccess, finished } from '../composables/summary'
+import { files } from '~/composables/client'
+import { filesFailed, filesSuccess, finished } from '~/composables/summary'
 
 const { width } = useWindowSize()
 const classes = computed(() => {

--- a/packages/ui/client/components/dashboard/DashboardEntry.vue
+++ b/packages/ui/client/components/dashboard/DashboardEntry.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-withDefaults(defineProps<{ tail?: boolean }>(), { tail: false })
+// const { tail = false } = defineProps<{ tail?: boolean }>()
 </script>
 
 <template>

--- a/packages/ui/client/components/dashboard/ErrorEntry.vue
+++ b/packages/ui/client/components/dashboard/ErrorEntry.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-  const props = defineProps<{
-    error: ErrorWithDiff
-  }>()
+import type { ErrorWithDiff } from '@vitest/utils'
+
+defineProps<{
+  error: ErrorWithDiff
+}>()
 </script>
 
 <template>

--- a/packages/ui/client/components/dashboard/TestFilesEntry.vue
+++ b/packages/ui/client/components/dashboard/TestFilesEntry.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { files, unhandledErrors } from '../../composables/client'
-import { filesFailed, filesSnapshotFailed, filesSuccess, time } from '../../composables/summary'
+import { files, unhandledErrors } from '~/composables/client'
+import { filesFailed, filesSnapshotFailed, filesSuccess, time } from '~/composables/summary'
 </script>
 
 <template>

--- a/packages/ui/client/components/dashboard/TestsEntry.vue
+++ b/packages/ui/client/components/dashboard/TestsEntry.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { tests, testsFailed, testsSkipped, testsSuccess, testsTodo } from '../../composables/summary'
+import { tests, testsFailed, testsSkipped, testsSuccess, testsTodo } from '~/composables/summary'
 
 const total = computed(() => tests.value.length)
 const pass = computed(() => testsSuccess.value.length)

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -3,7 +3,7 @@
 import type CodeMirror from 'codemirror'
 import type { ErrorWithDiff, File } from 'vitest'
 import { createTooltip, destroyTooltip } from 'floating-vue'
-import { openInEditor } from '../../composables/error'
+import { openInEditor } from '~/composables/error'
 import { client } from '~/composables/client'
 
 const props = defineProps<{

--- a/packages/ui/client/components/views/ViewReportError.vue
+++ b/packages/ui/client/components/views/ViewReportError.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ErrorWithDiff } from 'vitest'
 import { openInEditor, shouldOpenInEditor } from '~/composables/error'
-import { escapeHtml } from '~/utils/escape';
+import { escapeHtml } from '~/utils/escape'
 
 const props = defineProps<{
   root: string

--- a/packages/ui/client/composables/params.ts
+++ b/packages/ui/client/composables/params.ts
@@ -12,9 +12,3 @@ export const params = useUrlSearchParams<Params>('hash', {
 
 export const activeFileId = toRef(params, 'file')
 export const viewMode = toRef(params, 'view')
-
-// reset tab to reload the graph
-watch(activeFileId, (id) => {
-  if (id && viewMode.value)
-    viewMode.value = null
-}, { immediate: true, flush: 'post' })

--- a/packages/ui/client/composables/params.ts
+++ b/packages/ui/client/composables/params.ts
@@ -12,3 +12,9 @@ export const params = useUrlSearchParams<Params>('hash', {
 
 export const activeFileId = toRef(params, 'file')
 export const viewMode = toRef(params, 'view')
+
+// reset tab to reload the graph
+watch(activeFileId, (id) => {
+  if (id && viewMode.value)
+    viewMode.value = null
+}, { immediate: true, flush: 'post' })

--- a/packages/ui/client/pages/index.vue
+++ b/packages/ui/client/pages/index.vue
@@ -39,19 +39,19 @@ function resizeMain() {
         <Navigation />
       </Pane>
       <Pane :size="mainSizes[1]">
-        <transition v-if="!browserState">
+        <transition v-if="!browserState" key="ui-detail">
           <Dashboard v-if="dashboardVisible" key="summary" />
           <Coverage v-else-if="coverageVisible" key="coverage" :src="coverageUrl" />
-          <FileDetails v-else />
+          <FileDetails v-else key="details" />
         </transition>
-        <Splitpanes v-else key="detail" id="details-splitpanes" @resize="onBrowserPanelResizing(true)" @resized="onModuleResized">
+        <Splitpanes v-else key="browser-detail" id="details-splitpanes" @resize="onBrowserPanelResizing(true)" @resized="onModuleResized">
           <Pane :size="detailSizes[0]" min-size="10">
             <BrowserIframe v-once />
           </Pane>
           <Pane :size="detailSizes[1]" min-size="5">
             <Dashboard v-if="dashboardVisible" key="summary" />
             <Coverage v-else-if="coverageVisible" key="coverage" :src="coverageUrl" />
-            <FileDetails v-else />
+            <FileDetails v-else key="details" />
           </Pane>
         </Splitpanes>
       </Pane>


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR includes:
- load module graph only when the graph tab is selected and when the current module changes
- show file name relative to the root config in `FileDetails.vue` header (rigth now, `relativeToRoot` function using `config.root` where `config` is a vue ref, and so the full path is shown)
- added some icons to the tabs: since we've moved the details from the mid panel, we've some extra space (check screenshot below)
- normalize all composable imports using `~`  instead relative paths: I'll check next weekend to configure autoimport properly, we should remove all composable  imports from vue files
- ~~WIP: change module entry dialog header to include the project and the relative path: in the current version showing only the full path (check screenshot below)~~
- ~~added watcher to select report tab in details pane when selected file change~~
- ~~WIP: I'll try to remove previous watcher and reload the graph when the active file changes and the current tab is the graph~~
- ~~WIP: switch navigation behavior, right now selecting the task expands the nested tests/tasks and clicking on the details button opens the file details; the new behaviour will open the file details when clicking on the task and will expand the nested tests/tasks when clicking the details button~~

<!-- You can also add additional context here -->

_New icon tabs_

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/8f9dcd39-0177-4ab8-8edb-1f69eaf83eb8)

_Module graph entry detail_

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/d578c124-dea1-4386-a4bb-0201aabb6236)



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
