### PR TITLE
chore: set `resolve.mainFields` and `resolve.conditions` for SSR environment

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -113,7 +113,8 @@ export async function VitestPlugin(
             // https://github.com/vitejs/vite/pull/16453
             emptyOutDir: false,
           },
-          // @ts-expect-error environments only exists in Vite 6
+          // eslint-disable-next-line ts/ban-ts-comment 
+          // @ts-ignore Vite 6 compat
           environments: {
             ssr: {
               resolve: {

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -113,6 +113,17 @@ export async function VitestPlugin(
             // https://github.com/vitejs/vite/pull/16453
             emptyOutDir: false,
           },
+          // @ts-expect-error environments only exists in Vite 6
+          environments: {
+            ssr: {
+              resolve: {
+                // by default Vite resolves `module` field, which not always a native ESM module
+                // setting this option can bypass that and fallback to cjs version
+                mainFields: [],
+                conditions: ['node'],
+              },
+            },
+          },
           test: {
             poolOptions: {
               threads: {

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -113,7 +113,7 @@ export async function VitestPlugin(
             // https://github.com/vitejs/vite/pull/16453
             emptyOutDir: false,
           },
-          // eslint-disable-next-line ts/ban-ts-comment 
+          // eslint-disable-next-line ts/ban-ts-comment
           // @ts-ignore Vite 6 compat
           environments: {
             ssr: {

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -96,7 +96,8 @@ export function WorkspaceVitestPlugin(
               ),
             },
           },
-          // @ts-expect-error environments only exists in Vite 6
+          // eslint-disable-next-line ts/ban-ts-comment 
+          // @ts-ignore Vite 6 compat
           environments: {
             ssr: {
               resolve: {

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -96,6 +96,17 @@ export function WorkspaceVitestPlugin(
               ),
             },
           },
+          // @ts-expect-error environments only exists in Vite 6
+          environments: {
+            ssr: {
+              resolve: {
+                // by default Vite resolves `module` field, which not always a native ESM module
+                // setting this option can bypass that and fallback to cjs version
+                mainFields: [],
+                conditions: ['node'],
+              },
+            },
+          },
           test: {
             name,
           },

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -96,7 +96,7 @@ export function WorkspaceVitestPlugin(
               ),
             },
           },
-          // eslint-disable-next-line ts/ban-ts-comment 
+          // eslint-disable-next-line ts/ban-ts-comment
           // @ts-ignore Vite 6 compat
           environments: {
             ssr: {


### PR DESCRIPTION
### Description

Since https://github.com/vitejs/vite/pull/18395, `ssr.resolve.conditions`/`ssr.resolve.mainField`(this does not exist yet, maybe needed?) does not inherit `resolve.conditions`/`resolve.mainFields` anymore.
This PR sets those values by `environments.ssr.resolve.conditions`/`environments.ssr.resolve.mainFields`.

This PR should fix the ecosystem-ci fail for vite-plugin-react.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
