### PR TITLE
fix(browser): exports of context in package.json

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,7 +26,7 @@
     },
     "./context": {
       "types": "./context.d.ts",
-      "default": "./context.js"
+      "default": "./dist/context.js"
     },
     "./client": {
       "default": "./dist/client.js"


### PR DESCRIPTION
### Description

I tried to run vitest in browser mode, but it failed for the error `The requested module '@vitest/browser/context' does not provide an export named 'page'`. Then I noticed that in the `package.json` we're exporting the wrong (empty) file.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
