### PR TITLE
feat(browser): expose cdp in the browser

### DIFF
--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -453,6 +453,8 @@ export const page: {
    */
   screenshot: (options?: ScreenshotOptions) => Promise<string>
 }
+
+export const cdp: () => CDPSession
 ```
 
 ## Interactivity API
@@ -840,6 +842,29 @@ it('handles files', async () => {
   await removeFile(file)
 })
 ```
+
+## CDP Session
+
+Vitest exposes access to raw Chrome Devtools Protocol via the `cdp` method exported from `@vitest/browser/context`. It is mostly useful to library authors to build tools on top of it.
+
+```ts
+import { cdp } from '@vitest/browser/context'
+
+const input = document.createElement('input')
+document.body.appendChild(input)
+input.focus()
+
+await cdp().send('Input.dispatchKeyEvent', {
+  type: 'keyDown',
+  text: 'a',
+})
+
+expect(input).toHaveValue('a')
+```
+
+::: warning
+CDP session works only with `playwright` provider and only when using `chromium` browser. You can read more about it in playwright's [`CDPSession`](https://playwright.dev/docs/api/class-cdpsession) documentation.
+:::
 
 ## Custom Commands
 

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -19,6 +19,14 @@ export interface FsOptions {
   flag?: string | number
 }
 
+export interface CDPSession {
+  established(): Promise<void>
+  on(event: string, listener: (payload: any) => void): void
+  once(event: string, listener: (payload: any) => void): void
+  off(event: string, listener: (payload: any) => void): void
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>
+}
+
 export interface ScreenshotOptions {
   element?: Element
   /**
@@ -242,3 +250,4 @@ export interface BrowserPage {
 }
 
 export const page: BrowserPage
+export const cdp: () => CDPSession

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -20,10 +20,7 @@ export interface FsOptions {
 }
 
 export interface CDPSession {
-  on(event: string, listener: (payload: any) => void): void
-  once(event: string, listener: (payload: any) => void): void
-  off(event: string, listener: (payload: any) => void): void
-  send(method: string, params?: Record<string, unknown>): Promise<unknown>
+  // methods are defined by the provider type augmentation
 }
 
 export interface ScreenshotOptions {

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -20,7 +20,6 @@ export interface FsOptions {
 }
 
 export interface CDPSession {
-  established(): Promise<void>
   on(event: string, listener: (payload: any) => void): void
   once(event: string, listener: (payload: any) => void): void
   off(event: string, listener: (payload: any) => void): void

--- a/packages/browser/providers/playwright.d.ts
+++ b/packages/browser/providers/playwright.d.ts
@@ -4,7 +4,9 @@ import type {
   Frame,
   LaunchOptions,
   Page,
+  CDPSession
 } from 'playwright'
+import { Protocol } from 'playwright-core/types/protocol'
 import '../matchers.js'
 
 declare module 'vitest/node' {
@@ -40,4 +42,23 @@ declare module '@vitest/browser/context' {
   export interface UserEventDragOptions extends UserEventDragAndDropOptions {}
 
   export interface ScreenshotOptions extends PWScreenshotOptions {}
+
+  export interface CDPSession {
+    send<T extends keyof Protocol.CommandParameters>(
+      method: T,
+      params?: Protocol.CommandParameters[T]
+    ): Promise<Protocol.CommandReturnValues[T]>
+    on<T extends keyof Protocol.Events>(
+      event: T,
+      listener: (payload: Protocol.Events[T]) => void
+    ): this;
+    once<T extends keyof Protocol.Events>(
+      event: T,
+      listener: (payload: Protocol.Events[T]) => void
+    ): this;
+    off<T extends keyof Protocol.Events>(
+      event: T,
+      listener: (payload: Protocol.Events[T]) => void
+    ): this;
+  }
 }

--- a/packages/browser/src/client/client.ts
+++ b/packages/browser/src/client/client.ts
@@ -56,6 +56,13 @@ function createClient() {
         }
         getBrowserState().createTesters?.(files)
       },
+      cdpEvent(event: string, payload: unknown) {
+        const cdp = getBrowserState().cdp
+        if (!cdp) {
+          return
+        }
+        cdp.emit(event, payload)
+      },
     },
     {
       post: msg => ctx.ws.send(msg),

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -163,6 +163,10 @@ function getSimpleSelectOptions(element: Element, value: string | string[] | HTM
   })
 }
 
+export function cdp() {
+  return runner().cdp!
+}
+
 const screenshotIds: Record<string, Record<string, string>> = {}
 export const page: BrowserPage = {
   get config() {

--- a/packages/browser/src/client/tester/state.ts
+++ b/packages/browser/src/client/tester/state.ts
@@ -69,9 +69,6 @@ function createCdp() {
   }
 
   const cdp = {
-    async established() {
-      await rpc().cdpEstablished(contextId)
-    },
     send(method: string, params: Record<string, any>) {
       return rpc().sendCdpEvent(contextId, method, params)
     },

--- a/packages/browser/src/client/tester/state.ts
+++ b/packages/browser/src/client/tester/state.ts
@@ -1,8 +1,10 @@
 import type { WorkerGlobalState } from 'vitest'
 import { parse } from 'flatted'
 import { getBrowserState } from '../utils'
+import type { BrowserRPC } from '../client'
 
 const config = getBrowserState().config
+const contextId = getBrowserState().contextId
 
 const providedContext = parse(getBrowserState().providedContext)
 
@@ -44,3 +46,74 @@ const state: WorkerGlobalState = {
 globalThis.__vitest_browser__ = true
 // @ts-expect-error not typed global
 globalThis.__vitest_worker__ = state
+
+getBrowserState().cdp = createCdp()
+
+function rpc() {
+  return state.rpc as any as BrowserRPC
+}
+
+function createCdp() {
+  const listenersMap = new WeakMap<Function, string>()
+
+  function getId(listener: Function) {
+    const id = listenersMap.get(listener) || crypto.randomUUID()
+    listenersMap.set(listener, id)
+    return id
+  }
+
+  const listeners: Record<string, Function[]> = {}
+
+  const error = (err: unknown) => {
+    window.dispatchEvent(new ErrorEvent('error', { error: err }))
+  }
+
+  const cdp = {
+    async established() {
+      await rpc().cdpEstablished(contextId)
+    },
+    send(method: string, params: Record<string, any>) {
+      return rpc().sendCdpEvent(contextId, method, params)
+    },
+    on(event: string, listener: (payload: any) => void) {
+      const listenerId = getId(listener)
+      listeners[event] = listeners[event] || []
+      listeners[event].push(listener)
+      rpc().trackCdpEvent(contextId, 'on', event, listenerId).catch(error)
+      return cdp
+    },
+    once(event: string, listener: (payload: any) => void) {
+      const listenerId = getId(listener)
+      const handler = (data: any) => {
+        listener(data)
+        cdp.off(event, listener)
+      }
+      listeners[event] = listeners[event] || []
+      listeners[event].push(handler)
+      rpc().trackCdpEvent(contextId, 'once', event, listenerId).catch(error)
+      return cdp
+    },
+    off(event: string, listener: (payload: any) => void) {
+      const listenerId = getId(listener)
+      if (listeners[event]) {
+        listeners[event] = listeners[event].filter(l => l !== listener)
+      }
+      rpc().trackCdpEvent(contextId, 'off', event, listenerId).catch(error)
+      return cdp
+    },
+    emit(event: string, payload: unknown) {
+      if (listeners[event]) {
+        listeners[event].forEach((l) => {
+          try {
+            l(payload)
+          }
+          catch (err) {
+            error(err)
+          }
+        })
+      }
+    },
+  }
+
+  return cdp
+}

--- a/packages/browser/src/client/tester/state.ts
+++ b/packages/browser/src/client/tester/state.ts
@@ -69,7 +69,7 @@ function createCdp() {
   }
 
   const cdp = {
-    send(method: string, params: Record<string, any>) {
+    send(method: string, params?: Record<string, any>) {
       return rpc().sendCdpEvent(contextId, method, params)
     },
     on(event: string, listener: (payload: any) => void) {

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -1,5 +1,4 @@
 import type { ResolvedConfig, WorkerGlobalState } from 'vitest'
-import type { CDPSession } from '../../context'
 
 export async function importId(id: string) {
   const name = `/@id/${id}`
@@ -26,7 +25,11 @@ export interface BrowserRunnerState {
   contextId: string
   runTests?: (tests: string[]) => Promise<void>
   createTesters?: (files: string[]) => Promise<void>
-  cdp?: CDPSession & {
+  cdp?: {
+    on: (event: string, listener: (payload: any) => void) => void
+    once: (event: string, listener: (payload: any) => void) => void
+    off: (event: string, listener: (payload: any) => void) => void
+    send: (method: string, params?: Record<string, unknown>) => Promise<unknown>
     emit: (event: string, payload: unknown) => void
   }
 }

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -1,4 +1,5 @@
 import type { ResolvedConfig, WorkerGlobalState } from 'vitest'
+import type { CDPSession } from '../../context'
 
 export async function importId(id: string) {
   const name = `/@id/${id}`
@@ -25,6 +26,9 @@ export interface BrowserRunnerState {
   contextId: string
   runTests?: (tests: string[]) => Promise<void>
   createTesters?: (files: string[]) => Promise<void>
+  cdp?: CDPSession & {
+    emit: (event: string, payload: unknown) => void
+  }
 }
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/browser/src/node/cdp.ts
+++ b/packages/browser/src/node/cdp.ts
@@ -1,0 +1,58 @@
+import type { CDPSession } from 'vitest/node'
+import type { WebSocketBrowserRPC } from './types'
+
+export class BrowserServerCDPHandler {
+  private listenerIds: Record<string, string[]> = {}
+
+  private listeners: Record<string, (payload: unknown) => void> = {}
+
+  constructor(
+    private session: CDPSession,
+    private tester: WebSocketBrowserRPC,
+  ) {}
+
+  send(method: string, params?: Record<string, unknown>) {
+    return this.session.send(method, params)
+  }
+
+  detach() {
+    return this.session.detach()
+  }
+
+  on(event: string, id: string, once = false) {
+    if (!this.listenerIds[event]) {
+      this.listenerIds[event] = []
+    }
+    this.listenerIds[event].push(id)
+
+    if (!this.listeners[event]) {
+      this.listeners[event] = (payload) => {
+        this.tester.cdpEvent(
+          event,
+          payload,
+        )
+        if (once) {
+          this.off(event, id)
+        }
+      }
+
+      this.session.on(event, this.listeners[event])
+    }
+  }
+
+  off(event: string, id: string) {
+    if (!this.listenerIds[event]) {
+      this.listenerIds[event] = []
+    }
+    this.listenerIds[event] = this.listenerIds[event].filter(l => l !== id)
+
+    if (!this.listenerIds[event].length) {
+      this.session.off(event, this.listeners[event])
+      delete this.listeners[event]
+    }
+  }
+
+  once(event: string, listener: string) {
+    this.on(event, listener, true)
+  }
+}

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -176,11 +176,11 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
     },
     {
       name: 'vitest:browser:resolve-virtual',
-      async resolveId(rawId, importer) {
+      async resolveId(rawId) {
         if (rawId.startsWith('/__virtual_vitest__')) {
           const url = new URL(rawId, 'http://localhost')
           if (!url.searchParams.has('id')) {
-            throw new TypeError(`Invalid virtual module id: ${rawId}, requires "id" query. Imported from ${importer}`)
+            return
           }
 
           const id = decodeURIComponent(url.searchParams.get('id')!)

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -176,11 +176,11 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
     },
     {
       name: 'vitest:browser:resolve-virtual',
-      async resolveId(rawId) {
+      async resolveId(rawId, importer) {
         if (rawId.startsWith('/__virtual_vitest__')) {
           const url = new URL(rawId, 'http://localhost')
           if (!url.searchParams.has('id')) {
-            throw new TypeError(`Invalid virtual module id: ${rawId}, requires "id" query.`)
+            throw new TypeError(`Invalid virtual module id: ${rawId}, requires "id" query. Imported from ${importer}`)
           }
 
           const id = decodeURIComponent(url.searchParams.get('id')!)

--- a/packages/browser/src/node/plugins/pluginContext.ts
+++ b/packages/browser/src/node/plugins/pluginContext.ts
@@ -67,7 +67,7 @@ async function generateContextFile(
   const distContextPath = slash(`/@fs/${resolve(__dirname, 'context.js')}`)
 
   return `
-import { page, userEvent as __userEvent_CDP__ } from '${distContextPath}'
+import { page, userEvent as __userEvent_CDP__, cdp } from '${distContextPath}'
 ${userEventNonProviderImport}
 const filepath = () => ${filepathCode}
 const rpc = () => __vitest_worker__.rpc
@@ -84,7 +84,7 @@ export const server = {
 }
 export const commands = server.commands
 export const userEvent = ${getUserEvent(provider)}
-export { page }
+export { page, cdp }
 `
 }
 

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -130,6 +130,29 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     await browserPage.goto(url)
   }
 
+  async getCDPSession(contextId: string) {
+    const page = this.getPage(contextId)
+    const cdp = await page.context().newCDPSession(page)
+    return {
+      async send(method: string, params: any) {
+        const result = await cdp.send(method as 'DOM.querySelector', params)
+        return result as unknown
+      },
+      on(event: string, listener: (...args: any[]) => void) {
+        cdp.on(event as 'Accessibility.loadComplete', listener)
+      },
+      off(event: string, listener: (...args: any[]) => void) {
+        cdp.off(event as 'Accessibility.loadComplete', listener)
+      },
+      once(event: string, listener: (...args: any[]) => void) {
+        cdp.once(event as 'Accessibility.loadComplete', listener)
+      },
+      detach() {
+        return cdp.detach()
+      },
+    }
+  }
+
   async close() {
     const browser = this.browser
     this.browser = null

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -193,9 +193,6 @@ export function setupBrowserRpc(
           const cdp = await server.ensureCDPHandler(contextId, sessionId)
           cdp[type](event, listenerId)
         },
-        async cdpEstablished(contextId: string) {
-          await server.ensureCDPHandler(contextId, sessionId)
-        },
       },
       {
         post: msg => ws.send(msg),

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -40,7 +40,7 @@ export function setupBrowserRpc(
     wss.handleUpgrade(request, socket, head, (ws) => {
       wss.emit('connection', ws, request)
 
-      const rpc = setupClient(ws)
+      const rpc = setupClient(sessionId, ws)
       const state = server.state
       const clients = type === 'tester' ? state.testers : state.orchestrators
       clients.set(sessionId, rpc)
@@ -50,6 +50,7 @@ export function setupBrowserRpc(
       ws.on('close', () => {
         debug?.('[%s] Browser API disconnected from %s', sessionId, type)
         clients.delete(sessionId)
+        server.state.removeCDPHandler(sessionId)
       })
     })
   })
@@ -62,7 +63,7 @@ export function setupBrowserRpc(
     }
   }
 
-  function setupClient(ws: WebSocket) {
+  function setupClient(sessionId: string, ws: WebSocket) {
     const rpc = createBirpc<WebSocketBrowserEvents, WebSocketBrowserHandlers>(
       {
         async onUnhandledError(error, type) {
@@ -182,11 +183,24 @@ export function setupBrowserRpc(
             }
           })
         },
+
+        // CDP
+        async sendCdpEvent(contextId: string, event: string, payload: Record<string, unknown>) {
+          const cdp = await server.ensureCDPHandler(contextId, sessionId)
+          return cdp.send(event, payload)
+        },
+        async trackCdpEvent(contextId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) {
+          const cdp = await server.ensureCDPHandler(contextId, sessionId)
+          cdp[type](event, listenerId)
+        },
+        async cdpEstablished(contextId: string) {
+          await server.ensureCDPHandler(contextId, sessionId)
+        },
       },
       {
         post: msg => ws.send(msg),
         on: fn => ws.on('message', fn),
-        eventNames: ['onCancel'],
+        eventNames: ['onCancel', 'cdpEvent'],
         serialize: (data: any) => stringify(data, stringifyReplace),
         deserialize: parse,
         onTimeoutError(functionName) {

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -185,7 +185,7 @@ export function setupBrowserRpc(
         },
 
         // CDP
-        async sendCdpEvent(contextId: string, event: string, payload: Record<string, unknown>) {
+        async sendCdpEvent(contextId: string, event: string, payload?: Record<string, unknown>) {
           const cdp = await server.ensureCDPHandler(contextId, sessionId)
           return cdp.send(event, payload)
         },

--- a/packages/browser/src/node/state.ts
+++ b/packages/browser/src/node/state.ts
@@ -1,12 +1,14 @@
 import { createDefer } from '@vitest/utils'
 import type { BrowserServerStateContext, BrowserServerState as IBrowserServerState } from 'vitest/node'
 import type { WebSocketBrowserRPC } from './types'
+import type { BrowserServerCDPHandler } from './cdp'
 
 export class BrowserServerState implements IBrowserServerState {
-  public orchestrators = new Map<string, WebSocketBrowserRPC>()
-  public testers = new Map<string, WebSocketBrowserRPC>()
+  public readonly orchestrators = new Map<string, WebSocketBrowserRPC>()
+  public readonly testers = new Map<string, WebSocketBrowserRPC>()
+  public readonly cdps = new Map<string, BrowserServerCDPHandler>()
 
-  private contexts = new Map<string, BrowserServerStateContext >()
+  private contexts = new Map<string, BrowserServerStateContext>()
 
   getContext(contextId: string) {
     return this.contexts.get(contextId)
@@ -23,5 +25,9 @@ export class BrowserServerState implements IBrowserServerState {
       reject: defer.reject,
     })
     return defer
+  }
+
+  async removeCDPHandler(sessionId: string) {
+    this.cdps.delete(sessionId)
   }
 }

--- a/packages/browser/src/node/types.ts
+++ b/packages/browser/src/node/types.ts
@@ -42,7 +42,7 @@ export interface WebSocketBrowserHandlers {
   ) => SourceMap | null | { mappings: '' } | undefined
 
   // cdp
-  sendCdpEvent: (contextId: string, event: string, payload: Record<string, unknown>) => unknown
+  sendCdpEvent: (contextId: string, event: string, payload?: Record<string, unknown>) => unknown
   trackCdpEvent: (contextId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) => void
 }
 

--- a/packages/browser/src/node/types.ts
+++ b/packages/browser/src/node/types.ts
@@ -40,6 +40,11 @@ export interface WebSocketBrowserHandlers {
   getBrowserFileSourceMap: (
     id: string
   ) => SourceMap | null | { mappings: '' } | undefined
+
+  // cdp
+  sendCdpEvent: (contextId: string, event: string, payload: Record<string, unknown>) => unknown
+  trackCdpEvent: (contextId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) => void
+  cdpEstablished: (contextId: string) => Promise<void>
 }
 
 export interface WebSocketEvents
@@ -58,6 +63,7 @@ export interface WebSocketEvents
 export interface WebSocketBrowserEvents {
   onCancel: (reason: CancelReason) => void
   createTesters: (files: string[]) => Promise<void>
+  cdpEvent: (event: string, payload: unknown) => void
 }
 
 export type WebSocketBrowserRPC = BirpcReturn<

--- a/packages/browser/src/node/types.ts
+++ b/packages/browser/src/node/types.ts
@@ -44,7 +44,6 @@ export interface WebSocketBrowserHandlers {
   // cdp
   sendCdpEvent: (contextId: string, event: string, payload: Record<string, unknown>) => unknown
   trackCdpEvent: (contextId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) => void
-  cdpEstablished: (contextId: string) => Promise<void>
 }
 
 export interface WebSocketEvents

--- a/packages/vitest/src/node/index.ts
+++ b/packages/vitest/src/node/index.ts
@@ -25,6 +25,7 @@ export { BaseSequencer } from './sequencers/BaseSequencer'
 export type {
   BrowserProviderInitializationOptions,
   BrowserProvider,
+  CDPSession,
   BrowserProviderModule,
   ResolvedBrowserOptions,
   BrowserProviderOptions,

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -9,6 +9,14 @@ export interface BrowserProviderInitializationOptions {
   options?: BrowserProviderOptions
 }
 
+export interface CDPSession {
+  send: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+  on: (event: string, listener: (...args: unknown[]) => void) => void
+  once: (event: string, listener: (...args: unknown[]) => void) => void
+  off: (event: string, listener: (...args: unknown[]) => void) => void
+  detach: () => Promise<void>
+}
+
 export interface BrowserProvider {
   name: string
   /**
@@ -20,6 +28,7 @@ export interface BrowserProvider {
   afterCommand?: (command: string, args: unknown[]) => Awaitable<void>
   getCommandsContext: (contextId: string) => Record<string, unknown>
   openPage: (contextId: string, url: string) => Promise<void>
+  getCDPSession?: (contextId: string) => Promise<CDPSession>
   close: () => Awaitable<void>
   // eslint-disable-next-line ts/method-signature-style -- we want to allow extended options
   initialize(

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -23,8 +23,8 @@ describe('running browser tests', async () => {
       console.error(stderr)
     })
 
-    expect(browserResultJson.testResults).toHaveLength(17)
-    expect(passedTests).toHaveLength(15)
+    expect(browserResultJson.testResults).toHaveLength(18)
+    expect(passedTests).toHaveLength(16)
     expect(failedTests).toHaveLength(2)
 
     expect(stderr).not.toContain('has been externalized for browser compatibility')

--- a/test/browser/test/cdp.test.ts
+++ b/test/browser/test/cdp.test.ts
@@ -1,7 +1,7 @@
 import { cdp, server } from '@vitest/browser/context'
 import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
-describe.skipIf(server.provider !== 'playwright')('cdp in chromium browsers', () => {
+describe.skipIf(server.provider !== 'playwright' || server.browser !== 'chromium')('cdp in chromium browsers', () => {
   it('cdp sends events correctly', async () => {
     const div = document.createElement('div')
     document.body.appendChild(div)

--- a/test/browser/test/cdp.test.ts
+++ b/test/browser/test/cdp.test.ts
@@ -1,0 +1,30 @@
+import { cdp, server } from '@vitest/browser/context'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
+
+describe.skipIf(server.provider !== 'playwright')('cdp in chromium browsers', () => {
+  it('cdp sends events correctly', async () => {
+    const div = document.createElement('div')
+    document.body.appendChild(div)
+    const messageAdded = vi.fn()
+
+    cdp().on('Console.messageAdded', messageAdded)
+
+    await cdp().send('Console.enable')
+    onTestFinished(async () => {
+      await cdp().send('Console.disable')
+    })
+
+    console.error('MESSAGE ADDED')
+
+    await vi.waitFor(() => {
+      expect(messageAdded).toHaveBeenCalledWith({
+        message: expect.objectContaining({
+          column: expect.any(Number),
+          text: 'MESSAGE ADDED',
+          source: 'console-api',
+          url: expect.any(String),
+        }),
+      })
+    })
+  })
+})

--- a/test/browser/test/cdp.test.ts
+++ b/test/browser/test/cdp.test.ts
@@ -27,4 +27,21 @@ describe.skipIf(server.provider !== 'playwright')('cdp in chromium browsers', ()
       })
     })
   })
+
+  it('cdp keyboard works correctly', async () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    await cdp().send('Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      text: 'a',
+    })
+    expect(input).toHaveValue('a')
+
+    await cdp().send('Input.insertText', {
+      text: 'some text',
+    })
+    expect(input).toHaveValue('asome text')
+  })
 })


### PR DESCRIPTION
### Description

This PR exposes the CDP connection via `cdp` method from `@vitest/browser/context` (only works with `playwright`):

```ts
import { cdp } from '@vitest/browser/context'

cdp().on('Console.messageAdded', (data) => {
  // data.message.text === 'MESSAGE ADDED'
})

await cdp().send('Console.enable')

console.error('MESSAGE ADDED')

const input = document.createElement('input')
document.body.appendChild(input)
input.focus()

await cdp().send('Input.dispatchKeyEvent', {
  type: 'keyDown',
  text: 'a',
})
expect(input).toHaveValue('a')

await cdp().send('Input.insertText', {
  text: 'some text',
})
expect(input).toHaveValue('asome text')
```

TODO:

- [x] Docs
- [x] More tests

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
