### PR TITLE
docs: Fix argument name in expect.md

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1362,7 +1362,7 @@ test('"id" is a number', () => {
 
 `expect.closeTo` is useful when comparing floating point numbers in object properties or array item. If you need to compare a number, please use `.toBeCloseTo` instead.
 
-The optional `numDigits` argument limits the number of digits to check **after** the decimal point. For the default value `2`, the test criterion is `Math.abs(expected - received) < 0.005 (that is, 10 ** -2 / 2)`.
+The optional `precision` argument limits the number of digits to check **after** the decimal point. For the default value `2`, the test criterion is `Math.abs(expected - received) < 0.005 (that is, 10 ** -2 / 2)`.
 
 For example, this test passes with a precision of 5 digits:
 


### PR DESCRIPTION
### Description

`expect.closeTo` has a second optional argument which is called `precision` and not `numDigits`.
I think the description has been copied from https://vitest.dev/api/expect.html#tobecloseto.
I checked the [source code](https://github.com/vitest-dev/vitest/blob/c997937bf37c0a39883bcf29d5c4188b96ae3924/packages/expect/src/jest-asymmetric-matchers.ts#L358) where it is called `precision` but it refers to the number of digits.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

I have not because I quickly created this PR via the GitHub web interface.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
