### PR TITLE
fix(browser): serve ui assets as static

### DIFF
--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -295,8 +295,14 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
     },
     {
       name: 'vitest:browser:assets',
+      configureServer(server) {
+        server.middlewares.use(
+          '/__vitest__',
+          sirv(resolve(distRoot, 'client/__vitest__')),
+        )
+      },
       resolveId(id) {
-        if (id.startsWith('/__vitest_browser__/') || id.startsWith('/__vitest__/')) {
+        if (id.startsWith('/__vitest_browser__/')) {
           return resolve(distRoot, 'client', id.slice(1))
         }
       },

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -94,4 +94,14 @@ export default defineConfig({
       BROWSER: browser,
     },
   },
+  plugins: [
+    {
+      name: 'test-no-transform-ui',
+      transform(_code, id, _options) {
+        if (id.includes('/__vitest__/')) {
+          throw new Error(`Unexpected transform: ${id}`)
+        }
+      },
+    },
+  ],
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/6559

I add a middleware to serve `/__vitest__/assets` files directly to avoid Vite's transform of css. This is similar to how `@vitest/ui` serve assets.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
