### PR TITLE
feat: introduce experimental reported tasks

### DIFF
--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -70,7 +70,7 @@ export function setupBrowserRpc(
           ctx.state.catchError(error, type)
         },
         async onCollected(files) {
-          ctx.state.collectFiles(files)
+          ctx.state.collectFiles(project, files)
           await ctx.report('onCollected', files)
         },
         async onTaskUpdate(packs) {

--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -1,4 +1,5 @@
 import { processError } from '@vitest/utils/error'
+import { toArray } from '@vitest/utils'
 import type { File, SuiteHooks } from './types/tasks'
 import type { VitestRunner } from './types/runner'
 import {
@@ -34,11 +35,18 @@ export async function collectTests(
     clearCollectorContext(filepath, runner)
 
     try {
-      const setupStart = now()
-      await runSetupFiles(config, runner)
+      const setupFiles = toArray(config.setupFiles)
+      if (setupFiles.length) {
+        const setupStart = now()
+        await runSetupFiles(config, setupFiles, runner)
+        const setupEnd = now()
+        file.setupDuration = setupEnd - setupStart
+      }
+      else {
+        file.setupDuration = 0
+      }
 
       const collectStart = now()
-      file.setupDuration = collectStart - setupStart
 
       await runner.importFile(filepath, 'collect')
 

--- a/packages/runner/src/setup.ts
+++ b/packages/runner/src/setup.ts
@@ -1,11 +1,10 @@
-import { toArray } from '@vitest/utils'
 import type { VitestRunner, VitestRunnerConfig } from './types/runner'
 
 export async function runSetupFiles(
   config: VitestRunnerConfig,
+  files: string[],
   runner: VitestRunner,
 ): Promise<void> {
-  const files = toArray(config.setupFiles)
   if (config.sequence.setupFiles === 'parallel') {
     await Promise.all(
       files.map(async (fsPath) => {

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -9,7 +9,7 @@ import type {
 } from 'vitest'
 import { parse } from 'flatted'
 import { decompressSync, strFromU8 } from 'fflate'
-import { StateManager } from '../../../../vitest/src/node/state'
+import { StateManager } from '../../../../ws-client/src/state'
 
 interface HTMLReportMetadata {
   paths: string[]
@@ -55,7 +55,6 @@ export function createStaticClient(): VitestClient {
     },
     getTransformResult: asyncNoop,
     onDone: noop,
-    onCollected: asyncNoop,
     onTaskUpdate: noop,
     writeFile: asyncNoop,
     rerun: asyncNoop,

--- a/packages/utils/src/diff/index.ts
+++ b/packages/utils/src/diff/index.ts
@@ -69,7 +69,7 @@ const FALLBACK_FORMAT_OPTIONS = {
  * @param options Diff options
  * @returns {string | null} a string diff
  */
-export function diff(a: any, b: any, options?: DiffOptions): string | null {
+export function diff(a: any, b: any, options?: DiffOptions): string | undefined {
   if (Object.is(a, b)) {
     return ''
   }
@@ -80,11 +80,11 @@ export function diff(a: any, b: any, options?: DiffOptions): string | null {
   if (aType === 'object' && typeof a.asymmetricMatch === 'function') {
     if (a.$$typeof !== Symbol.for('jest.asymmetricMatcher')) {
       // Do not know expected type of user-defined asymmetric matcher.
-      return null
+      return undefined
     }
     if (typeof a.getExpectedType !== 'function') {
       // For example, expect.anything() matches either null or undefined
-      return null
+      return undefined
     }
     expectedType = a.getExpectedType()
     // Primitive types boolean and number omit difference below.
@@ -104,7 +104,7 @@ export function diff(a: any, b: any, options?: DiffOptions): string | null {
   }
 
   if (omitDifference) {
-    return null
+    return undefined
   }
 
   switch (aType) {
@@ -234,7 +234,7 @@ export function printDiffOrStringify(
   expected: unknown,
   received: unknown,
   options?: DiffOptions,
-): string | null {
+): string | undefined {
   const { aAnnotation, bAnnotation } = normalizeDiffOptions(options)
 
   if (

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -142,10 +142,6 @@ export function processError(
     })
   }
 
-  if (err.diffOptions) {
-    err.diffOptions = undefined
-  }
-
   if (typeof err.expected !== 'string') {
     err.expected = stringify(err.expected, 10)
   }

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,5 +1,6 @@
 import { type DiffOptions, printDiffOrStringify } from './diff'
 import { format, stringify } from './display'
+import type { TestError } from './types'
 
 // utils is bundled for any environment and might not support `Element`
 declare class Element {
@@ -26,7 +27,7 @@ function getUnserializableMessage(err: unknown) {
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
-export function serializeError(val: any, seen: WeakMap<WeakKey, any> = new WeakMap()): any {
+export function serializeValue(val: any, seen: WeakMap<WeakKey, any> = new WeakMap()): any {
   if (!val || typeof val === 'string') {
     return val
   }
@@ -41,7 +42,7 @@ export function serializeError(val: any, seen: WeakMap<WeakKey, any> = new WeakM
   }
   // cannot serialize immutables as immutables
   if (isImmutable(val)) {
-    return serializeError(val.toJSON(), seen)
+    return serializeValue(val.toJSON(), seen)
   }
   if (
     val instanceof Promise
@@ -56,7 +57,7 @@ export function serializeError(val: any, seen: WeakMap<WeakKey, any> = new WeakM
     return `${val.toString()} ${format(val.sample)}`
   }
   if (typeof val.toJSON === 'function') {
-    return serializeError(val.toJSON(), seen)
+    return serializeValue(val.toJSON(), seen)
   }
 
   if (seen.has(val)) {
@@ -69,7 +70,7 @@ export function serializeError(val: any, seen: WeakMap<WeakKey, any> = new WeakM
     seen.set(val, clone)
     val.forEach((e, i) => {
       try {
-        clone[i] = serializeError(e, seen)
+        clone[i] = serializeValue(e, seen)
       }
       catch (err) {
         clone[i] = getUnserializableMessage(err)
@@ -90,7 +91,7 @@ export function serializeError(val: any, seen: WeakMap<WeakKey, any> = new WeakM
           return
         }
         try {
-          clone[key] = serializeError(val[key], seen)
+          clone[key] = serializeValue(val[key], seen)
         }
         catch (err) {
           // delete in case it has a setter from prototype that might throw
@@ -104,18 +105,22 @@ export function serializeError(val: any, seen: WeakMap<WeakKey, any> = new WeakM
   }
 }
 
+export { serializeValue as serializeError }
+
 function normalizeErrorMessage(message: string) {
   return message.replace(/__(vite_ssr_import|vi_import)_\d+__\./g, '')
 }
 
 export function processError(
-  err: any,
+  _err: any,
   diffOptions?: DiffOptions,
   seen: WeakSet<WeakKey> = new WeakSet(),
 ): any {
-  if (!err || typeof err !== 'object') {
-    return { message: err }
+  if (!_err || typeof _err !== 'object') {
+    return { message: String(_err) }
   }
+  const err = _err as TestError
+
   // stack is not serialized in worker communication
   // we stringify it first
   if (err.stack) {
@@ -133,8 +138,12 @@ export function processError(
   ) {
     err.diff = printDiffOrStringify(err.actual, err.expected, {
       ...diffOptions,
-      ...err.diffOptions,
+      ...err.diffOptions as DiffOptions,
     })
+  }
+
+  if (err.diffOptions) {
+    err.diffOptions = undefined
   }
 
   if (typeof err.expected !== 'string') {
@@ -163,10 +172,10 @@ export function processError(
   catch {}
 
   try {
-    return serializeError(err)
+    return serializeValue(err)
   }
   catch (e: any) {
-    return serializeError(
+    return serializeValue(
       new Error(
         `Failed to fully serialize error: ${e?.message}\nInner error message: ${err?.message}`,
       ),

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -47,4 +47,6 @@ export type {
   Constructable,
   ParsedStack,
   ErrorWithDiff,
+  SerialisedError,
+  TestError,
 } from './types'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -47,6 +47,6 @@ export type {
   Constructable,
   ParsedStack,
   ErrorWithDiff,
-  SerialisedError,
+  SerializedError,
   TestError,
 } from './types'

--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -15,7 +15,7 @@ export interface StackTraceParserOptions {
   ignoreStackEntries?: (RegExp | string)[]
   getSourceMap?: (file: string) => unknown
   getFileName?: (id: string) => string
-  frameFilter?: (error: Error, frame: ParsedStack) => boolean | void
+  frameFilter?: (error: ErrorWithDiff, frame: ParsedStack) => boolean | void
 }
 
 const CHROME_IE_STACK_REGEXP = /^\s*at .*(?:\S:\d+|\(native\))/m

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -32,16 +32,16 @@ export interface ParsedStack {
   column: number
 }
 
-export interface SerialisedError {
+export interface SerializedError {
   message: string
   stack?: string
   name?: string
   stacks?: ParsedStack[]
-  cause?: SerialisedError
+  cause?: SerializedError
   [key: string]: unknown
 }
 
-export interface TestError extends SerialisedError {
+export interface TestError extends SerializedError {
   cause?: TestError
   diff?: string
   actual?: string

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -32,8 +32,29 @@ export interface ParsedStack {
   column: number
 }
 
-export interface ErrorWithDiff extends Error {
-  name: string
+export interface SerialisedError {
+  message: string
+  stack?: string
+  name?: string
+  stacks?: ParsedStack[]
+  cause?: SerialisedError
+  [key: string]: unknown
+}
+
+export interface TestError extends SerialisedError {
+  cause?: TestError
+  diff?: string
+  actual?: string
+  expected?: string
+}
+
+/**
+ * @deprecated Use `TestError` instead
+ */
+export interface ErrorWithDiff {
+  message: string
+  name?: string
+  cause?: unknown
   nameStr?: string
   stack?: string
   stackStr?: string

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -95,7 +95,7 @@ const plugins = [
   json(),
   commonjs(),
   esbuild({
-    target: 'node14',
+    target: 'node18',
   }),
 ]
 

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -46,10 +46,6 @@ export function setup(ctx: Vitest, _server?: ViteDevServer) {
   function setupClient(ws: WebSocket) {
     const rpc = createBirpc<WebSocketEvents, WebSocketHandlers>(
       {
-        async onCollected(files) {
-          ctx.state.collectFiles(files)
-          await ctx.report('onCollected', files)
-        },
         async onTaskUpdate(packs) {
           ctx.state.updateTasks(packs)
           await ctx.report('onTaskUpdate', packs)

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -27,7 +27,6 @@ export interface TransformResultWithSource {
 }
 
 export interface WebSocketHandlers {
-  onCollected: (files?: File[]) => Promise<void>
   onTaskUpdate: (packs: TaskResultPack[]) => void
   getFiles: () => File[]
   getTestFiles: () => Promise<SerializedSpec[]>

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -440,7 +440,7 @@ export class Vitest {
       files.forEach((file) => {
         file.logs?.forEach(log => this.state.updateUserLog(log))
       })
-      this.state.collectFiles(files)
+      this.state.collectFiles(project, files)
     }
 
     await this.report('onCollected', files).catch(noop)

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -306,7 +306,7 @@ function printModuleWarningForSourceCode(logger: Logger, path: string) {
   )
 }
 
-export function displayDiff(diff: string | null, console: Console) {
+export function displayDiff(diff: string | undefined, console: Console) {
   if (diff) {
     console.error(`\n${diff}\n`)
   }

--- a/packages/vitest/src/node/pools/forks.ts
+++ b/packages/vitest/src/node/pools/forks.ts
@@ -137,7 +137,7 @@ export function createForksPool(
           && error instanceof Error
           && /The task has been cancelled/.test(error.message)
         ) {
-          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
+          ctx.state.cancelFiles(files, project)
         }
         else {
           throw error

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -76,7 +76,7 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       return ctx.report('onPathsCollected', paths)
     },
     onCollected(files) {
-      ctx.state.collectFiles(files)
+      ctx.state.collectFiles(project, files)
       return ctx.report('onCollected', files)
     },
     onAfterSuiteRun(meta) {

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -135,7 +135,7 @@ export function createThreadsPool(
           && error instanceof Error
           && /The task has been cancelled/.test(error.message)
         ) {
-          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
+          ctx.state.cancelFiles(files, project)
         }
         else {
           throw error

--- a/packages/vitest/src/node/pools/typecheck.ts
+++ b/packages/vitest/src/node/pools/typecheck.ts
@@ -61,7 +61,7 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
     checker.setFiles(files)
 
     checker.onParseStart(async () => {
-      ctx.state.collectFiles(checker.getTestFiles())
+      ctx.state.collectFiles(project, checker.getTestFiles())
       await ctx.report('onCollected')
     })
 
@@ -80,7 +80,7 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
       }
 
       await checker.collectTests()
-      ctx.state.collectFiles(checker.getTestFiles())
+      ctx.state.collectFiles(project, checker.getTestFiles())
 
       await ctx.report('onTaskUpdate', checker.getTestPacks())
       await ctx.report('onCollected')
@@ -107,7 +107,7 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
       const checker = await createWorkspaceTypechecker(project, files)
       checker.setFiles(files)
       await checker.collectTests()
-      ctx.state.collectFiles(checker.getTestFiles())
+      ctx.state.collectFiles(project, checker.getTestFiles())
       await ctx.report('onCollected')
     }
   }
@@ -135,7 +135,7 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
       })
       const triggered = await _p
       if (project.typechecker && !triggered) {
-        ctx.state.collectFiles(project.typechecker.getTestFiles())
+        ctx.state.collectFiles(project, project.typechecker.getTestFiles())
         await ctx.report('onCollected')
         await onParseEnd(project, project.typechecker.getResult())
         continue

--- a/packages/vitest/src/node/pools/vmForks.ts
+++ b/packages/vitest/src/node/pools/vmForks.ts
@@ -147,7 +147,7 @@ export function createVmForksPool(
           && error instanceof Error
           && /The task has been cancelled/.test(error.message)
         ) {
-          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
+          ctx.state.cancelFiles(files, project)
         }
         else {
           throw error

--- a/packages/vitest/src/node/pools/vmThreads.ts
+++ b/packages/vitest/src/node/pools/vmThreads.ts
@@ -141,7 +141,7 @@ export function createVmThreadsPool(
           && error instanceof Error
           && /The task has been cancelled/.test(error.message)
         ) {
-          ctx.state.cancelFiles(files, ctx.config.root, project.config.name)
+          ctx.state.cancelFiles(files, project)
         }
         else {
           throw error

--- a/packages/vitest/src/node/reported-workspace-project.ts
+++ b/packages/vitest/src/node/reported-workspace-project.ts
@@ -20,10 +20,6 @@ export class TestProject {
    */
   public readonly config: ResolvedProjectConfig
   /**
-   * Serialized project configuration. This is the config that tests receive.
-   */
-  public readonly serializedConfig: SerializedConfig
-  /**
    * Resolved global configuration. If there are no workspace projects, this will be the same as `config`.
    */
   public readonly globalConfig: ResolvedConfig
@@ -33,7 +29,13 @@ export class TestProject {
     this.vitest = workspaceProject.ctx
     this.globalConfig = workspaceProject.ctx.config
     this.config = workspaceProject.config
-    this.serializedConfig = workspaceProject.serializedConfig
+  }
+
+  /**
+   * Serialized project configuration. This is the config that tests receive.
+   */
+  public get serializedConfig() {
+    return this.workspaceProject.getSerializableConfig()
   }
 
   /**

--- a/packages/vitest/src/node/reported-workspace-project.ts
+++ b/packages/vitest/src/node/reported-workspace-project.ts
@@ -53,7 +53,7 @@ export class TestProject {
   }
 
   /**
-   * Provide a custom context to the project. This context will be available to tests once they run.
+   * Provide a custom context to the project. This context will be available for tests once they run.
    */
   public provide<T extends keyof ProvidedContext & string>(
     key: T,

--- a/packages/vitest/src/node/reported-workspace-project.ts
+++ b/packages/vitest/src/node/reported-workspace-project.ts
@@ -24,11 +24,17 @@ export class TestProject {
    */
   public readonly globalConfig: ResolvedConfig
 
+  /**
+   * The name of the project or an empty string if not set.
+   */
+  public readonly name: string
+
   constructor(workspaceProject: WorkspaceProject) {
     this.workspaceProject = workspaceProject
     this.vitest = workspaceProject.ctx
     this.globalConfig = workspaceProject.ctx.config
     this.config = workspaceProject.config
+    this.name = workspaceProject.getName()
   }
 
   /**
@@ -36,13 +42,6 @@ export class TestProject {
    */
   public get serializedConfig() {
     return this.workspaceProject.getSerializableConfig()
-  }
-
-  /**
-   * The name of the project or an empty string if not set.
-   */
-  public name(): string {
-    return this.workspaceProject.getName()
   }
 
   /**
@@ -64,7 +63,7 @@ export class TestProject {
 
   public toJSON(): SerializedTestProject {
     return {
-      name: this.name(),
+      name: this.name,
       serializedConfig: this.serializedConfig,
       context: this.context(),
     }

--- a/packages/vitest/src/node/reported-workspace-project.ts
+++ b/packages/vitest/src/node/reported-workspace-project.ts
@@ -20,22 +20,20 @@ export class TestProject {
    */
   public readonly config: ResolvedProjectConfig
   /**
+   * Serialized project configuration. This is the config that tests receive.
+   */
+  public readonly serializedConfig: SerializedConfig
+  /**
    * Resolved global configuration. If there are no workspace projects, this will be the same as `config`.
    */
   public readonly globalConfig: ResolvedConfig
 
-  private constructor(workspaceProject: WorkspaceProject) {
+  constructor(workspaceProject: WorkspaceProject) {
     this.workspaceProject = workspaceProject
     this.vitest = workspaceProject.ctx
     this.globalConfig = workspaceProject.ctx.config
     this.config = workspaceProject.config
-  }
-
-  /**
-   * Serialized project configuration. This is the config that tests receive.
-   */
-  public get serializedConfig(): SerializedConfig {
-    return this.workspaceProject.getSerializableConfig()
+    this.serializedConfig = workspaceProject.serializedConfig
   }
 
   /**
@@ -62,9 +60,17 @@ export class TestProject {
     this.workspaceProject.provide(key, value)
   }
 
-  static register(workspaceProject: WorkspaceProject): TestProject {
-    const project = new TestProject(workspaceProject)
-    workspaceProject.ctx.state.reportedProjectsMap.set(workspaceProject, project)
-    return project
+  public toJSON(): SerializedTestProject {
+    return {
+      name: this.name(),
+      serializedConfig: this.serializedConfig,
+      context: this.context(),
+    }
   }
+}
+
+interface SerializedTestProject {
+  name: string
+  serializedConfig: SerializedConfig
+  context: ProvidedContext
 }

--- a/packages/vitest/src/node/reported-workspace.ts
+++ b/packages/vitest/src/node/reported-workspace.ts
@@ -1,0 +1,70 @@
+import type { ProvidedContext } from '../types/general'
+import type { ResolvedConfig, ResolvedProjectConfig, SerializedConfig } from './types/config'
+import type { WorkspaceProject } from './workspace'
+import type { Vitest } from './core'
+
+export class TestProject {
+  /**
+   * The global vitest instance.
+   * @experimental The public Vitest API is experimental and does not follow semver.
+   */
+  public readonly vitest: Vitest
+  /**
+   * The workspace project this test project is associated with.
+   * @experimental The public Vitest API is experimental and does not follow semver.
+   */
+  public readonly workspaceProject: WorkspaceProject
+
+  /**
+   * Resolved project configuration.
+   */
+  public readonly config: ResolvedProjectConfig
+  /**
+   * Resolved global configuration. If there are no workspace projects, this will be the same as `config`.
+   */
+  public readonly globalConfig: ResolvedConfig
+
+  private constructor(workspaceProject: WorkspaceProject) {
+    this.workspaceProject = workspaceProject
+    this.vitest = workspaceProject.ctx
+    this.globalConfig = workspaceProject.ctx.config
+    this.config = workspaceProject.config
+  }
+
+  /**
+   * Serialized project configuration. This is the config that tests receive.
+   */
+  public get serializedConfig(): SerializedConfig {
+    return this.workspaceProject.getSerializableConfig()
+  }
+
+  /**
+   * The name of the project or an empty string if not set.
+   */
+  public name(): string {
+    return this.workspaceProject.getName()
+  }
+
+  /**
+   * Custom context provided to the project.
+   */
+  public context(): ProvidedContext {
+    return this.workspaceProject.getProvidedContext()
+  }
+
+  /**
+   * Provide a custom context to the project. This context will be available to tests once they run.
+   */
+  public provide<T extends keyof ProvidedContext & string>(
+    key: T,
+    value: ProvidedContext[T],
+  ): void {
+    this.workspaceProject.provide(key, value)
+  }
+
+  static register(workspaceProject: WorkspaceProject): TestProject {
+    const project = new TestProject(workspaceProject)
+    workspaceProject.ctx.state.reportedProjectsMap.set(workspaceProject, project)
+    return project
+  }
+}

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -28,8 +28,18 @@ export {
 }
 export type { BaseReporter, Reporter }
 
-export { TestCase, TestFile, TestSuite } from '../server-tasks'
-export type { TaskOptions, TestDiagnostic, TestError, SerialisedError, ReportedTask } from '../server-tasks'
+export { TestCase, TestFile, TestSuite } from './reported-tasks'
+export type {
+  TestCollection,
+
+  TaskOptions,
+  TestDiagnostic,
+
+  TestResult,
+  TestResultFailed,
+  TestResultPassed,
+  TestResultSkipped,
+} from './reported-tasks'
 
 export type {
   JsonAssertionResult,

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -28,6 +28,9 @@ export {
 }
 export type { BaseReporter, Reporter }
 
+export { TestCase, TestFile, TestSuite } from '../server-tasks'
+export type { TaskOptions, TestDiagnostic, TestError, SerialisedError, ReportedTask } from '../server-tasks'
+
 export type {
   JsonAssertionResult,
   JsonTestResult,

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -34,6 +34,7 @@ export type {
 
   TaskOptions,
   TestDiagnostic,
+  FileDiagnostic,
 
   TestResult,
   TestResultFailed,

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -452,12 +452,12 @@ function getTestState(test: TestCase): TestResult['state'] | 'running' {
   return result ? result.state : 'running'
 }
 
-function storeTask(project: WorkspaceProject, runnerTask: RunnerTask, reportedTask: TestCase | TestSuite | TestFile) {
+function storeTask(project: WorkspaceProject, runnerTask: RunnerTask, reportedTask: TestCase | TestSuite | TestFile): void {
   project.ctx.state.reportedTasksMap.set(runnerTask, reportedTask)
 }
 
 function getReportedTask(project: WorkspaceProject, runnerTask: RunnerTask): TestCase | TestSuite | TestFile {
-  const reportedTask = project.ctx.state.reportedTasksMap.get(runnerTask)
+  const reportedTask = project.ctx.state.getReportedEntity(runnerTask)
   if (!reportedTask) {
     throw new Error(`Task instance was not found for ${runnerTask.type} ${runnerTask.name}`)
   }

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -53,7 +53,7 @@ class ReportedTaskImplementation {
   ) {
     this.task = task
     this.project = project
-    this.file = project.ctx.state.reportedTasksMap.get(task.file) as TestFile
+    this.file = getReportedTask(project, task.file) as TestFile
     this.name = task.name
     this.id = task.id
     this.location = task.location

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -9,7 +9,7 @@ import type {
 import type { TestError } from '@vitest/utils'
 import { getTestName } from '../../utils/tasks'
 import type { WorkspaceProject } from '../workspace'
-import type { TestProject } from '../reported-workspace-project'
+import { TestProject } from '../reported-workspace-project'
 
 class ReportedTaskImplementation {
   /**
@@ -40,7 +40,7 @@ class ReportedTaskImplementation {
     project: WorkspaceProject,
   ) {
     this.task = task
-    this.project = project.ctx.state.getReportedProject(project)
+    this.project = project.testProject || (project.testProject = new TestProject(project))
     this.id = task.id
     this.location = task.location
   }

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -9,7 +9,7 @@ import type {
 import type { TestError } from '@vitest/utils'
 import { getTestName } from '../../utils/tasks'
 import type { WorkspaceProject } from '../workspace'
-import type { TestProject } from '../reported-workspace'
+import type { TestProject } from '../reported-workspace-project'
 
 class ReportedTaskImplementation {
   /**

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -188,54 +188,12 @@ class TestCollection {
   }
 
   /**
-   * Looks for a test or a suite by `name` only inside the current suite.
-   * If `name` is a string, it will look for an exact match.
-   */
-  find(type: 'test', name: string | RegExp): TestCase | undefined
-  find(type: 'suite', name: string | RegExp): TestSuite | undefined
-  find(type: 'test' | 'suite', name: string | RegExp): TestCase | TestSuite | undefined
-  find(type: 'test' | 'suite', name: string | RegExp): TestCase | TestSuite | undefined {
-    const isString = typeof name === 'string'
-    for (const task of this) {
-      if (task.type === type) {
-        if (task.name === name || (!isString && name.test(task.name))) {
-          return task
-        }
-      }
-    }
-  }
-
-  /**
-   * Looks for a test or a suite by `name` inside the current suite and its children.
-   * If `name` is a string, it will look for an exact match.
-   */
-  deepFind(type: 'test', name: string | RegExp): TestCase | undefined
-  deepFind(type: 'suite', name: string | RegExp): TestSuite | undefined
-  deepFind(type: 'test' | 'suite', name: string | RegExp): TestCase | TestSuite | undefined
-  deepFind(type: 'test' | 'suite', name: string | RegExp): TestCase | TestSuite | undefined {
-    const isString = typeof name === 'string'
-    for (const task of this) {
-      if (task.type === type) {
-        if (task.name === name || (!isString && name.test(task.name))) {
-          return task
-        }
-      }
-      if (task.type === 'suite') {
-        const result = task.children.deepFind(type, name)
-        if (result) {
-          return result
-        }
-      }
-    }
-  }
-
-  /**
    * Filters all tests that are part of this collection's suite and its children.
    */
-  *deepTests(state?: TestResult['state'] | 'running'): IterableIterator<TestCase> {
+  *allTests(state?: TestResult['state'] | 'running'): IterableIterator<TestCase> {
     for (const child of this) {
       if (child.type === 'suite') {
-        yield * child.children.deepTests(state)
+        yield * child.children.allTests(state)
       }
       else if (state) {
         const testState = getTestState(child)
@@ -284,11 +242,11 @@ class TestCollection {
   /**
    * Filters all suites that are part of this collection's suite and its children.
    */
-  *deepSuites(): IterableIterator<TestSuite> {
+  *allSuites(): IterableIterator<TestSuite> {
     for (const child of this) {
       if (child.type === 'suite') {
         yield child
-        yield * child.children.deepSuites()
+        yield * child.children.allSuites()
       }
     }
   }

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -391,13 +391,18 @@ export type TestResult = TestResultPassed | TestResultFailed | TestResultSkipped
 export interface TestResultPassed {
   state: 'passed'
   /**
-   * If test was retried successfully, errors will still be reported.
+   * Errors that were thrown during the test execution.
+   *
+   * **Note**: If test was retried successfully, errors will still be reported.
    */
   errors: TestError[] | undefined
 }
 
 export interface TestResultFailed {
   state: 'failed'
+  /**
+   * Errors that were thrown during the test execution.
+   */
   errors: TestError[]
 }
 

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -20,7 +20,6 @@ class ReportedTaskImplementation {
 
   /**
    * The project assosiacted with the test or suite.
-   * @experimental Public project API is experimental and does not follow semver.
    */
   public readonly project: TestProject
 

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -159,6 +159,9 @@ class TestCollection {
     this.#project = project
   }
 
+  /**
+   * Test or a suite at a specific index in the array.
+   */
   at(index: number): TestCase | TestSuite | undefined {
     if (index < 0) {
       index = this.size + index
@@ -451,7 +454,7 @@ function storeTask(project: WorkspaceProject, runnerTask: RunnerTask, reportedTa
 function getReportedTask(project: WorkspaceProject, runnerTask: RunnerTask): TestCase | TestSuite | TestFile {
   const reportedTask = project.ctx.state.reportedTasksMap.get(runnerTask)
   if (!reportedTask) {
-    throw new Error(`Task instance was not found for task ${runnerTask.id}`)
+    throw new Error(`Task instance was not found for ${runnerTask.type} ${runnerTask.name}`)
   }
   return reportedTask
 }

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -149,6 +149,48 @@ export abstract class SuiteImplementation extends Task {
   declare public readonly task: SuiteTask | FileTask
 
   /**
+   * Looks for a test by `name`.
+   * If `name` is a string, it will look for an exact match.
+   */
+  public findTest(name: string | RegExp): TestCase | undefined {
+    if (typeof name === 'string') {
+      for (const test of this.tests()) {
+        if (test.name === name) {
+          return test
+        }
+      }
+    }
+    else {
+      for (const test of this.tests()) {
+        if (name.test(test.name)) {
+          return test
+        }
+      }
+    }
+  }
+
+  /**
+   * Looks for a test by `name`.
+   * If `name` is a string, it will look for an exact match.
+   */
+  public findSuite(name: string | RegExp): TestSuite | undefined {
+    if (typeof name === 'string') {
+      for (const suite of this.children()) {
+        if (suite.type === 'suite' && suite.name === name) {
+          return suite
+        }
+      }
+    }
+    else {
+      for (const suite of this.children()) {
+        if (suite.type === 'suite' && name.test(suite.name)) {
+          return suite
+        }
+      }
+    }
+  }
+
+  /**
    * Parent suite. If suite was called directly inside the file, the parent will be the file.
    */
   public parent(): TestSuite | TestFile {

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -177,11 +177,11 @@ export abstract class SuiteImplementation extends Task {
    */
   public *tests(): Iterable<TestCase> {
     for (const child of this.children()) {
-      if (child.type === 'test' || child.type === 'custom') {
-        yield child as TestCase
+      if (child.type === 'suite') {
+        yield * child.tests()
       }
       else {
-        yield * (child as TestSuite).tests()
+        yield child
       }
     }
   }

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -5,7 +5,7 @@ import type { WorkspaceProject } from './workspace'
 
 const tasksMap = new WeakMap<
   Test | Custom | FileTask | SuiteTask,
-  TestCase | File | Suite
+  TestCase | TestFile | TestSuite
 >()
 
 class Task {
@@ -37,8 +37,8 @@ class Task {
   /**
    * Direct reference to the file task where the test or suite is defined.
    */
-  public file(): File {
-    return tasksMap.get(this.task.file) as File
+  public file(): TestFile {
+    return tasksMap.get(this.task.file) as TestFile
   }
 
   /**
@@ -84,10 +84,10 @@ export class TestCase extends Task {
   /**
    * Parent suite of the test. If test was called directly inside the file, the parent will be the file.
    */
-  public parent(): Suite | File {
+  public parent(): TestSuite | TestFile {
     const suite = this.task.suite
     if (suite) {
-      return tasksMap.get(suite) as Suite
+      return tasksMap.get(suite) as TestSuite
     }
     return this.file()
   }
@@ -151,10 +151,10 @@ export abstract class SuiteImplementation extends Task {
   /**
    * Parent suite. If suite was called directly inside the file, the parent will be the file.
    */
-  public parent(): Suite | File {
+  public parent(): TestSuite | TestFile {
     const suite = this.task.suite
     if (suite) {
-      return tasksMap.get(suite) as Suite
+      return tasksMap.get(suite) as TestSuite
     }
     return this.file()
   }
@@ -162,13 +162,13 @@ export abstract class SuiteImplementation extends Task {
   /**
    * An array of suites and tests that are part of this suite.
    */
-  public children(): (Suite | TestCase)[] {
+  public children(): (TestSuite | TestCase)[] {
     return this.task.tasks.map((task) => {
       const taskInstance = tasksMap.get(task)
       if (!taskInstance) {
         throw new Error(`Task instance was not found for task ${task.id}`)
       }
-      return taskInstance as Suite | TestCase
+      return taskInstance as TestSuite | TestCase
     })
   }
 
@@ -182,14 +182,14 @@ export abstract class SuiteImplementation extends Task {
         tests.push(child as TestCase)
       }
       else {
-        tests.push(...(child as Suite).tests())
+        tests.push(...(child as TestSuite).tests())
       }
     }
     return tests
   }
 }
 
-export class Suite extends SuiteImplementation {
+export class TestSuite extends SuiteImplementation {
   declare public readonly task: SuiteTask
   public readonly type = 'suite'
   #options: TaskOptions | undefined
@@ -205,7 +205,7 @@ export class Suite extends SuiteImplementation {
   }
 }
 
-export class File extends SuiteImplementation {
+export class TestFile extends SuiteImplementation {
   declare public readonly task: FileTask
   public readonly type = 'file'
 

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -352,7 +352,7 @@ function buildOptions(task: Test | Custom | FileTask | SuiteTask): TaskOptions {
   }
 }
 
-interface SerialisedError {
+export interface SerialisedError {
   message: string
   stack?: string
   name: string
@@ -360,13 +360,13 @@ interface SerialisedError {
   [key: string]: unknown
 }
 
-interface TestError extends SerialisedError {
+export interface TestError extends SerialisedError {
   diff?: string
   actual?: string
   expected?: string
 }
 
-type TestResult = TestResultPassed | TestResultFailed | TestResultSkipped
+export type TestResult = TestResultPassed | TestResultFailed | TestResultSkipped
 
 interface TestResultPassed {
   state: 'passed'

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -162,30 +162,28 @@ export abstract class SuiteImplementation extends Task {
   /**
    * An array of suites and tests that are part of this suite.
    */
-  public children(): (TestSuite | TestCase)[] {
-    return this.task.tasks.map((task) => {
+  public *children(): Iterable<TestSuite | TestCase> {
+    for (const task of this.task.tasks) {
       const taskInstance = tasksMap.get(task)
       if (!taskInstance) {
         throw new Error(`Task instance was not found for task ${task.id}`)
       }
-      return taskInstance as TestSuite | TestCase
-    })
+      yield taskInstance as TestSuite | TestCase
+    }
   }
 
   /**
    * An array of all tests that are part of this suite and its children.
    */
-  public tests(): TestCase[] {
-    const tests: TestCase[] = []
+  public *tests(): Iterable<TestCase> {
     for (const child of this.children()) {
       if (child.type === 'test' || child.type === 'custom') {
-        tests.push(child as TestCase)
+        yield child as TestCase
       }
       else {
-        tests.push(...(child as TestSuite).tests())
+        yield * (child as TestSuite).tests()
       }
     }
-    return tests
   }
 }
 

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -153,18 +153,10 @@ export abstract class SuiteImplementation extends Task {
    * If `name` is a string, it will look for an exact match.
    */
   public findTest(name: string | RegExp): TestCase | undefined {
-    if (typeof name === 'string') {
-      for (const test of this.tests()) {
-        if (test.name === name) {
-          return test
-        }
-      }
-    }
-    else {
-      for (const test of this.tests()) {
-        if (name.test(test.name)) {
-          return test
-        }
+    const isString = typeof name === 'string'
+    for (const test of this.tests()) {
+      if (test.name === name || (!isString && name.test(test.name))) {
+        return test
       }
     }
   }
@@ -174,18 +166,13 @@ export abstract class SuiteImplementation extends Task {
    * If `name` is a string, it will look for an exact match.
    */
   public findSuite(name: string | RegExp): TestSuite | undefined {
-    if (typeof name === 'string') {
-      for (const suite of this.children()) {
-        if (suite.type === 'suite' && suite.name === name) {
-          return suite
-        }
+    const isString = typeof name === 'string'
+    for (const suite of this.children()) {
+      if (suite.type !== 'suite') {
+        continue
       }
-    }
-    else {
-      for (const suite of this.children()) {
-        if (suite.type === 'suite' && name.test(suite.name)) {
-          return suite
-        }
+      if (suite.name === name || (!isString && name.test(suite.name))) {
+        return suite
       }
     }
   }

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -76,7 +76,7 @@ export class TestCase extends Task {
     }
   }
 
-  public get meta(): TaskMeta {
+  public meta(): TaskMeta {
     return this.task.meta
   }
 

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -3,6 +3,10 @@ import { getFullName } from '../utils'
 import type { ParsedStack } from '../types'
 import type { WorkspaceProject } from './workspace'
 
+// rule for function/getter
+// getter is a readonly property that doesn't change in time
+// method can return different objects depending on when it's called
+
 const tasksMap = new WeakMap<
   Test | Custom | FileTask | SuiteTask,
   TestCase | TestFile | TestSuite

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -20,12 +20,12 @@ import type { WorkspaceProject } from './workspace'
 
 export type ReportedTask = TestCase | TestFile | TestSuite
 
-class Task {
+class ReportedTaskImplementation {
   #fullName: string | undefined
 
   /**
    * Task instance.
-   * @experimental Public task API is experimental and does not follow semver.
+   * @experimental Public runner task API is experimental and does not follow semver.
    */
   public readonly task: RunnerTask
 
@@ -82,7 +82,7 @@ class Task {
   }
 }
 
-export class TestCase extends Task {
+export class TestCase extends ReportedTaskImplementation {
   declare public readonly task: Test | Custom
   public readonly type: 'test' | 'custom' = 'test'
   /**
@@ -287,7 +287,7 @@ class TaskCollection {
   }
 }
 
-abstract class SuiteImplementation extends Task {
+abstract class SuiteImplementation extends ReportedTaskImplementation {
   declare public readonly task: SuiteTask | FileTask
   /**
    * Parent suite. If suite was called directly inside the file, the parent will be the file.

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -209,19 +209,17 @@ export abstract class SuiteImplementation extends Task {
       if (child.type === 'suite') {
         yield * child.tests(state)
       }
-      else {
-        if (state) {
-          const result = child.result()
-          if (!result && state === 'running') {
-            yield child
-          }
-          else if (result && result.state === state) {
-            yield child
-          }
-        }
-        else {
+      else if (state) {
+        const result = child.result()
+        if (!result && state === 'running') {
           yield child
         }
+        else if (result && result.state === state) {
+          yield child
+        }
+      }
+      else {
+        yield child
       }
     }
   }

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -1,0 +1,153 @@
+import type { Custom, File as FileTask, Suite as SuiteTask, TaskMeta, TaskResult, Test } from '@vitest/runner'
+import { getFullName } from '../utils'
+import type { WorkspaceProject } from './workspace'
+
+const tasksMap = new WeakMap<
+  Test | Custom | FileTask | SuiteTask,
+  TestCase | File | Suite
+>()
+
+class Task {
+  #fullName: string | undefined
+  #project: WorkspaceProject
+
+  constructor(
+    public readonly task: Test | Custom | FileTask | SuiteTask,
+    project: WorkspaceProject,
+  ) {
+    this.#project = project
+  }
+
+  public project(): WorkspaceProject {
+    return this.#project
+  }
+
+  public file(): File {
+    return tasksMap.get(this.task.file) as File
+  }
+
+  public parent(): Suite | File {
+    const suite = this.task.suite
+    if (suite) {
+      return tasksMap.get(suite) as Suite
+    }
+    return this.file()
+  }
+
+  public get name(): string {
+    return this.task.name
+  }
+
+  public get fullName(): string {
+    if (this.#fullName === undefined) {
+      this.#fullName = getFullName(this.task, ' > ')
+    }
+    return this.#fullName
+  }
+
+  public get id(): string {
+    return this.task.id
+  }
+
+  public get location(): { line: number; column: number } | undefined {
+    return this.task.location
+  }
+}
+
+export class TestCase extends Task {
+  declare public readonly task: Test | Custom
+  public readonly type = 'test'
+  #options: TaskOptions | undefined
+
+  public get meta(): TaskMeta {
+    return this.task.meta
+  }
+
+  public options(): TaskOptions {
+    if (this.#options === undefined) {
+      this.#options = buildOptions(this.task)
+      // mode is the only one that can change dinamically
+      this.#options.mode = this.task.mode
+    }
+    return this.#options
+  }
+
+  public diagnostic(): TestDiagnostic {
+    const result = (this.task.result || {} as TaskResult)
+    return {
+      heap: result.heap,
+      duration: result.duration,
+      startTime: result.startTime,
+      retryCount: result.retryCount,
+      repeatCount: result.repeatCount,
+    }
+  }
+}
+
+export abstract class SuiteImplementation extends Task {
+  declare public readonly task: SuiteTask | FileTask
+
+  public children(): (Suite | TestCase)[] {
+    return this.task.tasks.map((task) => {
+      const taskInstance = tasksMap.get(task)
+      if (!taskInstance) {
+        throw new Error(`Task instance was not found for task ${task.id}`)
+      }
+      return taskInstance as Suite | TestCase
+    })
+  }
+}
+
+export class Suite extends SuiteImplementation {
+  declare public readonly task: SuiteTask
+  public readonly type = 'suite'
+  #options: TaskOptions | undefined
+
+  public options(): TaskOptions {
+    if (this.#options === undefined) {
+      this.#options = buildOptions(this.task)
+    }
+    return this.#options
+  }
+}
+
+export class File extends SuiteImplementation {
+  declare public readonly task: FileTask
+  public readonly type = 'file'
+
+  public get moduleId(): string {
+    return this.task.filepath
+  }
+
+  public get location(): undefined {
+    return undefined
+  }
+}
+
+export interface TaskOptions {
+  each: boolean | undefined
+  concurrent: boolean | undefined
+  shuffle: boolean | undefined
+  retry: number | undefined
+  repeats: number | undefined
+  mode: 'run' | 'only' | 'skip' | 'todo'
+}
+
+function buildOptions(task: Test | Custom | FileTask | SuiteTask): TaskOptions {
+  return {
+    each: task.each,
+    concurrent: task.concurrent,
+    shuffle: task.shuffle,
+    retry: task.retry,
+    repeats: task.repeats,
+    mode: task.mode,
+  }
+}
+
+export interface TestDiagnostic {
+  heap: number | undefined
+  duration: number | undefined
+  startTime: number | undefined
+  retryCount: number | undefined
+  repeatCount: number | undefined
+}

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -27,14 +27,6 @@ class Task {
     return tasksMap.get(this.task.file) as File
   }
 
-  public parent(): Suite | File {
-    const suite = this.task.suite
-    if (suite) {
-      return tasksMap.get(suite) as Suite
-    }
-    return this.file()
-  }
-
   public get name(): string {
     return this.task.name
   }
@@ -57,8 +49,16 @@ class Task {
 
 export class TestCase extends Task {
   declare public readonly task: Test | Custom
-  public readonly type = 'test'
+  public readonly type: 'test' | 'custom' = 'test'
   #options: TaskOptions | undefined
+
+  public parent(): Suite | File {
+    const suite = this.task.suite
+    if (suite) {
+      return tasksMap.get(suite) as Suite
+    }
+    return this.file()
+  }
 
   public result(): TestResult | undefined {
     const result = this.task.result
@@ -103,6 +103,14 @@ export class TestCase extends Task {
 
 export abstract class SuiteImplementation extends Task {
   declare public readonly task: SuiteTask | FileTask
+
+  public parent(): Suite | File {
+    const suite = this.task.suite
+    if (suite) {
+      return tasksMap.get(suite) as Suite
+    }
+    return this.file()
+  }
 
   public children(): (Suite | TestCase)[] {
     return this.task.tasks.map((task) => {

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -142,7 +142,7 @@ export class TestCase extends Task {
   }
 }
 
-export abstract class SuiteImplementation extends Task {
+abstract class SuiteImplementation extends Task {
   declare public readonly task: SuiteTask | FileTask
   /**
    * Parent suite. If suite was called directly inside the file, the parent will be the file.

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -83,9 +83,9 @@ export class TestCase extends Task {
   public options(): TaskOptions {
     if (this.#options === undefined) {
       this.#options = buildOptions(this.task)
-      // mode is the only one that can change dinamically
-      this.#options.mode = this.task.mode
     }
+    // mode is the only one that can change dinamically
+    this.#options.mode = this.task.mode
     return this.#options
   }
 

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -139,8 +139,9 @@ export class TestCase extends Task {
       heap: result.heap,
       duration: result.duration!,
       startTime: result.startTime,
-      retryCount: result.retryCount,
-      repeatCount: result.repeatCount,
+      retryCount: result.retryCount ?? 0,
+      repeatCount: result.repeatCount ?? 0,
+      flaky: !!result.retryCount && result.state === 'pass' && result.retryCount > 0,
     }
   }
 }
@@ -386,8 +387,12 @@ export interface TestDiagnostic {
   heap: number | undefined
   duration: number
   startTime: number
-  retryCount: number | undefined
-  repeatCount: number | undefined
+  retryCount: number
+  repeatCount: number
+  /**
+   * If test passed on a second retry.
+   */
+  flaky: boolean
 }
 
 function getTestState(test: TestCase): TestResult['state'] | 'running' {

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -49,7 +49,7 @@ class ReportedTaskImplementation {
    */
   public readonly id: string
   /**
-   * Full name of the test or the suite including all parent suites separated with `>`.
+   * Location in the file where the test or suite is defined.
    */
   public readonly location: { line: number; column: number } | undefined
 

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -204,13 +204,24 @@ export abstract class SuiteImplementation extends Task {
   /**
    * An array of all tests that are part of this suite and its children.
    */
-  public *tests(): Iterable<TestCase> {
+  public *tests(state?: TestResult['state'] | 'running'): Iterable<TestCase> {
     for (const child of this.children()) {
       if (child.type === 'suite') {
-        yield * child.tests()
+        yield * child.tests(state)
       }
       else {
-        yield child
+        if (state) {
+          const result = child.result()
+          if (!result && state === 'running') {
+            yield child
+          }
+          else if (result && result.state === state) {
+            yield child
+          }
+        }
+        else {
+          yield child
+        }
       }
     }
   }

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -30,14 +30,14 @@ class Task {
    * Current task's project.
    * @experimental Public project API is experimental and does not follow semver.
    */
-  public project(): WorkspaceProject {
+  public get project(): WorkspaceProject {
     return this.#project
   }
 
   /**
    * Direct reference to the file task where the test or suite is defined.
    */
-  public file(): TestFile {
+  public get file(): TestFile {
     return tasksMap.get(this.task.file) as TestFile
   }
 
@@ -84,12 +84,12 @@ export class TestCase extends Task {
   /**
    * Parent suite of the test. If test was called directly inside the file, the parent will be the file.
    */
-  public parent(): TestSuite | TestFile {
+  public get parent(): TestSuite | TestFile {
     const suite = this.task.suite
     if (suite) {
       return tasksMap.get(suite) as TestSuite
     }
-    return this.file()
+    return this.file
   }
 
   /**
@@ -180,12 +180,12 @@ export abstract class SuiteImplementation extends Task {
   /**
    * Parent suite. If suite was called directly inside the file, the parent will be the file.
    */
-  public parent(): TestSuite | TestFile {
+  public get parent(): TestSuite | TestFile {
     const suite = this.task.suite
     if (suite) {
       return tasksMap.get(suite) as TestSuite
     }
-    return this.file()
+    return this.file
   }
 
   /**

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -176,11 +176,11 @@ class TaskCollection {
         if (task.name === name || (!isString && name.test(task.name))) {
           return task
         }
-        if (task.type === 'suite') {
-          const result = task.children.find(type, name)
-          if (result) {
-            return result
-          }
+      }
+      if (task.type === 'suite') {
+        const result = task.children.find(type, name)
+        if (result) {
+          return result
         }
       }
     }

--- a/packages/vitest/src/node/server-tasks.ts
+++ b/packages/vitest/src/node/server-tasks.ts
@@ -115,7 +115,7 @@ export class TestCase extends Task {
     return {
       state,
       errors: result.errors as TestError[] | undefined,
-    }
+    } as TestResult
   }
 
   /**
@@ -365,9 +365,21 @@ interface TestError extends SerialisedError {
   expected?: string
 }
 
-interface TestResult {
-  state: 'passed' | 'failed' | 'skipped'
-  errors?: TestError[]
+type TestResult = TestResultPassed | TestResultFailed | TestResultSkipped
+
+interface TestResultPassed {
+  state: 'passed'
+  errors: undefined
+}
+
+interface TestResultFailed {
+  state: 'failed'
+  errors: TestError[]
+}
+
+interface TestResultSkipped {
+  state: 'skipped'
+  errors: undefined
 }
 
 export interface TestDiagnostic {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -171,7 +171,7 @@ export class StateManager {
     }
   }
 
-  _experimental_getReportedEntity(task: Task) {
+  getReportedEntity(task: Task) {
     return this.reportedTasksMap.get(task)
   }
 

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -3,8 +3,7 @@ import { createFileTask } from '@vitest/runner/utils'
 import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
 import type { UserConsoleLog } from '../types/general'
 import type { WorkspaceProject } from './workspace'
-import type { ReportedTask } from './server-tasks'
-import { TestCase, TestFile, TestSuite } from './server-tasks'
+import { TestCase, TestFile, TestSuite } from './reporters/reported-tasks'
 
 export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
   if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {
@@ -21,7 +20,7 @@ export class StateManager {
   taskFileMap = new WeakMap<Task, File>()
   errorsSet = new Set<unknown>()
   processTimeoutCauses = new Set<string>()
-  reportedTasksMap = new WeakMap<Task, ReportedTask>()
+  reportedTasksMap = new WeakMap<Task, TestCase | TestFile | TestSuite>()
 
   catchError(err: unknown, type: string): void {
     if (isAggregateError(err)) {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -4,7 +4,6 @@ import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
 import type { UserConsoleLog } from '../types/general'
 import type { WorkspaceProject } from './workspace'
 import { TestCase, TestFile, TestSuite } from './reporters/reported-tasks'
-import { TestProject } from './reported-workspace-project'
 
 export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
   if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {
@@ -22,7 +21,6 @@ export class StateManager {
   errorsSet = new Set<unknown>()
   processTimeoutCauses = new Set<string>()
   reportedTasksMap = new WeakMap<Task, TestCase | TestFile | TestSuite>()
-  reportedProjectsMap = new WeakMap<WorkspaceProject, TestProject>()
 
   catchError(err: unknown, type: string): void {
     if (isAggregateError(err)) {
@@ -175,14 +173,6 @@ export class StateManager {
 
   getReportedEntity(task: Task) {
     return this.reportedTasksMap.get(task)
-  }
-
-  getReportedProject(project: WorkspaceProject) {
-    const reportedProject = this.reportedProjectsMap.get(project)
-    if (!reportedProject) {
-      return TestProject.register(project)
-    }
-    return reportedProject
   }
 
   updateTasks(packs: TaskResultPack[]) {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -171,7 +171,7 @@ export class StateManager {
     }
   }
 
-  _experimental_getServerTask(task: Task) {
+  _experimental_getReportedEntity(task: Task) {
     return this.reportedTasksMap.get(task)
   }
 

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -4,7 +4,7 @@ import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
 import type { UserConsoleLog } from '../types/general'
 import type { WorkspaceProject } from './workspace'
 import { TestCase, TestFile, TestSuite } from './reporters/reported-tasks'
-import { TestProject } from './reported-workspace'
+import { TestProject } from './reported-workspace-project'
 
 export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
   if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -4,6 +4,7 @@ import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
 import type { UserConsoleLog } from '../types/general'
 import type { WorkspaceProject } from './workspace'
 import { TestCase, TestFile, TestSuite } from './reporters/reported-tasks'
+import { TestProject } from './reported-workspace'
 
 export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
   if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {
@@ -21,6 +22,7 @@ export class StateManager {
   errorsSet = new Set<unknown>()
   processTimeoutCauses = new Set<string>()
   reportedTasksMap = new WeakMap<Task, TestCase | TestFile | TestSuite>()
+  reportedProjectsMap = new WeakMap<WorkspaceProject, TestProject>()
 
   catchError(err: unknown, type: string): void {
     if (isAggregateError(err)) {
@@ -173,6 +175,14 @@ export class StateManager {
 
   getReportedEntity(task: Task) {
     return this.reportedTasksMap.get(task)
+  }
+
+  getReportedProject(project: WorkspaceProject) {
+    const reportedProject = this.reportedProjectsMap.get(project)
+    if (!reportedProject) {
+      return TestProject.register(project)
+    }
+    return reportedProject
   }
 
   updateTasks(packs: TaskResultPack[]) {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -96,7 +96,7 @@ export class StateManager {
     })
   }
 
-  collectFiles(files: File[] = [], project: WorkspaceProject) {
+  collectFiles(project: WorkspaceProject, files: File[] = []) {
     files.forEach((file) => {
       const existing = this.filesMap.get(file.filepath) || []
       const otherProject = existing.filter(
@@ -116,12 +116,10 @@ export class StateManager {
     })
   }
 
-  // this file is reused by ws-client, and should not rely on heavy dependencies like workspace
   clearFiles(
-    _project: { config: { name: string | undefined; root: string } },
+    project: WorkspaceProject,
     paths: string[] = [],
   ) {
-    const project = _project as WorkspaceProject
     paths.forEach((path) => {
       const files = this.filesMap.get(path)
       const fileTask = createFileTask(
@@ -208,8 +206,10 @@ export class StateManager {
 
   cancelFiles(files: string[], project: WorkspaceProject) {
     this.collectFiles(
-      files.map(filepath => createFileTask(filepath, project.config.root, project.config.name)),
       project,
+      files.map(filepath =>
+        createFileTask(filepath, project.config.root, project.config.name),
+      ),
     )
   }
 }

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -3,7 +3,8 @@ import { createFileTask } from '@vitest/runner/utils'
 import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
 import type { UserConsoleLog } from '../types/general'
 import type { WorkspaceProject } from './workspace'
-import { TestCase, TestFile, TestSuite, _experimental_getServerTask } from './server-tasks'
+import type { ReportedTask } from './server-tasks'
+import { TestCase, TestFile, TestSuite } from './server-tasks'
 
 export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
   if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {
@@ -20,6 +21,7 @@ export class StateManager {
   taskFileMap = new WeakMap<Task, File>()
   errorsSet = new Set<unknown>()
   processTimeoutCauses = new Set<string>()
+  reportedTasksMap = new WeakMap<Task, ReportedTask>()
 
   catchError(err: unknown, type: string): void {
     if (isAggregateError(err)) {
@@ -171,7 +173,7 @@ export class StateManager {
   }
 
   _experimental_getServerTask(task: Task) {
-    return _experimental_getServerTask(task)
+    return this.reportedTasksMap.get(task)
   }
 
   updateTasks(packs: TaskResultPack[]) {

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -10,7 +10,7 @@ import type {
 } from '../reporters'
 import type { TestSequencerConstructor } from '../sequencers/types'
 import type { ChaiConfig } from '../../integrations/chai/config'
-import type { Arrayable, ParsedStack } from '../../types/general'
+import type { Arrayable, ErrorWithDiff, ParsedStack } from '../../types/general'
 import type { JSDOMOptions } from '../../types/jsdom-options'
 import type { HappyDOMOptions } from '../../types/happy-dom-options'
 import type { EnvironmentOptions } from '../../types/environment'
@@ -620,7 +620,7 @@ export interface InlineConfig {
    *
    * Return `false` to omit the frame.
    */
-  onStackTrace?: (error: Error, frame: ParsedStack) => boolean | void
+  onStackTrace?: (error: ErrorWithDiff, frame: ParsedStack) => boolean | void
 
   /**
    * Indicates if CSS files should be processed.

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -1019,9 +1019,7 @@ export interface ResolvedConfig
   minWorkers: number
 }
 
-export type ProjectConfig = Omit<
-  UserConfig,
-  | 'sequencer'
+type NonProjectOptions =
   | 'shard'
   | 'watch'
   | 'run'
@@ -1029,7 +1027,6 @@ export type ProjectConfig = Omit<
   | 'update'
   | 'reporters'
   | 'outputFile'
-  | 'poolOptions'
   | 'teardownTimeout'
   | 'silent'
   | 'forceRerunTriggers'
@@ -1047,11 +1044,17 @@ export type ProjectConfig = Omit<
   | 'slowTestThreshold'
   | 'inspect'
   | 'inspectBrk'
-  | 'deps'
   | 'coverage'
   | 'maxWorkers'
   | 'minWorkers'
   | 'fileParallelism'
+
+export type ProjectConfig = Omit<
+  UserConfig,
+  NonProjectOptions
+  | 'sequencer'
+  | 'deps'
+  | 'poolOptions'
 > & {
   sequencer?: Omit<SequenceOptions, 'sequencer' | 'seed'>
   deps?: Omit<DepsOptions, 'moduleDirectories'>
@@ -1064,5 +1067,10 @@ export type ProjectConfig = Omit<
     forks?: Pick<NonNullable<PoolOptions['forks']>, 'singleFork' | 'isolate'>
   }
 }
+
+export type ResolvedProjectConfig = Omit<
+  ResolvedConfig,
+  NonProjectOptions
+>
 
 export type { UserWorkspaceConfig } from '../../public/config'

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs'
-import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+import { rm } from 'node:fs/promises'
 import fg from 'fast-glob'
 import mm from 'micromatch'
 import {
@@ -38,6 +38,7 @@ import { MocksPlugins } from './plugins/mocks'
 import { CoverageTransform } from './plugins/coverageTransform'
 import { serializeConfig } from './config/serializeConfig'
 import type { Vitest } from './core'
+import { TestProject } from './reported-workspace-project'
 
 interface InitializeProjectOptions extends UserWorkspaceConfig {
   workspaceConfigPath: string
@@ -97,6 +98,8 @@ export class WorkspaceProject {
   closingPromise: Promise<unknown> | undefined
 
   testFilesList: string[] | null = null
+
+  public testProject!: TestProject
 
   public readonly id = nanoid()
   public readonly tmpDir = join(tmpdir(), this.id)
@@ -367,6 +370,7 @@ export class WorkspaceProject {
       ctx.config,
       ctx.server.config,
     )
+    project.testProject = new TestProject(project)
     return project
   }
 
@@ -391,6 +395,7 @@ export class WorkspaceProject {
       this.ctx.config,
       server.config,
     )
+    this.testProject = new TestProject(this)
 
     this.server = server
 
@@ -440,7 +445,7 @@ export class WorkspaceProject {
 
   private async clearTmpDir() {
     try {
-      await rm(this.tmpDir, { force: true, recursive: true })
+      await rm(this.tmpDir, { recursive: true })
     }
     catch {}
   }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -88,7 +88,6 @@ export class WorkspaceProject {
   configOverride: Partial<ResolvedConfig> | undefined
 
   config!: ResolvedConfig
-  serializedConfig!: SerializedConfig
   server!: ViteDevServer
   vitenode!: ViteNodeServer
   runner!: ViteNodeRunner
@@ -365,11 +364,6 @@ export class WorkspaceProject {
     project.server = ctx.server
     project.runner = ctx.runner
     project.config = ctx.config
-    project.serializedConfig = serializeConfig(
-      ctx.config,
-      ctx.config,
-      ctx.server.config,
-    )
     project.testProject = new TestProject(project)
     return project
   }
@@ -389,11 +383,6 @@ export class WorkspaceProject {
       },
       server.config,
       this.ctx.logger,
-    )
-    this.serializedConfig = serializeConfig(
-      this.config,
-      this.ctx.config,
-      server.config,
     )
     this.testProject = new TestProject(this)
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -420,11 +420,17 @@ export class WorkspaceProject {
   }
 
   getSerializableConfig(): SerializedConfig {
+    // TODO: serialize the config _once_ or when needed
+    const config = serializeConfig(
+      this.config,
+      this.ctx.config,
+      this.server.config,
+    )
     if (!this.ctx.configOverride) {
-      return this.serializedConfig
+      return config
     }
     return deepMerge(
-      this.serializedConfig,
+      config,
       this.ctx.configOverride,
     )
   }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -362,6 +362,11 @@ export class WorkspaceProject {
     project.server = ctx.server
     project.runner = ctx.runner
     project.config = ctx.config
+    project.serializedConfig = serializeConfig(
+      ctx.config,
+      ctx.config,
+      ctx.server.config,
+    )
     return project
   }
 

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -201,6 +201,8 @@ export type {
   AfterSuiteRunMeta,
 } from '../types/general'
 
+export type { TestError, SerializedError } from '@vitest/utils'
+
 /** @deprecated import from `vitest/environments` instead */
 export type EnvironmentReturn = EnvironmentReturn_
 /** @deprecated import from `vitest/environments` instead */

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -3,6 +3,13 @@ import '../node/types/vite'
 import '../types/global'
 
 import type {
+  Custom as Custom_,
+  File as File_,
+  Suite as Suite_,
+  Task as Task_,
+  Test as Test_,
+} from '@vitest/runner'
+import type {
   CollectLineNumbers as CollectLineNumbers_,
   CollectLines as CollectLines_,
   Context as Context_,
@@ -120,16 +127,28 @@ export type RootAndTarget = RootAndTarget_
 /** @deprecated import `TypeCheckContext` from `vitest/node` instead */
 export type Context = Context_
 
+/** @deprecated use `RunnerTestSuite` instead */
+export type Suite = Suite_
+/** @deprecated use `RunnerTestFile` instead */
+export type File = File_
+/** @deprecated use `RunnerTestCase` instead */
+export type Test = Test_
+/** @deprecated use `RunnerCustomCase` instead */
+export type Custom = Custom_
+/** @deprecated use `RunnerTask` instead */
+export type Task = Task_
+
 export type {
   RunMode,
   TaskState,
   TaskBase,
   TaskResult,
   TaskResultPack,
-  Suite,
-  File,
-  Test,
-  Task,
+  Suite as RunnerTestSuite,
+  File as RunnerTestFile,
+  Test as RunnerTestCase,
+  Task as RunnerTask,
+  Custom as RunnerCustomCase,
   DoneCallback,
   TestFunction,
   TestOptions,
@@ -144,7 +163,6 @@ export type {
   TestContext,
   TaskContext,
   ExtendedContext,
-  Custom,
   TaskCustomOptions,
   OnTestFailedHandler,
   TaskMeta,

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -81,6 +81,7 @@ export type {
   UserConfig,
   ResolvedConfig,
   ProjectConfig,
+  ResolvedProjectConfig,
   UserWorkspaceConfig,
   RuntimeConfig,
 } from '../node/types/config'

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -50,6 +50,8 @@ export type * as Vite from 'vite'
 
 export { TestCase, TestFile, TestSuite } from '../node/reporters/reported-tasks'
 export type {
+  TestCollection,
+
   TaskOptions,
   TestDiagnostic,
   FileDiagnostic,

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -49,6 +49,7 @@ export { isFileServingAllowed, createServer, parseAst, parseAstAsync } from 'vit
 export type * as Vite from 'vite'
 
 export { TestCase, TestFile, TestSuite } from '../node/reporters/reported-tasks'
+export { TestProject } from '../node/reported-workspace-project'
 export type {
   TestCollection,
 

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -48,6 +48,17 @@ export type { HTMLOptions } from '../node/reporters/html'
 export { isFileServingAllowed, createServer, parseAst, parseAstAsync } from 'vite'
 export type * as Vite from 'vite'
 
+export { TestCase, TestFile, TestSuite } from '../node/reporters/reported-tasks'
+export type {
+  TaskOptions,
+  TestDiagnostic,
+  FileDiagnostic,
+  TestResult,
+  TestResultPassed,
+  TestResultFailed,
+  TestResultSkipped,
+} from '../node/reporters/reported-tasks'
+
 export type {
   SequenceHooks,
   SequenceSetupFiles,

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -4,7 +4,7 @@ import { parse, stringify } from 'flatted'
 
 // eslint-disable-next-line no-restricted-imports
 import type { WebSocketEvents, WebSocketHandlers } from 'vitest'
-import { StateManager } from '../../vitest/src/node/state'
+import { StateManager } from './state'
 
 export * from '../../vitest/src/utils/tasks'
 

--- a/packages/ws-client/src/state.ts
+++ b/packages/ws-client/src/state.ts
@@ -1,67 +1,15 @@
 import type { File, Task, TaskResultPack } from '@vitest/runner'
+// eslint-disable-next-line no-restricted-imports
+import type { UserConsoleLog } from 'vitest'
+
+// can't import actual functions from utils, because it's incompatible with @vitest/browsers
 import { createFileTask } from '@vitest/runner/utils'
-import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
-import type { UserConsoleLog } from '../types/general'
-import type { WorkspaceProject } from './workspace'
-import { TestCase, TestFile, TestSuite, _experimental_getServerTask } from './server-tasks'
 
-export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
-  if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {
-    return true
-  }
-
-  return err instanceof Error && 'errors' in err
-}
-
+// Note this file is shared for both node and browser, be aware to avoid node specific logic
 export class StateManager {
   filesMap = new Map<string, File[]>()
   pathsSet: Set<string> = new Set()
   idMap = new Map<string, Task>()
-  taskFileMap = new WeakMap<Task, File>()
-  errorsSet = new Set<unknown>()
-  processTimeoutCauses = new Set<string>()
-
-  catchError(err: unknown, type: string): void {
-    if (isAggregateError(err)) {
-      return err.errors.forEach(error => this.catchError(error, type))
-    }
-
-    if (err === Object(err)) {
-      (err as Record<string, unknown>).type = type
-    }
-    else {
-      err = { type, message: err }
-    }
-
-    const _err = err as Record<string, any>
-    if (_err && typeof _err === 'object' && _err.code === 'VITEST_PENDING') {
-      const task = this.idMap.get(_err.taskId)
-      if (task) {
-        task.mode = 'skip'
-        task.result ??= { state: 'skip' }
-        task.result.state = 'skip'
-      }
-      return
-    }
-
-    this.errorsSet.add(err)
-  }
-
-  clearErrors() {
-    this.errorsSet.clear()
-  }
-
-  getUnhandledErrors() {
-    return Array.from(this.errorsSet.values())
-  }
-
-  addProcessTimeoutCause(cause: string) {
-    this.processTimeoutCauses.add(cause)
-  }
-
-  getProcessTimeoutCauses() {
-    return Array.from(this.processTimeoutCauses.values())
-  }
 
   getPaths() {
     return Array.from(this.pathsSet)
@@ -96,7 +44,7 @@ export class StateManager {
     })
   }
 
-  collectFiles(files: File[] = [], project: WorkspaceProject) {
+  collectFiles(files: File[] = []) {
     files.forEach((file) => {
       const existing = this.filesMap.get(file.filepath) || []
       const otherProject = existing.filter(
@@ -112,7 +60,7 @@ export class StateManager {
       }
       otherProject.push(file)
       this.filesMap.set(file.filepath, otherProject)
-      this.updateId(file, project)
+      this.updateId(file)
     })
   }
 
@@ -121,16 +69,15 @@ export class StateManager {
     _project: { config: { name: string | undefined; root: string } },
     paths: string[] = [],
   ) {
-    const project = _project as WorkspaceProject
+    const project = _project
     paths.forEach((path) => {
       const files = this.filesMap.get(path)
       const fileTask = createFileTask(
         path,
         project.config.root,
-        project.config.name,
+        project.config.name || '',
       )
       fileTask.local = true
-      TestFile.register(fileTask, project)
       this.idMap.set(fileTask.id, fileTask)
       if (!files) {
         this.filesMap.set(path, [fileTask])
@@ -149,31 +96,16 @@ export class StateManager {
     })
   }
 
-  updateId(task: Task, project: WorkspaceProject) {
+  updateId(task: Task) {
     if (this.idMap.get(task.id) === task) {
       return
     }
-
-    if (task.type === 'suite' && 'filepath' in task) {
-      TestFile.register(task, project)
-    }
-    else if (task.type === 'suite') {
-      TestSuite.register(task, project)
-    }
-    else {
-      TestCase.register(task, project)
-    }
-
     this.idMap.set(task.id, task)
     if (task.type === 'suite') {
       task.tasks.forEach((task) => {
-        this.updateId(task, project)
+        this.updateId(task)
       })
     }
-  }
-
-  _experimental_getServerTask(task: Task) {
-    return _experimental_getServerTask(task)
   }
 
   updateTasks(packs: TaskResultPack[]) {
@@ -198,18 +130,5 @@ export class StateManager {
       }
       task.logs.push(log)
     }
-  }
-
-  getCountOfFailedTests() {
-    return Array.from(this.idMap.values()).filter(
-      t => t.result?.state === 'fail',
-    ).length
-  }
-
-  cancelFiles(files: string[], project: WorkspaceProject) {
-    this.collectFiles(
-      files.map(filepath => createFileTask(filepath, project.config.root, project.config.name)),
-      project,
-    )
   }
 }

--- a/test/cli/fixtures/reported-tasks/1_first.test.ts
+++ b/test/cli/fixtures/reported-tasks/1_first.test.ts
@@ -79,6 +79,6 @@ it('registers a metadata', (ctx) => {
 
 declare module 'vitest' {
   interface TaskMeta {
-    key: string
+    key?: string
   }
 }

--- a/test/cli/fixtures/reported-tasks/1_first.test.ts
+++ b/test/cli/fixtures/reported-tasks/1_first.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-it('runs a test', () => {
+it('runs a test', async () => {
+  await new Promise(r => setTimeout(r, 10))
   expect(1).toBe(1)
 })
 
-it('fails a test', () => {
+it('fails a test', async () => {
+  await new Promise(r => setTimeout(r, 10))
   expect(1).toBe(2)
 })
 

--- a/test/cli/fixtures/reported-tasks/1_first.test.ts
+++ b/test/cli/fixtures/reported-tasks/1_first.test.ts
@@ -73,7 +73,7 @@ describe.each([1])('each group %s', (groupValue) => {
   })
 })
 
-it('regesters a metadata', (ctx) => {
+it('registers a metadata', (ctx) => {
   ctx.task.meta.key = 'value'
 })
 

--- a/test/cli/fixtures/reported-tasks/1_first.test.ts
+++ b/test/cli/fixtures/reported-tasks/1_first.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+it('runs a test', () => {
+  expect(1).toBe(1)
+})
+
+it('fails a test', () => {
+  expect(1).toBe(2)
+})
+
+it('fails multiple times', () => {
+  expect.soft(1).toBe(2)
+  expect.soft(3).toBe(3)
+  expect.soft(2).toBe(3)
+})
+
+it('skips an option test', { skip: true })
+it.skip('skips a .modifier test')
+
+it('todos an option test', { todo: true })
+it.todo('todos a .modifier test')
+
+it('retries a test', { retry: 5 }, () => {
+  expect(1).toBe(2)
+})
+
+let counter = 0
+it('retries a test with success', { retry: 5 }, () => {
+  expect(counter++).toBe(2)
+})
+
+it('repeats a test', { repeats: 5 }, () => {
+  expect(1).toBe(2)
+})
+
+describe('a group', () => {
+  it('runs a test in a group', () => {
+    expect(1).toBe(1)
+  })
+
+  it('todos an option test in a group', { todo: true })
+
+  describe('a nested group', () => {
+    it('runs a test in a nested group', () => {
+      expect(1).toBe(1)
+    })
+
+    it('fails a test in a nested group', () => {
+      expect(1).toBe(2)
+    })
+
+    it.concurrent('runs first concurrent test in a nested group', () => {
+      expect(1).toBe(1)
+    })
+
+    it.concurrent('runs second concurrent test in a nested group', () => {
+      expect(1).toBe(1)
+    })
+  })
+})
+
+describe.shuffle('shuffled group', () => {
+  it('runs a test in a shuffled group', () => {
+    expect(1).toBe(1)
+  })
+})
+
+describe.each([1])('each group %s', (groupValue) => {
+  it.each([2])('each test %s', (itValue) => {
+    expect(groupValue + itValue).toBe(3)
+  })
+})
+
+it('regesters a metadata', (ctx) => {
+  ctx.task.meta.key = 'value'
+})
+
+declare module 'vitest' {
+  interface TaskMeta {
+    key: string
+  }
+}

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -6,10 +6,13 @@ import type { WorkspaceProject } from 'vitest/node'
 import { runVitest } from '../../test-utils'
 import type { TestFile } from '../../../packages/vitest/src/node/reporters/reported-tasks'
 
+const now = new Date()
 // const finishedFiles: File[] = []
 const collectedFiles: File[] = []
 let state: StateManager
 let project: WorkspaceProject
+let files: File[]
+let testFile: TestFile
 
 beforeAll(async () => {
   const { ctx } = await runVitest({
@@ -27,25 +30,26 @@ beforeAll(async () => {
       },
     ],
     includeTaskLocation: true,
+    logHeapUsage: true,
   })
   state = ctx!.state
   project = ctx!.getCoreWorkspaceProject()
+  files = state.getFiles()
+  expect(files).toHaveLength(1)
+  testFile = state._experimental_getReportedEntity(files[0])! as TestFile
+  expect(testFile).toBeDefined()
 })
 
-it('correctly reports a file', async () => {
-  const files = state.getFiles() || []
-  expect(files).toHaveLength(1)
-
-  const testFile = state._experimental_getReportedEntity(files[0])! as TestFile
-  expect(testFile).toBeDefined()
+it('correctly reports a file', () => {
   // suite properties not available on file
   expect(testFile).not.toHaveProperty('parent')
   expect(testFile).not.toHaveProperty('options')
   expect(testFile).not.toHaveProperty('file')
+  expect(testFile).not.toHaveProperty('fullName')
+  expect(testFile).not.toHaveProperty('name')
 
+  expect(testFile.type).toBe('file')
   expect(testFile.task).toBe(files[0])
-  expect(testFile.fullName).toBe('1_first.test.ts')
-  expect(testFile.name).toBe('1_first.test.ts')
   expect(testFile.id).toBe(files[0].id)
   expect(testFile.location).toBeUndefined()
   expect(testFile.moduleId).toBe(resolve('./fixtures/reported-tasks/1_first.test.ts'))
@@ -71,3 +75,159 @@ it('correctly reports a file', async () => {
   // doesn't have a setup file
   expect(diagnostic.setupDuration).toBe(0)
 })
+
+it('correctly reports a passed test', () => {
+  const passedTest = testFile.children.find('test', 'runs a test')!
+  expect(passedTest.type).toBe('test')
+  expect(passedTest.task).toBe(files[0].tasks[0])
+  expect(passedTest.name).toBe('runs a test')
+  expect(passedTest.fullName).toBe('runs a test')
+  expect(passedTest.file).toBe(testFile)
+  expect(passedTest.parent).toBe(testFile)
+  expect(passedTest.options).toEqual({
+    each: undefined,
+    concurrent: undefined,
+    shuffle: undefined,
+    retry: undefined,
+    repeats: undefined,
+    mode: 'run',
+  })
+  expect(passedTest.meta()).toEqual({})
+
+  const result = passedTest.result()!
+  expect(result).toBeDefined()
+  expect(result.state).toBe('passed')
+  expect(result.errors).toBeUndefined()
+
+  const diagnostic = passedTest.diagnostic()!
+  expect(diagnostic).toBeDefined()
+  expect(diagnostic.heap).toBeGreaterThan(0)
+  expect(diagnostic.duration).toBeGreaterThan(0)
+  expect(date(new Date(diagnostic.startTime))).toBe(date(now))
+  expect(diagnostic.flaky).toBe(false)
+  expect(diagnostic.repeatCount).toBe(0)
+  expect(diagnostic.repeatCount).toBe(0)
+})
+
+it('correctly reports failed test', () => {
+  const passedTest = testFile.children.find('test', 'fails a test')!
+  expect(passedTest.type).toBe('test')
+  expect(passedTest.task).toBe(files[0].tasks[1])
+  expect(passedTest.name).toBe('fails a test')
+  expect(passedTest.fullName).toBe('fails a test')
+  expect(passedTest.file).toBe(testFile)
+  expect(passedTest.parent).toBe(testFile)
+  expect(passedTest.options).toEqual({
+    each: undefined,
+    concurrent: undefined,
+    shuffle: undefined,
+    retry: undefined,
+    repeats: undefined,
+    mode: 'run',
+  })
+  expect(passedTest.meta()).toEqual({})
+
+  const result = passedTest.result()!
+  expect(result).toBeDefined()
+  expect(result.state).toBe('failed')
+  expect(result.errors).toHaveLength(1)
+  expect(result.errors![0]).toMatchObject({
+    diff: expect.any(String),
+    message: 'expected 1 to be 2 // Object.is equality',
+    ok: false,
+    stack: expect.stringContaining('expected 1 to be 2 // Object.is equality'),
+    stacks: [
+      {
+        column: 13,
+        file: resolve('./fixtures/reported-tasks/1_first.test.ts'),
+        line: 10,
+        method: '',
+      },
+    ],
+  })
+
+  const diagnostic = passedTest.diagnostic()!
+  expect(diagnostic).toBeDefined()
+  expect(diagnostic.heap).toBeGreaterThan(0)
+  expect(diagnostic.duration).toBeGreaterThan(0)
+  expect(date(new Date(diagnostic.startTime))).toBe(date(now))
+  expect(diagnostic.flaky).toBe(false)
+  expect(diagnostic.repeatCount).toBe(0)
+  expect(diagnostic.repeatCount).toBe(0)
+})
+
+it('correctly reports multiple failures', () => {
+  const testCase = testFile.children.find('test', 'fails multiple times')!
+  const result = testCase.result()!
+  expect(result).toBeDefined()
+  expect(result.state).toBe('failed')
+  expect(result.errors).toHaveLength(2)
+  expect(result.errors![0]).toMatchObject({
+    message: 'expected 1 to be 2 // Object.is equality',
+  })
+  expect(result.errors![1]).toMatchObject({
+    message: 'expected 2 to be 3 // Object.is equality',
+  })
+})
+
+it('correctly reports test assigned options', () => {
+  const testOptionSkip = testFile.children.find('test', 'skips an option test')!
+  expect(testOptionSkip.options.mode).toBe('skip')
+  const testModifierSkip = testFile.children.find('test', 'skips a .modifier test')!
+  expect(testModifierSkip.options.mode).toBe('skip')
+
+  const testOptionTodo = testFile.children.find('test', 'todos an option test')!
+  expect(testOptionTodo.options.mode).toBe('todo')
+  const testModifierTodo = testFile.children.find('test', 'todos a .modifier test')!
+  expect(testModifierTodo.options.mode).toBe('todo')
+})
+
+it('correctly reports retried tests', () => {
+  const testRetry = testFile.children.find('test', 'retries a test')!
+  expect(testRetry.options.retry).toBe(5)
+  expect(testRetry.options.repeats).toBeUndefined()
+  expect(testRetry.result()!.state).toBe('failed')
+})
+
+it('correctly reports flaky tests', () => {
+  const testFlaky = testFile.children.find('test', 'retries a test with success')!
+  const diagnostic = testFlaky.diagnostic()!
+  expect(diagnostic.flaky).toBe(true)
+  expect(diagnostic.retryCount).toBe(2)
+  expect(diagnostic.repeatCount).toBe(0)
+  const result = testFlaky.result()!
+  expect(result.state).toBe('passed')
+  expect(result.errors).toHaveLength(2)
+})
+
+it('correctly reports repeated tests', () => {
+  const testRepeated = testFile.children.find('test', 'repeats a test')!
+  const diagnostic = testRepeated.diagnostic()!
+  expect(diagnostic.flaky).toBe(false)
+  expect(diagnostic.retryCount).toBe(0)
+  expect(diagnostic.repeatCount).toBe(5)
+  const result = testRepeated.result()!
+  expect(result.state).toBe('failed')
+  expect(result.errors).toHaveLength(6)
+})
+
+it('correctly passed down metadata', () => {
+  const testMetadata = testFile.children.find('test', 'regesters a metadata')!
+  const meta = testMetadata.meta()
+  expect(meta.key).toBe('value')
+})
+
+it('correctly finds test in nested suites', () => {
+  const oneNestedTest = testFile.children.deepFind('test', 'runs a test in a group')!
+  const oneTestedSuite = testFile.children.find('suite', 'a group')!
+  expect(oneNestedTest.parent).toEqual(oneTestedSuite)
+
+  const twoNestedTest = testFile.children.deepFind('test', 'runs a test in a nested group')!
+  expect(twoNestedTest.parent).toEqual(
+    oneTestedSuite.children.find('suite', 'a nested group'),
+  )
+})
+
+function date(time: Date) {
+  return `${time.getDate()}/${time.getMonth() + 1}/${time.getFullYear()}`
+}

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -214,7 +214,7 @@ it('correctly reports repeated tests', () => {
 it('correctly passed down metadata', () => {
   const testMetadata = findTest(testFile.children, 'registers a metadata')
   const meta = testMetadata.meta()
-  expect(meta.key).toBe('value')
+  expect(meta).toHaveProperty('key', 'value')
 })
 
 function date(time: Date) {

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, expect, it } from 'vitest'
+import { resolve } from 'pathe'
+import type { File } from 'vitest'
+import type { StateManager } from 'vitest/src/node/state.js'
+import type { WorkspaceProject } from 'vitest/node'
+import { runVitest } from '../../test-utils'
+import type { TestFile } from '../../../packages/vitest/src/node/reporters/reported-tasks'
+
+// const finishedFiles: File[] = []
+const collectedFiles: File[] = []
+let state: StateManager
+let project: WorkspaceProject
+
+beforeAll(async () => {
+  const { ctx } = await runVitest({
+    root: resolve(__dirname, '..', 'fixtures', 'reported-tasks'),
+    include: ['**/*.test.ts'],
+    reporters: [
+      'verbose',
+      {
+        // onFinished(files) {
+        //   finishedFiles.push(...files || [])
+        // },
+        onCollected(files) {
+          collectedFiles.push(...files || [])
+        },
+      },
+    ],
+    includeTaskLocation: true,
+  })
+  state = ctx!.state
+  project = ctx!.getCoreWorkspaceProject()
+})
+
+it('correctly reports a file', async () => {
+  const files = state.getFiles() || []
+  expect(files).toHaveLength(1)
+
+  const testFile = state._experimental_getReportedEntity(files[0])! as TestFile
+  expect(testFile).toBeDefined()
+  // suite properties not available on file
+  expect(testFile).not.toHaveProperty('parent')
+  expect(testFile).not.toHaveProperty('options')
+  expect(testFile).not.toHaveProperty('file')
+
+  expect(testFile.task).toBe(files[0])
+  expect(testFile.fullName).toBe('1_first.test.ts')
+  expect(testFile.name).toBe('1_first.test.ts')
+  expect(testFile.id).toBe(files[0].id)
+  expect(testFile.location).toBeUndefined()
+  expect(testFile.moduleId).toBe(resolve('./fixtures/reported-tasks/1_first.test.ts'))
+  expect(testFile.project).toBe(project)
+  expect(testFile.children.size).toBe(14)
+
+  const tests = [...testFile.children.tests()]
+  expect(tests).toHaveLength(11)
+  const deepTests = [...testFile.children.deepTests()]
+  expect(deepTests).toHaveLength(19)
+
+  const suites = [...testFile.children.suites()]
+  expect(suites).toHaveLength(3)
+  const deepSuites = [...testFile.children.deepSuites()]
+  expect(deepSuites).toHaveLength(4)
+
+  const diagnostic = testFile.diagnostic()
+  expect(diagnostic).toBeDefined()
+  expect(diagnostic.environmentSetupDuration).toBeGreaterThan(0)
+  expect(diagnostic.prepareDuration).toBeGreaterThan(0)
+  expect(diagnostic.collectDuration).toBeGreaterThan(0)
+  expect(diagnostic.duration).toBeGreaterThan(0)
+  // doesn't have a setup file
+  expect(diagnostic.setupDuration).toBe(0)
+})

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -53,7 +53,7 @@ it('correctly reports a file', () => {
   expect(testFile.id).toBe(files[0].id)
   expect(testFile.location).toBeUndefined()
   expect(testFile.moduleId).toBe(resolve('./fixtures/reported-tasks/1_first.test.ts'))
-  expect(testFile.project).toBe(project)
+  expect(testFile.project.workspaceProject).toBe(project)
   expect(testFile.children.size).toBe(14)
 
   const tests = [...testFile.children.tests()]

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -36,7 +36,7 @@ beforeAll(async () => {
   project = ctx!.getCoreWorkspaceProject()
   files = state.getFiles()
   expect(files).toHaveLength(1)
-  testFile = state._experimental_getReportedEntity(files[0])! as TestFile
+  testFile = state.getReportedEntity(files[0])! as TestFile
   expect(testFile).toBeDefined()
 })
 
@@ -212,7 +212,7 @@ it('correctly reports repeated tests', () => {
 })
 
 it('correctly passed down metadata', () => {
-  const testMetadata = findTest(testFile.children, 'regesters a metadata')
+  const testMetadata = findTest(testFile.children, 'registers a metadata')
   const meta = testMetadata.meta()
   expect(meta.key).toBe('value')
 })

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`asymmetric matcher error 1`] = `
 {
   "actual": "hello",
-  "diff": null,
+  "diff": undefined,
   "expected": "StringContaining "xx"",
   "message": "expected 'hello' to deeply equal StringContaining "xx"",
 }
@@ -12,7 +12,7 @@ exports[`asymmetric matcher error 1`] = `
 exports[`asymmetric matcher error 2`] = `
 {
   "actual": "hello",
-  "diff": null,
+  "diff": undefined,
   "expected": "StringNotContaining "ll"",
   "message": "expected 'hello' to deeply equal StringNotContaining "ll"",
 }
@@ -200,7 +200,7 @@ exports[`asymmetric matcher error 13`] = `
 exports[`asymmetric matcher error 14`] = `
 {
   "actual": "hello",
-  "diff": null,
+  "diff": undefined,
   "expected": "StringMatching /xx/",
   "message": "expected 'hello' to deeply equal StringMatching /xx/",
 }
@@ -222,7 +222,7 @@ exports[`asymmetric matcher error 15`] = `
 exports[`asymmetric matcher error 16`] = `
 {
   "actual": "hello",
-  "diff": null,
+  "diff": undefined,
   "expected": "StringContaining "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"",
   "message": "expected 'hello' to deeply equal StringContaining{…}",
 }
@@ -231,7 +231,7 @@ exports[`asymmetric matcher error 16`] = `
 exports[`asymmetric matcher error 17`] = `
 {
   "actual": "hello",
-  "diff": null,
+  "diff": undefined,
   "expected": "StringContaining "xx"",
   "message": "expected error to match asymmetric matcher",
 }
@@ -253,7 +253,7 @@ stringContainingCustom<xx>
 exports[`asymmetric matcher error 19`] = `
 {
   "actual": "hello",
-  "diff": null,
+  "diff": undefined,
   "expected": "StringContaining "ll"",
   "message": "expected error not to match asymmetric matcher",
 }

--- a/test/core/test/serialize.test.ts
+++ b/test/core/test/serialize.test.ts
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 
-import { serializeError } from '@vitest/utils/error'
+import { serializeValue } from '@vitest/utils/error'
 import { describe, expect, it } from 'vitest'
 
 describe('error serialize', () => {
   it('works', () => {
-    expect(serializeError(undefined)).toEqual(undefined)
-    expect(serializeError(null)).toEqual(null)
-    expect(serializeError('hi')).toEqual('hi')
+    expect(serializeValue(undefined)).toEqual(undefined)
+    expect(serializeValue(null)).toEqual(null)
+    expect(serializeValue('hi')).toEqual('hi')
 
-    expect(serializeError({
+    expect(serializeValue({
       foo: 'hi',
       promise: new Promise(() => {}),
       fn: () => {},
@@ -35,7 +35,7 @@ describe('error serialize', () => {
     error.whateverArray = [error, error]
     error.whateverArrayClone = error.whateverArray
 
-    expect(serializeError(error)).toMatchSnapshot()
+    expect(serializeValue(error)).toMatchSnapshot()
   })
 
   it('Should handle object with getter/setter correctly', () => {
@@ -51,7 +51,7 @@ describe('error serialize', () => {
       },
     }
 
-    expect(serializeError(user)).toEqual({
+    expect(serializeValue(user)).toEqual({
       name: 'John',
       surname: 'Smith',
       fullName: 'John Smith',
@@ -70,7 +70,7 @@ describe('error serialize', () => {
 
     Object.defineProperty(user, 'fullName', { enumerable: false, value: 'John Smith' })
 
-    const serialized = serializeError(user)
+    const serialized = serializeValue(user)
     expect(serialized).not.toBe(user)
     expect(serialized).toEqual({
       name: 'John',
@@ -86,7 +86,7 @@ describe('error serialize', () => {
     // `MessagePort`, so the serialized error object should have been recreated as plain object.
     const error = new Error('test')
 
-    const serialized = serializeError(error)
+    const serialized = serializeValue(error)
     expect(Object.getPrototypeOf(serialized)).toBe(null)
     expect(serialized).toEqual({
       constructor: 'Function<Error>',
@@ -114,7 +114,7 @@ describe('error serialize', () => {
         },
       }],
     })
-    expect(serializeError(error)).toEqual({
+    expect(serializeValue(error)).toEqual({
       array: [
         {
           name: '<unserializable>: name cannot be accessed',
@@ -131,7 +131,7 @@ describe('error serialize', () => {
 
   it('can serialize DOMException', () => {
     const err = new DOMException('You failed', 'InvalidStateError')
-    expect(serializeError(err)).toMatchObject({
+    expect(serializeValue(err)).toMatchObject({
       NETWORK_ERR: 19,
       name: 'InvalidStateError',
       message: 'You failed',
@@ -160,7 +160,7 @@ describe('error serialize', () => {
       immutableRecord,
     })
 
-    expect(serializeError(error)).toMatchObject({
+    expect(serializeValue(error)).toMatchObject({
       stack: expect.stringContaining('Error: test'),
       immutableList: ['foo'],
       immutableRecord: { foo: 'bar' },
@@ -186,7 +186,7 @@ describe('error serialize', () => {
       },
     }
 
-    const serialized = serializeError(error)
+    const serialized = serializeValue(error)
 
     expect(serialized).toEqual({
       key: 'value',


### PR DESCRIPTION
### Description

This PR introduces a new way to work with the runner tasks on the server by implementing `TestCase`, `TestSuite`, and `TestFile` interfaces.

These values will be passed down to the new reporter interface. I am opening a draft to discuss the direction of this API.

The goal of this API is to provide a public interface that has an easy to understand methods and properties. It should also have useful method to travers and filter tests. The API should be documented with JSDocs commends and have a section in the advanced reporter guide.

```ts
onFinished(tests) {
  // to get the reported task, use `state.getReportedEntity` for now 
  // in the future, it will be passed down to the reporter
  const testFile = this.ctx.state.getReportedEntity(tests[0]) as TestFile
  const filePath = testFile.moduleId
  console.log('tests in, filePath, 'finished running')

  // iterate over all tests in the file
  for (const test of testFile.children.allTests()) {
    console.log('test', test.fullName, test.result()?.state || 'running')
  }
  // iterate over only top level failed tests
  for (const test of testFile.children.tests('failed')) {
    console.log('test failed with errors', ...test.result()?.errors)
  }

  const myTest = testFile.children.at(0)!
  const duration = myTest.diagnostic()?.duration
  const myCustomMeta = myTest.meta().myCustomProperty
  if (myCustomMeta === 'success') {
    cosnole.log(myTest.fullName, 'did the thing')
  }
}
```

```ts
declare class TestTask {
    readonly project: TestProject;
    /**
     * Direct reference to the test file where the test is defined.
     */
    readonly file: TestFile;
    /**
     * Name of the test or the suite.
     */
    readonly name: string;
    /**
     * Full name of the test or the suite including all parent suites separated with `>`.
     */
    readonly fullName: string;
    /**
     * Unique identifier.
     * This ID is deterministic and will be the same for the same test across multiple runs.
     * The ID is based on the file path and test position.
     */
    readonly id: string;
    /**
     * Location in the file where the test or suite was defined.
     * Locations are collected only if `includeTaskLocation` is enabled in the config.
     */
    readonly location: {
        line: number;
        column: number;
    } | undefined;
}

declare class TestCase extends TestTask {
    /**
     * Task instance.
     * @experimental Public task API is experimental and does not follow semver.
     */
    readonly task: Test | Custom;
    readonly type = "test" | "custom";
    /**
     * Custom metadata that was attached to the test during its execution.
     */
    meta(): TaskMeta;
    /**
     * Parent suite of the test. If test was called directly inside the file, the parent will be the file.
     */
    readonly parent: TestSuite | TestFile;
    /**
     * Options that test was initiated with.
     */
    readonly options: TaskOptions;
    /**
     * Result of the test. Will be `undefined` if test is not finished yet or was just collected.
     */
    result(): TestResult | undefined
    /**
     * Useful information about the test like duration, memory usage, etc.
     */
    diagnostic(): TestDiagnostic | undefined;
}


declare class TestCollection {
    /**
     * Test or a suite at a specific index in the array.
     */
    at(index: number): TestCase | TestSuite | undefined
    /**
     * The number of tests and suites in the collection.
     */
    size: number
    /**
     * The same collection, but in an array form for easier manipulation.
     */
    array(): (TestCase | TestSuite)[];
    /**
     * Iterates over all tests and suites in the collection.
     */
    values(): IterableIterator<TestCase | TestSuite>;
    /**
     * Returns all suites that are part of this suite and its children.
     */
    allSuites(): IterableIterator<TestSuite>;
    /**
     * Returns all tests that are part of this suite and its children.
     */
    allTests(state?: TestResult['state'] | 'running'): IterableIterator<TestCase>;
    /**
     * Returns only tests that are part of this suite.
     */
    tests(state?: TestResult['state'] | 'running'): IterableIterator<TestCase>;
    /**
     * Returns only suites that are part of this suite.
     */
    suites(): IterableIterator<TestSuite>;
    [Symbol.iterator](): IterableIterator<TestSuite | TestCase>;
}

declare class TestSuite extends TestTask {
    /**
     * Task instance.
     * @experimental Public task API is experimental and does not follow semver.
     */
    readonly task: Suite;
    readonly type = "suite";
    /**
     * Parent suite. If suite was called directly inside the file, the parent will be the file.
     */
    readonly parent: TestSuite | TestFile;
    /**
     * Collection of suites and tests that are part of this suite.
     */
    readonly children: TaskCollection;
    /**
     * Options that the suite was initiated with.
     */
    readonly options: TaskOptions;
}
declare class TestFile extends TestTask {
    /**
     * Task instance.
     * @experimental Public task API is experimental and does not follow semver.
     */
    readonly task: File;
    readonly type = "file";
    /**
     * Collection of suites and tests that are part of this suite.
     */
    readonly children: TaskCollection;
    /**
     * This is usually an absolute UNIX file path.
     * It can be a virtual id if the file is not on the disk.
     * This value corresponds to Vite's `ModuleGraph` id.
     */
    readonly moduleId: string;
    readonly location: undefined;
}

declare class TestProject {
    /**
     * The global vitest instance.
     * @experimental The public Vitest API is experimental and does not follow semver.
     */
    readonly vitest: Vitest;
    /**
     * The workspace project this test project is associated with.
     * @experimental The public Vitest API is experimental and does not follow semver.
     */
    readonly workspaceProject: WorkspaceProject;
    /**
     * Resolved project configuration.
     */
    readonly config: ResolvedProjectConfig;
    /**
     * Resolved global configuration. If there are no workspace projects, this will be the same as `config`.
     */
    readonly globalConfig: ResolvedConfig;
    /**
     * Serialized project configuration. This is the config that tests receive.
     */
    get serializedConfig(): SerializedConfig;
    /**
     * The name of the project or an empty string if not set.
     */
    name(): string;
    /**
     * Custom context provided to the project.
     */
    context(): ProvidedContext;
    /**
     * Provide a custom context to the project. This context will be available for tests once they run.
     */
    provide<T extends keyof ProvidedContext & string>(key: T, value: ProvidedContext[T]): void;
}

interface TaskOptions {
    each: boolean | undefined;
    concurrent: boolean | undefined;
    shuffle: boolean | undefined;
    retry: number | undefined;
    repeats: number | undefined;
    mode: 'run' | 'only' | 'skip' | 'todo';
}
interface TestDiagnostic {
    heap: number | undefined;
    duration: number;
    startTime: number;
    retryCount: number;
    repeatCount: number;
    flaky: boolean
}

interface SerialisedError {
  message: string
  stack: string
  name: string
  stacks?: ParsedStack[]
  [key: string]: unknown
}

interface TestError extends SerialisedError {
  diff?: string
  actual?: string
  expected?: string
}

interface TestResult {
  state: 'passed' | 'failed' | 'skipped'
  errors?: TestError[]
}
```