### PR TITLE
fix(vite-node): invalidate source map cache

### DIFF
--- a/packages/vite-node/src/hmr/emitter.ts
+++ b/packages/vite-node/src/hmr/emitter.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import type { HMRPayload, Plugin } from 'vite'
+import { sourceMapCache } from '../source-map-cache'
 
 export type EventType = string | symbol
 export type Handler<T = unknown> = (event: T) => void
@@ -72,6 +73,10 @@ export function viteNodeHmrPlugin(): Plugin {
           emitter.emit('message', payload)
         }
       }
+    },
+
+    handleHotUpdate(ctx) {
+      delete sourceMapCache[ctx.file]
     },
   }
 }

--- a/packages/vite-node/src/source-map-cache.ts
+++ b/packages/vite-node/src/source-map-cache.ts
@@ -1,0 +1,7 @@
+import type { TraceMap } from '@jridgewell/trace-mapping'
+
+// Maps a file path to a source map for that file
+export const sourceMapCache: Record<
+  string,
+  { url: string | null; map: TraceMap | null }
+> = {}

--- a/packages/vite-node/src/source-map-handler.ts
+++ b/packages/vite-node/src/source-map-handler.ts
@@ -10,18 +10,13 @@ import type {
   SourceMapInput,
 } from '@jridgewell/trace-mapping'
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
+import { sourceMapCache } from './source-map-cache'
 
 // Only install once if called multiple times
 let errorFormatterInstalled = false
 
 // Maps a file path to a string containing the file contents
 const fileContentsCache: Record<string, string> = {}
-
-// Maps a file path to a source map for that file
-const sourceMapCache: Record<
-  string,
-  { url: string | null; map: TraceMap | null }
-> = {}
 
 // Regex for detecting source maps
 const reSourceMap = /^data:application\/json[^,]+base64,/

--- a/test/vite-node/src/watch/source-map.ts
+++ b/test/vite-node/src/watch/source-map.ts
@@ -1,0 +1,16 @@
+// 1
+// 1
+async function main() {
+  try {
+    // 2
+    // 2
+    throw new Error('boom')
+  }
+  catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e)
+  }
+}
+// 3
+// 3
+main()

--- a/test/vite-node/test/cli.test.ts
+++ b/test/vite-node/test/cli.test.ts
@@ -52,3 +52,11 @@ it.each(['index.js', 'index.cjs', 'index.mjs'])('correctly runs --watch %s', asy
   editFile(entryPath, c => c.replace('test 1', 'test 2'))
   await viteNode.waitForStdout('test 2')
 })
+
+it('invalidate source map cache', async () => {
+  const entryPath = resolve(__dirname, '../src/watch/source-map.ts')
+  const { viteNode } = await runViteNodeCli('--watch', entryPath)
+  await viteNode.waitForStdout('source-map.ts:7:11')
+  editFile(entryPath, c => c.replaceAll('    // 2\n', ''))
+  await viteNode.waitForStdout('source-map.ts:5:11')
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6642

This is a sort of stop gap to fix stale `sourceMapCache` if client/server lives in the same process (e.g. vite-node cli). Ideally, we should structure it like Vite 6 module runner to cache decoded source map on client, so we don't need to cache it globally. I'll explore that approach later, but I'm pushing this fix first.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
