### PR TITLE
fix(ui, browser): disable mouse events when resizing main navigation panel

### DIFF
--- a/packages/ui/client/pages/index.vue
+++ b/packages/ui/client/pages/index.vue
@@ -34,7 +34,7 @@ function resizeMain() {
 <template>
   <ProgressBar />
   <div h-screen w-screen overflow="hidden">
-    <Splitpanes class="pt-4px" @resized="onMainResized" @ready="resizeMain">
+    <Splitpanes class="pt-4px" @resized="onMainResized" @resize="onBrowserPanelResizing(true)" @ready="resizeMain">
       <Pane :size="mainSizes[0]">
         <Navigation />
       </Pane>


### PR DESCRIPTION
### Description

We need to disable mouse events when resizing main navigation panel, when running in browser mode the browser iframe will prevent resizing it (the resizer is inside the iframe "view").
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
