### PR TITLE
docs: update VP theme configuration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,8 +37,8 @@ export default ({ mode }: { mode: string }) => {
     },
     head: [
       ['meta', { name: 'theme-color', content: '#729b1a' }],
-      ['link', { rel: 'icon', href: '/favicon.ico', sizes: 'any' }],
-      ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
+      ['link', { rel: 'icon', href: '/favicon.ico', sizes: '48x48' }],
+      ['link', { rel: 'icon', href: '/logo.svg', sizes: 'any', type: 'image/svg+xml' }],
       ['meta', { name: 'author', content: `${teamMembers.map(c => c.name).join(', ')} and ${vitestName} contributors` }],
       ['meta', { name: 'keywords', content: 'vitest, vite, test, coverage, snapshot, react, vue, preact, svelte, solid, lit, marko, ruby, cypress, puppeteer, jsdom, happy-dom, test-runner, jest, typescript, esm, tinypool, tinyspy, node' }],
       ['meta', { property: 'og:title', content: vitestName }],
@@ -139,7 +139,7 @@ export default ({ mode }: { mode: string }) => {
                   link: releases,
                 },
                 {
-                  text: 'Contributing ',
+                  text: 'Contributing',
                   link: contributing,
                 },
               ],

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
 import { h } from 'vue'
-import Theme, { VPBadge } from 'vitepress/theme'
-import type { EnhanceAppContext } from 'vitepress'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import { inBrowser } from 'vitepress'
 import '../style/main.css'
 import '../style/vars.css'
@@ -15,16 +15,14 @@ if (inBrowser) {
 }
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   Layout() {
-    return h(Theme.Layout, null, {
+    return h(DefaultTheme.Layout, null, {
       'home-features-after': () => h(HomePage),
     })
   },
-  enhanceApp({ app }: EnhanceAppContext) {
-    // Vitepress v1+ doesn't seem to expose it as a global "Badge"
-    app.component('Badge', VPBadge)
+  enhanceApp({ app }) {
     app.component('Version', Version)
-    app.use(TwoslashFloatingVue as any)
+    app.use(TwoslashFloatingVue)
   },
-}
+} satisfies Theme

--- a/docs/guide/browser/context.md
+++ b/docs/guide/browser/context.md
@@ -41,6 +41,7 @@ export const userEvent: {
   setup: () => UserEvent
   click: (element: Element, options?: UserEventClickOptions) => Promise<void>
   dblClick: (element: Element, options?: UserEventDoubleClickOptions) => Promise<void>
+  tripleClick: (element: Element, options?: UserEventTripleClickOptions) => Promise<void>
   selectOptions: (
     element: Element,
     values: HTMLElement | HTMLElement[] | string | string[],

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "ESNext"],
     "baseUrl": ".",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "paths": {
       "~/*": ["src/*"]
     },


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR includes:
- fix types in VP theme:
  -  add VP types removing hack for enhanceApp
  -  use Bundler instead node10 in tsconfig file: breaks shiki twoslash client plugin type
- destructucting default VP theme removes internal VP `enhanceApp` (which has things like badge): using `extends` works
- change favicon sizes: check https://vite-pwa-org.netlify.app/assets-generator/migrations.html#from-minimal-to-minimal-2023-preset
- include missing `tripleClick` in `guide/browser/context` page code snippet

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
