### PR TITLE
fix: `--inspect-brk` stop on Windows

### DIFF
--- a/packages/vitest/src/runtime/inspector.ts
+++ b/packages/vitest/src/runtime/inspector.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module'
-
+import { pathToFileURL } from 'node:url'
 import type { ContextRPC, ResolvedConfig } from '../types'
 
 const __require = createRequire(import.meta.url)
@@ -37,7 +37,7 @@ export function setupInspect(ctx: ContextRPC) {
           session.post('Debugger.enable')
           session.post('Debugger.setBreakpointByUrl', {
             lineNumber: 0,
-            url: new URL(firstTestFile, import.meta.url).href,
+            url: pathToFileURL(firstTestFile),
           })
         }
       }

--- a/test/cli/test/inspect.test.ts
+++ b/test/cli/test/inspect.test.ts
@@ -2,12 +2,11 @@ import type { InspectorNotification } from 'node:inspector'
 import { expect, test } from 'vitest'
 import WebSocket from 'ws'
 
-import { isWindows } from '../../../packages/vite-node/src/utils'
 import { runVitestCli } from '../../test-utils'
 
 type Message = Partial<InspectorNotification<any>>
 
-test.skipIf(isWindows)('--inspect-brk stops at test file', async () => {
+test('--inspect-brk stops at test file', async () => {
   const { vitest, waitForClose } = await runVitestCli(
     '--root',
     'fixtures/inspect',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/6103

This works on all platforms except Windows:

```js
const filename = resolve("./target.mjs");
const url = new URL(filename, import.meta.url).href;

session.post("Debugger.setBreakpointByUrl", { url, lineNumber: 0 });
```

This works on Windows too:

```js
const filename = resolve("./target.mjs");
const url = pathToFileURL(filename);

session.post("Debugger.setBreakpointByUrl", { url, lineNumber: 0 });
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
