### PR TITLE
fix(spy): fix `mockImplementation` for function overload and unions

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -141,6 +141,8 @@ export interface MockContext<T extends Procedure> {
 }
 
 type Procedure = (...args: any[]) => any
+// pick a single function type from function overloads, unions, etc...
+type NormalizedPrecedure<T extends Procedure> = (...args: Parameters<T>) => ReturnType<T>;
 
 type Methods<T> = keyof {
   [K in keyof T as T[K] extends Procedure ? K : never]: T[K];
@@ -204,14 +206,14 @@ export interface MockInstance<T extends Procedure = Procedure> {
    *
    * If mock was created with `vi.spyOn`, it will return `undefined` unless a custom implementation was provided.
    */
-  getMockImplementation(): T | undefined
+  getMockImplementation(): NormalizedPrecedure<T> | undefined
   /**
    * Accepts a function that will be used as an implementation of the mock.
    * @example
    * const increment = vi.fn().mockImplementation(count => count + 1);
    * expect(increment(3)).toBe(4);
    */
-  mockImplementation(fn: T): this
+  mockImplementation(fn: NormalizedPrecedure<T>): this
   /**
    * Accepts a function that will be used as a mock implementation during the next call. Can be chained so that multiple function calls produce different results.
    * @example
@@ -219,7 +221,7 @@ export interface MockInstance<T extends Procedure = Procedure> {
    * expect(fn(3)).toBe(4);
    * expect(fn(3)).toBe(3);
    */
-  mockImplementationOnce(fn: T): this
+  mockImplementationOnce(fn: NormalizedPrecedure<T>): this
   /**
    * Overrides the original mock implementation temporarily while the callback is being executed.
    * @example
@@ -231,7 +233,7 @@ export interface MockInstance<T extends Procedure = Procedure> {
    *
    * myMockFn() // 'original'
    */
-  withImplementation<T2>(fn: T, cb: () => T2): T2 extends Promise<unknown> ? Promise<this> : this
+  withImplementation<T2>(fn: NormalizedPrecedure<T>, cb: () => T2): T2 extends Promise<unknown> ? Promise<this> : this
 
   /**
    * Use this if you need to return `this` context from the method without invoking actual implementation.

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -142,7 +142,7 @@ export interface MockContext<T extends Procedure> {
 
 type Procedure = (...args: any[]) => any
 // pick a single function type from function overloads, unions, etc...
-type NormalizedPrecedure<T extends Procedure> = (...args: Parameters<T>) => ReturnType<T>;
+type NormalizedPrecedure<T extends Procedure> = (...args: Parameters<T>) => ReturnType<T>
 
 type Methods<T> = keyof {
   [K in keyof T as T[K] extends Procedure ? K : never]: T[K];

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -152,6 +152,22 @@ describe('testing vi utils', () => {
     expectTypeOf(gSpy.mock.contexts).toEqualTypeOf<unknown[]>()
   })
 
+  test('mockImplementation types', async () => {
+    // overload
+    const fs = await import("node:fs");
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => "str");
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => Buffer.from("buf"));
+    vi.fn(fs.readFileSync).mockImplementation(() => "str");
+    vi.fn(fs.readFileSync).mockImplementation(() => Buffer.from("buf"));
+
+    // union
+    interface Handler {
+      (v: number): number;
+      other(v: number): number;
+    }
+    vi.fn<Handler>().mockImplementation((v) => v + 1);
+  })
+
   test('can change config', () => {
     const state = getWorkerState()
     expect(state.config.hookTimeout).toBe(10000)

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -154,18 +154,18 @@ describe('testing vi utils', () => {
 
   test('mockImplementation types', async () => {
     // overload
-    const fs = await import("node:fs");
-    vi.spyOn(fs, 'readFileSync').mockImplementation(() => "str");
-    vi.spyOn(fs, 'readFileSync').mockImplementation(() => Buffer.from("buf"));
-    vi.fn(fs.readFileSync).mockImplementation(() => "str");
-    vi.fn(fs.readFileSync).mockImplementation(() => Buffer.from("buf"));
+    const fs = await import('node:fs')
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => 'str')
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => Buffer.from('buf'))
+    vi.fn(fs.readFileSync).mockImplementation(() => 'str')
+    vi.fn(fs.readFileSync).mockImplementation(() => Buffer.from('buf'))
 
     // union
     interface Handler {
-      (v: number): number;
-      other(v: number): number;
+      (v: number): number
+      other: (v: number) => number
     }
-    vi.fn<Handler>().mockImplementation((v) => v + 1);
+    vi.fn<Handler>().mockImplementation(v => v + 1)
   })
 
   test('can change config', () => {

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -154,7 +154,7 @@ describe('testing vi utils', () => {
 
   test('mockImplementation types', async () => {
     // overload
-    const fs = await import('node:fs')
+    const fs = { readFileSync() {} } as any as typeof import('node:fs')
     vi.spyOn(fs, 'readFileSync').mockImplementation(() => 'str')
     vi.spyOn(fs, 'readFileSync').mockImplementation(() => Buffer.from('buf'))
     vi.fn(fs.readFileSync).mockImplementation(() => 'str')


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6155 (broken in v2.0.0)
- closes https://github.com/vitest-dev/vitest/issues/6182 (broken in v2.0.3)

Previously we had `mockImplementation(fn: T)` where `T extends (...args: any[]) => any`, but such `T` can include arbitrary overload and union types, so it looks like it's important to have singly picked function type `(...args: Paramters<T>) => ReturnType<T>` for the most reasonable usability.

There are probably two ways to solve this. One way is like this PR to `NormalizedPrecedure<T>` inside `MockInstance<T>`. Another way which Jest does is to have a wrapper `SpiedFunction<T>` for `MockInstance<(...args: Parameters<T>) => ReturnType<T>>`.

I think what Jest does still have issues left (though I'm not sure if it's intentional or not). For example, `SpiedFunction` doesn't cover the case of `vi.mocked` helper, so it would fail the example from OP https://github.com/vitest-dev/vitest/issues/6155. So, I thought it's more robust to go with the former approach.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
