### PR TITLE
perf: use `hash` to replace `createHash`

### DIFF
--- a/packages/vitest/src/integrations/css/css-modules.ts
+++ b/packages/vitest/src/integrations/css/css-modules.ts
@@ -1,8 +1,8 @@
-import { createHash } from 'node:crypto'
+import { hash } from '../../utils'
 import type { CSSModuleScopeStrategy } from '../../node/types/config'
 
 export function generateCssFilenameHash(filepath: string) {
-  return createHash('md5').update(filepath).digest('hex').slice(0, 6)
+  return hash('md5', filepath, 'hex').slice(0, 6)
 }
 
 export function generateScopedClassName(

--- a/packages/vitest/src/integrations/css/css-modules.ts
+++ b/packages/vitest/src/integrations/css/css-modules.ts
@@ -1,4 +1,4 @@
-import { hash } from '../../utils'
+import { hash } from '../../node/hash'
 import type { CSSModuleScopeStrategy } from '../../node/types/config'
 
 export function generateCssFilenameHash(filepath: string) {

--- a/packages/vitest/src/node/cache/index.ts
+++ b/packages/vitest/src/node/cache/index.ts
@@ -1,6 +1,5 @@
-import crypto from 'node:crypto'
 import { resolve } from 'pathe'
-import { slash } from '../../utils'
+import { hash, slash } from '../../utils'
 import { FilesStatsCache } from './files'
 import { ResultsCache } from './results'
 
@@ -26,7 +25,7 @@ export class VitestCache {
       ? resolve(
         root,
         baseDir,
-        crypto.createHash('md5').update(projectName, 'utf-8').digest('hex'),
+        hash('md5', projectName, 'hex'),
       )
       : resolve(root, baseDir)
   }

--- a/packages/vitest/src/node/cache/index.ts
+++ b/packages/vitest/src/node/cache/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'pathe'
-import { hash, slash } from '../../utils'
+import { slash } from '../../utils'
+import { hash } from '../hash'
 import { FilesStatsCache } from './files'
 import { ResultsCache } from './results'
 

--- a/packages/vitest/src/node/hash.ts
+++ b/packages/vitest/src/node/hash.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 
 export const hash = crypto.hash ?? ((
-    algorithm: string,
-    data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding,
-  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
+  algorithm: string,
+  data: crypto.BinaryLike,
+  outputEncoding: crypto.BinaryToTextEncoding,
+) => crypto.createHash(algorithm).update(data).digest(outputEncoding))

--- a/packages/vitest/src/node/hash.ts
+++ b/packages/vitest/src/node/hash.ts
@@ -1,0 +1,7 @@
+import crypto from 'node:crypto'
+
+export const hash = crypto.hash ?? ((
+    algorithm: string,
+    data: crypto.BinaryLike,
+    outputEncoding: crypto.BinaryToTextEncoding,
+  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -1,9 +1,9 @@
-import { createHash } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 import type { RawSourceMap } from 'vite-node'
 import { join } from 'pathe'
 import type { WorkspaceProject } from '../workspace'
 import type { RuntimeRPC } from '../../types/rpc'
+import { hash } from '../../utils'
 
 const created = new Set()
 const promises = new Map<string, Promise<void>>()
@@ -47,7 +47,7 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       }
 
       const dir = join(project.tmpDir, transformMode)
-      const name = createHash('sha1').update(id).digest('hex')
+      const name = hash('sha1', id, 'hex')
       const tmp = join(dir, name)
       if (promises.has(tmp)) {
         await promises.get(tmp)

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -3,7 +3,7 @@ import type { RawSourceMap } from 'vite-node'
 import { join } from 'pathe'
 import type { WorkspaceProject } from '../workspace'
 import type { RuntimeRPC } from '../../types/rpc'
-import { hash } from '../../utils'
+import { hash } from '../hash'
 
 const created = new Set()
 const promises = new Map<string, Promise<void>>()

--- a/packages/vitest/src/node/sequencers/BaseSequencer.ts
+++ b/packages/vitest/src/node/sequencers/BaseSequencer.ts
@@ -1,6 +1,6 @@
 import { relative, resolve } from 'pathe'
 import { slash } from 'vite-node/utils'
-import { hash } from '../../utils'
+import { hash } from '../hash'
 import type { Vitest } from '../core'
 import type { WorkspaceSpec } from '../pool'
 import type { TestSequencer } from './types'

--- a/packages/vitest/src/node/sequencers/BaseSequencer.ts
+++ b/packages/vitest/src/node/sequencers/BaseSequencer.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto'
 import { relative, resolve } from 'pathe'
 import { slash } from 'vite-node/utils'
+import { hash } from '../../utils'
 import type { Vitest } from '../core'
 import type { WorkspaceSpec } from '../pool'
 import type { TestSequencer } from './types'
@@ -25,7 +25,7 @@ export class BaseSequencer implements TestSequencer {
         const specPath = fullPath?.slice(config.root.length)
         return {
           spec,
-          hash: createHash('sha1').update(specPath).digest('hex'),
+          hash: hash('sha1', specPath, 'hex'),
         }
       })
       .sort((a, b) => (a.hash < b.hash ? -1 : a.hash > b.hash ? 1 : 0))

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { relative } from 'pathe'
 import { getWorkerState } from '../utils'
 
@@ -54,3 +55,9 @@ export function objectAttr(
   }
   return result
 }
+
+export const hash = crypto.hash ?? ((
+  algorithm: string,
+  data: crypto.BinaryLike,
+  outputEncoding: crypto.BinaryToTextEncoding,
+) => crypto.createHash(algorithm).update(data).digest(outputEncoding))

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto'
 import { relative } from 'pathe'
 import { getWorkerState } from '../utils'
 
@@ -55,9 +54,3 @@ export function objectAttr(
   }
   return result
 }
-
-export const hash = crypto.hash ?? ((
-  algorithm: string,
-  data: crypto.BinaryLike,
-  outputEncoding: crypto.BinaryToTextEncoding,
-) => crypto.createHash(algorithm).update(data).digest(outputEncoding))


### PR DESCRIPTION
### Description
`crypto.hash` seems to be faster than `crypto.createHash`.

https://nodejs.org/docs/latest-v20.x/api/crypto.html#cryptohashalgorithm-data-outputencoding)

I did a simple test and `crypto.hash` seems to be 1.6 times faster.

<img width="844" alt="image" src="https://github.com/user-attachments/assets/3ce51d6b-e769-44bd-862e-6a08ce91fda3">

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
