### PR TITLE
fix(vitest): decouple fake/real time in waitFor()'s check

### DIFF
--- a/packages/vitest/src/integrations/wait.ts
+++ b/packages/vitest/src/integrations/wait.ts
@@ -110,7 +110,7 @@ export function waitFor<T>(
     }
 
     timeoutId = setTimeout(handleTimeout, timeout)
-    intervalId = setInterval(checkCallback, interval)
+    intervalId = setInterval(checkCallback, vi.isFakeTimers() ? 20 : interval)
   })
 }
 

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -102,6 +102,20 @@ describe('waitFor', () => {
     vi.useRealTimers()
   })
 
+  test('fakeTimer long interval works', async () => {
+    vi.useFakeTimers()
+
+    await vi.waitFor(() => {
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve()
+        }, 60000)
+      })
+    }, { interval: 30000 })
+
+    vi.useRealTimers()
+  })
+
   test('callback stops running after timeout', async () => {
     let timedOut = false
     let callbackRanAfterTimeout = false


### PR DESCRIPTION
When running with fake timers, and when polling for promise to complete, make sure we do the poll in a short *real* time interval, independent of the fake time interval.

This makes it possible to use long time intervals in fake time without needing to wait for the corresponding amount of real time passing. A unit test is added to illustrate this behaviour: with the previous code, this unit test would have taken over a minute to complete, now it is near instantaneous.
