### PR TITLE
fix(snapshot): reject multiple `toMatchInlineSnapshot` updates at the same location

### DIFF
--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -159,11 +159,11 @@ export default class SnapshotState {
       // https://github.com/vitejs/vite/issues/8657
       stack.column--
       // reject multiple inline snapshots at the same location
-      const duplicateIndex = this._inlineSnapshots.findIndex(s => s.file === stack.file && s.line === stack.line && s.column === stack.column);
+      const duplicateIndex = this._inlineSnapshots.findIndex(s => s.file === stack.file && s.line === stack.line && s.column === stack.column)
       if (duplicateIndex >= 0) {
         // remove the first one to avoid updating an inline snapshot
-        this._inlineSnapshots.splice(duplicateIndex, 1);
-        throw new Error("toMatchInlineSnapshot cannot be called multiple times at the same location.");
+        this._inlineSnapshots.splice(duplicateIndex, 1)
+        throw new Error('toMatchInlineSnapshot cannot be called multiple times at the same location.')
       }
       this._inlineSnapshots.push({
         snapshot: receivedSerialized,

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -158,6 +158,13 @@ export default class SnapshotState {
       // location for js files, but `column-1` points to the same in both js/ts
       // https://github.com/vitejs/vite/issues/8657
       stack.column--
+      // reject multiple inline snapshots at the same location
+      const duplicateIndex = this._inlineSnapshots.findIndex(s => s.file === stack.file && s.line === stack.line && s.column === stack.column);
+      if (duplicateIndex >= 0) {
+        // remove the first one to avoid updating an inline snapshot
+        this._inlineSnapshots.splice(duplicateIndex, 1);
+        throw new Error("toMatchInlineSnapshot cannot be called multiple times at the same location.");
+      }
       this._inlineSnapshots.push({
         snapshot: receivedSerialized,
         ...stack,

--- a/test/cli/fixtures/fails/inline-snapshop-inside-loop-update-all.test.ts
+++ b/test/cli/fixtures/fails/inline-snapshop-inside-loop-update-all.test.ts
@@ -10,14 +10,6 @@ test("fail 1", () => {
   }
 });
 
-// this test causes infinite re-run when --watch and --update
-// since snapshot update switches between "foo" and "bar" forever.
-// test("fail 2", () => {
-//   for (const str of ["foo", "bar"]) {
-//     expect(str).toMatchInlineSnapshot(`"bar"`);
-//   }
-// });
-
 test("fail 3", () => {
   for (const str of ["ok", "ok"]) {
     expect(str).toMatchInlineSnapshot();

--- a/test/cli/fixtures/fails/inline-snapshop-inside-loop-update-none.test.ts
+++ b/test/cli/fixtures/fails/inline-snapshop-inside-loop-update-none.test.ts
@@ -1,0 +1,9 @@
+import {test, expect} from "vitest";
+
+// this test causes infinite re-run when --watch and --update
+// since snapshot update switches between "foo" and "bar" forever.
+test("fail 2", () => {
+  for (const str of ["foo", "bar"]) {
+    expect(str).toMatchInlineSnapshot(`"bar"`);
+  }
+});

--- a/test/cli/fixtures/fails/inline-snapshop-inside-loop.test.ts
+++ b/test/cli/fixtures/fails/inline-snapshop-inside-loop.test.ts
@@ -12,11 +12,11 @@ test("fail 1", () => {
 
 // this test causes infinite re-run when --watch and --update
 // since snapshot update switches between "foo" and "bar" forever.
-test("fail 2", () => {
-  for (const str of ["foo", "bar"]) {
-    expect(str).toMatchInlineSnapshot(`"bar"`);
-  }
-});
+// test("fail 2", () => {
+//   for (const str of ["foo", "bar"]) {
+//     expect(str).toMatchInlineSnapshot(`"bar"`);
+//   }
+// });
 
 test("fail 3", () => {
   for (const str of ["ok", "ok"]) {

--- a/test/cli/fixtures/fails/inline-snapshop-inside-loop.test.ts
+++ b/test/cli/fixtures/fails/inline-snapshop-inside-loop.test.ts
@@ -1,0 +1,31 @@
+import {test, expect} from "vitest";
+
+test("ok", () => {
+  expect("ok").toMatchInlineSnapshot(`"ok"`);
+});
+
+test("fail 1", () => {
+  for (const str of ["foo", "bar"]) {
+    expect(str).toMatchInlineSnapshot();
+  }
+});
+
+// this test causes infinite re-run when --watch and --update
+// since snapshot update switches between "foo" and "bar" forever.
+test("fail 2", () => {
+  for (const str of ["foo", "bar"]) {
+    expect(str).toMatchInlineSnapshot(`"bar"`);
+  }
+});
+
+test("fail 3", () => {
+  for (const str of ["ok", "ok"]) {
+    expect(str).toMatchInlineSnapshot();
+  }
+});
+
+test("somehow ok", () => {
+  for (const str of ["ok", "ok"]) {
+    expect(str).toMatchInlineSnapshot(`"ok"`);
+  }
+});

--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -33,7 +33,6 @@ Error: InlineSnapshot cannot be used inside of test.each or describe.each"
 
 exports[`should fail inline-snapshop-inside-loop.test.ts > inline-snapshop-inside-loop.test.ts 1`] = `
 "Error: toMatchInlineSnapshot cannot be called multiple times at the same location.
-Error: Snapshot \`fail 2 1\` mismatched
 Error: toMatchInlineSnapshot cannot be called multiple times at the same location."
 `;
 

--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -31,6 +31,12 @@ Error: InlineSnapshot cannot be used inside of test.each or describe.each
 Error: InlineSnapshot cannot be used inside of test.each or describe.each"
 `;
 
+exports[`should fail inline-snapshop-inside-loop.test.ts > inline-snapshop-inside-loop.test.ts 1`] = `
+"Error: toMatchInlineSnapshot cannot be called multiple times at the same location.
+Error: Snapshot \`fail 2 1\` mismatched
+Error: toMatchInlineSnapshot cannot be called multiple times at the same location."
+`;
+
 exports[`should fail mock-import-proxy-module.test.ts > mock-import-proxy-module.test.ts 1`] = `"Error: There are some problems in resolving the mocks API."`;
 
 exports[`should fail nested-suite.test.ts > nested-suite.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;

--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -31,10 +31,12 @@ Error: InlineSnapshot cannot be used inside of test.each or describe.each
 Error: InlineSnapshot cannot be used inside of test.each or describe.each"
 `;
 
-exports[`should fail inline-snapshop-inside-loop.test.ts > inline-snapshop-inside-loop.test.ts 1`] = `
+exports[`should fail inline-snapshop-inside-loop-update-all.test.ts > inline-snapshop-inside-loop-update-all.test.ts 1`] = `
 "Error: toMatchInlineSnapshot cannot be called multiple times at the same location.
 Error: toMatchInlineSnapshot cannot be called multiple times at the same location."
 `;
+
+exports[`should fail inline-snapshop-inside-loop-update-none.test.ts > inline-snapshop-inside-loop-update-none.test.ts 1`] = `"Error: Snapshot \`fail 2 1\` mismatched"`;
 
 exports[`should fail mock-import-proxy-module.test.ts > mock-import-proxy-module.test.ts 1`] = `"Error: There are some problems in resolving the mocks API."`;
 

--- a/test/cli/test/fails.test.ts
+++ b/test/cli/test/fails.test.ts
@@ -10,7 +10,7 @@ const files = await fg('**/*.test.ts', { cwd: root, dot: true })
 it.each(files)('should fail %s', async (file) => {
   const { stderr } = await runVitest({
     root,
-    update: file === 'inline-snapshop-inside-loop.test.ts' ? true : undefined,
+    update: file === 'inline-snapshop-inside-loop-update-all.test.ts' ? true : undefined,
   }, [file])
 
   expect(stderr).toBeTruthy()

--- a/test/cli/test/fails.test.ts
+++ b/test/cli/test/fails.test.ts
@@ -8,7 +8,10 @@ const root = resolve(__dirname, '../fixtures/fails')
 const files = await fg('**/*.test.ts', { cwd: root, dot: true })
 
 it.each(files)('should fail %s', async (file) => {
-  const { stderr } = await runVitest({ root }, [file])
+  const { stderr } = await runVitest({
+    root,
+    update: file === 'inline-snapshop-inside-loop.test.ts' ? true : undefined,
+  }, [file])
 
   expect(stderr).toBeTruthy()
   const msg = String(stderr)


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/6327

There are some odd cases not handled well, but I think this will catch common cases and notify users effectively with an understandable error message. I tested on Jest and the behaviors of the test cases added here are same.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
