### PR TITLE
chore: add hook test to react example

### DIFF
--- a/examples/react/components/Link.tsx
+++ b/examples/react/components/Link.tsx
@@ -1,32 +1,46 @@
 import React, { useState } from 'react'
 
-const STATUS = {
+export const LINK_STATUS = {
   HOVERED: 'hovered',
   NORMAL: 'normal',
 }
 
-function Link({ page, children }: React.PropsWithChildren<{ page: string }>) {
-  const [status, setStatus] = useState(STATUS.NORMAL)
-
-  const onMouseEnter = () => {
-    setStatus(STATUS.HOVERED)
-  }
-
-  const onMouseLeave = () => {
-    setStatus(STATUS.NORMAL)
-  }
+export function Link({
+  page,
+  children,
+}: React.PropsWithChildren<{ page: string }>) {
+  const [status, statusHandlers] = useLinkState()
 
   return (
     <a
       className={status}
       href={page || '#'}
       aria-label={`Link is ${status}`}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
+      {...statusHandlers}
     >
       {children}
     </a>
   )
 }
 
-export default Link
+// Understand that this is merely for showing how to work with hooks.
+// At this point, it hardly makes sense to have this as a custom hook.
+export function useLinkState() {
+  const [status, setStatus] = useState(LINK_STATUS.NORMAL)
+
+  const onMouseEnter = () => {
+    setStatus(LINK_STATUS.HOVERED)
+  }
+
+  const onMouseLeave = () => {
+    setStatus(LINK_STATUS.NORMAL)
+  }
+
+  return [
+    status,
+    {
+      onMouseEnter,
+      onMouseLeave,
+    },
+  ] as const
+}

--- a/examples/react/test/basic.test.tsx
+++ b/examples/react/test/basic.test.tsx
@@ -1,7 +1,7 @@
-import { expect, test } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { assert, expect, test } from 'vitest'
+import { act, render, renderHook, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import Link from '../components/Link.jsx'
+import { LINK_STATUS, Link, useLinkState } from '../components/Link.jsx'
 
 test('Link changes the state when hovered', async () => {
   render(
@@ -19,4 +19,25 @@ test('Link changes the state when hovered', async () => {
   await userEvent.unhover(link)
 
   expect(link).toHaveAccessibleName('Link is normal')
+})
+
+test('useLinkState updates result', async () => {
+  const { result } = renderHook(() => useLinkState())
+
+  let [status, handlers] = result.current
+
+  assert(status === LINK_STATUS.NORMAL)
+  assert(handlers.onMouseEnter)
+  assert(handlers.onMouseLeave)
+
+  act(() => {
+    handlers.onMouseEnter()
+  })
+
+  ;[status, handlers] = result.current
+
+  assert(
+    status === LINK_STATUS.HOVERED,
+    `status is ${status}, but should be ${LINK_STATUS.HOVERED}`,
+  )
 })

--- a/test/typescript/test-d/test.test-d.ts
+++ b/test/typescript/test-d/test.test-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ts/prefer-ts-expect-error */
 /* eslint-disable ts/ban-ts-comment */
 
 import { google, type sheets_v4 } from 'googleapis'


### PR DESCRIPTION
### Description

When adding tests for `react` hooks, I was too tired to actually understand what I was doing wrong. I looked at `vitest`'s example code but it failed to fix my confusion. To help people in the same situation, this shows how to test `react` hooks with `vitest`, which I find a good idea anyway.

This is superficially related to #4000 and #5004, although they result from different root causes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
