### PR TITLE
fix(expect): fix `toBeDefined` with `expect.poll`

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -386,7 +386,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def('toBeDefined', function () {
     const obj = utils.flag(this, 'object')
     this.assert(
-      typeof obj !== "undefined",
+      typeof obj !== 'undefined',
       'expected #{this} to be defined',
       'expected #{this} to be undefined',
       obj,

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -384,14 +384,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     return this.be.null
   })
   def('toBeDefined', function () {
-    const negate = utils.flag(this, 'negate')
-    utils.flag(this, 'negate', false)
-
-    if (negate) {
-      return this.be.undefined
-    }
-
-    return this.not.be.undefined
+    const obj = utils.flag(this, 'object')
+    this.assert(
+      typeof obj !== "undefined",
+      'expected #{this} to be defined',
+      'expected #{this} to be undefined',
+      obj,
+    )
   })
   def(
     'toBeTypeOf',

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -89,7 +89,7 @@ test('toBeDefined', async () => {
   await expect.poll(() => undefined).not.toBeDefined()
 
   await expect(() =>
-    expect.poll(() => 1, { timeout: 100, interval: 10 }).not.toBeDefined()
+    expect.poll(() => 1, { timeout: 100, interval: 10 }).not.toBeDefined(),
   ).rejects.toThrowError(expect.objectContaining({
     message: 'Matcher did not succeed in 100ms',
     cause: expect.objectContaining({
@@ -98,7 +98,7 @@ test('toBeDefined', async () => {
   }))
 
   await expect(() =>
-    expect.poll(() => undefined, { timeout: 100, interval: 10 }).toBeDefined()
+    expect.poll(() => undefined, { timeout: 100, interval: 10 }).toBeDefined(),
   ).rejects.toThrowError(expect.objectContaining({
     message: 'Matcher did not succeed in 100ms',
     cause: expect.objectContaining({

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -83,3 +83,26 @@ test('custom matcher works correctly', async () => {
   expect(fn).toHaveBeenCalledTimes(3)
   expect(fn).toHaveBeenCalledWith({ poll: true })
 })
+
+test('toBeDefined', async () => {
+  await expect.poll(() => 1).toBeDefined()
+  await expect.poll(() => undefined).not.toBeDefined()
+
+  await expect(() =>
+    expect.poll(() => 1, { timeout: 100, interval: 10 }).not.toBeDefined()
+  ).rejects.toThrowError(expect.objectContaining({
+    message: 'Matcher did not succeed in 100ms',
+    cause: expect.objectContaining({
+      message: 'expected 1 to be undefined',
+    }),
+  }))
+
+  await expect(() =>
+    expect.poll(() => undefined, { timeout: 100, interval: 10 }).toBeDefined()
+  ).rejects.toThrowError(expect.objectContaining({
+    message: 'Matcher did not succeed in 100ms',
+    cause: expect.objectContaining({
+      message: 'expected undefined to be defined',
+    }),
+  }))
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/6557

It looks like `this.not.be.undefined` is messing up `negate` state and I wasn't entirely sure what's happening. It looks like this is simply enough to not reuse chai helper, so I rewrite `toBeDefined` with our custom message. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
