### PR TITLE
docs: default pool in the types of 2.0 config

### DIFF
--- a/packages/vitest/src/types/config.ts
+++ b/packages/vitest/src/types/config.ts
@@ -333,7 +333,7 @@ export interface InlineConfig {
    *
    * Supports 'threads', 'forks', 'vmThreads'
    *
-   * @default 'threads'
+   * @default 'forks'
    */
   pool?: Exclude<Pool, 'browser'>
 


### PR DESCRIPTION
### Description

The default pool was changed to `forks` in Vitest 2.0:
https://github.com/vitest-dev/vitest/pull/5047

But the JSDoc `@default` was not.
The PR fixes that discrepancy.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
