### PR TITLE
chore: fix browser build plugin

### DIFF
--- a/packages/browser/src/client/vite.config.ts
+++ b/packages/browser/src/client/vite.config.ts
@@ -42,13 +42,14 @@ export default defineConfig({
         )
 
         const ui = resolve(root, 'ui/dist/client')
+        const uiEntryPoint = resolve(ui, 'index.html')
         const browser = resolve(root, 'browser/dist/client/__vitest__/')
 
         const timeout = setTimeout(
           () => console.log('[copy-ui-plugin] Waiting for UI to be built...'),
           1000,
         )
-        await waitFor(() => fs.existsSync(ui))
+        await waitFor(() => fs.existsSync(ui) && fs.existsSync(uiEntryPoint))
         clearTimeout(timeout)
 
         const files = globSync(['**/*'], { cwd: ui, expandDirectories: false })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Looks like on my Windows laptop the browser build plugin is finishing before Vite finish building the UI and so there is no UI entry point in the dist folder.

With this PR we ensure the `browser/dist/client/__vitest__` folder will always have at least the UI entry point.

/cc @patak-dev IIRC Vite will copy the entry point after building the assets, please confirm this (I think it is true: I deal this it in the PWA plugin)

✔️  confirmed (check step 10 here ;) ) https://vite-pwa-org.netlify.app/guide/cookbook.html#vite-build-cli

Vitest hanging when running any browser test with the UI in my local, running the `test:browser:preview` script  with `--reporter=hanging-process`:

![imagen](https://github.com/user-attachments/assets/40e951e1-5477-49f1-acb9-a8c918f823a6)

![imagen](https://github.com/user-attachments/assets/4fbae7f3-4037-49ef-913e-a972bd9cde1c)


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
