### PR TITLE
fix: vi.waitFor/vi.waitUntil interval is now cleared after it times out

### DIFF
--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -115,6 +115,8 @@ export function waitUntil<T>(callback: WaitUntilCallback<T>, options: number | W
     let intervalId: ReturnType<typeof setInterval>
 
     const onReject = (error?: Error) => {
+      if (intervalId)
+        clearInterval(intervalId)
       if (!error)
         error = copyStackTrace(new Error('Timed out in waitUntil!'), STACK_TRACE_ERROR)
       reject(error)

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -40,10 +40,10 @@ export function waitFor<T>(callback: WaitForCallback<T>, options: number | WaitF
         clearTimeout(timeoutId)
       if (intervalId)
         clearInterval(intervalId)
-    
-    resolve(result)
+
+      resolve(result)
     }
-    
+
     const handleTimeout = () => {
       if (intervalId)
         clearInterval(intervalId)

--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -40,11 +40,13 @@ export function waitFor<T>(callback: WaitForCallback<T>, options: number | WaitF
         clearTimeout(timeoutId)
       if (intervalId)
         clearInterval(intervalId)
-
-      resolve(result)
+    
+    resolve(result)
     }
-
+    
     const handleTimeout = () => {
+      if (intervalId)
+        clearInterval(intervalId)
       let error = lastError
       if (!error)
         error = copyStackTrace(new Error('Timed out in waitFor!'), STACK_TRACE_ERROR)

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -99,6 +99,28 @@ describe('waitFor', () => {
 
     vi.useRealTimers()
   })
+
+  test('callback stops running after timeout', async () => {
+    vi.useFakeTimers()
+    let timedOut = false
+    let callbackRanAfterTimeout = false
+    try {
+      await vi.waitFor(() => {
+        callbackRanAfterTimeout = timedOut
+        throw new Error('waitFor error')
+      }, {
+        interval: 100,
+        timeout: 200,
+      })
+    }
+    catch (error) {
+      timedOut = true
+    }
+    await vi.advanceTimersByTimeAsync(100)
+    expect(timedOut).toBe(true)
+    expect(callbackRanAfterTimeout).toBe(false)
+    vi.useRealTimers()
+  })
 })
 
 describe('waitUntil', () => {
@@ -178,6 +200,28 @@ describe('waitUntil', () => {
       })
     }, 200)
 
+    vi.useRealTimers()
+  })
+
+  test('callback stops running after timeout', async () => {
+    vi.useFakeTimers()
+    let timedOut = false
+    let callbackRanAfterTimeout = false
+    try {
+      await vi.waitUntil(() => {
+        callbackRanAfterTimeout = timedOut
+        return false
+      }, {
+        interval: 100,
+        timeout: 200,
+      })
+    }
+    catch (error) {
+      timedOut = true
+    }
+    await vi.advanceTimersByTimeAsync(100)
+    expect(timedOut).toBe(true)
+    expect(callbackRanAfterTimeout).toBe(false)
     vi.useRealTimers()
   })
 })


### PR DESCRIPTION
### Description

When using `vi.waitFor` in browser mode, an unsuccessful resolution of its callback will cause the wait for to run indefinitely.
A simple test like the following will cause the issue:

```ts
it.only('hangs', async () => {
    await vi.waitFor(
        () => {
            console.log('here', performance.now())
            throw new Error()
        },
        {
            interval: 100,
            timeout: 500,
        },
    )
})
```

I put some console logs in the waitFor code while debugging and it produced this:
![Screenshot from 2024-06-11 15-41-46](https://github.com/vitest-dev/vitest/assets/7131232/3a109eaa-ace0-4271-a4f3-ff8921c831b6)

After the handler timeout call, the check callback continues running because the interval is not cleared.
This PR just adds a `clearInterval` call to the `handleTimeout` function, just like in `onResolve`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
