### PR TITLE
fix: capture `unhandledRejection` even when base reporter is not used

### DIFF
--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -46,6 +46,7 @@ export class Logger {
     this.console = new Console({ stdout: outputStream, stderr: errorStream })
     this.logUpdate = createLogUpdate(this.outputStream)
     this._highlights.clear()
+    this.registerUnhandledRejection()
   }
 
   log(...args: any[]) {
@@ -316,5 +317,25 @@ export class Logger {
       this.printError(err, { fullStack: true })
     })
     this.log(c.red(divider()))
+  }
+
+  private registerUnhandledRejection() {
+    const onUnhandledRejection = (err: unknown) => {
+      process.exitCode = 1
+
+      this.printError(err, {
+        fullStack: true,
+        type: 'Unhandled Rejection',
+      })
+
+      this.error('\n\n')
+      process.exit()
+    }
+
+    process.on('unhandledRejection', onUnhandledRejection)
+
+    this.ctx.onClose(() => {
+      process.off('unhandledRejection', onUnhandledRejection)
+    })
   }
 }

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -59,11 +59,9 @@ export abstract class BaseReporter implements Reporter {
   private _lastRunTimer: NodeJS.Timeout | undefined
   private _lastRunCount = 0
   private _timeStart = new Date()
-  private _offUnhandledRejection?: () => void
 
   constructor(options: BaseOptions = {}) {
     this.isTTY = options.isTTY ?? ((isNode || isDeno) && process.stdout?.isTTY && !isCI)
-    this.registerUnhandledRejection()
   }
 
   get mode() {
@@ -72,9 +70,6 @@ export abstract class BaseReporter implements Reporter {
 
   onInit(ctx: Vitest) {
     this.ctx = ctx
-    ctx.onClose(() => {
-      this._offUnhandledRejection?.()
-    })
     ctx.logger.printBanner()
     this.start = performance.now()
   }
@@ -624,22 +619,6 @@ export abstract class BaseReporter implements Reporter {
         task: tasks[0],
       })
       errorDivider()
-    }
-  }
-
-  registerUnhandledRejection() {
-    const onUnhandledRejection = async (err: unknown) => {
-      process.exitCode = 1
-      this.ctx.logger.printError(err, {
-        fullStack: true,
-        type: 'Unhandled Rejection',
-      })
-      this.ctx.logger.error('\n\n')
-      process.exit()
-    }
-    process.on('unhandledRejection', onUnhandledRejection)
-    this._offUnhandledRejection = () => {
-      process.off('unhandledRejection', onUnhandledRejection)
     }
   }
 }

--- a/test/config/fixtures/unhandled-rejections/setup-unhandled-rejections.ts
+++ b/test/config/fixtures/unhandled-rejections/setup-unhandled-rejections.ts
@@ -1,0 +1,3 @@
+export function setup() {
+  void new Promise((_, reject) => reject(new Error('intentional unhandled rejection')))
+}

--- a/test/config/fixtures/unhandled-rejections/tests/example.test.ts
+++ b/test/config/fixtures/unhandled-rejections/tests/example.test.ts
@@ -1,0 +1,4 @@
+import { test } from "vitest"
+
+test("Some test", () => {})
+

--- a/test/config/test/unhandled-rejections.test.ts
+++ b/test/config/test/unhandled-rejections.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+
+import { runVitest } from '../../test-utils'
+
+test('unhandled rejections of main thread are reported even when no reporter is used', async () => {
+  const { stderr, exitCode } = await runVitest({
+    root: 'fixtures/unhandled-rejections',
+    globalSetup: ['setup-unhandled-rejections.ts'],
+    reporters: [{ onInit: () => {} }],
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain('Unhandled Rejection')
+  expect(stderr).toContain('Error: intentional unhandled rejection')
+  expect(stderr).toContain('setup-unhandled-rejections.ts:2:42')
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Users should see Vitest handling main thread's `unhandledRejection` even when their custom reporters are not extending Vitest's base reporter
- Basically this moves handling of `unhandledRejection` errors from reporter's responsibility to logger's

This is all preparations for larger reporter improvements. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
