### PR TITLE
fix(benchmark): clear `BenchmarkResult.samples` array to reduce memory usage

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -24,6 +24,7 @@ export const benchmarkConfigDefaults: Required<
   exclude: defaultExclude,
   includeSource: [],
   reporters: ['default'],
+  includeSamples: false,
 }
 
 const defaultCoverageExcludes = [

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -160,5 +160,8 @@ export function serializeConfig(
     standalone: config.standalone,
     printConsoleTrace:
       config.printConsoleTrace ?? coreConfig.printConsoleTrace,
+    benchmark: config.benchmark && {
+      includeSamples: config.benchmark.includeSamples,
+    },
   }
 }

--- a/packages/vitest/src/node/reporters/benchmark/table/index.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/index.ts
@@ -167,10 +167,8 @@ interface FormattedBenchmarkGroup {
   benchmarks: FormattedBenchmarkResult[]
 }
 
-export type FormattedBenchmarkResult = Omit<BenchmarkResult, 'samples'> & {
+export type FormattedBenchmarkResult = BenchmarkResult & {
   id: string
-  sampleCount: number
-  median: number
 }
 
 function createFormattedBenchmarkReport(files: File[]) {
@@ -183,18 +181,7 @@ function createFormattedBenchmarkReport(files: File[]) {
         for (const t of task.tasks) {
           const benchmark = t.meta.benchmark && t.result?.benchmark
           if (benchmark) {
-            const { samples, ...rest } = benchmark
-            benchmarks.push({
-              id: t.id,
-              sampleCount: samples.length,
-              median:
-                samples.length % 2
-                  ? samples[Math.floor(samples.length / 2)]
-                  : (samples[samples.length / 2]
-                  + samples[samples.length / 2 - 1])
-                  / 2,
-              ...rest,
-            })
+            benchmarks.push({ id: t.id, ...benchmark, samples: [] })
           }
         }
         if (benchmarks.length) {

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -68,7 +68,7 @@ function renderBenchmarkItems(result: BenchmarkResult) {
     formatNumber(result.p995 || 0),
     formatNumber(result.p999 || 0),
     `±${(result.rme || 0).toFixed(2)}%`,
-    result.samples.length.toString(),
+    (result.sampleCount || 0).toString(),
   ]
 }
 
@@ -124,10 +124,7 @@ export function renderTree(
       }
       const baseline = options.compare?.[t.id]
       if (baseline) {
-        benchMap[t.id].baseline = {
-          ...baseline,
-          samples: Array.from({ length: baseline.sampleCount }),
-        }
+        benchMap[t.id].baseline = baseline
       }
     }
   }

--- a/packages/vitest/src/node/types/benchmark.ts
+++ b/packages/vitest/src/node/types/benchmark.ts
@@ -50,4 +50,11 @@ export interface BenchmarkUserOptions {
    * benchmark output file
    */
   outputJson?: string
+
+  /**
+   * Include `samples` array of benchmark results for API or custom reporter usages.
+   * This is diabled by default to reduce memory usage.
+   * @default false
+   */
+  includeSamples?: boolean
 }

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -129,6 +129,9 @@ export interface SerializedConfig {
   standalone: boolean
   logHeapUsage: boolean | undefined
   coverage: SerializedCoverageConfig
+  benchmark?: {
+    includeSamples: boolean
+  }
 }
 
 export interface SerializedCoverageConfig {

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -139,8 +139,9 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
           result.median = samples.length % 2
             ? samples[Math.floor(samples.length / 2)]
             : (samples[samples.length / 2] + samples[samples.length / 2 - 1]) / 2
-          // clear samples array before sending a result to reduce memory usage
-          result.samples = []
+          if (!runner.config.benchmark?.includeSamples) {
+            result.samples = []
+          }
           updateTask(benchmark)
         }
       })

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -133,6 +133,14 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
         if (benchmark) {
           const result = benchmark.result!.benchmark!
           result.rank = Number(idx) + 1
+
+          const samples = result.samples
+          result.sampleCount = samples.length
+          result.median = samples.length % 2
+            ? samples[Math.floor(samples.length / 2)]
+            : (samples[samples.length / 2] + samples[samples.length / 2 - 1]) / 2
+          // TODO: config to clear samples before sending results
+          // result.samples = []
           updateTask(benchmark)
         }
       })

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -72,6 +72,15 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
           const taskRes = task.result!
           const result = benchmark.result!.benchmark!
           Object.assign(result, taskRes)
+          // compute extra stats and free raw samples as early as possible
+          const samples = result.samples
+          result.sampleCount = samples.length
+          result.median = samples.length % 2
+            ? samples[Math.floor(samples.length / 2)]
+            : (samples[samples.length / 2] + samples[samples.length / 2 - 1]) / 2
+          if (!runner.config.benchmark?.includeSamples) {
+            result.samples.length = 0
+          }
           updateTask(benchmark)
         },
         {
@@ -133,15 +142,6 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
         if (benchmark) {
           const result = benchmark.result!.benchmark!
           result.rank = Number(idx) + 1
-
-          const samples = result.samples
-          result.sampleCount = samples.length
-          result.median = samples.length % 2
-            ? samples[Math.floor(samples.length / 2)]
-            : (samples[samples.length / 2] + samples[samples.length / 2 - 1]) / 2
-          if (!runner.config.benchmark?.includeSamples) {
-            result.samples = []
-          }
           updateTask(benchmark)
         }
       })

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -139,8 +139,8 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
           result.median = samples.length % 2
             ? samples[Math.floor(samples.length / 2)]
             : (samples[samples.length / 2] + samples[samples.length / 2 - 1]) / 2
-          // TODO: config to clear samples before sending results
-          // result.samples = []
+          // clear samples array before sending a result to reduce memory usage
+          result.samples = []
           updateTask(benchmark)
         }
       })

--- a/packages/vitest/src/runtime/types/benchmark.ts
+++ b/packages/vitest/src/runtime/types/benchmark.ts
@@ -18,6 +18,8 @@ export interface Benchmark extends Custom {
 export interface BenchmarkResult extends TinybenchResult {
   name: string
   rank: number
+  sampleCount: number
+  median: number
 }
 
 export type BenchFunction = (this: BenchFactory) => Promise<void> | void

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -28,22 +28,23 @@ it('non-tty', async () => {
   expect(lines).toMatchObject(expected.trim().split('\n').map(s => expect.stringContaining(s)))
 })
 
-it('no samples in results', async () => {
-  const root = pathe.join(import.meta.dirname, '../fixtures/reporter')
-  const result = await runVitest({ root }, ['summary.bench.ts'], 'benchmark')
+it.for([true, false])('includeSamples %s', async (includeSamples) => {
+  const result = await runVitest(
+    {
+      root: pathe.join(import.meta.dirname, '../fixtures/reporter'),
+      benchmark: { includeSamples },
+    },
+    ['summary.bench.ts'],
+    'benchmark',
+  )
   assert(result.ctx)
   const allSamples = [...result.ctx.state.idMap.values()]
     .filter(t => t.meta.benchmark)
     .map(t => t.result?.benchmark?.samples)
-  expect(allSamples[0]).toEqual([])
-})
-
-it('includeSamples', async () => {
-  const root = pathe.join(import.meta.dirname, '../fixtures/reporter')
-  const result = await runVitest({ root, benchmark: { includeSamples: true } }, ['summary.bench.ts'], 'benchmark')
-  assert(result.ctx)
-  const allSamples = [...result.ctx.state.idMap.values()]
-    .filter(t => t.meta.benchmark)
-    .map(t => t.result?.benchmark?.samples)
-  expect(allSamples[0]).not.toEqual([])
+  if (includeSamples) {
+    expect(allSamples[0]).not.toEqual([])
+  }
+  else {
+    expect(allSamples[0]).toEqual([])
+  }
 })

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest'
+import { assert, expect, it } from 'vitest'
 import * as pathe from 'pathe'
 import { runVitest } from '../../test-utils'
 
@@ -26,4 +26,21 @@ it('non-tty', async () => {
    · timeout25
 `
   expect(lines).toMatchObject(expected.trim().split('\n').map(s => expect.stringContaining(s)))
+})
+
+it('no samples in results', async () => {
+  const root = pathe.join(import.meta.dirname, '../fixtures/reporter')
+  const result = await runVitest({ root }, ['summary.bench.ts'], 'benchmark')
+  assert(result.ctx)
+  const allSamples = [...result.ctx.state.idMap.values()]
+    .filter(t => t.meta.benchmark)
+    .map(t => t.result?.benchmark?.samples)
+  expect(allSamples).toMatchInlineSnapshot(`
+    [
+      [],
+      [],
+      [],
+      [],
+    ]
+  `)
 })

--- a/test/benchmark/test/reporter.test.ts
+++ b/test/benchmark/test/reporter.test.ts
@@ -35,12 +35,15 @@ it('no samples in results', async () => {
   const allSamples = [...result.ctx.state.idMap.values()]
     .filter(t => t.meta.benchmark)
     .map(t => t.result?.benchmark?.samples)
-  expect(allSamples).toMatchInlineSnapshot(`
-    [
-      [],
-      [],
-      [],
-      [],
-    ]
-  `)
+  expect(allSamples[0]).toEqual([])
+})
+
+it('includeSamples', async () => {
+  const root = pathe.join(import.meta.dirname, '../fixtures/reporter')
+  const result = await runVitest({ root, benchmark: { includeSamples: true } }, ['summary.bench.ts'], 'benchmark')
+  assert(result.ctx)
+  const allSamples = [...result.ctx.state.idMap.values()]
+    .filter(t => t.meta.benchmark)
+    .map(t => t.result?.benchmark?.samples)
+  expect(allSamples[0]).not.toEqual([])
 })


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6539

I think we should clear `BenchmarkResult.samples` by default on test runner side. I added `benchmark.includeSamples` option which allows returning samples, but it's disabled by default.

The fix is verified with this reproduction https://github.com/hi-ogawa/reproductions/tree/main/vitest-6539-bench-heap-oom

<details><summary>Plot of "used_heap_size"</summary>

![image](https://github.com/user-attachments/assets/171f9a2e-88ee-47dd-ba88-06fa1d5f8e93)

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
