### PR TITLE
refactor: throw an error if the internal suite is not found

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -184,7 +184,14 @@ let runner: VitestRunner
 let defaultSuite: SuiteCollector
 let currentTestFilepath: string
 
+function assert(condition: any, message: string) {
+  if (!condition) {
+    throw new Error(`Vitest failed to find ${message}. This is a bug in Vitest. Please, open an issue with reproduction.`)
+  }
+}
+
 export function getDefaultSuite(): SuiteCollector<object> {
+  assert(defaultSuite, 'the default suite')
   return defaultSuite
 }
 
@@ -193,6 +200,7 @@ export function getTestFilepath(): string {
 }
 
 export function getRunner(): VitestRunner {
+  assert(runner, 'the runner')
   return runner
 }
 
@@ -216,9 +224,11 @@ export function clearCollectorContext(
   collectorContext.currentSuite = defaultSuite
 }
 
-export function getCurrentSuite<ExtraContext = object>() {
-  return (collectorContext.currentSuite
+export function getCurrentSuite<ExtraContext = object>(): SuiteCollector<ExtraContext> {
+  const currentSuite = (collectorContext.currentSuite
     || defaultSuite) as SuiteCollector<ExtraContext>
+  assert(currentSuite, 'the current suite')
+  return currentSuite
 }
 
 export function createSuiteHooks(): SuiteHooks {

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -495,7 +495,7 @@ function createSuite() {
         : this.todo
           ? 'todo'
           : 'run'
-    const currentSuite = getCurrentSuite()
+    const currentSuite: SuiteCollector | undefined = collectorContext.currentSuite || defaultSuite
 
     let { options, handler: factory } = parseArguments(
       factoryOrOptions,


### PR DESCRIPTION
### Description

This is not a fix, but a more friendly message related to #5251

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
