### PR TITLE
fix: `expect.getState().testPath` always returns correct path

### DIFF
--- a/packages/expect/src/state.ts
+++ b/packages/expect/src/state.ts
@@ -39,6 +39,10 @@ export function setState<State extends MatcherState = MatcherState>(
 ): void {
   const map = (globalThis as any)[MATCHERS_OBJECT]
   const current = map.get(expect) || {}
-  Object.assign(current, state)
-  map.set(expect, current)
+  // so it keeps getters from `testPath`
+  const results = Object.defineProperties(current, {
+    ...Object.getOwnPropertyDescriptors(current),
+    ...Object.getOwnPropertyDescriptors(state),
+  })
+  map.set(expect, results)
 }

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -39,7 +39,6 @@ export function createExpect(test?: TaskPopulated) {
   // @ts-expect-error global is not typed
   const globalState = getState(globalThis[GLOBAL_EXPECT]) || {}
 
-  const testPath = getTestFile()
   setState<MatcherState>(
     {
       // this should also add "snapshotState" that is added conditionally
@@ -50,7 +49,9 @@ export function createExpect(test?: TaskPopulated) {
       expectedAssertionsNumber: null,
       expectedAssertionsNumberErrorGen: null,
       environment: getCurrentEnvironment(),
-      testPath,
+      get testPath() {
+        return getWorkerState().filepath
+      },
       currentTestName: test
         ? getTestName(test as Test)
         : globalState.currentTestName,
@@ -109,11 +110,6 @@ export function createExpect(test?: TaskPopulated) {
   chai.util.addMethod(expect, 'hasAssertions', hasAssertions)
 
   return expect
-}
-
-function getTestFile() {
-  const state = getWorkerState()
-  return state.filepath
 }
 
 const globalExpect = createExpect()

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -39,7 +39,7 @@ export function createExpect(test?: TaskPopulated) {
   // @ts-expect-error global is not typed
   const globalState = getState(globalThis[GLOBAL_EXPECT]) || {}
 
-  const testPath = getTestFile(test)
+  const testPath = getTestFile()
   setState<MatcherState>(
     {
       // this should also add "snapshotState" that is added conditionally
@@ -111,10 +111,7 @@ export function createExpect(test?: TaskPopulated) {
   return expect
 }
 
-function getTestFile(test?: TaskPopulated) {
-  if (test) {
-    return test.file.filepath
-  }
+function getTestFile() {
   const state = getWorkerState()
   return state.filepath
 }

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -2,6 +2,11 @@ import { assert, expect, it, suite, test } from 'vitest'
 import { two } from '../src/submodule'
 import { timeout } from '../src/timeout'
 
+const testPath = expect.getState().testPath
+if (!testPath || !testPath.includes('basic.test.ts')) {
+  throw new Error(`testPath is not correct: ${testPath}`)
+}
+
 test('Math.sqrt()', async () => {
   assert.equal(Math.sqrt(4), two)
   assert.equal(Math.sqrt(2), Math.SQRT2)
@@ -63,8 +68,3 @@ test('escaping', () => {
   expect(['\\123']).toEqual(['\\123'])
   expect('\\123').toEqual('\\123')
 })
-
-const testPath = expect.getState().testPath
-if (!testPath || !testPath.includes('basic.test.ts')) {
-  throw new Error(`testPath not correct: ${testPath}`)
-}

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -63,3 +63,8 @@ test('escaping', () => {
   expect(['\\123']).toEqual(['\\123'])
   expect('\\123').toEqual('\\123')
 })
+
+const testPath = expect.getState().testPath
+if (!testPath || !testPath.includes('basic.test.ts')) {
+  throw new Error(`testPath not correct: ${testPath}`)
+}


### PR DESCRIPTION
### Description

Fixes #6367

- [x] TODO: tests

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
