### PR TITLE
fix(vitest): don't start a websocket server if api is disabled

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -98,6 +98,7 @@ export async function VitestPlugin(
             ...testConfig.api,
             open,
             hmr: false,
+            ws: testConfig.api?.middlewareMode ? false : undefined,
             preTransformRequests: false,
             fs: {
               allow: resolveFsAllow(getRoot(), testConfig.config),

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -85,6 +85,7 @@ export function WorkspaceVitestPlugin(
             watch: null,
             open: false,
             hmr: false,
+            ws: false,
             preTransformRequests: false,
             middlewareMode: true,
             fs: {


### PR DESCRIPTION
### Description

Fixes #5474

This requires Vite 5.3.0 or higher to work.

Checked locally that it works in `examples/basic`. The `test/core` started the ws server because it always has `api` enabled.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
