### PR TITLE
refactor(api): rename TestFile to TestModule

### DIFF
--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -13,6 +13,8 @@ import type { BaseOptions, BaseReporter } from './base'
 import type { HTMLOptions } from './html'
 import type { BlobOptions } from './blob'
 import { BlobReporter } from './blob'
+import { TestModule as _TestFile } from './reported-tasks'
+import type { ModuleDiagnostic as _FileDiagnostic } from './reported-tasks'
 
 export {
   DefaultReporter,
@@ -28,20 +30,27 @@ export {
 }
 export type { BaseReporter, Reporter }
 
-export { TestCase, TestFile, TestSuite } from './reported-tasks'
+export { TestCase, TestModule, TestSuite } from './reported-tasks'
+/**
+ * @deprecated Use `TestModule` instead
+ */
+export const TestFile = _TestFile
 export type { TestProject } from '../reported-workspace-project'
 export type {
   TestCollection,
 
   TaskOptions,
   TestDiagnostic,
-  FileDiagnostic,
 
   TestResult,
   TestResultFailed,
   TestResultPassed,
   TestResultSkipped,
 } from './reported-tasks'
+/**
+ * @deprecated Use `ModuleDiagnostic` instead
+ */
+export type FileDiagnostic = _FileDiagnostic
 
 export type {
   JsonAssertionResult,

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -468,16 +468,16 @@ export interface ModuleDiagnostic {
    */
   prepareDuration: number
   /**
-   * The time it takes to import the test file.
-   * This includes importing everything in the file and executing suite callbacks.
+   * The time it takes to import the test module.
+   * This includes importing everything in the module and executing suite callbacks.
    */
   collectDuration: number
   /**
-   * The time it takes to import the setup file.
+   * The time it takes to import the setup module.
    */
   setupDuration: number
   /**
-   * Accumulated duration of all tests and hooks in the file.
+   * Accumulated duration of all tests and hooks in the module.
    */
   duration: number
 }

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -26,12 +26,12 @@ class ReportedTaskImplementation {
   /**
    * Unique identifier.
    * This ID is deterministic and will be the same for the same test across multiple runs.
-   * The ID is based on the project name, file path and test position.
+   * The ID is based on the project name, module url and test position.
    */
   public readonly id: string
 
   /**
-   * Location in the file where the test or suite is defined.
+   * Location in the module where the test or suite is defined.
    */
   public readonly location: { line: number; column: number } | undefined
 
@@ -49,7 +49,7 @@ class ReportedTaskImplementation {
    * Creates a new reported task instance and stores it in the project's state for future use.
    */
   static register(task: RunnerTask, project: WorkspaceProject) {
-    const state = new this(task, project) as TestCase | TestSuite | TestFile
+    const state = new this(task, project) as TestCase | TestSuite | TestModule
     storeTask(project, task, state)
     return state
   }
@@ -62,9 +62,9 @@ export class TestCase extends ReportedTaskImplementation {
   public readonly type = 'test'
 
   /**
-   * Direct reference to the test file where the test or suite is defined.
+   * Direct reference to the test module where the test or suite is defined.
    */
-  public readonly file: TestFile
+  public readonly module: TestModule
 
   /**
    * Name of the test.
@@ -77,21 +77,21 @@ export class TestCase extends ReportedTaskImplementation {
   public readonly options: TaskOptions
 
   /**
-   * Parent suite. If the test was called directly inside the file, the parent will be the file.
+   * Parent suite. If the test was called directly inside the module, the parent will be the module itself.
    */
-  public readonly parent: TestSuite | TestFile
+  public readonly parent: TestSuite | TestModule
 
   protected constructor(task: RunnerTestCase | RunnerCustomCase, project: WorkspaceProject) {
     super(task, project)
 
     this.name = task.name
-    this.file = getReportedTask(project, task.file) as TestFile
+    this.module = getReportedTask(project, task.file) as TestModule
     const suite = this.task.suite
     if (suite) {
       this.parent = getReportedTask(project, suite) as TestSuite
     }
     else {
-      this.parent = this.file
+      this.parent = this.module
     }
     this.options = buildOptions(task)
   }
@@ -294,14 +294,14 @@ export class TestSuite extends SuiteImplementation {
   public readonly name: string
 
   /**
-   * Direct reference to the test file where the test or suite is defined.
+   * Direct reference to the test module where the test or suite is defined.
    */
-  public readonly file: TestFile
+  public readonly module: TestModule
 
   /**
-   * Parent suite. If suite was called directly inside the file, the parent will be the file.
+   * Parent suite. If suite was called directly inside the module, the parent will be the module itself.
    */
-  public readonly parent: TestSuite | TestFile
+  public readonly parent: TestSuite | TestModule
 
   /**
    * Options that suite was initiated with.
@@ -312,13 +312,13 @@ export class TestSuite extends SuiteImplementation {
     super(task, project)
 
     this.name = task.name
-    this.file = getReportedTask(project, task.file) as TestFile
+    this.module = getReportedTask(project, task.file) as TestModule
     const suite = this.task.suite
     if (suite) {
       this.parent = getReportedTask(project, suite) as TestSuite
     }
     else {
-      this.parent = this.file
+      this.parent = this.module
     }
     this.options = buildOptions(task)
   }
@@ -334,10 +334,10 @@ export class TestSuite extends SuiteImplementation {
   }
 }
 
-export class TestFile extends SuiteImplementation {
+export class TestModule extends SuiteImplementation {
   declare public readonly task: RunnerTestFile
   declare public readonly location: undefined
-  public readonly type = 'file'
+  public readonly type = 'module'
 
   /**
    * This is usually an absolute UNIX file path.
@@ -352,10 +352,10 @@ export class TestFile extends SuiteImplementation {
   }
 
   /**
-   * Useful information about the file like duration, memory usage, etc.
-   * If the file was not executed yet, all diagnostic values will return `0`.
+   * Useful information about the module like duration, memory usage, etc.
+   * If the module was not executed yet, all diagnostic values will return `0`.
    */
-  public diagnostic(): FileDiagnostic {
+  public diagnostic(): ModuleDiagnostic {
     const setupDuration = this.task.setupDuration || 0
     const collectDuration = this.task.collectDuration || 0
     const prepareDuration = this.task.prepareDuration || 0
@@ -458,7 +458,7 @@ export interface TestDiagnostic {
   flaky: boolean
 }
 
-export interface FileDiagnostic {
+export interface ModuleDiagnostic {
   /**
    * The time it takes to import and initiate an environment.
    */
@@ -487,11 +487,11 @@ function getTestState(test: TestCase): TestResult['state'] | 'running' {
   return result ? result.state : 'running'
 }
 
-function storeTask(project: WorkspaceProject, runnerTask: RunnerTask, reportedTask: TestCase | TestSuite | TestFile): void {
+function storeTask(project: WorkspaceProject, runnerTask: RunnerTask, reportedTask: TestCase | TestSuite | TestModule): void {
   project.ctx.state.reportedTasksMap.set(runnerTask, reportedTask)
 }
 
-function getReportedTask(project: WorkspaceProject, runnerTask: RunnerTask): TestCase | TestSuite | TestFile {
+function getReportedTask(project: WorkspaceProject, runnerTask: RunnerTask): TestCase | TestSuite | TestModule {
   const reportedTask = project.ctx.state.getReportedEntity(runnerTask)
   if (!reportedTask) {
     throw new Error(`Task instance was not found for ${runnerTask.type} "${runnerTask.name}"`)

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -380,7 +380,9 @@ export interface TaskOptions {
   mode: 'run' | 'only' | 'skip' | 'todo'
 }
 
-function buildOptions(task: RunnerTestCase | RunnerCustomCase | RunnerTestFile | RunnerTestSuite): TaskOptions {
+function buildOptions(
+  task: RunnerTestCase | RunnerCustomCase | RunnerTestFile | RunnerTestSuite,
+): TaskOptions {
   return {
     each: task.each,
     concurrent: task.concurrent,
@@ -487,14 +489,23 @@ function getTestState(test: TestCase): TestResult['state'] | 'running' {
   return result ? result.state : 'running'
 }
 
-function storeTask(project: WorkspaceProject, runnerTask: RunnerTask, reportedTask: TestCase | TestSuite | TestModule): void {
+function storeTask(
+  project: WorkspaceProject,
+  runnerTask: RunnerTask,
+  reportedTask: TestCase | TestSuite | TestModule,
+): void {
   project.ctx.state.reportedTasksMap.set(runnerTask, reportedTask)
 }
 
-function getReportedTask(project: WorkspaceProject, runnerTask: RunnerTask): TestCase | TestSuite | TestModule {
+function getReportedTask(
+  project: WorkspaceProject,
+  runnerTask: RunnerTask,
+): TestCase | TestSuite | TestModule {
   const reportedTask = project.ctx.state.getReportedEntity(runnerTask)
   if (!reportedTask) {
-    throw new Error(`Task instance was not found for ${runnerTask.type} "${runnerTask.name}"`)
+    throw new Error(
+      `Task instance was not found for ${runnerTask.type} "${runnerTask.name}"`,
+    )
   }
   return reportedTask
 }

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -3,7 +3,7 @@ import { createFileTask } from '@vitest/runner/utils'
 import type { AggregateError as AggregateErrorPonyfill } from '../utils/base'
 import type { UserConsoleLog } from '../types/general'
 import type { WorkspaceProject } from './workspace'
-import { TestCase, TestFile, TestSuite } from './reporters/reported-tasks'
+import { TestCase, TestModule, TestSuite } from './reporters/reported-tasks'
 
 export function isAggregateError(err: unknown): err is AggregateErrorPonyfill {
   if (typeof AggregateError !== 'undefined' && err instanceof AggregateError) {
@@ -20,7 +20,7 @@ export class StateManager {
   taskFileMap = new WeakMap<Task, File>()
   errorsSet = new Set<unknown>()
   processTimeoutCauses = new Set<string>()
-  reportedTasksMap = new WeakMap<Task, TestCase | TestFile | TestSuite>()
+  reportedTasksMap = new WeakMap<Task, TestCase | TestSuite | TestModule>()
 
   catchError(err: unknown, type: string): void {
     if (isAggregateError(err)) {
@@ -138,7 +138,7 @@ export class StateManager {
         project.config.name,
       )
       fileTask.local = true
-      TestFile.register(fileTask, project)
+      TestModule.register(fileTask, project)
       this.idMap.set(fileTask.id, fileTask)
       if (!files) {
         this.filesMap.set(path, [fileTask])
@@ -163,7 +163,7 @@ export class StateManager {
     }
 
     if (task.type === 'suite' && 'filepath' in task) {
-      TestFile.register(task, project)
+      TestModule.register(task, project)
     }
     else if (task.type === 'suite') {
       TestSuite.register(task, project)

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -1,3 +1,6 @@
+import { TestModule as _TestFile } from '../node/reporters/reported-tasks'
+import type { ModuleDiagnostic as _FileDiagnostic } from '../node/reporters/reported-tasks'
+
 export type { Vitest } from '../node/core'
 export type { WorkspaceProject } from '../node/workspace'
 export { createVitest } from '../node/create'
@@ -48,19 +51,28 @@ export type { HTMLOptions } from '../node/reporters/html'
 export { isFileServingAllowed, createServer, parseAst, parseAstAsync } from 'vite'
 export type * as Vite from 'vite'
 
-export { TestCase, TestFile, TestSuite } from '../node/reporters/reported-tasks'
+export { TestCase, TestModule, TestSuite } from '../node/reporters/reported-tasks'
+/**
+ * @deprecated Use `TestModule` instead
+ */
+export const TestFile = _TestFile
 export { TestProject } from '../node/reported-workspace-project'
 export type {
   TestCollection,
 
   TaskOptions,
   TestDiagnostic,
-  FileDiagnostic,
+  ModuleDiagnostic,
   TestResult,
   TestResultPassed,
   TestResultFailed,
   TestResultSkipped,
 } from '../node/reporters/reported-tasks'
+
+/**
+ * @deprecated Use `ModuleDiagnostic` instead
+ */
+export type FileDiagnostic = _FileDiagnostic
 
 export type {
   SequenceHooks,

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -1,18 +1,18 @@
 import { beforeAll, expect, it } from 'vitest'
 import { resolve } from 'pathe'
-import type { File } from 'vitest'
+import type { RunnerTestFile } from 'vitest'
 import type { StateManager } from 'vitest/src/node/state.js'
 import type { WorkspaceProject } from 'vitest/node'
 import { runVitest } from '../../test-utils'
-import type { TestCase, TestCollection, TestFile } from '../../../packages/vitest/src/node/reporters/reported-tasks'
+import type { TestCase, TestCollection, TestModule } from '../../../packages/vitest/src/node/reporters/reported-tasks'
 
 const now = new Date()
 // const finishedFiles: File[] = []
-const collectedFiles: File[] = []
+const collectedFiles: RunnerTestFile[] = []
 let state: StateManager
 let project: WorkspaceProject
-let files: File[]
-let testFile: TestFile
+let files: RunnerTestFile[]
+let testModule: TestModule
 
 beforeAll(async () => {
   const { ctx } = await runVitest({
@@ -36,37 +36,37 @@ beforeAll(async () => {
   project = ctx!.getCoreWorkspaceProject()
   files = state.getFiles()
   expect(files).toHaveLength(1)
-  testFile = state.getReportedEntity(files[0])! as TestFile
-  expect(testFile).toBeDefined()
+  testModule = state.getReportedEntity(files[0])! as TestModule
+  expect(testModule).toBeDefined()
 })
 
 it('correctly reports a file', () => {
   // suite properties not available on file
-  expect(testFile).not.toHaveProperty('parent')
-  expect(testFile).not.toHaveProperty('options')
-  expect(testFile).not.toHaveProperty('file')
-  expect(testFile).not.toHaveProperty('fullName')
-  expect(testFile).not.toHaveProperty('name')
+  expect(testModule).not.toHaveProperty('parent')
+  expect(testModule).not.toHaveProperty('options')
+  expect(testModule).not.toHaveProperty('file')
+  expect(testModule).not.toHaveProperty('fullName')
+  expect(testModule).not.toHaveProperty('name')
 
-  expect(testFile.type).toBe('file')
-  expect(testFile.task).toBe(files[0])
-  expect(testFile.id).toBe(files[0].id)
-  expect(testFile.location).toBeUndefined()
-  expect(testFile.moduleId).toBe(resolve('./fixtures/reported-tasks/1_first.test.ts'))
-  expect(testFile.project.workspaceProject).toBe(project)
-  expect(testFile.children.size).toBe(14)
+  expect(testModule.type).toBe('file')
+  expect(testModule.task).toBe(files[0])
+  expect(testModule.id).toBe(files[0].id)
+  expect(testModule.location).toBeUndefined()
+  expect(testModule.moduleId).toBe(resolve('./fixtures/reported-tasks/1_first.test.ts'))
+  expect(testModule.project.workspaceProject).toBe(project)
+  expect(testModule.children.size).toBe(14)
 
-  const tests = [...testFile.children.tests()]
+  const tests = [...testModule.children.tests()]
   expect(tests).toHaveLength(11)
-  const deepTests = [...testFile.children.allTests()]
+  const deepTests = [...testModule.children.allTests()]
   expect(deepTests).toHaveLength(19)
 
-  const suites = [...testFile.children.suites()]
+  const suites = [...testModule.children.suites()]
   expect(suites).toHaveLength(3)
-  const deepSuites = [...testFile.children.allSuites()]
+  const deepSuites = [...testModule.children.allSuites()]
   expect(deepSuites).toHaveLength(4)
 
-  const diagnostic = testFile.diagnostic()
+  const diagnostic = testModule.diagnostic()
   expect(diagnostic).toBeDefined()
   expect(diagnostic.environmentSetupDuration).toBeGreaterThan(0)
   expect(diagnostic.prepareDuration).toBeGreaterThan(0)
@@ -77,13 +77,13 @@ it('correctly reports a file', () => {
 })
 
 it('correctly reports a passed test', () => {
-  const passedTest = findTest(testFile.children, 'runs a test')
+  const passedTest = findTest(testModule.children, 'runs a test')
   expect(passedTest.type).toBe('test')
   expect(passedTest.task).toBe(files[0].tasks[0])
   expect(passedTest.name).toBe('runs a test')
   expect(passedTest.fullName).toBe('runs a test')
-  expect(passedTest.file).toBe(testFile)
-  expect(passedTest.parent).toBe(testFile)
+  expect(passedTest.module).toBe(testModule)
+  expect(passedTest.parent).toBe(testModule)
   expect(passedTest.options).toEqual({
     each: undefined,
     concurrent: undefined,
@@ -110,13 +110,13 @@ it('correctly reports a passed test', () => {
 })
 
 it('correctly reports failed test', () => {
-  const passedTest = findTest(testFile.children, 'fails a test')
+  const passedTest = findTest(testModule.children, 'fails a test')
   expect(passedTest.type).toBe('test')
   expect(passedTest.task).toBe(files[0].tasks[1])
   expect(passedTest.name).toBe('fails a test')
   expect(passedTest.fullName).toBe('fails a test')
-  expect(passedTest.file).toBe(testFile)
-  expect(passedTest.parent).toBe(testFile)
+  expect(passedTest.module).toBe(testModule)
+  expect(passedTest.parent).toBe(testModule)
   expect(passedTest.options).toEqual({
     each: undefined,
     concurrent: undefined,
@@ -157,7 +157,7 @@ it('correctly reports failed test', () => {
 })
 
 it('correctly reports multiple failures', () => {
-  const testCase = findTest(testFile.children, 'fails multiple times')
+  const testCase = findTest(testModule.children, 'fails multiple times')
   const result = testCase.result()!
   expect(result).toBeDefined()
   expect(result.state).toBe('failed')
@@ -171,26 +171,26 @@ it('correctly reports multiple failures', () => {
 })
 
 it('correctly reports test assigned options', () => {
-  const testOptionSkip = findTest(testFile.children, 'skips an option test')
+  const testOptionSkip = findTest(testModule.children, 'skips an option test')
   expect(testOptionSkip.options.mode).toBe('skip')
-  const testModifierSkip = findTest(testFile.children, 'skips a .modifier test')
+  const testModifierSkip = findTest(testModule.children, 'skips a .modifier test')
   expect(testModifierSkip.options.mode).toBe('skip')
 
-  const testOptionTodo = findTest(testFile.children, 'todos an option test')
+  const testOptionTodo = findTest(testModule.children, 'todos an option test')
   expect(testOptionTodo.options.mode).toBe('todo')
-  const testModifierTodo = findTest(testFile.children, 'todos a .modifier test')
+  const testModifierTodo = findTest(testModule.children, 'todos a .modifier test')
   expect(testModifierTodo.options.mode).toBe('todo')
 })
 
 it('correctly reports retried tests', () => {
-  const testRetry = findTest(testFile.children, 'retries a test')
+  const testRetry = findTest(testModule.children, 'retries a test')
   expect(testRetry.options.retry).toBe(5)
   expect(testRetry.options.repeats).toBeUndefined()
   expect(testRetry.result()!.state).toBe('failed')
 })
 
 it('correctly reports flaky tests', () => {
-  const testFlaky = findTest(testFile.children, 'retries a test with success')
+  const testFlaky = findTest(testModule.children, 'retries a test with success')
   const diagnostic = testFlaky.diagnostic()!
   expect(diagnostic.flaky).toBe(true)
   expect(diagnostic.retryCount).toBe(2)
@@ -201,7 +201,7 @@ it('correctly reports flaky tests', () => {
 })
 
 it('correctly reports repeated tests', () => {
-  const testRepeated = findTest(testFile.children, 'repeats a test')
+  const testRepeated = findTest(testModule.children, 'repeats a test')
   const diagnostic = testRepeated.diagnostic()!
   expect(diagnostic.flaky).toBe(false)
   expect(diagnostic.retryCount).toBe(0)
@@ -212,7 +212,7 @@ it('correctly reports repeated tests', () => {
 })
 
 it('correctly passed down metadata', () => {
-  const testMetadata = findTest(testFile.children, 'registers a metadata')
+  const testMetadata = findTest(testModule.children, 'registers a metadata')
   const meta = testMetadata.meta()
   expect(meta).toHaveProperty('key', 'value')
 })

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -44,11 +44,11 @@ it('correctly reports a file', () => {
   // suite properties not available on file
   expect(testModule).not.toHaveProperty('parent')
   expect(testModule).not.toHaveProperty('options')
-  expect(testModule).not.toHaveProperty('file')
+  expect(testModule).not.toHaveProperty('module')
   expect(testModule).not.toHaveProperty('fullName')
   expect(testModule).not.toHaveProperty('name')
 
-  expect(testModule.type).toBe('file')
+  expect(testModule.type).toBe('module')
   expect(testModule.task).toBe(files[0])
   expect(testModule.id).toBe(files[0].id)
   expect(testModule.location).toBeUndefined()


### PR DESCRIPTION
### Description

This PR renames the reported task class `TestFile` to `TestModule`. This is done to potentially support virtual tests in the future.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
