### PR TITLE
fix: toJSON recursive error serialization (fix #5848)

### DIFF
--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -45,7 +45,7 @@ export function serializeError(val: any, seen = new WeakMap()): any {
   if (typeof val.asymmetricMatch === 'function')
     return `${val.toString()} ${format(val.sample)}`
   if (typeof val.toJSON === 'function')
-    return val.toJSON()
+    return serializeError(val.toJSON(), seen)
 
   if (seen.has(val))
     return seen.get(val)

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -9,22 +9,20 @@ describe('error serialize', () => {
     expect(serializeError(null)).toEqual(null)
     expect(serializeError('hi')).toEqual('hi')
 
-    expect(
-      serializeError({
-        foo: 'hi',
-        promise: new Promise(() => {}),
-        fn: () => {},
-        null: null,
-        symbol: Symbol('hi'),
-        nested: {
-          false: false,
-          class: class {},
-        },
-        // Intentionally test with a sparse array to verify it remains sparse during serialization.
-        // eslint-disable-next-line no-sparse-arrays
-        array: [1, , 3],
-      }),
-    ).toMatchSnapshot()
+    expect(serializeError({
+      foo: 'hi',
+      promise: new Promise(() => {}),
+      fn: () => {},
+      null: null,
+      symbol: Symbol('hi'),
+      nested: {
+        false: false,
+        class: class {},
+      },
+      // Intentionally test with a sparse array to verify it remains sparse during serialization.
+      // eslint-disable-next-line no-sparse-arrays
+      array: [1,, 3],
+    })).toMatchSnapshot()
   })
 
   it('Should skip circular references to prevent hit the call stack limit', () => {
@@ -70,10 +68,7 @@ describe('error serialize', () => {
       base: true,
     })
 
-    Object.defineProperty(user, 'fullName', {
-      enumerable: false,
-      value: 'John Smith',
-    })
+    Object.defineProperty(user, 'fullName', { enumerable: false, value: 'John Smith' })
 
     const serialized = serializeError(user)
     expect(serialized).not.toBe(user)
@@ -113,13 +108,11 @@ describe('error serialize', () => {
       },
     })
     Object.defineProperty(error, 'array', {
-      value: [
-        {
-          get name() {
-            throw new Error('name cannot be accessed')
-          },
+      value: [{
+        get name() {
+          throw new Error('name cannot be accessed')
         },
-      ],
+      }],
     })
     expect(serializeError(error)).toEqual({
       array: [


### PR DESCRIPTION
### Description

Sometimes error's toJSON() method doesn't return a json-compatible object, so we have to recursively apply serialization function to reach JSON-compatible state.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
