### PR TITLE
chore: fix browser package dev watch

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -64,7 +64,7 @@
     "build:client": "vite build src/client",
     "build:node": "rollup -c",
     "dev:client": "vite build src/client --watch",
-    "dev:node": "rollup -c --watch --watch.include 'src/node/**'",
+    "dev:node": "rollup -c --watch --watch.include 'src/**'",
     "dev": "rimraf dist && pnpm run --stream '/^dev:/'"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

I noticed `pnpm dev` is not rebuilding when modifying `packages/browser/src/client/tester/context.ts`. To fix this, I loosened `rollup --watch.include` since some client entries are built by rollup.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
