### PR TITLE
fix(vite-node): top-level throw in module is not reported properly

### DIFF
--- a/packages/vite-node/src/hmr/hmr.ts
+++ b/packages/vite-node/src/hmr/hmr.ts
@@ -160,7 +160,7 @@ async function fetchUpdate(
   }
 }
 
-function warnFailedFetch(err: any, path: string | string[]) {
+function warnFailedFetch(err: unknown, path: string | string[]) {
   if (!(err instanceof Error) || !err.message.match('fetch')) {
     console.error(err)
   }

--- a/packages/vite-node/src/hmr/hmr.ts
+++ b/packages/vite-node/src/hmr/hmr.ts
@@ -160,8 +160,8 @@ async function fetchUpdate(
   }
 }
 
-function warnFailedFetch(err: Error, path: string | string[]) {
-  if (!err.message.match('fetch')) {
+function warnFailedFetch(err: any, path: string | string[]) {
+  if (!(err instanceof Error) || !err.message.match('fetch')) {
     console.error(err)
   }
 

--- a/test/vite-node/src/hmr-throw.js
+++ b/test/vite-node/src/hmr-throw.js
@@ -1,0 +1,11 @@
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {})
+  if (import.meta.hot.data.value == null) {
+    import.meta.hot.data.value = 0
+  }
+  else {
+    // eslint-disable-next-line no-throw-literal
+    throw 'some error'
+  }
+}
+console.error('ready')

--- a/test/vite-node/test/hmr.test.ts
+++ b/test/vite-node/test/hmr.test.ts
@@ -15,3 +15,16 @@ test('hmr.accept works correctly', async () => {
   await viteNode.waitForStderr('Accept')
   await viteNode.waitForStdout(`[vite-node] hot updated: ${scriptFile}`)
 })
+
+test('can handle top-level throw in self-accepting module', async () => {
+  const scriptFile = resolve(__dirname, '../src/hmr-throw.js')
+
+  const { viteNode } = await runViteNodeCli('--watch', scriptFile)
+
+  await viteNode.waitForStderr('ready')
+
+  editFile(scriptFile, content => `${content}\nconsole.error("done")`)
+
+  await viteNode.waitForStderr('some error')
+  await viteNode.waitForStderr(`[hmr] Failed to reload ${scriptFile}. This could be due to syntax errors or importing non-existent modules. (see errors above)`)
+})


### PR DESCRIPTION
### Description

A `throw` statement in a watched module can sometimes cause `vite-node` itself to crash (when trying to report that error), leading to the original error being lost.

Here is an example of this happening:
https://stackblitz.com/edit/vitest-dev-vitest-agi4oq?file=basic.ts

If you edit the file after the `ready` message is printed, `vite-node` will print the following error:

```
[vite-node] Failed to execute file: 
 TypeError: Cannot read properties of undefined (reading 'match')
    at warnFailedFetch (file:///home/projects/vitest-dev-vitest-agi4oq/node_modules/vite-node/dist/chunk-hmr.mjs:149:20)
    at fetchUpdate (file:///home/projects/vitest-dev-vitest-agi4oq/node_modules/vite-node/dist/chunk-hmr.mjs:137:7)
    at async queueUpdate (file:///home/projects/vitest-dev-vitest-agi4oq/node_modules/vite-node/dist/chunk-hmr.mjs:113:6)
    at async Module.handleMessage (file:///home/projects/vitest-dev-vitest-agi4oq/node_modules/vite-node/dist/chunk-hmr.mjs:164:7)
```

### Explanation

This happens when a module is reloaded and throws something that is not an `Error`, e.g. a string.

This error propagates from `runModule()`
https://github.com/vitest-dev/vitest/blob/1a8d67090f00917cb4f31a41df9d7fd4d94277d9/packages/vite-node/src/client.ts#L508-L510

to `warnFailedFetch()`, where it fails at line 164 when it tries to call `match` on a non-existing `message` property of a string:

https://github.com/vitest-dev/vitest/blob/1a8d67090f00917cb4f31a41df9d7fd4d94277d9/packages/vite-node/src/hmr/hmr.ts#L163-L166

### Solution

The easiest solution is to check if the error is actually an `Error` when printing before reading the `message` property.

I thought of wrapping the thrown object in an `Error` with `cause` in `runModule()`, but that would change how the error message is shown (since now the  message and stacktrace would be from that error and not the original error).
