### PR TITLE
fix: don't change the working directory when loading workspace projects

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -41,6 +41,7 @@ export async function createBrowserServer(
   const vite = await createViteServer({
     ...project.options, // spread project config inlined in root workspace config
     base: '/',
+    root: project.config.root,
     logLevel,
     customLogger: {
       ...logger,

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -41,7 +41,6 @@ export async function createBrowserServer(
   const vite = await createViteServer({
     ...project.options, // spread project config inlined in root workspace config
     base: '/',
-    root: project.config.root,
     logLevel,
     customLogger: {
       ...logger,

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -2,9 +2,8 @@ import type { Vitest } from '../core'
 import type { UserConfig, UserWorkspaceConfig, WorkspaceProjectConfiguration } from '../types/config'
 import type { WorkspaceProject } from '../workspace'
 import { existsSync, promises as fs } from 'node:fs'
-import { isMainThread } from 'node:worker_threads'
 import fg from 'fast-glob'
-import { dirname, relative, resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import { mergeConfig } from 'vite'
 import { configFiles as defaultConfigFiles } from '../../constants'
 import { initializeProject } from '../workspace'
@@ -49,41 +48,25 @@ export async function resolveWorkspace(
     return acc
   }, {} as UserConfig)
 
-  const cwd = process.cwd()
-
   const projects: WorkspaceProject[] = []
   const fileProjects = [...configFiles, ...nonConfigDirectories]
 
-  try {
-    // we have to resolve them one by one because CWD should depend on the project
-    for (const filepath of fileProjects) {
-      // if file leads to the root config, then we can just reuse it because we already initialized it
-      if (vitest.server.config.configFile === filepath) {
-        const project = await vitest._createCoreProject()
-        projects.push(project)
-        continue
-      }
-
-      const directory = filepath.endsWith('/')
-        ? filepath.slice(0, -1)
-        : dirname(filepath)
-
-      if (isMainThread) {
-        process.chdir(directory)
-      }
-      projects.push(
-        await initializeProject(
-          filepath,
-          vitest,
-          { workspaceConfigPath, test: cliOverrides },
-        ),
-      )
+  // we have to resolve them one by one because CWD should depend on the project
+  for (const filepath of fileProjects) {
+    // if file leads to the root config, then we can just reuse it because we already initialized it
+    if (vitest.server.config.configFile === filepath) {
+      const project = await vitest._createCoreProject()
+      projects.push(project)
+      continue
     }
-  }
-  finally {
-    if (isMainThread) {
-      process.chdir(cwd)
-    }
+
+    projects.push(
+      await initializeProject(
+        filepath,
+        vitest,
+        { workspaceConfigPath, test: cliOverrides },
+      ),
+    )
   }
 
   const projectPromises: Promise<WorkspaceProject>[] = []

--- a/test/workspaces/space_1/test/env-injected.spec.ts
+++ b/test/workspaces/space_1/test/env-injected.spec.ts
@@ -31,6 +31,9 @@ test('cwd is resolved correctly', () => {
 
   expect(process.env.ROOT_CWD_CONFIG).toBe(rootPath)
   expect(process.env.ROOT_CWD_SERVER).toBe(rootPath)
-  expect(process.env.SPACE_2_CWD_CONFIG).toBe(spaceRoot)
-  expect(process.env.SPACE_2_CWD_SERVER).toBe(spaceRoot)
+
+  // ideally, it should be a `spaceRoot`, but support was reverted
+  // in https://github.com/vitest-dev/vitest/pull/6811
+  expect(process.env.SPACE_2_CWD_CONFIG).toBe(rootPath)
+  expect(process.env.SPACE_2_CWD_SERVER).toBe(rootPath)
 })


### PR DESCRIPTION
### Description

Closes #6706
Fixes #6832

This behaviour is inconsistent with how the CWD works everywhere else (global setup files keep the original one; the plugin callbacks will also keep the original CWD). The team decided to revert it. 

We might explore loading projects in a separate process with a different `CWD` in the future.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
