### PR TITLE
fix(browser): don't add `v=` queries to setup files imports

### DIFF
--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -17,7 +17,7 @@ interface BrowserRunnerOptions {
 
 export const browserHashMap = new Map<
   string,
-  [test: boolean, timstamp: string]
+  string
 >()
 
 interface CoverageHandler {
@@ -122,15 +122,15 @@ export function createBrowserRunner(
     }
 
     importFile = async (filepath: string) => {
-      let [test, hash] = this.hashMap.get(filepath) ?? [false, '']
-      if (hash === '') {
+      let hash = this.hashMap.get(filepath)
+      if (!hash) {
         hash = Date.now().toString()
-        this.hashMap.set(filepath, [false, hash])
+        this.hashMap.set(filepath, hash)
       }
 
       // on Windows we need the unit to resolve the test file
       const prefix = `/${/^\w:/.test(filepath) ? '@fs/' : ''}`
-      const query = `${test ? 'browserv' : 'v'}=${hash}`
+      const query = `browserv=${hash}`
       const importpath = `${prefix}${filepath}?${query}`.replace(/\/+/g, '/')
       await import(/* @vite-ignore */ importpath)
     }

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -75,7 +75,7 @@ async function prepareTestEnvironment(files: string[]) {
   files.forEach((filename) => {
     const currentVersion = browserHashMap.get(filename)
     if (!currentVersion || currentVersion[1] !== version) {
-      browserHashMap.set(filename, [true, version])
+      browserHashMap.set(filename, version)
     }
   })
 

--- a/test/browser/fixtures/setup-file/browser-setup.ts
+++ b/test/browser/fixtures/setup-file/browser-setup.ts
@@ -1,0 +1,6 @@
+import { beforeEach } from 'vitest';
+import * as source from './source';
+
+beforeEach<{ source: any }>((t) => {
+  t.source = source
+})

--- a/test/browser/fixtures/setup-file/module-equality.test.ts
+++ b/test/browser/fixtures/setup-file/module-equality.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import * as source from './source'
+
+test<{ source: any }>('modules are the same', (t) => {
+  expect(source).toBe(t.source)
+})

--- a/test/browser/fixtures/setup-file/source.ts
+++ b/test/browser/fixtures/setup-file/source.ts
@@ -1,0 +1,3 @@
+export function answer() {
+  return 42
+}

--- a/test/browser/fixtures/setup-file/vitest.config.ts
+++ b/test/browser/fixtures/setup-file/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const provider = process.env.PROVIDER || 'playwright'
+const name =
+  process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome')
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  test: {
+    setupFiles: ['./browser-setup.ts'],
+    browser: {
+      enabled: true,
+      provider,
+      name,
+      headless: false,
+    },
+  },
+})

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -12,6 +12,7 @@
     "test-mocking": "vitest --root ./fixtures/mocking",
     "test-mocking-watch": "vitest --root ./fixtures/mocking-watch",
     "test-locators": "vitest --root ./fixtures/locators",
+    "test-setup-file": "vitest --root ./fixtures/setup-file",
     "test-snapshots": "vitest --root ./fixtures/update-snapshot",
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes",
     "test:browser:preview": "PROVIDER=preview vitest",

--- a/test/browser/specs/setup-file.test.ts
+++ b/test/browser/specs/setup-file.test.ts
@@ -1,0 +1,23 @@
+// fix https://github.com/vitest-dev/vitest/issues/6690
+
+import { expect, test } from 'vitest'
+import { runBrowserTests } from './utils'
+
+test('setup file imports the same modules', async () => {
+  const { stderr, ctx } = await runBrowserTests(
+    {
+      root: './fixtures/setup-file',
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(
+    Object.fromEntries(
+      ctx.state.getFiles().map(f => [f.name, f.result.state]),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "module-equality.test.ts": "pass",
+    }
+  `)
+})

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -1,5 +1,5 @@
 import type { UserConfig as ViteUserConfig } from 'vite'
-import type { UserConfig } from 'vitest'
+import type { UserConfig } from 'vitest/node'
 import { runVitest } from '../../test-utils'
 
 export const provider = process.env.PROVIDER || 'playwright'


### PR DESCRIPTION
### Description

Fixes https://github.com/vitest-dev/vitest/issues/6690
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
