### PR TITLE
docs: Mocking: Config option is called unstubEnvs, method is called unstubAllEnvs

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -761,7 +761,7 @@ it('the value is restored before running an other test', () => {
 // vitest.config.ts
 export default defineConfig({
   test: {
-    unstubAllEnvs: true,
+    unstubEnvs: true,
   }
 })
 ```


### PR DESCRIPTION

### Description

The config option is called `unstubEnvs`, while the method is called `unstubAllEnvs`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [X] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
