### PR TITLE
fix(vitest): Fix `cacheDir` not being honored if `deps.optimizer.{mode}.enabled` is `true`

### DIFF
--- a/packages/vitest/src/node/create.ts
+++ b/packages/vitest/src/node/create.ts
@@ -36,6 +36,7 @@ export async function createVitest(
     // this will make "mode": "test" | "benchmark" inside defineConfig
     mode: options.mode || mode,
     plugins: await VitestPlugin(options, ctx),
+    test: options,
   }
 
   const server = await createViteServer(

--- a/packages/vitest/src/node/plugins/optimizer.ts
+++ b/packages/vitest/src/node/plugins/optimizer.ts
@@ -11,16 +11,12 @@ export function VitestOptimizer(): Plugin {
         const webOptimizer = resolveOptimizerConfig(
           testConfig.deps?.optimizer?.web,
           viteConfig.optimizeDeps,
-          testConfig,
         )
         const ssrOptimizer = resolveOptimizerConfig(
           testConfig.deps?.optimizer?.ssr,
           viteConfig.ssr?.optimizeDeps,
-          testConfig,
         )
 
-        viteConfig.cacheDir
-          = viteConfig.cacheDir || webOptimizer.cacheDir || ssrOptimizer.cacheDir
         viteConfig.optimizeDeps = webOptimizer.optimizeDeps
         viteConfig.ssr ??= {}
         viteConfig.ssr.optimizeDeps = ssrOptimizer.optimizeDeps

--- a/packages/vitest/src/node/plugins/optimizer.ts
+++ b/packages/vitest/src/node/plugins/optimizer.ts
@@ -20,7 +20,7 @@ export function VitestOptimizer(): Plugin {
         )
 
         viteConfig.cacheDir
-          = webOptimizer.cacheDir || ssrOptimizer.cacheDir || viteConfig.cacheDir
+          = viteConfig.cacheDir || webOptimizer.cacheDir || ssrOptimizer.cacheDir
         viteConfig.optimizeDeps = webOptimizer.optimizeDeps
         viteConfig.ssr ??= {}
         viteConfig.ssr.optimizeDeps = ssrOptimizer.optimizeDeps

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -3,19 +3,17 @@ import type {
   ResolvedConfig,
   UserConfig as ViteConfig,
 } from 'vite'
-import type { DepsOptimizationOptions, InlineConfig } from '../types/config'
+import type { DepsOptimizationOptions } from '../types/config'
 import { dirname } from 'pathe'
 import { searchForWorkspaceRoot, version as viteVersion } from 'vite'
 import { rootDir } from '../../paths'
-import { VitestCache } from '../cache'
 
 export function resolveOptimizerConfig(
   _testOptions: DepsOptimizationOptions | undefined,
   viteOptions: DepOptimizationOptions | undefined,
-  testConfig: InlineConfig,
 ) {
   const testOptions = _testOptions || {}
-  const newConfig: { cacheDir?: string; optimizeDeps: DepOptimizationOptions }
+  const newConfig: { optimizeDeps: DepOptimizationOptions }
     = {} as any
   const [major, minor, fix] = viteVersion.split('.').map(Number)
   const allowed
@@ -32,7 +30,6 @@ export function resolveOptimizerConfig(
     testOptions.enabled ??= false
   }
   if (!allowed || testOptions?.enabled !== true) {
-    newConfig.cacheDir = undefined
     newConfig.optimizeDeps = {
       // experimental in Vite >2.9.2, entries remains to help with older versions
       disabled: true,
@@ -40,9 +37,6 @@ export function resolveOptimizerConfig(
     }
   }
   else {
-    const root = testConfig.root ?? process.cwd()
-    const cacheDir
-      = testConfig.cache !== false ? testConfig.cache?.dir : undefined
     const currentInclude = testOptions.include || viteOptions?.include || []
     const exclude = [
       'vitest',
@@ -60,8 +54,6 @@ export function resolveOptimizerConfig(
       (n: string) => !exclude.includes(n),
     )
 
-    newConfig.cacheDir
-      = cacheDir ?? VitestCache.resolveCacheDir(root, cacheDir, testConfig.name)
     newConfig.optimizeDeps = {
       ...viteOptions,
       ...testOptions,


### PR DESCRIPTION
### Description
Fixes #6733

So initially it just seemed like the `viteConfig.cacheDir` set within optimizer should have been prioritizing the one defined in the config but there were other issues with the way `cacheDir` was being handled within the `resolveOptimizerConfig` function so I decided to remove the `cacheDir` logic entirely since it seemed to be unnecessary.

With this, I also fixed an issue where the `runVitest` function used within some of the tests wasn't properly passing through the options that were given to it. This uncovered the failures within `cache.test.ts` that should have been happening all along.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.