### PR TITLE
feat(ui): show all suites/tests when parent matches

### DIFF
--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -53,10 +53,6 @@ export class ExplorerTree {
     this.rafCollector = useRafFn(this.runCollect.bind(this), { fpsLimit: 10, immediate: false })
   }
 
-  async uiEntries() {
-    return import('./state').then(({ uiEntries }) => uiEntries.value)
-  }
-
   loadFiles(remoteFiles: File[]) {
     runLoadFiles(
       remoteFiles,

--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -53,6 +53,10 @@ export class ExplorerTree {
     this.rafCollector = useRafFn(this.runCollect.bind(this), { fpsLimit: 10, immediate: false })
   }
 
+  async uiEntries() {
+    return import('./state').then(({ uiEntries }) => uiEntries.value)
+  }
+
   loadFiles(remoteFiles: File[]) {
     runLoadFiles(
       remoteFiles,

--- a/packages/ui/client/composables/explorer/types.ts
+++ b/packages/ui/client/composables/explorer/types.ts
@@ -38,10 +38,12 @@ export interface UITaskTreeNode extends TaskTreeNode {
 }
 
 export interface TestTreeNode extends UITaskTreeNode {
+  fileId: string
   type: 'test'
 }
 
 export interface CustomTestTreeNode extends UITaskTreeNode {
+  fileId: string
   type: 'custom'
 }
 
@@ -51,6 +53,7 @@ export interface ParentTreeNode extends UITaskTreeNode {
 }
 
 export interface SuiteTreeNode extends ParentTreeNode {
+  fileId: string
   type: 'suite'
   typecheck?: boolean
 }

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -115,7 +115,7 @@ export function createOrUpdateNodeTask(id: string) {
   }
 
   const task = client.state.idMap.get(id)
-  // if no children just return
+  // if it is not a test just return
   if (!task || !isAtomTest(task)) {
     return
   }
@@ -149,6 +149,7 @@ export function createOrUpdateNode(
       if (isAtomTest(task)) {
         taskNode = {
           id: task.id,
+          fileId: task.file.id,
           parentId,
           name: task.name,
           mode: task.mode,
@@ -158,11 +159,12 @@ export function createOrUpdateNode(
           indent: node.indent + 1,
           duration: task.result?.duration,
           state: task.result?.state,
-        }
+        } as TestTreeNode | CustomTestTreeNode
       }
       else {
         taskNode = {
           id: task.id,
+          fileId: task.file.id,
           parentId,
           name: task.name,
           mode: task.mode,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When searching and `Only Tests` unchecked, any file/suite matching the search will include its children.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
