### PR TITLE
fix(dev): fix relay of custom equality testers

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -501,7 +501,7 @@ export function iterableEquality(
   ) {
     const aEntries = Object.entries(a)
     const bEntries = Object.entries(b)
-    if (!equals(aEntries, bEntries)) {
+    if (!equals(aEntries, bEntries, filteredCustomTesters)) {
       return false
     }
   }

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -156,6 +156,28 @@ describe('expect.addEqualityTesters', () => {
   })
 })
 
+describe('recursive custom equality tester for numeric values', () => {
+  const areNumbersEqual: Tester = (a, b) => typeof b === 'number' ? a === b : undefined
+
+  expect.addEqualityTesters([areNumbersEqual])
+
+  test('within objects', () => {
+    expect({ foo: -0, bar: 0, baz: 0 }).toStrictEqual({ foo: 0, bar: -0, baz: 0 })
+  })
+
+  test('within arrays', () => {
+    expect([-0, 0, 0]).toStrictEqual([0, -0, 0])
+  })
+
+  test('within typed arrays', () => {
+    expect(Float64Array.of(-0, 0, 0)).toStrictEqual(Float64Array.of(0, -0, 0))
+  })
+
+  test('within deeply nested structures', () => {
+    expect({ foo: { bar: [1, [2, 0, [3, -0, 4]]] }, baz: 0 }).toStrictEqual({ foo: { bar: [1, [2, -0, [3, 0, 4]]] }, baz: -0 })
+  })
+})
+
 describe('recursive custom equality tester', () => {
   let personId = 0
 


### PR DESCRIPTION
close #6122

### Description

When adding a custom equality tester in vitest.setup, for example

```
function numberEquality(actual, expected) {
  return typeof expected === 'number' ? actual === expected : undefined;
}
expect.addEqualityTesters([
  numberEquality
]);
```

it is not relayed to typed-array values in toStrictEqual matches.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
