### PR TITLE
fix: Align RawMatcherFn type definition with Jest

### DIFF
--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -75,7 +75,6 @@ function JestExtendPlugin(
         ) {
           const { state, isNot, obj } = getMatcherState(this, expect)
 
-          // @ts-expect-error args wanting tuple
           const result = expectAssertion.call(state, obj, ...args)
 
           if (

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -85,7 +85,7 @@ export type AsyncExpectationResult = Promise<SyncExpectationResult>
 export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult
 
 export interface RawMatcherFn<T extends MatcherState = MatcherState> {
-  (this: T, received: any, expected: any, options?: any): ExpectationResult
+  (this: T, received: any, ...expected: Array<any>): ExpectationResult
 }
 
 export type MatchersObject<T extends MatcherState = MatcherState> = Record<


### PR DESCRIPTION
Might fix https://github.com/vitest-dev/vitest/issues/6350

### Description

Copied the typedef from jest, which is a better reflection of the fact vitest does actually use spread

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] ~Ideally, include a test that fails without this PR but passes with it.~ N/A - change to types, not implementation
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] ~Run the tests with `pnpm test:ci`.~ N/A - change to types, not implementation

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
