### PR TITLE
fix(browser): fix strip base for client script

### DIFF
--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -55,7 +55,7 @@ export async function resolveTester(
     const testerScripts = await server.formatScripts(
       project.config.browser.testerScripts,
     )
-    const clientScript = `<script type="module" src="${server.project.config.base || '/'}@vite/client"></script>`
+    const clientScript = `<script type="module" src="${server.base}@vite/client"></script>`
     const stateJs = typeof server.stateJs === 'string'
       ? server.stateJs
       : await server.stateJs


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6509

Browser mode's vite server forces `base: "/"` for vite server, but client script was using a base from the original config `server.project.config.base`.

https://github.com/vitest-dev/vitest/blob/54a066d09f72dbee184ab5a577aa0ae2c58db0d6/packages/browser/src/node/index.ts#L29

https://github.com/vitest-dev/vitest/blob/155b690c7bcfc044ac5337fdb2b1821e25b1bab9/packages/browser/src/node/index.ts#L37-L39

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
