### PR TITLE
fix: print ssrTransform error

### DIFF
--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -111,8 +111,8 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
 // serialize rollup error on server to preserve details as a test error
 function handleRollupError(e: unknown): never {
   if (
-    e instanceof Error &&
-    ('plugin' in e || 'frame' in e || 'id' in e || 'loc' in e)
+    e instanceof Error
+    && ('plugin' in e || 'frame' in e || 'id' in e)
   ) {
     // eslint-disable-next-line no-throw-literal
     throw {

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -110,7 +110,7 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
 
 // serialize rollup error on server to preserve details as a test error
 function handleRollupError(e: unknown): never {
-  if (e instanceof Error && 'plugin' in e) {
+  if (e instanceof Error && ('plugin' in e || 'frame' in e || 'id' in e || 'loc' in e)) {
     // eslint-disable-next-line no-throw-literal
     throw {
       name: e.name,

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -110,7 +110,10 @@ export function createMethodsRPC(project: WorkspaceProject, options: MethodsOpti
 
 // serialize rollup error on server to preserve details as a test error
 function handleRollupError(e: unknown): never {
-  if (e instanceof Error && ('plugin' in e || 'frame' in e || 'id' in e || 'loc' in e)) {
+  if (
+    e instanceof Error &&
+    ('plugin' in e || 'frame' in e || 'id' in e || 'loc' in e)
+  ) {
     // eslint-disable-next-line no-throw-literal
     throw {
       name: e.name,


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6882
- requires https://github.com/vitejs/vite/pull/18621

This also needed change on Vitest side since it only checked `error.plugin`. I widen the condition to cover the case without `plugin` for ssrTransform parse error.

Example: https://stackblitz.com/edit/vitest-dev-vitest-reyqqz?file=test%2Fsuite.test.js

![image](https://github.com/user-attachments/assets/9c713ffc-e30e-4b78-947a-4bbb8bc7d930)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
