### PR TITLE
fix(coverage): v8 to warn instead of crash when conversion fails

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -543,7 +543,13 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
           )
           await converter.load()
 
-          converter.applyCoverage(functions)
+          try {
+            converter.applyCoverage(functions)
+          }
+          catch (error) {
+            this.ctx.logger.error(`Failed to convert coverage for ${url}.\n`, error)
+          }
+
           coverageMap.merge(converter.toIstanbul())
         }),
       )

--- a/test/coverage-test/fixtures/src/cjs-package/entry.js
+++ b/test/coverage-test/fixtures/src/cjs-package/entry.js
@@ -1,0 +1,2 @@
+require("./target");
+module.exports = "Entry here"

--- a/test/coverage-test/fixtures/src/cjs-package/package.json
+++ b/test/coverage-test/fixtures/src/cjs-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cjs-package",
+  "main": "./entry.js",
+  "type": "commonjs"
+}

--- a/test/coverage-test/fixtures/src/cjs-package/target.js
+++ b/test/coverage-test/fixtures/src/cjs-package/target.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  fatal: 4,
+};

--- a/test/coverage-test/test/convert-failure.v8.test.ts
+++ b/test/coverage-test/test/convert-failure.v8.test.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module'
+import { expect } from 'vitest'
+import { coverageTest, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
+
+test('logs warning but doesn\'t crash when coverage conversion fails', async () => {
+  const { stderr, exitCode } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    coverage: { reporter: 'json', include: ['fixtures/src/**'], all: false },
+  }, { throwOnError: false })
+
+  // Logged warning should not set erroneous exit code
+  expect(exitCode).toBe(0)
+
+  expect(stderr).toMatch('Failed to convert coverage for file://')
+  expect(stderr).toMatch('/fixtures/src/cjs-package/target.js.')
+  expect(stderr).toMatch('TypeError: Cannot read properties of undefined (reading \'endCol\')')
+
+  const coverageMap = await readCoverageMap()
+
+  expect(coverageMap.files()).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/cjs-package/entry.js",
+      "<process-cwd>/fixtures/src/cjs-package/target.js",
+    ]
+  `)
+})
+
+coverageTest('load file both from Vite and outside it', async () => {
+  const entry = createRequire(import.meta.url)('../fixtures/src/cjs-package' as any)
+  const target = await import('../fixtures/src/cjs-package/target.js' as any)
+
+  expect(entry).toBe('Entry here')
+  expect(target.default).toStrictEqual({
+    debug: 0,
+    error: 3,
+    fatal: 4,
+    info: 1,
+    warn: 2,
+  })
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- When coverage conversion using `v8ToIstanbul` fails, log warning and proceed with rest of the report instead of crashing completely
- Related to https://github.com/vitest-dev/vitest/issues/6297 but does not fix it. Though this allows users to see report in cases like that.
- These errors can happen when source maps are incorrect, or when a single file is loaded from both outside and through Vite - see test case for example. In those cases we cannot know if `vite-node`'s wrapper should be applied in coverage remapping or not. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
