### PR TITLE
fix: -d prefix change to optional in defaultConfig.typecheck.include

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -128,7 +128,7 @@ const config = {
   dangerouslyIgnoreUnhandledErrors: false,
   typecheck: {
     checker: 'tsc' as const,
-    include: ['**/*.{test,spec}-d.?(c|m)[jt]s?(x)'],
+    include: ['**/*.{test,spec}?(-d).?(c|m)[jt]s?(x)'],
     exclude: defaultExclude,
   },
   slowTestThreshold: 300,

--- a/packages/vitest/src/typecheck/collect.ts
+++ b/packages/vitest/src/typecheck/collect.ts
@@ -101,7 +101,7 @@ export async function collectTests(
       } = node as any
       const property = callee?.property?.name
       let mode = !property || property === name ? 'run' : property
-      if (!['run', 'skip', 'todo', 'only', 'skipIf', 'runIf'].includes(mode)) {
+      if (!['run', 'skip', 'todo', 'each', 'only', 'skipIf', 'runIf'].includes(mode)) {
         throw new Error(
           `${name}.${mode} syntax is not supported when testing types`,
         )

--- a/test/typescript/failing/fail-without-prefix.test.ts
+++ b/test/typescript/failing/fail-without-prefix.test.ts
@@ -1,0 +1,5 @@
+import { expectTypeOf, test } from 'vitest'
+
+test('failing test', () => {
+  expectTypeOf(1).toEqualTypeOf<string>()
+})

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -85,6 +85,19 @@ describe('should fail', async () => {
 
     expect(stderr.replace(resolve(__dirname, '..'), '<root>')).toMatchSnapshot()
   })
+
+  it('should check type files that without -d prefix by default.', async () => {
+    const { stderr } = await runVitest({
+      root,
+      dir: './failing',
+      typecheck: {
+        enabled: true,
+      },
+    })
+
+    expect(stderr).toMatch('FAIL  fail-without-prefix.test.ts')
+    expect(stderr).toMatch(`TypeCheckError: Type 'string' is not assignable to type 'number'.`)
+  })
 })
 
 describe('ignoreSourceErrors', () => {


### PR DESCRIPTION
### Description
It is just to change "-d" to optional in typecheck regexp on default config.
But I don't know if this is a bug because this is an intended implementation.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

Resolve: #5868