### PR TITLE
fix(browser): resolve `coverage.reporter` from string values

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -358,7 +358,7 @@ export default (project: WorkspaceProject, base = '/'): Plugin[] => {
 function resolveCoverageFolder(project: WorkspaceProject) {
   const options = project.ctx.config
   const htmlReporter = options.coverage?.enabled
-    ? options.coverage.reporter.find((reporter) => {
+    ? toArray(options.coverage.reporter).find((reporter) => {
       if (typeof reporter === 'string') {
         return reporter === 'html'
       }

--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -4,6 +4,7 @@ import sirv from 'sirv'
 import type { Plugin } from 'vite'
 import { coverageConfigDefaults } from 'vitest/config'
 import type { Vitest } from 'vitest'
+import { toArray } from '@vitest/utils'
 
 export default (ctx: Vitest): Plugin => {
   return <Plugin>{
@@ -50,7 +51,7 @@ function resolveCoverageFolder(ctx: Vitest) {
   const options = ctx.config
   const htmlReporter
     = options.api?.port && options.coverage?.enabled
-      ? options.coverage.reporter.find((reporter) => {
+      ? toArray(options.coverage.reporter).find((reporter) => {
         if (typeof reporter === 'string') {
           return reporter === 'html'
         }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Browser and Vitest UI crash when passing `coverage.reporter` as `string`. 

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: options.coverage.reporter.find is not a function
    at resolveCoverageFolder
```

Example configuration that crashes with the two features:

```ts
coverage: { 
  enabled: true,
  reporter: 'json',
  provider: 'istanbul'
},
```

Currently adding a test case is a bit difficult. I would rather wait for https://github.com/vitest-dev/vitest/pull/5837 and add the required tests in there. 


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
