### PR TITLE
fix(vitest): show unrelated failed tests when rerunning a test

### DIFF
--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -201,7 +201,7 @@ export class WebSocketReporter implements Reporter {
     })
   }
 
-  onFinished(files?: File[], errors?: unknown[]) {
+  onFinished(files: File[], errors: unknown[]) {
     this.clients.forEach((client) => {
       client.onFinished?.(files, errors)?.catch?.(noop)
     })

--- a/packages/vitest/src/node/pools/typecheck.ts
+++ b/packages/vitest/src/node/pools/typecheck.ts
@@ -40,7 +40,7 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
 
     // triggered by TSC watcher, not Vitest watcher, so we need to emulate what Vitest does in this case
     if (ctx.config.watch && !ctx.runningPromise) {
-      await ctx.report('onFinished', files)
+      await ctx.report('onFinished', files, [])
       await ctx.report('onWatcherStart', files, [
         ...(project.config.typecheck.ignoreSourceErrors ? [] : sourceErrors),
         ...ctx.state.getUnhandledErrors(),

--- a/packages/vitest/src/node/reporters/basic.ts
+++ b/packages/vitest/src/node/reporters/basic.ts
@@ -1,8 +1,21 @@
+import { hasFailed } from '@vitest/runner/utils'
 import type { File } from '../../types/tasks'
 import { BaseReporter } from './base'
 
 export class BasicReporter extends BaseReporter {
   isTTY = false
+
+  onWatcherRerun(files: string[], trigger?: string) {
+    super.onWatcherRerun(files, trigger)
+
+    const failedTasks = this.ctx.state.getFiles().filter((file) => {
+      return hasFailed(file) && !files.includes(file.filepath)
+    })
+
+    for (const task of failedTasks) {
+      this.printTask(task)
+    }
+  }
 
   reportSummary(files: File[], errors: unknown[]) {
     // non-tty mode doesn't add a new line

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -19,11 +19,11 @@ export const hookSpinnerMap = new WeakMap<Task, Map<string, () => string>>()
 export const pointer = c.yellow(F_POINTER)
 export const skipped = c.dim(c.gray(F_DOWN))
 
-const benchmarkPass = c.green(F_DOT)
-const testPass = c.green(F_CHECK)
-const taskFail = c.red(F_CROSS)
-const suiteFail = c.red(F_POINTER)
-const pending = c.gray('·')
+export const benchmarkPass = c.green(F_DOT)
+export const testPass = c.green(F_CHECK)
+export const taskFail = c.red(F_CROSS)
+export const suiteFail = c.red(F_POINTER)
+export const pending = c.gray('·')
 
 export function getCols(delta = 0) {
   let length = process.stdout?.columns

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -19,6 +19,12 @@ export const hookSpinnerMap = new WeakMap<Task, Map<string, () => string>>()
 export const pointer = c.yellow(F_POINTER)
 export const skipped = c.dim(c.gray(F_DOWN))
 
+const benchmarkPass = c.green(F_DOT)
+const testPass = c.green(F_CHECK)
+const taskFail = c.red(F_CROSS)
+const suiteFail = c.red(F_POINTER)
+const pending = c.gray('·')
+
 export function getCols(delta = 0) {
   let length = process.stdout?.columns
   if (!length || Number.isNaN(length)) {
@@ -154,10 +160,9 @@ export function getStateSymbol(task: Task) {
   }
 
   if (!task.result) {
-    return c.gray('·')
+    return pending
   }
 
-  // pending
   if (task.result.state === 'run') {
     if (task.type === 'suite') {
       return pointer
@@ -171,11 +176,11 @@ export function getStateSymbol(task: Task) {
   }
 
   if (task.result.state === 'pass') {
-    return task.meta?.benchmark ? c.green(F_DOT) : c.green(F_CHECK)
+    return task.meta?.benchmark ? benchmarkPass : testPass
   }
 
   if (task.result.state === 'fail') {
-    return task.type === 'suite' ? pointer : c.red(F_CROSS)
+    return task.type === 'suite' ? suiteFail : taskFail
   }
 
   return ' '

--- a/packages/vitest/src/types/reporter.ts
+++ b/packages/vitest/src/types/reporter.ts
@@ -8,8 +8,8 @@ export interface Reporter {
   onSpecsCollected?: (specs?: SerializableSpec[]) => Awaitable<void>
   onCollected?: (files?: File[]) => Awaitable<void>
   onFinished?: (
-    files?: File[],
-    errors?: unknown[],
+    files: File[],
+    errors: unknown[],
     coverage?: unknown
   ) => Awaitable<void>
   onTaskUpdate?: (packs: TaskResultPack[]) => Awaitable<void>

--- a/test/core/vite.config.ts
+++ b/test/core/vite.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
     port: 3022,
   },
   test: {
-    reporters: ['dot'],
     api: {
       port: 3023,
     },


### PR DESCRIPTION
### Description

This PR fixes a situation when a test rerun would delete information about previously failed tests from the terminal making it harder to fix failed tests. We still do not print failed errors to not clutter the output with potentially irrelevant errors, but we do print previously failed files and test names.

Closes #4997

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
