### PR TITLE
fix(coverage): support import attributes in Istanbul coverage

### DIFF
--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -44,9 +44,10 @@
     "vitest": "workspace:*"
   },
   "dependencies": {
+    "@istanbuljs/schema": "^0.1.3",
     "debug": "^4.3.5",
     "istanbul-lib-coverage": "^3.2.2",
-    "istanbul-lib-instrument": "^6.0.2",
+    "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-lib-source-maps": "^5.0.4",
     "istanbul-reports": "^3.1.7",

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -28,6 +28,8 @@ import type { CoverageMap } from 'istanbul-lib-coverage'
 import libCoverage from 'istanbul-lib-coverage'
 import libSourceMaps from 'istanbul-lib-source-maps'
 import { type Instrumenter, createInstrumenter } from 'istanbul-lib-instrument'
+// @ts-expect-error @istanbuljs/schema has no type definitions
+import { defaults as istanbulDefaults } from '@istanbuljs/schema'
 
 // @ts-expect-error missing types
 import _TestExclude from 'test-exclude'
@@ -116,6 +118,13 @@ export class IstanbulCoverageProvider
       coverageGlobalScope: 'globalThis',
       coverageGlobalScopeFunc: false,
       ignoreClassMethods: this.options.ignoreClassMethods,
+      parserPlugins: [
+        ...istanbulDefaults.instrumenter.parserPlugins,
+        ['importAttributes', { deprecatedAssertSyntax: true }],
+      ],
+      generatorOpts: {
+        importAttributesKeyword: 'with',
+      },
     })
 
     this.testExclude = new _TestExclude({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
 
   packages/coverage-istanbul:
     dependencies:
+      '@istanbuljs/schema':
+        specifier: ^0.1.3
+        version: 0.1.3
       debug:
         specifier: ^4.3.5
         version: 4.3.5
@@ -506,8 +509,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2
       istanbul-lib-instrument:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
       istanbul-lib-report:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1762,6 +1765,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.24.5:
     resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
@@ -1807,7 +1811,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/generator@7.24.5:
     resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
@@ -1817,6 +1820,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.24.7:
     resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
@@ -1857,6 +1861,7 @@ packages:
       browserslist: 4.23.0
       lru-cache: 5.1.1
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-compilation-targets@7.24.7:
     resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
@@ -1867,7 +1872,6 @@ packages:
       browserslist: 4.23.0
       lru-cache: 5.1.1
       semver: 6.3.1
-    dev: true
 
   /@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.23.3):
     resolution: {integrity: sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==}
@@ -2017,6 +2021,7 @@ packages:
       '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
@@ -2064,7 +2069,6 @@ packages:
       '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-optimise-call-expression@7.24.7:
     resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
@@ -2194,6 +2198,7 @@ packages:
       '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.24.7:
     resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
@@ -2201,7 +2206,6 @@ packages:
     dependencies:
       '@babel/template': 7.24.7
       '@babel/types': 7.24.7
-    dev: true
 
   /@babel/highlight@7.24.7:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
@@ -2234,6 +2238,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.7
+    dev: true
 
   /@babel/parser@7.24.7:
     resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
@@ -3291,6 +3296,7 @@ packages:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
+    dev: true
 
   /@babel/template@7.24.7:
     resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
@@ -3316,6 +3322,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.24.7:
     resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
@@ -11123,15 +11130,15 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  /istanbul-lib-instrument@6.0.2:
-    resolution: {integrity: sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==}
+  /istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.24.4
-      '@babel/parser': 7.24.4
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -14021,7 +14028,6 @@ packages:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}

--- a/test/coverage-test/fixtures/src/json-data-import.ts
+++ b/test/coverage-test/fixtures/src/json-data-import.ts
@@ -1,0 +1,5 @@
+import data from "./json-data.json" with { "type": "json" };
+
+export function getJSON() {
+  return data
+};

--- a/test/coverage-test/fixtures/src/json-data.json
+++ b/test/coverage-test/fixtures/src/json-data.json
@@ -1,0 +1,4 @@
+{
+  "foo": false,
+  "bar": "baz"
+}

--- a/test/coverage-test/fixtures/test/import-attributes-fixture.test.ts
+++ b/test/coverage-test/fixtures/test/import-attributes-fixture.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+import {getJSON} from "../src/json-data-import";
+import json from "../src/json-data.json";
+
+test("JSON data", () => {
+  expect(getJSON()).toEqual(json);
+});

--- a/test/coverage-test/test/import-attributes.test.ts
+++ b/test/coverage-test/test/import-attributes.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'vitest'
+import { readCoverageMap, runVitest, test } from '../utils'
+
+test('import attributes work', async () => {
+  await runVitest({
+    include: ['fixtures/test/import-attributes-fixture.test.ts'],
+    coverage: { reporter: 'json', all: false },
+  })
+
+  const coverageMap = await readCoverageMap()
+  const files = coverageMap.files()
+
+  expect(files).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/json-data-import.ts",
+    ]
+  `)
+})

--- a/test/coverage-test/vitest.workspace.custom.ts
+++ b/test/coverage-test/vitest.workspace.custom.ts
@@ -67,6 +67,7 @@ export default defineWorkspace([
 
         // Other non-provider-specific tests that should be run on browser mode as well
         '**/ignore-hints.test.ts',
+        '**/import-attributes.test.ts',
         '**/multi-suite.test.ts',
         '**/setup-files.test.ts',
         '**/results-snapshot.test.ts',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds support for testing coverage of code with [import attributes](https://github.com/tc39/proposal-import-attributes) using Istanbul. It was previously discussed in issue #5537.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
