### PR TITLE
fix(snapshot): fix `toMatchFileSnapshot` with empty file

### DIFF
--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -159,7 +159,7 @@ export class SnapshotClient {
       options.filepath ||= filepath
       // resolve and read the raw snapshot file
       rawSnapshot.file = await snapshotState.environment.resolveRawPath(filepath, rawSnapshot.file)
-      rawSnapshot.content = await snapshotState.environment.readSnapshotFile(rawSnapshot.file) || undefined
+      rawSnapshot.content = await snapshotState.environment.readSnapshotFile(rawSnapshot.file) ?? undefined
     }
 
     return this.assert(options)

--- a/test/core/test/snapshot-file.test.ts
+++ b/test/core/test/snapshot-file.test.ts
@@ -18,3 +18,7 @@ describe('snapshots', () => {
     })
   }
 })
+
+test('handle empty file', () => {
+  expect('').toMatchFileSnapshot('./fixtures/snapshot-empty.txt')
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5891

It looks like empty string snapshot is considered non-existent snapshot due to `... || undefined`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
