### PR TITLE
feat(expect): add `toHaveBeenCalledOnceWith` expect matcher

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -595,6 +595,27 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       throw new AssertionError(formatCalls(spy, msg, args))
     }
   })
+  def('toHaveBeenCalledOnceWith', function (...args) {
+    const spy = getSpy(this)
+    const spyName = spy.getMockName()
+    const callCount = spy.mock.calls.length
+    const hasCallWithArgs = spy.mock.calls.some(callArg =>
+      jestEquals(callArg, args, [...customTesters, iterableEquality]),
+    )
+    const pass = hasCallWithArgs && callCount === 1
+    const isNot = utils.flag(this, 'negate') as boolean
+
+    const msg = utils.getMessage(this, [
+      pass,
+      `expected "${spyName}" to be called once with arguments: #{exp}`,
+      `expected "${spyName}" to not be called once with arguments: #{exp}`,
+      args,
+    ])
+
+    if ((pass && isNot) || (!pass && !isNot)) {
+      throw new AssertionError(formatCalls(spy, msg, args))
+    }
+  })
   def(
     ['toHaveBeenNthCalledWith', 'nthCalledWith'],
     function (times: number, ...args: any[]) {

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -636,6 +636,15 @@ export interface Assertion<T = any>
   toHaveBeenCalledOnce: () => void
 
   /**
+   * Ensure that a mock function is called with specific arguments and called
+   * exactly once.
+   *
+   * @example
+   * expect(mockFunc).toHaveBeenCalledOnceWith('arg1', 42);
+   */
+  toHaveBeenCalledOnceWith: <E extends any[]>(...args: E) => void
+
+  /**
    * Checks that a value satisfies a custom matcher function.
    *
    * @param matcher - A function returning a boolean based on the custom condition

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -634,6 +634,70 @@ describe('toHaveBeenCalledWith', () => {
   })
 })
 
+describe('toHaveBeenCalledOnceWith', () => {
+  describe('negated', () => {
+    it('fails if called', () => {
+      const mock = vi.fn()
+      mock(3)
+
+      expect(() => {
+        expect(mock).not.toHaveBeenCalledOnceWith(3)
+      }).toThrow(/^expected "spy" to not be called once with arguments: \[ 3 \][^e]/)
+    })
+
+    it('passes if called multiple times with args', () => {
+      const mock = vi.fn()
+      mock(3)
+      mock(3)
+
+      expect(mock).not.toHaveBeenCalledOnceWith(3)
+    })
+
+    it('passes if not called', () => {
+      const mock = vi.fn()
+      expect(mock).not.toHaveBeenCalledOnceWith(3)
+    })
+
+    it('passes if called with a different argument', () => {
+      const mock = vi.fn()
+      mock(4)
+
+      expect(mock).not.toHaveBeenCalledOnceWith(3)
+    })
+  })
+
+  it('fails if not called or called too many times', () => {
+    const mock = vi.fn()
+
+    expect(() => {
+      expect(mock).toHaveBeenCalledOnceWith(3)
+    }).toThrow(/^expected "spy" to be called once with arguments: \[ 3 \][^e]/)
+
+    mock(3)
+    mock(3)
+
+    expect(() => {
+      expect(mock).toHaveBeenCalledOnceWith(3)
+    }).toThrow(/^expected "spy" to be called once with arguments: \[ 3 \][^e]/)
+  })
+
+  it('fails if called with wrong args', () => {
+    const mock = vi.fn()
+    mock(4)
+
+    expect(() => {
+      expect(mock).toHaveBeenCalledOnceWith(3)
+    }).toThrow(/^expected "spy" to be called once with arguments: \[ 3 \][^e]/)
+  })
+
+  it('passes if called exactly once with args', () => {
+    const mock = vi.fn()
+    mock(3)
+
+    expect(mock).toHaveBeenCalledOnceWith(3)
+  })
+})
+
 describe('async expect', () => {
   it('resolves', async () => {
     await expect((async () => 'true')()).resolves.toBe('true')


### PR DESCRIPTION
### Description
This PR adds an `expect.toHaveBeenCalledOnceWith` method which asserts that a method has been called with the given arguments and has been called exactly once.

This fixes #6849

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
