### PR TITLE
test: fix test for node 22.10

### DIFF
--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -1,4 +1,3 @@
-import { AssertionError } from 'node:assert'
 import type { ErrorWithDiff, File, Suite, Task } from 'vitest'
 
 const file: File = {
@@ -26,12 +25,13 @@ const suite: Suite = {
   tasks: [],
 }
 
-const error: ErrorWithDiff = new AssertionError({
+const error: ErrorWithDiff = {
+  name: 'AssertionError',
   message: 'expected 2.23606797749979 to equal 2',
   actual: '2.23606797749979',
   expected: '2',
   operator: 'strictEqual',
-})
+}
 error.showDiff = true
 error.stack = 'AssertionError: expected 2.23606797749979 to equal 2\n'
 + '    at /vitest/test/core/test/basic.test.ts:8:32\n'


### PR DESCRIPTION
### Description

I'm not sure what exactly Node changed, but our use of artificial `AssertionError` seems affected and ubuntu/node-22 CI is failing https://github.com/vitest-dev/vitest/actions/runs/11397153823/job/31712854371?pr=6732#step:8:1098

I replaced it with a plain error result object.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
