### PR TITLE
fix(coverage): Vite to ignore dynamic import of provider

### DIFF
--- a/packages/coverage-istanbul/src/index.ts
+++ b/packages/coverage-istanbul/src/index.ts
@@ -4,6 +4,7 @@ export async function getProvider() {
   // to not bundle the provider
   const providerPath = './provider.js'
   const { IstanbulCoverageProvider } = (await import(
+    /* @vite-ignore */
     providerPath
   )) as typeof import('./provider')
   return new IstanbulCoverageProvider()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Mark dynamic import of provider to be ignored by Vite
<img width="400" src="https://github.com/vitest-dev/vitest/assets/14806298/3634d196-f882-40cf-920a-716a66bcb4f1" />

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
