### PR TITLE
docs: mention that the browser mode uses 63315 port

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1646,7 +1646,7 @@ Run every test in a separate iframe.
 - **Default:** `63315`
 - **CLI:** `--browser.api=63315`, `--browser.api.port=1234, --browser.api.host=example.com`
 
-Configure options for Vite server that serves code in the browser. Does not affect [`test.api`](#api) option.
+Configure options for Vite server that serves code in the browser. Does not affect [`test.api`](#api) option. By default, Vitest assigns port `63315` to avoid conflicts with the development server, allowing you to run both in parallel.
 
 #### browser.provider
 

--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -105,6 +105,10 @@ export default defineConfig({
 })
 ```
 
+::: info
+Vitest assigns port `63315` to avoid conflicts with the development server, allowing you to run both in parallel. You can change that with the [`browser.api`](/config/#browser-api) option.
+:::
+
 If you have not used Vite before, make sure you have your framework's plugin installed and specified in the config. Some frameworks might require extra configuration to work - check their Vite related documentation to be sure.
 
 ::: code-group

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -326,19 +326,17 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
         viteConfig.esbuild ||= {}
         viteConfig.esbuild.legalComments = 'inline'
 
-        const server = resolveApiServerConfig(
+        const api = resolveApiServerConfig(
           viteConfig.test?.browser || {},
           defaultBrowserPort,
         ) || {
           port: defaultBrowserPort,
         }
 
-        // browser never runs in middleware mode
-        server.middlewareMode = false
-
         viteConfig.server = {
           ...viteConfig.server,
-          ...server,
+          ...api,
+          middlewareMode: false,
           open: false,
         }
         viteConfig.server.fs ??= {}


### PR DESCRIPTION
### Description

Mention that the browser mode uses 63315 port to not clash with the dev server

Related #6677

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
