### PR TITLE
chore: make Vitest monorepo work with the vscode extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,8 @@
   //   { "rule": "*semi", "severity": "off" }
   // ],
 
+  "vitest.workspaceConfig": "./vitest.workspace.vscode.ts",
+
   // Enable eslint for all supported languages
   "eslint.validate": [
     "javascript",

--- a/vitest.workspace.vscode.ts
+++ b/vitest.workspace.vscode.ts
@@ -1,0 +1,5 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  './test/core',
+])


### PR DESCRIPTION
### Description

The Vitest monorepo has a lot of configs in tests that the extension picks up. Some of them fail because the test that checks it expects it to fail.

This PR creates a separate workspace config file that should always be picked up by the extension. Feel free to add new projects when testing. I think this is a good way to dogfood the extension.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
