### PR TITLE
fix(browser): use `/mockServiceWorker.js` instead of `/__vitest_msw__`

### DIFF
--- a/packages/browser/src/client/tester/msw.ts
+++ b/packages/browser/src/client/tester/msw.ts
@@ -36,7 +36,10 @@ export function createModuleMockerInterceptor() {
     globalThisAccessor: '"__vitest_mocker__"',
     mswOptions: {
       serviceWorker: {
-        url: '/__vitest_msw__',
+        url: '/mockServiceWorker.js',
+        options: {
+          scope: '/',
+        },
       },
       quiet: true,
     },

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -286,7 +286,7 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
     {
       name: 'vitest:browser:resolve-virtual',
       async resolveId(rawId) {
-        if (rawId === '/__vitest_msw__') {
+        if (rawId === '/mockServiceWorker.js') {
           return this.resolve('msw/mockServiceWorker.js', distRoot, {
             skipSelf: true,
           })


### PR DESCRIPTION
### Description

This change allows users to reuse the established Vitest msw worker instead of overriding it

Fixes #6633

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
