### PR TITLE
feat(runner): test context can inject values from the config's `provide`

### DIFF
--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -176,8 +176,60 @@ const test = base.extend({
   ],
 })
 
-test('', () => {})
+test('works correctly')
 ```
+
+#### Default fixture
+
+Since Vitest 2.2, you can provide different values in different [projects](/guide/workspace). To enable this feature, pass down `{ injected: true }` to the options. If the key is not specified in the [project configuration](/config/#provide), then the default value will be used.
+
+:::code-group
+```ts [fixtures.test.ts]
+import { test as base } from 'vitest'
+
+const test = base.extend({
+  url: [
+    // default value if "url" is not defined in the config
+    'default',
+    // mark the fixure as "injected" to allow the override
+    { injected: true },
+  ],
+})
+
+test('works correctly', ({ url }) => {
+  // url is "/default" in "project-new"
+  // url is "/full" in "project-full"
+  // url is "/empty" in "project-empty"
+})
+```
+```ts [vitest.workspace.ts]
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  {
+    test: {
+      name: 'project-new',
+    },
+  },
+  {
+    test: {
+      name: 'project-full',
+      provide: {
+        url: '/full',
+      },
+    },
+  },
+  {
+    test: {
+      name: 'project-empty',
+      provide: {
+        url: '/empty',
+      },
+    },
+  },
+])
+```
+:::
 
 #### TypeScript
 
@@ -194,7 +246,7 @@ const myTest = test.extend<MyFixtures>({
   archive: []
 })
 
-myTest('', (context) => {
+myTest('types are defined correctly', (context) => {
   expectTypeOf(context.todos).toEqualTypeOf<number[]>()
   expectTypeOf(context.archive).toEqualTypeOf<number[]>()
 })

--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -6,6 +6,10 @@ export interface FixtureItem extends FixtureOptions {
   prop: string
   value: any
   /**
+   * Indicated if the injected value should be preferred over the fixture value
+   */
+  injected?: boolean
+  /**
    * Indicates whether the fixture is a function
    */
   isFn: boolean
@@ -17,11 +21,12 @@ export interface FixtureItem extends FixtureOptions {
 
 export function mergeContextFixtures(
   fixtures: Record<string, any>,
-  context: { fixtures?: FixtureItem[] } = {},
+  context: { fixtures?: FixtureItem[] },
+  inject: (key: string) => unknown,
 ): {
     fixtures?: FixtureItem[]
   } {
-  const fixtureOptionKeys = ['auto']
+  const fixtureOptionKeys = ['auto', 'injected']
   const fixtureArray: FixtureItem[] = Object.entries(fixtures).map(
     ([prop, value]) => {
       const fixtureItem = { value } as FixtureItem
@@ -34,7 +39,10 @@ export function mergeContextFixtures(
       ) {
         // fixture with options
         Object.assign(fixtureItem, value[1])
-        fixtureItem.value = value[0]
+        const userValue = value[0]
+        fixtureItem.value = fixtureItem.injected
+          ? (inject(prop) ?? userValue)
+          : userValue
       }
 
       fixtureItem.prop = prop

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -710,7 +710,11 @@ export function createTaskCollector(
   }
 
   taskFn.extend = function (fixtures: Fixtures<Record<string, any>>) {
-    const _context = mergeContextFixtures(fixtures, context)
+    const _context = mergeContextFixtures(
+      fixtures,
+      context || {},
+      (key: string) => getRunner().injectValue?.(key),
+    )
 
     return createTest(function fn(
       name: string | Function,

--- a/packages/runner/src/types/runner.ts
+++ b/packages/runner/src/types/runner.ts
@@ -148,6 +148,10 @@ export interface VitestRunner {
    */
   importFile: (filepath: string, source: VitestRunnerImportSource) => unknown
   /**
+   * Function that is called when the runner attempts to get the value when `test.extend` is used with `{ injected: true }`
+   */
+  injectValue?: (key: string) => unknown
+  /**
    * Publicly available configuration.
    */
   config: VitestRunnerConfig

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -16,6 +16,7 @@ import type { VitestExecutor } from '../execute'
 import { getState, GLOBAL_EXPECT, setState } from '@vitest/expect'
 import { getNames, getTestName, getTests } from '@vitest/runner/utils'
 import { createExpect } from '../../integrations/chai/index'
+import { inject } from '../../integrations/inject'
 import { getSnapshotClient } from '../../integrations/snapshot/chai'
 import { vi } from '../../integrations/vi'
 import { rpc } from '../rpc'
@@ -87,6 +88,12 @@ export class VitestTestRunner implements VitestRunner {
 
   onCancel(_reason: CancelReason) {
     this.cancelRun = true
+  }
+
+  injectValue(key: string) {
+    // inject has a very limiting type controlled by ProvidedContext
+    // some tests override it which causes the build to fail
+    return (inject as any)(key)
   }
 
   async onBeforeRunTask(test: Task) {

--- a/test/workspaces/globalTest.ts
+++ b/test/workspaces/globalTest.ts
@@ -9,6 +9,8 @@ declare module 'vitest' {
     invalidValue: unknown
     projectConfigValue: boolean
     globalConfigValue: boolean
+
+    providedConfigValue: string
   }
 }
 

--- a/test/workspaces/globalTest.ts
+++ b/test/workspaces/globalTest.ts
@@ -37,8 +37,8 @@ export async function teardown() {
   try {
     assert.ok(results.success)
     assert.equal(results.numTotalTestSuites, 28)
-    assert.equal(results.numTotalTests, 31)
-    assert.equal(results.numPassedTests, 31)
+    assert.equal(results.numTotalTests, 33)
+    assert.equal(results.numPassedTests, 33)
     assert.ok(results.coverageMap)
 
     const shared = results.testResults.filter((r: any) => r.name.includes('space_shared/test.spec.ts'))

--- a/test/workspaces/space_shared/test.spec.ts
+++ b/test/workspaces/space_shared/test.spec.ts
@@ -4,6 +4,19 @@ declare global {
   const testValue: string
 }
 
+const custom = it.extend({
+  providedConfigValue: ['default value', { injected: true }],
+})
+
+custom('provided config value is injected', ({ providedConfigValue }) => {
+  expect(providedConfigValue).toBe(
+    // happy-dom provides the value in the workspace config
+    expect.getState().environment === 'node'
+      ? 'default value'
+      : 'actual config value',
+  )
+})
+
 it('the same file works with different projects', () => {
   expect(testValue).toBe(expect.getState().environment === 'node' ? 'node' : 'jsdom')
 })

--- a/test/workspaces/vitest.workspace.ts
+++ b/test/workspaces/vitest.workspace.ts
@@ -13,6 +13,9 @@ export default defineWorkspace([
       root: './space_shared',
       environment: 'happy-dom',
       setupFiles: ['./setup.jsdom.ts'],
+      provide: {
+        providedConfigValue: 'actual config value',
+      },
     },
   }),
   Promise.resolve({


### PR DESCRIPTION
### Description

Continuation of #6253
Related to #6226

This PR allows defining a context value that can be overridden by the project config:

```ts
// vitest.workspace.ts
export default defineWorkspace([
  {
    test: {
      environment: 'jsdom',
      provide: {
        myValue: 'injected',
      },
    },
  },
  {
    test: {
      environment: 'node',
    },
  },
])
```

```ts
const test = baseTest.extend({
  myValue: ['default', { injected: true }]
})

test('some test', ({ myValue }) => {
  // for the jsdom environment
  expect(myValue).toBe('injected')
  // for the node environment
  expect(myValue).toBe('default')
})
```

TODO
- [x] Docs (add for passing down values between the config and tests + context's `injected`)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
