### PR TITLE
fix(ui): restore splitpanes sizes

### DIFF
--- a/packages/ui/client/pages/index.vue
+++ b/packages/ui/client/pages/index.vue
@@ -42,12 +42,14 @@ const resizingMain = useDebounceFn((event: { size: number }[]) => {
 function resizeMain() {
   const width = window.innerWidth
   const panelWidth = Math.min(width / 3, 300)
-  mainSizes.value[0] = (100 * panelWidth) / width
-  mainSizes.value[1] = 100 - mainSizes.value[0]
-  recordMainResize([
-    { size: mainSizes.value[0] },
-    { size: mainSizes.value[1] },
-  ])
+  if (browserState) {
+    mainSizes.value[0] = (100 * panelWidth) / width
+    mainSizes.value[1] = 100 - mainSizes.value[0]
+  }
+  else {
+    detailSizes.value[0] = (100 * panelWidth) / width
+    detailSizes.value[1] = 100 - detailSizes.value[0]
+  }
 }
 
 function recordMainResize(event: { size: number }[]) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Cannot test browser ui on my local Windows laptop, we need to check the side effect opening UI (test/core) and then the Browser UI (test/browser running any any `test:browser:*` script)

resolves #6678

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
