### PR TITLE
fix(coverage): use project specific `vitenode` for uncovered files

### DIFF
--- a/docs/guide/workspace.md
+++ b/docs/guide/workspace.md
@@ -231,6 +231,4 @@ All configuration options that are not supported inside a project config have <N
 
 ## Coverage
 
-Coverage for workspace projects works out of the box. But if you have [`all`](/config/#coverage-all) option enabled and use non-conventional extensions in some of your projects, you will need to have a plugin that handles this extension in your root configuration file.
-
-For example, if you have a package that uses Vue files and it has its own config file, but some of the files are not imported in your tests, coverage will fail trying to analyze the usage of unused files, because it relies on the root configuration rather than project configuration.
+Coverage for workspace projects works out of the box.

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -414,13 +414,15 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
     const cacheKey = new Date().getTime()
     const coverageMap = libCoverage.createCoverageMap({})
 
+    const transform = this.createUncoveredFileTransformer(this.ctx)
+
     // Note that these cannot be run parallel as synchronous instrumenter.lastFileCoverage
     // returns the coverage of the last transformed file
     for (const [index, filename] of uncoveredFiles.entries()) {
       debug('Uncovered file %s %d/%d', filename, index, uncoveredFiles.length)
 
       // Make sure file is not served from cache so that instrumenter loads up requested file coverage
-      await this.ctx.vitenode.transformRequest(`${filename}?v=${cacheKey}`)
+      await transform(`${filename}?v=${cacheKey}`)
       const lastCoverage = this.instrumenter.lastFileCoverage()
       coverageMap.addFileCoverage(lastCoverage)
     }

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -368,6 +368,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
     const transformResults = normalizeTransformResults(
       this.ctx.vitenode.fetchCache,
     )
+    const transform = this.createUncoveredFileTransformer(this.ctx)
 
     const allFiles = await this.testExclude.glob(this.ctx.config.root)
     let includedFiles = allFiles.map(file =>
@@ -401,7 +402,7 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
           const { originalSource } = await this.getSources(
             filename.href,
             transformResults,
-            file => this.ctx.vitenode.transformRequest(file),
+            transform,
           )
 
           const coverage = {

--- a/test/coverage-test/fixtures/configs/vitest.workspace.multi-transforms.ts
+++ b/test/coverage-test/fixtures/configs/vitest.workspace.multi-transforms.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { Plugin, defineWorkspace } from "vitest/config";
+import MagicString from "magic-string";
+
+export default defineWorkspace([
+  // Project that uses its own "root" and custom transform plugin
+  {
+    test: {
+      name: "custom-with-root",
+      root: "fixtures/workspaces/custom-2",
+    },
+    plugins: [customFilePlugin("2")],
+  },
+
+  // Project that cannot transform "*.custom-x" files
+  {
+    test: {
+      name: "normal",
+      include: ["fixtures/test/math.test.ts"],
+    },
+  },
+
+  // Project that uses default "root" and has custom transform plugin
+  {
+    test: {
+      name: "custom",
+      include: ["fixtures/test/custom-1-syntax.test.ts"],
+    },
+    plugins: [customFilePlugin("1")],
+  },
+]);
+
+/**
+ * Plugin for transforming `.custom-1` and/or `.custom-2` files to Javascript
+ */
+function customFilePlugin(postfix: "1" | "2"): Plugin {
+  function transform(code: MagicString) {
+    code.replaceAll(
+      "<function covered>",
+      `
+function covered() {
+  return "Custom-${postfix} file loaded!"
+}
+  `.trim()
+    );
+
+    code.replaceAll(
+      "<function uncovered>",
+      `
+function uncovered() {
+  return "This should be uncovered!"
+}
+    `.trim()
+    );
+
+    code.replaceAll("<default export covered>", "export default covered()");
+    code.replaceAll("<default export uncovered>", "export default uncovered()");
+  }
+
+  return {
+    name: `custom-${postfix}-file-plugin`,
+    transform(_, id) {
+      const filename = id.split("?")[0];
+
+      if (filename.endsWith(`.custom-${postfix}`)) {
+        const content = readFileSync(filename, "utf8");
+
+        const s = new MagicString(content);
+        transform(s);
+
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: "boundary" }),
+        };
+      }
+    },
+  };
+}

--- a/test/coverage-test/fixtures/src/covered.custom-1
+++ b/test/coverage-test/fixtures/src/covered.custom-1
@@ -1,0 +1,5 @@
+<function covered>
+
+<function uncovered>
+
+<default export covered>

--- a/test/coverage-test/fixtures/src/uncovered.custom-1
+++ b/test/coverage-test/fixtures/src/uncovered.custom-1
@@ -1,0 +1,3 @@
+<function uncovered>
+
+<default export uncovered>

--- a/test/coverage-test/fixtures/test/custom-1-syntax.test.ts
+++ b/test/coverage-test/fixtures/test/custom-1-syntax.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest'
+
+// @ts-expect-error -- untyped
+import output from '../src/covered.custom-1'
+
+test('custom file loads fine', () => {
+  expect(output).toMatch('Custom-1 file loaded!')
+})

--- a/test/coverage-test/fixtures/workspaces/custom-2/src/covered.custom-2
+++ b/test/coverage-test/fixtures/workspaces/custom-2/src/covered.custom-2
@@ -1,0 +1,5 @@
+<function covered>
+
+<function uncovered>
+
+<default export covered>

--- a/test/coverage-test/fixtures/workspaces/custom-2/src/uncovered.custom-2
+++ b/test/coverage-test/fixtures/workspaces/custom-2/src/uncovered.custom-2
@@ -1,0 +1,3 @@
+<function uncovered>
+
+<default export uncovered>

--- a/test/coverage-test/fixtures/workspaces/custom-2/test/custom-2-syntax.test.ts
+++ b/test/coverage-test/fixtures/workspaces/custom-2/test/custom-2-syntax.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest'
+
+// @ts-expect-error -- untyped
+import output from '../src/covered.custom-2'
+
+test('custom-2 file loads fine', () => {
+  expect(output).toMatch('Custom-2 file loaded!')
+})

--- a/test/coverage-test/test/__snapshots__/custom-file-covered-1-istanbul.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-covered-1-istanbul.snapshot.json
@@ -1,0 +1,83 @@
+{
+  "path": "<process-cwd>/fixtures/src/covered.custom-1",
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    },
+    "1": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 20
+      }
+    }
+  },
+  "fnMap": {
+    "0": {
+      "name": "covered",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      }
+    },
+    "1": {
+      "name": "uncovered",
+      "decl": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      }
+    }
+  },
+  "branchMap": {},
+  "s": {
+    "0": 1,
+    "1": 0
+  },
+  "f": {
+    "0": 1,
+    "1": 0
+  },
+  "b": {}
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-covered-1-v8.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-covered-1-v8.snapshot.json
@@ -1,0 +1,150 @@
+{
+  "path": "<process-cwd>/fixtures/src/covered.custom-1",
+  "all": false,
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    },
+    "1": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 0
+      }
+    },
+    "2": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 20
+      }
+    },
+    "3": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 0
+      }
+    },
+    "4": {
+      "start": {
+        "line": 5,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 24
+      }
+    }
+  },
+  "s": {
+    "0": 1,
+    "1": 1,
+    "2": 0,
+    "3": 1,
+    "4": 1
+  },
+  "branchMap": {
+    "0": {
+      "type": "branch",
+      "line": 1,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "locations": [
+        {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        }
+      ]
+    }
+  },
+  "b": {
+    "0": [
+      1
+    ]
+  },
+  "fnMap": {
+    "0": {
+      "name": "covered",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "line": 1
+    },
+    "1": {
+      "name": "uncovered",
+      "decl": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "line": 3
+    }
+  },
+  "f": {
+    "0": 1,
+    "1": 0
+  }
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-covered-2-istanbul.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-covered-2-istanbul.snapshot.json
@@ -1,0 +1,83 @@
+{
+  "path": "<process-cwd>/fixtures/workspaces/custom-2/src/covered.custom-2",
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    },
+    "1": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 20
+      }
+    }
+  },
+  "fnMap": {
+    "0": {
+      "name": "covered",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      }
+    },
+    "1": {
+      "name": "uncovered",
+      "decl": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      }
+    }
+  },
+  "branchMap": {},
+  "s": {
+    "0": 1,
+    "1": 0
+  },
+  "f": {
+    "0": 1,
+    "1": 0
+  },
+  "b": {}
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-covered-2-v8.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-covered-2-v8.snapshot.json
@@ -1,0 +1,150 @@
+{
+  "path": "<process-cwd>/fixtures/workspaces/custom-2/src/covered.custom-2",
+  "all": false,
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    },
+    "1": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 0
+      }
+    },
+    "2": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 20
+      }
+    },
+    "3": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 0
+      }
+    },
+    "4": {
+      "start": {
+        "line": 5,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 24
+      }
+    }
+  },
+  "s": {
+    "0": 1,
+    "1": 1,
+    "2": 0,
+    "3": 1,
+    "4": 1
+  },
+  "branchMap": {
+    "0": {
+      "type": "branch",
+      "line": 1,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "locations": [
+        {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        }
+      ]
+    }
+  },
+  "b": {
+    "0": [
+      1
+    ]
+  },
+  "fnMap": {
+    "0": {
+      "name": "covered",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "line": 1
+    },
+    "1": {
+      "name": "uncovered",
+      "decl": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "line": 3
+    }
+  },
+  "f": {
+    "0": 1,
+    "1": 0
+  }
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-uncovered-1-istanbul.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-uncovered-1-istanbul.snapshot.json
@@ -1,0 +1,48 @@
+{
+  "path": "<process-cwd>/fixtures/src/uncovered.custom-1",
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    }
+  },
+  "fnMap": {
+    "0": {
+      "name": "uncovered",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 20
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 20
+        }
+      }
+    }
+  },
+  "branchMap": {},
+  "s": {
+    "0": 0
+  },
+  "f": {
+    "0": 0
+  },
+  "b": {}
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-uncovered-1-v8.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-uncovered-1-v8.snapshot.json
@@ -1,0 +1,103 @@
+{
+  "path": "<process-cwd>/fixtures/src/uncovered.custom-1",
+  "all": true,
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    },
+    "1": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 0
+      }
+    },
+    "2": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 26
+      }
+    }
+  },
+  "s": {
+    "0": 0,
+    "1": 0,
+    "2": 0
+  },
+  "branchMap": {
+    "0": {
+      "type": "branch",
+      "line": 1,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "locations": [
+        {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 26
+          }
+        }
+      ]
+    }
+  },
+  "b": {
+    "0": [
+      0
+    ]
+  },
+  "fnMap": {
+    "0": {
+      "name": "(empty-report)",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "line": 1
+    }
+  },
+  "f": {
+    "0": 0
+  }
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-uncovered-2-istanbul.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-uncovered-2-istanbul.snapshot.json
@@ -1,0 +1,48 @@
+{
+  "path": "<process-cwd>/fixtures/workspaces/custom-2/src/uncovered.custom-2",
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    }
+  },
+  "fnMap": {
+    "0": {
+      "name": "uncovered",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 20
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 20
+        }
+      }
+    }
+  },
+  "branchMap": {},
+  "s": {
+    "0": 0
+  },
+  "f": {
+    "0": 0
+  },
+  "b": {}
+}

--- a/test/coverage-test/test/__snapshots__/custom-file-uncovered-2-v8.snapshot.json
+++ b/test/coverage-test/test/__snapshots__/custom-file-uncovered-2-v8.snapshot.json
@@ -1,0 +1,103 @@
+{
+  "path": "<process-cwd>/fixtures/workspaces/custom-2/src/uncovered.custom-2",
+  "all": true,
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    },
+    "1": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 0
+      }
+    },
+    "2": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 26
+      }
+    }
+  },
+  "s": {
+    "0": 0,
+    "1": 0,
+    "2": 0
+  },
+  "branchMap": {
+    "0": {
+      "type": "branch",
+      "line": 1,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "locations": [
+        {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 26
+          }
+        }
+      ]
+    }
+  },
+  "b": {
+    "0": [
+      0
+    ]
+  },
+  "fnMap": {
+    "0": {
+      "name": "(empty-report)",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      },
+      "line": 1
+    }
+  },
+  "f": {
+    "0": 0
+  }
+}

--- a/test/coverage-test/test/all.test.ts
+++ b/test/coverage-test/test/all.test.ts
@@ -4,7 +4,7 @@ import { readCoverageMap, runVitest, test } from '../utils'
 test('{ all: true } includes uncovered files', async () => {
   await runVitest({
     include: ['fixtures/test/**'],
-    exclude: ['**/virtual-files-**'],
+    exclude: ['**/virtual-files-**', '**/custom-1-syntax**'],
     coverage: {
       include: ['fixtures/src/**'],
       all: true,
@@ -25,7 +25,7 @@ test('{ all: true } includes uncovered files', async () => {
 test('{ all: false } excludes uncovered files', async () => {
   await runVitest({
     include: ['fixtures/test/**'],
-    exclude: ['**/virtual-files-**'],
+    exclude: ['**/virtual-files-**', '**/custom-1-syntax**'],
     coverage: {
       include: ['fixtures/src/**'],
       all: false,

--- a/test/coverage-test/test/changed.test.ts
+++ b/test/coverage-test/test/changed.test.ts
@@ -33,6 +33,7 @@ afterAll(() => {
 test('{ changed: "HEAD" }', async () => {
   await runVitest({
     include: ['fixtures/test/**'],
+    exclude: ['**/custom-1-syntax**'],
     changed: 'HEAD',
     coverage: {
       include: ['fixtures/src/**'],

--- a/test/coverage-test/test/workspace.multi-transform.test.ts
+++ b/test/coverage-test/test/workspace.multi-transform.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'vitest'
+import { isV8Provider, readCoverageMap, runVitest, test } from '../utils'
+
+test('{ all: true } includes uncovered files that require custom transform', async () => {
+  await runVitest({
+    workspace: 'fixtures/configs/vitest.workspace.multi-transforms.ts',
+    coverage: {
+      all: true,
+      extension: ['.ts', '.custom-1', '.custom-2'],
+      reporter: ['json', 'html'],
+      include: ['**/*.custom-1', '**/*.custom-2', '**/math.ts'],
+    },
+  })
+
+  const coverageMap = await readCoverageMap()
+  const files = coverageMap.files()
+
+  // All files from workspace should be picked
+  expect(files).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/covered.custom-1",
+      "<process-cwd>/fixtures/src/math.ts",
+      "<process-cwd>/fixtures/src/uncovered.custom-1",
+      "<process-cwd>/fixtures/workspaces/custom-2/src/covered.custom-2",
+      "<process-cwd>/fixtures/workspaces/custom-2/src/uncovered.custom-2",
+    ]
+  `)
+
+  const covered1 = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/covered.custom-1')
+  const uncovered1 = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/uncovered.custom-1')
+  const covered2 = coverageMap.fileCoverageFor('<process-cwd>/fixtures/workspaces/custom-2/src/covered.custom-2')
+  const uncovered2 = coverageMap.fileCoverageFor('<process-cwd>/fixtures/workspaces/custom-2/src/uncovered.custom-2')
+
+  // Coverage maps indicate whether source maps are correct. Check html-report if these change
+  expect(JSON.stringify(covered1, null, 2)).toMatchFileSnapshot(snapshotName('covered-1'))
+  expect(JSON.stringify(uncovered1, null, 2)).toMatchFileSnapshot(snapshotName('uncovered-1'))
+  expect(JSON.stringify(covered2, null, 2)).toMatchFileSnapshot(snapshotName('covered-2'))
+  expect(JSON.stringify(uncovered2, null, 2)).toMatchFileSnapshot(snapshotName('uncovered-2'))
+})
+
+function snapshotName(label: string) {
+  return `__snapshots__/custom-file-${label}-${isV8Provider() ? 'v8' : 'istanbul'}.snapshot.json`
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/5856 

When picking up uncovered files (`coverage.all`) in workspace, try to find `vitenode` from a project whose `root` matches the uncovered file. If none are found, use core's `vitenode`. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
