### PR TITLE
fix(browser): fix default browser port

### DIFF
--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -331,12 +331,11 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
         const api = resolveApiServerConfig(
           viteConfig.test?.browser || {},
           defaultBrowserPort,
-        ) || {
-          port: defaultBrowserPort,
-        }
+        )
 
         viteConfig.server = {
           ...viteConfig.server,
+          port: defaultBrowserPort,
           ...api,
           middlewareMode: false,
           open: false,

--- a/test/browser/fixtures/server-url/vitest.config.ts
+++ b/test/browser/fixtures/server-url/vitest.config.ts
@@ -6,7 +6,7 @@ import basicSsl from '@vitejs/plugin-basic-ssl'
 // test https by
 //   TEST_HTTPS=1 pnpm test-fixtures --root fixtures/server-url
 
-const provider = process.env.PROVIDER || 'webdriverio';
+const provider = process.env.PROVIDER || 'playwright';
 const browser = process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome');
 
 // ignore https errors due to self-signed certificate from plugin-basic-ssl
@@ -17,7 +17,7 @@ const providerOptions = (function () {
     case 'playwright': return { page: { ignoreHTTPSErrors: true } }
     case 'webdriverio': return { strictSSL: false, capabilities: { acceptInsecureCerts: true } }
   }
-})()
+})() as any
 
 export default defineConfig({
   plugins: [
@@ -25,6 +25,7 @@ export default defineConfig({
   ],
   test: {
     browser: {
+      api: process.env.TEST_HTTPS ? 51122 : 51133,
       enabled: true,
       provider,
       name: browser,

--- a/test/browser/specs/server-url.test.ts
+++ b/test/browser/specs/server-url.test.ts
@@ -10,7 +10,7 @@ test('server-url http', async () => {
     root: './fixtures/server-url',
   })
   expect(stderr).toBe('')
-  expect(stdout).toContain(`Browser runner started by ${provider} at http://localhost:63315/`)
+  expect(stdout).toContain(`Browser runner started by ${provider} at http://localhost:51133/`)
 })
 
 test('server-url https', async () => {
@@ -19,6 +19,6 @@ test('server-url https', async () => {
     root: './fixtures/server-url',
   })
   expect(stderr).toBe('')
-  expect(stdout).toContain(`Browser runner started by ${provider} at https://localhost:63315/`)
+  expect(stdout).toContain(`Browser runner started by ${provider} at https://localhost:51122/`)
   expect(stdout).toContain('Test Files  1 passed')
 })

--- a/test/browser/specs/server-url.test.ts
+++ b/test/browser/specs/server-url.test.ts
@@ -10,7 +10,7 @@ test('server-url http', async () => {
     root: './fixtures/server-url',
   })
   expect(stderr).toBe('')
-  expect(stdout).toContain(`Browser runner started by ${provider} at http://localhost:5173/`)
+  expect(stdout).toContain(`Browser runner started by ${provider} at http://localhost:63315/`)
 })
 
 test('server-url https', async () => {
@@ -19,6 +19,6 @@ test('server-url https', async () => {
     root: './fixtures/server-url',
   })
   expect(stderr).toBe('')
-  expect(stdout).toContain(`Browser runner started by ${provider} at https://localhost:5173/`)
+  expect(stdout).toContain(`Browser runner started by ${provider} at https://localhost:63315/`)
   expect(stdout).toContain('Test Files  1 passed')
 })


### PR DESCRIPTION
### Description

Related: https://github.com/vitest-dev/vitest/issues/6677

`resolveApiServerConfig` is not working here and `defaultBrowserPort` is not used as default.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
