### PR TITLE
feat(reporter): added support function type support to classname option in the junit reporter

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -13,7 +13,7 @@ import { IndentedLogger } from './renderers/indented-logger'
 
 export interface JUnitOptions {
   outputFile?: string
-  classname?: string
+  classname?: string | ((task: Task) => string)
   suiteName?: string
   /**
    * Write <system-out> and <system-err> for console output
@@ -198,7 +198,9 @@ export class JUnitReporter implements Reporter {
       await this.writeElement(
         'testcase',
         {
-          classname: this.options.classname ?? filename,
+          classname: typeof this.options.classname === 'function'
+            ? this.options.classname(task)
+            : this.options.classname ?? filename,
           file: this.options.addFileAttribute ? filename : undefined,
           name: task.name,
           time: getDuration(task),

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -14,6 +14,35 @@ const file: File = {
 }
 file.file = file
 
+const passedFile: File = {
+  id: '1223128da3',
+  name: 'test/core/test/basic.test.ts',
+  type: 'suite',
+  meta: {},
+  mode: 'run',
+  filepath: '/vitest/test/core/test/basic.test.ts',
+  result: { state: 'pass', duration: 145.99284195899963 },
+  tasks: [
+    {
+      id: '1223128da3_0_0',
+      type: 'test',
+      name: 'Math.sqrt()',
+      mode: 'run',
+      fails: undefined,
+      meta: {},
+      file,
+      result: {
+        state: 'pass',
+        duration: 1.4422860145568848,
+      },
+      context: null as any,
+    },
+  ],
+  projectName: '',
+  file: null!,
+}
+passedFile.file = passedFile
+
 const suite: Suite = {
   id: '1223128da3_0',
   type: 'suite',
@@ -176,5 +205,6 @@ file.tasks = [suite]
 suite.tasks = tasks
 
 const files = [file]
+const passedFiles = [passedFile]
 
-export { files }
+export { files, passedFiles }

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -14,6 +14,28 @@ exports[`JUnit reporter 1`] = `
 "
 `;
 
+exports[`JUnit reporter with custom function classname 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
+        <testcase classname="file:test/core/test/basic.test.ts" name="Math.sqrt()" time="0.001442286">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
+exports[`JUnit reporter with custom string classname 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
+        <testcase classname="my-custom-classname" name="Math.sqrt()" time="0.001442286">
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
 exports[`JUnit reporter with outputFile 1`] = `
 "JUNIT report written to <process-cwd>/report.xml
 "
@@ -58,6 +80,17 @@ exports[`JUnit reporter with outputFile object in non-existing directory 1`] = `
 exports[`JUnit reporter with outputFile object in non-existing directory 2`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
 <testsuites name="vitest tests" tests="0" failures="0" errors="0" time="0">
+</testsuites>
+"
+`;
+
+exports[`JUnit reporter without classname 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+    <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
+        <testcase classname="test/core/test/basic.test.ts" name="Math.sqrt()" time="0.001442286">
+        </testcase>
+    </testsuite>
 </testsuites>
 "
 `;

--- a/test/reporters/tests/reporters.spec.ts
+++ b/test/reporters/tests/reporters.spec.ts
@@ -6,7 +6,7 @@ import { JUnitReporter } from '../../../packages/vitest/src/node/reporters/junit
 import { TapReporter } from '../../../packages/vitest/src/node/reporters/tap'
 import { TapFlatReporter } from '../../../packages/vitest/src/node/reporters/tap-flat'
 import { getContext } from '../src/context'
-import { files } from '../src/data'
+import { files, passedFiles } from '../src/data'
 
 const beautify = (json: string) => JSON.parse(json)
 
@@ -55,6 +55,48 @@ test('JUnit reporter', async () => {
   // Act
   await reporter.onInit(context.vitest)
   await reporter.onFinished([])
+
+  // Assert
+  expect(context.output).toMatchSnapshot()
+})
+
+test('JUnit reporter without classname', async () => {
+  // Arrange
+  const reporter = new JUnitReporter({})
+  const context = getContext()
+
+  // Act
+  await reporter.onInit(context.vitest)
+
+  await reporter.onFinished(passedFiles)
+
+  // Assert
+  expect(context.output).toMatchSnapshot()
+})
+
+test('JUnit reporter with custom string classname', async () => {
+  // Arrange
+  const reporter = new JUnitReporter({ classname: 'my-custom-classname' })
+  const context = getContext()
+
+  // Act
+  await reporter.onInit(context.vitest)
+
+  await reporter.onFinished(passedFiles)
+
+  // Assert
+  expect(context.output).toMatchSnapshot()
+})
+
+test('JUnit reporter with custom function classname', async () => {
+  // Arrange
+  const reporter = new JUnitReporter({ classname: task => `file:${task.file.name}` })
+  const context = getContext()
+
+  // Act
+  await reporter.onInit(context.vitest)
+
+  await reporter.onFinished(passedFiles)
 
   // Assert
   expect(context.output).toMatchSnapshot()


### PR DESCRIPTION
### Description

This PR adds support for a function as the classname option for the junit reporter.
It is currently possible to specify a static string as the classname of the junit reporter but it is not flexible enough in some case.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
