### PR TITLE
fix(vite-node): fix watch on vite 6

### DIFF
--- a/packages/vite-node/src/hmr/emitter.ts
+++ b/packages/vite-node/src/hmr/emitter.ts
@@ -63,8 +63,9 @@ export function viteNodeHmrPlugin(): Plugin {
         _send(payload)
         emitter.emit('message', payload)
       }
+      // eslint-disable-next-line ts/ban-ts-comment
       // @ts-ignore Vite 6 compat
-      const environments = server.environments;
+      const environments = server.environments
       if (environments) {
         environments.ssr.hot.send = function (payload: any) {
           _send(payload)

--- a/packages/vite-node/src/hmr/emitter.ts
+++ b/packages/vite-node/src/hmr/emitter.ts
@@ -63,6 +63,14 @@ export function viteNodeHmrPlugin(): Plugin {
         _send(payload)
         emitter.emit('message', payload)
       }
+      // @ts-ignore Vite 6 compat
+      const environments = server.environments;
+      if (environments) {
+        environments.ssr.hot.send = function (payload: any) {
+          _send(payload)
+          emitter.emit('message', payload)
+        }
+      }
     },
   }
 }


### PR DESCRIPTION
### Description

Currently vite-node is patching `server.ws.send` to intercept event, but this doesn't include server module graph's change.
As a temporary measure, we can probably try patching `server.environments.ssr.hot.send` in a similar way.

With this change, I verified `test/vite-node` passes on Vite 6.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
