### PR TITLE
feat(ui): add dark theme to istambul html reporter

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "test": "vitest",
     "test:ui": "vitest --ui",
+    "test:ui:coverage": "vitest --ui --open --coverage.enabled=true --coverage.reporter=html",
+    "test:ui:coverage:html": "vitest --ui --open --coverage.enabled=true --coverage.reporter=html --reporter=html",
     "test:run": "vitest run"
   },
   "devDependencies": {

--- a/examples/basic/src/basic.ts
+++ b/examples/basic/src/basic.ts
@@ -1,1 +1,3 @@
 export const squared = (n: number) => n * n
+
+export const doubleNumber = (n: number) => n * 2

--- a/examples/basic/src/uncovered.ts
+++ b/examples/basic/src/uncovered.ts
@@ -1,0 +1,1 @@
+export const squareRoot = (n: number) => Math.sqrt(n)

--- a/packages/ui/client/components/Coverage.vue
+++ b/packages/ui/client/components/Coverage.vue
@@ -10,7 +10,7 @@ defineProps<{
       <div class="i-carbon:folder-details-reference" />
       <span pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate>Coverage</span>
     </div>
-    <div flex-auto py-1 bg-white>
+    <div flex-auto bg-transparent>
       <iframe id="vitest-ui-coverage" :src="src" />
     </div>
   </div>

--- a/packages/ui/istambul-base.css
+++ b/packages/ui/istambul-base.css
@@ -1,0 +1,412 @@
+:root {
+  --color-text-light: #000;
+  --color-text-dark: #ddd;
+  --color-text: var(--color-text-light);
+  --background-color: white;
+  --anchor-color: #6b38fb;
+}
+
+html.dark {
+  --color-text: var(--color-text-dark);
+  --background-color: rgba(107, 114, 128, 0.05);
+  --anchor-color: #2fa3ff;
+  color-scheme: dark;
+}
+html,
+body {
+  height: 100%;
+  font-family: "Readex Pro", sans-serif;
+  scroll-behavior: smooth;
+  color: var(--color-text);
+  background-color: var(--background-color);
+  padding: 0;
+  margin: 0;
+}
+.small { font-size: 12px; }
+*, *:after, *:before {
+  -webkit-box-sizing:border-box;
+  -moz-box-sizing:border-box;
+  box-sizing:border-box;
+}
+h1 { font-size: 20px; margin: 0;}
+h2 { font-size: 14px; }
+pre {
+  font: 12px/1.4 Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  margin: 0;
+  padding: 0;
+  -moz-tab-size: 2;
+  -o-tab-size:  2;
+  tab-size: 2;
+}
+a { color:var(--anchor-color); text-decoration:none; }
+a:hover { text-decoration:underline; }
+.strong { font-weight: bold; }
+.space-top1 { padding: 10px 0 0 0; }
+.pad2y { padding: 20px 0; }
+.pad1y { padding: 10px 0; }
+.pad2x { padding: 0 20px; }
+.pad2 { padding: 20px; }
+.pad1 { padding: 10px; }
+.space-left2 { padding-left:55px; }
+.space-right2 { padding-right:20px; }
+.center { text-align:center; }
+.clearfix { display:block; }
+.clearfix:after {
+  content:'';
+  display:block;
+  height:0;
+  clear:both;
+  visibility:hidden;
+}
+.fl { float: left; }
+@media only screen and (max-width:640px) {
+  .col3 { width:100%; max-width:100%; }
+  .hide-mobile { display:none!important; }
+}
+
+.quiet {
+  color: var(--color-text);
+  opacity: 0.65;
+}
+
+.fraction {
+  font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 10px;
+  color: #555;
+  background: #E8E8E8;
+  padding: 4px 5px;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+div.path a:link, div.path a:visited { color: #333; }
+table.coverage {
+  border-collapse: collapse;
+  margin: 10px 0 0 0;
+  padding: 0;
+}
+
+table.coverage td {
+  margin: 0;
+  padding: 0;
+  vertical-align: top;
+}
+table.coverage td.line-count {
+  text-align: right;
+  padding: 0 5px 0 20px;
+}
+table.coverage td.line-coverage {
+  text-align: right;
+  padding-right: 10px;
+  min-width:20px;
+}
+
+table.coverage td span.cline-any {
+  display: inline-block;
+  padding: 0 5px;
+  width: 100%;
+}
+.missing-if-branch {
+  display: inline-block;
+  margin-right: 5px;
+  border-radius: 3px;
+  position: relative;
+  padding: 0 4px;
+  background: #333;
+  color: yellow;
+}
+
+.skip-if-branch {
+  display: none;
+  margin-right: 10px;
+  position: relative;
+  padding: 0 4px;
+  background: #ccc;
+  color: white;
+}
+.missing-if-branch .typ, .skip-if-branch .typ {
+  color: inherit !important;
+}
+.coverage-summary {
+  border-collapse: collapse;
+  width: 100%;
+}
+.coverage-summary tr { border-bottom: 1px solid #bbb; }
+.keyline-all { border: 1px solid #ddd; }
+.coverage-summary td, .coverage-summary th { padding: 10px; }
+.coverage-summary tbody { border: 1px solid #bbb; }
+.coverage-summary td { border-right: 1px solid #bbb; }
+.coverage-summary td:last-child { border-right: none; }
+.coverage-summary th {
+  text-align: left;
+  font-weight: normal;
+  white-space: nowrap;
+}
+.coverage-summary th.file { border-right: none !important; }
+.coverage-summary th.pct { }
+.coverage-summary th.pic,
+.coverage-summary th.abs,
+.coverage-summary td.pct,
+.coverage-summary td.abs { text-align: right; }
+.coverage-summary td.file { white-space: nowrap;  }
+.coverage-summary td.pic { min-width: 120px !important;  }
+.coverage-summary tfoot td { }
+
+.coverage-summary .sorter {
+  height: 10px;
+  width: 7px;
+  display: inline-block;
+  margin-left: 0.5em;
+  background: url(sort-arrow-sprite.png) no-repeat scroll 0 0 transparent;
+}
+html.dark .coverage-summary .sorter {
+  filter: invert(1) !important;
+}
+.coverage-summary .sorted .sorter {
+  background-position: 0 -20px;
+}
+.coverage-summary .sorted-desc .sorter {
+  background-position: 0 -10px;
+}
+.status-line {  height: 10px; }
+/* yellow */
+.cbranch-no { background: yellow !important; color: #111; }
+/* dark red */
+.red.solid, .status-line.low, .low .cover-fill { background:#C21F39 }
+.low .chart { border:1px solid #C21F39 }
+.highlighted,
+.highlighted .cstat-no, .highlighted .fstat-no, .highlighted .cbranch-no{
+  background: #C21F39 !important;
+}
+/* medium red */
+.cstat-no, .fstat-no, .cbranch-no, .cbranch-no { background:#F6C6CE }
+/* light red */
+.low, .cline-no { background:#FCE1E5 }
+/* light green */
+.high, .cline-yes { background:rgb(230,245,208) }
+/* medium green */
+.cstat-yes { background:rgb(161,215,106) }
+/* dark green */
+.status-line.high, .high .cover-fill { background:rgb(77,146,33) }
+.high .chart { border:1px solid rgb(77,146,33) }
+/* dark yellow (gold) */
+.status-line.medium, .medium .cover-fill { background: #f9cd0b; }
+.medium .chart { border:1px solid #f9cd0b; }
+/* light yellow */
+.medium { background: #fff4c2; }
+
+.cstat-skip { background: #ddd; color: #111; }
+.fstat-skip { background: #ddd; color: #111 !important; }
+.cbranch-skip { background: #ddd !important; color: #111; }
+
+span.cline-neutral { background: #eaeaea; }
+
+.coverage-summary td.empty {
+  opacity: .5;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  line-height: 1;
+  color: #888;
+}
+
+.cover-fill, .cover-empty {
+  display:inline-block;
+  height: 12px;
+}
+.chart {
+  line-height: 0;
+}
+.cover-empty {
+  background: white;
+}
+.cover-full {
+  border-right: none !important;
+}
+pre.prettyprint {
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.com { color: #999 !important; }
+.ignore-none { color: #999; font-weight: normal; }
+
+.wrapper {
+  min-height: 100%;
+  height: auto !important;
+  height: 100%;
+  margin: 0 auto -48px;
+}
+.footer, .push {
+  height: 48px;
+}
+
+html.dark pre {
+  font: 12px/1.4 Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  margin: 0;
+  padding: 0;
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+  background: #263238; /* Blue Grey Darken-2 */
+  color: #cfd8dc; /* Blue Grey Lighten-3 */
+}
+
+html.dark .fraction {
+  font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 10px;
+  color: #90a4ae; /* Blue Grey Lighten-2 */
+  background: #263238; /* Blue Grey */
+  padding: 4px 5px;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+html.dark div.path a:link,
+html.dark div.path a:visited {
+  color: #cfd8dc; /* Blue Grey Lighten-3 */
+}
+
+html.dark table.coverage {
+  border-collapse: collapse;
+  margin: 10px 0 0 0;
+  padding: 0;
+  background: #263238; /* Blue Grey */
+  color: #cfd8dc; /* Blue Grey Lighten-3 */
+}
+
+html.dark .missing-if-branch {
+  display: inline-block;
+  margin-right: 5px;
+  border-radius: 3px;
+  position: relative;
+  padding: 0 4px;
+  background: #37474f; /* Blue Grey Darken-2 */
+  color: #f9a825; /* Yellow Darken-2 */
+}
+
+html.dark .skip-if-branch {
+  display: none;
+  margin-right: 10px;
+  position: relative;
+  padding: 0 4px;
+  background: #546e7a; /* Blue Grey Darken-1 */
+  color: #fff;
+}
+
+html.dark .coverage-summary tr {
+  border-bottom: 1px solid #455a64; /* Blue Grey Darken-3 */
+}
+
+html.dark .keyline-all {
+  border: 1px solid #455a64; /* Blue Grey Darken-3 */
+}
+
+html.dark .coverage-summary tbody {
+  border: 1px solid #455a64; /* Blue Grey Darken-3 */
+}
+
+html.dark .coverage-summary td {
+  border-right: 1px solid #455a64; /* Blue Grey Darken-3 */
+}
+
+html.dark .cbranch-no {
+  background: #935b00 !important; /* Yellow Darken-2 */
+  color: #000;
+}
+
+html.dark .red.solid,
+html.dark .status-line.low,
+html.dark .low .cover-fill {
+  background: #e57373; /* Red Lighten-2 */
+}
+
+html.dark .low .chart {
+  border: 1px solid #e57373; /* Red Lighten-2 */
+}
+
+html.dark .highlighted,
+html.dark .highlighted .cstat-no,
+html.dark .highlighted .fstat-no,
+html.dark .highlighted .cbranch-no {
+  background: #e57373; /* Red Lighten-2 */
+}
+
+html.dark .cstat-no,
+html.dark .fstat-no,
+html.dark .cbranch-no,
+html.dark .cbranch-no {
+  background: #ff8a6547; /* Deep Orange Lighten-2 */
+}
+
+html.dark .low,
+html.dark .cline-no {
+  background: #900017; /* Brown Lighten-3 */
+}
+
+html.dark .high,
+html.dark .cline-yes {
+  background: #356400; /* Light Green */
+}
+
+html.dark .cstat-yes {
+  background: #a5d6a7; /* Green Lighten-2 */
+}
+
+html.dark .status-line.high,
+html.dark .high .cover-fill {
+  background: #81c784; /* Light Green Lighten-2 */
+}
+
+html.dark .medium,
+html.dark .status-line.medium,
+html.dark .medium .cover-fill {
+  background: #9b7600; /* Amber Lighten-2 */
+}
+
+html.dark .cstat-skip {
+  background: #90a4ae; /* Blue Grey Lighten-2 */
+  color: #000;
+}
+
+html.dark .fstat-skip {
+  background: #90a4ae; /* Blue Grey Lighten-2 */
+  color: #000 !important;
+}
+
+html.dark .cbranch-skip {
+  background: #90a4ae; /* Blue Grey Lighten-2 */
+  color: #000;
+}
+
+html.dark span.cline-neutral {
+  background: #37474f; /* Blue Grey Darken-2 */
+}
+
+html.dark .coverage-summary td.empty {
+  opacity: .5;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  line-height: 1;
+  color: #90a4ae; /* Blue Grey Lighten-2 */
+}
+
+html.dark .cover-empty {
+  background: #fff; /* White */
+}
+
+html.dark pre.prettyprint {
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  background: #263238; /* Blue Grey */
+  color: #cfd8dc; /* Blue Grey Lighten-3 */
+}
+
+html.dark .com {
+  color: #546e7a !important; /* Blue Grey */
+}
+
+html.dark .ignore-none {
+  color: #546e7a;
+  font-weight: normal;
+}

--- a/packages/ui/istambul-prettify.css
+++ b/packages/ui/istambul-prettify.css
@@ -1,0 +1,230 @@
+/* https://github.com/istanbuljs/istanbuljs/blob/main/packages/istanbul-reports/lib/html/assets/base.css */
+
+.pln {
+  color: #000
+}
+
+@media screen {
+  .str {
+    color: #080
+  }
+
+  .kwd {
+    color: #008
+  }
+
+  .com {
+    color: #800
+  }
+
+  .typ {
+    color: #606
+  }
+
+  .lit {
+    color: #066
+  }
+
+  .pun, .opn, .clo {
+    color: #660
+  }
+
+  .tag {
+    color: #008
+  }
+
+  .atn {
+    color: #606
+  }
+
+  .atv {
+    color: #080
+  }
+
+  .dec, .var {
+    color: #606
+  }
+
+  .fun {
+    color: red
+  }
+}
+
+@media print, projection {
+  .str {
+    color: #060
+  }
+
+  .kwd {
+    color: #006;
+    font-weight: bold
+  }
+
+  .com {
+    color: #600;
+    font-style: italic
+  }
+
+  .typ {
+    color: #404;
+    font-weight: bold
+  }
+
+  .lit {
+    color: #044
+  }
+
+  .pun, .opn, .clo {
+    color: #440
+  }
+
+  .tag {
+    color: #006;
+    font-weight: bold
+  }
+
+  .atn {
+    color: #404
+  }
+
+  .atv {
+    color: #060
+  }
+}
+
+pre.prettyprint {
+  padding: 2px;
+  border: 1px solid #888
+}
+
+ol.linenums {
+  margin-top: 0;
+  margin-bottom: 0
+}
+
+li.L0, li.L1, li.L2, li.L3, li.L5, li.L6, li.L7, li.L8 {
+  list-style-type: none
+}
+
+li.L1, li.L3, li.L5, li.L7, li.L9 {
+  background: #eee
+}
+
+/*
+ * dark theme: extracted from the source code and removed any css selector not changing color and bgcolor
+ * from this comment: https://github.com/istanbuljs/istanbuljs/pull/553#issuecomment-1934930904
+ * source code: https://userstyles.world/style/14631/istanbul-lcov-material-theme-darker
+ */
+html.dark .pln {
+  color: #c792ea; /* Purple */
+}
+
+html.dark .str {
+  color: #c3e88d; /* Green */
+}
+
+html.dark .kwd {
+  color: #ff5370; /* Red */
+}
+
+html.dark .com {
+  color: #546e7a; /* Blue Grey */
+  font-style: italic;
+}
+
+html.dark .typ {
+  color: #82aaff; /* Blue */
+  font-weight: bold;
+}
+
+html.dark .lit {
+  color: #f78c6c; /* Orange */
+}
+
+html.dark .pun,
+html.dark .opn,
+html.dark .clo {
+  color: #82aaff; /* Blue */
+}
+
+html.dark .tag {
+  color: #89ddff; /* Light Blue */
+  font-weight: bold;
+}
+
+html.dark .atn {
+  color: #546e7a; /* Blue Grey */
+}
+
+html.dark .atv {
+  color: #c3e88d; /* Green */
+}
+
+html.dark .dec,
+html.dark .var {
+  color: #82aaff; /* Blue */
+}
+
+html.dark .fun {
+  color: #c792ea; /* Purple */
+}
+
+/* Additional styles for print and projection media queries */
+@media print, projection {
+  html.dark .str {
+    color: #c3e88d; /* Green */
+  }
+
+  html.dark .kwd {
+    color: #ff5370; /* Red */
+    font-weight: bold;
+  }
+
+  html.dark .com {
+    color: #546e7a; /* Blue Grey */
+    font-style: italic;
+  }
+
+  html.dark .typ {
+    color: #82aaff; /* Blue */
+    font-weight: bold;
+  }
+
+  html.dark .lit {
+    color: #f78c6c; /* Orange */
+  }
+
+  html.dark .pun,
+  html.dark .opn,
+  html.dark .clo {
+    color: #82aaff; /* Blue */
+  }
+
+  html.dark .tag {
+    color: #89ddff; /* Light Blue */
+    font-weight: bold;
+  }
+
+  html.dark .atn {
+    color: #546e7a; /* Blue Grey */
+  }
+
+  html.dark .atv {
+    color: #c3e88d; /* Green */
+  }
+}
+
+html.dark pre.prettyprint {
+  padding: 2px;
+  border: 1px solid #263238; /* Blue Grey */
+  background-color: #263238; /* Blue Grey */
+  color: #c792ea; /* Purple */
+}
+
+html.dark li.L1,
+html.dark li.L3,
+html.dark li.L5,
+html.dark li.L7,
+html.dark li.L9 {
+  background: #37474f; /* Blue Grey Darken-2 */
+}

--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -1,10 +1,12 @@
 import { fileURLToPath } from 'node:url'
+import { readFile } from 'node:fs/promises'
 import { basename, resolve } from 'pathe'
 import sirv from 'sirv'
 import type { Plugin } from 'vite'
 import { coverageConfigDefaults } from 'vitest/config'
 import type { Vitest } from 'vitest'
 import { toArray } from '@vitest/utils'
+import { transformCoverageEntryPoint } from './utils'
 
 export default (ctx: Vitest): Plugin => {
   return <Plugin>{
@@ -22,6 +24,46 @@ export default (ctx: Vitest): Plugin => {
       }
 
       if (coverageFolder) {
+        const root = resolve(fileURLToPath(import.meta.url), '../')
+        const base = readFile(resolve(root, '../istambul-base.css'))
+        const prettify = readFile(resolve(root, '../istambul-prettify.css'))
+        server.middlewares.use(coveragePath!, async (req, res, next) => {
+          if (!req.url) {
+            return next()
+          }
+
+          const pathname = new URL(req.url, 'http://localhost').pathname
+          if (pathname !== '/' && pathname !== '/index.html' && pathname !== '/base.css' && pathname !== '/prettify.css' && !pathname.endsWith('.html')) {
+            return next()
+          }
+
+          if (pathname === '/base.css') {
+            res.setHeader('Content-Type', 'text/css')
+            res.setHeader('Cache-Control', 'public,max-age=0,must-revalidate')
+            res.end(await base)
+            // for testing purposes: don't remove it
+            // res.end(await readFile(resolve(fileURLToPath(import.meta.url), '../../istambul-base.css')))
+            return
+          }
+
+          if (pathname === '/prettify.css') {
+            res.setHeader('Content-Type', 'text/css')
+            res.setHeader('Cache-Control', 'public,max-age=0,must-revalidate')
+            res.end(await prettify)
+            // for testing purposes: don't remove it
+            // res.end(await readFile(resolve(fileURLToPath(import.meta.url), '../../istambul-prettify.css')))
+            return
+          }
+
+          const file = pathname.endsWith('.html')
+            ? pathname[0] === '/' ? pathname.slice(1) : pathname
+            : 'index.html'
+
+          const indexHtml = await readFile(resolve(coverageFolder[0], file), 'utf-8')
+          res.setHeader('Content-Type', 'text/html')
+          res.setHeader('Cache-Control', 'public,max-age=0,must-revalidate')
+          res.end(transformCoverageEntryPoint(indexHtml))
+        })
         server.middlewares.use(
           coveragePath!,
           sirv(coverageFolder[0], {

--- a/packages/ui/node/utils.ts
+++ b/packages/ui/node/utils.ts
@@ -1,0 +1,22 @@
+export function transformCoverageEntryPoint(
+  entryPoint: string,
+) {
+  return entryPoint.replace('</head>', `<script>
+(() => {
+ const theme = 'vueuse-color-scheme'
+ const preference = localStorage.getItem(theme)
+ const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+ if (!preference || preference === 'auto' ? prefersDark : preference === 'dark')
+   document.documentElement.classList.add('dark')
+
+ window.addEventListener('storage', (e) => {
+   if (e.key === theme) {
+     document.documentElement.classList.remove('dark')
+     if (!e.newValue || e.newValue === 'auto' ? prefersDark : e.newValue === 'dark')
+        document.documentElement.classList.add('dark')
+   }
+ })
+})();
+</script>
+</head>`)
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,7 +31,9 @@
   "types": "./dist/index.d.ts",
   "files": [
     "*.d.ts",
-    "dist"
+    "dist",
+    "istambul-base.css",
+    "istambul-prettify.css"
   ],
   "scripts": {
     "build": "rimraf dist && pnpm build:node && pnpm build:client",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds custom dark theme css for istambul html reporter modified from this https://userstyles.world/style/14631/istanbul-lcov-material-theme-darker

Check also https://github.com/istanbuljs/istanbuljs/pull/553#issuecomment-1934930904

I need to override the css files when using standalone, rn only work when running Vitest UI (shouldn't work when running `npx server coverage`)

<!-- You can also add additional context here -->

![imagen](https://github.com/user-attachments/assets/bb37728d-9deb-44fd-b6af-8bc0de79e692)

![imagen](https://github.com/user-attachments/assets/4cab4cca-b6a6-4243-8137-cb99257f3e76)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
