### PR TITLE
docs: change 'vitest' to '@vitest/expect' in the "Extending Matchers" example

### DIFF
--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -26,13 +26,13 @@ expect.extend({
 If you are using TypeScript, you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
 ```ts
-import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
+import type { Assertion, AsymmetricMatchersContaining } from '@vitest/expect'
 
 interface CustomMatchers<R = unknown> {
   toBeFoo: () => R
 }
 
-declare module 'vitest' {
+declare module '@vitest/expect' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining extends CustomMatchers {}
 }


### PR DESCRIPTION
### Description

The ambient declaration must modify @vitest/expect instead of vitest. Otherwise the type override won't work. This change appears to be necessary since v1.6.0 or earlier.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
