### PR TITLE
chore: fix edge case in license files bundling

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "@vite-pwa/vitepress": "^0.5.0",
     "@vitejs/plugin-vue": "^5.1.2",
     "https-localhost": "^4.7.1",
-    "tinyglobby": "^0.2.5",
+    "tinyglobby": "^0.2.6",
     "unocss": "^0.62.0",
     "unplugin-vue-components": "^0.27.4",
     "vite": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-esbuild": "^6.1.1",
     "rollup-plugin-license": "^3.5.2",
-    "tinyglobby": "^0.2.5",
+    "tinyglobby": "^0.2.6",
     "tsx": "^4.17.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,7 +52,7 @@
     "flatted": "^3.3.1",
     "pathe": "^1.1.2",
     "sirv": "^2.0.4",
-    "tinyglobby": "^0.2.5",
+    "tinyglobby": "^0.2.6",
     "tinyrainbow": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -590,6 +590,14 @@ License: MIT
 By: thecodrr
 Repository: git+https://github.com/thecodrr/fdir.git
 
+> Copyright 2023 Abdullah Atta
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ---------------------------------------
 
 ## fill-range
@@ -1262,6 +1270,29 @@ Repository: git+https://github.com/antfu/strip-literal.git
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
+
+---------------------------------------
+
+## tinyglobby
+License: ISC
+By: Superchupu
+Repository: git+https://github.com/SuperchupuDev/tinyglobby.git
+
+> ISC License
+>
+> Copyright (c) 2024 Madeline Gurriarán
+>
+> Permission to use, copy, modify, and/or distribute this software for any
+> purpose with or without fee is hereby granted, provided that the above
+> copyright notice and this permission notice appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+> MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+> ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+> WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+> ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+> OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
 

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -202,7 +202,7 @@
     "prompts": "^2.4.2",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
-    "tinyglobby": "^0.2.5",
+    "tinyglobby": "^0.2.6",
     "ws": "^8.18.0"
   }
 }

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -198,7 +198,10 @@ function licensePlugin() {
                     preserveSymlinks: false,
                   }),
                 )
-                const [licenseFile] = globSync([`${pkgDir}/(LICENSE)|(license)*`], { expandDirectories: false })
+                const [licenseFile] = globSync([`${pkgDir}/LICENSE*`], {
+                  expandDirectories: false,
+                  caseSensitiveMatch: false,
+                })
                 if (licenseFile) {
                   licenseText = fs.readFileSync(licenseFile, 'utf-8')
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ^3.5.2
         version: 3.5.2(rollup@4.20.0)
       tinyglobby:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.6
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
@@ -157,8 +157,8 @@ importers:
         specifier: ^4.7.1
         version: 4.7.1
       tinyglobby:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.6
       unocss:
         specifier: ^0.62.0
         version: 0.62.0(postcss@8.4.40)(rollup@4.20.0)(vite@5.4.0(@types/node@22.5.2)(terser@5.22.0))
@@ -762,8 +762,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4
       tinyglobby:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.6
       tinyrainbow:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1069,8 +1069,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tinyglobby:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.6
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -5826,8 +5826,8 @@ packages:
       picomatch:
         optional: true
 
-  fdir@6.2.0:
-    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
+  fdir@6.3.0:
+    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -8586,8 +8586,8 @@ packages:
   tinyexec@0.3.0:
     resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
 
-  tinyglobby@0.2.5:
-    resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
+  tinyglobby@0.2.6:
+    resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
     engines: {node: '>=12.0.0'}
 
   tinyhighlight@0.3.2:
@@ -12332,7 +12332,7 @@ snapshots:
       magic-string: 0.30.11
       pathe: 1.1.2
       perfect-debounce: 1.0.0
-      tinyglobby: 0.2.5
+      tinyglobby: 0.2.6
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -12365,7 +12365,7 @@ snapshots:
       css-tree: 2.3.1
       magic-string: 0.30.11
       postcss: 8.4.40
-      tinyglobby: 0.2.5
+      tinyglobby: 0.2.6
     transitivePeerDependencies:
       - supports-color
 
@@ -12461,7 +12461,7 @@ snapshots:
       '@unocss/transformer-directives': 0.62.0
       chokidar: 3.6.0
       magic-string: 0.30.11
-      tinyglobby: 0.2.5
+      tinyglobby: 0.2.6
       vite: 5.4.0(@types/node@22.5.2)(terser@5.22.0)
     transitivePeerDependencies:
       - rollup
@@ -14782,7 +14782,7 @@ snapshots:
 
   fdir@6.1.1: {}
 
-  fdir@6.2.0(picomatch@4.0.2):
+  fdir@6.3.0(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -17932,9 +17932,9 @@ snapshots:
 
   tinyexec@0.3.0: {}
 
-  tinyglobby@0.2.5:
+  tinyglobby@0.2.6:
     dependencies:
-      fdir: 6.2.0(picomatch@4.0.2)
+      fdir: 6.3.0(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinyhighlight@0.3.2(picocolors@1.0.1):
@@ -18435,7 +18435,7 @@ snapshots:
     dependencies:
       debug: 4.3.6
       pretty-bytes: 6.1.1
-      tinyglobby: 0.2.5
+      tinyglobby: 0.2.6
       vite: 5.4.0(@types/node@22.5.2)(terser@5.22.0)
       workbox-build: 7.1.0(@types/babel__core@7.20.5)
       workbox-window: 7.1.0


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
#6274 removed usage of the `caseSensitiveMatch` option as `tinyglobby` didn't have it at the time. It switched to a simple `(LICENSE)|(license)` matching instead. As you can imagine, this introduced an edge case that made mixed-case license files not match. Thankfully the edge case was never hit. The latest `tinyglobby` version added this option, so this PR makes usage of it, fixing this edge case.
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
