### PR TITLE
fix(vitest): deprecate UserConfig in favor of ViteUserConfig

### DIFF
--- a/packages/vitest/src/public/config.ts
+++ b/packages/vitest/src/public/config.ts
@@ -15,7 +15,11 @@ export { mergeConfig } from 'vite'
 export { extraInlineDeps } from '../constants'
 export type { Plugin } from 'vite'
 
-export type { ConfigEnv, ViteUserConfig as UserConfig }
+export type { ConfigEnv, ViteUserConfig }
+/**
+ * @deprecated Use `ViteUserConfig` instead
+ */
+export type UserConfig = ViteUserConfig
 export type { UserProjectConfigExport, UserProjectConfigFn, UserWorkspaceConfig, WorkspaceProjectConfiguration }
 export type UserConfigFnObject = (env: ConfigEnv) => ViteUserConfig
 export type UserConfigFnPromise = (env: ConfigEnv) => Promise<ViteUserConfig>

--- a/test/config/test/bail.test.ts
+++ b/test/config/test/bail.test.ts
@@ -1,5 +1,6 @@
-import { type UserConfig, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
+import type { UserConfig } from 'vitest/node'
 import { runVitest } from '../../test-utils'
 
 const configs: UserConfig[] = []

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -279,10 +279,3 @@ test('mergeReports doesn\'t work with watch mode enabled', async () => {
 
   expect(stderr).toMatch('Cannot merge reports with --watch enabled')
 })
-
-test('maxConcurrency 0 prints a warning', async () => {
-  const { stderr, ctx } = await runVitest({ maxConcurrency: 0 })
-
-  expect(ctx?.config.maxConcurrency).toBe(5)
-  expect(stderr).toMatch('The option "maxConcurrency" cannot be set to 0. Using default value 5 instead.')
-})

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, test } from 'vitest'
-import type { UserConfig } from 'vitest'
+import type { UserConfig } from 'vitest/node'
 import { version } from 'vitest/package.json'
 
 import { normalize, resolve } from 'pathe'
@@ -278,4 +278,12 @@ test('mergeReports doesn\'t work with watch mode enabled', async () => {
   const { stderr } = await runVitest({ watch: true, mergeReports: '.vitest-reports' })
 
   expect(stderr).toMatch('Cannot merge reports with --watch enabled')
+})
+
+test.only('maxConcurrency 0 prints a warning', async () => {
+  const { stderr, stdout, ctx } = await runVitest({ maxConcurrency: 0 })
+
+  // console.log(stdout, stderr)
+  expect(ctx?.config.maxConcurrency).toBe(5)
+  expect(stderr).toMatch('The option "maxConcurrency" cannot be set to 0. Using default value 5 instead.')
 })

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -280,10 +280,9 @@ test('mergeReports doesn\'t work with watch mode enabled', async () => {
   expect(stderr).toMatch('Cannot merge reports with --watch enabled')
 })
 
-test.only('maxConcurrency 0 prints a warning', async () => {
-  const { stderr, stdout, ctx } = await runVitest({ maxConcurrency: 0 })
+test('maxConcurrency 0 prints a warning', async () => {
+  const { stderr, ctx } = await runVitest({ maxConcurrency: 0 })
 
-  // console.log(stdout, stderr)
   expect(ctx?.config.maxConcurrency).toBe(5)
   expect(stderr).toMatch('The option "maxConcurrency" cannot be set to 0. Using default value 5 instead.')
 })

--- a/test/config/test/mixed-environments.test.ts
+++ b/test/config/test/mixed-environments.test.ts
@@ -1,4 +1,5 @@
-import { type UserConfig, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
+import type { UserConfig } from 'vitest/node'
 
 import { runVitest } from '../../test-utils'
 

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -1,4 +1,4 @@
-import type { UserConfig } from 'vitest'
+import type { UserConfig } from 'vitest/node'
 import type { UserConfig as ViteUserConfig } from 'vite'
 import { describe, expect, it } from 'vitest'
 import { createVitest, parseCLI } from 'vitest/node'

--- a/test/config/test/shard.test.ts
+++ b/test/config/test/shard.test.ts
@@ -1,6 +1,7 @@
-import { type UserConfig, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 import { basename } from 'pathe'
 
+import type { UserConfig } from 'vitest/node'
 import * as testUtils from '../../test-utils'
 
 function runVitest(config: UserConfig) {

--- a/test/config/test/shuffle-options.test.ts
+++ b/test/config/test/shuffle-options.test.ts
@@ -1,4 +1,4 @@
-import type { InlineConfig } from 'vitest'
+import type { InlineConfig } from 'vitest/node'
 import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 

--- a/test/config/test/workers-option.test.ts
+++ b/test/config/test/workers-option.test.ts
@@ -1,4 +1,5 @@
-import { type UserConfig, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+import type { UserConfig } from 'vitest/node'
 
 import { getWorkersCountByPercentage } from 'vitest/src/utils/workers.js'
 import * as testUtils from '../../test-utils'


### PR DESCRIPTION
### Description

Vitest exports its own `UserConfig` from `vitest/node`. Maybe in the future it should replace this export.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
