### PR TITLE
fix(coverage): consistent type-only file handling

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -54,7 +54,6 @@
     "magic-string": "^0.30.10",
     "magicast": "^0.3.4",
     "std-env": "^3.7.0",
-    "strip-literal": "^2.1.0",
     "test-exclude": "^7.0.1",
     "tinyrainbow": "^1.2.0"
   },

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -19,7 +19,6 @@ import remapping from '@ampproject/remapping'
 import { normalize, resolve } from 'pathe'
 import c from 'tinyrainbow'
 import { provider } from 'std-env'
-import { stripLiteral } from 'strip-literal'
 import createDebug from 'debug'
 import { cleanUrl } from 'vite-node/utils'
 import type { EncodedSourceMap, FetchResult } from 'vite-node'
@@ -391,15 +390,10 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
 
       const coverages = await Promise.all(
         chunk.map(async (filename) => {
-          const { originalSource, source } = await this.getSources(
+          const { originalSource } = await this.getSources(
             filename.href,
             transformResults,
           )
-
-          // Ignore empty files, e.g. files that contain only typescript types and no runtime code
-          if (source && stripLiteral(source).trim() === '') {
-            return null
-          }
 
           const coverage = {
             url: filename.href,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,9 +572,6 @@ importers:
       std-env:
         specifier: ^3.7.0
         version: 3.7.0
-      strip-literal:
-        specifier: ^2.1.0
-        version: 2.1.0
       test-exclude:
         specifier: ^7.0.1
         version: 7.0.1

--- a/test/coverage-test/test/empty-lines.v8.test.ts
+++ b/test/coverage-test/test/empty-lines.v8.test.ts
@@ -12,7 +12,6 @@ type LineCoverage = Record<number, CoveredLine | UncoveredLine | IgnoredLine>
 describe('include empty lines', () => {
   let coveredFileLines: LineCoverage
   let uncoveredFileLines: LineCoverage
-  let files: string[]
 
   beforeAll(async () => {
     await runVitest({
@@ -28,16 +27,7 @@ describe('include empty lines', () => {
       },
     })
 
-    ;({ coveredFileLines, uncoveredFileLines, files } = await readCoverage())
-  })
-
-  test('file containing only types is ignored', () => {
-    expect(files).toMatchInlineSnapshot(`
-      [
-        "<process-cwd>/fixtures/src/empty-lines.ts",
-        "<process-cwd>/fixtures/src/untested-file.ts",
-      ]
-    `)
+    ;({ coveredFileLines, uncoveredFileLines } = await readCoverage())
   })
 
   test('lines are included', async () => {
@@ -64,7 +54,7 @@ describe('include empty lines', () => {
 describe('ignore empty lines', () => {
   let coveredFileLines: LineCoverage
   let uncoveredFileLines: LineCoverage
-  let files: string[]
+  let typesOnlyFileLines: LineCoverage
 
   beforeAll(async () => {
     await runVitest({
@@ -79,16 +69,13 @@ describe('ignore empty lines', () => {
       },
     })
 
-    ;({ coveredFileLines, uncoveredFileLines, files } = await readCoverage())
+    ;({ coveredFileLines, uncoveredFileLines, typesOnlyFileLines } = await readCoverage())
   })
 
-  test('file containing only types is ignored', () => {
-    expect(files).toMatchInlineSnapshot(`
-      [
-        "<process-cwd>/fixtures/src/empty-lines.ts",
-        "<process-cwd>/fixtures/src/untested-file.ts",
-      ]
-    `)
+  test('file containing only types has no uncovered lines', () => {
+    expect(typesOnlyFileLines[1]).toBe(undefined)
+    expect(typesOnlyFileLines[2]).toBe(undefined)
+    expect(typesOnlyFileLines[3]).toBe(undefined)
   })
 
   test('empty lines are ignored', async () => {
@@ -184,12 +171,12 @@ coverageTest('cover some lines', () => {
 
 async function readCoverage() {
   const coverageMap = await readCoverageMap()
-  const files = coverageMap.files()
 
   const coveredFileLines = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/empty-lines.ts').getLineCoverage() as LineCoverage
   const uncoveredFileLines = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/untested-file.ts').getLineCoverage() as LineCoverage
+  const typesOnlyFileLines = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/types-only.ts').getLineCoverage() as LineCoverage
 
-  return { coveredFileLines, uncoveredFileLines, files }
+  return { coveredFileLines, uncoveredFileLines, typesOnlyFileLines }
 }
 
 function range(count: number, options: { base: number } = { base: 1 }) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/6164

During https://github.com/vitest-dev/vitest/pull/5457 the changes of https://github.com/vitest-dev/vitest/pull/5328 should have been reverted. The https://github.com/vitest-dev/vitest/pull/5457 implements type-only file detection in proper way while https://github.com/vitest-dev/vitest/pull/5328 was mostly a work-around since good solution was not available back then.

Files containing just types will show up in coverage report. But they will not have uncovered lines like they did before #5457.

> [!TIP]  
> To hide empty files from coverage reporters use reporter options:
> 
> ```js
> {
>   coverage: {
>     reporter: [
>       ['text', { 'skipEmpty': true }],
>       ['html', { 'skipEmpty': true }],
>     ]
>   }
> }
> ```
> 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
