### PR TITLE
refactor: proposal for the public Vitest API

### DIFF
--- a/packages/browser/src/node/pool.ts
+++ b/packages/browser/src/node/pool.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto'
 import { relative } from 'pathe'
 import type { BrowserProvider, ProcessPool, TestProject, TestSpecification, Vitest } from 'vitest/node'
 import { createDebugger } from 'vitest/node'
+import { getWorkspaceProjectFromTestProject } from 'vitest/src/node/reported-test-project.js'
 
 const debug = createDebugger('vitest:browser:pool')
 
@@ -20,7 +21,7 @@ export function createBrowserPool(ctx: Vitest): ProcessPool {
   const providers = new Set<BrowserProvider>()
 
   const executeTests = async (method: 'run' | 'collect', project: TestProject, files: string[]) => {
-    ctx.state.clearFiles(project.workspaceProject, files)
+    ctx.state.clearFiles(getWorkspaceProjectFromTestProject(project), files)
     const browser = project.browser!
 
     const threadsCount = getThreadsCount(project)

--- a/packages/vitest/src/node/cache/results.ts
+++ b/packages/vitest/src/node/cache/results.ts
@@ -45,6 +45,7 @@ export class ResultsCache {
 
     const resultsCache = await fs.promises.readFile(this.cachePath, 'utf8')
     const { results, version } = JSON.parse(resultsCache || '[]')
+    // TODO: check for version[0] to be 0
     // handling changed in 0.30.0
     if (Number(version.split('.')[1]) >= 30) {
       this.cache = new Map(results)

--- a/packages/vitest/src/node/context.ts
+++ b/packages/vitest/src/node/context.ts
@@ -1,0 +1,25 @@
+import type { ProvidedContext } from '../types/general'
+import type { WorkspaceProject } from './workspace'
+
+export class VitestContext {
+  constructor(private workspaceProject: WorkspaceProject) {
+    this.workspaceProject = workspaceProject
+  }
+
+  /**
+   * Provide a custom serializable context to the project. This context will be available for tests once they run.
+   */
+  public provide<T extends keyof ProvidedContext & string>(
+    key: T,
+    value: ProvidedContext[T],
+  ): void {
+    this.workspaceProject.provide(key, value)
+  }
+
+  /**
+   * Get a custom serializable context provided to the project.
+   */
+  public get<T extends keyof ProvidedContext & string>(name: T): ProvidedContext[T] {
+    return this.workspaceProject.getProvidedContext()[name]
+  }
+}

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -32,6 +32,7 @@ import type { Reporter } from './types/reporter'
 import type { CoverageProvider } from './types/coverage'
 import { resolveWorkspace } from './workspace/resolveWorkspace'
 import type { TestSpecification } from './spec'
+import { getWorkspaceProjectFromTestProject } from './reported-test-project'
 
 const WATCHER_DEBOUNCE = 100
 
@@ -466,7 +467,10 @@ export class Vitest {
       }))
     }
 
-    await addImports(spec.project.workspaceProject, spec.moduleId)
+    await addImports(
+      getWorkspaceProjectFromTestProject(spec.project),
+      spec.moduleId,
+    )
     deps.delete(spec.moduleId)
 
     return deps
@@ -549,7 +553,7 @@ export class Vitest {
   }
 
   async initializeGlobalSetup(paths: TestSpecification[]) {
-    const projects = new Set(paths.map(spec => spec.project.workspaceProject))
+    const projects = new Set(paths.map(spec => getWorkspaceProjectFromTestProject(spec.project)))
     const coreProject = this.getCoreWorkspaceProject()
     if (!projects.has(coreProject)) {
       projects.add(coreProject)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -660,7 +660,7 @@ export class Vitest {
         process.exitCode = 1
       }
     })()
-      .finally(async () => {
+      .finally(() => {
         this.runningPromise = undefined
 
         // all subsequent runs will treat this as a fresh run
@@ -1053,7 +1053,9 @@ export class Vitest {
           else if (runningServers > 1) {
             console.warn(`Tests closed successfully but something prevents ${runningServers} Vite servers from exiting`)
           }
-          else { console.warn('Tests closed successfully but something prevents the main process from exiting') }
+          else {
+            console.warn('Tests closed successfully but something prevents the main process from exiting')
+          }
 
           console.warn('You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters')
         }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -193,7 +193,6 @@ export class Vitest {
       this.config,
       this.projects.map(project => project.testProject),
       server,
-      this.vitenode.moduleGraph,
       this.logger,
     )
 

--- a/packages/vitest/src/node/pools/typecheck.ts
+++ b/packages/vitest/src/node/pools/typecheck.ts
@@ -7,6 +7,7 @@ import { hasFailed } from '../../utils/tasks'
 import type { Vitest } from '../core'
 import type { ProcessPool, WorkspaceSpec } from '../pool'
 import type { WorkspaceProject } from '../workspace'
+import { getWorkspaceProjectFromTestProject } from '../reported-test-project'
 
 export function createTypecheckPool(ctx: Vitest): ProcessPool {
   const promisesMap = new WeakMap<WorkspaceProject, DeferPromise<void>>()
@@ -104,10 +105,14 @@ export function createTypecheckPool(ctx: Vitest): ProcessPool {
     for (const name in specsByProject) {
       const project = specsByProject[name][0].project
       const files = specsByProject[name].map(spec => spec.moduleId)
-      const checker = await createWorkspaceTypechecker(project.workspaceProject, files)
+      const workspaceProject = getWorkspaceProjectFromTestProject(project)
+      const checker = await createWorkspaceTypechecker(
+        workspaceProject,
+        files,
+      )
       checker.setFiles(files)
       await checker.collectTests()
-      ctx.state.collectFiles(project.workspaceProject, checker.getTestFiles())
+      ctx.state.collectFiles(workspaceProject, checker.getTestFiles())
       await ctx.report('onCollected')
     }
   }

--- a/packages/vitest/src/node/publicResolver.ts
+++ b/packages/vitest/src/node/publicResolver.ts
@@ -1,0 +1,139 @@
+import { readFile } from 'node:fs/promises'
+import { glob } from 'tinyglobby'
+import type { ResolvedConfig } from './types/config'
+
+interface GlobOptions {
+  include: string[]
+  exclude: string[]
+  cwd: string
+}
+
+export class TestModulesResolver {
+  public testModules: FilesResolver
+  public inSourceTestModules: FilesResolver
+  public typecheckTestModules: FilesResolver
+
+  constructor(config: ResolvedConfig) {
+    this.testModules = new FilesResolver({
+      include: config.include,
+      exclude: config.exclude,
+      cwd: config.dir || config.root,
+    })
+    this.inSourceTestModules = new InSourceFilesResolver({
+      include: config.includeSource,
+      exclude: config.exclude,
+      cwd: config.dir || config.root,
+    })
+    this.typecheckTestModules = new FilesResolver({
+      include: config.typecheck.include,
+      exclude: config.typecheck.exclude,
+      cwd: config.dir || config.root,
+    })
+  }
+
+  getFiles() {
+    return {
+      testModules: Array.from(this.testModules.getFiles()),
+      inSourceTestModules: Array.from(this.inSourceTestModules.getFiles()),
+      typecheckTestModules: Array.from(this.typecheckTestModules.getFiles()),
+    }
+  }
+
+  async resolve() {
+    const [testModules, inSourceTestModules, typecheckTestModules] = await Promise.all([
+      this.testModules.resolve(),
+      this.inSourceTestModules.resolve(),
+      this.typecheckTestModules.resolve(),
+    ])
+    return {
+      testModules,
+      inSourceTestModules,
+      typecheckTestModules,
+    }
+  }
+
+  clear() {
+    this.testModules.clear()
+    this.inSourceTestModules.clear()
+    this.typecheckTestModules.clear()
+  }
+}
+
+export class FilesResolver {
+  protected files: Set<string> = new Set()
+  protected _isResolved = false
+
+  constructor(
+    protected options: GlobOptions,
+  ) {}
+
+  public clear() {
+    this.files.clear()
+    this._isResolved = false
+  }
+
+  public getFiles() {
+    return this.files
+  }
+
+  public addFile(file: string) {
+    this.files.add(file)
+  }
+
+  public removeFile(file: string) {
+    this.files.delete(file)
+  }
+
+  public isTestFile(file: string): boolean {
+    if (!this._isResolved) {
+      throw new Error('Test files were not resolved yet. Don\'t forget to call resolve() before using this API.')
+    }
+    return this.files.has(file)
+  }
+
+  public async resolve(): Promise<string[]> {
+    if (this._isResolved) {
+      return Array.from(this.files)
+    }
+    return this.glob()
+  }
+
+  public async glob(): Promise<string[]> {
+    if (!this.options.include?.length) {
+      this._isResolved = true
+      return []
+    }
+    const files = await glob(this.options.include, {
+      absolute: true,
+      dot: true,
+      cwd: this.options.cwd,
+      ignore: this.options.exclude,
+      expandDirectories: false,
+    })
+    this._isResolved = true
+    this.files = new Set(files)
+    return files
+  }
+}
+
+class InSourceFilesResolver extends FilesResolver {
+  override async glob(): Promise<string[]> {
+    const files = await this.glob()
+    const testFiles: string[] = []
+    await Promise.all(
+      files.map(async (file) => {
+        try {
+          const code = await readFile(file, 'utf-8')
+          if (code.includes('import.meta.vitest')) {
+            testFiles.push(file)
+          }
+        }
+        catch {
+          return null
+        }
+      }),
+    )
+    this.files = new Set(testFiles)
+    return testFiles
+  }
+}

--- a/packages/vitest/src/node/publicRunner.ts
+++ b/packages/vitest/src/node/publicRunner.ts
@@ -5,7 +5,6 @@ import { slash } from '../utils'
 import type { TestModule } from './reporters/reported-tasks'
 import type { Vitest as VitestCore } from './core'
 import type { TestSpecification } from './spec'
-import type { VitestModuleGraph } from './publicVitest'
 
 export interface VitestRunner {
   // Vitest starts a standalone runner, will react on watch changes, it doesn't run tests
@@ -19,7 +18,7 @@ export interface VitestRunner {
   run: () => Promise<TestRunResult>
   collect: () => Promise<TestRunResult>
   runModules: (moduleNames: string[]) => Promise<TestRunResult>
-  runTests: (filters: TestSpecification[]) => Promise<TestRunResult>
+  runTests: (filters: Array<TestSpecification>) => Promise<TestRunResult>
   mergeReports: () => Promise<TestRunResult>
 }
 
@@ -34,7 +33,6 @@ export class VitestRunner_ implements VitestRunner {
 
   constructor(
     vitest: VitestCore,
-    private readonly moduleGraph: VitestModuleGraph,
   ) {
     this[kVitest] = vitest
   }

--- a/packages/vitest/src/node/publicRunner.ts
+++ b/packages/vitest/src/node/publicRunner.ts
@@ -1,0 +1,284 @@
+import { readFileSync } from 'node:fs'
+import type { TestError } from '@vitest/utils'
+import mm from 'micromatch'
+import { slash } from '../utils'
+import type { TestModule } from './reporters/reported-tasks'
+import type { Vitest as VitestCore } from './core'
+import type { TestSpecification } from './spec'
+import type { VitestModuleGraph } from './publicVitest'
+
+export interface VitestRunner {
+  // Vitest starts a standalone runner, will react on watch changes, it doesn't run tests
+  start: () => void
+  stop: () => void
+
+  run: () => Promise<TestRunResult>
+  collect: () => Promise<TestRunResult>
+  runModules: (moduleNames: string[]) => Promise<TestRunResult>
+  runTests: (filters: TestSpecification[]) => Promise<TestRunResult>
+  mergeReports: () => Promise<TestRunResult>
+}
+
+const kVitest = Symbol('vitest')
+
+export class VitestRunner_ implements VitestRunner {
+  private readonly [kVitest]: VitestCore
+
+  private _stop = () => {}
+  private _invalidates = new Set<string>()
+  private _changedTests = new Set<string>()
+
+  constructor(
+    vitest: VitestCore,
+    private readonly moduleGraph: VitestModuleGraph,
+  ) {
+    this[kVitest] = vitest
+  }
+
+  start(): void {
+    const watcher = this[kVitest].server.watcher
+
+    watcher.on('change', this.onFileChanged)
+    watcher.on('unlink', this.onFileRemoved)
+    watcher.on('add', this.onFileCreated)
+
+    this._stop = () => {
+      watcher.off('change', this.onFileChanged)
+      watcher.off('unlink', this.onFileRemoved)
+      watcher.off('add', this.onFileCreated)
+      this._stop = () => {}
+    }
+  }
+
+  async run(): Promise<TestRunResult> {
+    return {
+      testModules: [],
+      errors: [],
+    }
+  }
+
+  async collect(): Promise<TestRunResult> {
+    return {
+      testModules: [],
+      errors: [],
+    }
+  }
+
+  async runModules(_moduleNames: string[]): Promise<TestRunResult> {
+    return {
+      testModules: [],
+      errors: [],
+    }
+  }
+
+  async runTests(_filters: TestSpecification[]): Promise<TestRunResult> {
+    return {
+      testModules: [],
+      errors: [],
+    }
+  }
+
+  async mergeReports(): Promise<TestRunResult> {
+    return {
+      testModules: [],
+      errors: [],
+    }
+  }
+
+  stop() {
+    this._stop()
+  }
+
+  private onFileChanged = safe((file: string) => {
+    file = slash(file)
+    this[kVitest].logger.clearHighlightCache(file)
+    this.moduleGraph.invalidateViteModulesByFile(file)
+
+    if (this.shouldRerun(file)) {
+      this.scheduleRerun(file)
+    }
+  })
+
+  private onFileRemoved = safe((file: string) => {
+    file = slash(file)
+    this[kVitest].logger.clearHighlightCache(file)
+    this._invalidates.add(file)
+    this.moduleGraph.invalidateViteModulesByFile(file)
+
+    const state = this[kVitest].state
+    const cache = this[kVitest].cache
+    const testFiles = state.filesMap.get(file)
+    if (!testFiles) {
+      return
+    }
+
+    // clear all caches that we keep for this file
+    state.filesMap.delete(file)
+    cache.results.removeFromCache(file)
+    cache.stats.removeStats(file)
+    this._changedTests.delete(file)
+    this[kVitest].report('onTestRemoved', file)
+  })
+
+  private onFileCreated = safe((file: string) => {
+    file = slash(file)
+    this.moduleGraph.invalidateViteModulesByFile(file)
+
+    const source = readFileSync(file, 'utf-8')
+
+    const fileProjects = this[kVitest].projects.filter((project) => {
+      if (project.isTargetFile(file, source)) {
+        // this is an array of all tests files that are related to this project
+        // it is populated at the start, we need to keep it up to date
+        project.testFilesList?.push(file)
+        return true
+      }
+      return false
+    })
+
+    if (fileProjects.length) {
+      this._changedTests.add(file)
+      this.scheduleRerun(file)
+    }
+    else {
+      // it's possible that file was already there but watcher triggered "add" event instead
+      if (this.shouldRerun(file)) {
+        this.scheduleRerun(file)
+      }
+    }
+  })
+
+  private _restartsCount = 0
+  private _rerunTimer: any
+  private _runningPromise: Promise<void> | null = null
+
+  private async scheduleRerun(file: string) {
+    const currentCount = this._restartsCount
+    clearTimeout(this._rerunTimer)
+    await this._runningPromise
+    clearTimeout(this._rerunTimer)
+
+    // server restarted
+    if (this._restartsCount !== currentCount) {
+      return
+    }
+
+    this._rerunTimer = setTimeout(async () => {
+      // TODO: run only watched tests
+
+      if (this._changedTests.size === 0) {
+        this._invalidates.clear()
+        return
+      }
+
+      // server restarted
+      if (this._restartsCount !== currentCount) {
+        return
+      }
+
+      this.isFirstRun = false
+
+      this.snapshot.clear()
+      let files = Array.from(this.changedTests)
+
+      if (this.filenamePattern) {
+        const filteredFiles = await this.globTestFiles([this.filenamePattern])
+        files = files.filter(file => filteredFiles.some(f => f[1] === file))
+
+        // A file that does not match the current filename pattern was changed
+        if (files.length === 0) {
+          return
+        }
+      }
+
+      this.changedTests.clear()
+
+      const triggerIds = new Set(triggerId.map(id => relative(this.config.root, id)))
+      const triggerLabel = Array.from(triggerIds).join(', ')
+      await this.report('onWatcherRerun', files, triggerLabel)
+
+      await this.runFiles(files.flatMap(file => this.getProjectsByTestFile(file)), false)
+
+      await this.report('onWatcherStart', this.state.getFiles(files))
+    }, WATCHER_DEBOUNCE)
+  }
+
+  private shouldRerun(filepath: string): boolean {
+    if (this._changedTests.has(filepath) || this._invalidates.has(filepath)) {
+      return false
+    }
+
+    const state = this[kVitest].state
+
+    if (mm.isMatch(filepath, this[kVitest].config.forceRerunTriggers)) {
+      state.getFilepaths().forEach(file => this._changedTests.add(file))
+      return true
+    }
+
+    const projects = this[kVitest].projects.filter((project) => {
+      const moduleNode = project.server.moduleGraph.getModulesByFile(filepath)
+      return moduleNode && moduleNode.size > 0
+    })
+    if (!projects.length) {
+      // if there are no modules it's possible that server was restarted
+      // we don't have information about importers anymore, so let's check if the file is a test file at least
+      if (state.filesMap.has(filepath) || this[kVitest].projects.some(project => project.isTestFile(filepath))) {
+        this._changedTests.add(filepath)
+        return true
+      }
+      return false
+    }
+
+    const files: string[] = []
+
+    for (const project of projects) {
+      const mods = project.getModulesByFilepath(filepath)
+      if (!mods.size) {
+        continue
+      }
+
+      this._invalidates.add(filepath)
+
+      // one of test files that we already run, or one of test files that we can run
+      if (state.filesMap.has(filepath) || project.isTestFile(filepath)) {
+        this._changedTests.add(filepath)
+        files.push(filepath)
+        continue
+      }
+
+      let rerun = false
+      for (const mod of mods) {
+        mod.importers.forEach((i) => {
+          if (!i.file) {
+            return
+          }
+
+          const heedsRerun = this.shouldRerun(i.file)
+          if (heedsRerun) {
+            rerun = true
+          }
+        })
+      }
+
+      if (rerun) {
+        files.push(filepath)
+      }
+    }
+
+    return files.length > 0
+  }
+}
+
+interface TestRunResult {
+  testModules: TestModule[]
+  errors: TestError[]
+}
+
+function safe<T>(cb: (...args: T[]) => void) {
+  return (...args: T[]) => {
+    try {
+      cb(...args)
+    }
+    catch {}
+  }
+}

--- a/packages/vitest/src/node/publicRunner.ts
+++ b/packages/vitest/src/node/publicRunner.ts
@@ -12,6 +12,10 @@ export interface VitestRunner {
   start: () => void
   stop: () => void
 
+  // file -> spec[]
+  // unique by project+pool, creating a new spec overrides the old one
+  readonly specifications: Map<string, Array<TestSpecification>>
+
   run: () => Promise<TestRunResult>
   collect: () => Promise<TestRunResult>
   runModules: (moduleNames: string[]) => Promise<TestRunResult>

--- a/packages/vitest/src/node/publicVitest.ts
+++ b/packages/vitest/src/node/publicVitest.ts
@@ -1,13 +1,17 @@
 /* eslint-disable ts/method-signature-style */
 import type { ModuleNode, ViteDevServer } from 'vite'
-import { SnapshotManager } from '@vitest/snapshot/manager'
+import type { SnapshotResult } from '@vitest/snapshot'
 import type { TestProject } from './reported-test-project'
-import type { TestModule } from './reporters/reported-tasks'
-import type { TestSpecification } from './spec'
 import type { ResolvedConfig } from './types/config'
-import type { VitestContext } from './context'
+import { VitestContext } from './context'
 import type { Logger } from './logger'
-import type { VitestPackageInstaller } from './packageInstaller'
+import type { Vitest as VitestCore } from './core'
+import { type VitestRunner, VitestRunner_ } from './publicRunner'
+
+interface _Reporter {
+  version: 2
+  onInit(vitest: Vitest): void
+}
 
 export interface Vitest {
   readonly config: ResolvedConfig
@@ -18,7 +22,6 @@ export interface Vitest {
   readonly context: VitestContext
   readonly snapshot: VitestSnapshot
   readonly logger: Logger
-  readonly packageInstaller: VitestPackageInstaller
 
   onClose(cb: () => void): void
 
@@ -26,26 +29,71 @@ export interface Vitest {
   exit(): Promise<void>
 }
 
-interface VitestModuleGraph {
+const kVitest = Symbol('vitest')
+
+export class _Vitest implements Vitest {
+  private readonly [kVitest]: VitestCore
+  public readonly runner: VitestRunner
+  public readonly context: VitestContext
+  public readonly snapshot: VitestSnapshot
+
+  constructor(
+    vitest: VitestCore,
+    public readonly config: ResolvedConfig,
+    public readonly projects: TestProject[],
+    public readonly vite: ViteDevServer,
+    public readonly moduleGraph: VitestModuleGraph,
+    public readonly logger: Logger,
+  ) {
+    this[kVitest] = vitest
+    this.runner = new VitestRunner_(vitest, moduleGraph)
+    this.context = new VitestContext(vitest.getCoreWorkspaceProject())
+    this.snapshot = new VitestSnapshot(vitest)
+  }
+
+  onClose(cb: () => void): void {
+    this[kVitest].onClose(cb)
+  }
+
+  async close(): Promise<void> {
+    await this[kVitest].close()
+  }
+
+  async exit(): Promise<void> {
+    await this[kVitest].exit()
+  }
+}
+
+export interface VitestModuleGraph {
   getTestModuleIds(moduleNames?: string[]): string[]
   getViteModuleNodeById(
     transformMode: 'web' | 'ssr' | 'browser',
     moduleId: string,
   ): ModuleNode | undefined
   getViteModuleNodesById(moduleId: string): ModuleNode[]
+  invalidateViteModulesByFile(file: string): void
 }
 
-interface VitestRunner {
-  // Vitest starts a standalone runner, will react on watch changes, it doesn't run tests
-  start(): Promise<void>
+class VitestSnapshot {
+  private readonly [kVitest]: VitestCore
 
-  run(): Promise<TestModule[]>
-  runModules(moduleNames: string[]): Promise<TestModule[]>
-  runTests(filters: TestSpecification[]): Promise<TestModule[]>
-}
+  constructor(vitest: VitestCore) {
+    this[kVitest] = vitest
+  }
 
-class VitestSnapshot extends SnapshotManager {
-  async update(_files?: string[]): Promise<void> {
-    // TODO
+  clear() {
+    this[kVitest].snapshot.clear()
+  }
+
+  add(result: SnapshotResult) {
+    this[kVitest].snapshot.add(result)
+  }
+
+  get summary() {
+    return this[kVitest].snapshot.summary
+  }
+
+  async update(files?: string[]): Promise<void> {
+    await this[kVitest].updateSnapshot(files)
   }
 }

--- a/packages/vitest/src/node/publicVitest.ts
+++ b/packages/vitest/src/node/publicVitest.ts
@@ -1,0 +1,48 @@
+/* eslint-disable ts/method-signature-style */
+import type { ModuleNode, ViteDevServer } from 'vite'
+import { SnapshotManager } from '@vitest/snapshot/manager'
+import type { TestProject } from './reported-workspace-project'
+import type { TestModule } from './reporters/reported-tasks'
+import type { TestSpecification } from './spec'
+import type { ResolvedConfig } from './types/config'
+import type { VitestContext } from './context'
+
+export interface Vitest {
+  readonly config: ResolvedConfig
+  readonly projects: TestProject[]
+  readonly vite: ViteDevServer
+  readonly moduleGraph: VitestModuleGraph
+  readonly runner: VitestRunner
+  readonly context: VitestContext
+  readonly snapshot: VitestSnapshot
+
+  onClose(cb: () => void): void
+
+  close(): Promise<void>
+  exit(): Promise<void>
+}
+
+interface VitestModuleGraph {
+  getTestModuleIds(moduleNames?: string[]): string[]
+  getViteModuleNodeById(
+    transformMode: 'web' | 'ssr' | 'browser',
+    moduleId: string,
+  ): ModuleNode | undefined
+  getViteModuleNodesById(moduleId: string): ModuleNode[]
+}
+
+interface VitestRunner {
+  // Vitest starts a standalone runner, will react on watch changes, it doesn't run tests
+  start(): Promise<void>
+
+  // Vitest will still start in a standalone mode if `watch` is `true`
+  run(): Promise<TestModule[]>
+  runModules(moduleNames: string[]): Promise<TestModule[]>
+  runTests(filters: TestSpecification[]): Promise<TestModule[]>
+}
+
+class VitestSnapshot extends SnapshotManager {
+  async update(_files?: string[]): Promise<void> {
+    // TODO
+  }
+}

--- a/packages/vitest/src/node/publicVitest.ts
+++ b/packages/vitest/src/node/publicVitest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable ts/method-signature-style */
 import type { ModuleNode, ViteDevServer } from 'vite'
 import { SnapshotManager } from '@vitest/snapshot/manager'
-import type { TestProject } from './reported-workspace-project'
+import type { TestProject } from './reported-test-project'
 import type { TestModule } from './reporters/reported-tasks'
 import type { TestSpecification } from './spec'
 import type { ResolvedConfig } from './types/config'
@@ -39,7 +39,6 @@ interface VitestRunner {
   // Vitest starts a standalone runner, will react on watch changes, it doesn't run tests
   start(): Promise<void>
 
-  // Vitest will still start in a standalone mode if `watch` is `true`
   run(): Promise<TestModule[]>
   runModules(moduleNames: string[]): Promise<TestModule[]>
   runTests(filters: TestSpecification[]): Promise<TestModule[]>

--- a/packages/vitest/src/node/publicVitest.ts
+++ b/packages/vitest/src/node/publicVitest.ts
@@ -1,5 +1,5 @@
 /* eslint-disable ts/method-signature-style */
-import type { ModuleNode, ViteDevServer } from 'vite'
+import type { ViteDevServer } from 'vite'
 import type { SnapshotResult } from '@vitest/snapshot'
 import type { TestProject } from './reported-test-project'
 import type { ResolvedConfig } from './types/config'
@@ -17,7 +17,6 @@ export interface Vitest {
   readonly config: ResolvedConfig
   readonly projects: TestProject[]
   readonly vite: ViteDevServer
-  readonly moduleGraph: VitestModuleGraph
   readonly runner: VitestRunner
   readonly context: VitestContext
   readonly snapshot: VitestSnapshot
@@ -42,11 +41,10 @@ export class _Vitest implements Vitest {
     public readonly config: ResolvedConfig,
     public readonly projects: TestProject[],
     public readonly vite: ViteDevServer,
-    public readonly moduleGraph: VitestModuleGraph,
     public readonly logger: Logger,
   ) {
     this[kVitest] = vitest
-    this.runner = new VitestRunner_(vitest, moduleGraph)
+    this.runner = new VitestRunner_(vitest)
     this.context = new VitestContext(vitest.getCoreWorkspaceProject())
     this.snapshot = new VitestSnapshot(vitest)
   }
@@ -62,16 +60,6 @@ export class _Vitest implements Vitest {
   async exit(): Promise<void> {
     await this[kVitest].exit()
   }
-}
-
-export interface VitestModuleGraph {
-  getTestModuleIds(moduleNames?: string[]): string[]
-  getViteModuleNodeById(
-    transformMode: 'web' | 'ssr' | 'browser',
-    moduleId: string,
-  ): ModuleNode | undefined
-  getViteModuleNodesById(moduleId: string): ModuleNode[]
-  invalidateViteModulesByFile(file: string): void
 }
 
 class VitestSnapshot {

--- a/packages/vitest/src/node/publicVitest.ts
+++ b/packages/vitest/src/node/publicVitest.ts
@@ -15,7 +15,7 @@ interface _Reporter {
 
 export interface Vitest {
   readonly config: ResolvedConfig
-  readonly projects: TestProject[]
+  readonly projects: Array<TestProject>
   readonly vite: ViteDevServer
   readonly runner: VitestRunner
   readonly context: VitestContext
@@ -44,7 +44,7 @@ export class _Vitest implements Vitest {
     public readonly logger: Logger,
   ) {
     this[kVitest] = vitest
-    this.runner = new VitestRunner_(vitest)
+    this.runner = new VitestRunner_(this, vitest)
     this.context = new VitestContext(vitest.getCoreWorkspaceProject())
     this.snapshot = new VitestSnapshot(vitest)
   }

--- a/packages/vitest/src/node/publicVitest.ts
+++ b/packages/vitest/src/node/publicVitest.ts
@@ -6,6 +6,8 @@ import type { TestModule } from './reporters/reported-tasks'
 import type { TestSpecification } from './spec'
 import type { ResolvedConfig } from './types/config'
 import type { VitestContext } from './context'
+import type { Logger } from './logger'
+import type { VitestPackageInstaller } from './packageInstaller'
 
 export interface Vitest {
   readonly config: ResolvedConfig
@@ -15,6 +17,8 @@ export interface Vitest {
   readonly runner: VitestRunner
   readonly context: VitestContext
   readonly snapshot: VitestSnapshot
+  readonly logger: Logger
+  readonly packageInstaller: VitestPackageInstaller
 
   onClose(cb: () => void): void
 

--- a/packages/vitest/src/node/reported-test-project.ts
+++ b/packages/vitest/src/node/reported-test-project.ts
@@ -1,23 +1,15 @@
+import type { ViteDevServer } from 'vite'
 import type { ProvidedContext } from '../types/general'
 import type { ResolvedConfig, ResolvedProjectConfig, SerializedConfig } from './types/config'
 import type { WorkspaceProject } from './workspace'
-import type { Vitest } from './core'
 import type { BrowserServer } from './types/browser'
-import { type WorkspaceSpec, getFilePoolName } from './pool'
+import { getFilePoolName } from './pool'
 import { VitestContext } from './context'
+import type { TestSpecification } from './spec'
+
+const kWorkspaceProject = Symbol('vitest.workspaceProject')
 
 export class TestProject {
-  /**
-   * The global vitest instance.
-   * @experimental The public Vitest API is experimental and does not follow semver.
-   */
-  public readonly vitest: Vitest
-  /**
-   * The workspace project this test project is associated with.
-   * @experimental The public Vitest API is experimental and does not follow semver.
-   */
-  public readonly workspaceProject: WorkspaceProject
-
   /**
    * Resolved project configuration.
    */
@@ -37,10 +29,18 @@ export class TestProject {
    */
   public readonly context: VitestContext
 
+  public readonly vite: ViteDevServer
+
+  /**
+   * The workspace project this test project is associated with.
+   * @experimental The public Vitest API is experimental and does not follow semver.
+   */
+  private readonly [kWorkspaceProject]: WorkspaceProject
+
   constructor(workspaceProject: WorkspaceProject) {
-    this.workspaceProject = workspaceProject
-    this.vitest = workspaceProject.ctx
+    this[kWorkspaceProject] = workspaceProject
     this.globalConfig = workspaceProject.ctx.config
+    this.vite = workspaceProject.server
     this.config = workspaceProject.config
     this.name = workspaceProject.getName()
     this.context = new VitestContext(workspaceProject)
@@ -50,14 +50,14 @@ export class TestProject {
    * Serialized project configuration. This is the config that tests receive.
    */
   public get serializedConfig(): SerializedConfig {
-    return this.workspaceProject.getSerializableConfig()
+    return this[kWorkspaceProject].getSerializableConfig()
   }
 
   /**
    * Browser server if the project has browser enabled.
    */
   public get browser(): BrowserServer | null {
-    return this.workspaceProject.browser || null
+    return this[kWorkspaceProject].browser || null
   }
 
   /**
@@ -65,20 +65,29 @@ export class TestProject {
    * @param moduleId File path to the module or an ID that Vite understands (like a virtual module).
    * @param pool The pool to run the test in. If not provided, a pool will be selected based on the project configuration.
    */
-  public createSpecification(moduleId: string, pool?: string): WorkspaceSpec {
-    return this.workspaceProject.createSpec(
+  public createSpecification(moduleId: string, pool?: string): TestSpecification {
+    return this[kWorkspaceProject].createSpec(
       moduleId,
-      pool || getFilePoolName(this.workspaceProject, moduleId),
+      pool || getFilePoolName(this[kWorkspaceProject], moduleId),
     )
   }
 
+  public workspaceProject = null
+
+  /**
+   * Serialize the project to JSON so it can be transferred between workers.
+   */
   public toJSON(): SerializedTestProject {
     return {
       name: this.name,
       serializedConfig: this.serializedConfig,
-      context: this.workspaceProject.getProvidedContext(),
+      context: this[kWorkspaceProject].getProvidedContext(),
     }
   }
+}
+
+export function getWorkspaceProjectFromTestProject(project: TestProject): WorkspaceProject {
+  return project[kWorkspaceProject]
 }
 
 interface SerializedTestProject {

--- a/packages/vitest/src/node/reported-test-project.ts
+++ b/packages/vitest/src/node/reported-test-project.ts
@@ -46,6 +46,10 @@ export class TestProject {
     this.context = new VitestContext(workspaceProject)
   }
 
+  public get testModules() {
+    return this[kWorkspaceProject]._testModules
+  }
+
   /**
    * Serialized project configuration. This is the config that tests receive.
    */

--- a/packages/vitest/src/node/reported-test-project.ts
+++ b/packages/vitest/src/node/reported-test-project.ts
@@ -72,8 +72,6 @@ export class TestProject {
     )
   }
 
-  public workspaceProject = null
-
   /**
    * Serialize the project to JSON so it can be transferred between workers.
    */

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -35,7 +35,7 @@ export { TestCase, TestModule, TestSuite } from './reported-tasks'
  * @deprecated Use `TestModule` instead
  */
 export const TestFile = _TestFile
-export type { TestProject } from '../reported-workspace-project'
+export type { TestProject } from '../reported-test-project'
 export type {
   TestCollection,
 

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -9,7 +9,7 @@ import type {
 import type { TestError } from '@vitest/utils'
 import { getTestName } from '../../utils/tasks'
 import type { WorkspaceProject } from '../workspace'
-import { TestProject } from '../reported-workspace-project'
+import { TestProject } from '../reported-test-project'
 
 class ReportedTaskImplementation {
   /**

--- a/packages/vitest/src/node/spec.ts
+++ b/packages/vitest/src/node/spec.ts
@@ -26,6 +26,7 @@ export class TestSpecification {
     workspaceProject: WorkspaceProject,
     moduleId: string,
     pool: Pool,
+    // inSource?: boolean,
     // location?: WorkspaceSpecLocation | undefined,
   ) {
     this[0] = workspaceProject

--- a/packages/vitest/src/node/spec.ts
+++ b/packages/vitest/src/node/spec.ts
@@ -1,5 +1,5 @@
 import type { SerializedTestSpecification } from '../runtime/types/utils'
-import type { TestProject } from './reported-workspace-project'
+import type { TestProject } from './reported-test-project'
 import type { Pool } from './types/pool-options'
 import type { WorkspaceProject } from './workspace'
 
@@ -53,9 +53,9 @@ export class TestSpecification {
    * @deprecated
    */
   *[Symbol.iterator]() {
-    yield this.project.workspaceProject
-    yield this.moduleId
-    yield this.pool
+    yield this[0]
+    yield this[1]
+    yield this[2]
   }
 }
 

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -41,6 +41,7 @@ import type { Vitest } from './core'
 import { TestProject } from './reported-test-project'
 import { TestSpecification } from './spec'
 import type { WorkspaceSpec as DeprecatedWorkspaceSpec } from './pool'
+import { TestModulesResolver } from './publicResolver'
 
 interface InitializeProjectOptions extends UserWorkspaceConfig {
   workspaceConfigPath: string
@@ -100,6 +101,9 @@ export class WorkspaceProject {
 
   testFilesList: string[] | null = null
   typecheckFilesList: string[] | null = null
+
+  /** @private */
+  _testModules!: TestModulesResolver
 
   public testProject!: TestProject
 
@@ -428,6 +432,7 @@ export class WorkspaceProject {
       )
     }
 
+    this._testModules = new TestModulesResolver(this.config)
     this.testProject = new TestProject(this)
 
     this.server = server

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -299,6 +299,9 @@ export class WorkspaceProject {
     return this.typecheckFilesList && this.typecheckFilesList.includes(id)
   }
 
+  /**
+   * @deprecated
+   */
   async globFiles(include: string[], exclude: string[], cwd: string) {
     return glob(include, {
       absolute: true,

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -305,7 +305,9 @@ export class WorkspaceProject {
     })
   }
 
-  async isTargetFile(id: string, source?: string): Promise<boolean> {
+  isTargetFile(id: string, source: string): boolean
+  isTargetFile(id: string): Promise<boolean>
+  isTargetFile(id: string, source?: string): Promise<boolean> | boolean {
     const relativeId = relative(this.config.dir || this.config.root, id)
     if (mm.isMatch(relativeId, this.config.exclude)) {
       return false
@@ -317,8 +319,14 @@ export class WorkspaceProject {
       this.config.includeSource?.length
       && mm.isMatch(relativeId, this.config.includeSource)
     ) {
-      source = source || (await fs.readFile(id, 'utf-8'))
-      return this.isInSourceTestFile(source)
+      if (source) {
+        return this.isInSourceTestFile(source)
+      }
+
+      return (async () => {
+        const source = await fs.readFile(id, 'utf-8')
+        return this.isInSourceTestFile(source)
+      })()
     }
     return false
   }

--- a/packages/vitest/src/node/workspace.ts
+++ b/packages/vitest/src/node/workspace.ts
@@ -38,7 +38,7 @@ import { MocksPlugins } from './plugins/mocks'
 import { CoverageTransform } from './plugins/coverageTransform'
 import { serializeConfig } from './config/serializeConfig'
 import type { Vitest } from './core'
-import { TestProject } from './reported-workspace-project'
+import { TestProject } from './reported-test-project'
 import { TestSpecification } from './spec'
 import type { WorkspaceSpec as DeprecatedWorkspaceSpec } from './pool'
 

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -66,7 +66,7 @@ export { TestCase, TestModule, TestSuite } from '../node/reporters/reported-task
  * @deprecated Use `TestModule` instead
  */
 export const TestFile = _TestFile
-export { TestProject } from '../node/reported-workspace-project'
+export { TestProject } from '../node/reported-test-project'
 export type {
   TestCollection,
 

--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -32,7 +32,7 @@ export async function groupFilesByEnv(
   const filesWithEnv = await Promise.all(
     files.map(async (spec) => {
       const file = spec.moduleId
-      const project = spec.project.workspaceProject
+      const project = spec.project
       const code = await fs.readFile(file, 'utf-8')
 
       // 1. Check for control comments in the file


### PR DESCRIPTION
sneaky draft proposal, look away

related #6147


```ts
// The main Vitest class
export interface Vitest {
  // the main config from the root of the project
  readonly config: ResolvedConfig
  // instances of projects defined in the workspace config
  // always has at least one project
  readonly projects: Map<string, TestProject>
  // global Vite server instance
  readonly vite: ViteDevServer
  // class that runs tests and stores results
  readonly runner: VitestRunner
  // global inject/provide context
  readonly context: VitestContext
  // snapshot state
  readonly snapshot: VitestSnapshot
  readonly logger: Logger

  onClose(cb: () => void): void

  close(): Promise<void>
  exit(): Promise<void>
}

interface TestProject {
  readonly config: ResolvedProjectConfig
  readonly globalConfig: ResolvedConfig // same as vitest.config
  readonly name: string
  // local project context
  readonly context: VitestContext
  readonly vite: ViteDevServer
  // config that can be sent as a json
  readonly serializedConfig: SerializedConfig
  // browser server instance if tests are running in the browser
  readonly browser: BrowserServer | null
  // an easy way to create a spec
  createSpecification(moduleId: string): TestSpecification
}

export interface VitestRunner {
  // Vitest starts a standalone runner, will react on watch changes, it doesn't run tests
  start: () => void
  stop: () => void

  // Map<filepath, spec[]>
  // unique by project+pool, creating a new spec overrides the old one
  readonly specifications: Map<string, Array<TestSpecification>>

  run: () => Promise<TestRunResult>
  collect: () => Promise<TestRunResult>
  // run module in every project
  runModules: (moduleNames: string[]) => Promise<TestRunResult>
  // run specific tests
  runTests: (specifications: Array<TestSpecification>) => Promise<TestRunResult>
  mergeReports: () => Promise<TestRunResult>
}

interface TestRunResult {
  testModules: TestModule[]
  errors: TestError[]
}
```