### PR TITLE
fix(vitest): silence import analysis warning

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -11,7 +11,7 @@ import { configDefaults, coverageConfigDefaults } from '../../defaults'
 import { generateScopedClassName } from '../../integrations/css/css-modules'
 import { resolveApiServerConfig } from '../config/resolveConfig'
 import { Vitest } from '../core'
-import { createViteLogger } from '../viteLogger'
+import { createViteLogger, silenceImportViteIgnoreWarning } from '../viteLogger'
 import { CoverageTransform } from './coverageTransform'
 import { CSSEnablerPlugin } from './cssEnabler'
 import { MocksPlugins } from './mocks'
@@ -140,6 +140,7 @@ export async function VitestPlugin(
             allowClearScreen: false,
           },
         )
+        config.customLogger = silenceImportViteIgnoreWarning(config.customLogger)
 
         // If "coverage.exclude" is not defined by user, add "test.include" to "coverage.exclude" automatically
         if (userConfig.coverage?.enabled && !userConfig.coverage.exclude && userConfig.include && config.test) {

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -6,7 +6,7 @@ import { deepMerge } from '@vitest/utils'
 import { basename, dirname, relative, resolve } from 'pathe'
 import { configDefaults } from '../../defaults'
 import { generateScopedClassName } from '../../integrations/css/css-modules'
-import { createViteLogger } from '../viteLogger'
+import { createViteLogger, silenceImportViteIgnoreWarning } from '../viteLogger'
 import { CoverageTransform } from './coverageTransform'
 import { CSSEnablerPlugin } from './cssEnabler'
 import { MocksPlugins } from './mocks'
@@ -132,6 +132,7 @@ export function WorkspaceVitestPlugin(
             allowClearScreen: false,
           },
         )
+        config.customLogger = silenceImportViteIgnoreWarning(config.customLogger)
 
         return config
       },

--- a/packages/vitest/src/node/viteLogger.ts
+++ b/packages/vitest/src/node/viteLogger.ts
@@ -135,3 +135,16 @@ export function createViteLogger(
 
   return logger
 }
+
+// silence warning by Vite for statically not analysizable dynamimc import
+export function silenceImportViteIgnoreWarning(logger: Logger): Logger {
+  return {
+    ...logger,
+    warn(msg, options) {
+      if (msg.includes('The above dynamic import cannot be analyzed by Vite')) {
+        return
+      }
+      logger.warn(msg, options)
+    },
+  }
+}

--- a/test/core/src/relative-import.ts
+++ b/test/core/src/relative-import.ts
@@ -1,3 +1,3 @@
 export function dynamicRelativeImport(file: string) {
-  return import(`./${file}.ts`)
+  return import(/* @vite-ignore */ `./${file}.ts`)
 }

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -90,7 +90,7 @@ test('dynamic import throws an error', async () => {
 test('can import @vite/client', async () => {
   const name = '@vite/client'
   await expect(import(name)).resolves.not.toThrow()
-  await expect(import(`/${name}`)).resolves.not.toThrow()
+  await expect(import(/* @vite-ignore */ `/${name}`)).resolves.not.toThrow()
 })
 
 describe('importing special files from node_modules', async () => {


### PR DESCRIPTION
### Description

Alternative to https://github.com/vitest-dev/vitest/pull/6784

Arbitrary dynamic import might be fairly common for Vitest users, so we can filter out this specific message from our logger.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
