### PR TITLE
fix(coverage): report uncovered files when re-run by `enter` or `'a'`

### DIFF
--- a/test/coverage-test/test/all.test.ts
+++ b/test/coverage-test/test/all.test.ts
@@ -3,8 +3,7 @@ import { readCoverageMap, runVitest, test } from '../utils'
 
 test('{ all: true } includes uncovered files', async () => {
   await runVitest({
-    include: ['fixtures/test/**'],
-    exclude: ['**/virtual-files-**', '**/custom-1-syntax**'],
+    include: ['fixtures/test/math.test.ts', 'fixtures/test/even.test.ts'],
     coverage: {
       include: ['fixtures/src/**'],
       all: true,
@@ -24,7 +23,7 @@ test('{ all: true } includes uncovered files', async () => {
 
 test('{ all: false } excludes uncovered files', async () => {
   await runVitest({
-    include: ['fixtures/test/**'],
+    include: ['fixtures/test/math.test.ts', 'fixtures/test/even.test.ts'],
     exclude: ['**/virtual-files-**', '**/custom-1-syntax**'],
     coverage: {
       include: ['fixtures/src/**'],
@@ -36,9 +35,46 @@ test('{ all: false } excludes uncovered files', async () => {
   const coverageMap = await readCoverageMap()
   const files = coverageMap.files()
 
-  expect(files.find(file => file.includes('untested-file'))).toBeFalsy()
-  expect(files.length).toBeGreaterThanOrEqual(3)
+  // Only executed files should be present on report
+  expect(files).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/even.ts",
+      "<process-cwd>/fixtures/src/math.ts",
+    ]
+  `)
+})
 
-  // Directories starting with dot should be excluded, check for ".should-be-excluded-from-coverage/excluded-from-coverage.ts"
-  expect(files.find(file => file.includes('excluded-from-coverage'))).toBeFalsy()
+test('{ all: true } includes uncovered files after watch-mode re-run', async () => {
+  const { vitest, ctx } = await runVitest({
+    watch: true,
+    include: ['fixtures/test/math.test.ts', 'fixtures/test/even.test.ts'],
+    coverage: {
+      include: ['fixtures/src/**'],
+      all: true,
+      reporter: 'json',
+    },
+  })
+
+  {
+    const coverageMap = await readCoverageMap()
+    const files = coverageMap.files()
+
+    expect(files).toContain('<process-cwd>/fixtures/src/untested-file.ts')
+    expect(files.length).toBeGreaterThanOrEqual(3)
+  }
+
+  vitest.write('a')
+
+  await vitest.waitForStdout('RERUN')
+  await vitest.waitForStdout('rerun all tests')
+  await vitest.waitForStdout('Waiting for file changes')
+  await ctx!.close()
+
+  {
+    const coverageMap = await readCoverageMap()
+    const files = coverageMap.files()
+
+    expect(files).toContain('<process-cwd>/fixtures/src/untested-file.ts')
+    expect(files.length).toBeGreaterThanOrEqual(3)
+  }
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Fixes bug reported on Discord:

> Reproduction: https://stackblitz.com/edit/vitest-dev-vitest-mxhjvd 
> 
> In this reproduction, basic2.ts is not covered by tests, but also not imported by any file in the repo (the only imported is commented-out). 
> 
> Do the following:
> 
> 1. Stop the command line script
> 2. Run npx vitest --coverage
> 3. Observe that basic2.ts is red (uncovered)
> 4. Press Enter to re-run the test
> 5. Observe that basic2.ts is not in the list anymore and coverage is green.


This has broken in `1.6.0`:

![image](https://github.com/user-attachments/assets/84a40ada-1c62-4767-afd0-812fd944db97)



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
