### PR TITLE
fix(vitest): Add missing defaults for server.deps.external

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -135,6 +135,11 @@ const config = {
     include: ['**/*.{test,spec}-d.?(c|m)[jt]s?(x)'],
     exclude: defaultExclude,
   },
+  server: { 
+    deps: {
+      external: [/\/node_modules\//]
+    }
+  },
   slowTestThreshold: 300,
   disableConsoleIntercept: false,
 } satisfies UserConfig


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #6806
According to the defaults described in the documentation: https://vitest.dev/config/#server-deps-external

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
