### PR TITLE
fix(docs): list default browser provider consistently

### DIFF
--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -258,7 +258,7 @@ Vitest browser requires spinning up the provider and the browser during the init
 
 ## Cross-Browser Testing
 
-When you specify a browser name in the browser option, Vitest will try to run the specified browser using [WebdriverIO](https://webdriver.io/) by default, and then run the tests there. This feature makes cross-browser testing easy to use and configure in environments like a CI. If you don't want to use WebdriverIO, you can configure the custom browser provider by using `browser.provider` option.
+When you specify a browser name in the browser option, Vitest will try to run the specified browser using `preview` by default, and then run the tests there. If you don't want to use `preview`, you can configure the custom browser provider by using `browser.provider` option.
 
 To specify a browser using the CLI, use the `--browser` flag followed by the browser name, like this:
 


### PR DESCRIPTION
### Description

The documentation was inconsistent in regards to what the default browser provider is. In once place it says that `preview` is the default, in another it says that `WebdriverIO` is the default. Since it seems `preview` is now the default, I have adjusted the docs accordingly.
Since this is not exactly a bug that can be reproduced, but rather just an inconsistency in the docs, I did not make an issue.
Regardless, it would be great to have a "Documentation" issue template for these kinds of errors.
Since this just changes a sentence in a markdown file, no test is needed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
