### PR TITLE
test: add retries to playwright ui tests

### DIFF
--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
       use: devices['Desktop Chrome'],
     },
   ],
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
 })


### PR DESCRIPTION
### Description

It looks like `test/ui` playwright tests are flaky https://github.com/vitest-dev/vitest/actions/runs/11330854757/job/31509575992#step:8:1005 Globally adding retires should be fine for this e2e.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
