### PR TITLE
feat(browser): support `--inspect`

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -38,6 +38,66 @@ You can also add a dedicated launch configuration to debug a test file in VS Cod
 
 Then in the debug tab, ensure 'Debug Current Test File' is selected. You can then open the test file you want to debug and press F5 to start debugging.
 
+### Browser mode
+
+To debug [Vitest Browser Mode](/guide/browser/index.md), pass `--inspect` in CLI or define it in your Vitest configuration:
+
+::: code-group
+```bash [CLI]
+vitest --inspect --browser
+```
+```ts [vitest.config.js]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    inspect: true,
+    browser: {
+      name: 'chromium',
+      provider: 'playwright',
+    },
+  },
+})
+```
+:::
+
+By default Vitest will use port `9229` as debugging port. You can overwrite it with by passing value in `inspect`:
+
+```bash
+vitest --inspect=127.0.0.1:3000 --browser
+```
+
+Use following [VSCode Compound configuration](https://code.visualstudio.com/docs/editor/debugging#_compound-launch-configurations) for launching Vitest and attaching debugger in the browser:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Vitest Browser",
+      "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+      "console": "integratedTerminal",
+      "args": ["--inspect", "--browser"]
+    },
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach to Vitest Browser",
+      "port": 9229
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug Vitest Browser",
+      "configurations": ["Attach to Vitest Browser", "Run Vitest Browser"],
+      "stopAll": true
+    }
+  ]
+}
+```
+
 ## IntelliJ IDEA
 
 Create a 'Node.js' run configuration. Use the following settings to run all tests in debug mode:

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -71,6 +71,18 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
         headless: options.headless,
       } satisfies LaunchOptions
 
+      if (this.ctx.config.inspector.enabled) {
+        // NodeJS equivalent defaults: https://nodejs.org/en/learn/getting-started/debugging#enable-inspector
+        const port = this.ctx.config.inspector.port || 9229
+        const host = this.ctx.config.inspector.host || '127.0.0.1'
+
+        launchOptions.args ||= []
+        launchOptions.args.push(`--remote-debugging-port=${port}`)
+        launchOptions.args.push(`--remote-debugging-address=${host}`)
+
+        this.ctx.logger.log(`Debugger listening on ws://${host}:${port}`)
+      }
+
       // start Vitest UI maximized only on supported browsers
       if (this.ctx.config.browser.ui && this.browserName === 'chromium') {
         if (!launchOptions.args) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Closes https://github.com/vitest-dev/vitest/issues/5090

Adds support for opening debugger session on Browser mode via `vitest --inspect --browser`. This is only supported in Chromium browsers with Playwright. 

[vitest-inspect.webm](https://github.com/user-attachments/assets/ad5a1afc-756e-4c0b-a2c2-db7c350f3ce4)


Support for `--inspect-brk`, where debugger stops at the first test file is possible but not yet implemented. There's some weird going on with source maps in browser mode. Let's leave that feature to separate PR.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
