### PR TITLE
test: refactor browser test utils

### DIFF
--- a/test/browser/specs/fix-4686.test.ts
+++ b/test/browser/specs/fix-4686.test.ts
@@ -4,16 +4,21 @@ import { expect, test } from 'vitest'
 import { runBrowserTests } from './utils'
 
 test('tests run in presence of config.base', async () => {
-  const { stderr, failedTests, passedTests, browserResultJson } = await runBrowserTests(
+  const { stderr, ctx } = await runBrowserTests(
     {
       config: './vitest.config-basepath.mts',
     },
     ['test/basic.test.ts'],
   )
 
-  expect(browserResultJson.testResults).toHaveLength(1)
-  expect(passedTests).toHaveLength(1)
-  expect(failedTests).toHaveLength(0)
-
   expect(stderr).toBe('')
+  expect(
+    Object.fromEntries(
+      ctx.state.getFiles().map(f => [f.name, f.result.state]),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "test/basic.test.ts": "pass",
+    }
+  `)
 })

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import { beforeAll, describe, expect, onTestFailed, test } from 'vitest'
 import { browser, runBrowserTests } from './utils'
 
@@ -12,10 +13,14 @@ describe('running browser tests', async () => {
     ({
       stderr,
       stdout,
-      browserResultJson,
-      passedTests,
-      failedTests,
     } = await runBrowserTests())
+
+    const browserResult = await readFile('./browser.json', 'utf-8')
+    browserResultJson = JSON.parse(browserResult)
+    const getPassed = results => results.filter(result => result.status === 'passed' && !result.mesage)
+    const getFailed = results => results.filter(result => result.status === 'failed')
+    passedTests = getPassed(browserResultJson.testResults)
+    failedTests = getFailed(browserResultJson.testResults)
   })
 
   test('tests are actually running', () => {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -1,21 +1,26 @@
-import type { RunnerTestFile } from 'vitest'
+import { readFile } from 'node:fs/promises'
 import { beforeAll, describe, expect, onTestFailed, test } from 'vitest'
 import { browser, runBrowserTests } from './utils'
 
 describe('running browser tests', async () => {
   let stderr: string
   let stdout: string
-  let testFiles: RunnerTestFile[]
-  let passedTests: RunnerTestFile[]
-  let failedTests: RunnerTestFile[]
+  let browserResultJson: any
+  let passedTests: any[]
+  let failedTests: any[]
 
   beforeAll(async () => {
-    const result = await runBrowserTests()
-    stdout = result.stdout
-    stderr = result.stderr
-    testFiles = result.ctx.state.getFiles()
-    passedTests = testFiles.filter(file => file.result.state === 'pass')
-    failedTests = testFiles.filter(file => file.result.state === 'fail')
+    ({
+      stderr,
+      stdout,
+    } = await runBrowserTests())
+
+    const browserResult = await readFile('./browser.json', 'utf-8')
+    browserResultJson = JSON.parse(browserResult)
+    const getPassed = results => results.filter(result => result.status === 'passed' && !result.mesage)
+    const getFailed = results => results.filter(result => result.status === 'failed')
+    passedTests = getPassed(browserResultJson.testResults)
+    failedTests = getFailed(browserResultJson.testResults)
   })
 
   test('tests are actually running', () => {
@@ -23,7 +28,7 @@ describe('running browser tests', async () => {
       console.error(stderr)
     })
 
-    expect(testFiles).toHaveLength(19)
+    expect(browserResultJson.testResults).toHaveLength(19)
     expect(passedTests).toHaveLength(17)
     expect(failedTests).toHaveLength(2)
 
@@ -33,9 +38,9 @@ describe('running browser tests', async () => {
 
   test('runs in-source tests', () => {
     expect(stdout).toContain('src/actions.ts')
-    const actionsTest = passedTests.find(t => t.name === 'src/actions.ts')
+    const actionsTest = passedTests.find(t => t.name.includes('/actions.ts'))
     expect(actionsTest).toBeDefined()
-    expect(actionsTest.tasks[0].name).toBe('in-source plus works correctly')
+    expect(actionsTest.assertionResults).toHaveLength(1)
   })
 
   test('correctly prints error', () => {

--- a/test/browser/specs/server-url.test.ts
+++ b/test/browser/specs/server-url.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, expect, test } from 'vitest'
-import { runBrowserTests } from './utils'
+import { provider, runBrowserTests } from './utils'
 
 afterEach(() => {
   delete process.env.TEST_HTTPS
 })
 
 test('server-url http', async () => {
-  const { stdout, stderr, provider } = await runBrowserTests({
+  const { stdout, stderr } = await runBrowserTests({
     root: './fixtures/server-url',
   })
   expect(stderr).toBe('')
@@ -15,7 +15,7 @@ test('server-url http', async () => {
 
 test('server-url https', async () => {
   process.env.TEST_HTTPS = '1'
-  const { stdout, stderr, provider } = await runBrowserTests({
+  const { stdout, stderr } = await runBrowserTests({
     root: './fixtures/server-url',
   })
   expect(stderr).toBe('')

--- a/test/browser/specs/unhandled.test.ts
+++ b/test/browser/specs/unhandled.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'vitest'
-import { runBrowserTests } from './utils'
+import { browser, runBrowserTests } from './utils'
 
 test('prints correct unhandled error stack', async () => {
-  const { stderr, browser } = await runBrowserTests({
+  const { stderr } = await runBrowserTests({
     root: './fixtures/unhandled',
   })
 

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -1,9 +1,8 @@
-import { readFile } from 'node:fs/promises'
 import type { UserConfig as ViteUserConfig } from 'vite'
 import type { UserConfig } from 'vitest'
 import { runVitest } from '../../test-utils'
 
-const provider = process.env.PROVIDER || 'playwright'
+export const provider = process.env.PROVIDER || 'playwright'
 export const browser = process.env.BROWSER || (provider !== 'playwright' ? 'chromium' : 'chrome')
 
 export async function runBrowserTests(
@@ -11,7 +10,7 @@ export async function runBrowserTests(
   include?: string[],
   viteOverrides?: Partial<ViteUserConfig>,
 ) {
-  const result = await runVitest({
+  return runVitest({
     watch: false,
     reporters: 'none',
     ...config,
@@ -20,15 +19,4 @@ export async function runBrowserTests(
       ...config?.browser,
     } as UserConfig['browser'],
   }, include, 'test', viteOverrides)
-
-  const browserResult = await readFile('./browser.json', 'utf-8')
-  const browserResultJson = JSON.parse(browserResult)
-
-  const getPassed = results => results.filter(result => result.status === 'passed' && !result.mesage)
-  const getFailed = results => results.filter(result => result.status === 'failed')
-
-  const passedTests = getPassed(browserResultJson.testResults)
-  const failedTests = getFailed(browserResultJson.testResults)
-
-  return { ...result, browserResultJson, passedTests, failedTests, browser, provider }
 }


### PR DESCRIPTION
### Description

Currently `runBrowserTests` utility is relying on json reporter output `browser.json`, which is causing a cryptic CI error in https://github.com/vitest-dev/vitest/pull/6512. I rewrote this part to use assertions based on vitest state API.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
