### PR TITLE
fix(vitest): show rollup error details as test error

### DIFF
--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -120,9 +120,7 @@ export function printError(
   }
 
   if ('__vitest_rollup_error__' in e) {
-    // TODO: format like vite?
-    const r = e.__vitest_rollup_error__ as any
-    logger.error(r)
+    logger.error(buildRollupErrorMessage(e.__vitest_rollup_error__))
   }
 
   // E.g. AssertionError from assert does not set showDiff but has both actual and expected properties
@@ -201,6 +199,22 @@ export function printError(
   handleImportOutsideModuleError(e.stack || e.stackStr || '', logger)
 
   return { nearest }
+}
+
+// https://github.com/vitejs/vite/blob/95020ab49e12d143262859e095025cf02423c1d9/packages/vite/src/node/server/middlewares/error.ts#L25-L36
+function buildRollupErrorMessage(
+  err: any,
+): string {
+  return [
+    err.plugin && `  Plugin: ${c.magenta(err.plugin)}`,
+    err.id && `  File: ${c.cyan(err.id)}${err.loc ? `:${err.loc.line}:${err.loc.column}` : ''}`,
+    err.frame && c.yellow(pad(err.frame)),
+  ].filter(Boolean).join('\n')
+}
+
+function pad(source: string, n = 2): string {
+  const lines = source.split(/\r?\n/g)
+  return lines.map(l => ` `.repeat(n) + l).join(`\n`)
 }
 
 function printErrorType(type: string, ctx: Vitest) {

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -120,7 +120,13 @@ export function printError(
   }
 
   if ('__vitest_rollup_error__' in e) {
-    logger.error(buildRollupErrorMessage(e.__vitest_rollup_error__))
+    // https://github.com/vitejs/vite/blob/95020ab49e12d143262859e095025cf02423c1d9/packages/vite/src/node/server/middlewares/error.ts#L25-L36
+    const err = e.__vitest_rollup_error__ as any
+    logger.error([
+      err.plugin && `  Plugin: ${c.magenta(err.plugin)}`,
+      err.id && `  File: ${c.cyan(err.id)}${err.loc ? `:${err.loc.line}:${err.loc.column}` : ''}`,
+      err.frame && c.yellow((err.frame as string).split(/\r?\n/g).map(l => ` `.repeat(2) + l).join(`\n`)),
+    ].filter(Boolean).join('\n'))
   }
 
   // E.g. AssertionError from assert does not set showDiff but has both actual and expected properties
@@ -199,22 +205,6 @@ export function printError(
   handleImportOutsideModuleError(e.stack || e.stackStr || '', logger)
 
   return { nearest }
-}
-
-// https://github.com/vitejs/vite/blob/95020ab49e12d143262859e095025cf02423c1d9/packages/vite/src/node/server/middlewares/error.ts#L25-L36
-function buildRollupErrorMessage(
-  err: any,
-): string {
-  return [
-    err.plugin && `  Plugin: ${c.magenta(err.plugin)}`,
-    err.id && `  File: ${c.cyan(err.id)}${err.loc ? `:${err.loc.line}:${err.loc.column}` : ''}`,
-    err.frame && c.yellow(pad(err.frame)),
-  ].filter(Boolean).join('\n')
-}
-
-function pad(source: string, n = 2): string {
-  const lines = source.split(/\r?\n/g)
-  return lines.map(l => ` `.repeat(n) + l).join(`\n`)
 }
 
 function printErrorType(type: string, ctx: Vitest) {

--- a/packages/vitest/src/node/error.ts
+++ b/packages/vitest/src/node/error.ts
@@ -119,6 +119,12 @@ export function printError(
     logger.error(`${e.codeFrame}\n`)
   }
 
+  if ('__vitest_rollup_error__' in e) {
+    // TODO: format like vite?
+    const r = e.__vitest_rollup_error__ as any
+    logger.error(r)
+  }
+
   // E.g. AssertionError from assert does not set showDiff but has both actual and expected properties
   if (e.diff) {
     displayDiff(e.diff, logger.console)

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -33,7 +33,7 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       return r?.map as RawSourceMap | undefined
     },
     async fetch(id, transformMode) {
-      const result = await project.vitenode.fetchResult(id, transformMode)
+      const result = await project.vitenode.fetchResult(id, transformMode).catch(e => handleRollupError(e))
       const code = result.code
       if (!cacheFs || result.externalize) {
         return result
@@ -66,10 +66,10 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       return { id: tmp }
     },
     resolveId(id, importer, transformMode) {
-      return project.vitenode.resolveId(id, importer, transformMode)
+      return project.vitenode.resolveId(id, importer, transformMode).catch(e => handleRollupError(e))
     },
     transform(id, environment) {
-      return project.vitenode.transformModule(id, environment)
+      return project.vitenode.transformModule(id, environment).catch(e => handleRollupError(e))
     },
     onPathsCollected(paths) {
       ctx.state.collectPaths(paths)
@@ -103,4 +103,25 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       return ctx.state.getCountOfFailedTests()
     },
   }
+}
+
+// serialize rollup error on server to preserve details as a test error
+function handleRollupError(e: unknown): never {
+  if (e instanceof Error && 'loc' in e && e.loc && typeof e.loc === 'object') {
+    // eslint-disable-next-line no-throw-literal
+    throw {
+      name: e.name,
+      message: e.message,
+      stack: e.stack,
+      cause: e.cause,
+      __vitest_rollup_error__: {
+        id: (e as any).id,
+        loc: (e as any).loc,
+        frame: (e as any).frame,
+        plugin: (e as any).plugin,
+        pluginCode: (e as any).pluginCode,
+      },
+    }
+  }
+  throw e
 }

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -107,7 +107,7 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
 
 // serialize rollup error on server to preserve details as a test error
 function handleRollupError(e: unknown): never {
-  if (e instanceof Error && 'loc' in e && e.loc && typeof e.loc === 'object') {
+  if (e instanceof Error && 'plugin' in e) {
     // eslint-disable-next-line no-throw-literal
     throw {
       name: e.name,
@@ -115,11 +115,10 @@ function handleRollupError(e: unknown): never {
       stack: e.stack,
       cause: e.cause,
       __vitest_rollup_error__: {
+        plugin: (e as any).plugin,
         id: (e as any).id,
         loc: (e as any).loc,
         frame: (e as any).frame,
-        plugin: (e as any).plugin,
-        pluginCode: (e as any).pluginCode,
       },
     }
   }

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -33,7 +33,7 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       return r?.map as RawSourceMap | undefined
     },
     async fetch(id, transformMode) {
-      const result = await project.vitenode.fetchResult(id, transformMode).catch(e => handleRollupError(e))
+      const result = await project.vitenode.fetchResult(id, transformMode).catch(handleRollupError)
       const code = result.code
       if (!cacheFs || result.externalize) {
         return result
@@ -66,10 +66,10 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       return { id: tmp }
     },
     resolveId(id, importer, transformMode) {
-      return project.vitenode.resolveId(id, importer, transformMode).catch(e => handleRollupError(e))
+      return project.vitenode.resolveId(id, importer, transformMode).catch(handleRollupError)
     },
     transform(id, environment) {
-      return project.vitenode.transformModule(id, environment).catch(e => handleRollupError(e))
+      return project.vitenode.transformModule(id, environment).catch(handleRollupError)
     },
     onPathsCollected(paths) {
       ctx.state.collectPaths(paths)

--- a/test/config/fixtures/rollup-error/not-found-export.test.ts
+++ b/test/config/fixtures/rollup-error/not-found-export.test.ts
@@ -1,0 +1,1 @@
+import "vite/no-such-export"

--- a/test/config/fixtures/rollup-error/not-found-package.test.ts
+++ b/test/config/fixtures/rollup-error/not-found-package.test.ts
@@ -1,0 +1,1 @@
+import '@vitejs/no-such-package'

--- a/test/config/fixtures/rollup-error/vitest.config.ts
+++ b/test/config/fixtures/rollup-error/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vitest/config";
+
+// pnpm -C test/config test -- --root fixtures/rollup-error --environment happy-dom
+// pnpm -C test/config test -- --root fixtures/rollup-error --environment node
+
+export default defineConfig({})

--- a/test/config/test/rollup-error.test.ts
+++ b/test/config/test/rollup-error.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+test('rollup error node', async () => {
+  const { stdout } = await runVitest({
+    root: './fixtures/rollup-error',
+    environment: 'node',
+    reporters: ['junit'],
+  })
+  expect(stdout).toContain(`Error: Missing &quot;./no-such-export&quot; specifier in &quot;vite&quot; package`)
+  expect(stdout).toContain(`Plugin: vite:import-analysis`)
+  expect(stdout).toContain(`Error: Failed to load url @vitejs/no-such-package`)
+})
+
+test('rollup error web', async () => {
+  const { stdout } = await runVitest({
+    root: './fixtures/rollup-error',
+    environment: 'jsdom',
+    reporters: ['junit'],
+  })
+  expect(stdout).toContain(`Error: Missing &quot;./no-such-export&quot; specifier in &quot;vite&quot; package`)
+  expect(stdout).toContain(`Plugin: vite:import-analysis`)
+  expect(stdout).toContain(`Error: Failed to resolve import &quot;@vitejs/no-such-package&quot; from &quot;fixtures/rollup-error/not-found-package.test.ts&quot;. Does the file exist?`)
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/4011

<details><summary>fixture test run</summary>

- environment: happy-dom

```sh
$ pnpm -C test/config test -- --root fixtures/rollup-error --environment happy-dom

> @vitest/test-config@ test /home/hiroshi/code/others/vitest/test/config
> vitest --typecheck.enabled "--root" "fixtures/rollup-error" "--environment" "happy-dom"

Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.

 DEV  v2.1.2 /home/hiroshi/code/others/vitest/test/config/fixtures/rollup-error

 ❯ not-found-export.test.ts (0)
 ❯ not-found-package.test.ts (0)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 2 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  not-found-export.test.ts [ not-found-export.test.ts ]
Error: Missing "./no-such-export" specifier in "vite" package
  Plugin: vite:import-analysis
  File: /home/hiroshi/code/others/vitest/test/config/fixtures/rollup-error/not-found-export.test.ts
 ❯ e ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:45942:25
 ❯ n ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:45942:627
 ❯ o ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:45942:1297
 ❯ resolveExportsOrImports ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46563:18
 ❯ resolveDeepImport ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46586:25
 ❯ tryNodeResolve ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46351:16
 ❯ ResolveIdContext.resolveId ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46101:19
 ❯ PluginContainer.resolveId ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:48893:17
 ❯ TransformPluginContext.resolve ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:49053:15

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  not-found-package.test.ts [ not-found-package.test.ts ]
Error: Failed to resolve import "@vitejs/no-such-package" from "fixtures/rollup-error/not-found-package.test.ts". Does the file exist?
  Plugin: vite:import-analysis
  File: /home/hiroshi/code/others/vitest/test/config/fixtures/rollup-error/not-found-package.test.ts:1:7
  1  |  import "@vitejs/no-such-package";
     |          ^
  2  |  
 ❯ TransformPluginContext._formatError ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:49133:41
 ❯ TransformPluginContext.error ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:49128:16
 ❯ normalizeUrl ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:63910:23
 ❯ ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:64042:39
 ❯ TransformPluginContext.transform ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:63969:7
 ❯ PluginContainer.transform ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:48974:18
 ❯ loadAndTransform ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:51796:27

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

 Test Files  2 failed (2)
      Tests  no tests
Type Errors  no errors
   Start at  15:52:03
   Duration  274ms (transform 9ms, setup 0ms, collect 0ms, tests 0ms, environment 269ms, prepare 79ms)


 FAIL  Tests failed. Watching for file changes...
       press h to show help, press q to quit
Cancelling test run. Press CTRL+c again to exit forcefully.
```

- environment: node

```
$ pnpm -C test/config test -- --root fixtures/rollup-error --environment node

> @vitest/test-config@ test /home/hiroshi/code/others/vitest/test/config
> vitest --typecheck.enabled "--root" "fixtures/rollup-error" "--environment" "node"

Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.

 DEV  v2.1.2 /home/hiroshi/code/others/vitest/test/config/fixtures/rollup-error

 ❯ not-found-export.test.ts (0)
 ❯ not-found-package.test.ts (0)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 2 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  not-found-export.test.ts [ not-found-export.test.ts ]
Error: Missing "./no-such-export" specifier in "vite" package
  Plugin: vite:import-analysis
  File: /home/hiroshi/code/others/vitest/test/config/fixtures/rollup-error/not-found-export.test.ts
 ❯ e ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:45942:25
 ❯ n ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:45942:627
 ❯ o ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:45942:1297
 ❯ resolveExportsOrImports ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46563:18
 ❯ resolveDeepImport ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46586:25
 ❯ tryNodeResolve ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46351:16
 ❯ ResolveIdContext.resolveId ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:46101:19
 ❯ PluginContainer.resolveId ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:48893:17
 ❯ TransformPluginContext.resolve ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:49053:15

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  not-found-package.test.ts [ not-found-package.test.ts ]
Error: Failed to load url @vitejs/no-such-package (resolved id: @vitejs/no-such-package) in /home/hiroshi/code/others/vitest/test/config/fixtures/rollup-error/not-found-package.test.ts. Does the file exist?
 ❯ loadAndTransform ../../../../node_modules/.pnpm/vite@5.4.0_@types+node@22.5.2_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-NjL7WTE1.js:51787:17

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

 Test Files  2 failed (2)
      Tests  no tests
Type Errors  no errors
   Start at  15:52:56
   Duration  142ms (transform 23ms, setup 0ms, collect 0ms, tests 0ms, environment 0ms, prepare 76ms)


 FAIL  Tests failed. Watching for file changes...
       press h to show help, press q to quit
Cancelling test run. Press CTRL+c again to exit forcefully.
```

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
