### PR TITLE
feat(runner)!: support `describe(..., { shuffle: boolean })` and inherit from parent suite

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -797,10 +797,23 @@ Vitest provides a way to run all tests in random order via CLI flag [`--sequence
 ```ts
 import { describe, test } from 'vitest'
 
+// or describe('suite', { shuffle: true }, ...)
 describe.shuffle('suite', () => {
   test('random test 1', async () => { /* ... */ })
   test('random test 2', async () => { /* ... */ })
   test('random test 3', async () => { /* ... */ })
+
+  // `shuffle` is inherited
+  describe('still random', () => {
+    test('random 4.1', async () => { /* ... */ })
+    test('random 4.2', async () => { /* ... */ })
+  })
+
+  // disable shuffle inside
+  describe('not random', { shuffle: false }, () => {
+    test('in order 5.1', async () => { /* ... */ })
+    test('in order 5.2', async () => { /* ... */ })
+  })
 })
 // order depends on sequence.seed option in config (Date.now() by default)
 ```

--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -29,7 +29,6 @@ export async function collectTests(
 
   for (const filepath of paths) {
     const file = createFileTask(filepath, config.root, config.name, runner.pool)
-    // TODO?
     file.shuffle = config.sequence.shuffle
 
     runner.onCollectStart?.(file)

--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -29,6 +29,8 @@ export async function collectTests(
 
   for (const filepath of paths) {
     const file = createFileTask(filepath, config.root, config.name, runner.pool)
+    // TODO?
+    file.shuffle = config.sequence.shuffle
 
     runner.onCollectStart?.(file)
 

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -409,7 +409,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner): Promise<void
           }
           else {
             const { sequence } = runner.config
-            if (sequence.shuffle || suite.shuffle) {
+            if (suite.shuffle) {
               // run describe block independently from tests
               const suites = tasksGroup.filter(
                 group => group.type === 'suite',

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -206,6 +206,7 @@ export function getRunner(): VitestRunner {
 }
 
 function createDefaultSuite(runner: VitestRunner) {
+  // TODO?
   const { concurrent, shuffle } = runner.config.sequence
   return suite('', { concurrent, shuffle }, () => {})
 }

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -206,7 +206,6 @@ export function getRunner(): VitestRunner {
 }
 
 function createDefaultSuite(runner: VitestRunner) {
-  // TODO?
   const { concurrent, shuffle } = runner.config.sequence
   return suite('', { concurrent, shuffle }, () => {})
 }

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -206,8 +206,8 @@ export function getRunner(): VitestRunner {
 }
 
 function createDefaultSuite(runner: VitestRunner) {
-  const { concurrent, shuffle } = runner.config.sequence
-  return suite('', { concurrent, shuffle }, () => {})
+  const config = runner.config.sequence
+  return suite('', { concurrent: config.concurrent }, () => {})
 }
 
 export function clearCollectorContext(
@@ -518,8 +518,10 @@ function createSuite() {
     )
 
     // inherit options from current suite
-    if (currentSuite?.options) {
-      options = { ...currentSuite.options, ...options }
+    options = {
+      ...currentSuite?.options,
+      ...options,
+      shuffle: this.shuffle ?? options.shuffle ?? currentSuite?.options?.shuffle ?? runner?.config.sequence.shuffle,
     }
 
     // inherit concurrent / sequential from suite
@@ -529,8 +531,6 @@ function createSuite() {
       = options.sequential || (this.sequential && !this.concurrent)
     options.concurrent = isConcurrent && !isSequential
     options.sequential = isSequential && !isConcurrent
-
-    options.shuffle = this.shuffle ?? options.shuffle
 
     return createSuiteCollector(
       formatName(name),

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -206,9 +206,8 @@ export function getRunner(): VitestRunner {
 }
 
 function createDefaultSuite(runner: VitestRunner) {
-  const config = runner.config.sequence
-  const api = config.shuffle ? suite.shuffle : suite
-  return api('', { concurrent: config.concurrent }, () => {})
+  const { concurrent, shuffle } = runner.config.sequence
+  return suite('', { concurrent, shuffle }, () => {})
 }
 
 export function clearCollectorContext(
@@ -331,9 +330,7 @@ function createSuiteCollector(
     ) {
       task.concurrent = true
     }
-    if (shuffle) {
-      task.shuffle = true
-    }
+    task.shuffle = suiteOptions?.shuffle
 
     const context = createTestContext(task, runner)
     // create test context
@@ -533,11 +530,13 @@ function createSuite() {
     options.concurrent = isConcurrent && !isSequential
     options.sequential = isSequential && !isConcurrent
 
+    options.shuffle = this.shuffle ?? options.shuffle
+
     return createSuiteCollector(
       formatName(name),
       factory,
       mode,
-      this.shuffle,
+      options.shuffle,
       this.each,
       options,
     )

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -291,7 +291,6 @@ function createSuiteCollector(
   name: string,
   factory: SuiteFactory = () => {},
   mode: RunMode,
-  shuffle?: boolean,
   each?: boolean,
   suiteOptions?: TestOptions,
 ) {
@@ -422,7 +421,7 @@ function createSuiteCollector(
       mode,
       each,
       file: undefined!,
-      shuffle,
+      shuffle: suiteOptions?.shuffle,
       tasks: [],
       meta: Object.create(null),
       concurrent: suiteOptions?.concurrent,
@@ -536,7 +535,6 @@ function createSuite() {
       formatName(name),
       factory,
       mode,
-      options.shuffle,
       this.each,
       options,
     )

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -275,16 +275,16 @@ interface EachFunctionReturn<T extends any[]> {
   (
     name: string | Function,
     fn: (...args: T) => Awaitable<void>,
-    options: TestOptions
+    options: TestCollectorOptions
   ): void
   (
     name: string | Function,
     fn: (...args: T) => Awaitable<void>,
-    options?: number | TestOptions
+    options?: number | TestCollectorOptions
   ): void
   (
     name: string | Function,
-    options: TestOptions,
+    options: TestCollectorOptions,
     fn: (...args: T) => Awaitable<void>
   ): void
 }
@@ -305,7 +305,7 @@ interface TestForFunctionReturn<Arg, Context> {
   ): void
   (
     name: string | Function,
-    options: TestOptions,
+    options: TestCollectorOptions,
     fn: (args: Arg, context: Context) => Awaitable<void>
   ): void
 }
@@ -336,16 +336,16 @@ interface TestCollectorCallable<C = object> {
   <ExtraContext extends C>(
     name: string | Function,
     fn: TestFunction<ExtraContext>,
-    options: TestOptions
+    options: TestCollectorOptions
   ): void
   <ExtraContext extends C>(
     name: string | Function,
     fn?: TestFunction<ExtraContext>,
-    options?: number | TestOptions
+    options?: number | TestCollectorOptions
   ): void
   <ExtraContext extends C>(
     name: string | Function,
-    options?: TestOptions,
+    options?: TestCollectorOptions,
     fn?: TestFunction<ExtraContext>
   ): void
 }
@@ -358,6 +358,8 @@ type ChainableTestAPI<ExtraContext = object> = ChainableFunction<
     for: TestForFunction<ExtraContext>
   }
 >
+
+type TestCollectorOptions = Omit<TestOptions, 'shuffle'>
 
 export interface TestOptions {
   /**

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -389,6 +389,10 @@ export interface TestOptions {
    */
   sequential?: boolean
   /**
+   * Whether the tasks of the suite run in a random order.
+   */
+  shuffle?: boolean
+  /**
    * Whether the test should be skipped.
    */
   skip?: boolean

--- a/test/config/fixtures/shuffle/basic.test.ts
+++ b/test/config/fixtures/shuffle/basic.test.ts
@@ -4,7 +4,7 @@ const numbers: number[] = []
 
 test.for([1, 2, 3, 4, 5])('test %s', (v) => {
   numbers.push(10 + v)
-}),
+})
 
 describe("inherit shuffle", () => {
   test.for([1, 2, 3, 4, 5])('test %s', (v) => {

--- a/test/config/fixtures/shuffle/basic.test.ts
+++ b/test/config/fixtures/shuffle/basic.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, describe, expect, test } from 'vitest'
+
+const numbers: number[] = []
+
+test.for([1, 2, 3, 4, 5])('test %s', (v) => {
+  numbers.push(10 + v)
+}),
+
+describe("inherit shuffle", () => {
+  test.for([1, 2, 3, 4, 5])('test %s', (v) => {
+    numbers.push(20 + v)
+  })
+})
+
+describe('unshuffle', { shuffle: false }, () => {
+  test.for([1, 2, 3, 4, 5])('test %s', (v) => {
+    numbers.push(30 + v)
+  })
+})
+
+afterAll(() => {
+  expect(numbers).toEqual([
+    11, 14, 13, 15, 12,
+    31, 32, 33, 34, 35,
+    21, 24, 23, 25, 22
+  ])
+})

--- a/test/config/fixtures/shuffle/vitest.config.ts
+++ b/test/config/fixtures/shuffle/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    sequence: {
+      seed: 101,
+      shuffle: true,
+    }
+  }
+})

--- a/test/config/test/shuffle-options.test.ts
+++ b/test/config/test/shuffle-options.test.ts
@@ -47,3 +47,18 @@ test.each([
   const { ctx } = await run({ shuffle, sequencer: CustomSequencer })
   expect(ctx?.config.sequence.sequencer.name).toBe('CustomSequencer')
 })
+
+test('shuffle', async () => {
+  const { stderr, ctx } = await runVitest({
+    root: './fixtures/shuffle',
+  })
+  expect(stderr).toBe('')
+  expect(ctx?.state.getFiles().map(f => [f.name, f.result?.state])).toMatchInlineSnapshot(`
+    [
+      [
+        "basic.test.ts",
+        "pass",
+      ],
+    ]
+  `);
+})

--- a/test/config/test/shuffle-options.test.ts
+++ b/test/config/test/shuffle-options.test.ts
@@ -60,5 +60,5 @@ test('shuffle', async () => {
         "pass",
       ],
     ]
-  `);
+  `)
 })

--- a/test/core/test/random.test.ts
+++ b/test/core/test/random.test.ts
@@ -1,15 +1,30 @@
-import { afterAll, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 // tests use seed of 101, so they have deterministic random order
 const numbers: number[] = []
 
 describe.shuffle('random tests', () => {
-  describe('inside', { shuffle: false }, () => {
+  describe('suite unshuffle', { shuffle: false }, () => {
     test('inside 1', () => {
       numbers.push(1)
     })
+    test('inside 1.5', () => {
+      numbers.push(1.5)
+    })
     test('inside 2', () => {
       numbers.push(2)
+    })
+
+    describe('suite shuffle', { shuffle: true }, () => {
+      test('inside 2.1', () => {
+        numbers.push(2.1)
+      })
+      test('inside 2.2', () => {
+        numbers.push(2.2)
+      })
+      test('inside 2.3', () => {
+        numbers.push(2.3)
+      })
     })
   })
 
@@ -22,8 +37,20 @@ describe.shuffle('random tests', () => {
   test('test 3', () => {
     numbers.push(5)
   })
+})
 
-  afterAll(() => {
-    expect(numbers).toStrictEqual([4, 5, 3, 1, 2])
-  })
+test('assert', () => {
+  expect(numbers).toMatchInlineSnapshot(`
+      [
+        4,
+        5,
+        3,
+        1,
+        1.5,
+        2,
+        2.2,
+        2.3,
+        2.1,
+      ]
+    `)
 })

--- a/test/core/test/random.test.ts
+++ b/test/core/test/random.test.ts
@@ -4,9 +4,7 @@ import { afterAll, describe, expect, test } from 'vitest'
 const numbers: number[] = []
 
 describe.shuffle('random tests', () => {
-  describe('inside', () => {
-    // shuffle is not inherited from parent
-
+  describe('inside', { shuffle: false }, () => {
     test('inside 1', () => {
       numbers.push(1)
     })


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/3922

This PR adds `TestOptions.shuffle` to allow "unshuffling" by `describe("...", { shuffle: false })`.

I noticed that `describe.shuffle` is not inherited to inner suites now, but probably changing this behavior would make sense to align with how `concurrent` works, so this change will be breaking.

One thing to note, when using `config.sequence.shuffle: true`, it's already shuffling all tests (as complained in  https://github.com/vitest-dev/vitest/issues/3922), so this use case is unchanged. What's breaking is when using `describe.shuffle` and using normal `describe` inside like in `test/core/test/random.test.ts`.

_todo_

- [x] should we hide types for `test("..", { shuffle: boolean })`?
- [x] test
- [x] docs

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
