### PR TITLE
fix(coverage): warn if `vitest` and `@vitest/*` versions don't match

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -26,11 +26,12 @@ import type { CoverageMap } from 'istanbul-lib-coverage'
 import libCoverage from 'istanbul-lib-coverage'
 import libSourceMaps from 'istanbul-lib-source-maps'
 import { type Instrumenter, createInstrumenter } from 'istanbul-lib-instrument'
-// @ts-expect-error @istanbuljs/schema has no type definitions
+// @ts-expect-error missing types
 import { defaults as istanbulDefaults } from '@istanbuljs/schema'
-
 // @ts-expect-error missing types
 import _TestExclude from 'test-exclude'
+
+import { version } from '../package.json' with { type: 'json' }
 import { COVERAGE_STORE_KEY } from './constants'
 
 type Options = ResolvedCoverageOptions<'istanbul'>
@@ -75,6 +76,16 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
 
   initialize(ctx: Vitest): void {
     const config: CoverageIstanbulOptions = ctx.config.coverage
+
+    if (ctx.version !== version) {
+      ctx.logger.warn(
+        c.yellow(
+          `Loaded ${c.inverse(c.yellow(` vitest@${ctx.version} `))} and ${c.inverse(c.yellow(` @vitest/coverage-istanbul@${version} `))}.`
+          + '\nRunning mixed versions is not supported and may lead into bugs'
+          + '\nUpdate your dependencies and make sure the versions match.',
+        ),
+      )
+    }
 
     this.ctx = ctx
     this.options = {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -34,9 +34,10 @@ import type {
   ResolvedCoverageOptions,
 } from 'vitest'
 import type { Vitest } from 'vitest/node'
-
 // @ts-expect-error missing types
 import _TestExclude from 'test-exclude'
+
+import { version } from '../package.json' with { type: 'json' }
 
 interface TestExclude {
   new (opts: {
@@ -90,6 +91,16 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
 
   initialize(ctx: Vitest): void {
     const config: CoverageV8Options = ctx.config.coverage
+
+    if (ctx.version !== version) {
+      ctx.logger.warn(
+        c.yellow(
+          `Loaded ${c.inverse(c.yellow(` vitest@${ctx.version} `))} and ${c.inverse(c.yellow(` @vitest/coverage-v8@${version} `))}.`
+          + '\nRunning mixed versions is not supported and may lead into bugs'
+          + '\nUpdate your dependencies and make sure the versions match.',
+        ),
+      )
+    }
 
     this.ctx = ctx
     this.options = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1276,6 +1276,9 @@ importers:
       magicast:
         specifier: ^0.3.3
         version: 0.3.3
+      strip-ansi:
+        specifier: ^7.1.0
+        version: 7.1.0
       unplugin-swc:
         specifier: ^1.4.4
         version: 1.4.4(@swc/core@1.4.1)(rollup@4.20.0)

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test": "vitest --workspace=vitest.workspace.custom.ts"
+    "test": "vitest --workspace=vitest.workspace.custom.ts",
+    "vitest": "vitest"
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.2.1",
@@ -19,6 +20,7 @@
     "istanbul-lib-report": "^3.0.1",
     "magic-string": "^0.30.10",
     "magicast": "^0.3.3",
+    "strip-ansi": "^7.1.0",
     "unplugin-swc": "^1.4.4",
     "vite": "latest",
     "vitest": "workspace:*",

--- a/test/coverage-test/test/mixed-versions-warning.unit.test.ts
+++ b/test/coverage-test/test/mixed-versions-warning.unit.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest'
+import { configDefaults } from 'vitest/config'
+import V8Provider from '@vitest/coverage-v8'
+import packageJson from '@vitest/coverage-v8/package.json'
+import IstanbulProvider from '@vitest/coverage-istanbul'
+import stripAnsi from 'strip-ansi'
+
+const version = packageJson.version
+
+test('v8 provider logs warning if versions do not match', async () => {
+  const provider = await V8Provider.getProvider()
+  const warn = vi.fn()
+
+  provider.initialize({
+    version: '1.0.0',
+    logger: { warn },
+    config: configDefaults,
+  } as any)
+
+  expect(warn).toHaveBeenCalled()
+
+  const message = warn.mock.calls[0][0]
+
+  expect(stripAnsi(message)).toMatchInlineSnapshot(`
+    "Loaded  vitest@1.0.0  and  @vitest/coverage-v8@${version} .
+    Running mixed versions is not supported and may lead into bugs
+    Update your dependencies and make sure the versions match."
+  `)
+})
+
+test('istanbul provider logs warning if versions do not match', async () => {
+  const provider = await IstanbulProvider.getProvider()
+  const warn = vi.fn()
+
+  provider.initialize({
+    version: '1.0.0',
+    logger: { warn },
+    config: configDefaults,
+  } as any)
+
+  expect(warn).toHaveBeenCalled()
+
+  const message = warn.mock.calls[0][0]
+
+  expect(stripAnsi(message)).toMatchInlineSnapshot(`
+    "Loaded  vitest@1.0.0  and  @vitest/coverage-istanbul@${version} .
+    Running mixed versions is not supported and may lead into bugs
+    Update your dependencies and make sure the versions match."
+  `)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Warn if test run loads different versions of `vitest` and `@vitest/coverage-*` packages
- This is just a warning as the packages still may work, but we don't support these cases. Vitest requires users to use 100% exact same versions for `vitest` and `@vitest/*` packages. This has been discussed quite much in the past. 

<img src="https://github.com/user-attachments/assets/c5bd91e6-1e1a-460c-b01f-7fd3dcbb459b" width="480" />


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
