### PR TITLE
fix(browser): fix dynamic import inside worker

### DIFF
--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -368,6 +368,20 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
         }
       },
     },
+    {
+      name: 'vitest:browser:worker',
+      transform(code, id, _options) {
+        // https://github.com/vitejs/vite/blob/ba56cf43b5480f8519349f7d7fe60718e9af5f1a/packages/vite/src/node/plugins/worker.ts#L46
+        if (/(?:\?|&)worker_file&type=\w+(?:&|$)/.test(id)) {
+          const s = new MagicString(code)
+          s.prepend('globalThis.__vitest_browser_runner__ = { wrapDynamicImport: f => f() };\n')
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: 'boundary' }),
+          }
+        }
+      },
+    },
     // TODO: remove this when @testing-library/vue supports ESM
     {
       name: 'vitest:browser:support-testing-library',

--- a/test/browser/fixtures/worker/src/basic.test.ts
+++ b/test/browser/fixtures/worker/src/basic.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+test('worker dynamic dep', async () => {
+  const worker = new Worker(new URL('./worker', import.meta.url), { type: 'module' });
+  const data = await new Promise((resolve, reject) => {
+    worker.addEventListener("message", (e) => resolve(e.data))
+    worker.addEventListener("messageerror", (e) => reject(e))
+    worker.postMessage("ping");
+  });
+  expect(data).toMatchInlineSnapshot(`"worker-dynamic-dep-ok"`);
+})

--- a/test/browser/fixtures/worker/src/worker-dynamic-dep.ts
+++ b/test/browser/fixtures/worker/src/worker-dynamic-dep.ts
@@ -1,0 +1,1 @@
+export default "worker-dynamic-dep-ok"

--- a/test/browser/fixtures/worker/src/worker.ts
+++ b/test/browser/fixtures/worker/src/worker.ts
@@ -1,0 +1,4 @@
+self.onmessage = async () => {
+  const mod = await import("./worker-dynamic-dep");
+  self.postMessage(mod.default);
+}

--- a/test/browser/fixtures/worker/vitest.config.ts
+++ b/test/browser/fixtures/worker/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const provider = process.env.PROVIDER || 'playwright'
+const name =
+  process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome')
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      name,
+    },
+  },
+})

--- a/test/browser/specs/worker.test.ts
+++ b/test/browser/specs/worker.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { runBrowserTests } from './utils'
+
+test('worker', async () => {
+  const { ctx } = await runBrowserTests({
+    root: './fixtures/worker',
+  })
+  expect(Object.fromEntries(ctx.state.getFiles().map(f => [f.name, f.result.state]))).toMatchInlineSnapshot(`
+    {
+      "src/basic.test.ts": "pass",
+    }
+  `)
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/6552

This shims `globalThis.__vitest_browser_runner__.wrapDynamicImport` for worker entry similar to how Vite injects env to `?worker_file` via `vite:worker` plugin.

Probably this is not a fundamental fix (something involving msw can break in worker?), but this seems okay as a stop gap.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
