### PR TITLE
fix(expect)!: loosen `toMatchObject` and `objectContaining` for `Proxy.get`

### DIFF
--- a/packages/expect/src/jest-asymmetric-matchers.ts
+++ b/packages/expect/src/jest-asymmetric-matchers.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@vitest/utils'
 import type { ChaiPlugin, MatcherState } from './types'
 import { GLOBAL_EXPECT } from './constants'
 import { getState } from './state'
@@ -147,7 +148,7 @@ export class ObjectContaining extends AsymmetricMatcher<
     const matcherContext = this.getMatcherContext()
     for (const property in this.sample) {
       if (
-        !this.hasProperty(other, property)
+        !isObject(other)
         || !equals(
           this.sample[property],
           other[property],

--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -565,8 +565,7 @@ export function subsetEquality(
             seenReferences.set(subset[key], true)
           }
           const result
-          = object != null
-          && hasPropertyInObject(object, key)
+          = isObject(object)
           && equals(object[key], subset[key], [
             ...filteredCustomTesters,
             subsetEqualityWithContext(seenReferences),

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -311,6 +311,78 @@ exports[`asymmetric matcher error 23`] = `
 }
 `;
 
+exports[`proxy 1`] = `
+{
+  "actual": "Object {}",
+  "diff": "- Expected
++ Received
+
+- Object {
+-   "key": "no",
+- }
++ Object {}",
+  "expected": "Object {
+  "key": "no",
+}",
+  "message": "expected {} to match object { key: 'no' }",
+}
+`;
+
+exports[`proxy 2`] = `
+{
+  "actual": "Object {
+  "key": "value",
+}",
+  "diff": "- Expected
++ Received
+
+  Object {
+-   "key": "no",
++   "key": "value",
+  }",
+  "expected": "Object {
+  "key": "no",
+}",
+  "message": "expected { key: 'value' } to match object { key: 'no' }",
+}
+`;
+
+exports[`proxy equality 1`] = `
+{
+  "actual": "Object {}",
+  "diff": "- Expected
++ Received
+
+- Object {
+-   "key": "no",
+- }
++ Object {}",
+  "expected": "Object {
+  "key": "no",
+}",
+  "message": "expected {} to match object { key: 'no' }",
+}
+`;
+
+exports[`proxy equality 2`] = `
+{
+  "actual": "Object {
+  "key": "value",
+}",
+  "diff": "- Expected
++ Received
+
+  Object {
+-   "key": "no",
++   "key": "value",
+  }",
+  "expected": "Object {
+  "key": "no",
+}",
+  "message": "expected { key: 'value' } to match object { key: 'no' }",
+}
+`;
+
 exports[`toHaveBeenNthCalledWith error 1`] = `
 {
   "actual": "Array [


### PR DESCRIPTION
### Description

I'm not sure if this behavior is ideal, but I'm creating a PR to test a few things.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
