### PR TITLE
fix: don't panic when coverage.reporter is a string

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -229,6 +229,8 @@ export function resolveConfig(
     )
   }
 
+  resolved.coverage.reporter = toArray(resolved.coverage.reporter)
+
   if (resolved.coverage.enabled && resolved.coverage.reportsDirectory) {
     const reportsDirectory = resolve(
       resolved.root,

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -78,7 +78,7 @@ export interface CoverageProviderModule {
 
 export type CoverageReporter = keyof ReportOptions | (string & {})
 
-type CoverageReporterWithOptions<
+export type CoverageReporterWithOptions<
   ReporterName extends CoverageReporter = CoverageReporter,
 > = ReporterName extends keyof ReportOptions
   ? ReportOptions[ReporterName] extends never

--- a/packages/vitest/src/utils/coverage.ts
+++ b/packages/vitest/src/utils/coverage.ts
@@ -2,6 +2,7 @@ import { relative } from 'pathe'
 import mm from 'micromatch'
 import type { CoverageMap } from 'istanbul-lib-coverage'
 import type { BaseCoverageOptions, ResolvedCoverageOptions } from '../node/types/coverage'
+import { resolveCoverageReporters } from '../node/config/resolveConfig'
 
 type Threshold = 'lines' | 'functions' | 'statements' | 'branches'
 
@@ -242,25 +243,7 @@ export class BaseCoverageProvider {
   resolveReporters(
     configReporters: NonNullable<BaseCoverageOptions['reporter']>,
   ): ResolvedCoverageOptions['reporter'] {
-    // E.g. { reporter: "html" }
-    if (!Array.isArray(configReporters)) {
-      return [[configReporters, {}]]
-    }
-
-    const resolvedReporters: ResolvedCoverageOptions['reporter'] = []
-
-    for (const reporter of configReporters) {
-      if (Array.isArray(reporter)) {
-        // E.g. { reporter: [ ["html", { skipEmpty: true }], ["lcov"], ["json", { file: "map.json" }] ]}
-        resolvedReporters.push([reporter[0], reporter[1] as Record<string, unknown> || {}])
-      }
-      else {
-        // E.g. { reporter: ["html", "json"]}
-        resolvedReporters.push([reporter, {}])
-      }
-    }
-
-    return resolvedReporters
+    return resolveCoverageReporters(configReporters) as any
   }
 
   hasTerminalReporter(reporters: ResolvedCoverageOptions['reporter']) {

--- a/test/coverage-test/test/reporters.test.ts
+++ b/test/coverage-test/test/reporters.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { expect } from 'vitest'
 import { runVitest, test } from '../utils'
 
@@ -15,6 +16,23 @@ test('reporter as string', async () => {
 
   const files = readdirSync('./coverage')
   expect(files).toContain('coverage-final.json')
+})
+
+test('reporter as string when coverage is disabled', async () => {
+  if (existsSync('./coverage')) {
+    await rm('./coverage', { recursive: true, force: true })
+  }
+
+  await runVitest({
+    include,
+    coverage: {
+      enabled: false,
+      reporter: 'json',
+      all: false,
+    },
+  })
+
+  expect(existsSync('./coverage')).toBe(false)
 })
 
 test('reporter as list of strings', async () => {


### PR DESCRIPTION
### Description

Fixes #6260

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
