### PR TITLE
fix(expect): prefer `unknown` in certain assertions

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -98,19 +98,19 @@ export interface ExpectStatic
   AsymmetricMatchersContaining {
   <T>(actual: T, message?: string): Assertion<T>
   extend: (expects: MatchersObject) => void
-  anything: () => any
-  any: (constructor: unknown) => any
+  anything: () => unknown
+  any: (constructor: unknown) => unknown
   getState: () => MatcherState
   setState: (state: Partial<MatcherState>) => void
   not: AsymmetricMatchersContaining
 }
 
 export interface AsymmetricMatchersContaining {
-  stringContaining: (expected: string) => any
-  objectContaining: <T = any>(expected: T) => any
-  arrayContaining: <T = unknown>(expected: Array<T>) => any
-  stringMatching: (expected: string | RegExp) => any
-  closeTo: (expected: number, precision?: number) => any
+  stringContaining: (expected: string) => unknown
+  objectContaining: <T = any>(expected: T) => unknown
+  arrayContaining: <T = unknown>(expected: Array<T>) => unknown
+  stringMatching: (expected: string | RegExp) => unknown
+  closeTo: (expected: number, precision?: number) => unknown
 }
 
 export interface JestAssertion<T = any> extends jest.Matchers<void, T> {


### PR DESCRIPTION
When `expect.Any(...)` returns `any` type, some ESLint configurations will flag this as potentially dangerous due to the fact that `any` simply turns off type checking for this object completely.

![Screenshot 2024-07-16 at 14 55 23](https://github.com/user-attachments/assets/e188feb1-f749-474a-828f-c7f869ac4184)

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
