### PR TITLE
docs: Address typos in expect.md

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -700,7 +700,7 @@ This ensures that a value matches the most recent snapshot.
 You can provide an optional `hint` string argument that is appended to the test name. Although Vitest always appends a number at the end of a snapshot name, short descriptive hints might be more useful than numbers to differentiate multiple snapshots in a single it or test block. Vitest sorts snapshots by name in the corresponding `.snap` file.
 
 :::tip
-  When snapshot mismatch and causing the test failing, if the mismatch is expected, you can press `u` key to update the snapshot for once. Or you can pass `-u` or `--update` CLI options to make Vitest always update the tests.
+  When a snapshot mismatches and causes the test to fail, if the mismatch is expected, you can press `u` key to update the snapshot once. Or you can pass `-u` or `--update` CLI options to make Vitest always update the tests.
 :::
 
 ```ts
@@ -1287,7 +1287,7 @@ test('callback was called', async () => {
 
 - **Type:** `(message?: string) => never`
 
-This method is used to asserting that a line should never be reached.
+This method is used to assert that a line should never be reached.
 
 For example, if we want to test that `build()` throws due to receiving directories having no `src` folder, and also handle each error separately, we could do this:
 


### PR DESCRIPTION
### Description

Spotted some minor typos in the [expects docs](https://vitest.dev/api/expect.html):
- In the [toMatchSnapshot](https://vitest.dev/api/expect.html#tomatchsnapshot) tip.
- In the [expect.unreachable](https://vitest.dev/api/expect.html#expect-unreachable) description.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
