### PR TITLE
fix(coverage): include `*.astro` by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1157,7 +1157,7 @@ List of files included in coverage as glob patterns
 #### coverage.extension
 
 - **Type:** `string | string[]`
-- **Default:** `['.js', '.cjs', '.mjs', '.ts', '.mts', '.tsx', '.jsx', '.vue', '.svelte', '.marko']`
+- **Default:** `['.js', '.cjs', '.mjs', '.ts', '.mts', '.tsx', '.jsx', '.vue', '.svelte', '.marko', '.astro']`
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.extension=<extension>`, `--coverage.extension=<extension1> --coverage.extension=<extension2>`
 

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -73,6 +73,7 @@ export const coverageConfigDefaults: ResolvedCoverageOptions = {
     '.vue',
     '.svelte',
     '.marko',
+    '.astro',
   ],
   allowExternal: false,
   excludeAfterRemap: false,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/6544

```bash
 RUN  v2.1.1 /x/astro-example
      Coverage enabled with v8

 ✓ example.test.ts (1)
   ✓ Card with slots

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  08:58:34
   Duration  1.11s (transform 389ms, setup 0ms, collect 708ms, tests 41ms, environment 0ms, prepare 59ms)

 % Coverage report from v8
---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |   21.21 |       50 |       0 |   21.21 |                   
 components    |     100 |      100 |     100 |     100 |                   
  Card.astro   |     100 |      100 |     100 |     100 |                   
 layouts       |       0 |        0 |       0 |       0 |                   
  Layout.astro |       0 |        0 |       0 |       0 | 1-20              
 pages         |       0 |        0 |       0 |       0 |                   
  index.astro  |       0 |        0 |       0 |       0 | 1-64              
---------------|---------|----------|---------|---------|-------------------
```

Though Astro's source maps seem to be missing some branches: [https://evanw.github.io/source-map-visualization/#MTkzNgBp...](https://evanw.github.io/source-map-visualization/#MTkzNgBpbXBvcnQgewogIHJlbmRlciBhcyAkJHJlbmRlciwKICBjcmVhdGVBc3RybyBhcyAkJGNyZWF0ZUFzdHJvLAogIGNyZWF0ZUNvbXBvbmVudCBhcyAkJGNyZWF0ZUNvbXBvbmVudCwKICBtYXliZVJlbmRlckhlYWQgYXMgJCRtYXliZVJlbmRlckhlYWQsCiAgYWRkQXR0cmlidXRlIGFzICQkYWRkQXR0cmlidXRlCn0gZnJvbSAiL25vZGVfbW9kdWxlcy8ucG5wbS9hc3Ryb0A0LjE1LjlfdHlwZXNjcmlwdEA1LjYuMi9ub2RlX21vZHVsZXMvYXN0cm8vZGlzdC9ydW50aW1lL2NvbXBpbGVyL2luZGV4LmpzIjsKaW1wb3J0ICIvc3JjL2NvbXBvbmVudHMvQ2FyZC5hc3Rybz9hc3RybyZ0eXBlPXN0eWxlJmluZGV4PTAmbGFuZy5jc3MiOwpjb25zdCAkJEFzdHJvID0gJCRjcmVhdGVBc3RybygpOwpjb25zdCBBc3RybyA9ICQkQXN0cm87CmNvbnN0ICQkQ2FyZCA9ICQkY3JlYXRlQ29tcG9uZW50KCgkJHJlc3VsdCwgJCRwcm9wcywgJCRzbG90cykgPT4gewogIGNvbnN0IEFzdHJvMiA9ICQkcmVzdWx0LmNyZWF0ZUFzdHJvKCQkQXN0cm8sICQkcHJvcHMsICQkc2xvdHMpOwogIEFzdHJvMi5zZWxmID0gJCRDYXJkOwogIGNvbnN0IHsgaHJlZiwgdGl0bGUsIGJvZHkgfSA9IEFzdHJvMi5wcm9wczsKICByZXR1cm4gJCRyZW5kZXJgJHskJG1heWJlUmVuZGVySGVhZCgkJHJlc3VsdCl9PGxpIGNsYXNzPSJsaW5rLWNhcmQiIGRhdGEtYXN0cm8tY2lkLWRvaGpuYW81IGRhdGEtYXN0cm8tc291cmNlLWZpbGU9Ii9Vc2Vycy9hcmkvR2l0L3JlcHJvcy9hc3Ryby1leGFtcGxlL3NyYy9jb21wb25lbnRzL0NhcmQuYXN0cm8iIGRhdGEtYXN0cm8tc291cmNlLWxvYz0iMTE6MjMiPiA8YSR7JCRhZGRBdHRyaWJ1dGUoaHJlZiwgImhyZWYiKX0gZGF0YS1hc3Ryby1jaWQtZG9oam5hbzUgZGF0YS1hc3Ryby1zb3VyY2UtZmlsZT0iL1VzZXJzL2FyaS9HaXQvcmVwcm9zL2FzdHJvLWV4YW1wbGUvc3JjL2NvbXBvbmVudHMvQ2FyZC5hc3RybyIgZGF0YS1hc3Ryby1zb3VyY2UtbG9jPSIxMjoxOCI+ICR7dGl0bGUgPyAkJHJlbmRlcmA8aDIgZGF0YS1hc3Ryby1jaWQtZG9oam5hbzUgZGF0YS1hc3Ryby1zb3VyY2UtZmlsZT0iL1VzZXJzL2FyaS9HaXQvcmVwcm9zL2FzdHJvLWV4YW1wbGUvc3JjL2NvbXBvbmVudHMvQ2FyZC5hc3RybyIgZGF0YS1hc3Ryby1zb3VyY2UtbG9jPSIxNToxMyI+ICR7dGl0bGV9IDxzcGFuIGRhdGEtYXN0cm8tY2lkLWRvaGpuYW81IGRhdGEtYXN0cm8tc291cmNlLWZpbGU9Ii9Vc2Vycy9hcmkvR2l0L3JlcHJvcy9hc3Ryby1leGFtcGxlL3NyYy9jb21wb25lbnRzL0NhcmQuYXN0cm8iIGRhdGEtYXN0cm8tc291cmNlLWxvYz0iMTc6MTciPiZyYXJyOzwvc3Bhbj4gPC9oMj5gIDogJCRyZW5kZXJgPGgyIGRhdGEtYXN0cm8tY2lkLWRvaGpuYW81IGRhdGEtYXN0cm8tc291cmNlLWZpbGU9Ii9Vc2Vycy9hcmkvR2l0L3JlcHJvcy9hc3Ryby1leGFtcGxlL3NyYy9jb21wb25lbnRzL0NhcmQuYXN0cm8iIGRhdGEtYXN0cm8tc291cmNlLWxvYz0iMjA6MTMiPk5vIHRpdGxlITwvaDI+YH0gPHAgZGF0YS1hc3Ryby1jaWQtZG9oam5hbzUgZGF0YS1hc3Ryby1zb3VyY2UtZmlsZT0iL1VzZXJzL2FyaS9HaXQvcmVwcm9zL2FzdHJvLWV4YW1wbGUvc3JjL2NvbXBvbmVudHMvQ2FyZC5hc3RybyIgZGF0YS1hc3Ryby1zb3VyY2UtbG9jPSIyMzo4Ij4gJHtib2R5fSA8L3A+IDwvYT4gPC9saT4gYDsKfSwgIi9Vc2Vycy9hcmkvR2l0L3JlcHJvcy9hc3Ryby1leGFtcGxlL3NyYy9jb21wb25lbnRzL0NhcmQuYXN0cm8iLCB2b2lkIDApOwpleHBvcnQgZGVmYXVsdCAkJENhcmQ7Cgpjb25zdCAkJGZpbGUgPSAiL1VzZXJzL2FyaS9HaXQvcmVwcm9zL2FzdHJvLWV4YW1wbGUvc3JjL2NvbXBvbmVudHMvQ2FyZC5hc3RybyI7CmNvbnN0ICQkdXJsID0gdW5kZWZpbmVkO2V4cG9ydCB7ICQkZmlsZSBhcyBmaWxlLCAkJHVybCBhcyB1cmwgfTsKMTcwNgB7InZlcnNpb24iOjMsInNvdXJjZXMiOlsiL1VzZXJzL2FyaS9HaXQvcmVwcm9zL2FzdHJvLWV4YW1wbGUvc3JjL2NvbXBvbmVudHMvQ2FyZC5hc3RybyJdLCJzb3VyY2VzQ29udGVudCI6WyItLS1cbmludGVyZmFjZSBQcm9wcyB7XG4gIHRpdGxlOiBzdHJpbmc7XG4gIGJvZHk6IHN0cmluZztcbiAgaHJlZjogc3RyaW5nO1xufVxuXG5jb25zdCB7IGhyZWYsIHRpdGxlLCBib2R5IH0gPSBBc3Ryby5wcm9wcztcbi0tLVxuXG48bGkgY2xhc3M9XCJsaW5rLWNhcmRcIj5cbiAgPGEgaHJlZj17aHJlZn0+XG4gICAge1xuICAgICAgdGl0bGUgPyAoXG4gICAgICAgIDxoMj5cbiAgICAgICAgICB7dGl0bGV9XG4gICAgICAgICAgPHNwYW4+JnJhcnI7PC9zcGFuPlxuICAgICAgICA8L2gyPlxuICAgICAgKSA6IChcbiAgICAgICAgPGgyPk5vIHRpdGxlITwvaDI+XG4gICAgICApXG4gICAgfVxuICAgIDxwPlxuICAgICAge2JvZHl9XG4gICAgPC9wPlxuICA8L2E+XG48L2xpPlxuPHN0eWxlPlxuICAubGluay1jYXJkIHtcbiAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgcGFkZGluZzogMXB4O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICMyMzI2MmQ7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogbm9uZTtcbiAgICBiYWNrZ3JvdW5kLXNpemU6IDQwMCU7XG4gICAgYm9yZGVyLXJhZGl1czogN3B4O1xuICAgIGJhY2tncm91bmQtcG9zaXRpb246IDEwMCU7XG4gICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1wb3NpdGlvbiAwLjZzIGN1YmljLWJlemllcigwLjIyLCAxLCAwLjM2LCAxKTtcbiAgICBib3gtc2hhZG93OiBpbnNldCAwIDAgMCAxcHggcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjEpO1xuICB9XG4gIC5saW5rLWNhcmQgPiBhIHtcbiAgICB3aWR0aDogMTAwJTtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgbGluZS1oZWlnaHQ6IDEuNDtcbiAgICBwYWRkaW5nOiBjYWxjKDEuNXJlbSAtIDFweCk7XG4gICAgYm9yZGVyLXJhZGl1czogOHB4O1xuICAgIGNvbG9yOiB3aGl0ZTtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMjMyNjJkO1xuICAgIG9wYWNpdHk6IDAuODtcbiAgfVxuICBoMiB7XG4gICAgbWFyZ2luOiAwO1xuICAgIGZvbnQtc2l6ZTogMS4yNXJlbTtcbiAgICB0cmFuc2l0aW9uOiBjb2xvciAwLjZzIGN1YmljLWJlemllcigwLjIyLCAxLCAwLjM2LCAxKTtcbiAgfVxuICBwIHtcbiAgICBtYXJnaW4tdG9wOiAwLjVyZW07XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgfVxuICAubGluay1jYXJkOmlzKDpob3ZlciwgOmZvY3VzLXdpdGhpbikge1xuICAgIGJhY2tncm91bmQtcG9zaXRpb246IDA7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogdmFyKC0tYWNjZW50LWdyYWRpZW50KTtcbiAgfVxuICAubGluay1jYXJkOmlzKDpob3ZlciwgOmZvY3VzLXdpdGhpbikgaDIge1xuICAgIGNvbG9yOiByZ2IodmFyKC0tYWNjZW50LWxpZ2h0KSk7XG4gIH1cbjwvc3R5bGU+Il0sIm1hcHBpbmdzIjoiOzs7Ozs7Ozs7Ozs7O0FBT0EsUUFBTSxFQUFFLE1BQU0sT0FBTyxLQUFLLElBQUlBLE9BQU07QUFQcEMsU0FBQSxXQUFBLGtCQUFBLFFBQUEsQ0FBQSx5S0FBQSxlQVdXLE1BWFgsTUFBQSxDQUFBLGtKQVlLLFFBWkwsNkpBZVcsS0FBSyw0S0FmaEIseUtBcUJJLG9KQUVHLElBQUk7QUF2QlgsR0FBQSxpRUFBQSxNQUFBO0FBQUEsZUFBQTsiLCJuYW1lcyI6WyJBc3RybyJdfQ==), for example the lin 20 there.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
