### PR TITLE
fix(coverage): remove work-around for implicit `else`

### DIFF
--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -49,7 +49,7 @@
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",
-    "istanbul-lib-source-maps": "^5.0.5",
+    "istanbul-lib-source-maps": "^5.0.6",
     "istanbul-reports": "^3.1.7",
     "magicast": "^0.3.4",
     "picocolors": "^1.0.1",

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -415,8 +415,6 @@ export class IstanbulCoverageProvider
 }
 
 async function transformCoverage(coverageMap: CoverageMap) {
-  includeImplicitElseBranches(coverageMap)
-
   const sourceMapStore = libSourceMaps.createSourceMapStore()
   return await sourceMapStore.transformCoverage(coverageMap)
 }
@@ -428,45 +426,4 @@ async function transformCoverage(coverageMap: CoverageMap) {
  */
 function removeQueryParameters(filename: string) {
   return filename.split('?')[0]
-}
-
-/**
- * Work-around for #1887 and #2239 while waiting for https://github.com/istanbuljs/istanbuljs/pull/706
- *
- * Goes through all files in the coverage map and checks if branchMap's have
- * if-statements with implicit else. When finds one, copies source location of
- * the if-statement into the else statement.
- */
-function includeImplicitElseBranches(coverageMap: CoverageMap) {
-  for (const file of coverageMap.files()) {
-    const fileCoverage = coverageMap.fileCoverageFor(file)
-
-    for (const branchMap of Object.values(fileCoverage.branchMap)) {
-      if (branchMap.type === 'if') {
-        const lastIndex = branchMap.locations.length - 1
-
-        if (lastIndex > 0) {
-          const elseLocation = branchMap.locations[lastIndex]
-
-          if (elseLocation && isEmptyCoverageRange(elseLocation)) {
-            const ifLocation = branchMap.locations[0]
-
-            elseLocation.start = { ...ifLocation.start }
-            elseLocation.end = { ...ifLocation.end }
-          }
-        }
-      }
-    }
-  }
-}
-
-function isEmptyCoverageRange(range: libCoverage.Range) {
-  return (
-    range.start === undefined
-    || range.start.line === undefined
-    || range.start.column === undefined
-    || range.end === undefined
-    || range.end.line === undefined
-    || range.end.column === undefined
-  )
 }

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -49,7 +49,7 @@
     "debug": "^4.3.5",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
-    "istanbul-lib-source-maps": "^5.0.5",
+    "istanbul-lib-source-maps": "^5.0.6",
     "istanbul-reports": "^3.1.7",
     "magic-string": "^0.30.10",
     "magicast": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       istanbul-lib-source-maps:
-        specifier: ^5.0.5
-        version: 5.0.5
+        specifier: ^5.0.6
+        version: 5.0.6
       istanbul-reports:
         specifier: ^3.1.7
         version: 3.1.7
@@ -564,8 +564,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       istanbul-lib-source-maps:
-        specifier: ^5.0.5
-        version: 5.0.5
+        specifier: ^5.0.6
+        version: 5.0.6
       istanbul-reports:
         specifier: ^3.1.7
         version: 3.1.7
@@ -11492,8 +11492,8 @@ packages:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  /istanbul-lib-source-maps@5.0.5:
-    resolution: {integrity: sha512-gKf4eJ8bHmSX/ljiOCpnd8vtmHTwG71uugm0kXYd5aqFCl6z8cj8k7QduXSwU6QOst6LCdSXTlaoc8W4554crQ==}
+  /istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25

--- a/test/coverage-test/test/__snapshots__/pre-transpiled-istanbul.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/pre-transpiled-istanbul.snapshot.json
@@ -156,14 +156,8 @@
             }
           },
           {
-            "start": {
-              "line": 2,
-              "column": 2
-            },
-            "end": {
-              "line": 5,
-              "column": 3
-            }
+            "start": {},
+            "end": {}
           }
         ]
       },
@@ -191,14 +185,8 @@
             }
           },
           {
-            "start": {
-              "line": 10,
-              "column": 2
-            },
-            "end": {
-              "line": 13,
-              "column": 3
-            }
+            "start": {},
+            "end": {}
           }
         ]
       },
@@ -226,14 +214,8 @@
             }
           },
           {
-            "start": {
-              "line": 15,
-              "column": 2
-            },
-            "end": {
-              "line": 18,
-              "column": 3
-            }
+            "start": {},
+            "end": {}
           }
         ]
       }

--- a/test/coverage-test/test/__snapshots__/results-istanbul.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/results-istanbul.snapshot.json
@@ -438,14 +438,8 @@
             }
           },
           {
-            "start": {
-              "line": 33,
-              "column": 2
-            },
-            "end": {
-              "line": 36,
-              "column": null
-            }
+            "start": {},
+            "end": {}
           }
         ]
       },
@@ -473,14 +467,8 @@
             }
           },
           {
-            "start": {
-              "line": 39,
-              "column": 2
-            },
-            "end": {
-              "line": 42,
-              "column": null
-            }
+            "start": {},
+            "end": {}
           }
         ]
       }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Upstream fix for `istanbul-lib-source-maps` was fixed and released, let's remove our patch
- Ref. https://github.com/istanbuljs/istanbuljs/pull/706
- Ref. https://github.com/vitest-dev/vitest/pull/2275

Test case:

https://github.com/vitest-dev/vitest/blob/b1a27d40493301f7b135b6ba99d52c9edc28fffb/test/coverage-test/test/implicit-else.istanbul.test.ts#L5-L20

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
