### PR TITLE
fix(browser): cleanup keyboard state

### DIFF
--- a/docs/guide/browser/context.md
+++ b/docs/guide/browser/context.md
@@ -20,6 +20,7 @@ The `userEvent` API is explained in detail at [Interactivity API](/guide/browser
  */
 export const userEvent: {
   setup: () => UserEvent
+  cleanup: () => Promise<void>
   click: (element: Element, options?: UserEventClickOptions) => Promise<void>
   dblClick: (element: Element, options?: UserEventDoubleClickOptions) => Promise<void>
   tripleClick: (element: Element, options?: UserEventTripleClickOptions) => Promise<void>

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -59,7 +59,12 @@ export interface UserEvent {
    * @see {@link https://vitest.dev/guide/browser/interactivity-api.html#userevent-setup}
    */
   setup: () => UserEvent
-  cleanup: () => Promise<void>;
+  /**
+   * Cleans up the user event instance, releasing any resources or state it holds,
+   * such as keyboard press state. For the default `userEvent` instance, this method
+   * is automatically called after each test case.
+   */
+  cleanup: () => Promise<void>
   /**
    * Click on an element. Uses provider's API under the hood and supports all its options.
    * @see {@link https://playwright.dev/docs/api/class-locator#locator-click} Playwright API

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -59,6 +59,7 @@ export interface UserEvent {
    * @see {@link https://vitest.dev/guide/browser/interactivity-api.html#userevent-setup}
    */
   setup: () => UserEvent
+  cleanup: () => Promise<void>;
   /**
    * Click on an element. Uses provider's API under the hood and supports all its options.
    * @see {@link https://playwright.dev/docs/api/class-locator#locator-click} Playwright API

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -38,6 +38,13 @@ export function createUserEvent(__tl_user_event__?: TestingLibraryUserEvent): Us
     setup(options?: any) {
       return createUserEvent(__tl_user_event__?.setup(options))
     },
+    async cleanup() {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return
+      }
+      await triggerCommand('__vitest_cleanup', keyboard)
+      keyboard.unreleased = []
+    },
     click(element: Element | Locator, options: UserEventClickOptions = {}) {
       return convertToLocator(element).click(processClickOptions(options))
     },

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -29,7 +29,8 @@ function triggerCommand<T>(command: string, ...args: any[]) {
   return rpc().triggerCommand<T>(contextId, command, filepath(), args)
 }
 
-export function createUserEvent(__tl_user_event__?: TestingLibraryUserEvent): UserEvent {
+export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent): UserEvent {
+  let __tl_user_event__ = __tl_user_event_base__?.setup({})
   const keyboard = {
     unreleased: [] as string[],
   }
@@ -40,6 +41,7 @@ export function createUserEvent(__tl_user_event__?: TestingLibraryUserEvent): Us
     },
     async cleanup() {
       if (typeof __tl_user_event__ !== 'undefined') {
+        __tl_user_event__ = __tl_user_event_base__?.setup({})
         return
       }
       await triggerCommand('__vitest_cleanup', keyboard)

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -1,6 +1,6 @@
 import type { RunnerTask } from 'vitest'
 import type { BrowserRPC } from '@vitest/browser/client'
-import type { UserEvent as TestingLibraryUserEvent } from '@testing-library/user-event'
+import type { Options as TestingLibraryOptions, UserEvent as TestingLibraryUserEvent } from '@testing-library/user-event'
 import type {
   BrowserPage,
   Locator,
@@ -29,19 +29,19 @@ function triggerCommand<T>(command: string, ...args: any[]) {
   return rpc().triggerCommand<T>(contextId, command, filepath(), args)
 }
 
-export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent): UserEvent {
-  let __tl_user_event__ = __tl_user_event_base__?.setup({})
+export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent, options?: TestingLibraryOptions): UserEvent {
+  let __tl_user_event__ = __tl_user_event_base__?.setup(options ?? {})
   const keyboard = {
     unreleased: [] as string[],
   }
 
   return {
     setup(options?: any) {
-      return createUserEvent(__tl_user_event__?.setup(options))
+      return createUserEvent(__tl_user_event_base__, options)
     },
     async cleanup() {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        __tl_user_event__ = __tl_user_event_base__?.setup({})
+      if (typeof __tl_user_event_base__ !== 'undefined') {
+        __tl_user_event__ = __tl_user_event_base__?.setup(options ?? {})
         return
       }
       await triggerCommand('__vitest_cleanup', keyboard)

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -4,7 +4,7 @@ import type { VitestExecutor } from 'vitest/execute'
 import { NodeBenchmarkRunner, VitestTestRunner } from 'vitest/runners'
 import { loadDiffConfig, loadSnapshotSerializers, takeCoverageInsideWorker } from 'vitest/browser'
 import { TraceMap, originalPositionFor } from 'vitest/utils'
-import { page } from '@vitest/browser/context'
+import { page, userEvent } from '@vitest/browser/context'
 import { globalChannel } from '@vitest/browser/client'
 import { executor } from '../utils'
 import { VitestBrowserSnapshotEnvironment } from './snapshot'
@@ -41,6 +41,7 @@ export function createBrowserRunner(
     }
 
     onAfterRunTask = async (task: Task) => {
+      await userEvent.cleanup()
       await super.onAfterRunTask?.(task)
 
       if (this.config.bail && task.result?.state === 'fail') {

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -168,6 +168,10 @@ async function executeTests(method: 'run' | 'collect', files: string[]) {
       if (cleanupSymbol in page) {
         (page[cleanupSymbol] as any)()
       }
+      // TODO: symbol?
+      if ('__cleanup' in page) {
+        await (page.__cleanup as any)()
+      }
     }
     catch (error: any) {
       await client.rpc.onUnhandledError({

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -11,7 +11,6 @@ import { VitestBrowserClientMocker } from './mocker'
 import { setupExpectDom } from './expect-element'
 
 const cleanupSymbol = Symbol.for('vitest:component-cleanup')
-const userEventCleanupSymbol = Symbol.for('vitest:user-event-cleanup')
 
 const url = new URL(location.href)
 const reloadStart = url.searchParams.get('__reloadStart')
@@ -168,9 +167,6 @@ async function executeTests(method: 'run' | 'collect', files: string[]) {
     try {
       if (cleanupSymbol in page) {
         (page[cleanupSymbol] as any)()
-      }
-      if (userEventCleanupSymbol in page) {
-        await (page[userEventCleanupSymbol] as any)()
       }
     }
     catch (error: any) {

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -11,6 +11,7 @@ import { VitestBrowserClientMocker } from './mocker'
 import { setupExpectDom } from './expect-element'
 
 const cleanupSymbol = Symbol.for('vitest:component-cleanup')
+const userEventCleanupSymbol = Symbol.for('vitest:user-event-cleanup')
 
 const url = new URL(location.href)
 const reloadStart = url.searchParams.get('__reloadStart')
@@ -168,9 +169,8 @@ async function executeTests(method: 'run' | 'collect', files: string[]) {
       if (cleanupSymbol in page) {
         (page[cleanupSymbol] as any)()
       }
-      // TODO: symbol?
-      if ('__cleanup' in page) {
-        await (page.__cleanup as any)()
+      if (userEventCleanupSymbol in page) {
+        await (page[userEventCleanupSymbol] as any)()
       }
     }
     catch (error: any) {

--- a/packages/browser/src/node/commands/index.ts
+++ b/packages/browser/src/node/commands/index.ts
@@ -4,7 +4,7 @@ import { clear } from './clear'
 import { fill } from './fill'
 import { selectOptions } from './select'
 import { tab } from './tab'
-import { keyboard } from './keyboard'
+import { keyboard, keyboardCleanup } from './keyboard'
 import { dragAndDrop } from './dragAndDrop'
 import { hover } from './hover'
 import { upload } from './upload'
@@ -34,4 +34,5 @@ export default {
   __vitest_selectOptions: selectOptions,
   __vitest_dragAndDrop: dragAndDrop,
   __vitest_hover: hover,
+  __vitest_cleanup: keyboardCleanup,
 }

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -60,6 +60,13 @@ export const keyboardCleanup: UserEventCommand<(state: KeyboardState) => Promise
       await page.keyboard.up(key)
     }
   }
+  else if (provider instanceof WebdriverBrowserProvider) {
+    const keyboard = provider.browser!.action('key')
+    for (const key of state.unreleased) {
+      keyboard.up(key)
+    }
+    await keyboard.perform()
+  }
 }
 
 export async function keyboardImplementation(

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -49,6 +49,19 @@ export const keyboard: UserEventCommand<(text: string, state: KeyboardState) => 
   }
 }
 
+export const keyboardCleanup: UserEventCommand<(state: KeyboardState) => Promise<void>> = async (
+  context,
+  state,
+) => {
+  const { provider, contextId } = context;
+  if (provider instanceof PlaywrightBrowserProvider) {
+    const page = provider.getPage(contextId)
+    for (const key of state.unreleased) {
+      await page.keyboard.up(key)
+    }
+  }
+}
+
 export async function keyboardImplementation(
   pressed: Set<string>,
   provider: BrowserProvider,

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -53,7 +53,7 @@ export const keyboardCleanup: UserEventCommand<(state: KeyboardState) => Promise
   context,
   state,
 ) => {
-  const { provider, contextId } = context;
+  const { provider, contextId } = context
   if (provider instanceof PlaywrightBrowserProvider) {
     const page = provider.getPage(contextId)
     for (const key of state.unreleased) {

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -67,6 +67,9 @@ export const keyboardCleanup: UserEventCommand<(state: KeyboardState) => Promise
     }
     await keyboard.perform()
   }
+  else {
+    throw new TypeError(`Provider "${context.provider.name}" does not support keyboard api`)
+  }
 }
 
 export async function keyboardImplementation(

--- a/packages/browser/src/node/plugins/pluginContext.ts
+++ b/packages/browser/src/node/plugins/pluginContext.ts
@@ -86,7 +86,6 @@ export const server = {
 export const commands = server.commands
 export const userEvent = createUserEvent(_userEventSetup)
 export { page, cdp }
-page[Symbol.for('vitest:user-event-cleanup')] = () => userEvent.cleanup()
 `
 }
 

--- a/packages/browser/src/node/plugins/pluginContext.ts
+++ b/packages/browser/src/node/plugins/pluginContext.ts
@@ -97,7 +97,8 @@ async function getUserEventImport(provider: BrowserProvider, resolve: (id: strin
   if (!resolved) {
     throw new Error(`Failed to resolve user-event package from ${__dirname}`)
   }
-  return `import { userEvent as __vitest_user_event__ } from '${slash(
-    `/@fs/${resolved.id}`,
-  )}'\nconst _userEventSetup = __vitest_user_event__.setup()\n`
+  return `\
+import { userEvent as __vitest_user_event__ } from '${slash(`/@fs/${resolved.id}`)}'
+const _userEventSetup = __vitest_user_event__
+`
 }

--- a/packages/browser/src/node/plugins/pluginContext.ts
+++ b/packages/browser/src/node/plugins/pluginContext.ts
@@ -85,6 +85,7 @@ export const server = {
 }
 export const commands = server.commands
 export const userEvent = createUserEvent(_userEventSetup)
+page.__cleanup = () => userEvent.cleanup()
 export { page, cdp }
 `
 }

--- a/packages/browser/src/node/plugins/pluginContext.ts
+++ b/packages/browser/src/node/plugins/pluginContext.ts
@@ -85,8 +85,8 @@ export const server = {
 }
 export const commands = server.commands
 export const userEvent = createUserEvent(_userEventSetup)
-page.__cleanup = () => userEvent.cleanup()
 export { page, cdp }
+page[Symbol.for('vitest:user-event-cleanup')] = () => userEvent.cleanup()
 `
 }
 

--- a/test/browser/fixtures/user-event/cleanup1.test.ts
+++ b/test/browser/fixtures/user-event/cleanup1.test.ts
@@ -12,8 +12,33 @@ test('cleanup1', async () => {
   })
 
   await userEvent.keyboard('{Tab}')
-  // keep alt being pressed, which should be reset
-  // before running cleanup2.test.ts
+  await userEvent.keyboard("{Alt>}")
+  expect(logs).toMatchInlineSnapshot(`
+    [
+      [
+        "Tab",
+        false,
+      ],
+      [
+        "Alt",
+        true,
+      ],
+    ]
+  `)
+})
+
+// test per-test cleanup
+test('cleanup1.2', async () => {
+  let logs: any[] = [];
+  function handler(e: KeyboardEvent) {
+    logs.push([e.key, e.altKey]);
+  };
+  document.addEventListener('keydown', handler)
+  onTestFinished(() => {
+    document.removeEventListener('keydown', handler);
+  })
+
+  await userEvent.keyboard('{Tab}')
   await userEvent.keyboard("{Alt>}")
   expect(logs).toMatchInlineSnapshot(`
     [

--- a/test/browser/fixtures/user-event/cleanup1.test.ts
+++ b/test/browser/fixtures/user-event/cleanup1.test.ts
@@ -1,0 +1,30 @@
+import { expect, onTestFinished, test } from 'vitest'
+import { userEvent } from '@vitest/browser/context'
+
+test('cleanup1', async () => {
+  let logs: any[] = [];
+  function handler(e: KeyboardEvent) {
+    logs.push([e.key, e.altKey]);
+  };
+  document.addEventListener('keydown', handler)
+  onTestFinished(() => {
+    document.removeEventListener('keydown', handler);
+  })
+
+  await userEvent.keyboard('{Tab}')
+  // keep alt being pressed, which should be reset
+  // before running cleanup2.test.ts
+  await userEvent.keyboard("{Alt>}")
+  expect(logs).toMatchInlineSnapshot(`
+    [
+      [
+        "Tab",
+        false,
+      ],
+      [
+        "Alt",
+        true,
+      ],
+    ]
+  `)
+})

--- a/test/browser/fixtures/user-event/cleanup2.test.ts
+++ b/test/browser/fixtures/user-event/cleanup2.test.ts
@@ -1,0 +1,28 @@
+import { expect, onTestFinished, test } from 'vitest'
+import { userEvent } from '@vitest/browser/context'
+
+test('cleanup2', async () => {
+  let logs: any[] = [];
+  function handler(e: KeyboardEvent) {
+    logs.push([e.key, e.altKey]);
+  };
+  document.addEventListener('keydown', handler)
+  onTestFinished(() => {
+    document.removeEventListener('keydown', handler);
+  })
+
+  await userEvent.keyboard('{Tab}')
+  await userEvent.keyboard("{Alt>}")
+  expect(logs).toMatchInlineSnapshot(`
+    [
+      [
+        "Tab",
+        false,
+      ],
+      [
+        "Alt",
+        true,
+      ],
+    ]
+  `)
+})

--- a/test/browser/fixtures/user-event/cleanup2.test.ts
+++ b/test/browser/fixtures/user-event/cleanup2.test.ts
@@ -1,7 +1,7 @@
 import { expect, onTestFinished, test } from 'vitest'
 import { userEvent } from '@vitest/browser/context'
 
-// exact same test as cleanup1.test.ts
+// test per-test-file cleanup just in case
 
 test('cleanup2', async () => {
   let logs: any[] = [];

--- a/test/browser/fixtures/user-event/cleanup2.test.ts
+++ b/test/browser/fixtures/user-event/cleanup2.test.ts
@@ -1,6 +1,8 @@
 import { expect, onTestFinished, test } from 'vitest'
 import { userEvent } from '@vitest/browser/context'
 
+// exact same test as cleanup1.test.ts
+
 test('cleanup2', async () => {
   let logs: any[] = [];
   function handler(e: KeyboardEvent) {

--- a/test/browser/fixtures/user-event/vitest.config.ts
+++ b/test/browser/fixtures/user-event/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const provider = process.env.PROVIDER || 'playwright'
+const name =
+  process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome')
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      name,
+    },
+  },
+})

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -137,3 +137,15 @@ error with a stack
     expect(stderr).toContain('Access denied to "/inaccesible/path".')
   })
 })
+
+test('user-event', async () => {
+  const { ctx } = await runBrowserTests({
+    root: './fixtures/user-event',
+  })
+  expect(Object.fromEntries(ctx.state.getFiles().map(f => [f.name, f.result.state]))).toMatchInlineSnapshot(`
+    {
+      "cleanup1.test.ts": "pass",
+      "cleanup2.test.ts": "pass",
+    }
+  `)
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6693

I added `userEvent.cleanup` to reset keyboard state and hooked into ~tester cleanup~ runner `onAfterRunTask`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
