### PR TITLE
refactor: replace `strip-ansi` with `stripVTControlCharacters` from `node:util`

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -200,7 +200,6 @@
     "micromatch": "^4.0.7",
     "pretty-format": "^29.7.0",
     "prompts": "^2.4.2",
-    "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
     "tinyglobby": "^0.2.6",
     "ws": "^8.18.0"

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -1,12 +1,12 @@
 /* eslint-disable prefer-template */
 import { existsSync, readFileSync } from 'node:fs'
 import { Writable } from 'node:stream'
+import { stripVTControlCharacters } from 'node:util'
 import { normalize, relative } from 'pathe'
 import c from 'tinyrainbow'
 import cliTruncate from 'cli-truncate'
 import type { ErrorWithDiff, ParsedStack } from '@vitest/utils'
 import { inspect } from '@vitest/utils'
-import stripAnsi from 'strip-ansi'
 import {
   lineSplitRE,
   positionToOffset,
@@ -398,7 +398,7 @@ export function generateCodeFrame(
         const lineLength = lines[j].length
 
         // too long, maybe it's a minified file, skip for codeframe
-        if (stripAnsi(lines[j]).length > 200) {
+        if (stripVTControlCharacters(lines[j]).length > 200) {
           return ''
         }
 

--- a/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
+++ b/packages/vitest/src/node/reporters/benchmark/table/tableRender.ts
@@ -1,6 +1,6 @@
+import { stripVTControlCharacters } from 'node:util'
 import c from 'tinyrainbow'
 import cliTruncate from 'cli-truncate'
-import stripAnsi from 'strip-ansi'
 import type { Task } from '@vitest/runner'
 import { getTests, notNullish } from '../../../../utils'
 import { F_RIGHT } from '../../../../utils/figures'
@@ -75,7 +75,7 @@ function renderBenchmarkItems(result: BenchmarkResult) {
 function computeColumnWidths(results: BenchmarkResult[]): number[] {
   const rows = [tableHead, ...results.map(v => renderBenchmarkItems(v))]
   return Array.from(tableHead, (_, i) =>
-    Math.max(...rows.map(row => stripAnsi(row[i]).length)))
+    Math.max(...rows.map(row => stripVTControlCharacters(row[i]).length)))
 }
 
 function padRow(row: string[], widths: number[]) {
@@ -215,7 +215,7 @@ export function renderTree(
     if (task.result?.state !== 'pass' && outputMap.get(task) != null) {
       let data: string | undefined = outputMap.get(task)
       if (typeof data === 'string') {
-        data = stripAnsi(data.trim().split('\n').filter(Boolean).pop()!)
+        data = stripVTControlCharacters(data.trim().split('\n').filter(Boolean).pop()!)
         if (data === '') {
           data = undefined
         }

--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -1,5 +1,5 @@
+import { stripVTControlCharacters } from 'node:util'
 import { getTasks } from '@vitest/runner/utils'
-import stripAnsi from 'strip-ansi'
 import type { File } from '@vitest/runner'
 import { getFullName } from '../../utils'
 import { capturePrintError } from '../error'
@@ -64,7 +64,7 @@ export class GithubActionsReporter implements Reporter {
           line: String(stack.line),
           column: String(stack.column),
         },
-        message: stripAnsi(result.output),
+        message: stripVTControlCharacters(result.output),
       })
       this.ctx.logger.log(`\n${formatted}`)
     }

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -1,10 +1,10 @@
 import { existsSync, promises as fs } from 'node:fs'
 import { hostname } from 'node:os'
+import { stripVTControlCharacters } from 'node:util'
 import { dirname, relative, resolve } from 'pathe'
 
 import type { Task } from '@vitest/runner'
 import { getSuites } from '@vitest/runner/utils'
-import stripAnsi from 'strip-ansi'
 import type { Vitest } from '../core'
 import type { Reporter } from '../types/reporter'
 import { getOutputFile } from '../../utils/config-helpers'
@@ -233,7 +233,7 @@ export class JUnitReporter implements Reporter {
                     { project: this.ctx.getProjectByTaskId(task.id), task },
                   )
                   await this.baseLog(
-                    escapeXML(stripAnsi(result.output.trim())),
+                    escapeXML(stripVTControlCharacters(result.output.trim())),
                   )
                 },
               )

--- a/packages/vitest/src/node/reporters/renderers/listRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/listRenderer.ts
@@ -1,6 +1,6 @@
+import { stripVTControlCharacters } from 'node:util'
 import c from 'tinyrainbow'
 import cliTruncate from 'cli-truncate'
-import stripAnsi from 'strip-ansi'
 import type { SuiteHooks, Task } from '@vitest/runner'
 import { getTests, notNullish } from '../../../utils'
 import { F_RIGHT } from '../../../utils/figures'
@@ -183,7 +183,7 @@ function renderTree(
     if (task.result?.state !== 'pass' && outputMap.get(task) != null) {
       let data: string | undefined = outputMap.get(task)
       if (typeof data === 'string') {
-        data = stripAnsi(data.trim().split('\n').filter(Boolean).pop()!)
+        data = stripVTControlCharacters(data.trim().split('\n').filter(Boolean).pop()!)
         if (data === '') {
           data = undefined
         }

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -1,6 +1,6 @@
+import { stripVTControlCharacters } from 'node:util'
 import { basename, dirname, isAbsolute, relative } from 'pathe'
 import c from 'tinyrainbow'
-import stripAnsi from 'strip-ansi'
 import type { SuiteHooks, Task } from '@vitest/runner'
 import type { SnapshotSummary } from '@vitest/snapshot'
 import { slash } from '../../../utils/base'
@@ -37,7 +37,7 @@ export function divider(text?: string, left?: number, right?: number) {
   const cols = getCols()
 
   if (text) {
-    const textLength = stripAnsi(text).length
+    const textLength = stripVTControlCharacters(text).length
     if (left == null && right != null) {
       left = cols - textLength - right
     }

--- a/packages/vitest/src/node/watch-filter.ts
+++ b/packages/vitest/src/node/watch-filter.ts
@@ -1,7 +1,7 @@
 import readline from 'node:readline'
 import type { Writable } from 'node:stream'
+import { stripVTControlCharacters } from 'node:util'
 import c from 'tinyrainbow'
-import stripAnsi from 'strip-ansi'
 import { createDefer } from '@vitest/utils'
 import { stdout as getStdout } from '../utils'
 
@@ -198,7 +198,7 @@ export class WatchFilter {
       const columns = 'columns' in this.stdout ? this.stdout.columns : 80
 
       // We have to take care of screen width in case of long lines
-      rows += 1 + Math.floor(Math.max(stripAnsi(line).length - 1, 0) / columns)
+      rows += 1 + Math.floor(Math.max(stripVTControlCharacters(line).length - 1, 0) / columns)
     }
 
     this.write(`${ESC}1G`) // move to the beginning of the line

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1151,9 +1151,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       url:
         specifier: ^0.11.3
         version: 0.11.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,9 +1071,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       strip-literal:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1268,9 +1265,6 @@ importers:
       memfs:
         specifier: ^4.8.2
         version: 4.8.2
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       sweetalert2:
         specifier: ^11.6.16
         version: 11.6.16
@@ -1340,9 +1334,6 @@ importers:
       magicast:
         specifier: ^0.3.3
         version: 0.3.3
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       unplugin-swc:
         specifier: ^1.4.4
         version: 1.4.4(@swc/core@1.4.1)(rollup@4.20.0)
@@ -1397,9 +1388,6 @@ importers:
       pkg-reporter:
         specifier: ./reportPkg/
         version: link:reportPkg
-      strip-ansi:
-        specifier: ^7.0.1
-        version: 7.0.1
       vitest:
         specifier: workspace:*
         version: link:../../packages/vitest
@@ -1415,9 +1403,6 @@ importers:
 
   test/test-utils:
     devDependencies:
-      strip-ansi:
-        specifier: ^7.0.1
-        version: 7.0.1
       tinyexec:
         specifier: ^0.3.0
         version: 0.3.0
@@ -8402,10 +8387,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-ansi@7.0.1:
-    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
-    engines: {node: '>=12'}
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
@@ -17736,10 +17717,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-ansi@7.0.1:
-    dependencies:
-      ansi-regex: 6.0.1
 
   strip-ansi@7.1.0:
     dependencies:

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -28,7 +28,6 @@
     "playwright": "^1.41.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "strip-ansi": "^7.1.0",
     "url": "^0.11.3",
     "vitest": "workspace:*",
     "vitest-browser-react": "^0.0.1",

--- a/test/browser/test/commands.test.ts
+++ b/test/browser/test/commands.test.ts
@@ -58,5 +58,7 @@ declare module '@vitest/browser/context' {
       arg1: string
       arg2: string
     }>
+
+    stripVTControlCharacters: (text: string) => Promise<string>
   }
 }

--- a/test/browser/test/utils.test.ts
+++ b/test/browser/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'vitest/utils'
 import { afterEach, expect, it, test } from 'vitest'
-import stripAnsi from 'strip-ansi'
+import { commands } from '@vitest/browser/context'
 
 import { prettyDOM } from '@vitest/browser/utils'
 
@@ -12,28 +12,28 @@ it('utils package correctly uses loupe', async () => {
   expect(inspect({ test: 1 })).toBe('{ test: 1 }')
 })
 
-test('prints default document', () => {
-  expect(stripAnsi(prettyDOM())).toMatchSnapshot()
+test('prints default document', async () => {
+  expect(await commands.stripVTControlCharacters(prettyDOM())).toMatchSnapshot()
 
   const div = document.createElement('div')
   div.innerHTML = '<span>hello</span>'
   document.body.append(div)
 
-  expect(stripAnsi(prettyDOM())).toMatchSnapshot()
+  expect(await commands.stripVTControlCharacters(prettyDOM())).toMatchSnapshot()
 })
 
-test('prints the element', () => {
+test('prints the element', async () => {
   const div = document.createElement('div')
   div.innerHTML = '<span>hello</span>'
   document.body.append(div)
 
-  expect(stripAnsi(prettyDOM())).toMatchSnapshot()
+  expect(await commands.stripVTControlCharacters(prettyDOM())).toMatchSnapshot()
 })
 
-test('prints the element with attributes', () => {
+test('prints the element with attributes', async () => {
   const div = document.createElement('div')
   div.innerHTML = '<span class="some-name" data-test-id="33" id="5">hello</span>'
   document.body.append(div)
 
-  expect(stripAnsi(prettyDOM())).toMatchSnapshot()
+  expect(await commands.stripVTControlCharacters(prettyDOM())).toMatchSnapshot()
 })

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -1,5 +1,6 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import * as util from 'node:util'
 import { defineConfig } from 'vitest/config'
 import type { BrowserCommand } from 'vitest/node'
 
@@ -12,6 +13,10 @@ const browser = process.env.BROWSER || (provider === 'playwright' ? 'chromium' :
 
 const myCustomCommand: BrowserCommand<[arg1: string, arg2: string]> = ({ testPath }, arg1, arg2) => {
   return { testPath, arg1, arg2 }
+}
+
+const stripVTControlCharacters: BrowserCommand<[text: string]> = (_, text) => {
+  return util.stripVTControlCharacters(text)
 }
 
 export default defineConfig({
@@ -70,6 +75,7 @@ export default defineConfig({
       ],
       commands: {
         myCustomCommand,
+        stripVTControlCharacters,
       },
     },
     alias: {

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -26,7 +26,6 @@
     "debug": "^4.3.4",
     "immutable": "5.0.0-beta.5",
     "memfs": "^4.8.2",
-    "strip-ansi": "^7.1.0",
     "sweetalert2": "^11.6.16",
     "tinyrainbow": "^1.2.0",
     "tinyspy": "^1.0.2",

--- a/test/core/test/diff.test.ts
+++ b/test/core/test/diff.test.ts
@@ -1,5 +1,5 @@
+import { stripVTControlCharacters } from 'node:util'
 import { expect, test, vi } from 'vitest'
-import stripAnsi from 'strip-ansi'
 import type { DiffOptions } from '@vitest/utils/diff'
 import { diff, diffStringsUnified, printDiffOrStringify } from '@vitest/utils/diff'
 import { processError } from '@vitest/runner'
@@ -10,7 +10,7 @@ test('displays string diff', () => {
   const stringB = 'Hello BWorld'
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(printDiffOrStringify(stringA, stringB), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     Expected: "Hello BWorld"
     Received: "Hello AWorld"
@@ -23,7 +23,7 @@ test('displays object diff', () => {
   const objectB = { a: 1, b: 3 }
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(objectA, objectB), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -42,7 +42,7 @@ test('display truncated object diff', () => {
   const objectB = { a: 1, b: 3, c: 4, d: 5, e: 6 }
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(objectA, objectB, { truncateThreshold: 4 }), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -63,7 +63,7 @@ test('display one line string diff', () => {
   const string2 = 'string2'
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(string1, string2), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -79,7 +79,7 @@ test('display one line string diff should not be affected by truncateThreshold',
   const string2 = 'string2'
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(string1, string2, { truncateThreshold: 3 }), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -95,7 +95,7 @@ test('display multiline string diff', () => {
   const string2 = 'string2\nstring2\nstring1'
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(string1, string2), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -114,7 +114,7 @@ test('display truncated multiline string diff', () => {
   const string2 = 'string2\nstring2\nstring1'
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(string1, string2, { truncateThreshold: 2 }), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -132,7 +132,7 @@ test('display truncated multiple items array diff', () => {
   const array2 = Array.from({ length: 45000 }).fill('bar')
   const console = { log: vi.fn(), error: vi.fn() }
   displayDiff(diff(array1, array2, { truncateThreshold: 3 }), console as any)
-  expect(stripAnsi(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(console.error.mock.calls[0][0])).toMatchInlineSnapshot(`
     "
     - Expected
     + Received
@@ -148,7 +148,7 @@ test('display truncated multiple items array diff', () => {
 })
 
 test('asymmetric matcher in object', () => {
-  expect(stripAnsi(getErrorDiff({ x: 0, y: 'foo' }, { x: 1, y: expect.anything() }))).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(getErrorDiff({ x: 0, y: 'foo' }, { x: 1, y: expect.anything() }))).toMatchInlineSnapshot(`
     "- Expected
     + Received
 
@@ -162,7 +162,7 @@ test('asymmetric matcher in object', () => {
 
 test('asymmetric matcher in object with truncated diff', () => {
   expect(
-    stripAnsi(getErrorDiff(
+    stripVTControlCharacters(getErrorDiff(
       { w: 'foo', x: 0, y: 'bar', z: 'baz' },
       { w: expect.anything(), x: 1, y: expect.anything(), z: 'bar' },
       { truncateThreshold: 3 },
@@ -180,7 +180,7 @@ test('asymmetric matcher in object with truncated diff', () => {
 })
 
 test('asymmetric matcher in array', () => {
-  expect(stripAnsi(getErrorDiff([0, 'foo'], [1, expect.anything()]))).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(getErrorDiff([0, 'foo'], [1, expect.anything()]))).toMatchInlineSnapshot(`
     "- Expected
     + Received
 
@@ -194,7 +194,7 @@ test('asymmetric matcher in array', () => {
 
 test('asymmetric matcher in array  with truncated diff', () => {
   expect(
-    stripAnsi(getErrorDiff(
+    stripVTControlCharacters(getErrorDiff(
       [0, 'foo', 2],
       [1, expect.anything(), 3],
       { truncateThreshold: 2 },
@@ -212,7 +212,7 @@ test('asymmetric matcher in array  with truncated diff', () => {
 
 test('asymmetric matcher in nested', () => {
   expect(
-    stripAnsi(getErrorDiff(
+    stripVTControlCharacters(getErrorDiff(
       [{ x: 0, y: 'foo' }, [0, 'bar']],
       [{ x: 1, y: expect.anything() }, [1, expect.anything()]],
     )),
@@ -237,7 +237,7 @@ test('asymmetric matcher in nested', () => {
 
 test('asymmetric matcher in nested with truncated diff', () => {
   expect(
-    stripAnsi(getErrorDiff(
+    stripVTControlCharacters(getErrorDiff(
       [{ x: 0, y: 'foo', z: 'bar' }, [0, 'bar', 'baz']],
       [{ x: 1, y: expect.anything(), z: expect.anything() }, [1, expect.anything(), expect.anything()]],
       { truncateThreshold: 5 },
@@ -266,7 +266,7 @@ test('diff for multi-line string compared by characters', () => {
   bar,
   `
   expect(
-    stripAnsi(diffStringsUnified(string1, string2)),
+    stripVTControlCharacters(diffStringsUnified(string1, string2)),
   ).toMatchInlineSnapshot(`
     "- Expected
     + Received
@@ -291,7 +291,7 @@ test('truncated diff for multi-line string compared by characters', () => {
   BAZ,
   `
   expect(
-    stripAnsi(diffStringsUnified(string1, string2, { truncateThreshold: 3 })),
+    stripVTControlCharacters(diffStringsUnified(string1, string2, { truncateThreshold: 3 })),
   ).toMatchInlineSnapshot(`
     "- Expected
     + Received
@@ -316,7 +316,7 @@ test('getter only property', () => {
     get: () => ({ a: 'b' }),
   })
   expect(
-    stripAnsi(getErrorDiff(x, y)),
+    stripVTControlCharacters(getErrorDiff(x, y)),
   ).toMatchInlineSnapshot(`
     "- Expected
     + Received

--- a/test/core/test/environments/jsdom.spec.ts
+++ b/test/core/test/environments/jsdom.spec.ts
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
+import { stripVTControlCharacters } from 'node:util'
 import { processError } from '@vitest/utils/error'
 import { expect, test } from 'vitest'
-import stripAnsi from 'strip-ansi'
 
 const nodeMajor = Number(process.version.slice(1).split('.')[0])
 
@@ -70,7 +70,7 @@ test('toContain correctly handles DOM nodes', () => {
     expect.unreachable()
   }
   catch (err: any) {
-    expect(stripAnsi(processError(err).diff)).toMatchInlineSnapshot(`
+    expect(stripVTControlCharacters(processError(err).diff)).toMatchInlineSnapshot(`
       "Expected: "flex flex-col flex-row"
       Received: "flex flex-col""
     `)
@@ -81,7 +81,7 @@ test('toContain correctly handles DOM nodes', () => {
     expect.unreachable()
   }
   catch (err: any) {
-    expect(stripAnsi(processError(err).diff)).toMatchInlineSnapshot(`
+    expect(stripVTControlCharacters(processError(err).diff)).toMatchInlineSnapshot(`
       "Expected: "flex-col"
       Received: "flex flex-col""
     `)

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -1,6 +1,6 @@
+import { stripVTControlCharacters } from 'node:util'
 import { parseAst } from 'rollup/parseAst'
 import { describe, expect, it, test } from 'vitest'
-import stripAnsi from 'strip-ansi'
 import { generateCodeFrame } from 'vitest/src/node/error.js'
 import type { HoistMocksPluginOptions } from '../../../packages/mocker/src/node/hoistMocksPlugin'
 import { hoistMocks } from '../../../packages/mocker/src/node/hoistMocksPlugin'
@@ -1430,6 +1430,6 @@ export const mocked = vi.unmock('./mocked')
   ])('correctly throws an error if %s', (_, code) => {
     const error = getErrorWhileHoisting(code)
     expect(error.message).toMatchSnapshot()
-    expect(stripAnsi(error.frame)).toMatchSnapshot()
+    expect(stripVTControlCharacters(error.frame)).toMatchSnapshot()
   })
 })

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-sparse-arrays */
 import { AssertionError } from 'node:assert'
+import { stripVTControlCharacters } from 'node:util'
 import { describe, expect, it, vi } from 'vitest'
 import { generateToBeMessage } from '@vitest/expect'
 import { processError } from '@vitest/utils/error'
-import stripAnsi from 'strip-ansi'
 
 class TestError extends Error {}
 
@@ -877,7 +877,7 @@ it('correctly prints diff', () => {
   }
   catch (err) {
     const error = processError(err)
-    const diff = stripAnsi(error.diff)
+    const diff = stripVTControlCharacters(error.diff)
     expect(diff).toContain('-   "a": 2')
     expect(diff).toContain('+   "a": 1')
   }
@@ -890,7 +890,7 @@ it('correctly prints diff for the cause', () => {
   }
   catch (err) {
     const error = processError(new Error('wrapper', { cause: err }))
-    const diff = stripAnsi(error.cause.diff)
+    const diff = stripVTControlCharacters(error.cause.diff)
     expect(diff).toContain('-   "a": 2')
     expect(diff).toContain('+   "a": 1')
   }
@@ -906,7 +906,7 @@ it('correctly prints diff with asymmetric matchers', () => {
   }
   catch (err) {
     const error = processError(err)
-    expect(stripAnsi(error.diff)).toMatchInlineSnapshot(`
+    expect(stripVTControlCharacters(error.diff)).toMatchInlineSnapshot(`
       "- Expected
       + Received
 
@@ -931,7 +931,7 @@ function getError(f: () => unknown) {
   }
   catch (error) {
     const processed = processError(error)
-    return [stripAnsi(processed.message), stripAnsi(trim(processed.diff))]
+    return [stripVTControlCharacters(processed.message), stripVTControlCharacters(trim(processed.diff))]
   }
 }
 
@@ -1136,8 +1136,8 @@ function snapshotError(f: () => unknown) {
   catch (error) {
     const e = processError(error)
     expect({
-      message: stripAnsi(e.message),
-      diff: e.diff ? stripAnsi(e.diff) : e.diff,
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : e.diff,
       expected: e.expected,
       actual: e.actual,
     }).toMatchSnapshot()

--- a/test/core/test/mocked.test.ts
+++ b/test/core/test/mocked.test.ts
@@ -1,5 +1,5 @@
+import { stripVTControlCharacters } from 'node:util'
 import { assert, describe, expect, test, vi, vitest } from 'vitest'
-import stripAnsi from 'strip-ansi'
 // @ts-expect-error not typed module
 import { value as virtualValue } from 'virtual-module'
 import { two } from '../src/submodule'
@@ -141,7 +141,7 @@ function getError(cb: () => void): string {
     cb()
   }
   catch (e: any) {
-    return stripAnsi(e.message)
+    return stripVTControlCharacters(e.message)
   }
   expect.unreachable()
   return 'unreachable'

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -20,7 +20,6 @@
     "istanbul-lib-report": "^3.0.1",
     "magic-string": "^0.30.10",
     "magicast": "^0.3.3",
-    "strip-ansi": "^7.1.0",
     "unplugin-swc": "^1.4.4",
     "vite": "latest",
     "vitest": "workspace:*",

--- a/test/coverage-test/test/mixed-versions-warning.unit.test.ts
+++ b/test/coverage-test/test/mixed-versions-warning.unit.test.ts
@@ -1,9 +1,9 @@
+import { stripVTControlCharacters } from 'node:util'
 import { expect, test, vi } from 'vitest'
 import { configDefaults } from 'vitest/config'
 import V8Provider from '@vitest/coverage-v8'
 import packageJson from '@vitest/coverage-v8/package.json'
 import IstanbulProvider from '@vitest/coverage-istanbul'
-import stripAnsi from 'strip-ansi'
 
 const version = packageJson.version
 
@@ -21,7 +21,7 @@ test('v8 provider logs warning if versions do not match', async () => {
 
   const message = warn.mock.calls[0][0]
 
-  expect(stripAnsi(message)).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(message)).toMatchInlineSnapshot(`
     "Loaded  vitest@1.0.0  and  @vitest/coverage-v8@${version} .
     Running mixed versions is not supported and may lead into bugs
     Update your dependencies and make sure the versions match."
@@ -42,7 +42,7 @@ test('istanbul provider logs warning if versions do not match', async () => {
 
   const message = warn.mock.calls[0][0]
 
-  expect(stripAnsi(message)).toMatchInlineSnapshot(`
+  expect(stripVTControlCharacters(message)).toMatchInlineSnapshot(`
     "Loaded  vitest@1.0.0  and  @vitest/coverage-istanbul@${version} .
     Running mixed versions is not supported and may lead into bugs
     Update your dependencies and make sure the versions match."

--- a/test/coverage-test/utils.ts
+++ b/test/coverage-test/utils.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { stripVTControlCharacters } from 'node:util'
 import { normalize } from 'pathe'
 import libCoverage from 'istanbul-lib-coverage'
 import type { FileCoverageData } from 'istanbul-lib-coverage'
 import type { TestFunction, UserConfig } from 'vitest'
 import { vi, describe as vitestDescribe, test as vitestTest } from 'vitest'
-import stripAnsi from 'strip-ansi'
 import * as testUtils from '../test-utils'
 
 export function test(name: string, fn: TestFunction, skip = false) {
@@ -112,6 +112,6 @@ export function captureStdout() {
 
   return function collect() {
     process.stdout.write = original
-    return stripAnsi(spy.mock.calls.map(call => call[0]).join(''))
+    return stripVTControlCharacters(spy.mock.calls.map(call => call[0]).join(''))
   }
 }

--- a/test/reporters/package.json
+++ b/test/reporters/package.json
@@ -8,7 +8,6 @@
   "devDependencies": {
     "flatted": "^3.2.9",
     "pkg-reporter": "./reportPkg/",
-    "strip-ansi": "^7.0.1",
     "vitest": "workspace:*",
     "vitest-sonar-reporter": "0.4.1"
   }

--- a/test/reporters/tests/html.test.ts
+++ b/test/reporters/tests/html.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import zlib from 'node:zlib'
+import { stripVTControlCharacters } from 'node:util'
 import { resolve } from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'flatted'
-import stripAnsi from 'strip-ansi'
 
 import { runVitest } from '../../test-utils'
 
@@ -68,7 +68,7 @@ describe('html reporter', async () => {
     expect(task.logs).toHaveLength(1)
     task.logs[0].taskId = 0
     task.logs[0].time = 0
-    expect(resultJson).toMatchSnapshot(`tests are ${stripAnsi(expected)}`)
+    expect(resultJson).toMatchSnapshot(`tests are ${stripVTControlCharacters(expected)}`)
     expect(indexHtml).toMatch('window.METADATA_PATH="html.meta.json.gz"')
   }, 120000)
 })

--- a/test/test-utils/cli.ts
+++ b/test/test-utils/cli.ts
@@ -1,5 +1,5 @@
 import type { Readable, Writable } from 'node:stream'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'node:util'
 
 type Listener = (() => void)
 type ReadableOrWritable = Readable | Writable
@@ -37,7 +37,7 @@ export class Cli {
   }
 
   private capture(source: Source, data: any) {
-    const msg = stripAnsi(data.toString())
+    const msg = stripVTControlCharacters(data.toString())
     this[source] += msg
     this[`${source}Listeners`].forEach(fn => fn())
   }

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -7,7 +7,6 @@
     "test": "echo \"No tests\""
   },
   "devDependencies": {
-    "strip-ansi": "^7.0.1",
     "tinyexec": "^0.3.0",
     "vite": "latest",
     "vite-node": "workspace:*",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- TIL ⭐ from this friendly comment that `strip-ansi` has Node built-in replacement: https://github.com/vitest-dev/vitest/discussions/6587#discussioncomment-10801808
- Removes `strip-ansi` from direct dependencies. It's still a transitive dependency of other transitive dependencies from the same author.

https://github.com/vitest-dev/vitest/blob/9edfa19ff172180143ae66c6f61357f2bfa380f0/packages/vitest/package.json#L117-L119

```sh
ari ~/Git/vitest (chore/strip-ansi) $ node
Welcome to Node.js v18.0.0.
Type ".help" for more information.
> util.stripVTControlCharacters
[Function: stripVTControlCharacters]
>

ari ~/Git/vitest (chore/strip-ansi) $ node
Welcome to Node.js v20.0.0.
Type ".help" for more information.
> util.stripVTControlCharacters
[Function: stripVTControlCharacters]
> 
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
