### PR TITLE
feat: `spy.mockRevert`

### DIFF
--- a/docs/api/mock.md
+++ b/docs/api/mock.md
@@ -271,7 +271,7 @@ Reverting a mock from `vi.spyOn(object, property)` will **not** restore the orig
 Note that reverting a mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
 Reverting a mock from `vi.fn(impl)` will set implementation to `impl`.
 
-If you want this method to be called before each test automatically, you can enable [`revertMocks`](/config/#revertMocks) setting in config.
+If you want this method to be called before each test automatically, you can enable [`revertMocks`](/config/#revertmocks) setting in config.
 
 ## mock.calls
 

--- a/docs/api/mock.md
+++ b/docs/api/mock.md
@@ -177,7 +177,10 @@ If you want this method to be called before each test automatically, you can ena
 
 Does what `mockReset` does and restores inner implementation to the original function.
 
-Note that restoring mock from `vi.fn()` will set implementation to an empty function that returns `undefined`. Restoring a `vi.fn(impl)` will restore implementation to `impl`.
+Restoring a mock from `vi.spyOn(object, property)` will also restore the original descriptor of the spied-on object.
+
+Note that restoring a mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
+Restoring a mock from `vi.fn(impl)` will set implementation to `impl`.
 
 If you want this method to be called before each test automatically, you can enable [`restoreMocks`](/config/#restoremocks) setting in config.
 
@@ -256,6 +259,19 @@ const myMockFn = vi
 // 'first call', 'second call', 'default', 'default'
 console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn())
 ```
+
+## mockRevert
+
+- **Type:** `() => MockInstance`
+
+Does what `mockReset` does and reverts inner implementation to the original function.
+
+Reverting a mock from `vi.spyOn(object, property)` will **not** restore the original descriptor of the spied-on object.
+
+Note that reverting a mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
+Reverting a mock from `vi.fn(impl)` will set implementation to `impl`.
+
+If you want this method to be called before each test automatically, you can enable [`revertMocks`](/config/#revertMocks) setting in config.
 
 ## mock.calls
 

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -400,7 +400,7 @@ This will clear mock history, restore each implementation to its original, and r
 
 ### vi.revertAllMocks
 
-Calls [`.mockRevert()`](/api/mock#mockrevert) on all spies before each test.
+Calls [`.mockRevert()`](/api/mock#mockrevert) on all spies.
 This will clear mock history and revert each implementation to its original without restoring original descriptors of spied-on objects.
 
 ### vi.spyOn

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -385,15 +385,23 @@ Checks that a given parameter is a mock function. If you are using TypeScript, i
 
 ### vi.clearAllMocks
 
-Will call [`.mockClear()`](/api/mock#mockclear) on all spies. This will clear mock history, but not reset its implementation to the default one.
+Calls [`.mockClear()`](/api/mock#mockclear) on all spies.
+This will clear mock history without affecting mock implementations.
 
 ### vi.resetAllMocks
 
-Will call [`.mockReset()`](/api/mock#mockreset) on all spies. This will clear mock history and reset its implementation to an empty function (will return `undefined`).
+Calls [`.mockReset()`](/api/mock#mockreset) on all spies.
+This will clear mock history and reset each implementation to an empty function (will return `undefined`).
 
 ### vi.restoreAllMocks
 
-Will call [`.mockRestore()`](/api/mock#mockrestore) on all spies. This will clear mock history and reset its implementation to the original one.
+Calls [`.mockRestore()`](/api/mock#mockrestore) on all spies.
+This will clear mock history, restore each implementation to their original, and restore original descriptors of spied-on objects.
+
+### vi.revertAllMocks
+
+Calls [`.mockRevert()`](/api/mock#mockrevert) on all spies before each test.
+This will clear mock history and revert each implementation to their original without restoring original descriptors of spied-on objects.
 
 ### vi.spyOn
 

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -396,12 +396,12 @@ This will clear mock history and reset each implementation to an empty function 
 ### vi.restoreAllMocks
 
 Calls [`.mockRestore()`](/api/mock#mockrestore) on all spies.
-This will clear mock history, restore each implementation to their original, and restore original descriptors of spied-on objects.
+This will clear mock history, restore each implementation to its original, and restore original descriptors of spied-on objects.
 
 ### vi.revertAllMocks
 
 Calls [`.mockRevert()`](/api/mock#mockrevert) on all spies before each test.
-This will clear mock history and revert each implementation to their original without restoring original descriptors of spied-on objects.
+This will clear mock history and revert each implementation to its original without restoring original descriptors of spied-on objects.
 
 ### vi.spyOn
 
@@ -425,7 +425,7 @@ expect(spy).toHaveReturnedWith(1)
 ```
 
 ::: tip
-You can call [`vi.restoreAllMocks`](#vi-restoreallmocks) inside [`afterEach`](/api/#aftereach) (or enable [`test.restoreMocks`](/config/#restoreMocks)) to restore all methods to their original implementations. This will restore the original [object descriptor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty), so you won't be able to change method's implementation:
+You can call [`vi.restoreAllMocks`](#vi-restoreallmocks) inside [`afterEach`](/api/#aftereach) (or enable [`test.restoreMocks`](/config/#restoreMocks)) to restore all methods to its original implementations. This will restore the original [object descriptor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty), so you won't be able to change method's implementation:
 
 ```ts
 const cart = {

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1830,7 +1830,7 @@ This will clear mock history and reset each implementation to an empty function 
 Will call [`.mockRestore()`](/api/mock#mockrestore) on all spies before each test.
 This will clear mock history, restore each implementation to its original, and restore original descriptors of spied-on objects.
 
-## revertMocks
+### revertMocks
 
 - **Type:** `boolean`
 - **Default:** `false`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1811,21 +1811,32 @@ Custom [commands](/guide/browser/commands) that can be imported during browser t
 - **Type:** `boolean`
 - **Default:** `false`
 
-Will call [`.mockClear()`](/api/mock#mockclear) on all spies before each test. This will clear mock history, but not reset its implementation to the default one.
+Will call [`.mockClear()`](/api/mock#mockclear) on all spies before each test.
+This will clear mock history without affecting mock implementations.
 
 ### mockReset
 
 - **Type:** `boolean`
 - **Default:** `false`
 
-Will call [`.mockReset()`](/api/mock#mockreset) on all spies before each test. This will clear mock history and reset its implementation to an empty function (will return `undefined`).
+Will call [`.mockReset()`](/api/mock#mockreset) on all spies before each test.
+This will clear mock history and reset each implementation to an empty function (will return `undefined`).
 
 ### restoreMocks
 
 - **Type:** `boolean`
 - **Default:** `false`
 
-Will call [`.mockRestore()`](/api/mock#mockrestore) on all spies before each test. This will clear mock history and reset its implementation to the original one.
+Will call [`.mockRestore()`](/api/mock#mockrestore) on all spies before each test.
+This will clear mock history, restore each implementation to their original, and restore original descriptors of spied-on objects.
+
+## revertMocks
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Will call [`.mockRevert()`](/api/mock#mockrevert) on all spies before each test.
+This will clear mock history and revert each implementation to their original without restoring original descriptors of spied-on objects.
 
 ### unstubEnvs {#unstubenvs}
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1828,7 +1828,7 @@ This will clear mock history and reset each implementation to an empty function 
 - **Default:** `false`
 
 Will call [`.mockRestore()`](/api/mock#mockrestore) on all spies before each test.
-This will clear mock history, restore each implementation to their original, and restore original descriptors of spied-on objects.
+This will clear mock history, restore each implementation to its original, and restore original descriptors of spied-on objects.
 
 ## revertMocks
 
@@ -1836,7 +1836,7 @@ This will clear mock history, restore each implementation to their original, and
 - **Default:** `false`
 
 Will call [`.mockRevert()`](/api/mock#mockrevert) on all spies before each test.
-This will clear mock history and revert each implementation to their original without restoring original descriptors of spied-on objects.
+This will clear mock history and revert each implementation to its original without restoring original descriptors of spied-on objects.
 
 ### unstubEnvs {#unstubenvs}
 

--- a/packages/mocker/src/automocker.ts
+++ b/packages/mocker/src/automocker.ts
@@ -120,7 +120,7 @@ export function mockObject(
                 const original = this[key]
                 const mock = spyOn(this, key as string)
                   .mockImplementation(original)
-                mock.mockRestore = () => {
+                mock.mockRevert = mock.mockRestore = () => {
                   mock.mockReset()
                   mock.mockImplementation(original)
                   return mock
@@ -132,7 +132,7 @@ export function mockObject(
         const mock = spyOn(newContainer, property)
         if (options.type === 'automock') {
           mock.mockImplementation(mockFunction)
-          mock.mockRestore = () => {
+          mock.mockRevert = mock.mockRestore = () => {
             mock.mockReset()
             mock.mockImplementation(mockFunction)
             return mock

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -185,20 +185,51 @@ export interface MockInstance<T extends Procedure = Procedure> {
    * Clears all information about every call. After calling it, all properties on `.mock` will return an empty state. This method does not reset implementations.
    *
    * It is useful if you need to clean up mock between different assertions.
+   *
+   * @see mockReset
+   * @see mockRestore
+   * @see mockRevert
    */
   mockClear(): this
   /**
-   * Does what `mockClear` does and makes inner implementation an empty function (returning `undefined` when invoked). This also resets all "once" implementations.
+   * Does what `mockClear` does and makes inner implementation an empty function (returning `undefined` when invoked).
+   * This also resets all "once" implementations.
    *
    * This is useful when you want to completely reset a mock to the default state.
+   *
+   * @see mockClear
+   * @see mockRestore
+   * @see mockRevert
    */
   mockReset(): this
   /**
    * Does what `mockReset` does and restores inner implementation to the original function.
    *
-   * Note that restoring mock from `vi.fn()` will set implementation to an empty function that returns `undefined`. Restoring a `vi.fn(impl)` will restore implementation to `impl`.
+   * Restoring a mock from `vi.spyOn(object, property)` will also restore the original
+   * descriptor of the spied-on object.
+   *
+   * Note that restoring mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
+   * Restoring a mock from `vi.fn(impl)` will set implementation to `impl`.
+   *
+   * @see mockClear
+   * @see mockReset
+   * @see mockRevert
    */
   mockRestore(): void
+  /**
+   * Does what `mockReset` does and reverts inner implementation to the original function.
+   *
+   * Reverting a mock from `vi.spyOn(object, property)` will **not** restore the original
+   * descriptor of the spied-on object.
+   *
+   * Note that reverting a mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
+   * Reverting a mock from `vi.fn(impl)` will set implementation to `impl`.
+   *
+   * @see mockClear
+   * @see mockReset
+   * @see mockRestore
+   */
+  mockRevert(): void
   /**
    * Returns current mock implementation if there is one.
    *
@@ -516,6 +547,12 @@ function enhanceSpy<T extends Procedure>(
   stub.mockRestore = () => {
     stub.mockReset()
     state.restore()
+    implementation = undefined
+    return stub
+  }
+
+  stub.mockRevert = () => {
+    stub.mockReset()
     implementation = undefined
     return stub
   }

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -106,6 +106,7 @@ const config = {
   pool: 'forks' as const,
   clearMocks: false,
   restoreMocks: false,
+  revertMocks: false,
   mockReset: false,
   unstubGlobals: false,
   unstubEnvs: false,

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -315,23 +315,40 @@ export interface VitestUtils {
   isMockFunction: (fn: any) => fn is MockInstance
 
   /**
-   * Calls [`.mockClear()`](https://vitest.dev/api/mock#mockclear) on every mocked function. This will only empty `.mock` state, it will not reset implementation.
+   * Calls [`.mockClear()`](https://vitest.dev/api/mock#mockclear) on every mocked function.
    *
-   * It is useful if you need to clean up mock between different assertions.
+   * This will only empty `.mock` state, it will not affect mock implementations.
+   *
+   * This is useful if you need to clean up mocks between different assertions within a test.
    */
   clearAllMocks: () => VitestUtils
 
   /**
-   * Calls [`.mockReset()`](https://vitest.dev/api/mock#mockreset) on every mocked function. This will empty `.mock` state, reset "once" implementations and force the base implementation to return `undefined` when invoked.
+   * Calls [`.mockReset()`](https://vitest.dev/api/mock#mockreset) on every mocked function.
    *
-   * This is useful when you want to completely reset a mock to the default state.
+   * This will empty `.mock` state, reset "once" implementations and force the base implementation to return `undefined` when invoked.
+   *
+   * This is useful when you want to completely reset mocks to the default state.
    */
   resetAllMocks: () => VitestUtils
 
   /**
-   * Calls [`.mockRestore()`](https://vitest.dev/api/mock#mockrestore) on every mocked function. This will restore all original implementations.
+   * Calls [`.mockRestore()`](https://vitest.dev/api/mock#mockrestore) on every mocked function.
+   *
+   * This will empty `.mock` state, restore all original mock implementations, and restore original descriptors of spied-on objects.
+   *
+   * This is useful for inter-test cleanup and/or removing mocks created by [`vi.spyOn(...)`](https://vitest.dev/api/vi#vi-spyon).
    */
   restoreAllMocks: () => VitestUtils
+
+  /**
+   * Calls [`.mockRevert()`](https://vitest.dev/api/mock#mockrevert) on every mocked function.
+   *
+   * This will empty `.mock` state and revert all mocks to their original implementations without restoring original descriptors of spied-on objects.
+   *
+   * This is useful for inter-test cleanup without removing mocks created by [`vi.spyOn(...)`](https://vitest.dev/api/vi#vi-spyon).
+   */
+  revertAllMocks: () => VitestUtils
 
   /**
    * Makes value available on global namespace.
@@ -652,6 +669,11 @@ function createVitest(): VitestUtils {
 
     restoreAllMocks() {
       mocks.forEach(spy => spy.mockRestore())
+      return utils
+    },
+
+    revertAllMocks() {
+      mocks.forEach(spy => spy.mockRevert())
       return utils
     },
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -774,6 +774,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
   unstubEnvs: null,
   related: null,
   restoreMocks: null,
+  revertMocks: null,
   runner: null,
   mockReset: null,
   forceRerunTriggers: null,

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -31,6 +31,7 @@ export function serializeConfig(
     clearMocks: config.clearMocks,
     mockReset: config.mockReset,
     restoreMocks: config.restoreMocks,
+    revertMocks: config.revertMocks,
     unstubEnvs: config.unstubEnvs,
     unstubGlobals: config.unstubGlobals,
     maxConcurrency: config.maxConcurrency,

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -501,6 +501,12 @@ export interface InlineConfig {
   restoreMocks?: boolean
 
   /**
+   * Will call `.mockRevert()` on all spies before each test
+   * @default false
+   */
+  revertMocks?: boolean
+
+  /**
    * Will restore all global stubs to their original values before each test
    * @default false
    */

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -28,6 +28,7 @@ export interface SerializedConfig {
   clearMocks: boolean
   mockReset: boolean
   restoreMocks: boolean
+  revertMocks: boolean
   unstubGlobals: boolean
   unstubEnvs: boolean
   // TODO: make optional
@@ -149,6 +150,7 @@ export type RuntimeConfig = Pick<
   | 'clearMocks'
   | 'mockReset'
   | 'restoreMocks'
+  | 'revertMocks'
   | 'fakeTimers'
   | 'maxConcurrency'
   | 'expect'

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -192,12 +192,15 @@ export class VitestTestRunner implements VitestRunner {
 }
 
 function clearModuleMocks(config: SerializedConfig) {
-  const { clearMocks, mockReset, restoreMocks, unstubEnvs, unstubGlobals }
+  const { clearMocks, mockReset, restoreMocks, revertMocks, unstubEnvs, unstubGlobals }
     = config
 
   // since each function calls another, we can just call one
   if (restoreMocks) {
     vi.restoreAllMocks()
+  }
+  else if (revertMocks) {
+    vi.revertAllMocks()
   }
   else if (mockReset) {
     vi.resetAllMocks()

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -218,7 +218,7 @@ describe('jest mock compat layer', () => {
     expect(a.mock.invocationCallOrder[0]).toBeLessThan(b.mock.invocationCallOrder[0])
   })
 
-  it('getter spyOn', () => {
+  it('should spy on property getter, and mockRestore should restore original descriptor', () => {
     const obj = {
       get getter() {
         return 'original'
@@ -244,9 +244,39 @@ describe('jest mock compat layer', () => {
     spy.mockRestore()
 
     expect(obj.getter).toBe('original')
+    expect(spy).not.toHaveBeenCalled()
   })
 
-  it('getter function spyOn', () => {
+  it('should spy on property getter, and mockRevert should not restore original descriptor', () => {
+    const obj = {
+      get getter() {
+        return 'original'
+      },
+    }
+
+    const spy = vi.spyOn(obj, 'getter', 'get')
+
+    expect(obj.getter).toBe('original')
+
+    spy.mockImplementation(() => 'mocked').mockImplementationOnce(() => 'once')
+
+    expect(obj.getter).toBe('once')
+    expect(obj.getter).toBe('mocked')
+    expect(obj.getter).toBe('mocked')
+
+    spy.mockReturnValue('returned').mockReturnValueOnce('returned-once')
+
+    expect(obj.getter).toBe('returned-once')
+    expect(obj.getter).toBe('returned')
+    expect(obj.getter).toBe('returned')
+
+    spy.mockRevert()
+
+    expect(obj.getter).toBe('original')
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('should spy on function returned from property getter', () => {
     const obj = {
       get getter() {
         return function () {
@@ -266,7 +296,7 @@ describe('jest mock compat layer', () => {
     expect(obj.getter()).toBe('mocked')
   })
 
-  it('setter spyOn', () => {
+  it('should spy on property setter (1)', () => {
     let setValue = 'original'
     let mockedValue = 'none'
 
@@ -309,7 +339,7 @@ describe('jest mock compat layer', () => {
     expect(setValue).toBe('last')
   })
 
-  it('should work - setter', () => {
+  it('should spy on property setter (2), and mockRestore should restore original descriptor', () => {
     const obj = {
       _property: false,
       set property(value) {
@@ -327,9 +357,33 @@ describe('jest mock compat layer', () => {
     obj.property = false
     spy.mockRestore()
     obj.property = true
-    // unlike jest, mockRestore only restores implementation to the original one,
-    // we are still spying on the setter
+    // like jest, mockRestore restores the original descriptor,
+    // we are not spying on the setter any more
     expect(spy).not.toHaveBeenCalled()
+    expect(obj.property).toBe(true)
+  })
+
+  it('should spy on property setter (2), and mockRevert should not restore original descriptor', () => {
+    const obj = {
+      _property: false,
+      set property(value) {
+        this._property = value
+      },
+      get property() {
+        return this._property
+      },
+    }
+
+    const spy = vi.spyOn(obj, 'property', 'set')
+    obj.property = true
+    expect(spy).toHaveBeenCalled()
+    expect(obj.property).toBe(true)
+    obj.property = false
+    spy.mockRevert()
+    obj.property = true
+    // unlike jest, vitest includes mockRevert, which does not restore the original descriptor.
+    // We are still spying on the setter
+    expect(spy).toHaveBeenCalled()
     expect(obj.property).toBe(true)
   })
 
@@ -406,6 +460,17 @@ describe('jest mock compat layer', () => {
     expect(testFn()).toBe(false)
 
     testFn.mockRestore()
+    expect(testFn()).toBe(true)
+  })
+
+  it('.mockRevert() should restore initial implementation', () => {
+    const testFn = vi.fn(() => true)
+    expect(testFn()).toBe(true)
+
+    testFn.mockReturnValue(false)
+    expect(testFn()).toBe(false)
+
+    testFn.mockRevert()
     expect(testFn()).toBe(true)
   })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adds a new method `mockRevert` to spies. It's in the same vein as `mockClear`, `mockReset`, `mockRestore` - it is most similar to `mockRestore`, with the key difference being that it does not 'un-spy' mocks created with `vi.spyOn()`. 

See #6308 for discussion.

<!-- You can also add additional context here -->

### PR Checklist
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`. (I am waiting for `playwright` to install)

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
