### PR TITLE
fix(expect): pass current equality testers to asymmetric matcher

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
+import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import type { Tester, TesterContext } from './types'
 import { isObject } from '@vitest/utils'
 
@@ -38,7 +39,7 @@ export function equals(
 
 const functionToString = Function.prototype.toString
 
-export function isAsymmetric(obj: any) {
+export function isAsymmetric(obj: any): obj is AsymmetricMatcher<any> {
   return (
     !!obj
     && typeof obj === 'object'
@@ -67,7 +68,7 @@ export function hasAsymmetric(obj: any, seen = new Set()): boolean {
   return false
 }
 
-function asymmetricMatch(a: any, b: any) {
+function asymmetricMatch(a: any, b: any, customTesters: Array<Tester>) {
   const asymmetricA = isAsymmetric(a)
   const asymmetricB = isAsymmetric(b)
 
@@ -76,11 +77,11 @@ function asymmetricMatch(a: any, b: any) {
   }
 
   if (asymmetricA) {
-    return a.asymmetricMatch(b)
+    return a.asymmetricMatch(b, customTesters)
   }
 
   if (asymmetricB) {
-    return b.asymmetricMatch(a)
+    return b.asymmetricMatch(a, customTesters)
   }
 }
 
@@ -96,7 +97,7 @@ function eq(
 ): boolean {
   let result = true
 
-  const asymmetricResult = asymmetricMatch(a, b)
+  const asymmetricResult = asymmetricMatch(a, b, customTesters)
   if (asymmetricResult !== undefined) {
     return asymmetricResult
   }

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -196,6 +196,36 @@ describe('jest-expect', () => {
     }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { sum: 0.30000000000000004 } to deeply equal { sum: NumberCloseTo 0.4 (2 digits) }]`)
   })
 
+  it('asymmetric matchers and equality testers', () => {
+    // iterable equality testers
+    expect([new Set(['x'])]).toEqual(
+      expect.arrayContaining([new Set(['x'])]),
+    )
+    expect([new Set()]).not.toEqual(
+      expect.arrayContaining([new Set(['x'])]),
+    )
+    expect({ foo: new Set(['x']) }).toEqual(
+      expect.objectContaining({ foo: new Set(['x']) }),
+    )
+    expect({ foo: new Set() }).not.toEqual(
+      expect.objectContaining({ foo: new Set(['x']) }),
+    )
+
+    // `toStrictEqual` testers
+    class Stock {
+      constructor(public type: string) {}
+    }
+    expect([new Stock('x')]).toEqual(
+      expect.arrayContaining([{ type: 'x' }]),
+    )
+    expect([new Stock('x')]).not.toStrictEqual(
+      expect.arrayContaining([{ type: 'x' }]),
+    )
+    expect([new Stock('x')]).toStrictEqual(
+      expect.arrayContaining([new Stock('x')]),
+    )
+  })
+
   it('asymmetric matchers negate', () => {
     expect('bar').toEqual(expect.not.stringContaining('zoo'))
     expect('bar').toEqual(expect.not.stringMatching(/zoo/))


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6820

This is breaking but this behavior probably makes more sense. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
