### PR TITLE
fix: allow inlining vite's cached dependencies

### DIFF
--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -120,7 +120,8 @@ async function _shouldExternalize(
     return id
   }
 
-  // always externalize Vite deps, they are too big to inline
+  // Unless the user explicitly opted to inline them, externalize Vite deps.
+  // They are too big to inline.
   if (options?.cacheDir && id.includes(options.cacheDir)) {
     return id
   }

--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -121,7 +121,7 @@ async function _shouldExternalize(
   }
 
   // Unless the user explicitly opted to inline them, externalize Vite deps.
-  // They are too big to inline.
+  // They are too big to inline by default.
   if (options?.cacheDir && id.includes(options.cacheDir)) {
     return id
   }

--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -111,17 +111,17 @@ async function _shouldExternalize(
 
   id = patchWindowsImportPath(id)
 
-  // always externalize Vite deps, they are too big to inline
-  if (options?.cacheDir && id.includes(options.cacheDir)) {
-    return id
-  }
-
   const moduleDirectories = options?.moduleDirectories || ['/node_modules/']
 
   if (matchExternalizePattern(id, moduleDirectories, options?.inline)) {
     return false
   }
   if (matchExternalizePattern(id, moduleDirectories, options?.external)) {
+    return id
+  }
+
+  // always externalize Vite deps, they are too big to inline
+  if (options?.cacheDir && id.includes(options.cacheDir)) {
     return id
   }
 

--- a/test/vite-node/test/server.test.ts
+++ b/test/vite-node/test/server.test.ts
@@ -229,3 +229,55 @@ describe('server correctly caches data', () => {
     expect(webFiles).toHaveLength(1)
   })
 })
+
+describe('externalize', () => {
+  describe('by default', () => {
+    test('should externalize vite\'s cached dependencies', async () => {
+      const vnServer = new ViteNodeServer({
+        config: {
+          root: '/',
+          cacheDir: '/node_modules/.vite',
+        },
+      } as any, {})
+
+      const externalize = await vnServer.shouldExternalize('/node_modules/.vite/cached.js')
+      expect(externalize).toBeTruthy()
+    })
+  })
+
+  describe('with server.deps.inline: true', () => {
+    test('should not externalize vite\'s cached dependencies', async () => {
+      const vnServer = new ViteNodeServer({
+        config: {
+          root: '/',
+          cacheDir: '/node_modules/.vite',
+        },
+      } as any, {
+        deps: {
+          inline: true,
+        },
+      })
+
+      const externalize = await vnServer.shouldExternalize('/node_modules/.vite/cached.js')
+      expect(externalize).toBeFalsy()
+    })
+  })
+
+  describe('with server.deps.inline including the cache dir', () => {
+    test('should not externalize vite\'s cached dependencies', async () => {
+      const vnServer = new ViteNodeServer({
+        config: {
+          root: '/',
+          cacheDir: '/node_modules/.vite',
+        },
+      } as any, {
+        deps: {
+          inline: [/node_modules\/\.vite/],
+        },
+      })
+
+      const externalize = await vnServer.shouldExternalize('/node_modules/.vite/cached.js')
+      expect(externalize).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

Allow the user to explicitly inline vite's cached dependencies. Either by specifying `inline: true` or providing a path that matches the vite cache directory.

This allows e.g. mocking calls made by a cached dependency.

This was briefly discussed [here on discord](https://discord.com/channels/917386801235247114/1263777870455640076).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
