### PR TITLE
fix: make example test callbacks async

### DIFF
--- a/packages/vitest/src/create/browser/examples.ts
+++ b/packages/vitest/src/create/browser/examples.ts
@@ -27,7 +27,7 @@ import { expect, test } from 'vitest'
 import { render } from '@testing-library/jsx'
 import HelloWorld from './HelloWorld.jsx'
 
-test('renders name', () => {
+test('renders name', async () => {
   const { getByText } = render(<HelloWorld name="Vitest" />)
   await expect.element(getByText('Hello Vitest!')).toBeInTheDocument()
 })
@@ -67,7 +67,7 @@ import { expect, test } from 'vitest'
 import { render } from 'vitest-browser-vue'
 import HelloWorld from './HelloWorld.vue'
 
-test('renders name', () => {
+test('renders name', async () => {
   const { getByText } = render(HelloWorld, {
     props: { name: 'Vitest' },
   })
@@ -97,7 +97,7 @@ import { expect, test } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import HelloWorld from './HelloWorld.svelte'
 
-test('renders name', () => {
+test('renders name', async () => {
   const { getByText } = render(HelloWorld, { name: 'Vitest' })
   await expect.element(getByText('Hello Vitest!')).toBeInTheDocument()
 })


### PR DESCRIPTION
A missing `async` threw an error in the Learn With Jason livestream on Vitest browser mode with Vladimir Sheremet.

Browser mode looks super cool!

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
