### PR TITLE
chore: move `@ampproject/remapping` as dev dep

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -150,7 +150,6 @@
     }
   },
   "dependencies": {
-    "@ampproject/remapping": "^2.3.0",
     "@vitest/expect": "workspace:*",
     "@vitest/mocker": "workspace:*",
     "@vitest/pretty-format": "workspace:^",
@@ -172,6 +171,7 @@
     "why-is-node-running": "^2.3.0"
   },
   "devDependencies": {
+    "@ampproject/remapping": "^2.3.0",
     "@antfu/install-pkg": "^0.4.1",
     "@edge-runtime/vm": "^4.0.1",
     "@sinonjs/fake-timers": "11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,9 +905,6 @@ importers:
 
   packages/vitest:
     dependencies:
-      '@ampproject/remapping':
-        specifier: ^2.3.0
-        version: 2.3.0
       '@vitest/browser':
         specifier: workspace:*
         version: link:../browser
@@ -972,6 +969,9 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
     devDependencies:
+      '@ampproject/remapping':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@antfu/install-pkg':
         specifier: ^0.4.1
         version: 0.4.1


### PR DESCRIPTION
### Description

Move `@ampproject/remapping` as dev dep. It was added as dep in https://github.com/vitest-dev/vitest/pull/5853, but then no longer needed with https://github.com/vitest-dev/vitest/pull/5924



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
