### PR TITLE
docs: Update common-errors to include dynamic import aliases

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -52,6 +52,10 @@ vi.mock(import('./path/to/module.js'), async (importOriginal) => {
 
 Under the hood, Vitest still operates on a string and not a module object.
 
+If you are using TypeScript with `paths` aliases configured in `tsconfig.json` however, the compiler won't be able to correctly resolve import types.
+In order to make it work, make sure to replace all aliased imports, with their corresponding relative paths.
+Eg. use `import('./path/to/module.js')` instead of `import('@/module')`.
+
 ::: warning
 `vi.mock` is hoisted (in other words, _moved_) to **top of the file**. It means that whenever you write it (be it inside `beforeEach` or `test`), it will actually be called before that.
 

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -43,6 +43,32 @@ export default defineConfig({
 })
 ```
 
+- 4. You used an aliased module with dynamic import.
+
+Since Vitest supports a module promise instead of a string in `vi.mock` method, there is a chance that you tried to use it alongside `paths` aliases configured in your `tsconfig.json`. This behavior however, is not supported by the TypeScript compiler, as such paths are not statically analyzable, and cannot be resolved at runtime.
+
+```ts
+vi.mock(import('@/path/to/module'), async (importOriginal) => {
+  const mod = await importOriginal()
+  return {
+    ...mod,
+    namedExport: vi.fn(),
+  }
+})
+```
+
+This syntax won't work unfortunately, and in order to make it work, `import` calls have to be replaced with a relative path instead.
+
+```ts
+vi.mock(import('./path/to/module.js'), async (importOriginal) => {
+  const mod = await importOriginal()
+  return {
+    ...mod,
+    namedExport: vi.fn(),
+  }
+})
+```
+
 ## Cannot mock "./mocked-file.js" because it is already loaded
 
 This error happens when `vi.mock` method is called on a module that was already loaded. Vitest throws this error because this call has no effect since cached modules are preferred.

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -43,32 +43,6 @@ export default defineConfig({
 })
 ```
 
-- 4. You used an aliased module with dynamic import.
-
-Since Vitest supports a module promise instead of a string in `vi.mock` method, there is a chance that you tried to use it alongside `paths` aliases configured in your `tsconfig.json`. This behavior however, is not supported by the TypeScript compiler, as such paths are not statically analyzable, and cannot be resolved at runtime.
-
-```ts
-vi.mock(import('@/path/to/module'), async (importOriginal) => {
-  const mod = await importOriginal()
-  return {
-    ...mod,
-    namedExport: vi.fn(),
-  }
-})
-```
-
-This syntax won't work unfortunately, and in order to make it work, `import` calls have to be replaced with a relative path instead.
-
-```ts
-vi.mock(import('./path/to/module.js'), async (importOriginal) => {
-  const mod = await importOriginal()
-  return {
-    ...mod,
-    namedExport: vi.fn(),
-  }
-})
-```
-
 ## Cannot mock "./mocked-file.js" because it is already loaded
 
 This error happens when `vi.mock` method is called on a module that was already loaded. Vitest throws this error because this call has no effect since cached modules are preferred.


### PR DESCRIPTION
Since Vite 2.0 `vi.mock` can accept `import()` as the first argument to detect which module to be mock. This however won't work with aliased paths, which can confuse some people.

I believe this is not solvable at the moment, as this is not a Vitest, but rather TypeScript shortcoming. 