### PR TITLE
fix: use TTY reporter when running in Deno

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -18,6 +18,7 @@ import {
   hasFailed,
   hasFailedSnapshot,
   isCI,
+  isDeno,
   isNode,
   relativePath,
   toArray,
@@ -75,7 +76,7 @@ export abstract class BaseReporter implements Reporter {
   private _offUnhandledRejection?: () => void
 
   constructor(options: BaseOptions = {}) {
-    this.isTTY = options.isTTY ?? (isNode && process.stdout?.isTTY && !isCI)
+    this.isTTY = options.isTTY ?? ((isNode || isDeno) && process.stdout?.isTTY && !isCI)
     this.registerUnhandledRejection()
   }
 

--- a/packages/vitest/src/utils/env.ts
+++ b/packages/vitest/src/utils/env.ts
@@ -1,7 +1,6 @@
 export const isNode: boolean
   = typeof process < 'u'
   && typeof process.stdout < 'u'
-  && !process.versions?.deno
   && !globalThis.window
 export const isWindows = isNode && process.platform === 'win32'
 export const isBrowser: boolean = typeof window !== 'undefined'

--- a/packages/vitest/src/utils/env.ts
+++ b/packages/vitest/src/utils/env.ts
@@ -1,7 +1,12 @@
 export const isNode: boolean
   = typeof process < 'u'
   && typeof process.stdout < 'u'
+  && !process.versions?.deno
   && !globalThis.window
-export const isWindows = isNode && process.platform === 'win32'
+export const isDeno: boolean
+  = typeof process < 'u'
+  && typeof process.stdout < 'u'
+  && process.versions?.deno !== undefined
+export const isWindows = (isNode || isDeno) && process.platform === 'win32'
 export const isBrowser: boolean = typeof window !== 'undefined'
 export { isCI, provider as stdProvider } from 'std-env'


### PR DESCRIPTION
### Description

Over at Deno we've been constantly improving our Node compatibility layer and are trying to get `vitest` to work natively. We noticed that the test reporter looks different compared to Node.

Initially, we thought this would be a bug our compatibility layer, but it turns out that `vitest` has a check for Deno that prevents it from using the TTY mode in the reporter.

Note, that there is still more work on our side to be done to get `vitest` fully running. But one step at a time ;)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
