### PR TITLE
docs: deprecate `benchmark.outputFile` option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -303,6 +303,10 @@ When defined, Vitest will run all matched files with `import.meta.vitest` inside
 
 Custom reporter for output. Can contain one or more built-in report names, reporter instances, and/or paths to custom reporters.
 
+#### benchmark.outputFile
+
+Deprecated in favor of `benchmark.outputJson`.
+
 #### benchmark.outputJson {#benchmark-outputJson}
 
 - **Type:** `string | undefined`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -303,15 +303,6 @@ When defined, Vitest will run all matched files with `import.meta.vitest` inside
 
 Custom reporter for output. Can contain one or more built-in report names, reporter instances, and/or paths to custom reporters.
 
-#### benchmark.outputFile
-
-- **Type:** `string | Record<string, string>`
-
-Write benchmark results to a file when the `--reporter=json` option is also specified.
-By providing an object instead of a string you can define individual outputs when using multiple reporters.
-
-To provide object via CLI command, use the following syntax: `--outputFile.json=./path --outputFile.junit=./other-path`.
-
 #### benchmark.outputJson {#benchmark-outputJson}
 
 - **Type:** `string | undefined`

--- a/packages/vitest/src/node/types/benchmark.ts
+++ b/packages/vitest/src/node/types/benchmark.ts
@@ -33,8 +33,7 @@ export interface BenchmarkUserOptions {
   reporters?: Arrayable<BenchmarkBuiltinReporters | Reporter>
 
   /**
-   * Write test results to a file when the `--reporter=json` option is also specified.
-   * Also definable individually per reporter by using an object instead.
+   * @deprecated Use `benchmark.outputJson` instead
    */
   outputFile?:
     | string


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5953

I thought we could remove it entirely, but there might be a need in the future to bring back the same code, so I only noted it's deprecated to avoid confusion.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
