### PR TITLE
feat(runner): implement `test.for`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -420,7 +420,7 @@ test.each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-])('add(%i, %i) -> %i', (a, b, expected) => {
+])('add(%i, %i) -> %i', (a, b, expected) => { // [!code --]
   expect(a + b).toBe(expected)
 })
 
@@ -429,7 +429,7 @@ test.for([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-])('add(%i, %i) -> %i', ([a, b, expected]) => {
+])('add(%i, %i) -> %i', ([a, b, expected]) => { // [!code ++]
   expect(a + b).toBe(expected)
 })
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -306,6 +306,11 @@ You cannot use this syntax, when using Vitest as [type checker](/guide/testing-t
 
 - **Alias:** `it.each`
 
+::: tip
+While `test.each` is provided for Jest compatibility,
+Vitest also has [`test.for`](#test-for) with an additional feature to integrate [`TestContext`](/guide/test-context).
+:::
+
 Use `test.each` when you need to run the same test with different variables.
 You can inject parameters with [printf formatting](https://nodejs.org/api/util.html#util_util_format_format_args) in the test name in the order of the test function parameters.
 
@@ -392,8 +397,6 @@ test.each`
 })
 ```
 
-If you want to have access to `TestContext`, use `describe.each` with a single test.
-
 ::: tip
 Vitest processes `$values` with Chai `format` method. If the value is too truncated, you can increase [chaiConfig.truncateThreshold](/config/#chaiconfig-truncatethreshold) in your config file.
 :::
@@ -401,6 +404,47 @@ Vitest processes `$values` with Chai `format` method. If the value is too trunca
 ::: warning
 You cannot use this syntax, when using Vitest as [type checker](/guide/testing-types).
 :::
+
+### test.for
+
+- **Alias:** `it.for`
+
+Alternative of `test.each` to provide [`TestContext`](/guide/test-context).
+
+The difference from `test.each` is how array case is provided in the arguments.
+Other non array case (including template string usage) works exactly same.
+
+```ts
+// `each` spreads array case
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add(%i, %i) -> %i', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})
+
+// `for` doesn't spread array case
+test.for([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add(%i, %i) -> %i', ([a, b, expected]) => {
+  expect(a + b).toBe(expected)
+})
+```
+
+2nd argument is [`TestContext`](/guide/test-context) and it can be used for concurrent snapshot, for example,
+
+```ts
+test.concurrent.for([
+  [1, 1],
+  [1, 2],
+  [2, 1],
+])('add(%i, %i)', ([a, b], { expect }) => {
+  expect(a + b).matchSnapshot()
+})
+```
 
 ## bench
 

--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -177,7 +177,13 @@ function getUsedProps(fn: Function) {
   if (!args.length)
     return []
 
-  const first = args[0]
+  let first = args[0]
+  if ('__VITEST_FIXTURE_INDEX__' in fn) {
+    first = args[(fn as any).__VITEST_FIXTURE_INDEX__]
+    if (!first)
+      return []
+  }
+
   if (!(first.startsWith('{') && first.endsWith('}')))
     throw new Error(`The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "${first}".`)
 

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -404,7 +404,11 @@ export function createTaskCollector(
       const _name = formatName(name)
       const { options, handler } = parseArguments(optionsOrFn, fnOrOptions)
       cases.forEach((item, idx) => {
-        test(formatTitle(_name, toArray(item), idx), options, () => handler(item))
+        // monkey-patch handler to allow parsing fixture
+        const handlerWrapper = (ctx: any) => handler(item, ctx);
+        (handlerWrapper as any).__VITEST_FIXTURE_INDEX__ = 1;
+        (handlerWrapper as any).toString = () => handler.toString()
+        test(formatTitle(_name, toArray(item), idx), options, handlerWrapper)
       })
     }
   }

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -1,4 +1,4 @@
-import { format, isNegativeNaN, isObject, objDisplay, objectAttr } from '@vitest/utils'
+import { format, isNegativeNaN, isObject, objDisplay, objectAttr, toArray } from '@vitest/utils'
 import { parseSingleStack } from '@vitest/utils/source-map'
 import type { Custom, CustomAPI, File, Fixtures, RunMode, Suite, SuiteAPI, SuiteCollector, SuiteFactory, SuiteHooks, Task, TaskCustomOptions, Test, TestAPI, TestFunction, TestOptions } from './types'
 import type { VitestRunner } from './types/runner'
@@ -380,6 +380,32 @@ export function createTaskCollector(
       })
 
       this.setContext('each', undefined)
+    }
+  }
+
+  taskFn.for = function <T>(
+    this: {
+      withContext: () => SuiteAPI
+      setContext: (key: string, value: boolean | undefined) => SuiteAPI
+    },
+    cases: ReadonlyArray<T>,
+    ...args: any[]
+  ) {
+    const test = this.withContext()
+
+    if (Array.isArray(cases) && args.length)
+      cases = formatTemplateString(cases, args)
+
+    return (
+      name: string | Function,
+      optionsOrFn: ((...args: T[]) => void) | TestOptions,
+      fnOrOptions?: ((...args: T[]) => void) | number | TestOptions,
+    ) => {
+      const _name = formatName(name)
+      const { options, handler } = parseArguments(optionsOrFn, fnOrOptions)
+      cases.forEach((item, idx) => {
+        test(formatTitle(_name, toArray(item), idx), options, () => handler(item))
+      })
     }
   }
 

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -143,6 +143,31 @@ interface TestEachFunction {
   (...args: [TemplateStringsArray, ...any]): EachFunctionReturn<any[]>
 }
 
+interface TestForFunctionReturn<Arg, Context> {
+  (
+    name: string | Function,
+    fn: (arg: Arg, context: Context) => Awaitable<void>,
+  ): void
+  (
+    name: string | Function,
+    options: TestOptions,
+    fn: (args: Arg, context: Context) => Awaitable<void>,
+  ): void
+}
+
+interface TestForFunction<ExtraContext> {
+  // test.for([1, 2, 3])
+  // test.for([[1, 2], [3, 4, 5]])
+  <T>(cases: ReadonlyArray<T>): TestForFunctionReturn<T, ExtendedContext<Test> & ExtraContext>
+
+  // test.for`
+  //    a  |  b
+  //   {1} | {2}
+  //   {3} | {4}
+  // `
+  (strings: TemplateStringsArray, ...values: any[]): TestForFunctionReturn<any, ExtendedContext<Test> & ExtraContext>
+}
+
 interface TestCollectorCallable<C = {}> {
   /**
    * @deprecated Use options as the second argument instead
@@ -157,6 +182,7 @@ type ChainableTestAPI<ExtraContext = {}> = ChainableFunction<
   TestCollectorCallable<ExtraContext>,
   {
     each: TestEachFunction
+    for: TestForFunction<ExtraContext>
   }
 >
 

--- a/test/core/test/__snapshots__/test-for.test.ts.snap
+++ b/test/core/test/__snapshots__/test-for.test.ts.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`basic case1 1`] = `
+{
+  "args": "case1",
+}
+`;
+
+exports[`basic case2 1`] = `
+{
+  "args": "case2",
+}
+`;

--- a/test/core/test/__snapshots__/test-for.test.ts.snap
+++ b/test/core/test/__snapshots__/test-for.test.ts.snap
@@ -1,5 +1,41 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`array case1-x 1`] = `
+{
+  "args": [
+    "case1-x",
+    "case1-y",
+  ],
+  "myFixture": 1234,
+}
+`;
+
+exports[`array case2-x 1`] = `
+{
+  "args": [
+    "case2-x",
+    "case1-y",
+  ],
+  "myFixture": 1234,
+}
+`;
+
+exports[`array destructure case1-x 1`] = `
+{
+  "myFixture": 1234,
+  "x": "case1-x",
+  "y": "case1-y",
+}
+`;
+
+exports[`array destructure case2-x 1`] = `
+{
+  "myFixture": 1234,
+  "x": "case2-x",
+  "y": "case1-y",
+}
+`;
+
 exports[`basic case1 1`] = `
 {
   "args": "case1",
@@ -9,5 +45,99 @@ exports[`basic case1 1`] = `
 exports[`basic case2 1`] = `
 {
   "args": "case2",
+}
+`;
+
+exports[`concurrent case1 1`] = `
+{
+  "args": "case1",
+  "myFixture": 1234,
+}
+`;
+
+exports[`concurrent case2 1`] = `
+{
+  "args": "case2",
+  "myFixture": 1234,
+}
+`;
+
+exports[`const case1 1`] = `
+{
+  "args": "case1",
+  "myFixture": 1234,
+}
+`;
+
+exports[`const case2 1`] = `
+{
+  "args": "case2",
+  "myFixture": 1234,
+}
+`;
+
+exports[`fixture case1 1`] = `
+{
+  "args": "case1",
+  "myFixture": 1234,
+}
+`;
+
+exports[`fixture case2 1`] = `
+{
+  "args": "case2",
+  "myFixture": 1234,
+}
+`;
+
+exports[`object { k: 'case1' } 1`] = `
+{
+  "args": {
+    "k": "case1",
+  },
+  "myFixture": 1234,
+}
+`;
+
+exports[`object { k: 'case2' } 1`] = `
+{
+  "args": {
+    "k": "case2",
+  },
+  "myFixture": 1234,
+}
+`;
+
+exports[`object destructure { k: 'case1' } 1`] = `
+{
+  "myFixture": 1234,
+  "v": "case1",
+}
+`;
+
+exports[`object destructure { k: 'case2' } 1`] = `
+{
+  "myFixture": 1234,
+  "v": "case2",
+}
+`;
+
+exports[`template context false 'x' true 1`] = `
+{
+  "args": {
+    "a": "x",
+    "b": true,
+  },
+  "myFixture": 1234,
+}
+`;
+
+exports[`template context false 'y' false 1`] = `
+{
+  "args": {
+    "a": "y",
+    "b": false,
+  },
+  "myFixture": 1234,
 }
 `;

--- a/test/core/test/__snapshots__/test-for.test.ts.snap
+++ b/test/core/test/__snapshots__/test-for.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`array case1-x 1`] = `
+exports[`array case1-x case1-y 1`] = `
 {
   "args": [
     "case1-x",
@@ -10,17 +10,17 @@ exports[`array case1-x 1`] = `
 }
 `;
 
-exports[`array case2-x 1`] = `
+exports[`array case2-x case2-y 1`] = `
 {
   "args": [
     "case2-x",
-    "case1-y",
+    "case2-y",
   ],
   "myFixture": 1234,
 }
 `;
 
-exports[`array destructure case1-x 1`] = `
+exports[`array destructure case1-x case1-y 1`] = `
 {
   "myFixture": 1234,
   "x": "case1-x",
@@ -28,11 +28,11 @@ exports[`array destructure case1-x 1`] = `
 }
 `;
 
-exports[`array destructure case2-x 1`] = `
+exports[`array destructure case2-x case2-y 1`] = `
 {
   "myFixture": 1234,
   "x": "case2-x",
-  "y": "case1-y",
+  "y": "case2-y",
 }
 `;
 
@@ -90,7 +90,7 @@ exports[`fixture case2 1`] = `
 }
 `;
 
-exports[`object { k: 'case1' } 1`] = `
+exports[`object 'case1' 1`] = `
 {
   "args": {
     "k": "case1",
@@ -99,7 +99,7 @@ exports[`object { k: 'case1' } 1`] = `
 }
 `;
 
-exports[`object { k: 'case2' } 1`] = `
+exports[`object 'case2' 1`] = `
 {
   "args": {
     "k": "case2",
@@ -108,21 +108,21 @@ exports[`object { k: 'case2' } 1`] = `
 }
 `;
 
-exports[`object destructure { k: 'case1' } 1`] = `
+exports[`object destructure 'case1' 1`] = `
 {
   "myFixture": 1234,
   "v": "case1",
 }
 `;
 
-exports[`object destructure { k: 'case2' } 1`] = `
+exports[`object destructure 'case2' 1`] = `
 {
   "myFixture": 1234,
   "v": "case2",
 }
 `;
 
-exports[`template context false 'x' true 1`] = `
+exports[`template 'x' true 1`] = `
 {
   "args": {
     "a": "x",
@@ -132,7 +132,7 @@ exports[`template context false 'x' true 1`] = `
 }
 `;
 
-exports[`template context false 'y' false 1`] = `
+exports[`template 'y' false 1`] = `
 {
   "args": {
     "a": "y",

--- a/test/core/test/__snapshots__/test-for.test.ts.snap
+++ b/test/core/test/__snapshots__/test-for.test.ts.snap
@@ -1,5 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`[docs] add(1, 1) 1`] = `2`;
+
+exports[`[docs] add(1, 2) 1`] = `3`;
+
+exports[`[docs] add(2, 1) 1`] = `3`;
+
 exports[`array case1-x case1-y 1`] = `
 {
   "args": [

--- a/test/core/test/test-for.test.ts
+++ b/test/core/test/test-for.test.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, test } from 'vitest'
+import { expect, expectTypeOf, test } from 'vitest'
 
 const myTest = test.extend<{ myFixture: number }>({
   myFixture: async ({}, use) => {
@@ -6,8 +6,25 @@ const myTest = test.extend<{ myFixture: number }>({
   },
 })
 
-myTest.concurrent.for(['case1', 'case2'])(
+test.only.for(['case1', 'case2'])(
   'basic %s',
+  (args) => {
+    expectTypeOf(args).toEqualTypeOf<string>()
+    expect({ args }).matchSnapshot()
+  },
+)
+
+myTest.for(['case1', 'case2'])(
+  'fixture %s',
+  (args, { myFixture }) => {
+    expectTypeOf(args).toEqualTypeOf<string>()
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ args, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for(['case1', 'case2'])(
+  'concurrent %s',
   (args, { expect, myFixture }) => {
     expectTypeOf(args).toEqualTypeOf<string>()
     expectTypeOf(myFixture).toEqualTypeOf<number>()

--- a/test/core/test/test-for.test.ts
+++ b/test/core/test/test-for.test.ts
@@ -41,8 +41,8 @@ myTest.concurrent.for(['case1', 'case2'] as const)(
   },
 )
 
-myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case1-y']])(
-  'array %s',
+myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case2-y']])(
+  'array %s %s',
   (args, { expect, myFixture }) => {
     expectTypeOf(args).toEqualTypeOf<string[]>()
     expectTypeOf(myFixture).toEqualTypeOf<number>()
@@ -50,8 +50,8 @@ myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case1-y']])(
   },
 )
 
-myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case1-y']])(
-  'array destructure %s',
+myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case2-y']])(
+  'array destructure %s %s',
   ([x, y], { expect, myFixture }) => {
     expectTypeOf(myFixture).toEqualTypeOf<number>()
     expect({ x, y, myFixture }).matchSnapshot()
@@ -59,7 +59,7 @@ myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case1-y']])(
 )
 
 myTest.concurrent.for([{ k: 'case1' }, { k: 'case2' }])(
-  'object %s',
+  'object $k',
   (args, { expect, myFixture }) => {
     expectTypeOf(args).toEqualTypeOf<{ k: string }>()
     expectTypeOf(myFixture).toEqualTypeOf<number>()
@@ -68,7 +68,7 @@ myTest.concurrent.for([{ k: 'case1' }, { k: 'case2' }])(
 )
 
 myTest.concurrent.for([{ k: 'case1' }, { k: 'case2' }])(
-  'object destructure %s',
+  'object destructure $k',
   ({ k: v }, { expect, myFixture }) => {
     expectTypeOf(myFixture).toEqualTypeOf<number>()
     expect({ v, myFixture }).matchSnapshot()
@@ -80,7 +80,7 @@ myTest.concurrent.for`
   ${'x'}    | ${true}
   ${'y'}    | ${false}
 `(
-  'template context false $a $b',
+  'template $a $b',
   (args, { expect, myFixture }) => {
     expectTypeOf(args).toEqualTypeOf<any>()
     expectTypeOf(myFixture).toEqualTypeOf<number>()

--- a/test/core/test/test-for.test.ts
+++ b/test/core/test/test-for.test.ts
@@ -1,0 +1,72 @@
+import { expectTypeOf, test } from 'vitest'
+
+const myTest = test.extend<{ myFixture: number }>({
+  myFixture: async ({}, use) => {
+    await use(1234)
+  },
+})
+
+myTest.concurrent.for(['case1', 'case2'])(
+  'basic %s',
+  (args, { expect, myFixture }) => {
+    expectTypeOf(args).toEqualTypeOf<string>()
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ args, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for(['case1', 'case2'] as const)(
+  'const %s',
+  (args, { expect, myFixture }) => {
+    expectTypeOf(args).toEqualTypeOf<'case1' | 'case2'>()
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ args, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case1-y']])(
+  'array %s',
+  (args, { expect, myFixture }) => {
+    expectTypeOf(args).toEqualTypeOf<string[]>()
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ args, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for([['case1-x', 'case1-y'], ['case2-x', 'case1-y']])(
+  'array destructure %s',
+  ([x, y], { expect, myFixture }) => {
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ x, y, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for([{ k: 'case1' }, { k: 'case2' }])(
+  'object %s',
+  (args, { expect, myFixture }) => {
+    expectTypeOf(args).toEqualTypeOf<{ k: string }>()
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ args, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for([{ k: 'case1' }, { k: 'case2' }])(
+  'object destructure %s',
+  ({ k: v }, { expect, myFixture }) => {
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ v, myFixture }).matchSnapshot()
+  },
+)
+
+myTest.concurrent.for`
+  a         | b
+  ${'x'}    | ${true}
+  ${'y'}    | ${false}
+`(
+  'template context false $a $b',
+  (args, { expect, myFixture }) => {
+    expectTypeOf(args).toEqualTypeOf<any>()
+    expectTypeOf(myFixture).toEqualTypeOf<number>()
+    expect({ args, myFixture }).toMatchSnapshot()
+  },
+)

--- a/test/core/test/test-for.test.ts
+++ b/test/core/test/test-for.test.ts
@@ -6,7 +6,7 @@ const myTest = test.extend<{ myFixture: number }>({
   },
 })
 
-test.only.for(['case1', 'case2'])(
+test.for(['case1', 'case2'])(
   'basic %s',
   (args) => {
     expectTypeOf(args).toEqualTypeOf<string>()

--- a/test/core/test/test-for.test.ts
+++ b/test/core/test/test-for.test.ts
@@ -87,3 +87,11 @@ myTest.concurrent.for`
     expect({ args, myFixture }).toMatchSnapshot()
   },
 )
+
+test.concurrent.for([
+  [1, 1],
+  [1, 2],
+  [2, 1],
+])('[docs] add(%i, %i)', ([a, b], { expect }) => {
+  expect(a + b).matchSnapshot()
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/4642
- closes https://github.com/vitest-dev/vitest/pull/4989 (supersedes)

`test.for` is an alternative API on `test.each`) (2nd one proposed in https://github.com/vitest-dev/vitest/issues/4642#issuecomment-1947507532) to simplify `TestContext` integration.

_todo_

- [x] docs

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
