### PR TITLE
perf: reuse full name in reported tasks, update generator types

### DIFF
--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -7,7 +7,6 @@ import type {
   TaskMeta,
 } from '@vitest/runner'
 import type { TestError } from '@vitest/utils'
-import { getTestName } from '../../utils/tasks'
 import type { WorkspaceProject } from '../workspace'
 import { TestProject } from '../reported-workspace-project'
 
@@ -101,7 +100,12 @@ export class TestCase extends ReportedTaskImplementation {
    */
   public get fullName(): string {
     if (this.#fullName === undefined) {
-      this.#fullName = getTestName(this.task, ' > ')
+      if (this.parent.type !== 'module') {
+        this.#fullName = `${this.parent.fullName} > ${this.name}`
+      }
+      else {
+        this.#fullName = this.name
+      }
     }
     return this.#fullName
   }
@@ -198,7 +202,7 @@ class TestCollection {
   /**
    * Filters all tests that are part of this collection and its children.
    */
-  *allTests(state?: TestResult['state'] | 'running'): IterableIterator<TestCase> {
+  *allTests(state?: TestResult['state'] | 'running'): Generator<TestCase, undefined, void> {
     for (const child of this) {
       if (child.type === 'suite') {
         yield * child.children.allTests(state)
@@ -218,7 +222,7 @@ class TestCollection {
   /**
    * Filters only the tests that are part of this collection.
    */
-  *tests(state?: TestResult['state'] | 'running'): IterableIterator<TestCase> {
+  *tests(state?: TestResult['state'] | 'running'): Generator<TestCase, undefined, void> {
     for (const child of this) {
       if (child.type !== 'test') {
         continue
@@ -239,7 +243,7 @@ class TestCollection {
   /**
    * Filters only the suites that are part of this collection.
    */
-  *suites(): IterableIterator<TestSuite> {
+  *suites(): Generator<TestSuite, undefined, void> {
     for (const child of this) {
       if (child.type === 'suite') {
         yield child
@@ -250,7 +254,7 @@ class TestCollection {
   /**
    * Filters all suites that are part of this collection and its children.
    */
-  *allSuites(): IterableIterator<TestSuite> {
+  *allSuites(): Generator<TestSuite, undefined, void> {
     for (const child of this) {
       if (child.type === 'suite') {
         yield child
@@ -259,7 +263,7 @@ class TestCollection {
     }
   }
 
-  *[Symbol.iterator](): IterableIterator<TestSuite | TestCase> {
+  *[Symbol.iterator](): Generator<TestSuite | TestCase, undefined, void> {
     for (const task of this.#task.tasks) {
       yield getReportedTask(this.#project, task) as TestSuite | TestCase
     }
@@ -328,7 +332,12 @@ export class TestSuite extends SuiteImplementation {
    */
   public get fullName(): string {
     if (this.#fullName === undefined) {
-      this.#fullName = getTestName(this.task, ' > ')
+      if (this.parent.type !== 'module') {
+        this.#fullName = `${this.parent.fullName} > ${this.name}`
+      }
+      else {
+        this.#fullName = this.name
+      }
     }
     return this.#fullName
   }

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -14,9 +14,11 @@ let project: WorkspaceProject
 let files: RunnerTestFile[]
 let testModule: TestModule
 
+const root = resolve(__dirname, '..', 'fixtures', 'reported-tasks')
+
 beforeAll(async () => {
   const { ctx } = await runVitest({
-    root: resolve(__dirname, '..', 'fixtures', 'reported-tasks'),
+    root,
     include: ['**/*.test.ts'],
     reporters: [
       'verbose',
@@ -52,7 +54,7 @@ it('correctly reports a file', () => {
   expect(testModule.task).toBe(files[0])
   expect(testModule.id).toBe(files[0].id)
   expect(testModule.location).toBeUndefined()
-  expect(testModule.moduleId).toBe(resolve('./fixtures/reported-tasks/1_first.test.ts'))
+  expect(testModule.moduleId).toBe(resolve(root, './1_first.test.ts'))
   expect(testModule.project.workspaceProject).toBe(project)
   expect(testModule.children.size).toBe(14)
 
@@ -139,7 +141,7 @@ it('correctly reports failed test', () => {
     stacks: [
       {
         column: 13,
-        file: resolve('./fixtures/reported-tasks/1_first.test.ts'),
+        file: resolve(root, './1_first.test.ts'),
         line: 10,
         method: '',
       },

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -217,6 +217,13 @@ it('correctly passed down metadata', () => {
   expect(meta).toHaveProperty('key', 'value')
 })
 
+it('correctly builds the full name', () => {
+  const suiteTopLevel = testModule.children.suites().next().value!
+  const suiteSecondLevel = suiteTopLevel.children.suites().next().value!
+  const test = suiteSecondLevel.children.at(0) as TestCase
+  expect(test.fullName).toBe('a group > a nested group > runs a test in a nested group')
+})
+
 function date(time: Date) {
   return `${time.getDate()}/${time.getMonth() + 1}/${time.getFullYear()}`
 }

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -222,6 +222,8 @@ it('correctly builds the full name', () => {
   const suiteSecondLevel = suiteTopLevel.children.suites().next().value!
   const test = suiteSecondLevel.children.at(0) as TestCase
   expect(test.fullName).toBe('a group > a nested group > runs a test in a nested group')
+  expect(suiteTopLevel.fullName).toBe('a group')
+  expect(suiteSecondLevel.fullName).toBe('a group > a nested group')
 })
 
 function date(time: Date) {

--- a/vitest.workspace.vscode.ts
+++ b/vitest.workspace.vscode.ts
@@ -2,4 +2,5 @@ import { defineWorkspace } from 'vitest/config'
 
 export default defineWorkspace([
   './test/core',
+  './test/cli',
 ])


### PR DESCRIPTION
### Description

Based on how @userquin did this in #6649

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
