### PR TITLE
remove fauly `only test()` warning from `soft`

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -55,10 +55,6 @@ test('expect.soft test', () => {
 })
 ```
 
-::: warning
-`expect.soft` can only be used inside the [`test`](/api/#test) function.
-:::
-
 ## poll
 
 - **Type:** `ExpectStatic & (actual: () => any, options: { interval, timeout, message }) => Assertions`


### PR DESCRIPTION
### Description

The warning stated that `expect.soft` can only be used in `test()` and not `it()`. That is invalid/outdated

Originally mentioned on discord here:
https://discord.com/channels/917386801235247114/1273883385265127434/1273921157955059743

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
