### PR TITLE
fix: `dangerouslyIgnoreUnhandledErrors` without base reporter

### DIFF
--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -94,7 +94,10 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
       ctx.state.catchError(err, type)
     },
     onFinished(files) {
-      return ctx.report('onFinished', files, ctx.state.getUnhandledErrors())
+      const errors = ctx.state.getUnhandledErrors()
+      ctx.checkUnhandledErrors(errors)
+
+      return ctx.report('onFinished', files, errors)
     },
     onCancel(reason) {
       ctx.cancelCurrentRun(reason)

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -90,11 +90,6 @@ export abstract class BaseReporter implements Reporter {
     this.end = performance.now()
 
     this.reportSummary(files, errors)
-    if (errors.length) {
-      if (!this.ctx.config.dangerouslyIgnoreUnhandledErrors) {
-        process.exitCode = 1
-      }
-    }
   }
 
   onTaskUpdate(packs: TaskResultPack[]) {

--- a/test/config/fixtures/dangerously-ignore-unhandled-errors/tests/throw-errors.test.ts
+++ b/test/config/fixtures/dangerously-ignore-unhandled-errors/tests/throw-errors.test.ts
@@ -1,0 +1,7 @@
+import { test } from "vitest"
+
+test("Some test", () => {
+  //
+})
+
+new Promise((_, reject) => reject(new Error("intentional unhandled error")))

--- a/test/config/test/dangerously-ignore-unhandled-errors.test.ts
+++ b/test/config/test/dangerously-ignore-unhandled-errors.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest'
+
+import { runVitest } from '../../test-utils'
+
+test('{ dangerouslyIgnoreUnhandledErrors: true }', async () => {
+  const { stderr, stdout, exitCode } = await runVitest({
+    root: 'fixtures/dangerously-ignore-unhandled-errors',
+    dangerouslyIgnoreUnhandledErrors: true,
+  })
+
+  expect(exitCode).toBe(0)
+  expect(stdout).toMatch('Vitest caught 1 unhandled error during the test run')
+  expect(stderr).toMatch('Error: intentional unhandled error')
+})
+
+test('{ dangerouslyIgnoreUnhandledErrors: true } without reporter', async () => {
+  const { exitCode } = await runVitest({
+    root: 'fixtures/dangerously-ignore-unhandled-errors',
+    dangerouslyIgnoreUnhandledErrors: true,
+    reporters: [{ onInit: () => {} }],
+  })
+
+  expect(exitCode).toBe(0)
+})
+
+test('{ dangerouslyIgnoreUnhandledErrors: false }', async () => {
+  const { stderr, stdout, exitCode } = await runVitest({
+    root: 'fixtures/dangerously-ignore-unhandled-errors',
+    dangerouslyIgnoreUnhandledErrors: false,
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stdout).toMatch('Vitest caught 1 unhandled error during the test run')
+  expect(stderr).toMatch('Error: intentional unhandled error')
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- `dangerouslyIgnoreUnhandledErrors` should work even when base reporter is not used

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
