### PR TITLE
fix(spy): fix type error when assigning `vi.spyOn` to `MockInstance` of function overload

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -401,11 +401,11 @@ export function spyOn<T, G extends Properties<Required<T>>>(
 export function spyOn<T, M extends Classes<Required<T>> | Methods<Required<T>>>(
   obj: T,
   methodName: M
-): Required<T>[M] extends
-| { new (...args: infer A): infer R }
-| ((...args: infer A) => infer R)
+): Required<T>[M] extends { new (...args: infer A): infer R }
   ? MockInstance<(this: R, ...args: A) => R>
-  : never
+  : T[M] extends Procedure
+    ? MockInstance<T[M]>
+    : never
 export function spyOn<T, K extends keyof T>(
   obj: T,
   method: K,

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -125,11 +125,9 @@ describe('testing vi utils', () => {
       scrollTo() {}
     }
 
-    const myElement = new MyElement()
-
     // verify `spyOn` is assignable to `MockInstance` with overload
     const spy: MockInstance<MyElement['scrollTo']> = vi.spyOn(
-      myElement,
+      MyElement.prototype,
       'scrollTo',
     )
 
@@ -138,6 +136,20 @@ describe('testing vi utils', () => {
     expectTypeOf(spy.mock.calls).toEqualTypeOf<
       [x: number, y: number][]
     >()
+  })
+
+  test(`mock.contexts types`, () => {
+    class TestClass {
+      f(this: TestClass) {}
+      g() {}
+    }
+
+    const fSpy = vi.spyOn(TestClass.prototype, 'f')
+    const gSpy = vi.spyOn(TestClass.prototype, 'g')
+
+    // contexts inferred only when `this` is explicitly annotated
+    expectTypeOf(fSpy.mock.contexts).toEqualTypeOf<TestClass[]>()
+    expectTypeOf(gSpy.mock.contexts).toEqualTypeOf<unknown[]>()
   })
 
   test('can change config', () => {

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import type { Mock, MockedFunction, MockedObject } from 'vitest'
+import type { Mock, MockInstance, MockedFunction, MockedObject } from 'vitest'
 import { describe, expect, expectTypeOf, test, vi } from 'vitest'
 import { getWorkerState } from '../../../packages/vitest/src/utils'
 
@@ -116,6 +116,21 @@ describe('testing vi utils', () => {
     expect(someFn2).not.toBeCalled()
     expect(someFn3).not.toBeCalled()
     expect(someFn4).not.toBeCalled()
+  })
+
+  test(`vi.spyOn for function overload types`, () => {
+    // verify `spyOn` is assignable to `MockInstance` for overload
+    //   scrollTo(options?: ScrollToOptions): void;
+    //   scrollTo(x: number, y: number): void;
+    const scrollToSpy: MockInstance<Element['scrollTo']> = vi.spyOn(
+      Element.prototype,
+      'scrollTo',
+    )
+
+    // however `Parameters` only picks up the last overload
+    expectTypeOf(scrollToSpy.mock.calls).toEqualTypeOf<
+      [x: number, y: number][]
+    >()
   })
 
   test('can change config', () => {

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -119,11 +119,20 @@ describe('testing vi utils', () => {
   })
 
   test(`vi.spyOn for function overload types`, () => {
+    /* eslint-disable ts/method-signature-style */
+    interface MyElement {
+      scrollTo(options?: ScrollToOptions): void
+      scrollTo(x: number, y: number): void
+    }
+    /* eslint-enable ts/method-signature-style */
+
+    const myElement: MyElement = {
+      scrollTo() {},
+    }
+
     // verify `spyOn` is assignable to `MockInstance` for overload
-    //   scrollTo(options?: ScrollToOptions): void;
-    //   scrollTo(x: number, y: number): void;
-    const scrollToSpy: MockInstance<Element['scrollTo']> = vi.spyOn(
-      Element.prototype,
+    const scrollToSpy: MockInstance<MyElement['scrollTo']> = vi.spyOn(
+      myElement,
       'scrollTo',
     )
 

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -119,25 +119,23 @@ describe('testing vi utils', () => {
   })
 
   test(`vi.spyOn for function overload types`, () => {
-    /* eslint-disable ts/method-signature-style */
-    interface MyElement {
+    class MyElement {
       scrollTo(options?: ScrollToOptions): void
       scrollTo(x: number, y: number): void
-    }
-    /* eslint-enable ts/method-signature-style */
-
-    const myElement: MyElement = {
-      scrollTo() {},
+      scrollTo() {}
     }
 
-    // verify `spyOn` is assignable to `MockInstance` for overload
-    const scrollToSpy: MockInstance<MyElement['scrollTo']> = vi.spyOn(
+    const myElement = new MyElement()
+
+    // verify `spyOn` is assignable to `MockInstance` with overload
+    const spy: MockInstance<MyElement['scrollTo']> = vi.spyOn(
       myElement,
       'scrollTo',
     )
 
     // however `Parameters` only picks up the last overload
-    expectTypeOf(scrollToSpy.mock.calls).toEqualTypeOf<
+    // due to typescript limitation
+    expectTypeOf(spy.mock.calls).toEqualTypeOf<
       [x: number, y: number][]
     >()
   })


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6085

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
