### PR TITLE
fix(vitest): benchmark word error change

### DIFF
--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -30,7 +30,7 @@ export class TableReporter extends BaseReporter {
     if (this.ctx.config.benchmark?.compare) {
       const compareFile = pathe.resolve(this.ctx.config.root, this.ctx.config.benchmark?.compare)
       try {
-        this.rendererOptions.compare = flattenFormattedBenchamrkReport(
+        this.rendererOptions.compare = flattenFormattedBenchmarkReport(
           JSON.parse(
             await fs.promises.readFile(compareFile, 'utf-8'),
           ),
@@ -80,7 +80,7 @@ export class TableReporter extends BaseReporter {
       const outputDirectory = pathe.dirname(outputFile)
       if (!fs.existsSync(outputDirectory))
         await fs.promises.mkdir(outputDirectory, { recursive: true })
-      const output = createFormattedBenchamrkReport(files)
+      const output = createFormattedBenchmarkReport(files)
       await fs.promises.writeFile(outputFile, JSON.stringify(output, null, 2))
       this.ctx.logger.log(`Benchmark report written to ${outputFile}`)
     }
@@ -109,7 +109,7 @@ export class TableReporter extends BaseReporter {
   }
 }
 
-export interface FormattedBenchamrkReport {
+export interface FormattedBenchmarkReport {
   files: {
     filepath: string
     groups: FormattedBenchmarkGroup[]
@@ -132,8 +132,8 @@ export type FormattedBenchmarkResult = Omit<BenchmarkResult, 'samples'> & {
   median: number
 }
 
-function createFormattedBenchamrkReport(files: File[]) {
-  const report: FormattedBenchamrkReport = { files: [] }
+function createFormattedBenchmarkReport(files: File[]) {
+  const report: FormattedBenchmarkReport = { files: [] }
   for (const file of files) {
     const groups: FormattedBenchmarkGroup[] = []
     for (const task of getTasks(file)) {
@@ -169,7 +169,7 @@ function createFormattedBenchamrkReport(files: File[]) {
   return report
 }
 
-function flattenFormattedBenchamrkReport(report: FormattedBenchamrkReport): FlatBenchmarkReport {
+function flattenFormattedBenchmarkReport(report: FormattedBenchmarkReport): FlatBenchmarkReport {
   const flat: FlatBenchmarkReport = {}
   for (const file of report.files) {
     for (const group of file.groups) {

--- a/test/benchmark/test/basic.test.ts
+++ b/test/benchmark/test/basic.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import { expect, it } from 'vitest'
 import * as pathe from 'pathe'
-import type { FormattedBenchamrkReport } from 'vitest/src/node/reporters/benchmark/table/index.js'
+import type { FormattedBenchmarkReport } from 'vitest/src/node/reporters/benchmark/table/index.js'
 import { runVitest } from '../../test-utils'
 
 it('basic', { timeout: 60_000 }, async () => {
@@ -17,7 +17,7 @@ it('basic', { timeout: 60_000 }, async () => {
   expect(result.exitCode).toBe(0)
 
   const benchResult = await fs.promises.readFile(benchFile, 'utf-8')
-  const resultJson: FormattedBenchamrkReport = JSON.parse(benchResult)
+  const resultJson: FormattedBenchmarkReport = JSON.parse(benchResult)
   const names = resultJson.files.map(f => f.groups.map(g => [g.fullName, g.benchmarks.map(b => b.name)]))
   expect(names).toMatchInlineSnapshot(`
     [


### PR DESCRIPTION
### Description

word typo has been corrected. 

- `createFormattedBenchamrkReport` -> `createFormattedBenchmarkReport`
- `flattenFormattedBenchamrkReport` -> `flattenFormattedBenchmarkReport`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
