### PR TITLE
fix(browser): stop the browser rpc when the pool is closed

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -77,7 +77,8 @@ export class Vitest {
 
   private coreWorkspaceProject!: WorkspaceProject
 
-  private resolvedProjects: WorkspaceProject[] = []
+  /** @private */
+  public resolvedProjects: WorkspaceProject[] = []
   public projects: WorkspaceProject[] = []
 
   public distPath = distDir

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -194,6 +194,7 @@ export interface BrowserServerStateContext {
 export interface BrowserOrchestrator {
   createTesters: (files: string[]) => Promise<void>
   onCancel: (reason: CancelReason) => Promise<void>
+  $close: () => void
 }
 
 export interface BrowserServerState {


### PR DESCRIPTION
### Description

Related #6738

This is not a fix, but it does make the behaviour more consistent.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
