### PR TITLE
fix(browser): print correct stack trace in source files

### DIFF
--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -27,7 +27,7 @@ export async function collectTests(
   const config = runner.config
 
   for (const filepath of paths) {
-    const file = createFileTask(filepath, config.root, config.name)
+    const file = createFileTask(filepath, config.root, config.name, runner.pool)
 
     runner.onCollectStart?.(file)
 

--- a/packages/runner/src/types/runner.ts
+++ b/packages/runner/src/types/runner.ts
@@ -148,4 +148,8 @@ export interface VitestRunner {
    * Publicly available configuration.
    */
   config: VitestRunnerConfig
+  /**
+   * The name of the current pool. Can affect how stack trace is inferred on the server side.
+   */
+  pool?: string
 }

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -63,6 +63,7 @@ export interface Suite extends TaskBase {
 }
 
 export interface File extends Suite {
+  pool?: string
   filepath: string
   projectName: string | undefined
   collectDuration?: number

--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -118,6 +118,7 @@ export function createFileTask(
   filepath: string,
   root: string,
   projectName: string,
+  pool?: string,
 ) {
   const path = relative(root, filepath)
   const file: File = {
@@ -130,6 +131,7 @@ export function createFileTask(
     meta: Object.create(null),
     projectName,
     file: undefined!,
+    pool,
   }
   file.file = file
   return file

--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -14,6 +14,7 @@ export type { SourceMapInput } from '@jridgewell/trace-mapping'
 export interface StackTraceParserOptions {
   ignoreStackEntries?: (RegExp | string)[]
   getSourceMap?: (file: string) => unknown
+  getFileName?: (id: string) => string
   frameFilter?: (error: Error, frame: ParsedStack) => boolean | void
 }
 
@@ -192,6 +193,10 @@ export function parseStacktrace(
     )
   }
   return stacks.map((stack) => {
+    if (options.getFileName) {
+      stack.file = options.getFileName(stack.file)
+    }
+
     const map = options.getSourceMap?.(stack.file) as
       | SourceMapInput
       | null

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -4,13 +4,11 @@ import { Writable } from 'node:stream'
 import { normalize, relative } from 'pathe'
 import c from 'picocolors'
 import cliTruncate from 'cli-truncate'
-import type { StackTraceParserOptions } from '@vitest/utils/source-map'
 import { inspect } from '@vitest/utils'
 import stripAnsi from 'strip-ansi'
 import type { ErrorWithDiff, ParsedStack } from '../types'
 import {
   lineSplitRE,
-  parseErrorStacktrace,
   positionToOffset,
 } from '../utils/source-map'
 import { F_POINTER } from '../utils/figures'
@@ -18,19 +16,20 @@ import { TypeCheckError } from '../typecheck/typechecker'
 import { isPrimitive } from '../utils'
 import type { Vitest } from './core'
 import { divider } from './reporters/renderers/utils'
+import type { ErrorOptions } from './logger'
 import { Logger } from './logger'
 import type { WorkspaceProject } from './workspace'
 
 interface PrintErrorOptions {
   type?: string
   logger: Logger
-  fullStack?: boolean
   showCodeFrame?: boolean
   printProperties?: boolean
   screenshotPaths?: string[]
+  parseErrorStacktrace: (error: ErrorWithDiff) => ParsedStack[]
 }
 
-interface PrintErrorResult {
+export interface PrintErrorResult {
   nearest?: ParsedStack
 }
 
@@ -38,7 +37,7 @@ interface PrintErrorResult {
 export function capturePrintError(
   error: unknown,
   ctx: Vitest,
-  project: WorkspaceProject,
+  options: ErrorOptions,
 ) {
   let output = ''
   const writable = new Writable({
@@ -47,9 +46,10 @@ export function capturePrintError(
       callback()
     },
   })
-  const result = printError(error, project, {
+  const logger = new Logger(ctx, writable, writable)
+  const result = logger.printError(error, {
     showCodeFrame: false,
-    logger: new Logger(ctx, writable, writable),
+    ...options,
   })
   return { nearest: result?.nearest, output }
 }
@@ -59,7 +59,7 @@ export function printError(
   project: WorkspaceProject | undefined,
   options: PrintErrorOptions,
 ): PrintErrorResult | undefined {
-  const { showCodeFrame = true, fullStack = false, type, printProperties = true } = options
+  const { showCodeFrame = true, type, printProperties = true } = options
   const logger = options.logger
   let e = error as ErrorWithDiff
 
@@ -84,16 +84,7 @@ export function printError(
     return
   }
 
-  const parserOptions: StackTraceParserOptions = {
-    // only browser stack traces require remapping
-    getSourceMap: file => project.getBrowserSourceMapModuleById(file),
-    frameFilter: project.config.onStackTrace,
-  }
-
-  if (fullStack) {
-    parserOptions.ignoreStackEntries = []
-  }
-  const stacks = parseErrorStacktrace(e, parserOptions)
+  const stacks = options.parseErrorStacktrace(e)
 
   const nearest
     = error instanceof TypeCheckError
@@ -195,9 +186,9 @@ export function printError(
   if (typeof e.cause === 'object' && e.cause && 'name' in e.cause) {
     (e.cause as any).name = `Caused by: ${(e.cause as any).name}`
     printError(e.cause, project, {
-      fullStack,
       showCodeFrame: false,
       logger: options.logger,
+      parseErrorStacktrace: options.parseErrorStacktrace,
     })
   }
 

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -108,11 +108,14 @@ export class Logger {
         // browser stack trace needs to be processed differently,
         // so there is a separate method for that
         if (options.task?.file.pool === 'browser' && project.browser) {
-          return project.browser.parseErrorStacktrace(error)
+          return project.browser.parseErrorStacktrace(error, {
+            ignoreStackEntries: fullStack ? [] : undefined,
+          })
         }
 
         // node.js stack trace already has correct source map locations
         return parseErrorStacktrace(error, {
+          frameFilter: project.config.onStackTrace,
           ignoreStackEntries: fullStack ? [] : undefined,
         })
       },

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -309,13 +309,15 @@ export abstract class BaseReporter implements Reporter {
       if (log.browser) {
         write('\n')
       }
+
       const project = log.taskId
         ? this.ctx.getProjectByTaskId(log.taskId)
         : this.ctx.getCoreWorkspaceProject()
-      const stack = parseStacktrace(log.origin, {
-        getSourceMap: file => project.getBrowserSourceMapModuleById(file),
-        frameFilter: project.config.onStackTrace,
-      })
+
+      const stack = log.browser
+        ? (project.browser?.parseStacktrace(log.origin) || [])
+        : parseStacktrace(log.origin)
+
       const highlight = task
         ? stack.find(i => i.file === task.file.filepath)
         : null
@@ -605,7 +607,12 @@ export abstract class BaseReporter implements Reporter {
       }
       const screenshots = tasks.filter(t => t.meta?.failScreenshotPath).map(t => t.meta?.failScreenshotPath as string)
       const project = this.ctx.getProjectByTaskId(tasks[0].id)
-      this.ctx.logger.printError(error, { project, verbose: this.verbose, screenshotPaths: screenshots })
+      this.ctx.logger.printError(error, {
+        project,
+        verbose: this.verbose,
+        screenshotPaths: screenshots,
+        task: tasks[0],
+      })
       errorDivider()
     }
   }

--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -18,6 +18,7 @@ export class GithubActionsReporter implements Reporter {
       project: WorkspaceProject
       title: string
       error: unknown
+      file?: File
     }>()
     for (const error of errors) {
       projectErrors.push({
@@ -40,14 +41,15 @@ export class GithubActionsReporter implements Reporter {
             project,
             title,
             error,
+            file,
           })
         }
       }
     }
 
     // format errors via `printError`
-    for (const { project, title, error } of projectErrors) {
-      const result = capturePrintError(error, this.ctx, project)
+    for (const { project, title, error, file } of projectErrors) {
+      const result = capturePrintError(error, this.ctx, { project, task: file })
       const stack = result?.nearest
       if (!stack) {
         continue

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -230,7 +230,7 @@ export class JUnitReporter implements Reporter {
                   const result = capturePrintError(
                     error,
                     this.ctx,
-                    this.ctx.getProjectByTaskId(task.id),
+                    { project: this.ctx.getProjectByTaskId(task.id), task },
                   )
                   await this.baseLog(
                     escapeXML(stripAnsi(result.output.trim())),

--- a/packages/vitest/src/node/reporters/tap.ts
+++ b/packages/vitest/src/node/reporters/tap.ts
@@ -86,11 +86,11 @@ export class TapReporter implements Reporter {
           this.logger.indent()
 
           task.result.errors.forEach((error) => {
-            const stacks = parseErrorStacktrace(error, {
-              getSourceMap: file =>
-                project.getBrowserSourceMapModuleById(file),
-              frameFilter: this.ctx.config.onStackTrace,
-            })
+            const stacks = task.file.pool === 'browser'
+              ? (project.browser?.parseErrorStacktrace(error) || [])
+              : parseErrorStacktrace(error, {
+                frameFilter: this.ctx.config.onStackTrace,
+              })
             const stack = stacks[0]
 
             this.logger.log('---')

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -28,6 +28,8 @@ export class VitestTestRunner implements VitestRunner {
 
   private assertionsErrors = new WeakMap<Readonly<Task>, Error>()
 
+  public pool = this.workerState.ctx.pool
+
   constructor(public config: ResolvedConfig) {}
 
   importFile(filepath: string, source: VitestRunnerImportSource): unknown {

--- a/packages/vitest/src/types/browser.ts
+++ b/packages/vitest/src/types/browser.ts
@@ -1,6 +1,7 @@
-import type { Awaitable } from '@vitest/utils'
+import type { Awaitable, ErrorWithDiff, ParsedStack } from '@vitest/utils'
 import type { ViteDevServer } from 'vite'
 import type { CancelReason } from '@vitest/runner'
+import type { StackTraceParserOptions } from '@vitest/utils/source-map'
 import type { WorkspaceProject } from '../node/workspace'
 import type { ApiConfig } from './config'
 
@@ -190,6 +191,8 @@ export interface BrowserServer {
   provider: BrowserProvider
   close: () => Promise<void>
   initBrowserProvider: () => Promise<void>
+  parseStacktrace: (stack: string) => ParsedStack[]
+  parseErrorStacktrace: (error: ErrorWithDiff, options?: StackTraceParserOptions) => ParsedStack[]
 }
 
 export interface BrowserCommand<Payload extends unknown[]> {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -105,7 +105,10 @@ error with a stack
 
   test(`stack trace points to correct file in every browser`, () => {
     // dependeing on the browser it references either `.toBe()` or `expect()`
-    expect(stderr).toMatch(/test\/failing.test.ts:4:(12|17)/)
+    expect(stderr).toMatch(/test\/failing.test.ts:5:(12|17)/)
+
+    // column is 18 in safari, 8 in others
+    expect(stderr).toMatch(/src\/error.ts:8:(18|8)/)
   })
 
   test('popup apis should log a warning', () => {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -108,7 +108,7 @@ error with a stack
     expect(stderr).toMatch(/test\/failing.test.ts:5:(12|17)/)
 
     // column is 18 in safari, 8 in others
-    expect(stderr).toMatch(/src\/error.ts:8:(18|8)/)
+    expect(stderr).toMatch(/throwError src\/error.ts:8:(18|8)/)
   })
 
   test('popup apis should log a warning', () => {

--- a/test/browser/src/error.ts
+++ b/test/browser/src/error.ts
@@ -1,0 +1,9 @@
+interface _SomeType {
+  _unused: string
+}
+
+// this should affect the line number
+
+export function throwError(_opts?: _SomeType) {
+  throw new Error('error')
+}

--- a/test/browser/test/failing.test.ts
+++ b/test/browser/test/failing.test.ts
@@ -1,5 +1,10 @@
 import { expect, it } from 'vitest'
+import { throwError } from '../src/error'
 
 it('correctly fails and prints a diff', () => {
   expect(1).toBe(2)
+})
+
+it('correctly print error in another file', () => {
+  throwError()
 })

--- a/test/reporters/tests/__snapshots__/html.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/html.test.ts.snap
@@ -13,6 +13,7 @@ exports[`html reporter > resolves to "failing" status for test file "json-fail" 
       "meta": {},
       "mode": "run",
       "name": "json-fail.test.ts",
+      "pool": "forks",
       "prepareDuration": 0,
       "result": {
         "duration": 0,
@@ -126,6 +127,7 @@ exports[`html reporter > resolves to "passing" status for test file "all-passing
       "meta": {},
       "mode": "run",
       "name": "all-passing-or-skipped.test.ts",
+      "pool": "forks",
       "prepareDuration": 0,
       "result": {
         "duration": 0,


### PR DESCRIPTION
### Description

Fixes #5996

Previously the browser mode printed the correct stack trace only if the error was inside the test file because of incorrect stack trace parsing (files were resolved relative to the server (`/src/file.js`) instead of being absolute (`/home/project/src/file.js`)).

Also, I think working with `printError` is quite hard at this stage - maybe we should refactor it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
