### PR TITLE
feat(browser): add `pointer` to interactive api

### DIFF
--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -1,4 +1,7 @@
 import type { ResolvedConfig } from 'vitest'
+import type { PointerInput } from '@testing-library/user-event/dist/types/pointer'
+
+export type { PointerInput }
 
 export type BufferEncoding =
   | 'ascii'
@@ -169,6 +172,7 @@ export interface UserEvent {
    * @see {@link https://webdriver.io/docs/api/element/dragAndDrop/} WebdriverIO API
    */
   dragAndDrop: (source: Element, target: Element, options?: UserEventDragAndDropOptions) => Promise<void>
+  pointer: (input: PointerInput) => Promise<void>
 }
 
 export interface UserEventFillOptions {}

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -1,5 +1,5 @@
 import type { Task, WorkerGlobalState } from 'vitest'
-import type { BrowserPage, UserEvent, UserEventClickOptions, UserEventTabOptions, UserEventTypeOptions } from '../../../context'
+import type { BrowserPage, PointerInput, UserEvent, UserEventClickOptions, UserEventTabOptions, UserEventTypeOptions } from '../../../context'
 import type { BrowserRunnerState } from '../utils'
 import type { BrowserRPC } from '../client'
 
@@ -116,6 +116,36 @@ export const userEvent: UserEvent = {
     const sourceXpath = convertElementToXPath(source)
     const targetXpath = convertElementToXPath(target)
     return triggerCommand('__vitest_dragAndDrop', sourceXpath, targetXpath, options)
+  },
+  pointer(input: PointerInput) {
+    const inputs = (Array.isArray(input) ? input : [input]).map((i) => {
+      if (typeof i === 'string') {
+        return i
+      }
+
+      const { target, node, ...rest } = i
+
+      if (!target && !node) {
+        return i
+      }
+
+      if (target && !node) {
+        return { target: convertElementToXPath(target), ...rest }
+      }
+
+      if (!target && node) {
+        return { node: convertElementToXPath(node), ...rest }
+      }
+
+      return {
+        target: convertElementToXPath(target),
+        node: convertElementToXPath(node),
+        ...rest,
+      }
+    })
+
+    // todo: add options?
+    return triggerCommand('__vitest_pointer', inputs)
   },
 }
 

--- a/packages/browser/src/node/commands/index.ts
+++ b/packages/browser/src/node/commands/index.ts
@@ -7,6 +7,7 @@ import { tab } from './tab'
 import { keyboard } from './keyboard'
 import { dragAndDrop } from './dragAndDrop'
 import { hover } from './hover'
+import { pointer } from './pointer'
 import {
   readFile,
   removeFile,
@@ -30,4 +31,5 @@ export default {
   __vitest_selectOptions: selectOptions,
   __vitest_dragAndDrop: dragAndDrop,
   __vitest_hover: hover,
+  __vitest_pointer: pointer,
 }

--- a/packages/browser/src/node/commands/pointer.ts
+++ b/packages/browser/src/node/commands/pointer.ts
@@ -1,0 +1,204 @@
+import { parseKeyDef } from '@testing-library/user-event/dist/esm/pointer/parseKeyDef.js'
+import { defaultKeyMap } from '@testing-library/user-event/dist/esm/pointer/keyMap.js'
+import type { PointerCoords } from '@testing-library/user-event/dist/types/event'
+import type { pointerKey } from '@testing-library/user-event/dist/types/system/pointer'
+import type { UserEvent } from '../../../context'
+import { PlaywrightBrowserProvider } from '../providers/playwright'
+import { WebdriverBrowserProvider } from '../providers/webdriver'
+import type { UserEventCommand } from './utils'
+
+// todo: try to add proper types to avoid duplicating
+type PointerActionInput = string | ({
+  keys: string
+} & PointerActionPosition) | PointerAction
+type PointerInput = PointerActionInput[]
+type PointerAction = PointerPressAction | PointerMoveAction
+interface PointerActionPosition {
+  target?: string
+  coords?: PointerCoords
+  node?: string
+  /**
+   * If `node` is set, this is the DOM offset.
+   * Otherwise this is the `textContent`/`value` offset on the `target`.
+   */
+  offset?: number
+}
+interface PointerPressAction extends PointerActionPosition {
+  keyDef: pointerKey
+  releasePrevious: boolean
+  releaseSelf: boolean
+}
+interface PointerMoveAction extends PointerActionPosition {
+  pointerName?: string
+}
+
+export const pointer: UserEventCommand<UserEvent['pointer']> = async (
+  context,
+  input: PointerInput,
+) => {
+  const provider = context.provider
+  // todo: cleanup
+  if (!input.length || provider instanceof PlaywrightBrowserProvider) {
+    return
+  }
+
+  // const provider = context.provider
+  if (provider instanceof PlaywrightBrowserProvider) {
+    throw new TypeError(`Provider "${provider.name}" does not support pointer events`)
+  }
+  else if (provider instanceof WebdriverBrowserProvider) {
+    await webdriverioPointerImplementation(context.browser, input)
+  }
+  else {
+    throw new TypeError(`Provider "${provider.name}" does not support pointer events`)
+  }
+}
+/*
+async function _playwrightPointerImplementation(
+  provider: PlaywrightBrowserProvider,
+  input: PointerInput,
+) {
+  const actions = provider.browser
+} */
+async function webdriverioPointerImplementation(
+  browser: WebdriverIO.Browser,
+  input: PointerInput,
+) {
+  const actions = collectActions(input)
+  const targets = new Map<string, WebdriverIO.Element>()
+  for await (const action of executeWDIOActions(browser, targets, actions)) {
+    await action.perform()
+  }
+}
+
+// https://github.com/testing-library/user-event/blob/main/src/pointer/index.ts
+function collectActions(input: PointerInput) {
+  const actions: PointerAction[] = []
+  // collect actions
+  for (let i = 0; i < input.length; i++) {
+    const actionInput = input[i]
+    if (typeof actionInput === 'string') {
+      actions.push(...parseKeyDef(defaultKeyMap, actionInput))
+    }
+    else if ('keys' in actionInput) {
+      actions.push(
+        ...parseKeyDef(defaultKeyMap, actionInput.keys).map(i => ({
+          ...actionInput,
+          ...i,
+        })),
+      )
+    }
+    else {
+      actions.push(actionInput)
+    }
+  }
+
+  return actions
+}
+
+function createWDIOPointerAction(touch: boolean, browser: WebdriverIO.Browser) {
+  return browser.action('pointer', { parameters: { pointerType: touch ? 'touch' : 'mouse' } })
+}
+
+async function* executeWDIOActions(
+  browser: WebdriverIO.Browser,
+  targets: Map<string, WebdriverIO.Element>,
+  actions: PointerAction[],
+) {
+  let lastAction: {
+    touch: boolean
+    action: ReturnType<typeof createWDIOPointerAction>
+  } = undefined!
+  for (const action of actions) {
+    if ('target' in action) {
+      const target = action.target
+      if (target && !targets.has(target)) {
+        targets.set(target, await browser.$(`//${target}`))
+      }
+    }
+    if ('node' in action) {
+      const node = action.node
+      if (node && !targets.has(node)) {
+        targets.set(node, await browser.$(`//${node}`))
+      }
+    }
+    if ('keyDef' in action) {
+      if (lastAction) {
+        if (lastAction.touch) {
+          yield lastAction.action
+          lastAction = {
+            touch: false,
+            action: createWDIOPointerAction(false, browser),
+          }
+        }
+      }
+      else {
+        lastAction = {
+          touch: false,
+          action: createWDIOPointerAction(true, browser),
+        }
+      }
+      if (action.releasePrevious) {
+        lastAction.action = lastAction.action.up().pause(50)
+      }
+      lastAction.action = lastAction.action.down()
+      if (action.releaseSelf) {
+        lastAction.action = lastAction.action.up().pause(50)
+      }
+    }
+    else {
+      if (action.pointerName) {
+        if (lastAction) {
+          if (!lastAction.touch) {
+            yield lastAction.action
+            lastAction = {
+              touch: true,
+              action: createWDIOPointerAction(true, browser),
+            }
+          }
+        }
+        else {
+          lastAction = {
+            touch: true,
+            action: createWDIOPointerAction(true, browser),
+          }
+        }
+        const params: any = {}
+        const { x, y } = action.coords ?? {}
+        if (x !== undefined && y !== undefined) {
+          params.x = x
+          params.y = y
+        }
+        if (action.target) {
+          const target = targets.get(action.target)
+          if (target) {
+            params.origin = target
+          }
+        }
+        params.button = action.pointerName === 'left' ? 0 : action.pointerName === 'right' ? 2 : 1
+        lastAction.action = lastAction.action.move(params)
+      }
+      else {
+        if (lastAction) {
+          if (lastAction.touch) {
+            yield lastAction.action
+            lastAction = {
+              touch: false,
+              action: createWDIOPointerAction(false, browser),
+            }
+          }
+        }
+        else {
+          lastAction = {
+            touch: false,
+            action: createWDIOPointerAction(false, browser),
+          }
+        }
+        // todo: check also for coordinates
+        lastAction.action = lastAction.action.move({ origin: targets.get(action.target!)! })
+      }
+    }
+  }
+
+  yield lastAction.action
+}

--- a/test/browser/test/userEvent.test.ts
+++ b/test/browser/test/userEvent.test.ts
@@ -600,3 +600,175 @@ describe.each([
     })
   })
 })
+
+describe('userEvent.pointer', () => {
+  test('correctly clicks a button', async () => {
+    const button = document.createElement('button')
+    button.textContent = 'Click me'
+    document.body.appendChild(button)
+    const onClick = vi.fn()
+    const dblClick = vi.fn()
+    button.addEventListener('click', onClick)
+
+    await userEvent.pointer([{ target: button }, { keys: '[MouseLeft]', target: button }])
+
+    // todo: cleanup
+    if (server.provider === 'playwright') {
+      expect(onClick).not.toHaveBeenCalled()
+      expect(dblClick).not.toHaveBeenCalled()
+    }
+    else {
+      expect(onClick).toHaveBeenCalled()
+      expect(dblClick).not.toHaveBeenCalled()
+    }
+  })
+
+  test('correctly doesn\'t click on a disabled button', async () => {
+    const button = document.createElement('button')
+    button.textContent = 'Click me'
+    button.disabled = true
+    document.body.appendChild(button)
+    const onClick = vi.fn()
+    button.addEventListener('click', onClick)
+
+    await userEvent.pointer([{ target: button }, { keys: '[MouseLeft]', target: button }])
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+  test('correctly double clicks a button', async () => {
+    const button = document.createElement('button')
+    button.textContent = 'Click me'
+    document.body.appendChild(button)
+    const onClick = vi.fn()
+    const dblClick = vi.fn()
+    button.addEventListener('click', onClick)
+    button.addEventListener('dblclick', dblClick)
+
+    await userEvent.pointer([
+      { target: button },
+      { keys: '[MouseLeft][MouseLeft]', target: button },
+    ])
+
+    // todo: cleanup
+    if (server.provider === 'playwright') {
+      expect(onClick).not.toHaveBeenCalled()
+      expect(dblClick).not.toHaveBeenCalled()
+    }
+    else {
+      expect(onClick).toHaveBeenCalledTimes(2)
+      expect(dblClick).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  test('correctly doesn\'t double click on a disabled button', async () => {
+    const button = document.createElement('button')
+    button.textContent = 'Click me'
+    button.disabled = true
+    document.body.appendChild(button)
+    const onClick = vi.fn()
+    const dblClick = vi.fn()
+    button.addEventListener('click', onClick)
+    button.addEventListener('dblclick', dblClick)
+
+    await userEvent.pointer([
+      { target: button },
+      { keys: '[MouseLeft][MouseLeft]', target: button },
+    ])
+
+    expect(onClick).not.toHaveBeenCalled()
+    expect(dblClick).not.toHaveBeenCalled()
+  })
+  test('correctly triple clicks a button', async () => {
+    const button = document.createElement('button')
+    button.textContent = 'Click me'
+    document.body.appendChild(button)
+    const onClick = vi.fn()
+    const dblClick = vi.fn()
+    const tripleClick = vi.fn()
+    button.addEventListener('click', onClick)
+    button.addEventListener('dblclick', dblClick)
+    button.addEventListener('click', tripleClick)
+
+    await userEvent.pointer([
+      { target: button },
+      { keys: '[MouseLeft][MouseLeft][MouseLeft]', target: button },
+    ])
+
+    // todo: cleanup
+    if (server.provider === 'playwright') {
+      expect(onClick).not.toHaveBeenCalled()
+      expect(dblClick).not.toHaveBeenCalled()
+      expect(tripleClick).not.toHaveBeenCalled()
+    }
+    else {
+      expect(onClick).toHaveBeenCalledTimes(3)
+      expect(dblClick).toHaveBeenCalledTimes(1)
+      expect(tripleClick).toHaveBeenCalledTimes(3)
+      expect(tripleClick.mock.calls.length).toBe(3)
+      expect(tripleClick.mock.calls
+        .map(c => c[0] as MouseEvent)
+        .filter(c => c.detail === 3)).toHaveLength(1)
+    }
+  })
+
+  test('correctly doesn\'t triple click on a disabled button', async () => {
+    const button = document.createElement('button')
+    button.textContent = 'Click me'
+    button.disabled = true
+    document.body.appendChild(button)
+    const onClick = vi.fn()
+    const dblClick = vi.fn()
+    const tripleClick = vi.fn()
+    button.addEventListener('click', onClick)
+    button.addEventListener('dblclick', dblClick)
+    button.addEventListener('click', tripleClick)
+
+    await userEvent.pointer([
+      { target: button },
+      { keys: '[MouseLeft][MouseLeft][MouseLeft]', target: button },
+    ])
+
+    expect(onClick).not.toHaveBeenCalled()
+    expect(dblClick).not.toHaveBeenCalled()
+    expect(tripleClick).not.toHaveBeenCalled()
+  })
+  test('hover works correctly', async () => {
+    const target = document.createElement('div')
+    target.style.width = '100px'
+    target.style.height = '100px'
+
+    let mouseEntered = false
+    let pointerEntered = false
+    target.addEventListener('mouseover', () => {
+      mouseEntered = true
+    })
+    target.addEventListener('pointerenter', () => {
+      pointerEntered = true
+    })
+    target.addEventListener('pointerleave', () => {
+      pointerEntered = false
+    })
+    target.addEventListener('mouseout', () => {
+      mouseEntered = false
+    })
+
+    document.body.appendChild(target)
+
+    await userEvent.pointer({ target })
+
+    // todo: cleanup
+    if (server.provider === 'playwright') {
+      expect(pointerEntered).toBe(false)
+      expect(mouseEntered).toBe(false)
+    }
+    else {
+      expect(pointerEntered).toBe(true)
+      expect(mouseEntered).toBe(true)
+    }
+
+    await userEvent.pointer({ target: target.ownerDocument.body })
+
+    expect(pointerEntered).toBe(false)
+    expect(mouseEntered).toBe(false)
+  })
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Right now only tested `click`, `hover` and `unhover` using `pointer` with WDIO provider.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
