### PR TITLE
fix: respect `cacheDir` when optimizer is enabled

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -680,6 +680,7 @@ export function resolveConfig(
       resolve(viteConfig.cacheDir, 'vitest'),
       resolved.name,
     )
+    // console.log("[resolveConfig]", [viteConfig.cacheDir, cacheDir])
 
     if (resolved.cache && resolved.cache.dir) {
       logger.console.warn(

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -677,10 +677,9 @@ export function resolveConfig(
   if (resolved.cache !== false) {
     let cacheDir = VitestCache.resolveCacheDir(
       '',
-      resolve(viteConfig.cacheDir, 'vitest'),
+      viteConfig.cacheDir,
       resolved.name,
     )
-    // console.log("[resolveConfig]", [viteConfig.cacheDir, cacheDir])
 
     if (resolved.cache && resolved.cache.dir) {
       logger.console.warn(

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -142,6 +142,7 @@ export async function VitestPlugin(
                   ?? viteConfig.test?.isolate,
               },
             },
+            deps: testConfig.deps ?? viteConfig.test?.deps,
           },
         }
 

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -142,6 +142,7 @@ export async function VitestPlugin(
                   ?? viteConfig.test?.isolate,
               },
             },
+            root: testConfig.root ?? viteConfig.test?.root,
             deps: testConfig.deps ?? viteConfig.test?.deps,
           },
         }

--- a/packages/vitest/src/node/plugins/optimizer.ts
+++ b/packages/vitest/src/node/plugins/optimizer.ts
@@ -12,12 +12,16 @@ export function VitestOptimizer(): Plugin {
           testConfig.deps?.optimizer?.web,
           viteConfig.optimizeDeps,
           testConfig,
+          viteConfig.cacheDir,
         )
         const ssrOptimizer = resolveOptimizerConfig(
           testConfig.deps?.optimizer?.ssr,
           viteConfig.ssr?.optimizeDeps,
           testConfig,
+          viteConfig.cacheDir,
         )
+
+        // console.log("[vitest:normalize-optimizer]", [testConfig, viteConfig.cacheDir, webOptimizer.cacheDir, ssrOptimizer.cacheDir]);
 
         viteConfig.cacheDir
           = webOptimizer.cacheDir || ssrOptimizer.cacheDir || viteConfig.cacheDir

--- a/packages/vitest/src/node/plugins/optimizer.ts
+++ b/packages/vitest/src/node/plugins/optimizer.ts
@@ -21,8 +21,6 @@ export function VitestOptimizer(): Plugin {
           viteConfig.cacheDir,
         )
 
-        // console.log("[vitest:normalize-optimizer]", [testConfig, viteConfig.cacheDir, webOptimizer.cacheDir, ssrOptimizer.cacheDir]);
-
         viteConfig.cacheDir
           = webOptimizer.cacheDir || ssrOptimizer.cacheDir || viteConfig.cacheDir
         viteConfig.optimizeDeps = webOptimizer.optimizeDeps

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -42,8 +42,6 @@ export function resolveOptimizerConfig(
   }
   else {
     const root = testConfig.root ?? process.cwd()
-    // const cacheDir
-    //   = testConfig.cache !== false ? testConfig.cache?.dir : undefined
     const currentInclude = testOptions.include || viteOptions?.include || []
     const exclude = [
       'vitest',
@@ -62,8 +60,6 @@ export function resolveOptimizerConfig(
     )
 
     newConfig.cacheDir = (testConfig.cache !== false && testConfig.cache?.dir) || VitestCache.resolveCacheDir(root, viteCacheDir, testConfig.name)
-    // newConfig.cacheDir
-    //   = cacheDir ?? VitestCache.resolveCacheDir(root, cacheDir, testConfig.name)
     newConfig.optimizeDeps = {
       ...viteOptions,
       ...testOptions,

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -13,6 +13,7 @@ export function resolveOptimizerConfig(
   _testOptions: DepsOptimizationOptions | undefined,
   viteOptions: DepOptimizationOptions | undefined,
   testConfig: InlineConfig,
+  viteCacheDir: string | undefined,
 ) {
   const testOptions = _testOptions || {}
   const newConfig: { cacheDir?: string; optimizeDeps: DepOptimizationOptions }
@@ -41,8 +42,8 @@ export function resolveOptimizerConfig(
   }
   else {
     const root = testConfig.root ?? process.cwd()
-    const cacheDir
-      = testConfig.cache !== false ? testConfig.cache?.dir : undefined
+    // const cacheDir
+    //   = testConfig.cache !== false ? testConfig.cache?.dir : undefined
     const currentInclude = testOptions.include || viteOptions?.include || []
     const exclude = [
       'vitest',
@@ -60,8 +61,9 @@ export function resolveOptimizerConfig(
       (n: string) => !exclude.includes(n),
     )
 
-    newConfig.cacheDir
-      = cacheDir ?? VitestCache.resolveCacheDir(root, cacheDir, testConfig.name)
+    newConfig.cacheDir = (testConfig.cache !== false && testConfig.cache?.dir) || VitestCache.resolveCacheDir(root, viteCacheDir, testConfig.name)
+    // newConfig.cacheDir
+    //   = cacheDir ?? VitestCache.resolveCacheDir(root, cacheDir, testConfig.name)
     newConfig.optimizeDeps = {
       ...viteOptions,
       ...testOptions,

--- a/test/config/test/cache.test.ts
+++ b/test/config/test/cache.test.ts
@@ -15,7 +15,7 @@ test('default', async () => {
   expect(stderr).toBe('')
 
   const cachePath = ctx!.cache.results.getCachePath()
-  const path = resolve(project, 'node_modules/.vite/vitest/results.json')
+  const path = resolve(project, 'node_modules/.vite/results.json')
   expect(cachePath).toMatch(path)
 })
 
@@ -53,7 +53,7 @@ test('use cacheDir', async () => {
   expect(stderr).toBe('')
 
   const cachePath = ctx!.cache.results.getCachePath()
-  const path = resolve(root, 'node_modules/.vite-custom/vitest/results.json')
+  const path = resolve(root, 'node_modules/.vite-custom/results.json')
   expect(cachePath).toMatch(path)
 })
 
@@ -117,7 +117,7 @@ describe('with optimizer enabled', () => {
     expect(stderr).toBe('')
 
     const cachePath = ctx!.cache.results.getCachePath()
-    const path = resolve(root, 'node_modules/.vite-custom/vitest/results.json')
+    const path = resolve(project, 'node_modules/.vite-custom/results.json')
     expect(cachePath).toBe(path)
   })
 })

--- a/test/config/test/cache.test.ts
+++ b/test/config/test/cache.test.ts
@@ -58,7 +58,6 @@ test('use cacheDir', async () => {
 })
 
 describe('with optimizer enabled', () => {
-  // TODO: is this working?
   const deps = {
     optimizer: {
       web: {

--- a/test/config/test/cache.test.ts
+++ b/test/config/test/cache.test.ts
@@ -77,7 +77,7 @@ describe('with optimizer enabled', () => {
     expect(stderr).toBe('')
 
     const cachePath = ctx!.cache.results.getCachePath()
-    const path = resolve(project, 'node_modules/.vite/vitest/results.json')
+    const path = resolve(root, 'node_modules/.vite/vitest/results.json')
     expect(cachePath).toBe(path)
   })
 
@@ -117,7 +117,7 @@ describe('with optimizer enabled', () => {
     expect(stderr).toBe('')
 
     const cachePath = ctx!.cache.results.getCachePath()
-    const path = resolve(project, 'node_modules/.vite-custom/results.json')
+    const path = resolve(root, 'node_modules/.vite-custom/results.json')
     expect(cachePath).toBe(path)
   })
 })

--- a/test/config/test/cache.test.ts
+++ b/test/config/test/cache.test.ts
@@ -58,6 +58,7 @@ test('use cacheDir', async () => {
 })
 
 describe('with optimizer enabled', () => {
+  // TODO: is this working?
   const deps = {
     optimizer: {
       web: {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/6733
- Related https://github.com/vitest-dev/vitest/pull/6902

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
