### PR TITLE
fix(browser): userEvent.setup initiates a separate state for userEvent instance

### DIFF
--- a/docs/guide/browser/interactivity-api.md
+++ b/docs/guide/browser/interactivity-api.md
@@ -163,7 +163,7 @@ test('trigger keystrokes', async () => {
 
 References:
 
-- [Playwright `locator.press` API](https://playwright.dev/docs/api/class-locator#locator-press)
+- [Playwright `Keyboard` API](https://playwright.dev/docs/api/class-keyboard)
 - [WebdriverIO `action('key')` API](https://webdriver.io/docs/api/browser/action#key-input-source)
 - [testing-library `type` API](https://testing-library.com/docs/user-event/utility/#type)
 
@@ -194,7 +194,7 @@ test('tab works', async () => {
 
 References:
 
-- [Playwright `locator.press` API](https://playwright.dev/docs/api/class-locator#locator-press)
+- [Playwright `Keyboard` API](https://playwright.dev/docs/api/class-keyboard)
 - [WebdriverIO `action('key')` API](https://webdriver.io/docs/api/browser/action#key-input-source)
 - [testing-library `tab` API](https://testing-library.com/docs/user-event/convenience/#tab)
 

--- a/docs/guide/browser/interactivity-api.md
+++ b/docs/guide/browser/interactivity-api.md
@@ -29,6 +29,29 @@ Almost every `userEvent` method inherits its provider options. To see all availa
 ```
 :::
 
+## userEvent.setup
+
+- **Type:** `() => UserEvent`
+
+Creates a new user event instance. This is useful if you need to keep the state of keyboard to press and release buttons correctly.
+
+::: warning
+Unlike `@testing-library/user-event`, the default `userEvent` instance from `@vitest/browser/context` is created once, not every time its methods are called! You can see the difference in how it works in this snippet:
+
+```ts
+import { userEvent as vitestUserEvent } from '@vitest/browser/context'
+import { userEvent as originalUserEvent } from '@testing-library/user-event'
+
+await vitestUserEvent.keyboard('{Shift}') // press shift without releasing
+await vitestUserEvent.keyboard('{/Shift}') // releases shift
+
+await originalUserEvent.keyboard('{Shift}') // press shift without releasing
+await originalUserEvent.keyboard('{/Shift}') // DID NOT release shift because the state is different
+```
+
+This behaviour is more useful because we do not emulate the keyboard, we actually press the Shift, so keeping the original behaviour would cause unexpected issues when typing in the field.
+:::
+
 ## userEvent.click
 
 - **Type:** `(element: Element, options?: UserEventClickOptions) => Promise<void>`

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -103,7 +103,7 @@ export interface UserEvent {
    * await userEvent.keyboard('foo') // translates to: f, o, o
    * await userEvent.keyboard('{{a[[') // translates to: {, a, [
    * await userEvent.keyboard('{Shift}{f}{o}{o}') // translates to: Shift, f, o, o
-   * @see {@link https://playwright.dev/docs/api/class-locator#locator-press} Playwright API
+   * @see {@link https://playwright.dev/docs/api/class-keyboard} Playwright API
    * @see {@link https://webdriver.io/docs/api/browser/keys} WebdriverIO API
    * @see {@link https://testing-library.com/docs/user-event/keyboard} testing-library API
    */
@@ -129,7 +129,7 @@ export interface UserEvent {
   clear: (element: Element) => Promise<void>
   /**
    * Sends a `Tab` key event. Uses provider's API under the hood.
-   * @see {@link https://playwright.dev/docs/api/class-locator#locator-press} Playwright API
+   * @see {@link https://playwright.dev/docs/api/class-keyboard} Playwright API
    * @see {@link https://webdriver.io/docs/api/element/keys} WebdriverIO API
    * @see {@link https://testing-library.com/docs/user-event/convenience/#tab} testing-library API
    */

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -49,6 +49,14 @@ export interface BrowserCommands {
 }
 
 export interface UserEvent {
+  /**
+   * Creates a new user event instance. This is useful if you need to keep the
+   * state of keyboard to press and release buttons correctly.
+   *
+   * **Note:** Unlike `@testing-library/user-event`, the default `userEvent` instance
+   * from `@vitest/browser/context` is created once, not every time its methods are called!
+   * @see {@link https://vitest.dev/guide/browser/interactivity-api.html#userevent-setup}
+   */
   setup: () => UserEvent
   /**
    * Click on an element. Uses provider's API under the hood and supports all its options.

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -155,7 +155,10 @@ export async function keyboardImplementation(
       }
     }
 
-    await keyboard.perform(skipRelease)
+    // seems like webdriverio doesn't release keys automatically if skipRelease is true and all events are keyUp
+    const allRelease = keyboard.toJSON().actions.every(action => action.type === 'keyUp')
+
+    await keyboard.perform(allRelease ? false : skipRelease)
   }
 
   return {

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -3,12 +3,16 @@ import { defaultKeyMap } from '@testing-library/user-event/dist/esm/keyboard/key
 import type { BrowserProvider } from 'vitest/node'
 import { PlaywrightBrowserProvider } from '../providers/playwright'
 import { WebdriverBrowserProvider } from '../providers/webdriver'
-import type { UserEvent } from '../../../context'
 import type { UserEventCommand } from './utils'
 
-export const keyboard: UserEventCommand<UserEvent['keyboard']> = async (
+export interface KeyboardState {
+  unreleased: string[]
+}
+
+export const keyboard: UserEventCommand<(text: string, state: KeyboardState) => Promise<{ unreleased: string[] }>> = async (
   context,
   text,
+  state,
 ) => {
   function focusIframe() {
     if (
@@ -28,7 +32,10 @@ export const keyboard: UserEventCommand<UserEvent['keyboard']> = async (
     await context.browser.execute(focusIframe)
   }
 
+  const pressed = new Set<string>(state.unreleased)
+
   await keyboardImplementation(
+    pressed,
     context.provider,
     context.contextId,
     text,
@@ -52,17 +59,20 @@ export const keyboard: UserEventCommand<UserEvent['keyboard']> = async (
     },
     true,
   )
+
+  return {
+    unreleased: Array.from(pressed),
+  }
 }
 
 export async function keyboardImplementation(
+  pressed: Set<string>,
   provider: BrowserProvider,
   contextId: string,
   text: string,
   selectAll: () => Promise<void>,
   skipRelease: boolean,
 ) {
-  const pressed = new Set<string>()
-
   if (provider instanceof PlaywrightBrowserProvider) {
     const page = provider.getPage(contextId)
     const actions = parseKeyDef(defaultKeyMap, text)

--- a/packages/browser/src/node/commands/type.ts
+++ b/packages/browser/src/node/commands/type.ts
@@ -11,6 +11,7 @@ export const type: UserEventCommand<UserEvent['type']> = async (
   options = {},
 ) => {
   const { skipClick = false, skipAutoClose = false } = options
+  const unreleased = new Set(Reflect.get(options, 'unreleased') as string[] ?? [])
 
   if (context.provider instanceof PlaywrightBrowserProvider) {
     const { iframe } = context
@@ -21,6 +22,7 @@ export const type: UserEventCommand<UserEvent['type']> = async (
     }
 
     await keyboardImplementation(
+      unreleased,
       context.provider,
       context.contextId,
       text,
@@ -37,6 +39,7 @@ export const type: UserEventCommand<UserEvent['type']> = async (
     }
 
     await keyboardImplementation(
+      unreleased,
       context.provider,
       context.contextId,
       text,
@@ -51,5 +54,9 @@ export const type: UserEventCommand<UserEvent['type']> = async (
   }
   else {
     throw new TypeError(`Provider "${context.provider.name}" does not support typing`)
+  }
+
+  return {
+    unreleased: Array.from(unreleased),
   }
 }

--- a/packages/browser/src/node/plugins/pluginContext.ts
+++ b/packages/browser/src/node/plugins/pluginContext.ts
@@ -94,10 +94,17 @@ function getUserEvent(provider: BrowserProvider) {
   }
   // TODO: have this in a separate file
   return `{
-  ...__vitest_user_event__,
-  fill: async (element, text) => {
-    await __vitest_user_event__.clear(element)
-    await __vitest_user_event__.type(element, text)
+  ..._userEventSetup,
+  setup() {
+    const userEvent = __vitest_user_event__.setup()
+    userEvent.setup = this.setup
+    userEvent.fill = this.fill.bind(userEvent)
+    userEvent.dragAndDrop = this.dragAndDrop
+    return userEvent
+  },
+  async fill(element, text) {
+    await this.clear(element)
+    await this.type(element, text)
   },
   dragAndDrop: async () => {
     throw new Error('Provider "preview" does not support dragging elements')
@@ -115,5 +122,5 @@ async function getUserEventImport(provider: BrowserProvider, resolve: (id: strin
   }
   return `import { userEvent as __vitest_user_event__ } from '${slash(
     `/@fs/${resolved.id}`,
-  )}'`
+  )}'\nconst _userEventSetup = __vitest_user_event__.setup()\n`
 }

--- a/test/browser/test/userEvent.test.ts
+++ b/test/browser/test/userEvent.test.ts
@@ -562,6 +562,7 @@ describe('userEvent.keyboard', async () => {
     ])
   })
 
+  // looks like wdio doesn't support releasing Enter on its own
   test('should not auto release', async () => {
     const spyKeydown = vi.fn()
     const spyKeyup = vi.fn()

--- a/test/browser/test/userEvent.test.ts
+++ b/test/browser/test/userEvent.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { server, userEvent } from '@vitest/browser/context'
+import { userEvent as _uE, server } from '@vitest/browser/context'
 import '../src/button.css'
 
 beforeEach(() => {
   // clear body
   document.body.replaceChildren()
 })
+
+const userEvent = _uE.setup()
 
 describe('userEvent.click', () => {
   test('correctly clicks a button', async () => {
@@ -347,11 +349,11 @@ describe.each(inputLike)('userEvent.type', (getElement) => {
   test('repeating without manual up works correctly', async () => {
     const { input, keydown, keyup, value } = createTextInput()
 
-    await userEvent.type(input, '{a>3}4')
-    expect(value()).toBe('aaa4')
+    const userEvent = _uE.setup()
+    await userEvent.type(input, '{a>2}4')
+    expect(value()).toBe('aa4')
 
     expect(keydown).toEqual([
-      'a',
       'a',
       'a',
       '4',
@@ -366,6 +368,7 @@ describe.each(inputLike)('userEvent.type', (getElement) => {
   test('repeating with manual up works correctly', async () => {
     const { input, keydown, keyup, value } = createTextInput()
 
+    const userEvent = _uE.setup()
     await userEvent.type(input, '{a>3/}4')
     expect(value()).toBe('aaa4')
 
@@ -385,6 +388,7 @@ describe.each(inputLike)('userEvent.type', (getElement) => {
   test('repeating with disabled up works correctly', async () => {
     const { input, keydown, keyup, value } = createTextInput()
 
+    const userEvent = _uE.setup()
     await userEvent.type(input, '{a>3}4', {
       skipAutoClose: true,
     })
@@ -406,6 +410,7 @@ describe.each(inputLike)('userEvent.type', (getElement) => {
     const shadowRoot = createShadowRoot()
     const { input, keydown, value } = createTextInput(shadowRoot)
 
+    const userEvent = _uE.setup()
     await userEvent.type(input, 'Hello')
     expect(value()).toBe('Hello')
     expect(keydown).toEqual([
@@ -569,8 +574,7 @@ describe('userEvent.keyboard', async () => {
     expect(spyKeydown).toHaveBeenCalledOnce()
     expect(spyKeyup).not.toHaveBeenCalled()
     await userEvent.keyboard('{/Enter}')
-    // userEvent doesn't fire any event here, but should we?
-    expect(spyKeyup).not.toHaveBeenCalled()
+    expect(spyKeyup).toHaveBeenCalled()
   })
 
   test('standalone keyboard works correctly with active input', async () => {


### PR DESCRIPTION
### Description

Closes #6082

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
