### PR TITLE
fix(workspace): correctly resolve workspace globs and file paths

### DIFF
--- a/packages/vitest/src/constants.ts
+++ b/packages/vitest/src/constants.ts
@@ -16,7 +16,7 @@ export const CONFIG_NAMES = ['vitest.config', 'vite.config']
 
 const WORKSPACES_NAMES = ['vitest.workspace', 'vitest.projects']
 
-const CONFIG_EXTENSIONS = ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs']
+export const CONFIG_EXTENSIONS = ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs']
 
 export const configFiles = CONFIG_NAMES.flatMap(name =>
   CONFIG_EXTENSIONS.map(ext => name + ext),

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1,10 +1,7 @@
 import { existsSync, promises as fs } from 'node:fs'
 import type { Writable } from 'node:stream'
-import { isMainThread } from 'node:worker_threads'
 import type { ViteDevServer } from 'vite'
-import { mergeConfig } from 'vite'
-import { basename, dirname, join, normalize, relative, resolve } from 'pathe'
-import fg from 'fast-glob'
+import { dirname, join, normalize, relative, resolve } from 'pathe'
 import mm from 'micromatch'
 import { ViteNodeRunner } from 'vite-node/client'
 import { SnapshotManager } from '@vitest/snapshot/manager'
@@ -14,7 +11,7 @@ import type { defineWorkspace } from 'vitest/config'
 import { version } from '../../package.json' with { type: 'json' }
 import { getTasks, hasFailed, noop, slash, toArray, wildcardPatternToRegExp } from '../utils'
 import { getCoverageProvider } from '../integrations/coverage'
-import { CONFIG_NAMES, configFiles, workspacesFiles as workspaceFiles } from '../constants'
+import { workspacesFiles as workspaceFiles } from '../constants'
 import { rootDir } from '../paths'
 import { WebSocketReporter } from '../api/setup'
 import type { SerializedCoverageConfig } from '../runtime/config'
@@ -27,13 +24,14 @@ import { StateManager } from './state'
 import { resolveConfig } from './config/resolveConfig'
 import { Logger } from './logger'
 import { VitestCache } from './cache'
-import { WorkspaceProject, initializeProject } from './workspace'
+import { WorkspaceProject } from './workspace'
 import { VitestPackageInstaller } from './packageInstaller'
 import { BlobReporter, readBlobs } from './reporters/blob'
 import { FilesNotFoundError, GitNotFoundError } from './errors'
-import type { ResolvedConfig, UserConfig, UserWorkspaceConfig, VitestRunMode } from './types/config'
+import type { ResolvedConfig, UserConfig, VitestRunMode } from './types/config'
 import type { Reporter } from './types/reporter'
 import type { CoverageProvider } from './types/coverage'
+import { resolveWorkspace } from './workspace/resolveWorkspace'
 
 const WATCHER_DEBOUNCE = 100
 
@@ -192,7 +190,10 @@ export class Vitest {
     this.getCoreWorkspaceProject().provide(key, value)
   }
 
-  private async createCoreProject() {
+  /**
+   * @internal
+   */
+  async createCoreProject() {
     this.coreWorkspaceProject = await WorkspaceProject.createCoreProject(this)
     return this.coreWorkspaceProject
   }
@@ -249,179 +250,15 @@ export class Vitest {
     }
 
     if (!workspaceModule.default || !Array.isArray(workspaceModule.default)) {
-      throw new Error(`Workspace config file ${workspaceConfigPath} must export a default array of project paths.`)
+      throw new TypeError(`Workspace config file "${workspaceConfigPath}" must export a default array of project paths.`)
     }
 
-    const workspaceConfigFiles: string[] = []
-    const workspaceGlobMatches: string[] = []
-    const projectsOptions: UserWorkspaceConfig[] = []
-
-    for (const project of workspaceModule.default) {
-      if (typeof project === 'string') {
-        const match = project.replace('<rootDir>', this.config.root)
-        if (!match.includes('*')) {
-          const file = resolve(workspaceConfigPath, match)
-
-          if (!existsSync(file)) {
-            throw new Error(`Workspace config file ${workspaceConfigPath} references a non-existing file or a directory: ${file}`)
-          }
-
-          const stats = await fs.stat(file)
-          if (stats.isFile()) {
-            workspaceConfigFiles.push(file)
-          }
-          else if (stats.isDirectory()) {
-            const filesInside = await fs.readdir(file)
-            const configFile = configFiles.find(config => filesInside.includes(config))
-            if (!configFile) {
-              throw new Error(`Workspace config file ${workspaceConfigPath} references a directory without a config file: ${file}`)
-            }
-            workspaceConfigFiles.push(file)
-          }
-          else {
-            throw new Error(`Unexpected file type: ${file}`)
-          }
-        }
-        else {
-          workspaceGlobMatches.push(project.replace('<rootDir>', this.config.root))
-        }
-      }
-      else if (typeof project === 'function') {
-        projectsOptions.push(await project({
-          command: this.server.config.command,
-          mode: this.server.config.mode,
-          isPreview: false,
-          isSsrBuild: false,
-        }))
-      }
-      else {
-        projectsOptions.push(await project)
-      }
-    }
-
-    const globOptions: fg.Options = {
-      absolute: true,
-      dot: true,
-      onlyFiles: false,
-      markDirectories: true,
-      cwd: this.config.root,
-      ignore: ['**/node_modules/**', '**/*.timestamp-*'],
-    }
-
-    const workspacesFs = await fg(workspaceGlobMatches, globOptions)
-    const resolvedWorkspacesPaths = await Promise.all(workspacesFs.filter((file) => {
-      if (file.endsWith('/')) {
-        // if it's a directory, check that we don't already have a workspace with a config inside
-        const hasWorkspaceWithConfig = workspacesFs.some((file2) => {
-          return file2 !== file && `${dirname(file2)}/` === file
-        })
-        return !hasWorkspaceWithConfig
-      }
-      const filename = basename(file)
-      return CONFIG_NAMES.some(configName => filename.startsWith(configName))
-    }).map(async (filepath) => {
-      if (filepath.endsWith('/')) {
-        const filesInside = await fs.readdir(filepath)
-        const configFile = configFiles.find(config => filesInside.includes(config))
-        return configFile ? join(filepath, configFile) : filepath
-      }
-      return filepath
-    }))
-
-    const workspacesByFolder = resolvedWorkspacesPaths
-      .reduce((configByFolder, filepath) => {
-        const dir = filepath.endsWith('/') ? filepath.slice(0, -1) : dirname(filepath)
-        configByFolder[dir] ??= []
-        configByFolder[dir].push(filepath)
-        return configByFolder
-      }, {} as Record<string, string[]>)
-
-    const filteredWorkspaces = Object.values(workspacesByFolder).flatMap((configFiles) => {
-      if (configFiles.length === 1) {
-        return configFiles[0]
-      }
-      const vitestConfig = configFiles.filter(configFile => basename(configFile).startsWith('vitest.config'))
-      return vitestConfig.length ? vitestConfig : configFiles[0]
-    })
-
-    const overridesOptions = [
-      'logHeapUsage',
-      'allowOnly',
-      'sequence',
-      'testTimeout',
-      'pool',
-      'update',
-      'globals',
-      'expandSnapshotDiff',
-      'disableConsoleIntercept',
-      'retry',
-      'testNamePattern',
-      'passWithNoTests',
-      'bail',
-      'isolate',
-      'printConsoleTrace',
-    ] as const
-
-    const cliOverrides = overridesOptions.reduce((acc, name) => {
-      if (name in cliOptions) {
-        acc[name] = cliOptions[name] as any
-      }
-      return acc
-    }, {} as UserConfig)
-
-    const cwd = process.cwd()
-
-    const projects: WorkspaceProject[] = []
-
-    try {
-      // we have to resolve them one by one because CWD should depend on the project
-      for (const filepath of filteredWorkspaces) {
-        if (this.server.config.configFile === filepath) {
-          const project = await this.createCoreProject()
-          projects.push(project)
-          continue
-        }
-        const dir = filepath.endsWith('/') ? filepath.slice(0, -1) : dirname(filepath)
-        if (isMainThread) {
-          process.chdir(dir)
-        }
-        projects.push(
-          await initializeProject(filepath, this, { workspaceConfigPath, test: cliOverrides }),
-        )
-      }
-    }
-    finally {
-      if (isMainThread) {
-        process.chdir(cwd)
-      }
-    }
-
-    const projectPromises: Promise<WorkspaceProject>[] = []
-
-    projectsOptions.forEach((options, index) => {
-      // we can resolve these in parallel because process.cwd() is not changed
-      projectPromises.push(initializeProject(index, this, mergeConfig(options, { workspaceConfigPath, test: cliOverrides }) as any))
-    })
-
-    if (!projects.length && !projectPromises.length) {
-      return [await this.createCoreProject()]
-    }
-
-    const resolvedProjects = await Promise.all([
-      ...projects,
-      ...await Promise.all(projectPromises),
-    ])
-    const names = new Set<string>()
-
-    for (const project of resolvedProjects) {
-      const name = project.getName()
-      if (names.has(name)) {
-        throw new Error(`Project name "${name}" is not unique. All projects in a workspace should have unique names.`)
-      }
-      names.add(name)
-    }
-
-    return resolvedProjects
+    return resolveWorkspace(
+      this,
+      cliOptions,
+      workspaceConfigPath,
+      workspaceModule.default,
+    )
   }
 
   private async initCoverageProvider() {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -193,7 +193,7 @@ export class Vitest {
   /**
    * @internal
    */
-  async createCoreProject() {
+  async _createCoreProject() {
     this.coreWorkspaceProject = await WorkspaceProject.createCoreProject(this)
     return this.coreWorkspaceProject
   }
@@ -242,7 +242,7 @@ export class Vitest {
     const workspaceConfigPath = await this.getWorkspaceConfigPath()
 
     if (!workspaceConfigPath) {
-      return [await this.createCoreProject()]
+      return [await this._createCoreProject()]
     }
 
     const workspaceModule = await this.runner.executeFile(workspaceConfigPath) as {

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -52,12 +52,6 @@ export async function initializeProject(
 ) {
   const project = new WorkspaceProject(workspacePath, ctx, options)
 
-  const configFile = options.extends
-    ? resolve(dirname(options.workspaceConfigPath), options.extends)
-    : typeof workspacePath === 'number' || workspacePath.endsWith('/')
-      ? false
-      : workspacePath
-
   const root
     = options.root
     || (typeof workspacePath === 'number'
@@ -65,6 +59,12 @@ export async function initializeProject(
       : workspacePath.endsWith('/')
         ? workspacePath
         : dirname(workspacePath))
+
+  const configFile = options.extends
+    ? resolve(dirname(options.workspaceConfigPath), options.extends)
+    : typeof workspacePath === 'number' || workspacePath.endsWith('/')
+      ? false
+      : workspacePath
 
   const config: ViteInlineConfig = {
     ...options,

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -95,7 +95,14 @@ export async function resolveWorkspace(
   for (const project of resolvedProjects) {
     const name = project.getName()
     if (names.has(name)) {
-      throw new Error(`Project name "${name}" is not unique. All projects in a workspace should have unique names.`)
+      const duplicate = resolvedProjects.find(p => p.getName() === name && p !== project)!
+      throw new Error([
+        `Project name "${name}"`,
+        project.server.config.configFile ? ` from "${relative(vitest.config.root, project.server.config.configFile)}"` : '',
+        ' is not unique. ',
+        duplicate?.server.config.configFile ? `The project is already defined by "${relative(vitest.config.root, duplicate.server.config.configFile)}".` : '',
+        ' All projects in a workspace should have unique names. Make sure your configuration is correct.',
+      ].join(''))
     }
     names.add(name)
   }

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -99,8 +99,8 @@ export async function resolveWorkspace(
       throw new Error([
         `Project name "${name}"`,
         project.server.config.configFile ? ` from "${relative(vitest.config.root, project.server.config.configFile)}"` : '',
-        ' is not unique. ',
-        duplicate?.server.config.configFile ? `The project is already defined by "${relative(vitest.config.root, duplicate.server.config.configFile)}".` : '',
+        ' is not unique.',
+        duplicate?.server.config.configFile ? ` The project is already defined by "${relative(vitest.config.root, duplicate.server.config.configFile)}".` : '',
         ' All projects in a workspace should have unique names. Make sure your configuration is correct.',
       ].join(''))
     }

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -210,8 +210,7 @@ async function resolveWorkspaceProjectConfigs(
 
       const workspacesFs = await fg(workspaceGlobMatches, globOptions)
 
-      await Promise.all(workspacesFs.map(async (filepath_) => {
-        const filepath = resolve(filepath_)
+      await Promise.all(workspacesFs.map(async (filepath) => {
         // directories are allowed with a glob like `packages/*`
         // in this case every directory is treated as a project
         if (filepath.endsWith('/')) {

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -1,0 +1,211 @@
+import { existsSync, promises as fs } from 'node:fs'
+import { isMainThread } from 'node:worker_threads'
+import { dirname, resolve } from 'pathe'
+import { mergeConfig } from 'vite'
+import fg from 'fast-glob'
+import c from 'tinyrainbow'
+import type { UserWorkspaceConfig, WorkspaceProjectConfiguration } from '../../public/config'
+import type { Vitest } from '../core'
+import type { UserConfig } from '../types/config'
+import type { WorkspaceProject } from '../workspace'
+import { initializeProject } from '../workspace'
+import { configFiles as defaultConfigFiles } from '../../constants'
+
+export async function resolveWorkspace(
+  vitest: Vitest,
+  cliOptions: UserConfig,
+  workspaceConfigPath: string,
+  workspaceDefinition: WorkspaceProjectConfiguration[],
+): Promise<WorkspaceProject[]> {
+  const { configFiles, projectConfigs, nonConfigProjects } = await resolveWorkspaceProjectConfigs(
+    vitest,
+    workspaceConfigPath,
+    workspaceDefinition,
+  )
+
+  const overridesOptions = [
+    'logHeapUsage',
+    'allowOnly',
+    'sequence',
+    'testTimeout',
+    'pool',
+    'update',
+    'globals',
+    'expandSnapshotDiff',
+    'disableConsoleIntercept',
+    'retry',
+    'testNamePattern',
+    'passWithNoTests',
+    'bail',
+    'isolate',
+    'printConsoleTrace',
+  ] as const
+
+  const cliOverrides = overridesOptions.reduce((acc, name) => {
+    if (name in cliOptions) {
+      acc[name] = cliOptions[name] as any
+    }
+    return acc
+  }, {} as UserConfig)
+
+  const cwd = process.cwd()
+
+  const projects: WorkspaceProject[] = []
+
+  try {
+    // we have to resolve them one by one because CWD should depend on the project
+    for (const filepath of [...configFiles, ...nonConfigProjects]) {
+      if (vitest.server.config.configFile === filepath) {
+        const project = await vitest.createCoreProject()
+        projects.push(project)
+        continue
+      }
+      const dir = filepath.endsWith('/') ? filepath.slice(0, -1) : dirname(filepath)
+      if (isMainThread) {
+        process.chdir(dir)
+      }
+      projects.push(
+        await initializeProject(filepath, vitest, { workspaceConfigPath, test: cliOverrides }),
+      )
+    }
+  }
+  finally {
+    if (isMainThread) {
+      process.chdir(cwd)
+    }
+  }
+
+  const projectPromises: Promise<WorkspaceProject>[] = []
+
+  projectConfigs.forEach((options, index) => {
+    // we can resolve these in parallel because process.cwd() is not changed
+    projectPromises.push(initializeProject(index, vitest, mergeConfig(options, { workspaceConfigPath, test: cliOverrides }) as any))
+  })
+
+  if (!projects.length && !projectPromises.length) {
+    return [await vitest.createCoreProject()]
+  }
+
+  const resolvedProjects = await Promise.all([
+    ...projects,
+    ...await Promise.all(projectPromises),
+  ])
+  const names = new Set<string>()
+
+  for (const project of resolvedProjects) {
+    const name = project.getName()
+    if (names.has(name)) {
+      throw new Error(`Project name "${name}" is not unique. All projects in a workspace should have unique names.`)
+    }
+    names.add(name)
+  }
+
+  return resolvedProjects
+}
+
+async function resolveWorkspaceProjectConfigs(
+  vitest: Vitest,
+  workspaceConfigPath: string,
+  workspaceDefinition: WorkspaceProjectConfiguration[],
+) {
+  const projectsOptions: UserWorkspaceConfig[] = []
+  const workspaceConfigFiles: string[] = []
+  const workspaceGlobMatches: string[] = []
+  let nonConfigProjectDirectories: string[] = []
+
+  for (const definition of workspaceDefinition) {
+    if (typeof definition === 'string') {
+      const stringOption = definition.replace('<rootDir>', vitest.config.root)
+      if (!stringOption.includes('*')) {
+        const file = resolve(workspaceConfigPath, stringOption)
+
+        if (!existsSync(file)) {
+          throw new Error(`Workspace config file "${workspaceConfigPath}" references a non-existing file or a directory: ${file}`)
+        }
+
+        const stats = await fs.stat(file)
+        if (stats.isFile()) {
+          workspaceConfigFiles.push(file)
+        }
+        else if (stats.isDirectory()) {
+          nonConfigProjectDirectories.push(file)
+        }
+        else {
+          throw new TypeError(`Unexpected file type: ${file}`)
+        }
+      }
+      else {
+        workspaceGlobMatches.push(stringOption)
+      }
+    }
+    else if (typeof definition === 'function') {
+      projectsOptions.push(await definition({
+        command: vitest.server.config.command,
+        mode: vitest.server.config.mode,
+        isPreview: false,
+        isSsrBuild: false,
+      }))
+    }
+    else {
+      projectsOptions.push(await definition)
+    }
+
+    if (workspaceGlobMatches.length) {
+      const globOptions: fg.Options = {
+        absolute: true,
+        dot: true,
+        onlyFiles: false,
+        markDirectories: true,
+        cwd: vitest.config.root,
+        ignore: ['**/node_modules/**', '**/*.timestamp-*'],
+      }
+
+      const workspacesFs = await fg(workspaceGlobMatches, globOptions)
+
+      await Promise.all(workspacesFs.map(async (filepath) => {
+        // the directories are allowed with a glob like `packages/*`
+        if (filepath.endsWith('/')) {
+          nonConfigProjectDirectories.push(filepath)
+        }
+        else {
+          workspaceConfigFiles.push(filepath)
+        }
+      }))
+    }
+  }
+
+  const projectConfigFiles = [...new Set(workspaceConfigFiles)]
+  const duplicateDirectories = new Set()
+
+  for (const config of projectConfigFiles) {
+    // ignore custom config names because it won't be picked up by the default resolver later
+    if (!defaultConfigFiles.includes(config)) {
+      continue
+    }
+
+    const configDirectory = `${dirname(config)}/`
+    // if for some reason there is already a config file in a directory that was found by a glob
+    // we remove it from the list to avoid duplicates when the project is initialized
+    for (const directory of nonConfigProjectDirectories) {
+      if (directory === configDirectory) {
+        vitest.logger.warn(
+          c.yellow(
+            `The specified config file "${config}" is located in the directory already found by a glob match. `
+            + `The config file will override the directory match to avoid duplicates. You can silence this message by excluding the directory from the glob in "${workspaceConfigPath}".`,
+          ),
+        )
+        duplicateDirectories.add(directory)
+      }
+    }
+  }
+
+  if (duplicateDirectories.size) {
+    nonConfigProjectDirectories = nonConfigProjectDirectories.filter(dir => !duplicateDirectories.has(dir))
+  }
+
+  return {
+    projectConfigs: projectsOptions,
+    nonConfigProjects: nonConfigProjectDirectories,
+    configFiles: projectConfigFiles,
+  }
+}

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -145,7 +145,6 @@ async function resolveWorkspaceProjectConfigs(
           workspaceConfigFiles.push(file)
         }
         // user can specify a directory that should be used as a project
-        // the config file inside will be resolved by the default resolver later
         else if (stats.isDirectory()) {
           const configFile = await resolveDirectoryConfig(file)
           if (configFile) {
@@ -189,7 +188,7 @@ async function resolveWorkspaceProjectConfigs(
       const workspacesFs = await fg(workspaceGlobMatches, globOptions)
 
       await Promise.all(workspacesFs.map(async (filepath) => {
-        // the directories are allowed with a glob like `packages/*`
+        // directories are allowed with a glob like `packages/*`
         if (filepath.endsWith('/')) {
           const configFile = await resolveDirectoryConfig(filepath)
           if (configFile) {

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -118,7 +118,7 @@ async function resolveWorkspaceProjectConfigs(
   // project configurations that were specified directly
   const projectsOptions: UserWorkspaceConfig[] = []
 
-  // custom config files that were specified directly
+  // custom config files that were specified directly or resolved from a directory
   const workspaceConfigFiles: string[] = []
 
   // custom glob matches that should be resolved as directories or config files

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -126,9 +126,12 @@ async function resolveWorkspaceProjectConfigs(
         }
 
         const stats = await fs.stat(file)
+        // user can specify a config file directly
         if (stats.isFile()) {
           workspaceConfigFiles.push(file)
         }
+        // user can specify a directory that should be used as a project
+        // the config file inside will be resolved by the default resolver later
         else if (stats.isDirectory()) {
           const directory = file[file.length - 1] === '/' ? file : `${file}/`
           nonConfigProjectDirectories.push(directory)
@@ -165,7 +168,7 @@ async function resolveWorkspaceProjectConfigs(
 
       const workspacesFs = await fg(workspaceGlobMatches, globOptions)
 
-      await Promise.all(workspacesFs.map(async (filepath) => {
+      workspacesFs.forEach((filepath) => {
         // the directories are allowed with a glob like `packages/*`
         if (filepath.endsWith('/')) {
           nonConfigProjectDirectories.push(filepath)
@@ -173,7 +176,7 @@ async function resolveWorkspaceProjectConfigs(
         else {
           workspaceConfigFiles.push(filepath)
         }
-      }))
+      })
     }
   }
 

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -65,7 +65,11 @@ export async function resolveWorkspace(
         process.chdir(dir)
       }
       projects.push(
-        await initializeProject(filepath, vitest, { workspaceConfigPath, test: cliOverrides }),
+        await initializeProject(
+          filepath,
+          vitest,
+          { workspaceConfigPath, test: cliOverrides },
+        ),
       )
     }
   }
@@ -79,7 +83,11 @@ export async function resolveWorkspace(
 
   projectConfigs.forEach((options, index) => {
     // we can resolve these in parallel because process.cwd() is not changed
-    projectPromises.push(initializeProject(index, vitest, mergeConfig(options, { workspaceConfigPath, test: cliOverrides }) as any))
+    projectPromises.push(initializeProject(
+      index,
+      vitest,
+      mergeConfig(options, { workspaceConfigPath, test: cliOverrides }) as any,
+    ))
   })
 
   if (!projects.length && !projectPromises.length) {

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -88,7 +88,7 @@ export async function resolveWorkspace(
 
   const resolvedProjects = await Promise.all([
     ...projects,
-    ...await Promise.all(projectPromises),
+    ...projectPromises,
   ])
   const names = new Set<string>()
 

--- a/packages/vitest/src/public/config.ts
+++ b/packages/vitest/src/public/config.ts
@@ -58,7 +58,7 @@ export function defineProject(config: UserProjectConfigExport): UserProjectConfi
   return config
 }
 
-type WorkspaceProjectConfiguration = string | (UserProjectConfigExport & {
+export type WorkspaceProjectConfiguration = string | (UserProjectConfigExport & {
   /**
    * Relative path to the extendable config. All other options will be merged with this config.
    * @example '../vite.config.ts'

--- a/test/config/fixtures/workspace/invalid-duplicate-configs/vitest.workspace.ts
+++ b/test/config/fixtures/workspace/invalid-duplicate-configs/vitest.workspace.ts
@@ -1,0 +1,6 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  './vitest1.config.js',
+  './vitest2.config.js',
+])

--- a/test/config/fixtures/workspace/invalid-duplicate-configs/vitest1.config.js
+++ b/test/config/fixtures/workspace/invalid-duplicate-configs/vitest1.config.js
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    name: 'test',
+  }
+}

--- a/test/config/fixtures/workspace/invalid-duplicate-configs/vitest2.config.js
+++ b/test/config/fixtures/workspace/invalid-duplicate-configs/vitest2.config.js
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    name: 'test',
+  }
+}

--- a/test/config/fixtures/workspace/invalid-duplicate-inline/vitest.workspace.ts
+++ b/test/config/fixtures/workspace/invalid-duplicate-inline/vitest.workspace.ts
@@ -1,0 +1,14 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  {
+    test: {
+      name: 'test',
+    },
+  },
+  {
+    test: {
+      name: 'test',
+    },
+  },
+])

--- a/test/config/fixtures/workspace/invalid-non-existing-config/vitest.workspace.ts
+++ b/test/config/fixtures/workspace/invalid-non-existing-config/vitest.workspace.ts
@@ -1,0 +1,5 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  './vitest.config.js'
+])

--- a/test/config/fixtures/workspace/several-configs/test/1_test.test.ts
+++ b/test/config/fixtures/workspace/several-configs/test/1_test.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('1 + 1 = 2', () => {
+  expect(1 + 1).toBe(2);
+})

--- a/test/config/fixtures/workspace/several-configs/test/2_test.test.ts
+++ b/test/config/fixtures/workspace/several-configs/test/2_test.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('2 + 2 = 4', () => {
+  expect(2 + 2).toBe(4);
+})

--- a/test/config/fixtures/workspace/several-configs/test/vitest.config.one.ts
+++ b/test/config/fixtures/workspace/several-configs/test/vitest.config.one.ts
@@ -1,0 +1,8 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  test: {
+    name: '1_test',
+    include: ['./1_test.test.ts'],
+  }
+})

--- a/test/config/fixtures/workspace/several-configs/test/vitest.config.two.ts
+++ b/test/config/fixtures/workspace/several-configs/test/vitest.config.two.ts
@@ -1,0 +1,8 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  test: {
+    name: '2_test',
+    include: ['./2_test.test.ts'],
+  }
+})

--- a/test/config/fixtures/workspace/several-configs/vitest.workspace.ts
+++ b/test/config/fixtures/workspace/several-configs/vitest.workspace.ts
@@ -1,0 +1,3 @@
+export default [
+  './test/*.config.*.ts'
+]

--- a/test/config/test/workspace.test.ts
+++ b/test/config/test/workspace.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from 'vitest'
+import { resolve } from 'pathe'
 import { runVitest } from '../../test-utils'
 
 it('correctly runs workspace tests when workspace config path is specified', async () => {
@@ -22,4 +23,34 @@ it('runs the workspace if there are several vitest config files', async () => {
   expect(stdout).toContain('| 2_test')
   expect(stdout).toContain('1 + 1 = 2')
   expect(stdout).toContain('2 + 2 = 4')
+})
+
+it('fails if project names are identical with a nice error message', async () => {
+  const { stderr } = await runVitest({
+    root: 'fixtures/workspace/invalid-duplicate-configs',
+    workspace: './fixtures/workspace/invalid-duplicate-configs/vitest.workspace.ts',
+  }, [], 'test', {}, { fails: true })
+  expect(stderr).toContain(
+    'Project name "test" from "vitest2.config.js" is not unique. The project is already defined by "vitest1.config.js". All projects in a workspace should have unique names. Make sure your configuration is correct.',
+  )
+})
+
+it('fails if project names are identical inside the inline config', async () => {
+  const { stderr } = await runVitest({
+    root: 'fixtures/workspace/invalid-duplicate-inline',
+    workspace: './fixtures/workspace/invalid-duplicate-inline/vitest.workspace.ts',
+  }, [], 'test', {}, { fails: true })
+  expect(stderr).toContain(
+    'Project name "test" is not unique. All projects in a workspace should have unique names. Make sure your configuration is correct.',
+  )
+})
+
+it('fails if referenced file doesnt exist', async () => {
+  const { stderr } = await runVitest({
+    root: 'fixtures/workspace/invalid-non-existing-config',
+    workspace: './fixtures/workspace/invalid-non-existing-config/vitest.workspace.ts',
+  }, [], 'test', {}, { fails: true })
+  expect(stderr).toContain(
+    `Workspace config file "vitest.workspace.ts" references a non-existing file or a directory: ${resolve('fixtures/workspace/invalid-non-existing-config/vitest.config.js')}`,
+  )
 })

--- a/test/config/test/workspace.test.ts
+++ b/test/config/test/workspace.test.ts
@@ -10,3 +10,16 @@ it('correctly runs workspace tests when workspace config path is specified', asy
   expect(stdout).toContain('1 + 1 = 2')
   expect(stdout).not.toContain('2 + 2 = 4')
 })
+
+it('runs the workspace if there are several vitest config files', async () => {
+  const { stderr, stdout } = await runVitest({
+    root: 'fixtures/workspace/several-configs',
+    workspace: './fixtures/workspace/several-configs/vitest.workspace.ts',
+  })
+  expect(stderr).toBe('')
+  expect(stdout).toContain('workspace/several-configs')
+  expect(stdout).toContain('| 1_test')
+  expect(stdout).toContain('| 2_test')
+  expect(stdout).toContain('1 + 1 = 2')
+  expect(stdout).toContain('2 + 2 = 4')
+})

--- a/test/test-utils/cli.ts
+++ b/test/test-utils/cli.ts
@@ -76,7 +76,7 @@ export class Cli {
       }
 
       const timeout = setTimeout(() => {
-        error.message = `Timeout when waiting for error "${expected}".\nReceived:\n${this[source]}`
+        error.message = `Timeout when waiting for error "${expected}".\nReceived:\nstdout: ${this.stdout}\nstderr: ${this.stderr}`
         reject(error)
       }, process.env.CI ? 20_000 : 4_000)
 

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -12,6 +12,7 @@ import { Cli } from './cli'
 
 interface VitestRunnerCLIOptions {
   std?: 'inherit'
+  fails?: boolean
 }
 
 export async function runVitest(
@@ -83,7 +84,9 @@ export async function runVitest(
     })
   }
   catch (e: any) {
-    console.error(e)
+    if (runnerOptions.fails !== true) {
+      console.error(e)
+    }
     cli.stderr += e.stack
   }
   finally {

--- a/test/workspaces/vitest.workspace.ts
+++ b/test/workspaces/vitest.workspace.ts
@@ -5,7 +5,8 @@ import type { Plugin } from 'vite'
 
 export default defineWorkspace([
   'space_2',
-  './space_*/*.config.ts',
+  './space_*/vitest.config.ts',
+  './space_1/*.config.ts',
   async () => ({
     test: {
       name: 'happy-dom',


### PR DESCRIPTION
### Description

Fixes #5530 

Workspace resolution now respects the glob even if it catches both `vite` _and_ `vitest` config at the same time. You should use a different glob pattern in that case.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
