### PR TITLE
feat(vitest): show test "path" when filtering

### DIFF
--- a/packages/vitest/src/node/watch-filter.ts
+++ b/packages/vitest/src/node/watch-filter.ts
@@ -9,13 +9,19 @@ const MAX_RESULT_COUNT = 10
 const SELECTION_MAX_INDEX = 7
 const ESC = '\u001B['
 
-type FilterFunc = (keyword: string) => Promise<string[]> | string[]
+export interface FilterType {
+  name: string
+  toString: () => string
+}
+type FilterItemType<T extends 'string' | 'object' = 'string'> = T extends 'string' ? string : FilterType
+type FilterFuncType<T extends 'string' | 'object' = 'string'> = (keyword: string) => Promise<FilterItemType<T>[]> | FilterItemType<T>[]
+// type FilterPatternFunc = (keyword: string) => Promise<{ name: string; toString: () => string }[]>
 
-export class WatchFilter {
+export class WatchFilter<T extends 'string' | 'object' = 'string'> {
   private filterRL: readline.Interface
   private currentKeyword: string | undefined = undefined
   private message: string
-  private results: string[] = []
+  private results: FilterItemType<T>[] = []
   private selectionIndex = -1
   private onKeyPress?: (str: string, key: any) => void
   private stdin: NodeJS.ReadStream
@@ -40,7 +46,7 @@ export class WatchFilter {
     }
   }
 
-  public async filter(filterFunc: FilterFunc): Promise<string | undefined> {
+  public async filter(filterFunc: FilterFuncType<T>): Promise<string | undefined> {
     this.write(this.promptLine())
 
     const resultPromise = createDefer<string | undefined>()
@@ -58,7 +64,7 @@ export class WatchFilter {
   }
 
   private filterHandler(
-    filterFunc: FilterFunc,
+    filterFunc: FilterFuncType<T>,
     onSubmit: (result?: string) => void,
   ) {
     return async (str: string | undefined, key: any) => {
@@ -78,12 +84,17 @@ export class WatchFilter {
           onSubmit(undefined)
           break
         case key?.name === 'enter':
-        case key?.name === 'return':
+        case key?.name === 'return': {
+          const selection = this.results[this.selectionIndex]
+          const result = typeof selection === 'string'
+            ? selection
+            : selection?.name
           onSubmit(
-            this.results[this.selectionIndex] || this.currentKeyword || '',
+            result || this.currentKeyword || '',
           )
           this.currentKeyword = undefined
           break
+        }
         case key?.name === 'up':
           if (this.selectionIndex && this.selectionIndex > 0) {
             this.selectionIndex--


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR is related to _filtering from command line_ here: https://github.com/vitest-dev/vitest/pull/6641 (compare screenshots there and here)

This PR allow declare the watcher filter using a new interface to display the list with the test paths removing duplicates files when using workspaces. Right now, filtering tests will run any test in any files and workspace matching the name of the selected item (test name).

**NOTE**: we should add a new `runById` to allow run only a test (the UI will use it)

<details>
<summary><i>filtering from command line with this PR</i></summary>

![imagen](https://github.com/user-attachments/assets/49465c16-cff1-445f-bbfa-29527ab8d30c)
</details>


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
