### PR TITLE
feat(browser): allow custom HTML path, respect plugins `transformIndexHtml`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1640,6 +1640,14 @@ Run the browser in a `headless` mode. If you are running Vitest in CI, it will b
 
 Run every test in a separate iframe.
 
+#### browser.testerHtmlPath
+
+- **Type:** `string`
+- **Default:** `@vitest/browser/tester.html`
+- **Version:** Since Vitest 2.1.4
+
+A path to the HTML entry point. Can be relative to the root of the project. This file will be processed with [`transformIndexHtml`](https://vite.dev/guide/api-plugin#transformindexhtml) hook.
+
 #### browser.api
 
 - **Type:** `number | { port?, strictPort?, host? }`

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -107,7 +107,7 @@ export default () =>
       input: './src/client/tester/state.ts',
       output: {
         file: 'dist/state.js',
-        format: 'esm',
+        format: 'iife',
       },
       plugins: [
         esbuild({

--- a/packages/browser/src/client/public/esm-client-injector.js
+++ b/packages/browser/src/client/public/esm-client-injector.js
@@ -1,50 +1,52 @@
-const moduleCache = new Map();
+(() => {
+  const moduleCache = new Map();
 
-function wrapModule(module) {
-  if (typeof module === "function") {
-    const promise = new Promise((resolve, reject) => {
-      if (typeof __vitest_mocker__ === "undefined")
-        return module().then(resolve, reject);
-      __vitest_mocker__.prepare().finally(() => {
-        module().then(resolve, reject);
+  function wrapModule(module) {
+    if (typeof module === "function") {
+      const promise = new Promise((resolve, reject) => {
+        if (typeof __vitest_mocker__ === "undefined")
+          return module().then(resolve, reject);
+        __vitest_mocker__.prepare().finally(() => {
+          module().then(resolve, reject);
+        });
       });
-    });
-    moduleCache.set(promise, { promise, evaluated: false });
-    return promise.finally(() => moduleCache.delete(promise));
+      moduleCache.set(promise, { promise, evaluated: false });
+      return promise.finally(() => moduleCache.delete(promise));
+    }
+    return module;
   }
-  return module;
-}
 
-window.__vitest_browser_runner__ = {
-  wrapModule,
-  wrapDynamicImport: wrapModule,
-  moduleCache,
-  config: { __VITEST_CONFIG__ },
-  viteConfig: { __VITEST_VITE_CONFIG__ },
-  files: { __VITEST_FILES__ },
-  type: { __VITEST_TYPE__ },
-  contextId: { __VITEST_CONTEXT_ID__ },
-  testerId: { __VITEST_TESTER_ID__ },
-  provider: { __VITEST_PROVIDER__ },
-  providedContext: { __VITEST_PROVIDED_CONTEXT__ },
-};
+  window.__vitest_browser_runner__ = {
+    wrapModule,
+    wrapDynamicImport: wrapModule,
+    moduleCache,
+    config: { __VITEST_CONFIG__ },
+    viteConfig: { __VITEST_VITE_CONFIG__ },
+    files: { __VITEST_FILES__ },
+    type: { __VITEST_TYPE__ },
+    contextId: { __VITEST_CONTEXT_ID__ },
+    testerId: { __VITEST_TESTER_ID__ },
+    provider: { __VITEST_PROVIDER__ },
+    providedContext: { __VITEST_PROVIDED_CONTEXT__ },
+  };
 
-const config = __vitest_browser_runner__.config;
+  const config = __vitest_browser_runner__.config;
 
-if (config.testNamePattern)
-  config.testNamePattern = parseRegexp(config.testNamePattern);
+  if (config.testNamePattern)
+    config.testNamePattern = parseRegexp(config.testNamePattern);
 
-function parseRegexp(input) {
-  // Parse input
-  const m = input.match(/(\/?)(.+)\1([a-z]*)/i);
+  function parseRegexp(input) {
+    // Parse input
+    const m = input.match(/(\/?)(.+)\1([a-z]*)/i);
 
-  // match nothing
-  if (!m) return /$^/;
+    // match nothing
+    if (!m) return /$^/;
 
-  // Invalid flags
-  if (m[3] && !/^(?!.*?(.).*?\1)[gmixXsuUAJ]+$/.test(m[3]))
-    return RegExp(input);
+    // Invalid flags
+    if (m[3] && !/^(?!.*?(.).*?\1)[gmixXsuUAJ]+$/.test(m[3]))
+      return RegExp(input);
 
-  // Create the regular expression
-  return new RegExp(m[2], m[3]);
-}
+    // Create the regular expression
+    return new RegExp(m[2], m[3]);
+  }
+})();

--- a/packages/browser/src/client/tester/tester.html
+++ b/packages/browser/src/client/tester/tester.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="{__VITEST_FAVICON__}" type="image/svg+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{__VITEST_TITLE__}</title>
+    <title>Vitest Browser Tester</title>
     <style>
       html {
         padding: 0;
@@ -16,13 +16,8 @@
         min-height: 100vh;
       }
     </style>
-    {__VITEST_INJECTOR__}
-    <script>{__VITEST_STATE__}</script>
-    {__VITEST_INTERNAL_SCRIPTS__}
-    {__VITEST_SCRIPTS__}
   </head>
   <body>
     <script type="module" src="./tester.ts"></script>
-    {__VITEST_APPEND__}
   </body>
 </html>

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -73,9 +73,11 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
             return
           }
 
-          const html = await resolveTester(browserServer, url, res)
-          res.write(html, 'utf-8')
-          res.end()
+          const html = await resolveTester(browserServer, url, res, next)
+          if (html) {
+            res.write(html, 'utf-8')
+            res.end()
+          }
         })
 
         server.middlewares.use(

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -456,9 +456,6 @@ export default (browserServer: BrowserServer, base = '/'): Plugin[] => {
           },
           {
             tag: 'script',
-            attrs: {
-              type: 'module',
-            },
             children: stateJs,
             injectTo: 'head-prepend',
           } as const,

--- a/packages/browser/src/node/pool.ts
+++ b/packages/browser/src/node/pool.ts
@@ -101,8 +101,7 @@ export function createBrowserPool(ctx: Vitest): ProcessPool {
         url.searchParams.set('contextId', contextId)
         const page = provider
           .openPage(contextId, url.toString(), () => setBreakpoint(contextId, files[0]))
-          .then(() => waitPromise)
-        promises.push(page)
+        promises.push(page, waitPromise)
       }
     })
 

--- a/packages/browser/src/node/server.ts
+++ b/packages/browser/src/node/server.ts
@@ -151,7 +151,11 @@ export class BrowserServer implements IBrowserServer {
           attrs: {
             type,
             ...(async ? { async: '' } : {}),
-            ...(srcLink ? { src: slash(`/@fs/${srcLink}`) } : {}),
+            ...(srcLink
+              ? {
+                  src: srcLink.startsWith('http') ? srcLink : slash(`/@fs/${srcLink}`),
+                }
+              : {}),
           },
           injectTo: 'head',
           children: contentProcessed || '',

--- a/packages/browser/src/node/server.ts
+++ b/packages/browser/src/node/server.ts
@@ -1,5 +1,5 @@
-import type { ErrorWithDiff } from '@vitest/utils'
-import type { SerializedConfig } from 'vitest'
+import type { HtmlTagDescriptor } from 'vite'
+import type { ErrorWithDiff, SerializedConfig } from 'vitest'
 import type {
   BrowserProvider,
   BrowserScript,
@@ -8,6 +8,7 @@ import type {
   Vite,
   WorkspaceProject,
 } from 'vitest/node'
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { slash } from '@vitest/utils'
@@ -22,10 +23,11 @@ export class BrowserServer implements IBrowserServer {
   public prefixTesterUrl: string
 
   public orchestratorScripts: string | undefined
-  public testerScripts: string | undefined
+  public testerScripts: HtmlTagDescriptor[] | undefined
 
   public manifest: Promise<Vite.Manifest> | Vite.Manifest
   public testerHtml: Promise<string> | string
+  public testerFilepath: string
   public orchestratorHtml: Promise<string> | string
   public injectorJs: Promise<string> | string
   public errorCatcherUrl: string
@@ -76,8 +78,16 @@ export class BrowserServer implements IBrowserServer {
       )
     })().then(manifest => (this.manifest = manifest))
 
+    const testerHtmlPath = project.config.browser.testerHtmlPath
+      ? resolve(project.config.root, project.config.browser.testerHtmlPath)
+      : resolve(distRoot, 'client/tester/tester.html')
+    if (!existsSync(testerHtmlPath)) {
+      throw new Error(`Tester HTML file not found at "${testerHtmlPath}".`)
+    }
+    this.testerFilepath = testerHtmlPath
+
     this.testerHtml = readFile(
-      resolve(distRoot, 'client/tester/tester.html'),
+      testerHtmlPath,
       'utf8',
     ).then(html => (this.testerHtml = html))
     this.orchestratorHtml = (project.config.browser.ui
@@ -124,11 +134,11 @@ export class BrowserServer implements IBrowserServer {
     scripts: BrowserScript[] | undefined,
   ) {
     if (!scripts?.length) {
-      return ''
+      return []
     }
     const server = this.vite
     const promises = scripts.map(
-      async ({ content, src, async, id, type = 'module' }, index) => {
+      async ({ content, src, async, id, type = 'module' }, index): Promise<HtmlTagDescriptor> => {
         const srcLink = (src ? (await server.pluginContainer.resolveId(src))?.id : undefined) || src
         const transformId = srcLink || join(server.config.root, `virtual__${id || `injected-${index}.js`}`)
         await server.moduleGraph.ensureEntryFromUrl(transformId)
@@ -136,12 +146,19 @@ export class BrowserServer implements IBrowserServer {
           = content && type === 'module'
             ? (await server.pluginContainer.transform(content, transformId)).code
             : content
-        return `<script type="${type}"${async ? ' async' : ''}${
-          srcLink ? ` src="${slash(`/@fs/${srcLink}`)}"` : ''
-        }>${contentProcessed || ''}</script>`
+        return {
+          tag: 'script',
+          attrs: {
+            type,
+            ...(async ? { async: '' } : {}),
+            ...(srcLink ? { src: slash(`/@fs/${srcLink}`) } : {}),
+          },
+          injectTo: 'head',
+          children: contentProcessed || '',
+        }
       },
     )
-    return (await Promise.all(promises)).join('\n')
+    return (await Promise.all(promises))
   }
 
   async initBrowserProvider() {

--- a/packages/browser/src/node/server.ts
+++ b/packages/browser/src/node/server.ts
@@ -82,7 +82,7 @@ export class BrowserServer implements IBrowserServer {
       ? resolve(project.config.root, project.config.browser.testerHtmlPath)
       : resolve(distRoot, 'client/tester/tester.html')
     if (!existsSync(testerHtmlPath)) {
-      throw new Error(`Tester HTML file not found at "${testerHtmlPath}".`)
+      throw new Error(`Tester HTML file "${testerHtmlPath}" doesn't exist.`)
     }
     this.testerFilepath = testerHtmlPath
 

--- a/packages/browser/src/node/serverOrchestrator.ts
+++ b/packages/browser/src/node/serverOrchestrator.ts
@@ -38,9 +38,16 @@ export async function resolveOrchestrator(
   res.removeHeader('Content-Security-Policy')
 
   if (!server.orchestratorScripts) {
-    server.orchestratorScripts = await server.formatScripts(
+    server.orchestratorScripts = (await server.formatScripts(
       project.config.browser.orchestratorScripts,
-    )
+    )).map((script) => {
+      let html = '<script '
+      for (const attr in script.attrs || {}) {
+        html += `${attr}="${script.attrs![attr]}" `
+      }
+      html += `>${script.children}</script>`
+      return html
+    }).join('\n')
   }
 
   let baseHtml = typeof server.orchestratorHtml === 'string'

--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -65,7 +65,7 @@ export async function resolveTester(
     __vitest_browser_runner__.runningFiles = ${tests}
     __vitest_browser_runner__.iframeId = ${iframeId}
     __vitest_browser_runner__.${method === 'run' ? 'runTests' : 'collectTests'}(__vitest_browser_runner__.runningFiles)
-    // document.querySelector('script[data-vitest-append]').remove()
+    document.querySelector('script[data-vitest-append]').remove()
     `,
     })
   }

--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Connect } from 'vite'
 import type { BrowserServer } from './server'
 import crypto from 'node:crypto'
 import { stringify } from 'flatted'
-import type { Connect } from 'vite'
 import { replacer } from './utils'
 
 export async function resolveTester(

--- a/packages/browser/src/node/utils.ts
+++ b/packages/browser/src/node/utils.ts
@@ -1,7 +1,7 @@
 import type { BrowserProviderModule, ResolvedBrowserOptions, WorkspaceProject } from 'vitest/node'
 
 export function replacer(code: string, values: Record<string, string>) {
-  return code.replace(/\{\s*(\w+)\s*\}/g, (_, key) => values[key] ?? '')
+  return code.replace(/\{\s*(\w+)\s*\}/g, (_, key) => values[key] ?? _)
 }
 
 const builtinProviders = ['webdriverio', 'playwright', 'preview']

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -415,6 +415,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
       screenshotDirectory: null,
       screenshotFailures: null,
       locators: null,
+      testerHtmlPath: null,
     },
   },
   pool: {

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -156,8 +156,13 @@ export interface BrowserConfigOptions {
 
   /**
    * Scripts injected into the tester iframe.
+   * @deprecated Will be removed in the future, use `testerHtmlPath` instead.
    */
   testerScripts?: BrowserScript[]
+  /**
+   * Path to the index.html file that will be used to run tests.
+   */
+  testerHtmlPath?: string
 
   /**
    * Scripts injected into the main window.

--- a/test/config/fixtures/browser-custom-html/browser-basic.test.ts
+++ b/test/config/fixtures/browser-custom-html/browser-basic.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from 'vitest';
+
+test('basic', async () => {
+  const div = document.createElement('div')
+  div.textContent = ' Vitest'
+  document.body.appendChild(div)
+  expect(document.body.textContent).toContain('HELLO WORLD')
+  expect(document.body.textContent).toContain('Vitest')
+})

--- a/test/config/fixtures/browser-custom-html/browser-custom.test.ts
+++ b/test/config/fixtures/browser-custom-html/browser-custom.test.ts
@@ -3,3 +3,7 @@ import { test, expect } from 'vitest';
 test('custom', () => {
   expect(window).toHaveProperty('CUSTOM_INJECTED', true)
 })
+
+test('importmap is injected', () => {
+  expect(import.meta.resolve('some-lib')).toBe('https://vitest.dev/some-lib')
+})

--- a/test/config/fixtures/browser-custom-html/browser-custom.test.ts
+++ b/test/config/fixtures/browser-custom-html/browser-custom.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from 'vitest';
+
+test('custom', () => {
+  expect(window).toHaveProperty('CUSTOM_INJECTED', true)
+})

--- a/test/config/fixtures/browser-custom-html/custom-html.html
+++ b/test/config/fixtures/browser-custom-html/custom-html.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  HELLO WORLD
+</body>
+</html>

--- a/test/config/fixtures/browser-custom-html/vitest.config.correct.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.correct.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['browser-basic.test.ts'],
+    browser: {
+      name: 'chromium',
+      enabled: true,
+      headless: true,
+      provider: 'playwright',
+      testerHtmlPath: './custom-html.html'
+    },
+  },
+})

--- a/test/config/fixtures/browser-custom-html/vitest.config.custom-transformIndexHtml.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.custom-transformIndexHtml.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'test:html',
+      transformIndexHtml() {
+        return [
+          {
+            tag: 'script',
+            children: 'window.CUSTOM_INJECTED = true',
+            injectTo: 'head',
+          }
+        ]
+      },
+    },
+  ],
+  test: {
+    include: ['./browser-custom.test.ts'],
+    browser: {
+      name: 'chromium',
+      enabled: true,
+      headless: true,
+      provider: 'playwright',
+      testerHtmlPath: './custom-html.html',
+    },
+  },
+})

--- a/test/config/fixtures/browser-custom-html/vitest.config.custom-transformIndexHtml.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.custom-transformIndexHtml.ts
@@ -8,9 +8,21 @@ export default defineConfig({
         return [
           {
             tag: 'script',
+            injectTo: 'head-prepend',
+            attrs: {
+              type: 'importmap'
+            },
+            children: JSON.stringify({
+              "imports": {
+                "some-lib": "https://vitest.dev/some-lib",
+              },
+            })
+          },
+          {
+            tag: 'script',
             children: 'window.CUSTOM_INJECTED = true',
             injectTo: 'head',
-          }
+          },
         ]
       },
     },

--- a/test/config/fixtures/browser-custom-html/vitest.config.default-transformIndexHtml.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.default-transformIndexHtml.ts
@@ -8,6 +8,18 @@ export default defineConfig({
         return [
           {
             tag: 'script',
+            injectTo: 'head-prepend',
+            attrs: {
+              type: 'importmap'
+            },
+            children: JSON.stringify({
+              "imports": {
+                "some-lib": "https://vitest.dev/some-lib",
+              },
+            })
+          },
+          {
+            tag: 'script',
             children: 'window.CUSTOM_INJECTED = true',
             injectTo: 'head',
           }

--- a/test/config/fixtures/browser-custom-html/vitest.config.default-transformIndexHtml.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.default-transformIndexHtml.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'test:html',
+      transformIndexHtml() {
+        return [
+          {
+            tag: 'script',
+            children: 'window.CUSTOM_INJECTED = true',
+            injectTo: 'head',
+          }
+        ]
+      },
+    },
+  ],
+  test: {
+    include: ['./browser-custom.test.ts'],
+    browser: {
+      name: 'chromium',
+      enabled: true,
+      headless: true,
+      provider: 'playwright',
+    },
+  },
+})

--- a/test/config/fixtures/browser-custom-html/vitest.config.error-hook.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.error-hook.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'test:html',
+      transformIndexHtml() {
+        throw new Error('expected error in transformIndexHtml')
+      },
+    },
+  ],
+  test: {
+    include: ['./browser-basic.test.ts'],
+    browser: {
+      name: 'chromium',
+      enabled: true,
+      headless: true,
+      provider: 'playwright',
+      testerHtmlPath: './custom-html.html'
+    },
+  },
+})

--- a/test/config/fixtures/browser-custom-html/vitest.config.non-existing.ts
+++ b/test/config/fixtures/browser-custom-html/vitest.config.non-existing.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    browser: {
+      name: 'chromium',
+      enabled: true,
+      headless: true,
+      provider: 'playwright',
+      testerHtmlPath: './some-non-existing-path'
+    },
+  },
+})

--- a/test/config/test/browser-html.test.ts
+++ b/test/config/test/browser-html.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+import { resolve } from 'pathe'
+import { runVitest } from '../../test-utils'
+
+const root = resolve(import.meta.dirname, '../fixtures/browser-custom-html')
+
+test('throws an error with non-existing path', async () => {
+  const { stderr, thrown } = await runVitest({
+    root,
+    config: './vitest.config.non-existing.ts',
+  }, [], 'test', {}, { fails: true })
+  expect(thrown).toBe(true)
+  expect(stderr).toContain(`Tester HTML file "${resolve(root, './some-non-existing-path')}" doesn't exist.`)
+})
+
+test('throws an error and exits if there is an error in the html file hook', async () => {
+  const { stderr, stdout, exitCode } = await runVitest({
+    root,
+    config: './vitest.config.error-hook.ts',
+  })
+  expect(stderr).toContain('expected error in transformIndexHtml')
+  // error happens when browser is opened
+  expect(stdout).toContain('Browser runner started by playwright')
+  expect(exitCode).toBe(1)
+})
+
+test('allows correct custom html', async () => {
+  const { stderr, stdout, exitCode } = await runVitest({
+    root,
+    config: './vitest.config.correct.ts',
+    reporters: ['basic'],
+  })
+  expect(stderr).toBe('')
+  expect(stdout).toContain('Browser runner started by playwright')
+  expect(stdout).toContain('✓ browser-basic.test.ts')
+  expect(exitCode).toBe(0)
+})
+
+test('allows custom transformIndexHtml with custom html file', async () => {
+  const { stderr, stdout, exitCode } = await runVitest({
+    root,
+    config: './vitest.config.custom-transformIndexHtml.ts',
+    reporters: ['basic'],
+  })
+  expect(stderr).toBe('')
+  expect(stdout).toContain('Browser runner started by playwright')
+  expect(stdout).toContain('✓ browser-custom.test.ts')
+  expect(exitCode).toBe(0)
+})
+
+test('allows custom transformIndexHtml without custom html file', async () => {
+  const { stderr, stdout, exitCode } = await runVitest({
+    root,
+    config: './vitest.config.default-transformIndexHtml.ts',
+    reporters: ['basic'],
+  })
+  expect(stderr).toBe('')
+  expect(stdout).toContain('Browser runner started by playwright')
+  expect(stdout).toContain('✓ browser-custom.test.ts')
+  expect(exitCode).toBe(0)
+})

--- a/test/config/test/browser-html.test.ts
+++ b/test/config/test/browser-html.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from 'vitest'
 import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 
 const root = resolve(import.meta.dirname, '../fixtures/browser-custom-html')

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -55,6 +55,7 @@ export async function runVitest(
   const cli = new Cli({ stdin, stdout, stderr })
 
   let ctx: Vitest | undefined
+  let thrown = false
   try {
     const { reporters, ...rest } = config
 
@@ -88,6 +89,7 @@ export async function runVitest(
     if (runnerOptions.fails !== true) {
       console.error(e)
     }
+    thrown = true
     cli.stderr += e.stack
   }
   finally {
@@ -111,6 +113,7 @@ export async function runVitest(
   }
 
   return {
+    thrown,
     ctx,
     exitCode,
     vitest: cli,


### PR DESCRIPTION
### Description

Closes #6394
Closes #6768
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds an option to specify your own HTML file for the Browser Mode. Now Vitest also always calls `transformIndexHtml` plugin hook when serving the tester file.

```ts
export default defineConfig({
  test: {
    browser: {
      testerHtmlPath: './component-testing.html',
    },
  },
})
```

Since Browser Mode is experimental, this PR can be merged with fixes and doesn't need to follow semver.

TODO
- [x] Tests
  - Non-existing file path 
  - Error during `transformIndexHtml`
  - Valid HTML
  - Valid custom `transformIndexHtml` hook