### PR TITLE
chore(deps): replace `execa` with `tinyexec`

### DIFF
--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -1586,35 +1586,6 @@ Repository: git+https://github.com/antfu/strip-literal.git
 
 ---------------------------------------
 
-## tinyexec
-License: MIT
-By: James Garbutt
-Repository: git+https://github.com/tinylibs/tinyexec.git
-
-> MIT License
->
-> Copyright (c) 2024 Tinylibs
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
----------------------------------------
-
 ## to-regex-range
 License: MIT
 By: Jon Schlinkert, Rouven Weßling

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -159,6 +159,7 @@
     "@vitest/utils": "workspace:*",
     "chai": "^5.1.1",
     "debug": "^4.3.6",
+    "execa": "^8.0.1",
     "magic-string": "^0.30.11",
     "pathe": "^1.1.2",
     "std-env": "^3.7.0",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -164,6 +164,7 @@
     "pathe": "^1.1.2",
     "std-env": "^3.7.0",
     "tinybench": "^2.9.0",
+    "tinyexec": "^0.3.0",
     "tinypool": "^1.0.0",
     "tinyrainbow": "^1.2.0",
     "vite": "^5.0.0",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -159,7 +159,6 @@
     "@vitest/utils": "workspace:*",
     "chai": "^5.1.1",
     "debug": "^4.3.6",
-    "execa": "^8.0.1",
     "magic-string": "^0.30.11",
     "pathe": "^1.1.2",
     "std-env": "^3.7.0",

--- a/packages/vitest/src/create/browser/creator.ts
+++ b/packages/vitest/src/create/browser/creator.ts
@@ -6,7 +6,7 @@ import c from 'tinyrainbow'
 import type { Agent } from '@antfu/install-pkg'
 import { detectPackageManager, installPackage } from '@antfu/install-pkg'
 import { findUp } from 'find-up'
-import { execa } from 'execa'
+import { x } from 'tinyexec'
 import type { BrowserBuiltinProvider } from '../../node/types/browser'
 import { configFiles } from '../../constants'
 import { generateExampleFiles } from './examples'
@@ -499,9 +499,10 @@ export async function create() {
     const allArgs = [...args, 'playwright', 'install', '--with-deps']
     log(c.cyan('◼'), `Installing Playwright dependencies with \`${c.bold(command)} ${c.bold(allArgs.join(' '))}\`...`)
     log()
-    await execa(command, allArgs, {
-      stdout: 'inherit',
-      stderr: 'inherit',
+    await x(command, allArgs, {
+      nodeOptions: {
+        stdio: ['pipe', 'inherit', 'inherit'],
+      },
     })
   }
 

--- a/packages/vitest/src/node/git.ts
+++ b/packages/vitest/src/node/git.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'pathe'
-import { execa } from 'execa'
-import type { ExecaReturnValue } from 'execa'
+import type { Output } from 'tinyexec'
+import { x } from 'tinyexec'
 
 export interface GitOptions {
   changedSince?: string | boolean
@@ -12,10 +12,10 @@ export class VitestGit {
   constructor(private cwd: string) {}
 
   private async resolveFilesWithGitCommand(args: string[]): Promise<string[]> {
-    let result: ExecaReturnValue
+    let result: Output
 
     try {
-      result = await execa('git', args, { cwd: this.root })
+      result = await x('git', args, { nodeOptions: { cwd: this.root } })
     }
     catch (e: any) {
       e.message = e.stderr
@@ -75,12 +75,12 @@ export class VitestGit {
   }
 
   async getRoot(cwd: string) {
-    const options = ['rev-parse', '--show-cdup']
+    const args = ['rev-parse', '--show-cdup']
 
     try {
-      const result = await execa('git', options, { cwd })
+      const result = await x('git', args, { nodeOptions: { cwd } })
 
-      return resolve(cwd, result.stdout)
+      return resolve(cwd, result.stdout.trim())
     }
     catch {
       return null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1196,9 +1196,9 @@ importers:
 
   test/config:
     devDependencies:
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
+      tinyexec:
+        specifier: ^0.3.0
+        version: 0.3.0
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.5.2)(terser@5.22.0)
@@ -1342,7 +1342,7 @@ importers:
         version: 3.4.37(typescript@5.5.4)
       webdriverio:
         specifier: latest
-        version: 9.0.8
+        version: 9.0.9
 
   test/global-setup:
     devDependencies:
@@ -1475,7 +1475,7 @@ importers:
         version: link:../../packages/vitest
       webdriverio:
         specifier: latest
-        version: 9.0.8
+        version: 9.0.9
 
   test/workspaces:
     devDependencies:
@@ -9288,8 +9288,8 @@ packages:
       devtools:
         optional: true
 
-  webdriverio@9.0.8:
-    resolution: {integrity: sha512-tule4UqQYIw+MfgO3k5KRTYNMFjEhg5o8ycAwK3Aygyq+tuyPSN2QGilC/XMIT6ZaS8cJNGZIRNBMOLkWc4SRg==}
+  webdriverio@9.0.9:
+    resolution: {integrity: sha512-IwvKzhcJ9NjOL55xwj27uTTKkfxsg77dmAfqoKFSP5dQ70JzU+NgxiALEjjWQDybtt1yGIkHk7wjjxjboMU1uw==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: ^22.3.0
@@ -18781,7 +18781,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@9.0.8:
+  webdriverio@9.0.9:
     dependencies:
       '@types/node': 20.14.15
       '@types/sinonjs__fake-timers': 8.1.5(patch_hash=ggdsr7nrdrzokhhihsihc2hdja)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,9 +1400,6 @@ importers:
 
   test/test-utils:
     devDependencies:
-      execa:
-        specifier: ^7.1.1
-        version: 7.1.1
       strip-ansi:
         specifier: ^7.0.1
         version: 7.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
       tinybench:
         specifier: ^2.9.0
         version: 2.9.0
+      tinyexec:
+        specifier: ^0.3.0
+        version: 0.3.0
       tinypool:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1339,7 +1342,7 @@ importers:
         version: 3.4.37(typescript@5.5.4)
       webdriverio:
         specifier: latest
-        version: 9.0.7
+        version: 9.0.8
 
   test/global-setup:
     devDependencies:
@@ -1469,7 +1472,7 @@ importers:
         version: link:../../packages/vitest
       webdriverio:
         specifier: latest
-        version: 9.0.7
+        version: 9.0.8
 
   test/workspaces:
     devDependencies:
@@ -4268,9 +4271,9 @@ packages:
     resolution: {integrity: sha512-RED2vcdX5Zdd6r+K+aWcjK4douxjJY4LP/8YvvavgqM0TURd5PDI0Y7IEz7+BIJOT4Uh+3atZawIN9/3yWFeag==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/config@9.0.6':
-    resolution: {integrity: sha512-WsACM5QjT3ZsoPVqHroYt8pOkZx4/6PTdNKm45VL8NHhQe5w9IFbl1fKxFHQ7ZkPI3F+EFvFvubO8puJ0OcSmQ==}
-    engines: {node: '>=18'}
+  '@wdio/config@9.0.8':
+    resolution: {integrity: sha512-37L+hd+A1Nyehd/pgfTrLC6w+Ngbu0CIoFh9Vv6v8Cgu5Hih0TLofvlg+J1BNbcTd5eQ2tFKZBDeFMhQaIiTpg==}
+    engines: {node: '>=18.20.0'}
 
   '@wdio/logger@8.28.0':
     resolution: {integrity: sha512-/s6zNCqwy1hoc+K4SJypis0Ud0dlJ+urOelJFO1x0G0rwDRWyFiUP6ijTaCcFxAm29jYEcEPWijl2xkVIHwOyA==}
@@ -4280,9 +4283,9 @@ packages:
     resolution: {integrity: sha512-kcHL86RmNbcQP+Gq/vQUGlArfU6IIcbbnNp32rRIraitomZow+iEoc519rdQmSVusDozMS5DZthkgDdxK+vz6Q==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/logger@9.0.4':
-    resolution: {integrity: sha512-b6gcu0PTVb3fgK4kyAH/k5UUWN5FOUdAfhA4PAY/IZvxZTMFYMqnrZb0WRWWWqL6nu9pcrOVtCOdPBvj0cb+Nw==}
-    engines: {node: '>=18'}
+  '@wdio/logger@9.0.8':
+    resolution: {integrity: sha512-uIyYIDBwLczmsp9JE5hN3ME8Xg+9WNBfSNXD69ICHrY9WPTzFf94UeTuavK7kwSKF3ro2eJbmNZItYOfnoovnw==}
+    engines: {node: '>=18.20.0'}
 
   '@wdio/protocols@8.32.0':
     resolution: {integrity: sha512-inLJRrtIGdTz/YPbcsvpSvPlYQFTVtF3OYBwAXhG2FiP1ZwE1CQNLP/xgRGye1ymdGCypGkexRqIx3KBGm801Q==}
@@ -4290,16 +4293,16 @@ packages:
   '@wdio/protocols@8.38.0':
     resolution: {integrity: sha512-7BPi7aXwUtnXZPeWJRmnCNFjyDvGrXlBmN9D4Pi58nILkyjVRQKEY9/qv/pcdyB0cvmIvw++Kl/1Lg+RxG++UA==}
 
-  '@wdio/protocols@9.0.4':
-    resolution: {integrity: sha512-T9v8Jkp94NxLLil5J7uJ/+YHk5/7fhOggzGcN+LvuCHS6jbJFZ/11c4SUEuXw27Yqk01fFXPBbF6TwcTTOuW/Q==}
+  '@wdio/protocols@9.0.8':
+    resolution: {integrity: sha512-xRH54byFf623/w/KW62xkf/C2mGyigSfMm+UT3tNEAd5ZA9X2VAWQWQBPzdcrsck7Fxk4zlQX8Kb34RSs7Cy4Q==}
 
   '@wdio/repl@8.24.12':
     resolution: {integrity: sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/repl@9.0.4':
-    resolution: {integrity: sha512-5Bc5ARjWA7t6MZNnVJ9WvO1iDsy6iOsrSDWiP7APWAdaF/SJCP3SFE2c+PdQJpJWhr2Kk0fRGuyDM+GdsmZhwg==}
-    engines: {node: '>=18'}
+  '@wdio/repl@9.0.8':
+    resolution: {integrity: sha512-3iubjl4JX5zD21aFxZwQghqC3lgu+mSs8c3NaiYYNCC+IT5cI/8QuKlgh9s59bu+N3gG988jqMJeCYlKuUv/iw==}
+    engines: {node: '>=18.20.0'}
 
   '@wdio/types@8.32.2':
     resolution: {integrity: sha512-jq8LcBBQpBP9ZF5kECKEpXv8hN7irCGCjLFAN0Bd5ScRR6qu6MGWvwkDkau2sFPr0b++sKDCEaMzQlwrGFjZXg==}
@@ -4309,9 +4312,9 @@ packages:
     resolution: {integrity: sha512-86lcYROTapOJuFd9ouomFDfzDnv3Kn+jE0RmqfvN9frZAeLVJ5IKjX9M6HjplsyTZhjGO1uCaehmzx+HJus33Q==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/types@9.0.4':
-    resolution: {integrity: sha512-MN7O4Uk3zPWvkN8d6SNdIjd7qHUlTxS7j0QfRPu6TdlYbHu6BJJ8Rr84y7GcUzCnTAJ1nOIpvUyR8MY3hOaVKg==}
-    engines: {node: '>=18'}
+  '@wdio/types@9.0.8':
+    resolution: {integrity: sha512-pmz2iRWddTanrv8JC7v3wUGm17KRv2WyyJhQfklMSANn9V1ep6pw1RJG2WJnKq4NojMvH1nVv1sMZxXrYPhpYw==}
+    engines: {node: '>=18.20.0'}
 
   '@wdio/utils@8.32.2':
     resolution: {integrity: sha512-PJcP4d1Fr8Zp+YIfGN93G0fjDj/6J0I6Gf6p0IpJk8qKQpdFDm4gB+lc202iv2YkyC+oT6b4Ik2W9LzvpSKNoQ==}
@@ -4321,9 +4324,9 @@ packages:
     resolution: {integrity: sha512-leYcCUSaAdLUCVKqRKNgMCASPOUo/VvOTKETiZ/qpdY2azCBt/KnLugtiycCzakeYg6Kp+VIjx5fkm0M7y4qhA==}
     engines: {node: ^16.13 || >=18}
 
-  '@wdio/utils@9.0.6':
-    resolution: {integrity: sha512-cnPXeW/sfqyKFuRRmADRZDNvFwEBMr7j7wwWLO6q5opoW++dwOdJW4WV0wDZbPcXTtGFCSrGCDLLdGcTAWMb3A==}
-    engines: {node: '>=18'}
+  '@wdio/utils@9.0.8':
+    resolution: {integrity: sha512-p3EgOdkhCvMxJFd3WTtSChqYFQu2mz69/5tOsljDaL+4QYwnRR7O8M9wFsL3/9XMVcHdnC4Ija2VRxQ/lb+hHQ==}
+    engines: {node: '>=18.20.0'}
 
   '@yeger/debounce@2.0.9':
     resolution: {integrity: sha512-yapSa71O56W0zotDlgv7z/equgK61Ozb8rSEWsNX7oN543oUMucWVWIlDp73/Jg7D08xAkw+E23OVLe1xIBS7A==}
@@ -9260,9 +9263,9 @@ packages:
     resolution: {integrity: sha512-GoRR94m3yL8tWC9Myf+xIBSdVK8fi1ilZgEZZaYT8+XIWewR02dvrC6rml+/2ZjXUQzeee0RFGDwk9IC7cyYrg==}
     engines: {node: ^16.13 || >=18}
 
-  webdriver@9.0.7:
-    resolution: {integrity: sha512-0PN4omqCGlgi3RG0LyrQXr0RUmlDCenNtpN+dfzikfYoV+CHiCw2GMnZp2XCuYUnU01MaCKgRQxLuGobyZov+A==}
-    engines: {node: '>=18'}
+  webdriver@9.0.8:
+    resolution: {integrity: sha512-UnV0ANriSTUgypGk0pz8lApeQuHt+72WEDQG5hFwkkSvggtKLyWdT7+PQkNoXvDajTmiLIqUOq8XPI/Pm71rtw==}
+    engines: {node: '>=18.20.0'}
 
   webdriverio@8.32.2:
     resolution: {integrity: sha512-Z0Wc/dHFfWGWJZpaQ8u910/LG0E9EIVTO7J5yjqWx2XtXz2LzQMxYwNRnvNLhY/1tI4y/cZxI6kFMWr8wD2TtA==}
@@ -9282,9 +9285,9 @@ packages:
       devtools:
         optional: true
 
-  webdriverio@9.0.7:
-    resolution: {integrity: sha512-/6CvJkKpUWYbX/59PNJCHXGLPwulQ/bXZwlIUrsF6MWKdf8Eb6yTaXkMJBaBy5x496b50PQcXkbe+qpfsnqXsg==}
-    engines: {node: '>=18'}
+  webdriverio@9.0.8:
+    resolution: {integrity: sha512-tule4UqQYIw+MfgO3k5KRTYNMFjEhg5o8ycAwK3Aygyq+tuyPSN2QGilC/XMIT6ZaS8cJNGZIRNBMOLkWc4SRg==}
+    engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: ^22.3.0
     peerDependenciesMeta:
@@ -11327,7 +11330,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.14.15
+      '@types/node': 22.5.2
       '@types/yargs': 17.0.12
       chalk: 4.1.2
 
@@ -12113,7 +12116,7 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 20.14.15
+      '@types/node': 22.5.2
 
   '@types/natural-compare@1.4.3': {}
 
@@ -12211,7 +12214,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.15
+      '@types/node': 22.5.2
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.3.0(@typescript-eslint/parser@8.3.0(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4))(eslint@9.9.0(jiti@1.21.6))(typescript@5.5.4)':
@@ -12844,11 +12847,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wdio/config@9.0.6':
+  '@wdio/config@9.0.8':
     dependencies:
-      '@wdio/logger': 9.0.4
-      '@wdio/types': 9.0.4
-      '@wdio/utils': 9.0.6
+      '@wdio/logger': 9.0.8
+      '@wdio/types': 9.0.8
+      '@wdio/utils': 9.0.8
       decamelize: 6.0.0
       deepmerge-ts: 7.1.0
       glob: 10.4.1
@@ -12870,7 +12873,7 @@ snapshots:
       loglevel-plugin-prefix: 0.8.4
       strip-ansi: 7.1.0
 
-  '@wdio/logger@9.0.4':
+  '@wdio/logger@9.0.8':
     dependencies:
       chalk: 5.3.0
       loglevel: 1.8.1
@@ -12881,13 +12884,13 @@ snapshots:
 
   '@wdio/protocols@8.38.0': {}
 
-  '@wdio/protocols@9.0.4': {}
+  '@wdio/protocols@9.0.8': {}
 
   '@wdio/repl@8.24.12':
     dependencies:
       '@types/node': 20.14.15
 
-  '@wdio/repl@9.0.4':
+  '@wdio/repl@9.0.8':
     dependencies:
       '@types/node': 20.14.15
 
@@ -12899,7 +12902,7 @@ snapshots:
     dependencies:
       '@types/node': 20.14.15
 
-  '@wdio/types@9.0.4':
+  '@wdio/types@9.0.8':
     dependencies:
       '@types/node': 20.14.15
 
@@ -12939,11 +12942,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wdio/utils@9.0.6':
+  '@wdio/utils@9.0.8':
     dependencies:
       '@puppeteer/browsers': 2.3.1
-      '@wdio/logger': 9.0.4
-      '@wdio/types': 9.0.4
+      '@wdio/logger': 9.0.8
+      '@wdio/types': 9.0.8
       decamelize: 6.0.0
       deepmerge-ts: 7.1.0
       edgedriver: 5.6.1
@@ -14976,7 +14979,7 @@ snapshots:
 
   geckodriver@4.4.3:
     dependencies:
-      '@wdio/logger': 9.0.4
+      '@wdio/logger': 9.0.8
       '@zip.js/zip.js': 2.7.48
       decamelize: 6.0.0
       http-proxy-agent: 7.0.2
@@ -15659,7 +15662,7 @@ snapshots:
   jest-util@29.0.1:
     dependencies:
       '@jest/types': 29.0.1
-      '@types/node': 20.14.15
+      '@types/node': 22.5.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -18693,15 +18696,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.0.7:
+  webdriver@9.0.8:
     dependencies:
       '@types/node': 20.14.15
       '@types/ws': 8.5.12
-      '@wdio/config': 9.0.6
-      '@wdio/logger': 9.0.4
-      '@wdio/protocols': 9.0.4
-      '@wdio/types': 9.0.4
-      '@wdio/utils': 9.0.6
+      '@wdio/config': 9.0.8
+      '@wdio/logger': 9.0.8
+      '@wdio/protocols': 9.0.8
+      '@wdio/types': 9.0.8
+      '@wdio/utils': 9.0.8
       deepmerge-ts: 7.1.0
       ws: 8.18.0
     transitivePeerDependencies:
@@ -18775,16 +18778,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@9.0.7:
+  webdriverio@9.0.8:
     dependencies:
       '@types/node': 20.14.15
       '@types/sinonjs__fake-timers': 8.1.5(patch_hash=ggdsr7nrdrzokhhihsihc2hdja)
-      '@wdio/config': 9.0.6
-      '@wdio/logger': 9.0.4
-      '@wdio/protocols': 9.0.4
-      '@wdio/repl': 9.0.4
-      '@wdio/types': 9.0.4
-      '@wdio/utils': 9.0.6
+      '@wdio/config': 9.0.8
+      '@wdio/logger': 9.0.8
+      '@wdio/protocols': 9.0.8
+      '@wdio/repl': 9.0.8
+      '@wdio/types': 9.0.8
+      '@wdio/utils': 9.0.8
       archiver: 7.0.1
       aria-query: 5.3.0
       cheerio: 1.0.0
@@ -18803,7 +18806,7 @@ snapshots:
       rgb2hex: 0.2.5
       serialize-error: 11.0.3
       urlpattern-polyfill: 10.0.0
-      webdriver: 9.0.7
+      webdriver: 9.0.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,9 +941,6 @@ importers:
       debug:
         specifier: ^4.3.6
         version: 4.3.6
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
       magic-string:
         specifier: ^0.30.11
         version: 0.30.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1406,6 +1406,9 @@ importers:
       strip-ansi:
         specifier: ^7.0.1
         version: 7.0.1
+      tinyexec:
+        specifier: ^0.3.0
+        version: 0.3.0
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.5.2)(terser@5.22.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,9 @@ importers:
       debug:
         specifier: ^4.3.6
         version: 4.3.6
+      execa:
+        specifier: ^8.0.1
+        version: 8.0.1
       magic-string:
         specifier: ^0.30.11
         version: 0.30.11

--- a/test/cli/test/dotted-files.test.ts
+++ b/test/cli/test/dotted-files.test.ts
@@ -4,7 +4,7 @@ import { runVitestCli } from '../../test-utils'
 
 it('run tests even though they are inside the .cache directory', async () => {
   const { stderr } = await runVitestCli({
-    cwd: resolve(process.cwd(), 'fixtures/dotted-files/.cache/projects/test'),
+    nodeOptions: { cwd: resolve(process.cwd(), 'fixtures/dotted-files/.cache/projects/test') },
   }, '--no-watch')
   expect(stderr).toBe('')
 })

--- a/test/config/package.json
+++ b/test/config/package.json
@@ -6,7 +6,7 @@
     "test": "vitest --typecheck.enabled"
   },
   "devDependencies": {
-    "execa": "^8.0.1",
+    "tinyexec": "^0.3.0",
     "vite": "latest",
     "vitest": "workspace:*"
   }

--- a/test/config/test/console-color.test.ts
+++ b/test/config/test/console-color.test.ts
@@ -1,28 +1,30 @@
 import { expect, test } from 'vitest'
-import { execa } from 'execa'
+import { x } from 'tinyexec'
 
-// use "execa" directly since "runVitestCli" strips color
+// use "x" directly since "runVitestCli" strips color
 
 test('with color', async () => {
-  const proc = await execa('vitest', ['run', '--root=./fixtures/console-color'], {
-    env: {
-      CI: '1',
-      FORCE_COLOR: '1',
-      NO_COLOR: undefined,
-      GITHUB_ACTIONS: undefined,
+  const proc = await x('vitest', ['run', '--root=./fixtures/console-color'], {
+    nodeOptions: {
+      env: {
+        CI: '1',
+        FORCE_COLOR: '1',
+        NO_COLOR: undefined,
+        GITHUB_ACTIONS: undefined,
+      },
     },
   })
   expect(proc.stdout).toContain('\n\x1B[33mtrue\x1B[39m\n')
 })
 
 test('without color', async () => {
-  const proc = await execa('vitest', ['run', '--root=./fixtures/console-color'], {
-    env: {
+  const proc = await x('vitest', ['run', '--root=./fixtures/console-color'], {
+    nodeOptions: { env: {
       CI: '1',
       FORCE_COLOR: undefined,
       NO_COLOR: '1',
       GITHUB_ACTIONS: undefined,
-    },
+    } },
   })
   expect(proc.stdout).toContain('\ntrue\n')
 })

--- a/test/config/test/console-color.test.ts
+++ b/test/config/test/console-color.test.ts
@@ -19,12 +19,14 @@ test('with color', async () => {
 
 test('without color', async () => {
   const proc = await x('vitest', ['run', '--root=./fixtures/console-color'], {
-    nodeOptions: { env: {
-      CI: '1',
-      FORCE_COLOR: undefined,
-      NO_COLOR: '1',
-      GITHUB_ACTIONS: undefined,
-    } },
+    nodeOptions: {
+      env: {
+        CI: '1',
+        FORCE_COLOR: undefined,
+        NO_COLOR: '1',
+        GITHUB_ACTIONS: undefined,
+      },
+    },
   })
   expect(proc.stdout).toContain('\ntrue\n')
 })

--- a/test/config/test/exec-args.test.ts
+++ b/test/config/test/exec-args.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { execa } from 'execa'
+import { x } from 'tinyexec'
 import { runVitest } from '../../test-utils'
 
 const [nodeMajor, nodeMinor] = process.version.slice(1).split('.').map(Number)
@@ -35,18 +35,20 @@ test.each([
 })
 
 test('should not pass execArgv to workers when not specified in the config', async () => {
-  const { stdout, stderr } = await execa('node', [
+  const { stdout, stderr } = await x('node', [
     '--title',
     'this-works-only-on-main-thread',
     '../../../../node_modules/vitest/vitest.mjs',
     '--run',
   ], {
-    cwd: `${process.cwd()}/fixtures/no-exec-args-fixtures`,
-    reject: false,
-    env: {
-      VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
-      NO_COLOR: '1',
+    nodeOptions: {
+      cwd: `${process.cwd()}/fixtures/no-exec-args-fixtures`,
+      env: {
+        VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
+        NO_COLOR: '1',
+      },
     },
+    throwOnError: false,
   })
 
   expect(stderr).not.toContain('Error: Initiated Worker with invalid execArgv flags: --title')
@@ -55,19 +57,21 @@ test('should not pass execArgv to workers when not specified in the config', asy
 })
 
 test('should let allowed args pass to workers', async () => {
-  const { stdout, stderr } = await execa('node', [
+  const { stdout, stderr } = await x('node', [
     '--heap-prof',
     '--diagnostic-dir=/tmp/vitest-diagnostics',
     '--heap-prof-name=heap.prof',
     '../../../../node_modules/vitest/vitest.mjs',
     '--run',
   ], {
-    cwd: `${process.cwd()}/fixtures/allowed-exec-args-fixtures`,
-    reject: false,
-    env: {
-      VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
-      NO_COLOR: '1',
+    nodeOptions: {
+      cwd: `${process.cwd()}/fixtures/allowed-exec-args-fixtures`,
+      env: {
+        VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
+        NO_COLOR: '1',
+      },
     },
+    throwOnError: false,
   })
 
   expect(stderr).toBe('')

--- a/test/reporters/tests/custom-reporter.spec.ts
+++ b/test/reporters/tests/custom-reporter.spec.ts
@@ -13,7 +13,7 @@ async function runWithRetry(...runOptions: string[]) {
 
   for (let i = count; i >= 0; i--) {
     try {
-      const vitest = await runVitestCli({ cwd: root, windowsHide: false }, 'run', ...runOptions)
+      const vitest = await runVitestCli({ nodeOptions: { cwd: root, windowsHide: false } }, 'run', ...runOptions)
       return vitest.stdout
     }
     catch (e) {

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -123,7 +123,7 @@ export async function runVitest(
   }
 }
 
-export async function runCli(command: string, _options?: Options, ...args: string[]) {
+export async function runCli(command: string, _options?: Partial<Options> | string, ...args: string[]) {
   let options = _options
 
   if (typeof _options === 'string') {
@@ -131,7 +131,7 @@ export async function runCli(command: string, _options?: Options, ...args: strin
     options = undefined
   }
 
-  const subprocess = x(command, args, options).process!
+  const subprocess = x(command, args, options as Options).process!
   const cli = new Cli({
     stdin: subprocess.stdin!,
     stdout: subprocess.stdout!,
@@ -181,12 +181,12 @@ export async function runCli(command: string, _options?: Options, ...args: strin
   return output()
 }
 
-export async function runVitestCli(_options?: Options, ...args: string[]) {
+export async function runVitestCli(_options?: Partial<Options> | string, ...args: string[]) {
   process.env.VITE_TEST_WATCHER_DEBUG = 'true'
   return runCli('vitest', _options, ...args)
 }
 
-export async function runViteNodeCli(_options?: Options, ...args: string[]) {
+export async function runViteNodeCli(_options?: Partial<Options> | string, ...args: string[]) {
   process.env.VITE_TEST_WATCHER_DEBUG = 'true'
   const { vitest, ...rest } = await runCli('vite-node', _options, ...args)
 

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -5,7 +5,8 @@ import type { UserConfig as ViteUserConfig } from 'vite'
 import { type UserConfig, type VitestRunMode, type WorkerGlobalState, afterEach, onTestFinished } from 'vitest'
 import type { Vitest } from 'vitest/node'
 import { startVitest } from 'vitest/node'
-import { type Options, execa } from 'execa'
+import type { Options } from 'tinyexec'
+import { x } from 'tinyexec'
 import { dirname, resolve } from 'pathe'
 import { getCurrentTest } from 'vitest/suite'
 import { Cli } from './cli'
@@ -122,7 +123,7 @@ export async function runVitest(
   }
 }
 
-export async function runCli(command: string, _options?: Options | string, ...args: string[]) {
+export async function runCli(command: string, _options?: Options, ...args: string[]) {
   let options = _options
 
   if (typeof _options === 'string') {
@@ -130,7 +131,7 @@ export async function runCli(command: string, _options?: Options | string, ...ar
     options = undefined
   }
 
-  const subprocess = execa(command, args, options as Options)
+  const subprocess = x(command, args, options).process!
   const cli = new Cli({
     stdin: subprocess.stdin!,
     stdout: subprocess.stdout!,
@@ -180,12 +181,12 @@ export async function runCli(command: string, _options?: Options | string, ...ar
   return output()
 }
 
-export async function runVitestCli(_options?: Options | string, ...args: string[]) {
+export async function runVitestCli(_options?: Options, ...args: string[]) {
   process.env.VITE_TEST_WATCHER_DEBUG = 'true'
   return runCli('vitest', _options, ...args)
 }
 
-export async function runViteNodeCli(_options?: Options | string, ...args: string[]) {
+export async function runViteNodeCli(_options?: Options, ...args: string[]) {
   process.env.VITE_TEST_WATCHER_DEBUG = 'true'
   const { vitest, ...rest } = await runCli('vite-node', _options, ...args)
 

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -7,7 +7,6 @@
     "test": "echo \"No tests\""
   },
   "devDependencies": {
-    "execa": "^7.1.1",
     "strip-ansi": "^7.0.1",
     "tinyexec": "^0.3.0",
     "vite": "latest",

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "execa": "^7.1.1",
     "strip-ansi": "^7.0.1",
+    "tinyexec": "^0.3.0",
     "vite": "latest",
     "vite-node": "workspace:*",
     "vitest": "workspace:*"

--- a/test/watch/test/workspaces.test.ts
+++ b/test/watch/test/workspaces.test.ts
@@ -28,7 +28,7 @@ test("dynamic test case", () => {
 
 async function startVitest() {
   const { vitest } = await runVitestCli(
-    { cwd: root, env: { TEST_WATCH: 'true' } },
+    { nodeOptions: { cwd: root, env: { TEST_WATCH: 'true' } } },
     '--root',
     root,
     '--config',


### PR DESCRIPTION
### Description

This PR replaces `execa` with a lighter `tinyexec` as discussed here: https://github.com/vitest-dev/vitest/pull/5713. Some notes inline as a code review, please let me know whether it'd make sense to comment the code accordingly in those places.

Not sure how to handle the third item in the checklist – should I revert the changes that remove the `execa` dependency?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
