### PR TITLE
fix(coverage): ignore `*.cts` files

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1103,7 +1103,7 @@ List of files included in coverage as glob patterns
 #### coverage.extension
 
 - **Type:** `string | string[]`
-- **Default:** `['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.vue', '.svelte', '.marko']`
+- **Default:** `['.js', '.cjs', '.mjs', '.ts', '.mts', '.tsx', '.jsx', '.vue', '.svelte', '.marko']`
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.extension=<extension>`, `--coverage.extension=<extension1> --coverage.extension=<extension2>`
 

--- a/docs/guide/cli-table.md
+++ b/docs/guide/cli-table.md
@@ -20,7 +20,7 @@
 | `--coverage.enabled` | Enables coverage collection. Can be overridden using the `--coverage` CLI option (default: `false`) |
 | `--coverage.include <pattern>` | Files included in coverage as glob patterns. May be specified more than once when using multiple patterns (default: `**`) |
 | `--coverage.exclude <pattern>` | Files to be excluded in coverage. May be specified more than once when using multiple extensions (default: Visit [`coverage.exclude`](https://vitest.dev/config/#coverage-exclude)) |
-| `--coverage.extension <extension>` | Extension to be included in coverage. May be specified more than once when using multiple extensions (default: `[".js", ".cjs", ".mjs", ".ts", ".mts", ".cts", ".tsx", ".jsx", ".vue", ".svelte"]`) |
+| `--coverage.extension <extension>` | Extension to be included in coverage. May be specified more than once when using multiple extensions (default: `[".js", ".cjs", ".mjs", ".ts", ".mts", ".tsx", ".jsx", ".vue", ".svelte"]`) |
 | `--coverage.clean` | Clean coverage results before running tests (default: true) |
 | `--coverage.cleanOnRerun` | Clean coverage report on watch rerun (default: true) |
 | `--coverage.reportsDirectory <path>` | Directory to write coverage report to (default: ./coverage) |

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -68,7 +68,6 @@ export const coverageConfigDefaults: ResolvedCoverageOptions = {
     '.mjs',
     '.ts',
     '.mts',
-    '.cts',
     '.tsx',
     '.jsx',
     '.vue',

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -203,7 +203,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
       },
       extension: {
         description:
-          'Extension to be included in coverage. May be specified more than once when using multiple extensions (default: `[".js", ".cjs", ".mjs", ".ts", ".mts", ".cts", ".tsx", ".jsx", ".vue", ".svelte"]`)',
+          'Extension to be included in coverage. May be specified more than once when using multiple extensions (default: `[".js", ".cjs", ".mjs", ".ts", ".mts", ".tsx", ".jsx", ".vue", ".svelte"]`)',
         argument: '<extension>',
         array: true,
       },

--- a/test/coverage-test/fixtures/src/should-be-excluded-by-default.cts
+++ b/test/coverage-test/fixtures/src/should-be-excluded-by-default.cts
@@ -1,0 +1,7 @@
+/*
+ * Vite does not transform `*.cts` files.
+ * If this file is picked by Istanbul provider, it will make Babel crash on TS syntax.
+ */
+interface Props {
+  name: string;
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/6161

Vite does not transform `*.cts` files into Javascript. This makes Istanbul's babel crash on TS syntax when untested files are picked by `coverage.all`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
