### PR TITLE
docs(browser): set `browser.name: 'chromium'` when using `playwright`

### DIFF
--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -93,7 +93,7 @@ export default defineConfig({
     browser: {
       provider: 'playwright', // or 'webdriverio'
       enabled: true,
-      name: 'chrome', // browser name is required
+      name: 'chromium', // browser name is required
     },
   }
 })
@@ -112,7 +112,7 @@ export default defineConfig({
     browser: {
       enabled: true,
       provider: 'playwright',
-      name: 'chrome',
+      name: 'chromium',
     }
   }
 })
@@ -127,7 +127,7 @@ export default defineConfig({
     browser: {
       enabled: true,
       provider: 'playwright',
-      name: 'chrome',
+      name: 'chromium',
     }
   }
 })
@@ -142,7 +142,7 @@ export default defineConfig({
     browser: {
       enabled: true,
       provider: 'playwright',
-      name: 'chrome',
+      name: 'chromium',
     }
   }
 })
@@ -157,7 +157,7 @@ export default defineConfig({
     browser: {
       enabled: true,
       provider: 'playwright',
-      name: 'chrome',
+      name: 'chromium',
     }
   }
 })


### PR DESCRIPTION
When copy the example code to project and run `vitest`, the error will occur: `Error: [] Browser "chrome" is not supported by the browser provider "playwright". Supported browsers: firefox, webkit, chromium.`

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
