### PR TITLE
fix(ui): encode html entities in task name

### DIFF
--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -60,6 +60,7 @@ function expandTests() {
           v-tooltip.bottom="'Collapse tests'"
           title="Collapse tests"
           :disabled="!initialized"
+          data-testid="collapse-all"
           icon="i-carbon:collapse-all"
           @click="collapseTests()"
         />
@@ -68,6 +69,7 @@ function expandTests() {
           v-tooltip.bottom="'Expand tests'"
           :disabled="!initialized"
           title="Expand tests"
+          data-testid="expand-all"
           icon="i-carbon:expand-all"
           @click="expandTests()"
         />

--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -7,7 +7,7 @@ import { client, isReport, runFiles } from '~/composables/client'
 import { coverageEnabled } from '~/composables/navigation'
 import type { TaskTreeNodeType } from '~/composables/explorer/types'
 import { explorerTree } from '~/composables/explorer'
-import { search } from '~/composables/explorer/state'
+import { escapeHtml, highlightRegex } from '~/composables/explorer/state'
 import { showSource } from '~/composables/codemirror'
 
 // TODO: better handling of "opened" - it means to forcefully open the tree item and set in TasksList right now
@@ -107,16 +107,13 @@ const gridStyles = computed(() => {
   } ${gridColumns.join(' ')};`
 })
 
-const highlightRegex = computed(() => {
-  const searchString = search.value.toLowerCase()
-  return searchString.length ? new RegExp(`(${searchString})`, 'gi') : null
-})
-
+const escapedName = computed(() => escapeHtml(name))
 const highlighted = computed(() => {
   const regex = highlightRegex.value
+  const useName = escapedName.value
   return regex
-    ? name.replace(regex, match => `<span class="highlight">${match}</span>`)
-    : name
+    ? useName.replace(regex, match => `<span class="highlight">${match}</span>`)
+    : useName
 })
 
 const disableShowDetails = computed(() => type !== 'file' && disableTaskLocation)

--- a/packages/ui/client/composables/explorer/state.ts
+++ b/packages/ui/client/composables/explorer/state.ts
@@ -22,6 +22,20 @@ export const treeFilter = useLocalStorage<TreeFilterState>(
   },
 )
 export const search = ref<string>(treeFilter.value.search)
+const htmlEntities: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&#39;',
+}
+export function escapeHtml(str: string) {
+  return str.replace(/[&<>"']/g, m => htmlEntities[m])
+}
+export const highlightRegex = computed(() => {
+  const searchString = search.value.toLowerCase()
+  return searchString.length ? new RegExp(`(${escapeHtml(searchString)})`, 'gi') : null
+})
 export const isFiltered = computed(() => search.value.trim() !== '')
 export const filter = reactive<Filter>({
   failed: treeFilter.value.failed,

--- a/test/ui/fixtures/task-name.test.ts
+++ b/test/ui/fixtures/task-name.test.ts
@@ -1,10 +1,9 @@
 import { it, expect} from "vitest"
 
-
 it('<MyComponent />', () => {
   expect(true).toBe(true)
 })
 
-it('<>\'">', () => {
+it('<>\'"', () => {
   expect(true).toBe(true)
 })

--- a/test/ui/fixtures/task-name.test.ts
+++ b/test/ui/fixtures/task-name.test.ts
@@ -1,0 +1,10 @@
+import { it, expect} from "vitest"
+
+
+it('<MyComponent />', () => {
+  expect(true).toBe(true)
+})
+
+it('<>\'">', () => {
+  expect(true).toBe(true)
+})

--- a/test/ui/package.json
+++ b/test/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test-e2e": "GITHUB_ACTIONS=false playwright test",
+    "test-e2e-ui": "GITHUB_ACTIONS=false playwright test --ui",
     "test-fixtures": "vitest"
   },
   "devDependencies": {

--- a/test/ui/test/html-report.spec.ts
+++ b/test/ui/test/html-report.spec.ts
@@ -31,8 +31,8 @@ test.describe('html report', () => {
 
     await page.goto(pageUrl)
 
-    // dashbaord
-    await expect(page.locator('[aria-labelledby=tests]')).toContainText('6 Pass 1 Fail 7 Total')
+    // dashboard
+    await expect(page.locator('[aria-labelledby=tests]')).toContainText('8 Pass 1 Fail 9 Total')
 
     // unhandled errors
     await expect(page.getByTestId('unhandled-errors')).toContainText(

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -36,8 +36,8 @@ test.describe('ui', () => {
 
     await page.goto(pageUrl)
 
-    // dashbaord
-    await expect(page.locator('[aria-labelledby=tests]')).toContainText('6 Pass 1 Fail 7 Total')
+    // dashboard
+    await expect(page.locator('[aria-labelledby=tests]')).toContainText('8 Pass 1 Fail 9 Total')
 
     // unhandled errors
     await expect(page.getByTestId('unhandled-errors')).toContainText(
@@ -96,7 +96,7 @@ test.describe('ui', () => {
 
     // match all files when no filter
     await page.getByPlaceholder('Search...').fill('')
-    await page.getByText('PASS (3)').click()
+    await page.getByText('PASS (4)').click()
     await expect(page.getByTestId('details-panel').getByText('fixtures/sample.test.ts', { exact: true })).toBeVisible()
 
     // match nothing
@@ -123,14 +123,15 @@ test.describe('ui', () => {
     await expect(page.getByTestId('details-panel').getByText('fixtures/console.test.ts', { exact: true })).toBeVisible()
     await expect(page.getByTestId('details-panel').getByText('fixtures/sample.test.ts', { exact: true })).toBeHidden()
 
+    // todo: PW cannot detect these nodes, any locator selector (css, xpath) will fail (even with custom evaluate + querySelectorAll)
     // html entities in task names are escaped
-    await page.getByPlaceholder('Search...').fill('<MyComponent />')
+    /* await page.getByPlaceholder('Search...').fill('<MyComponent />')
     await page.getByText('<MyComponent />').click()
     await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible()
 
     // html entities in task names are escaped
-    await page.getByPlaceholder('Search...').fill('<>\'">')
-    await page.getByText('<>\'">').click()
-    await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible()
+    await page.getByPlaceholder('Search...').fill('<>\'"')
+    await page.getByText('<>\'"').click()
+    await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible() */
   })
 })

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -123,15 +123,18 @@ test.describe('ui', () => {
     await expect(page.getByTestId('details-panel').getByText('fixtures/console.test.ts', { exact: true })).toBeVisible()
     await expect(page.getByTestId('details-panel').getByText('fixtures/sample.test.ts', { exact: true })).toBeHidden()
 
-    // todo: PW cannot detect these nodes, any locator selector (css, xpath) will fail (even with custom evaluate + querySelectorAll)
     // html entities in task names are escaped
-    /* await page.getByPlaceholder('Search...').fill('<MyComponent />')
-    await page.getByText('<MyComponent />').click()
+    await page.locator('span').filter({ hasText: /^Pass$/ }).click()
+    await page.getByPlaceholder('Search...').fill('<MyComponent />')
+    // for some reason, the tree is collapsed by default: we need to click on the nav buttons to expand it
+    await page.getByTestId('collapse-all').click()
+    await page.getByTestId('expand-all').click()
+    await expect(page.getByText('<MyComponent />')).toBeVisible()
     await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible()
 
     // html entities in task names are escaped
     await page.getByPlaceholder('Search...').fill('<>\'"')
-    await page.getByText('<>\'"').click()
-    await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible() */
+    await expect(page.getByText('<>\'"')).toBeVisible()
+    await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible()
   })
 })

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -122,5 +122,15 @@ test.describe('ui', () => {
     await page.getByText('PASS (1)').click()
     await expect(page.getByTestId('details-panel').getByText('fixtures/console.test.ts', { exact: true })).toBeVisible()
     await expect(page.getByTestId('details-panel').getByText('fixtures/sample.test.ts', { exact: true })).toBeHidden()
+
+    // html entities in task names are escaped
+    await page.getByPlaceholder('Search...').fill('<MyComponent />')
+    await page.getByText('<MyComponent />').click()
+    await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible()
+
+    // html entities in task names are escaped
+    await page.getByPlaceholder('Search...').fill('<>\'">')
+    await page.getByText('<>\'">').click()
+    await expect(page.getByTestId('details-panel').getByText('fixtures/task-name.test.ts', { exact: true })).toBeVisible()
   })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR also reduces regex number to just 1: moved to explorer state composable (we only need 1 regex for the the search string 🚀 ).

Added ui fixture and test to verify the html is there: the fixture doing dummy Vitest test.

Right now `test/ui` failing on my local (PW), we'll need #6069 merged here (no idea why CI is working 🤞 ).

closes #6061

<!-- You can also add additional context here -->

![imagen](https://github.com/vitest-dev/vitest/assets/6311119/864af21e-492c-48e8-abf7-e92d9bd94fc1)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
