### PR TITLE
fix(ui): update running todo tests inside todo suites (each)

### DIFF
--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -10,7 +10,7 @@ import {
   createOrUpdateFileNode,
   createOrUpdateNodeTask,
   createOrUpdateSuiteTask,
-  isTodoTestNodeRunning,
+  isRunningTestNode,
 } from '~/composables/explorer/utils'
 import { isSuite } from '~/utils/task'
 import { openedTreeItems, treeFilter, uiEntries, uiFiles } from '~/composables/explorer/state'
@@ -96,14 +96,14 @@ export function runCollect(
   })
 }
 
-function* collectTodoTestsMode() {
-  yield * uiEntries.value.filter(isTodoTestNodeRunning)
+function* collectRunningTodoTests() {
+  yield * uiEntries.value.filter(isRunningTestNode)
 }
 
-function updateTodoTestsMode() {
+function updateRunningTodoTests() {
   const idMap = client.state.idMap
   let task: Task | undefined
-  for (const test of collectTodoTestsMode()) {
+  for (const test of collectRunningTodoTests()) {
     // lookup the parent
     task = idMap.get(test.parentId)
     if (task && isSuite(task) && task.mode === 'todo') {
@@ -191,7 +191,7 @@ function doRunFilter(
 function refreshExplorer(search: string, filter: Filter, end: boolean) {
   runFilter(search, filter)
   // update only at the end
-  end && updateTodoTestsMode()
+  end && updateRunningTodoTests()
 }
 
 function createOrUpdateEntry(tasks: Task[]) {

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -10,7 +10,7 @@ export function isTestNode(node: UITaskTreeNode): node is FileTreeNode {
   return node.type === 'test' || node.type === 'custom'
 }
 
-export function isTodoTestNodeRunning(node: UITaskTreeNode): node is FileTreeNode {
+export function isRunningTestNode(node: UITaskTreeNode): node is FileTreeNode {
   return node.mode === 'run' && (node.type === 'test' || node.type === 'custom')
 }
 

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -17,7 +17,7 @@ export function isTestNode(node: UITaskTreeNode): node is TestTreeNode | CustomT
   return node.type === 'test' || node.type === 'custom'
 }
 
-export function isRunningTestNode(node: UITaskTreeNode): node is FileTreeNode {
+export function isRunningTestNode(node: UITaskTreeNode): node is TestTreeNode | CustomTestTreeNode {
   return node.mode === 'run' && (node.type === 'test' || node.type === 'custom')
 }
 

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -10,6 +10,10 @@ export function isTestNode(node: UITaskTreeNode): node is FileTreeNode {
   return node.type === 'test' || node.type === 'custom'
 }
 
+export function isTodoTestNodeRunning(node: UITaskTreeNode): node is FileTreeNode {
+  return node.mode === 'run' && (node.type === 'test' || node.type === 'custom')
+}
+
 export function isFileNode(node: UITaskTreeNode): node is FileTreeNode {
   return node.type === 'file'
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Todo tests inside todo suites (each) not being reported and so the running spinner in the ui: this PR updates the mode to `todo` for any tests running inside any test suite (will run at the end).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
