### PR TITLE
docs: improve extending matchers docs

### DIFF
--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -26,11 +26,13 @@ expect.extend({
 If you are using TypeScript, you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
 ```ts
+import 'vitest'
+
 interface CustomMatchers<R = unknown> {
   toBeFoo: () => R
 }
 
-declare module '@vitest/expect' {
+declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining extends CustomMatchers {}
 }

--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -26,13 +26,11 @@ expect.extend({
 If you are using TypeScript, you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
 ```ts
-import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
-
 interface CustomMatchers<R = unknown> {
   toBeFoo: () => R
 }
 
-declare module 'vitest' {
+declare module '@vitest/expect' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining extends CustomMatchers {}
 }
@@ -45,7 +43,7 @@ Don't forget to include the ambient declaration file in your `tsconfig.json`.
 The return value of a matcher should be compatible with the following interface:
 
 ```ts
-interface MatcherResult {
+interface ExpectationResult {
   pass: boolean
   message: () => string
   // If you pass these, they will automatically appear inside a diff when


### PR DESCRIPTION
### Description

This PR improves the docs for setting up custom matchers. With the current guide I wasn't able to properly configure TypeScript, so I needed to take a look at [Testing LIbrary Jest DOM matchers](https://github.com/testing-library/jest-dom/blob/main/types/vitest.d.ts) how they handle it. Their approach worked for me, so I suggest updating the docs accordingly.

- change ambient declaration file to how it is configured inside [testing lib](https://github.com/testing-library/jest-dom/blob/main/types/vitest.d.ts) since the current way didn't work for me
- rename MatcherResult to ExpectationResult as this is the current name of custom matcher return type according to source code (see MatchersObject > RawMatcherFn > ExpectationResult)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
