### PR TITLE
test: add `@vite-ignore` to silence warning

### DIFF
--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -15,7 +15,7 @@ test('dynamic relative import works', async () => {
   const stringTimeoutMod = await import('./../src/timeout')
 
   const timeoutPath = './../src/timeout'
-  const variableTimeoutMod = await import(timeoutPath)
+  const variableTimeoutMod = await import(/* @vite-ignore */ timeoutPath)
 
   expect(stringTimeoutMod).toBe(variableTimeoutMod)
 })
@@ -31,7 +31,7 @@ test('dynamic aliased import works', async () => {
   const stringTimeoutMod = await import('./../src/timeout')
 
   const timeoutPath = '#/timeout'
-  const variableTimeoutMod = await import(timeoutPath)
+  const variableTimeoutMod = await import(/* @vite-ignore */ timeoutPath)
 
   expect(stringTimeoutMod).toBe(variableTimeoutMod)
 })
@@ -40,7 +40,7 @@ test('dynamic absolute from root import works', async () => {
   const stringTimeoutMod = await import('./../src/timeout')
 
   const timeoutPath = '/src/timeout'
-  const variableTimeoutMod = await import(timeoutPath)
+  const variableTimeoutMod = await import(/* @vite-ignore */ timeoutPath)
 
   expect(stringTimeoutMod).toBe(variableTimeoutMod)
 })
@@ -49,20 +49,20 @@ test('dynamic absolute with extension import works', async () => {
   const stringTimeoutMod = await import('./../src/timeout')
 
   const timeoutPath = '/src/timeout.ts'
-  const variableTimeoutMod = await import(timeoutPath)
+  const variableTimeoutMod = await import(/* @vite-ignore */ timeoutPath)
 
   expect(stringTimeoutMod).toBe(variableTimeoutMod)
 })
 
 test('data with dynamic import works', async () => {
   const dataUri = 'data:text/javascript;charset=utf-8,export default "hi"'
-  const { default: hi } = await import(dataUri)
+  const { default: hi } = await import(/* @vite-ignore */ dataUri)
   expect(hi).toBe('hi')
 })
 
 test('dynamic import coerces to string', async () => {
   const dataUri = 'data:text/javascript;charset=utf-8,export default "hi"'
-  const { default: hi } = await import({ toString: () => dataUri } as string)
+  const { default: hi } = await import(/* @vite-ignore */ { toString: () => dataUri } as string)
   expect(hi).toBe('hi')
 })
 
@@ -81,7 +81,7 @@ test('dynamic import has null prototype', async () => {
 
 test('dynamic import throws an error', async () => {
   const path = './some-unknown-path'
-  const imported = import(path)
+  const imported = import(/* @vite-ignore */ path)
   await expect(imported).rejects.toThrowError(/Failed to load url \.\/some-unknown-path/)
   // @ts-expect-error path does not exist
   await expect(() => import('./some-unknown-path')).rejects.toThrowError(/Failed to load/)
@@ -89,8 +89,8 @@ test('dynamic import throws an error', async () => {
 
 test('can import @vite/client', async () => {
   const name = '@vite/client'
-  await expect(import(name)).resolves.not.toThrow()
-  await expect(import(`/${name}`)).resolves.not.toThrow()
+  await expect(import(/* @vite-ignore */ name)).resolves.not.toThrow()
+  await expect(import(/* @vite-ignore */ `/${name}`)).resolves.not.toThrow()
 })
 
 describe('importing special files from node_modules', async () => {
@@ -104,7 +104,7 @@ describe('importing special files from node_modules', async () => {
     writeFile(css, '.foo { color: red; }'),
     writeFile(mp3, ''),
   ])
-  const importModule = (path: string) => import(path)
+  const importModule = (path: string) => import(/* @vite-ignore */ path)
 
   test('importing wasm with ?url query', async () => {
     const mod = await importModule('../src/node_modules/file.wasm?url')
@@ -141,8 +141,8 @@ describe.runIf(process.platform === 'win32')('importing files with different dri
     const lowercasePath = filepath.replace(`${upperDrive}:`, `${drive}:`)
     const uppercasePath = filepath.replace(`${drive}:`, `${upperDrive}:`)
     expect(lowercasePath).not.toBe(uppercasePath)
-    const mod1 = await import(lowercasePath)
-    const mod2 = await import(uppercasePath)
+    const mod1 = await import(/* @vite-ignore */ lowercasePath)
+    const mod2 = await import(/* @vite-ignore */ uppercasePath)
     const mod3 = await import('./../src/timeout')
     expect(mod1).toBe(mod2)
     expect(mod1).toBe(mod3)
@@ -156,9 +156,9 @@ describe.runIf(process.platform === 'win32')('importing files with different dri
     const lowercasePath = filepath.replace(`${upperDrive}:`, `${drive}:`)
     const uppercasePath = filepath.replace(`${drive}:`, `${upperDrive}:`)
     expect(lowercasePath).not.toBe(uppercasePath)
-    const mod1 = await import(lowercasePath)
+    const mod1 = await import(/* @vite-ignore */ lowercasePath)
     vi.resetModules() // since they reference the same global ESM cache, it should not matter
-    const mod2 = await import(uppercasePath)
+    const mod2 = await import(/* @vite-ignore */ uppercasePath)
     expect(mod1).toBe(mod2)
   })
 })

--- a/test/core/test/wasm.test.ts
+++ b/test/core/test/wasm.test.ts
@@ -34,7 +34,7 @@ test('supports dynamic wasm imports', async () => {
 
 test('supports imports from "data:application/wasm" URI with base64 encoding', async () => {
   const importedWasmModule = await import(
-    `data:application/wasm;base64,${wasmFileBuffer.toString('base64')}`
+    /* @vite-ignore */ `data:application/wasm;base64,${wasmFileBuffer.toString('base64')}`
   )
   expect(importedWasmModule.add(0, 42)).toBe(42)
 })
@@ -43,7 +43,7 @@ test('supports imports from "data:application/wasm" URI with base64 encoding', a
 const isVm = process.execArgv.includes('--experimental-vm-modules')
 
 test('imports from "data:application/wasm" URI without explicit encoding fail', async () => {
-  const error = await getError(() => import(`data:application/wasm,${wasmFileBuffer.toString('base64')}`))
+  const error = await getError(() => import(/* @vite-ignore */ `data:application/wasm,${wasmFileBuffer.toString('base64')}`))
   if (isVm) {
     expect(error).toMatchInlineSnapshot(`[Error: Missing data URI encoding]`)
   }
@@ -54,7 +54,7 @@ test('imports from "data:application/wasm" URI without explicit encoding fail', 
 
 test('imports from "data:application/wasm" URI with invalid encoding fail', async () => {
   // @ts-expect-error import is not typed
-  const error = await getError(() => import('data:application/wasm;charset=utf-8,oops'))
+  const error = await getError(() => import(/* @vite-ignore */ 'data:application/wasm;charset=utf-8,oops'))
   if (isVm) {
     expect(error).toMatchInlineSnapshot(`[Error: Invalid data URI encoding: charset=utf-8]`)
   }


### PR DESCRIPTION
### Description

- related https://github.com/vitest-dev/vitest/pull/6724

I just noticed Vitest emits import analysis warning after the change https://github.com/vitest-dev/vitest/pull/6724. For now I added a bunch of `@vite-ignore` for our tests.

Alternatively, we can probably silence this by default since adding `@vite-ignore` might not be an option for existing users when it's coming from inlined dependency. I made a PR for this approach https://github.com/vitest-dev/vitest/pull/6785.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
