### PR TITLE
chore: remove __VITEST_APPEND__ after it was initiated

### DIFF
--- a/packages/browser/src/client/tester/locators/index.ts
+++ b/packages/browser/src/client/tester/locators/index.ts
@@ -150,7 +150,7 @@ export abstract class Locator {
   public element(): Element {
     const element = this.query()
     if (!element) {
-      throw getElementError(this._pwSelector || this.selector, this._container || document.documentElement)
+      throw getElementError(this._pwSelector || this.selector, this._container || document.body)
     }
     return element
   }

--- a/packages/browser/src/client/tester/locators/preview.ts
+++ b/packages/browser/src/client/tester/locators/preview.ts
@@ -52,7 +52,7 @@ class PreviewLocator extends Locator {
   override get selector() {
     const selectors = this.elements().map(element => convertElementToCssSelector(element))
     if (!selectors.length) {
-      throw getElementError(this._pwSelector, this._container || document.documentElement)
+      throw getElementError(this._pwSelector, this._container || document.body)
     }
     return selectors.join(', ')
   }

--- a/packages/browser/src/client/tester/locators/webdriverio.ts
+++ b/packages/browser/src/client/tester/locators/webdriverio.ts
@@ -48,7 +48,7 @@ class WebdriverIOLocator extends Locator {
   override get selector() {
     const selectors = this.elements().map(element => convertElementToCssSelector(element))
     if (!selectors.length) {
-      throw getElementError(this._pwSelector, this._container || document.documentElement)
+      throw getElementError(this._pwSelector, this._container || document.body)
     }
     return selectors.join(', ')
   }

--- a/packages/browser/src/client/tester/tester.html
+++ b/packages/browser/src/client/tester/tester.html
@@ -23,6 +23,5 @@
   </head>
   <body>
     <script type="module" src="./tester.ts"></script>
-    {__VITEST_APPEND__}
   </body>
 </html>

--- a/packages/browser/src/client/tester/tester.html
+++ b/packages/browser/src/client/tester/tester.html
@@ -23,5 +23,6 @@
   </head>
   <body>
     <script type="module" src="./tester.ts"></script>
+    {__VITEST_APPEND__}
   </body>
 </html>

--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -75,11 +75,12 @@ export async function resolveTester(
     __VITEST_INTERNAL_SCRIPTS__: [
       `<script type="module" src="${server.errorCatcherUrl}"></script>`,
       server.locatorsUrl ? `<script type="module" src="${server.locatorsUrl}"></script>` : '',
-      `<script type="module">
+    ].join('\n'),
+    __VITEST_APPEND__: `<script data-script-start type="module">
 __vitest_browser_runner__.runningFiles = ${tests}
 __vitest_browser_runner__.iframeId = ${iframeId}
 __vitest_browser_runner__.${method === 'run' ? 'runTests' : 'collectTests'}(__vitest_browser_runner__.runningFiles)
+document.querySelector('script[data-script-start]').remove()
 </script>`,
-    ].join('\n'),
   })
 }

--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -76,11 +76,11 @@ export async function resolveTester(
       `<script type="module" src="${server.errorCatcherUrl}"></script>`,
       server.locatorsUrl ? `<script type="module" src="${server.locatorsUrl}"></script>` : '',
     ].join('\n'),
-    __VITEST_APPEND__: `<script data-script-start type="module">
+    __VITEST_APPEND__: `<script data-vitest-append type="module">
 __vitest_browser_runner__.runningFiles = ${tests}
 __vitest_browser_runner__.iframeId = ${iframeId}
 __vitest_browser_runner__.${method === 'run' ? 'runTests' : 'collectTests'}(__vitest_browser_runner__.runningFiles)
-document.querySelector('script[data-script-start]').remove()
+document.querySelector('script[data-vitest-append]').remove()
 </script>`,
   })
 }

--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -75,12 +75,11 @@ export async function resolveTester(
     __VITEST_INTERNAL_SCRIPTS__: [
       `<script type="module" src="${server.errorCatcherUrl}"></script>`,
       server.locatorsUrl ? `<script type="module" src="${server.locatorsUrl}"></script>` : '',
-    ].join('\n'),
-    __VITEST_APPEND__:
       `<script type="module">
 __vitest_browser_runner__.runningFiles = ${tests}
 __vitest_browser_runner__.iframeId = ${iframeId}
 __vitest_browser_runner__.${method === 'run' ? 'runTests' : 'collectTests'}(__vitest_browser_runner__.runningFiles)
 </script>`,
+    ].join('\n'),
   })
 }

--- a/packages/browser/utils.d.ts
+++ b/packages/browser/utils.d.ts
@@ -5,7 +5,7 @@
 import { LocatorSelectors } from '@vitest/browser/context'
 import { StringifyOptions } from 'vitest/utils'
 
-type PrettyDOMOptions = Omit<StringifyOptions, 'maxLength'>
+export type PrettyDOMOptions = Omit<StringifyOptions, 'maxLength'>
 
 export declare function getElementLocatorSelectors(element: Element): LocatorSelectors
 export declare function debug(


### PR DESCRIPTION
### Description

This is needed so that when the `getBy*` locator fails, users won't see the content of the script

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
