### PR TITLE
feat(ws-client): allow change reactive for state, filesMap and idMap

### DIFF
--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -14,7 +14,7 @@ export interface VitestClientOptions {
   reconnectInterval?: number
   reconnectTries?: number
   connectTimeout?: number
-  reactive?: <T>(v: T) => T
+  reactive?: <T>(v: T, forKey: 'state' | 'idMap' | 'filesMap') => T
   ref?: <T>(v: T) => { value: T }
   WebSocketConstructor?: typeof WebSocket
 }
@@ -44,10 +44,10 @@ export function createClient(url: string, options: VitestClientOptions = {}) {
     state: new StateManager(),
     waitForConnection,
     reconnect,
-  }) as VitestClient
+  }, 'state') as VitestClient
 
-  ctx.state.filesMap = reactive(ctx.state.filesMap)
-  ctx.state.idMap = reactive(ctx.state.idMap)
+  ctx.state.filesMap = reactive(ctx.state.filesMap, 'filesMap')
+  ctx.state.idMap = reactive(ctx.state.idMap, 'idMap')
 
   let onMessage: Function
   const functions: WebSocketEvents = {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Right now there is no way to change reactive for each entry, if using vue reactive then filesMap and idMap also reactive.

I need this change to allow use vue reactive for state and shallowRef for filesMap and idMap: when running `test/core` with main branch, the ui blocking the main thread (vue 3.4.27), we receive a lot of ws messages, check discord screenshots.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
