### PR TITLE
fix(types): Allow Callbacks Passed to before*/after* to Return Anything

### DIFF
--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -498,28 +498,31 @@ export type HookListener<T extends any[], Return = void> = (
   ...args: T
 ) => Awaitable<Return>
 
-export type HookCleanupCallback = (() => Awaitable<unknown>) | void
+/**
+ * @deprecated
+ */
+export type HookCleanupCallback = unknown
 
 export interface BeforeAllListener {
-  (suite: Readonly<Suite | File>): Awaitable<HookCleanupCallback>
+  (suite: Readonly<Suite | File>): Awaitable<unknown>
 }
 
 export interface AfterAllListener {
-  (suite: Readonly<Suite | File>): Awaitable<void>
+  (suite: Readonly<Suite | File>): Awaitable<unknown>
 }
 
 export interface BeforeEachListener<ExtraContext = object> {
   (
     context: ExtendedContext<Test | Custom> & ExtraContext,
     suite: Readonly<Suite>
-  ): Awaitable<HookCleanupCallback>
+  ): Awaitable<unknown>
 }
 
 export interface AfterEachListener<ExtraContext = object> {
   (
     context: ExtendedContext<Test | Custom> & ExtraContext,
     suite: Readonly<Suite>
-  ): Awaitable<void>
+  ): Awaitable<unknown>
 }
 
 export interface SuiteHooks<ExtraContext = object> {

--- a/test/core/test/hooks.test.ts
+++ b/test/core/test/hooks.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, expect, it, suite } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, suite } from 'vitest'
 
 let count = -1
 
@@ -75,6 +75,28 @@ suite('hooks cleanup', () => {
     })
     it('two', () => {
       expect(cleanUpCount).toBe(11)
+    })
+  })
+  it('end', () => {
+    expect(cleanUpCount).toBe(0)
+  })
+
+  suite('do nothing when given a non-function value as cleanupCallback', () => {
+    beforeAll(() => {
+      return 1
+    })
+    beforeEach(() => {
+      return null
+    })
+    afterAll(() => {
+      return '1'
+    })
+    afterEach(() => {
+      return {}
+    })
+
+    it('one', () => {
+      expect(cleanUpCount).toBe(0)
     })
   })
   it('end', () => {


### PR DESCRIPTION
### Description

Hey team! 👋

- Current implementation of callCleanupHooks already accepts non-function values as cleanupCallback
- Type definition currently restricts cleanupCallback to functions only
- This PR updates the type definition to allow non-function values
- No changes to the actual implementation, only type definitions are modified

```
async function callCleanupHooks(cleanups: HookCleanupCallback[]) {
  await Promise.all(
    cleanups.map(async (fn) => {
      if (typeof fn !== 'function') {
        return
      }
      await fn()
    }),
  )
}
```

Close: #6033

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
