### PR TITLE
fix(runner): run `onTestFinished` and `onTestFailed` during `retry` and `repeats`

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -271,6 +271,26 @@ export async function runTest(test: Test | Custom, runner: VitestRunner): Promis
         failTask(test.result, e, runner.config.diffOptions)
       }
 
+      try {
+        await callTaskHooks(test, test.onFinished || [], 'stack')
+      }
+      catch (e) {
+        failTask(test.result, e, runner.config.diffOptions)
+      }
+
+      if (test.result.state === 'fail') {
+        try {
+          await callTaskHooks(
+            test,
+            test.onFailed || [],
+            runner.config.sequence.hooks,
+          )
+        }
+        catch (e) {
+          failTask(test.result, e, runner.config.diffOptions)
+        }
+      }
+
       if (test.result.state === 'pass') {
         break
       }
@@ -283,26 +303,6 @@ export async function runTest(test: Test | Custom, runner: VitestRunner): Promis
 
       // update retry info
       updateTask(test, runner)
-    }
-  }
-
-  try {
-    await callTaskHooks(test, test.onFinished || [], 'stack')
-  }
-  catch (e) {
-    failTask(test.result, e, runner.config.diffOptions)
-  }
-
-  if (test.result.state === 'fail') {
-    try {
-      await callTaskHooks(
-        test,
-        test.onFailed || [],
-        runner.config.sequence.hooks,
-      )
-    }
-    catch (e) {
-      failTask(test.result, e, runner.config.diffOptions)
     }
   }
 

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -291,6 +291,9 @@ export async function runTest(test: Test | Custom, runner: VitestRunner): Promis
         }
       }
 
+      delete test.onFailed
+      delete test.onFinished
+
       if (test.result.state === 'pass') {
         break
       }

--- a/test/core/test/on-finished.test.ts
+++ b/test/core/test/on-finished.test.ts
@@ -63,31 +63,28 @@ it('after', () => {
 describe('repeats pass', () => {
   const state: string[] = []
 
-  it('run', { repeats: 2 }, () => {
-    state.push('run')
+  it('run', { repeats: 2 }, (t) => {
+    const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
+    state.push(tag + "run")
 
     onTestFinished(() => {
-      state.push('finish')
+      state.push(tag + 'finish')
     })
 
     onTestFailed(() => {
-      state.push('fail')
+      state.push(tag + 'fail')
     })
   })
 
   it('assert', () => {
-    // TODO: 010101
     expect(state).toMatchInlineSnapshot(`
       [
-        "run",
-        "finish",
-        "run",
-        "finish",
-        "finish",
-        "run",
-        "finish",
-        "finish",
-        "finish",
+        "(0, 0) run",
+        "(0, 0) finish",
+        "(0, 1) run",
+        "(0, 1) finish",
+        "(0, 2) run",
+        "(0, 2) finish",
       ]
     `)
   })
@@ -97,14 +94,15 @@ describe('repeats fail', () => {
   const state: string[] = []
 
   it.fails('run', { repeats: 2 }, (t) => {
-    state.push('run')
+    const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
+    state.push(tag + "run")
 
     onTestFinished(() => {
-      state.push('finish')
+      state.push(tag + 'finish')
     })
 
     onTestFailed(() => {
-      state.push('fail')
+      state.push(tag + 'fail')
     })
 
     if (t.task.result?.repeatCount === 1) {
@@ -113,23 +111,16 @@ describe('repeats fail', () => {
   })
 
   it('assert', () => {
-    // TODO: 012012012
     expect(state).toMatchInlineSnapshot(`
       [
-        "run",
-        "finish",
-        "run",
-        "finish",
-        "finish",
-        "fail",
-        "fail",
-        "run",
-        "finish",
-        "finish",
-        "finish",
-        "fail",
-        "fail",
-        "fail",
+        "(0, 0) run",
+        "(0, 0) finish",
+        "(0, 1) run",
+        "(0, 1) finish",
+        "(0, 1) fail",
+        "(0, 2) run",
+        "(0, 2) finish",
+        "(0, 2) fail",
       ]
     `)
   })
@@ -139,14 +130,15 @@ describe('retry pass', () => {
   const state: string[] = []
 
   it('run', { retry: 2 }, (t) => {
-    state.push('run')
+    const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
+    state.push(tag + "run")
 
     onTestFinished(() => {
-      state.push('finish')
+      state.push(tag + 'finish')
     })
 
     onTestFailed(() => {
-      state.push('fail')
+      state.push(tag + 'fail')
     })
 
     if (t.task.result?.retryCount && t.task.result?.retryCount > 1) {
@@ -156,21 +148,16 @@ describe('retry pass', () => {
   })
 
   it('assert', () => {
-    // TODO: 01201201
     expect(state).toMatchInlineSnapshot(`
       [
-        "run",
-        "finish",
-        "fail",
-        "run",
-        "finish",
-        "finish",
-        "fail",
-        "fail",
-        "run",
-        "finish",
-        "finish",
-        "finish",
+        "(0, 0) run",
+        "(0, 0) finish",
+        "(0, 0) fail",
+        "(1, 0) run",
+        "(1, 0) finish",
+        "(1, 0) fail",
+        "(2, 0) run",
+        "(2, 0) finish",
       ]
     `)
   })
@@ -179,39 +166,33 @@ describe('retry pass', () => {
 describe('retry fail', () => {
   const state: string[] = []
 
-  it.fails('run', { retry: 2 }, () => {
-    state.push('run')
+  it.fails('run', { retry: 2 }, (t) => {
+    const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
+    state.push(tag + "run")
 
     onTestFinished(() => {
-      state.push('finish')
+      state.push(tag + 'finish')
     })
 
     onTestFailed(() => {
-      state.push('fail')
+      state.push(tag + 'fail')
     })
 
     throw new Error('fail')
   })
 
   it('assert', () => {
-    // TODO: 012012012
     expect(state).toMatchInlineSnapshot(`
       [
-        "run",
-        "finish",
-        "fail",
-        "run",
-        "finish",
-        "finish",
-        "fail",
-        "fail",
-        "run",
-        "finish",
-        "finish",
-        "finish",
-        "fail",
-        "fail",
-        "fail",
+        "(0, 0) run",
+        "(0, 0) finish",
+        "(0, 0) fail",
+        "(1, 0) run",
+        "(1, 0) finish",
+        "(1, 0) fail",
+        "(2, 0) run",
+        "(2, 0) finish",
+        "(2, 0) fail",
       ]
     `)
   })

--- a/test/core/test/on-finished.test.ts
+++ b/test/core/test/on-finished.test.ts
@@ -65,14 +65,14 @@ describe('repeats pass', () => {
 
   it('run', { repeats: 2 }, (t) => {
     const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
-    state.push(tag + "run")
+    state.push(`${tag}run`)
 
     onTestFinished(() => {
-      state.push(tag + 'finish')
+      state.push(`${tag}finish`)
     })
 
     onTestFailed(() => {
-      state.push(tag + 'fail')
+      state.push(`${tag}fail`)
     })
   })
 
@@ -95,14 +95,14 @@ describe('repeats fail', () => {
 
   it.fails('run', { repeats: 2 }, (t) => {
     const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
-    state.push(tag + "run")
+    state.push(`${tag}run`)
 
     onTestFinished(() => {
-      state.push(tag + 'finish')
+      state.push(`${tag}finish`)
     })
 
     onTestFailed(() => {
-      state.push(tag + 'fail')
+      state.push(`${tag}fail`)
     })
 
     if (t.task.result?.repeatCount === 1) {
@@ -131,14 +131,14 @@ describe('retry pass', () => {
 
   it('run', { retry: 2 }, (t) => {
     const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
-    state.push(tag + "run")
+    state.push(`${tag}run`)
 
     onTestFinished(() => {
-      state.push(tag + 'finish')
+      state.push(`${tag}finish`)
     })
 
     onTestFailed(() => {
-      state.push(tag + 'fail')
+      state.push(`${tag}fail`)
     })
 
     if (t.task.result?.retryCount && t.task.result?.retryCount > 1) {
@@ -168,14 +168,14 @@ describe('retry fail', () => {
 
   it.fails('run', { retry: 2 }, (t) => {
     const tag = `(${t.task.result?.retryCount}, ${t.task.result?.repeatCount}) `
-    state.push(tag + "run")
+    state.push(`${tag}run`)
 
     onTestFinished(() => {
-      state.push(tag + 'finish')
+      state.push(`${tag}finish`)
     })
 
     onTestFailed(() => {
-      state.push(tag + 'fail')
+      state.push(`${tag}fail`)
     })
 
     throw new Error('fail')

--- a/test/core/test/on-finished.test.ts
+++ b/test/core/test/on-finished.test.ts
@@ -61,17 +61,17 @@ it('after', () => {
 })
 
 describe('repeats pass', () => {
-  const state = new Array<number>()
+  const state: string[] = []
 
   it('run', { repeats: 2 }, () => {
-    state.push(0)
+    state.push('run')
 
     onTestFinished(() => {
-      state.push(1)
+      state.push('finish')
     })
 
     onTestFailed(() => {
-      state.push(2)
+      state.push('fail')
     })
   })
 
@@ -79,32 +79,32 @@ describe('repeats pass', () => {
     // TODO: 010101
     expect(state).toMatchInlineSnapshot(`
       [
-        0,
-        1,
-        0,
-        1,
-        1,
-        0,
-        1,
-        1,
-        1,
+        "run",
+        "finish",
+        "run",
+        "finish",
+        "finish",
+        "run",
+        "finish",
+        "finish",
+        "finish",
       ]
     `)
   })
 })
 
 describe('repeats fail', () => {
-  const state = new Array<number>()
+  const state: string[] = []
 
   it.fails('run', { repeats: 2 }, (t) => {
-    state.push(0)
+    state.push('run')
 
     onTestFinished(() => {
-      state.push(1)
+      state.push('finish')
     })
 
     onTestFailed(() => {
-      state.push(2)
+      state.push('fail')
     })
 
     if (t.task.result?.repeatCount === 1) {
@@ -116,37 +116,37 @@ describe('repeats fail', () => {
     // TODO: 012012012
     expect(state).toMatchInlineSnapshot(`
       [
-        0,
-        1,
-        0,
-        1,
-        1,
-        2,
-        2,
-        0,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
+        "run",
+        "finish",
+        "run",
+        "finish",
+        "finish",
+        "fail",
+        "fail",
+        "run",
+        "finish",
+        "finish",
+        "finish",
+        "fail",
+        "fail",
+        "fail",
       ]
     `)
   })
 })
 
 describe('retry pass', () => {
-  const state = new Array<number>()
+  const state: string[] = []
 
   it('run', { retry: 2 }, (t) => {
-    state.push(0)
+    state.push('run')
 
     onTestFinished(() => {
-      state.push(1)
+      state.push('finish')
     })
 
     onTestFailed(() => {
-      state.push(2)
+      state.push('fail')
     })
 
     if (t.task.result?.retryCount && t.task.result?.retryCount > 1) {
@@ -159,35 +159,35 @@ describe('retry pass', () => {
     // TODO: 01201201
     expect(state).toMatchInlineSnapshot(`
       [
-        0,
-        1,
-        2,
-        0,
-        1,
-        1,
-        2,
-        2,
-        0,
-        1,
-        1,
-        1,
+        "run",
+        "finish",
+        "fail",
+        "run",
+        "finish",
+        "finish",
+        "fail",
+        "fail",
+        "run",
+        "finish",
+        "finish",
+        "finish",
       ]
     `)
   })
 })
 
 describe('retry fail', () => {
-  const state = new Array<number>()
+  const state: string[] = []
 
   it.fails('run', { retry: 2 }, () => {
-    state.push(0)
+    state.push('run')
 
     onTestFinished(() => {
-      state.push(1)
+      state.push('finish')
     })
 
     onTestFailed(() => {
-      state.push(2)
+      state.push('fail')
     })
 
     throw new Error('fail')
@@ -197,21 +197,21 @@ describe('retry fail', () => {
     // TODO: 012012012
     expect(state).toMatchInlineSnapshot(`
       [
-        0,
-        1,
-        2,
-        0,
-        1,
-        1,
-        2,
-        2,
-        0,
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
+        "run",
+        "finish",
+        "fail",
+        "run",
+        "finish",
+        "finish",
+        "fail",
+        "fail",
+        "run",
+        "finish",
+        "finish",
+        "finish",
+        "fail",
+        "fail",
+        "fail",
       ]
     `)
   })


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/5869

I just hit this issue when writing e2e on Vite.

I moved `callTaskHooks` inside retry/repeat for-loops and it seems okay.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
