### PR TITLE
fix(browser): support non US key input

### DIFF
--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -72,6 +72,10 @@ export const keyboardCleanup: UserEventCommand<(state: KeyboardState) => Promise
   }
 }
 
+// fallback to insertText for non US key
+// https://github.com/microsoft/playwright/blob/50775698ae13642742f2a1e8983d1d686d7f192d/packages/playwright-core/src/server/input.ts#L95
+const VALID_KEYS = new Set(['Escape', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'Backquote', '`', '~', 'Digit1', '1', '!', 'Digit2', '2', '@', 'Digit3', '3', '#', 'Digit4', '4', '$', 'Digit5', '5', '%', 'Digit6', '6', '^', 'Digit7', '7', '&', 'Digit8', '8', '*', 'Digit9', '9', '(', 'Digit0', '0', ')', 'Minus', '-', '_', 'Equal', '=', '+', 'Backslash', '\\', '|', 'Backspace', 'Tab', 'KeyQ', 'q', 'Q', 'KeyW', 'w', 'W', 'KeyE', 'e', 'E', 'KeyR', 'r', 'R', 'KeyT', 't', 'T', 'KeyY', 'y', 'Y', 'KeyU', 'u', 'U', 'KeyI', 'i', 'I', 'KeyO', 'o', 'O', 'KeyP', 'p', 'P', 'BracketLeft', '[', '{', 'BracketRight', ']', '}', 'CapsLock', 'KeyA', 'a', 'A', 'KeyS', 's', 'S', 'KeyD', 'd', 'D', 'KeyF', 'f', 'F', 'KeyG', 'g', 'G', 'KeyH', 'h', 'H', 'KeyJ', 'j', 'J', 'KeyK', 'k', 'K', 'KeyL', 'l', 'L', 'Semicolon', ';', ':', 'Quote', '\'', '"', 'Enter', '\n', '\r', 'ShiftLeft', 'Shift', 'KeyZ', 'z', 'Z', 'KeyX', 'x', 'X', 'KeyC', 'c', 'C', 'KeyV', 'v', 'V', 'KeyB', 'b', 'B', 'KeyN', 'n', 'N', 'KeyM', 'm', 'M', 'Comma', ',', '<', 'Period', '.', '>', 'Slash', '/', '?', 'ShiftRight', 'ControlLeft', 'Control', 'MetaLeft', 'Meta', 'AltLeft', 'Alt', 'Space', ' ', 'AltRight', 'AltGraph', 'MetaRight', 'ContextMenu', 'ControlRight', 'PrintScreen', 'ScrollLock', 'Pause', 'PageUp', 'PageDown', 'Insert', 'Delete', 'Home', 'End', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'NumLock', 'NumpadDivide', 'NumpadMultiply', 'NumpadSubtract', 'Numpad7', 'Numpad8', 'Numpad9', 'Numpad4', 'Numpad5', 'Numpad6', 'NumpadAdd', 'Numpad1', 'Numpad2', 'Numpad3', 'Numpad0', 'NumpadDecimal', 'NumpadEnter'])
+
 export async function keyboardImplementation(
   pressed: Set<string>,
   provider: BrowserProvider,
@@ -91,7 +95,9 @@ export async function keyboardImplementation(
       // together, and call `type` once for all non special keys,
       // and then `press` for special keys
       if (pressed.has(key)) {
-        await page.keyboard.up(key)
+        if (VALID_KEYS.has(key)) {
+          await page.keyboard.up(key)
+        }
         pressed.delete(key)
       }
 
@@ -102,11 +108,18 @@ export async function keyboardImplementation(
         }
 
         for (let i = 1; i <= repeat; i++) {
-          await page.keyboard.down(key)
+          if (VALID_KEYS.has(key)) {
+            await page.keyboard.down(key)
+          }
+          else {
+            await page.keyboard.insertText(key)
+          }
         }
 
         if (releaseSelf) {
-          await page.keyboard.up(key)
+          if (VALID_KEYS.has(key)) {
+            await page.keyboard.up(key)
+          }
         }
         else {
           pressed.add(key)
@@ -116,7 +129,9 @@ export async function keyboardImplementation(
 
     if (!skipRelease && pressed.size) {
       for (const key of pressed) {
-        await page.keyboard.up(key)
+        if (VALID_KEYS.has(key)) {
+          await page.keyboard.up(key)
+        }
       }
     }
   }

--- a/packages/browser/src/node/commands/keyboard.ts
+++ b/packages/browser/src/node/commands/keyboard.ts
@@ -76,6 +76,37 @@ export const keyboardCleanup: UserEventCommand<(state: KeyboardState) => Promise
 // https://github.com/microsoft/playwright/blob/50775698ae13642742f2a1e8983d1d686d7f192d/packages/playwright-core/src/server/input.ts#L95
 const VALID_KEYS = new Set(['Escape', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'Backquote', '`', '~', 'Digit1', '1', '!', 'Digit2', '2', '@', 'Digit3', '3', '#', 'Digit4', '4', '$', 'Digit5', '5', '%', 'Digit6', '6', '^', 'Digit7', '7', '&', 'Digit8', '8', '*', 'Digit9', '9', '(', 'Digit0', '0', ')', 'Minus', '-', '_', 'Equal', '=', '+', 'Backslash', '\\', '|', 'Backspace', 'Tab', 'KeyQ', 'q', 'Q', 'KeyW', 'w', 'W', 'KeyE', 'e', 'E', 'KeyR', 'r', 'R', 'KeyT', 't', 'T', 'KeyY', 'y', 'Y', 'KeyU', 'u', 'U', 'KeyI', 'i', 'I', 'KeyO', 'o', 'O', 'KeyP', 'p', 'P', 'BracketLeft', '[', '{', 'BracketRight', ']', '}', 'CapsLock', 'KeyA', 'a', 'A', 'KeyS', 's', 'S', 'KeyD', 'd', 'D', 'KeyF', 'f', 'F', 'KeyG', 'g', 'G', 'KeyH', 'h', 'H', 'KeyJ', 'j', 'J', 'KeyK', 'k', 'K', 'KeyL', 'l', 'L', 'Semicolon', ';', ':', 'Quote', '\'', '"', 'Enter', '\n', '\r', 'ShiftLeft', 'Shift', 'KeyZ', 'z', 'Z', 'KeyX', 'x', 'X', 'KeyC', 'c', 'C', 'KeyV', 'v', 'V', 'KeyB', 'b', 'B', 'KeyN', 'n', 'N', 'KeyM', 'm', 'M', 'Comma', ',', '<', 'Period', '.', '>', 'Slash', '/', '?', 'ShiftRight', 'ControlLeft', 'Control', 'MetaLeft', 'Meta', 'AltLeft', 'Alt', 'Space', ' ', 'AltRight', 'AltGraph', 'MetaRight', 'ContextMenu', 'ControlRight', 'PrintScreen', 'ScrollLock', 'Pause', 'PageUp', 'PageDown', 'Insert', 'Delete', 'Home', 'End', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'NumLock', 'NumpadDivide', 'NumpadMultiply', 'NumpadSubtract', 'Numpad7', 'Numpad8', 'Numpad9', 'Numpad4', 'Numpad5', 'Numpad6', 'NumpadAdd', 'Numpad1', 'Numpad2', 'Numpad3', 'Numpad0', 'NumpadDecimal', 'NumpadEnter'])
 
+// make string work as codepoint array to cheat `parseKeyDef` implementation
+// '😊'.length = 2    => createCodepointArrayProxy('😊').length = 1
+// '😊'[0] = '\ud83d' => createCodepointArrayProxy('😊')[0] = '😊
+function createCodepointArrayString(s: string): string {
+  const codepoints = [...s]
+  if (codepoints.length === s.length) {
+    return s
+  }
+  return new Proxy({
+    length: codepoints.length,
+    toString() {
+      return s
+    },
+    slice(start?: number, end?: number) {
+      return createCodepointArrayString(
+        codepoints.slice(start, end).join(''),
+      )
+    },
+  }, {
+    get(target, p, receiver) {
+      if (typeof p === 'string') {
+        const i = Number.parseInt(p)
+        if (i >= 0 && i < codepoints.length) {
+          return codepoints[i]
+        }
+      }
+      return Reflect.get(target, p, receiver)
+    },
+  }) as any
+}
+
 export async function keyboardImplementation(
   pressed: Set<string>,
   provider: BrowserProvider,
@@ -86,7 +117,7 @@ export async function keyboardImplementation(
 ) {
   if (provider instanceof PlaywrightBrowserProvider) {
     const page = provider.getPage(contextId)
-    const actions = parseKeyDef(defaultKeyMap, text)
+    const actions = parseKeyDef(defaultKeyMap, createCodepointArrayString(text))
 
     for (const { releasePrevious, releaseSelf, repeat, keyDef } of actions) {
       const key = keyDef.key!

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -7,7 +7,7 @@ test('non US keys', async () => {
     <input placeholder="emoji" />
   `;
   await userEvent.type(page.getByPlaceholder("#7396"), 'éèù')
-  expect.element(page.getByPlaceholder("#7396")).toHaveValue('éèù')
+  await expect.element(page.getByPlaceholder("#7396")).toHaveValue('éèù')
 
   try {
     // surrogate pair is still inconsistent
@@ -15,6 +15,6 @@ test('non US keys', async () => {
     // - webdriverio: throw an error
     // - preview: works
     await userEvent.type(page.getByPlaceholder("emoji"), '😊')
-    expect.element(page.getByPlaceholder("emoji")).toHaveValue('😊')
+    await expect.element(page.getByPlaceholder("emoji")).toHaveValue('😊')
   } catch {}
 })

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { userEvent, page, server } from '@vitest/browser/context'
+import { userEvent, page } from '@vitest/browser/context'
 
 test('non US keys', async () => {
   document.body.innerHTML = `

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -3,14 +3,34 @@ import { userEvent, page, server } from '@vitest/browser/context'
 
 test('non US keys', async () => {
   document.body.innerHTML = `
-    <input placeholder="#7396" />
-    <input placeholder="emoji" />
+    <input placeholder="type-#7396" />
+    <input placeholder="fill-#7396" />
+    <input placeholder="type-emoji" />
+    <input placeholder="fill-emoji" />
   `;
-  await userEvent.type(page.getByPlaceholder("#7396"), 'éèù')
-  await expect.element(page.getByPlaceholder("#7396")).toHaveValue('éèù')
 
-  if (server.provider !== 'webdriverio') {
-    await userEvent.type(page.getByPlaceholder("emoji"), '😊')
-    await expect.element(page.getByPlaceholder("emoji")).toHaveValue('😊')
+  await userEvent.type(page.getByPlaceholder("type-#7396"), 'éèù')
+  await expect.element(page.getByPlaceholder("type-#7396")).toHaveValue('éèù')
+  await userEvent.fill(page.getByPlaceholder("fill-#7396"), 'éèù')
+  await expect.element(page.getByPlaceholder("fill-#7396")).toHaveValue('éèù')
+
+  // playwright: garbled characters
+  // webdriverio: error
+  // preview: ok
+  try {
+    await userEvent.fill(page.getByPlaceholder("type-emoji"), '😊😍')
+    await expect.element(page.getByPlaceholder("type-emoji")).toHaveValue('😊😍')
+  } catch (e) {
+    console.error(e)
+  }
+
+  // playwright: ok
+  // webdriverio: error
+  // preview: ok
+  try {
+    await userEvent.type(page.getByPlaceholder("fill-emoji"), '😊😍')
+    await expect.element(page.getByPlaceholder("fill-emoji")).toHaveValue('😊😍')
+  } catch (e) {
+    console.error(e)
   }
 })

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import { userEvent, page } from '@vitest/browser/context'
+
+test('non US keys', async () => {
+  document.body.innerHTML = `
+    <input placeholder="#7396" />
+    <input placeholder="emoji" />
+  `;
+  await userEvent.type(page.getByPlaceholder("#7396"), 'éèù')
+  // TODO: surrogate pair doesn't work since `parseKeyDef` doesn't support it.
+  await userEvent.type(page.getByPlaceholder("emoji"), '😊')
+
+  expect.element(page.getByPlaceholder("#7396")).toHaveValue('éèù')
+  expect.element(page.getByPlaceholder("emoji")).not.toHaveValue('😊')
+})

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -15,20 +15,20 @@ test('non US keys', async () => {
   await expect.element(page.getByPlaceholder("fill-#7396")).toHaveValue('éèù')
 
   // playwright: garbled characters
-  // webdriverio: error
+  // webdriverio: error: invalid argument: missing command parameters
   // preview: ok
   try {
-    await userEvent.fill(page.getByPlaceholder("type-emoji"), '😊😍')
+    await userEvent.type(page.getByPlaceholder("type-emoji"), '😊😍')
     await expect.element(page.getByPlaceholder("type-emoji")).toHaveValue('😊😍')
   } catch (e) {
     console.error(e)
   }
 
   // playwright: ok
-  // webdriverio: error
+  // webdriverio: error: ChromeDriver only supports characters in the BMP
   // preview: ok
   try {
-    await userEvent.type(page.getByPlaceholder("fill-emoji"), '😊😍')
+    await userEvent.fill(page.getByPlaceholder("fill-emoji"), '😊😍')
     await expect.element(page.getByPlaceholder("fill-emoji")).toHaveValue('😊😍')
   } catch (e) {
     console.error(e)

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { userEvent, page } from '@vitest/browser/context'
+import { userEvent, page, server } from '@vitest/browser/context'
 
 test('non US keys', async () => {
   document.body.innerHTML = `
@@ -7,9 +7,14 @@ test('non US keys', async () => {
     <input placeholder="emoji" />
   `;
   await userEvent.type(page.getByPlaceholder("#7396"), 'éèù')
-  // TODO: surrogate pair doesn't work since `parseKeyDef` doesn't support it.
-  await userEvent.type(page.getByPlaceholder("emoji"), '😊')
-
   expect.element(page.getByPlaceholder("#7396")).toHaveValue('éèù')
-  expect.element(page.getByPlaceholder("emoji")).not.toHaveValue('😊')
+
+  try {
+    // surrogate pair is still inconsistent
+    // - playwright: garbled characters
+    // - webdriverio: throw an error
+    // - preview: works
+    await userEvent.type(page.getByPlaceholder("emoji"), '😊')
+    expect.element(page.getByPlaceholder("emoji")).toHaveValue('😊')
+  } catch {}
 })

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { userEvent, page } from '@vitest/browser/context'
+import { userEvent, page, server } from '@vitest/browser/context'
 
 test('non US keys', async () => {
   document.body.innerHTML = `
@@ -9,12 +9,8 @@ test('non US keys', async () => {
   await userEvent.type(page.getByPlaceholder("#7396"), 'éèù')
   await expect.element(page.getByPlaceholder("#7396")).toHaveValue('éèù')
 
-  try {
-    // surrogate pair is still inconsistent
-    // - playwright: garbled characters
-    // - webdriverio: throw an error
-    // - preview: works
+  if (server.provider !== 'webdriverio') {
     await userEvent.type(page.getByPlaceholder("emoji"), '😊')
     await expect.element(page.getByPlaceholder("emoji")).toHaveValue('😊')
-  } catch {}
+  }
 })

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -147,6 +147,7 @@ test('user-event', async () => {
       "cleanup-retry.test.ts": "pass",
       "cleanup1.test.ts": "pass",
       "cleanup2.test.ts": "pass",
+      "keyboard.test.ts": "pass",
     }
   `)
 })


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6871

_todo_

- [x] playwright
  - workaround by `Input.insertText` like playwright
- [x] webdriverio: ok
- [x] preview: ok
- [ ] deal with surrogate pair (e.g. emoji)
  - webdriverio doesn't support it at all even for `fill` (aka `setValue`).
  - for playwright, we can support this by patching `parseKeyDef`, but probably that's too much and users should just use `fill` for emojis.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
