### PR TITLE
feat(api): make spec into a class instead of a tuple

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -16,10 +16,6 @@ export async function createBrowserServer(
 ) {
   const server = new BrowserServer(project, '/')
 
-  const root = project.config.root
-
-  await project.ctx.packageInstaller.ensureInstalled('@vitest/browser', root)
-
   const configPath = typeof configFile === 'string' ? configFile : false
 
   const vite = await createServer({

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -102,14 +102,14 @@ export function setup(ctx: Vitest, _server?: ViteDevServer) {
           return ctx.state.getUnhandledErrors()
         },
         async getTestFiles() {
-          const spec = await ctx.globTestFiles()
-          return spec.map(([project, file, options]) => [
+          const spec = await ctx.globTestSpecs()
+          return spec.map(spec => [
             {
-              name: project.config.name,
-              root: project.config.root,
+              name: spec.project.config.name,
+              root: spec.project.config.root,
             },
-            file,
-            options,
+            spec.moduleId,
+            { pool: spec.pool },
           ])
         },
       },

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -17,8 +17,8 @@ import { WebSocketReporter } from '../api/setup'
 import type { SerializedCoverageConfig } from '../runtime/config'
 import type { SerializedSpec } from '../runtime/types/utils'
 import type { ArgumentsType, OnServerRestartHandler, ProvidedContext, UserConsoleLog } from '../types/general'
-import type { ProcessPool } from './pool'
-import { WorkspaceSpec, createPool, getFilePoolName } from './pool'
+import type { ProcessPool, WorkspaceSpec } from './pool'
+import { createPool, getFilePoolName } from './pool'
 import { createBenchmarkReporters, createReporters } from './reporters/utils'
 import { StateManager } from './state'
 import { resolveConfig } from './config/resolveConfig'
@@ -531,10 +531,10 @@ export class Vitest {
     for (const project of this.projects) {
       if (project.isTestFile(file)) {
         const pool = getFilePoolName(project, file)
-        specs.push(new WorkspaceSpec(project, file, pool))
+        specs.push(project.createSpec(file, pool))
       }
       if (project.isTypecheckFile(file)) {
-        specs.push(new WorkspaceSpec(project, file, 'typescript'))
+        specs.push(project.createSpec(file, 'typescript'))
       }
     }
     specs.forEach(spec => this.ensureSpecCached(spec))
@@ -1092,12 +1092,12 @@ export class Vitest {
       const { testFiles, typecheckTestFiles } = await project.globTestFiles(filters)
       testFiles.forEach((file) => {
         const pool = getFilePoolName(project, file)
-        const spec = new WorkspaceSpec(project, file, pool)
+        const spec = project.createSpec(file, pool)
         this.ensureSpecCached(spec)
         files.push(spec)
       })
       typecheckTestFiles.forEach((file) => {
-        const spec = new WorkspaceSpec(project, file, 'typescript')
+        const spec = project.createSpec(file, 'typescript')
         this.ensureSpecCached(spec)
         files.push(spec)
       })

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -9,9 +9,22 @@ import { createVmThreadsPool } from './pools/vmThreads'
 import type { WorkspaceProject } from './workspace'
 import { createTypecheckPool } from './pools/typecheck'
 import { createVmForksPool } from './pools/vmForks'
-import { WorkspaceSpec } from './spec'
+import type { WorkspaceSpec as _WorkspaceSpec } from './spec'
 
-export { WorkspaceSpec }
+export type WorkspaceSpec = _WorkspaceSpec & [
+  /**
+   * @deprecated use spec.project instead
+   */
+  project: WorkspaceProject,
+  /**
+   * @deprecated use spec.moduleId instead
+   */
+  file: string,
+  /**
+   * @deprecated use spec.pool instead
+   */
+  options: { pool: Pool },
+]
 
 export type RunWithFiles = (
   files: WorkspaceSpec[],

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -9,8 +9,10 @@ import { createVmThreadsPool } from './pools/vmThreads'
 import type { WorkspaceProject } from './workspace'
 import { createTypecheckPool } from './pools/typecheck'
 import { createVmForksPool } from './pools/vmForks'
+import { WorkspaceSpec } from './spec'
 
-export type WorkspaceSpec = [project: WorkspaceProject, testFile: string, options: { pool: Pool }]
+export { WorkspaceSpec }
+
 export type RunWithFiles = (
   files: WorkspaceSpec[],
   invalidates?: string[]

--- a/packages/vitest/src/node/pools/forks.ts
+++ b/packages/vitest/src/node/pools/forks.ts
@@ -166,17 +166,19 @@ export function createForksPool(
       }
 
       const workspaceMap = new Map<string, WorkspaceProject[]>()
-      for (const [project, file] of specs) {
+      for (const spec of specs) {
+        const file = spec.moduleId
+        const project = spec.project.workspaceProject
         const workspaceFiles = workspaceMap.get(file) ?? []
         workspaceFiles.push(project)
         workspaceMap.set(file, workspaceFiles)
       }
 
       const singleFork = specs.filter(
-        ([project]) => project.config.poolOptions?.forks?.singleFork,
+        spec => spec.project.config.poolOptions?.forks?.singleFork,
       )
       const multipleForks = specs.filter(
-        ([project]) => !project.config.poolOptions?.forks?.singleFork,
+        spec => !spec.project.config.poolOptions?.forks?.singleFork,
       )
 
       if (multipleForks.length) {

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -170,10 +170,10 @@ export function createThreadsPool(
       }
 
       const singleThreads = specs.filter(
-        ([project]) => project.config.poolOptions?.threads?.singleThread,
+        spec => spec.project.config.poolOptions?.threads?.singleThread,
       )
       const multipleThreads = specs.filter(
-        ([project]) => !project.config.poolOptions?.threads?.singleThread,
+        spec => !spec.project.config.poolOptions?.threads?.singleThread,
       )
 
       if (multipleThreads.length) {

--- a/packages/vitest/src/node/pools/typecheck.ts
+++ b/packages/vitest/src/node/pools/typecheck.ts
@@ -100,20 +100,20 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
   }
 
   async function collectTests(specs: WorkspaceSpec[]) {
-    const specsByProject = groupBy(specs, ([project]) => project.getName())
+    const specsByProject = groupBy(specs, spec => spec.project.name)
     for (const name in specsByProject) {
-      const project = specsByProject[name][0][0]
-      const files = specsByProject[name].map(([_, file]) => file)
-      const checker = await createWorkspaceTypechecker(project, files)
+      const project = specsByProject[name][0].project
+      const files = specsByProject[name].map(spec => spec.moduleId)
+      const checker = await createWorkspaceTypechecker(project.workspaceProject, files)
       checker.setFiles(files)
       await checker.collectTests()
-      ctx.state.collectFiles(project, checker.getTestFiles())
+      ctx.state.collectFiles(project.workspaceProject, checker.getTestFiles())
       await ctx.report('onCollected')
     }
   }
 
   async function runTests(specs: WorkspaceSpec[]) {
-    const specsByProject = groupBy(specs, ([project]) => project.getName())
+    const specsByProject = groupBy(specs, spec => spec.project.name)
     const promises: Promise<void>[] = []
 
     for (const name in specsByProject) {

--- a/packages/vitest/src/node/sequencers/BaseSequencer.ts
+++ b/packages/vitest/src/node/sequencers/BaseSequencer.ts
@@ -21,7 +21,7 @@ export class BaseSequencer implements TestSequencer {
     const shardEnd = shardSize * index
     return [...files]
       .map((spec) => {
-        const fullPath = resolve(slash(config.root), slash(spec[1]))
+        const fullPath = resolve(slash(config.root), slash(spec.moduleId))
         const specPath = fullPath?.slice(config.root.length)
         return {
           spec,
@@ -37,8 +37,8 @@ export class BaseSequencer implements TestSequencer {
   public async sort(files: WorkspaceSpec[]): Promise<WorkspaceSpec[]> {
     const cache = this.ctx.cache
     return [...files].sort((a, b) => {
-      const keyA = `${a[0].getName()}:${relative(this.ctx.config.root, a[1])}`
-      const keyB = `${b[0].getName()}:${relative(this.ctx.config.root, b[1])}`
+      const keyA = `${a.project.name}:${relative(this.ctx.config.root, a.moduleId)}`
+      const keyB = `${b.project.name}:${relative(this.ctx.config.root, b.moduleId)}`
 
       const aState = cache.getFileTestResults(keyA)
       const bState = cache.getFileTestResults(keyB)

--- a/packages/vitest/src/node/spec.ts
+++ b/packages/vitest/src/node/spec.ts
@@ -20,13 +20,13 @@ export class WorkspaceSpec {
   public readonly project: TestProject
   public readonly moduleId: string
   public readonly pool: Pool
-  public readonly location: WorkspaceSpecLocation | undefined
+  // public readonly location: WorkspaceSpecLocation | undefined
 
   constructor(
     workspaceProject: WorkspaceProject,
     moduleId: string,
     pool: Pool,
-    location?: WorkspaceSpecLocation | undefined,
+    // location?: WorkspaceSpecLocation | undefined,
   ) {
     this[0] = workspaceProject
     this[1] = moduleId
@@ -34,7 +34,7 @@ export class WorkspaceSpec {
     this.project = workspaceProject.testProject
     this.moduleId = moduleId
     this.pool = pool
-    this.location = location
+    // this.location = location
   }
 
   /**
@@ -48,7 +48,7 @@ export class WorkspaceSpec {
   }
 }
 
-interface WorkspaceSpecLocation {
-  start: number
-  end: number
-}
+// interface WorkspaceSpecLocation {
+//   start: number
+//   end: number
+// }

--- a/packages/vitest/src/node/spec.ts
+++ b/packages/vitest/src/node/spec.ts
@@ -1,0 +1,54 @@
+import type { TestProject } from './reported-workspace-project'
+import type { Pool } from './types/pool-options'
+import type { WorkspaceProject } from './workspace'
+
+export class WorkspaceSpec {
+  // backwards compatibility
+  /**
+   * @deprecated
+   */
+  public readonly 0: WorkspaceProject
+  /**
+   * @deprecated
+   */
+  public readonly 1: string
+  /**
+   * @deprecated
+   */
+  public readonly 2: { pool: Pool }
+
+  public readonly project: TestProject
+  public readonly moduleId: string
+  public readonly pool: Pool
+  public readonly location: WorkspaceSpecLocation | undefined
+
+  constructor(
+    workspaceProject: WorkspaceProject,
+    moduleId: string,
+    pool: Pool,
+    location?: WorkspaceSpecLocation | undefined,
+  ) {
+    this[0] = workspaceProject
+    this[1] = moduleId
+    this[2] = { pool }
+    this.project = workspaceProject.testProject
+    this.moduleId = moduleId
+    this.pool = pool
+    this.location = location
+  }
+
+  /**
+   * for backwards compatibility
+   * @deprecated
+   */
+  *[Symbol.iterator]() {
+    yield this.project.workspaceProject
+    yield this.moduleId
+    yield this.pool
+  }
+}
+
+interface WorkspaceSpecLocation {
+  start: number
+  end: number
+}

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -39,6 +39,8 @@ import { CoverageTransform } from './plugins/coverageTransform'
 import { serializeConfig } from './config/serializeConfig'
 import type { Vitest } from './core'
 import { TestProject } from './reported-workspace-project'
+import { WorkspaceSpec } from './spec'
+import type { WorkspaceSpec as DeprecatedWorkspaceSpec } from './pool'
 
 interface InitializeProjectOptions extends UserWorkspaceConfig {
   workspaceConfigPath: string
@@ -149,6 +151,10 @@ export class WorkspaceProject {
       ...this.ctx.getCoreWorkspaceProject().getProvidedContext(),
       ...this._provided,
     }
+  }
+
+  public createSpec(moduleId: string, pool: string): DeprecatedWorkspaceSpec {
+    return new WorkspaceSpec(this, moduleId, pool) as DeprecatedWorkspaceSpec
   }
 
   async initializeGlobalSetup() {

--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -30,7 +30,9 @@ export async function groupFilesByEnv(
   files: Array<WorkspaceSpec>,
 ) {
   const filesWithEnv = await Promise.all(
-    files.map(async ([project, file]) => {
+    files.map(async (spec) => {
+      const file = spec.moduleId
+      const project = spec.project.workspaceProject
       const code = await fs.readFile(file, 'utf-8')
 
       // 1. Check for control comments in the file

--- a/test/core/test/sequencers.test.ts
+++ b/test/core/test/sequencers.test.ts
@@ -1,9 +1,9 @@
-import type { Vitest } from 'vitest'
+import type { Vitest, WorkspaceProject } from 'vitest/node'
 import { describe, expect, test, vi } from 'vitest'
-import type { WorkspaceProject } from 'vitest/node'
 import { RandomSequencer } from '../../../packages/vitest/src/node/sequencers/RandomSequencer'
 import { BaseSequencer } from '../../../packages/vitest/src/node/sequencers/BaseSequencer'
-import type { WorkspaceSpec } from '../../../packages/vitest/src/node/pool'
+import { WorkspaceSpec } from '../../../packages/vitest/src/node/spec'
+import type { WorkspaceSpec as DeprecatedWorkspaceSpec } from '../../../packages/vitest/src/node/pool'
 
 function buildCtx() {
   return {
@@ -26,7 +26,7 @@ function buildWorkspace() {
 const workspace = buildWorkspace()
 
 function workspaced(files: string[]) {
-  return files.map(file => [workspace, file, { pool: 'forks' }] satisfies WorkspaceSpec)
+  return files.map(file => new WorkspaceSpec(workspace, file, 'forks')) as DeprecatedWorkspaceSpec[]
 }
 
 describe('base sequencer', () => {

--- a/test/core/test/sequencers.test.ts
+++ b/test/core/test/sequencers.test.ts
@@ -19,7 +19,9 @@ function buildCtx() {
 
 function buildWorkspace() {
   return {
-    getName: () => 'test',
+    testProject: {
+      name: 'test',
+    },
   } as any as WorkspaceProject
 }
 


### PR DESCRIPTION
### Description

This PR replaces public `WorkspaceSpec` with a class implementation, but keeps `0, 1, 2` and `Symbol.iterator` for backward compatibility. It will be removed in Vitest 3.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
