### PR TITLE
test: fix `test/snapshots` and add it to ci

### DIFF
--- a/test/snapshots/package.json
+++ b/test/snapshots/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/snapshots",
+  "name": "@vitest/test-snapshots",
   "type": "module",
   "private": true,
   "scripts": {

--- a/test/snapshots/test/custom-serializers.test.ts
+++ b/test/snapshots/test/custom-serializers.test.ts
@@ -6,6 +6,6 @@ test('it should pass', async () => {
     root: 'test/fixtures/custom-serializers',
   })
 
-  expect(stdout).toContain('✓ custom-serializers.test.ts >')
+  expect(stdout).toContain('✓ custom-serializers.test.ts (1)')
   expect(stderr).toBe('')
 })

--- a/test/snapshots/test/custom-serializers.test.ts
+++ b/test/snapshots/test/custom-serializers.test.ts
@@ -6,6 +6,6 @@ test('it should pass', async () => {
     root: 'test/fixtures/custom-serializers',
   })
 
-  expect(stdout).toContain('✓ custom-serializers.test.ts (1)')
+  expect(stdout).toContain('✓ custom-serializers.test.ts')
   expect(stderr).toBe('')
 })


### PR DESCRIPTION
### Description

I noticed `pnpm -C test/snapshots test` is failing locally and it looks like this one has been excluded on ci because `pnpm test:ci` filters only `@vitest/test-*` packages.

I added this back in by renaming it to `@vitest/test-snapshots` and also updated a failing test.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
