### PR TITLE
fix: flipped erase scrollback and clear screen to fix the issue with iTerm2 refresh

### DIFF
--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -63,7 +63,7 @@ export class Logger {
       return
     }
 
-    this.console.log(`${ERASE_SCROLLBACK}${CLEAR_SCREEN}${message}`)
+    this.console.log(`${CLEAR_SCREEN}${ERASE_SCROLLBACK}${message}`)
   }
 
   clearScreen(message: string, force = false) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
iTerm2 does not fully clear the scrollback history and the screen. The problem that clearing scrollback history removes the history, and leaves current page in the scrollback history. The correct sequence is clear the screen, so it's empty and then the scrollback history leaving the terminal nice and clear. 

Issue: https://github.com/vitest-dev/vitest/issues/5977

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
