### PR TITLE
feat(cli): support excluding projects with `--project=!pattern`

### DIFF
--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -752,7 +752,7 @@ Path to a custom tsconfig file
 - **CLI:** `--project <name>`
 - **Config:** [project](/config/#project)
 
-The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: `--project=1 --project=2`. You can also filter projects using wildcards like `--project=packages*`
+The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: `--project=1 --project=2`. You can also filter projects using wildcards like `--project=packages*`, and exclude projects with `--project=!pattern`.
 
 ### slowTestThreshold
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -700,7 +700,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   project: {
     description:
-      'The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: `--project=1 --project=2`. You can also filter projects using wildcards like `--project=packages*`',
+      'The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: `--project=1 --project=2`. You can also filter projects using wildcards like `--project=packages*`, and exclude projects with `--project=!pattern`.',
     argument: '<name>',
     array: true,
   },

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -24,8 +24,17 @@ export function escapeRegExp(s: string) {
 }
 
 export function wildcardPatternToRegExp(pattern: string): RegExp {
-  return new RegExp(
-    `^${pattern.split('*').map(escapeRegExp).join('.*')}$`,
-    'i',
-  )
+  const negated = pattern.startsWith('!')
+
+  if (negated) {
+    pattern = pattern.slice(1)
+  }
+
+  let regexp = `${pattern.split('*').map(escapeRegExp).join('.*')}$`
+
+  if (negated) {
+    regexp = `(?!${regexp})`
+  }
+
+  return new RegExp(`^${regexp}`, 'i')
 }

--- a/test/config/test/project.test.ts
+++ b/test/config/test/project.test.ts
@@ -11,14 +11,11 @@ test.each([
   { pattern: '!project*', expected: ['space_1'] },
   { pattern: '!project', expected: ['project_1', 'project_2', 'space_1'] },
 ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
-  const { stdout, stderr } = await runVitest({
+  const { ctx } = await runVitest({
     root: 'fixtures/project',
     reporters: ['basic'],
     project: pattern,
   })
 
-  expect(stderr).toBeFalsy()
-  expect(stdout).toBeTruthy()
-
-  expected.forEach(name => expect(stdout).toContain(name))
+  expect(ctx?.projects.map(p => p.name).sort()).toEqual(expected)
 })

--- a/test/config/test/project.test.ts
+++ b/test/config/test/project.test.ts
@@ -7,6 +7,9 @@ test.each([
   { pattern: '*j*', expected: ['project_1', 'project_2'] },
   { pattern: 'project*', expected: ['project_1', 'project_2'] },
   { pattern: 'space*', expected: ['space_1'] },
+  { pattern: '!project_1', expected: ['project_2', 'space_1'] },
+  { pattern: '!project*', expected: ['space_1'] },
+  { pattern: '!project', expected: ['project_1', 'project_2', 'space_1'] },
 ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
   const { stdout, stderr } = await runVitest({
     root: 'fixtures/project',

--- a/test/config/test/project.test.ts
+++ b/test/config/test/project.test.ts
@@ -1,21 +1,35 @@
 import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 
+const allProjects = ['project_1', 'project_2', 'space_1']
+
 test.each([
   { pattern: 'project_1', expected: ['project_1'] },
-  { pattern: '*', expected: ['project_1', 'project_2', 'space_1'] },
+  { pattern: '*', expected: allProjects },
   { pattern: '*j*', expected: ['project_1', 'project_2'] },
   { pattern: 'project*', expected: ['project_1', 'project_2'] },
   { pattern: 'space*', expected: ['space_1'] },
   { pattern: '!project_1', expected: ['project_2', 'space_1'] },
   { pattern: '!project*', expected: ['space_1'] },
-  { pattern: '!project', expected: ['project_1', 'project_2', 'space_1'] },
+  { pattern: '!project', expected: allProjects },
 ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
-  const { ctx } = await runVitest({
+  const { ctx, stderr, stdout } = await runVitest({
     root: 'fixtures/project',
     reporters: ['basic'],
     project: pattern,
   })
+
+  expect(stderr).toBeFalsy()
+  expect(stdout).toBeTruthy()
+
+  for (const project of allProjects) {
+    if (expected.includes(project)) {
+      expect(stdout).toContain(project)
+    }
+    else {
+      expect(stdout).not.toContain(project)
+    }
+  }
 
   expect(ctx?.projects.map(p => p.name).sort()).toEqual(expected)
 })


### PR DESCRIPTION
### Description

This PR allows a leading `!` to negate patterns in the `--project` option, making it possible to exclude certain projects when running `vitest`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
