### PR TITLE
fix(coverage): pass thresholds errors to `stderr` of `startVitest()`

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -336,6 +336,7 @@ export class IstanbulCoverageProvider
       this.checkThresholds({
         thresholds: resolvedThresholds,
         perFile: this.options.thresholds.perFile,
+        onError: error => this.ctx.logger.error(error),
       })
 
       if (this.options.thresholds.autoUpdate && allTestsRun) {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -324,6 +324,7 @@ export class V8CoverageProvider
       this.checkThresholds({
         thresholds: resolvedThresholds,
         perFile: this.options.thresholds.perFile,
+        onError: error => this.ctx.logger.error(error),
       })
 
       if (this.options.thresholds.autoUpdate && allTestsRun) {

--- a/packages/vitest/src/utils/coverage.ts
+++ b/packages/vitest/src/utils/coverage.ts
@@ -95,9 +95,11 @@ export class BaseCoverageProvider {
   checkThresholds({
     thresholds: allThresholds,
     perFile,
+    onError,
   }: {
     thresholds: ResolvedThreshold[]
     perFile?: boolean
+    onError: (error: string) => void
   }) {
     for (const { coverageMap, thresholds, name } of allThresholds) {
       if (
@@ -154,7 +156,7 @@ export class BaseCoverageProvider {
                 )}`
               }
 
-              console.error(errorMessage)
+              onError(errorMessage)
             }
           }
         }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Forward errors of `coverage.thresholds` to `ctx.logger` instead of global `console`
- Allows capturing these errors when using `startVitest()` Node API 
- Ref. https://github.com/vitest-dev/vitest/pull/5837, which contains the test cases too
 
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
