### PR TITLE
fix(vitest)!: don't expose default toFake config

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2527,7 +2527,7 @@ Installs fake timers with the specified Unix epoch.
 #### fakeTimers.toFake
 
 - **Type:** `('setTimeout' | 'clearTimeout' | 'setImmediate' | 'clearImmediate' | 'setInterval' | 'clearInterval' | 'Date' | 'nextTick' | 'hrtime' | 'requestAnimationFrame' | 'cancelAnimationFrame' | 'requestIdleCallback' | 'cancelIdleCallback' | 'performance' | 'queueMicrotask')[]`
-- **Default:** `['setTimeout', 'clearTimeout', 'setImmediate', 'clearImmediate', 'setInterval', 'clearInterval', 'Date']`
+- **Default:** everything available globally except `nextTick`
 
 An array with names of global methods and APIs to fake.
 

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -88,15 +88,6 @@ export const coverageConfigDefaults: ResolvedCoverageOptions = {
 export const fakeTimersDefaults = {
   loopLimit: 10_000,
   shouldClearNativeTimers: true,
-  toFake: [
-    'setTimeout',
-    'clearTimeout',
-    'setInterval',
-    'clearInterval',
-    'setImmediate',
-    'clearImmediate',
-    'Date',
-  ],
 } satisfies NonNullable<UserConfig['fakeTimers']>
 
 const config = {

--- a/patches/@types__sinonjs__fake-timers@8.1.5.patch
+++ b/patches/@types__sinonjs__fake-timers@8.1.5.patch
@@ -10,7 +10,7 @@ index 5aa018cde4336aca4dadefb8338549c378792e14..2e0c38efc15e793dc37e401e25130162
 -     * For instance, `FakeTimers.install({ toFake: ['setTimeout', 'nextTick'] })` will fake only `setTimeout()` and `nextTick()`
 +     * An array with names of global methods and APIs to fake.
 +     * For instance, `vi.useFakeTimer({ toFake: ['setTimeout', 'performance'] })` will fake only `setTimeout()` and `performance.now()`
-+     * @default ['setTimeout', 'clearTimeout', 'setImmediate', 'clearImmediate', 'setInterval', 'clearInterval', 'Date']
++     * @default everything available globally except `nextTick`
       */
      toFake?: FakeMethod[] | undefined;
  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: s5kzatt2y2dzfxfynxzvzt5kbm
     path: patches/@types__chai@4.3.6.patch
   '@types/sinonjs__fake-timers@8.1.5':
-    hash: ggdsr7nrdrzokhhihsihc2hdja
+    hash: yuuqouzdhxwdvk3q6qf2uf434a
     path: patches/@types__sinonjs__fake-timers@8.1.5.patch
   acorn@8.11.3:
     hash: no36qihqjrd3chyjw73dk5xfkm
@@ -949,7 +949,7 @@ importers:
         version: 2.4.9
       '@types/sinonjs__fake-timers':
         specifier: ^8.1.5
-        version: 8.1.5(patch_hash=ggdsr7nrdrzokhhihsihc2hdja)
+        version: 8.1.5(patch_hash=yuuqouzdhxwdvk3q6qf2uf434a)
       acorn-walk:
         specifier: ^8.3.4
         version: 8.3.4
@@ -12205,7 +12205,7 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@types/sinonjs__fake-timers@8.1.5(patch_hash=ggdsr7nrdrzokhhihsihc2hdja)': {}
+  '@types/sinonjs__fake-timers@8.1.5(patch_hash=yuuqouzdhxwdvk3q6qf2uf434a)': {}
 
   '@types/stack-utils@2.0.3':
     optional: true
@@ -19114,7 +19114,7 @@ snapshots:
   webdriverio@9.4.1:
     dependencies:
       '@types/node': 20.14.15
-      '@types/sinonjs__fake-timers': 8.1.5(patch_hash=ggdsr7nrdrzokhhihsihc2hdja)
+      '@types/sinonjs__fake-timers': 8.1.5(patch_hash=yuuqouzdhxwdvk3q6qf2uf434a)
       '@wdio/config': 9.2.8
       '@wdio/logger': 9.1.3
       '@wdio/protocols': 9.2.2


### PR DESCRIPTION
### Description

This PR removes `toFake` from the default `fakeTimers` options because it forces fake methods that might not be available and leaves out methods that are actually available (like `performance`)

Fixes #4004

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
