### PR TITLE
chore(ui): fix teardown type in Error shim

### DIFF
--- a/packages/ui/client/shim.d.ts
+++ b/packages/ui/client/shim.d.ts
@@ -9,6 +9,6 @@ declare interface Window {
 
 declare interface Error {
   VITEST_TEST_NAME?: string
-  VITEST_AFTER_ENV_TEARDOWN?: string
+  VITEST_AFTER_ENV_TEARDOWN?: boolean
   VITEST_TEST_PATH?: string
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The type for `Error.VITEST_AFTER_ENV_TEARDOWN` included in #5944 is wrong, should be a boolean not an string

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
