### PR TITLE
refactor(coverage): move re-usable parts to base provider

### DIFF
--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -62,6 +62,7 @@
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/istanbul-lib-source-maps": "^4.0.4",
     "@types/istanbul-reports": "^3.0.4",
+    "@types/test-exclude": "^6.0.2",
     "pathe": "^1.1.2",
     "vitest": "workspace:*"
   }

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -73,6 +73,7 @@
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/istanbul-lib-source-maps": "^4.0.4",
     "@types/istanbul-reports": "^3.0.4",
+    "@types/test-exclude": "^6.0.2",
     "@vitest/browser": "workspace:*",
     "pathe": "^1.1.2",
     "v8-to-istanbul": "^9.3.0",

--- a/packages/vitest/src/utils/coverage.ts
+++ b/packages/vitest/src/utils/coverage.ts
@@ -1,8 +1,12 @@
-import { relative } from 'pathe'
+import { existsSync, promises as fs, readdirSync, writeFileSync } from 'node:fs'
+import { relative, resolve } from 'pathe'
 import mm from 'micromatch'
+import c from 'tinyrainbow'
 import type { CoverageMap } from 'istanbul-lib-coverage'
+import { coverageConfigDefaults } from '../defaults'
+import type { AfterSuiteRunMeta } from '../types/general'
 import type { Vitest } from '../node/core'
-import type { BaseCoverageOptions, ResolvedCoverageOptions } from '../node/types/coverage'
+import type { BaseCoverageOptions, ReportContext, ResolvedCoverageOptions } from '../node/types/coverage'
 import { resolveCoverageReporters } from '../node/config/resolveConfig'
 
 type Threshold = 'lines' | 'functions' | 'statements' | 'branches'
@@ -13,6 +17,31 @@ interface ResolvedThreshold {
   thresholds: Partial<Record<Threshold, number | undefined>>
 }
 
+/**
+ * Holds info about raw coverage results that are stored on file system:
+ *
+ * ```json
+ * "project-a": {
+ *   "web": {
+ *     "tests/math.test.ts": "coverage-1.json",
+ *     "tests/utils.test.ts": "coverage-2.json",
+ * //                          ^^^^^^^^^^^^^^^ Raw coverage on file system
+ *   },
+ *   "ssr": { ... },
+ *   "browser": { ... },
+ * },
+ * "project-b": ...
+ * ```
+ */
+type CoverageFiles = Map<
+  NonNullable<AfterSuiteRunMeta['projectName']> | symbol,
+  Record<
+    AfterSuiteRunMeta['transformMode'],
+    { [TestFilenames: string]: string }
+  >
+>
+type Entries<T> = [keyof T, T[keyof T]][]
+
 const THRESHOLD_KEYS: Readonly<Threshold[]> = [
   'lines',
   'functions',
@@ -20,19 +49,352 @@ const THRESHOLD_KEYS: Readonly<Threshold[]> = [
   'branches',
 ]
 const GLOBAL_THRESHOLDS_KEY = 'global'
+const DEFAULT_PROJECT: unique symbol = Symbol.for('default-project')
+let uniqueId = 0
 
-export class BaseCoverageProvider {
+export class BaseCoverageProvider<Options extends ResolvedCoverageOptions<'istanbul' | 'v8'>> {
+  ctx!: Vitest
+  readonly name!: 'v8' | 'istanbul'
+  version!: string
+  options!: Options
+
+  coverageFiles: CoverageFiles = new Map()
+  pendingPromises: Promise<void>[] = []
+  coverageFilesDirectory!: string
+
+  _initialize(ctx: Vitest) {
+    this.ctx = ctx
+
+    if (ctx.version !== this.version) {
+      ctx.logger.warn(
+        c.yellow(
+          `Loaded ${c.inverse(c.yellow(` vitest@${ctx.version} `))} and ${c.inverse(c.yellow(` @vitest/coverage-${this.name}@${this.version} `))}.`
+          + '\nRunning mixed versions is not supported and may lead into bugs'
+          + '\nUpdate your dependencies and make sure the versions match.',
+        ),
+      )
+    }
+
+    const config = ctx.config.coverage as Options
+
+    this.options = {
+      ...coverageConfigDefaults,
+
+      // User's options
+      ...config,
+
+      // Resolved fields
+      provider: this.name,
+      reportsDirectory: resolve(
+        ctx.config.root,
+        config.reportsDirectory || coverageConfigDefaults.reportsDirectory,
+      ),
+      reporter: resolveCoverageReporters(
+        config.reporter || coverageConfigDefaults.reporter,
+      ),
+      thresholds: config.thresholds && {
+        ...config.thresholds,
+        lines: config.thresholds['100'] ? 100 : config.thresholds.lines,
+        branches: config.thresholds['100'] ? 100 : config.thresholds.branches,
+        functions: config.thresholds['100'] ? 100 : config.thresholds.functions,
+        statements: config.thresholds['100'] ? 100 : config.thresholds.statements,
+      },
+    }
+
+    const shard = this.ctx.config.shard
+    const tempDirectory = `.tmp${
+      shard ? `-${shard.index}-${shard.count}` : ''
+    }`
+
+    this.coverageFilesDirectory = resolve(
+      this.options.reportsDirectory,
+      tempDirectory,
+    )
+  }
+
+  createCoverageMap(): CoverageMap {
+    throw new Error('BaseReporter\'s createCoverageMap was not overwritten')
+  }
+
+  async generateReports(_: CoverageMap, __: boolean | undefined) {
+    throw new Error('BaseReporter\'s generateReports was not overwritten')
+  }
+
+  async parseConfigModule(_: string): Promise<{ generate: () => { code: string } }> {
+    throw new Error('BaseReporter\'s parseConfigModule was not overwritten')
+  }
+
+  resolveOptions() {
+    return this.options
+  }
+
+  async clean(clean = true): Promise<void> {
+    if (clean && existsSync(this.options.reportsDirectory)) {
+      await fs.rm(this.options.reportsDirectory, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+      })
+    }
+
+    if (existsSync(this.coverageFilesDirectory)) {
+      await fs.rm(this.coverageFilesDirectory, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+      })
+    }
+
+    await fs.mkdir(this.coverageFilesDirectory, { recursive: true })
+
+    this.coverageFiles = new Map()
+    this.pendingPromises = []
+  }
+
+  onAfterSuiteRun({ coverage, transformMode, projectName, testFiles }: AfterSuiteRunMeta): void {
+    if (!coverage) {
+      return
+    }
+
+    if (transformMode !== 'web' && transformMode !== 'ssr' && transformMode !== 'browser') {
+      throw new Error(`Invalid transform mode: ${transformMode}`)
+    }
+
+    let entry = this.coverageFiles.get(projectName || DEFAULT_PROJECT)
+
+    if (!entry) {
+      entry = { web: {}, ssr: {}, browser: {} }
+      this.coverageFiles.set(projectName || DEFAULT_PROJECT, entry)
+    }
+
+    const testFilenames = testFiles.join()
+    const filename = resolve(
+      this.coverageFilesDirectory,
+      `coverage-${uniqueId++}.json`,
+    )
+
+    // If there's a result from previous run, overwrite it
+    entry[transformMode][testFilenames] = filename
+
+    const promise = fs.writeFile(filename, JSON.stringify(coverage), 'utf-8')
+    this.pendingPromises.push(promise)
+  }
+
+  async readCoverageFiles<CoverageType>({ onFileRead, onFinished, onDebug }: {
+    /** Callback invoked with a single coverage result */
+    onFileRead: (data: CoverageType) => void
+    /** Callback invoked once all results of a project for specific transform mode are read */
+    onFinished: (project: Vitest['projects'][number], transformMode: AfterSuiteRunMeta['transformMode']) => Promise<void>
+    onDebug: ((...logs: any[]) => void) & { enabled: boolean }
+  }) {
+    let index = 0
+    const total = this.pendingPromises.length
+
+    await Promise.all(this.pendingPromises)
+    this.pendingPromises = []
+
+    for (const [projectName, coveragePerProject] of this.coverageFiles.entries()) {
+      for (const [transformMode, coverageByTestfiles] of Object.entries(coveragePerProject) as Entries<typeof coveragePerProject>) {
+        const filenames = Object.values(coverageByTestfiles)
+        const project = this.ctx.getProjectByName(projectName as string)
+
+        for (const chunk of this.toSlices(filenames, this.options.processingConcurrency)) {
+          if (onDebug.enabled) {
+            index += chunk.length
+            onDebug('Covered files %d/%d', index, total)
+          }
+
+          await Promise.all(chunk.map(async (filename) => {
+            const contents = await fs.readFile(filename, 'utf-8')
+            const coverage = JSON.parse(contents)
+
+            onFileRead(coverage)
+          }),
+          )
+        }
+
+        await onFinished(project, transformMode)
+      }
+    }
+  }
+
+  async cleanAfterRun() {
+    this.coverageFiles = new Map()
+    await fs.rm(this.coverageFilesDirectory, { recursive: true })
+
+    // Remove empty reports directory, e.g. when only text-reporter is used
+    if (readdirSync(this.options.reportsDirectory).length === 0) {
+      await fs.rm(this.options.reportsDirectory, { recursive: true })
+    }
+  }
+
+  async onTestFailure() {
+    if (!this.options.reportOnFailure) {
+      await this.cleanAfterRun()
+    }
+  }
+
+  async reportCoverage(coverageMap: unknown, { allTestsRun }: ReportContext): Promise<void> {
+    await this.generateReports(
+      (coverageMap as CoverageMap) || this.createCoverageMap(),
+      allTestsRun,
+    )
+
+    // In watch mode we need to preserve the previous results if cleanOnRerun is disabled
+    const keepResults = !this.options.cleanOnRerun && this.ctx.config.watch
+
+    if (!keepResults) {
+      await this.cleanAfterRun()
+    }
+  }
+
+  async reportThresholds(coverageMap: CoverageMap, allTestsRun: boolean | undefined) {
+    const resolvedThresholds = this.resolveThresholds(coverageMap)
+    this.checkThresholds(resolvedThresholds)
+
+    if (this.options.thresholds?.autoUpdate && allTestsRun) {
+      if (!this.ctx.server.config.configFile) {
+        throw new Error(
+          'Missing configurationFile. The "coverage.thresholds.autoUpdate" can only be enabled when configuration file is used.',
+        )
+      }
+
+      const configFilePath = this.ctx.server.config.configFile
+      const configModule = await this.parseConfigModule(configFilePath)
+
+      await this.updateThresholds({
+        thresholds: resolvedThresholds,
+        configurationFile: configModule,
+        onUpdate: () =>
+          writeFileSync(
+            configFilePath,
+            configModule.generate().code,
+            'utf-8',
+          ),
+
+      })
+    }
+  }
+
+  /**
+   * Constructs collected coverage and users' threshold options into separate sets
+   * where each threshold set holds their own coverage maps. Threshold set is either
+   * for specific files defined by glob pattern or global for all other files.
+   */
+  private resolveThresholds(coverageMap: CoverageMap): ResolvedThreshold[] {
+    const resolvedThresholds: ResolvedThreshold[] = []
+    const files = coverageMap.files()
+    const globalCoverageMap = this.createCoverageMap()
+
+    for (const key of Object.keys(this.options.thresholds!) as `${keyof NonNullable<typeof this.options.thresholds>}`[]) {
+      if (
+        key === 'perFile'
+        || key === 'autoUpdate'
+        || key === '100'
+        || THRESHOLD_KEYS.includes(key)
+      ) {
+        continue
+      }
+
+      const glob = key
+      const globThresholds = resolveGlobThresholds(this.options.thresholds![glob])
+      const globCoverageMap = this.createCoverageMap()
+
+      const matchingFiles = files.filter(file =>
+        mm.isMatch(relative(this.ctx.config.root, file), glob),
+      )
+
+      for (const file of matchingFiles) {
+        const fileCoverage = coverageMap.fileCoverageFor(file)
+        globCoverageMap.addFileCoverage(fileCoverage)
+      }
+
+      resolvedThresholds.push({
+        name: glob,
+        coverageMap: globCoverageMap,
+        thresholds: globThresholds,
+      })
+    }
+
+    // Global threshold is for all files, even if they are included by glob patterns
+    for (const file of files) {
+      const fileCoverage = coverageMap.fileCoverageFor(file)
+      globalCoverageMap.addFileCoverage(fileCoverage)
+    }
+
+    resolvedThresholds.unshift({
+      name: GLOBAL_THRESHOLDS_KEY,
+      coverageMap: globalCoverageMap,
+      thresholds: {
+        branches: this.options.thresholds?.branches,
+        functions: this.options.thresholds?.functions,
+        lines: this.options.thresholds?.lines,
+        statements: this.options.thresholds?.statements,
+      },
+    })
+
+    return resolvedThresholds
+  }
+
+  /**
+   * Check collected coverage against configured thresholds. Sets exit code to 1 when thresholds not reached.
+   */
+  private checkThresholds(allThresholds: ResolvedThreshold[]) {
+    for (const { coverageMap, thresholds, name } of allThresholds) {
+      if (
+        thresholds.branches === undefined
+        && thresholds.functions === undefined
+        && thresholds.lines === undefined
+        && thresholds.statements === undefined
+      ) {
+        continue
+      }
+
+      // Construct list of coverage summaries where thresholds are compared against
+      const summaries = this.options.thresholds?.perFile
+        ? coverageMap.files().map((file: string) => ({
+          file,
+          summary: coverageMap.fileCoverageFor(file).toSummary(),
+        }))
+        : [{ file: null, summary: coverageMap.getCoverageSummary() }]
+
+      // Check thresholds of each summary
+      for (const { summary, file } of summaries) {
+        for (const thresholdKey of THRESHOLD_KEYS) {
+          const threshold = thresholds[thresholdKey]
+
+          if (threshold !== undefined) {
+            const coverage = summary.data[thresholdKey].pct
+
+            if (coverage < threshold) {
+              process.exitCode = 1
+
+              /*
+               * Generate error message based on perFile flag:
+               * - ERROR: Coverage for statements (33.33%) does not meet threshold (85%) for src/math.ts
+               * - ERROR: Coverage for statements (50%) does not meet global threshold (85%)
+               */
+              let errorMessage = `ERROR: Coverage for ${thresholdKey} (${coverage}%) does not meet ${
+                name === GLOBAL_THRESHOLDS_KEY ? name : `"${name}"`
+              } threshold (${threshold}%)`
+
+              if (this.options.thresholds?.perFile && file) {
+                errorMessage += ` for ${relative('./', file).replace(/\\/g, '/')}`
+              }
+
+              this.ctx.logger.error(errorMessage)
+            }
+          }
+        }
+      }
+    }
+  }
+
   /**
    * Check if current coverage is above configured thresholds and bump the thresholds if needed
    */
-  updateThresholds({
-    thresholds: allThresholds,
-    perFile,
-    configurationFile,
-    onUpdate,
-  }: {
+  async updateThresholds({ thresholds: allThresholds, onUpdate, configurationFile }: {
     thresholds: ResolvedThreshold[]
-    perFile?: boolean
     configurationFile: unknown // ProxifiedModule from magicast
     onUpdate: () => void
   }) {
@@ -42,7 +404,7 @@ export class BaseCoverageProvider {
     assertConfigurationModule(config)
 
     for (const { coverageMap, thresholds, name } of allThresholds) {
-      const summaries = perFile
+      const summaries = this.options.thresholds?.perFile
         ? coverageMap
           .files()
           .map((file: string) =>
@@ -74,177 +436,26 @@ export class BaseCoverageProvider {
           config.test.coverage.thresholds[threshold] = newValue
         }
         else {
-          const glob = config.test.coverage.thresholds[
-            name as Threshold
-          ] as ResolvedThreshold['thresholds']
+          const glob = config.test.coverage.thresholds[name as Threshold] as ResolvedThreshold['thresholds']
           glob[threshold] = newValue
         }
       }
     }
 
     if (updatedThresholds) {
-      // eslint-disable-next-line no-console
-      console.log(
-        'Updating thresholds to configuration file. You may want to push with updated coverage thresholds.',
-      )
+      this.ctx.logger.log('Updating thresholds to configuration file. You may want to push with updated coverage thresholds.')
       onUpdate()
     }
   }
 
-  /**
-   * Check collected coverage against configured thresholds. Sets exit code to 1 when thresholds not reached.
-   */
-  checkThresholds({
-    thresholds: allThresholds,
-    perFile,
-    onError,
-  }: {
-    thresholds: ResolvedThreshold[]
-    perFile?: boolean
-    onError: (error: string) => void
-  }) {
-    for (const { coverageMap, thresholds, name } of allThresholds) {
-      if (
-        thresholds.branches === undefined
-        && thresholds.functions === undefined
-        && thresholds.lines === undefined
-        && thresholds.statements === undefined
-      ) {
-        continue
-      }
+  async mergeReports(coverageMaps: unknown[]): Promise<void> {
+    const coverageMap = this.createCoverageMap()
 
-      // Construct list of coverage summaries where thresholds are compared against
-      const summaries = perFile
-        ? coverageMap.files().map((file: string) => ({
-          file,
-          summary: coverageMap.fileCoverageFor(file).toSummary(),
-        }))
-        : [
-            {
-              file: null,
-              summary: coverageMap.getCoverageSummary(),
-            },
-          ]
-
-      // Check thresholds of each summary
-      for (const { summary, file } of summaries) {
-        for (const thresholdKey of [
-          'lines',
-          'functions',
-          'statements',
-          'branches',
-        ] as const) {
-          const threshold = thresholds[thresholdKey]
-
-          if (threshold !== undefined) {
-            const coverage = summary.data[thresholdKey].pct
-
-            if (coverage < threshold) {
-              process.exitCode = 1
-
-              /*
-               * Generate error message based on perFile flag:
-               * - ERROR: Coverage for statements (33.33%) does not meet threshold (85%) for src/math.ts
-               * - ERROR: Coverage for statements (50%) does not meet global threshold (85%)
-               */
-              let errorMessage = `ERROR: Coverage for ${thresholdKey} (${coverage}%) does not meet ${
-                name === GLOBAL_THRESHOLDS_KEY ? name : `"${name}"`
-              } threshold (${threshold}%)`
-
-              if (perFile && file) {
-                errorMessage += ` for ${relative('./', file).replace(
-                  /\\/g,
-                  '/',
-                )}`
-              }
-
-              onError(errorMessage)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Constructs collected coverage and users' threshold options into separate sets
-   * where each threshold set holds their own coverage maps. Threshold set is either
-   * for specific files defined by glob pattern or global for all other files.
-   */
-  resolveThresholds({
-    coverageMap,
-    thresholds,
-    createCoverageMap,
-    root,
-  }: {
-    coverageMap: CoverageMap
-    thresholds: NonNullable<BaseCoverageOptions['thresholds']>
-    createCoverageMap: () => CoverageMap
-    root: string
-  }): ResolvedThreshold[] {
-    const resolvedThresholds: ResolvedThreshold[] = []
-    const files = coverageMap.files()
-    const globalCoverageMap = createCoverageMap()
-
-    for (const key of Object.keys(
-      thresholds,
-    ) as `${keyof typeof thresholds}`[]) {
-      if (
-        key === 'perFile'
-        || key === 'autoUpdate'
-        || key === '100'
-        || THRESHOLD_KEYS.includes(key)
-      ) {
-        continue
-      }
-
-      const glob = key
-      const globThresholds = resolveGlobThresholds(thresholds[glob])
-      const globCoverageMap = createCoverageMap()
-
-      const matchingFiles = files.filter(file =>
-        mm.isMatch(relative(root, file), glob),
-      )
-
-      for (const file of matchingFiles) {
-        const fileCoverage = coverageMap.fileCoverageFor(file)
-        globCoverageMap.addFileCoverage(fileCoverage)
-      }
-
-      resolvedThresholds.push({
-        name: glob,
-        coverageMap: globCoverageMap,
-        thresholds: globThresholds,
-      })
+    for (const coverage of coverageMaps) {
+      coverageMap.merge(coverage as CoverageMap)
     }
 
-    // Global threshold is for all files, even if they are included by glob patterns
-    for (const file of files) {
-      const fileCoverage = coverageMap.fileCoverageFor(file)
-      globalCoverageMap.addFileCoverage(fileCoverage)
-    }
-
-    resolvedThresholds.unshift({
-      name: GLOBAL_THRESHOLDS_KEY,
-      coverageMap: globalCoverageMap,
-      thresholds: {
-        branches: thresholds.branches,
-        functions: thresholds.functions,
-        lines: thresholds.lines,
-        statements: thresholds.statements,
-      },
-    })
-
-    return resolvedThresholds
-  }
-
-  /**
-   * Resolve reporters from various configuration options
-   */
-  resolveReporters(
-    configReporters: NonNullable<BaseCoverageOptions['reporter']>,
-  ): ResolvedCoverageOptions['reporter'] {
-    return resolveCoverageReporters(configReporters) as any
+    await this.generateReports(coverageMap, true)
   }
 
   hasTerminalReporter(reporters: ResolvedCoverageOptions['reporter']) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       '@types/istanbul-reports':
         specifier: ^3.0.4
         version: 3.0.4
+      '@types/test-exclude':
+        specifier: ^6.0.2
+        version: 6.0.2
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -537,6 +540,9 @@ importers:
       '@types/istanbul-reports':
         specifier: ^3.0.4
         version: 3.0.4
+      '@types/test-exclude':
+        specifier: ^6.0.2
+        version: 6.0.2
       '@vitest/browser':
         specifier: workspace:*
         version: link:../browser
@@ -3862,6 +3868,9 @@ packages:
 
   '@types/tern@0.23.4':
     resolution: {integrity: sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==}
+
+  '@types/test-exclude@6.0.2':
+    resolution: {integrity: sha512-s/ec1VRsab6A/N4Zdn3MkBLKDaIjnXMHJOg2MfbfC6Vp4Z+UDV/slrA35JQJIjuQ4wFirRcqdX/c+rm8eqhh0w==}
 
   '@types/through@0.0.30':
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
@@ -12442,6 +12451,8 @@ snapshots:
   '@types/tern@0.23.4':
     dependencies:
       '@types/estree': 1.0.5
+
+  '@types/test-exclude@6.0.2': {}
 
   '@types/through@0.0.30':
     dependencies:

--- a/test/coverage-test/test/threshold-auto-update.unit.test.ts
+++ b/test/coverage-test/test/threshold-auto-update.unit.test.ts
@@ -148,15 +148,15 @@ async function updateThresholds(configurationFile: ReturnType<typeof parseModule
   return new Promise((resolve, reject) => {
     const provider = new BaseCoverageProvider()
 
-    try {
-      provider.updateThresholds({
-        thresholds,
-        configurationFile,
-        onUpdate: () => resolve(configurationFile.generate().code),
-      })
-    }
-    catch (error) {
-      reject(error)
-    }
+    provider._initialize({
+      config: { coverage: { } },
+      logger: { log: () => {} },
+    } as any)
+
+    provider.updateThresholds({
+      thresholds,
+      configurationFile,
+      onUpdate: () => resolve(configurationFile.generate().code),
+    }).catch(error => reject(error))
   })
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Refactors v8 and istanbul coverage providers by moving re-usable logic into base provider
- Note that we cannot move parts where dependencies of coverage providers are used as we don't want to bring those into `vitest` package

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
