### PR TITLE
fix(test): add missing `await`

### DIFF
--- a/test/core/test/snapshot-file.test.ts
+++ b/test/core/test/snapshot-file.test.ts
@@ -13,7 +13,7 @@ describe('snapshots', () => {
   for (const [path, file] of Object.entries(files)) {
     test(path, async () => {
       const entries = JSON.parse(await file()) as any[]
-      expect(entries.map(i => objectToCSS(i[0], i[1])).join('\n'))
+      await expect(entries.map(i => objectToCSS(i[0], i[1])).join('\n'))
         .toMatchFileSnapshot(path.replace('input.json', 'output.css'))
     })
   }


### PR DESCRIPTION
### Description

https://vitest.dev/api/expect.html#tomatchfilesnapshot says:

> Note that since file system operation is async, you need to use await with toMatchFileSnapshot().

However, that wasn't being done here. It might be nice for the docs to expand upon what could happen if you don't `await`. E.g. could it report that the test is successful when the assertion would otherwise fail or is it not really necessary?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
