### PR TITLE
feat: print project name as a label

### DIFF
--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -931,23 +931,6 @@ Repository: micromatch/micromatch
 
 ---------------------------------------
 
-## mimic-fn
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/mimic-fn
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
 ## mlly
 License: MIT
 Repository: unjs/mlly
@@ -973,23 +956,6 @@ Repository: unjs/mlly
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
-
----------------------------------------
-
-## onetime
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/onetime
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
 
@@ -1171,23 +1137,6 @@ Repository: privatenumber/resolve-pkg-maps
 
 ---------------------------------------
 
-## restore-cursor
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/restore-cursor
-
-> MIT License
->
-> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
 ## reusify
 License: MIT
 By: Matteo Collina
@@ -1242,30 +1191,6 @@ Repository: git://github.com/feross/run-parallel.git
 > COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 > IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 > CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
-## signal-exit
-License: ISC
-By: Ben Coe
-Repository: https://github.com/tapjs/signal-exit.git
-
-> The ISC License
->
-> Copyright (c) 2015, Contributors
->
-> Permission to use, copy, modify, and/or distribute this software
-> for any purpose with or without fee is hereby granted, provided
-> that the above copyright notice and this permission notice
-> appear in all copies.
->
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
-> OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
-> LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
-> OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-> WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
-> ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -76,6 +76,7 @@ export class Vitest {
 
   public packageInstaller: VitestPackageInstaller
 
+  /** TODO: rename to `_coreRootProject` */
   /** @internal */
   public coreWorkspaceProject!: TestProject
 
@@ -91,7 +92,7 @@ export class Vitest {
   /** @deprecated use `_cachedSpecs` */
   projectTestFiles = this._cachedSpecs
 
-  /** @private */
+  /** @internal */
   public _browserLastPort = defaultBrowserPort
 
   constructor(

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -276,15 +276,15 @@ export class Logger {
         + '\nThis might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.',
       ),
     )
-    this.log(c.red(divider(c.bold(c.inverse(' Unhandled Errors ')))))
-    this.log(errorMessage)
+    this.error(c.red(divider(c.bold(c.inverse(' Unhandled Errors ')))))
+    this.error(errorMessage)
     errors.forEach((err) => {
       this.printError(err, {
         fullStack: true,
         type: (err as ErrorWithDiff).type || 'Unhandled Error',
       })
     })
-    this.log(c.red(divider()))
+    this.error(c.red(divider()))
   }
 
   printSourceTypeErrors(errors: TypeCheckError[]) {

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -406,12 +406,12 @@ export abstract class BaseReporter implements Reporter {
     const errorDivider = () => this.error(`${c.red(c.dim(divider(`[${current++}/${failedTotal}]`, undefined, 1)))}\n`)
 
     if (failedSuites.length) {
-      this.error(`${errorBanner(`Failed Suites ${failedSuites.length}`)}\n`)
+      this.error(`\n${errorBanner(`Failed Suites ${failedSuites.length}`)}\n`)
       this.printTaskErrors(failedSuites, errorDivider)
     }
 
     if (failedTests.length) {
-      this.error(`${errorBanner(`Failed Tests ${failedTests.length}`)}\n`)
+      this.error(`\n${errorBanner(`Failed Tests ${failedTests.length}`)}\n`)
       this.printTaskErrors(failedTests, errorDivider)
     }
 
@@ -492,7 +492,7 @@ export abstract class BaseReporter implements Reporter {
         }
 
         this.ctx.logger.error(
-          `${c.red(c.bold(c.inverse(' FAIL ')))}${formatProjectName(projectName)} ${name}`,
+          `${c.red(c.bold(c.inverse(' FAIL ')))} ${formatProjectName(projectName)}${name}`,
         )
       }
 

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -239,13 +239,16 @@ export function formatProjectName(name: string | undefined, suffix = ' ') {
   if (!name) {
     return ''
   }
+  if (!c.isColorSupported) {
+    return `|${name}|${suffix}`
+  }
   const index = name
     .split('')
     .reduce((acc, v, idx) => acc + v.charCodeAt(0) + idx, 0)
 
-  const colors = [c.blue, c.yellow, c.cyan, c.green, c.magenta]
+  const colors = [c.black, c.yellow, c.cyan, c.green, c.magenta]
 
-  return colors[index % colors.length](`|${name}|`) + suffix
+  return c.inverse(colors[index % colors.length](` ${name} `)) + suffix
 }
 
 export function withLabel(color: 'red' | 'green' | 'blue' | 'cyan' | 'yellow', label: string, message?: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1342,6 +1342,9 @@ importers:
       tinyexec:
         specifier: ^0.3.0
         version: 0.3.0
+      tinyrainbow:
+        specifier: ^1.2.0
+        version: 1.2.0
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.9.0)(terser@5.36.0)

--- a/test/cli/test/__snapshots__/stacktraces.test.ts.snap
+++ b/test/cli/test/__snapshots__/stacktraces.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`stacktrace filtering > filters stacktraces > stacktrace-filtering 1`] = `
-"⎯⎯ Failed Tests 1 ⎯⎯
+"
+⎯⎯ Failed Tests 1 ⎯⎯
 
  FAIL  error-with-stack.test.js > error in deps
 Error: Something truly horrible has happened!
@@ -22,7 +23,8 @@ Error: Something truly horrible has happened!
 `;
 
 exports[`stacktrace in vmThreads 1`] = `
-"⎯⎯ Failed Tests 1 ⎯⎯
+"
+⎯⎯ Failed Tests 1 ⎯⎯
 
  FAIL  error-with-stack.test.js > error in deps
 Error: Something truly horrible has happened!
@@ -44,7 +46,8 @@ Error: Something truly horrible has happened!
 `;
 
 exports[`stacktrace should print error frame source file correctly > error-in-deps > error-in-deps 1`] = `
-"⎯⎯ Failed Tests 1 ⎯⎯
+"
+⎯⎯ Failed Tests 1 ⎯⎯
 
  FAIL  error-in-deps.test.js > error in deps
 ReferenceError: bar is not defined

--- a/test/cli/test/custom-pool.test.ts
+++ b/test/cli/test/custom-pool.test.ts
@@ -4,7 +4,7 @@ import { runVitest } from '../../test-utils'
 test('can run custom pools with Vitest', async () => {
   const vitest = await runVitest({
     root: './fixtures/custom-pool',
-    reporters: ['basic'],
+    reporters: [['default', { isTTY: false }]],
   })
 
   expect(vitest.stderr).toMatchInlineSnapshot(`

--- a/test/cli/vitest.config.ts
+++ b/test/cli/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     chaiConfig: {
       truncateThreshold: 999,
     },
+    env: {
+      NO_COLOR: 'true',
+    },
   },
   server: {
     watch: {

--- a/test/cli/vitest.config.ts
+++ b/test/cli/vitest.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
     chaiConfig: {
       truncateThreshold: 999,
     },
-    env: {
-      NO_COLOR: 'true',
-    },
   },
   server: {
     watch: {

--- a/test/config/test/dangerously-ignore-unhandled-errors.test.ts
+++ b/test/config/test/dangerously-ignore-unhandled-errors.test.ts
@@ -3,13 +3,13 @@ import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 
 test('{ dangerouslyIgnoreUnhandledErrors: true }', async () => {
-  const { stderr, stdout, exitCode } = await runVitest({
+  const { stderr, exitCode } = await runVitest({
     root: 'fixtures/dangerously-ignore-unhandled-errors',
     dangerouslyIgnoreUnhandledErrors: true,
   })
 
   expect(exitCode).toBe(0)
-  expect(stdout).toMatch('Vitest caught 1 unhandled error during the test run')
+  expect(stderr).toMatch('Vitest caught 1 unhandled error during the test run')
   expect(stderr).toMatch('Error: intentional unhandled error')
 })
 
@@ -24,12 +24,12 @@ test('{ dangerouslyIgnoreUnhandledErrors: true } without reporter', async () => 
 })
 
 test('{ dangerouslyIgnoreUnhandledErrors: false }', async () => {
-  const { stderr, stdout, exitCode } = await runVitest({
+  const { stderr, exitCode } = await runVitest({
     root: 'fixtures/dangerously-ignore-unhandled-errors',
     dangerouslyIgnoreUnhandledErrors: false,
   })
 
   expect(exitCode).toBe(1)
-  expect(stdout).toMatch('Vitest caught 1 unhandled error during the test run')
+  expect(stderr).toMatch('Vitest caught 1 unhandled error during the test run')
   expect(stderr).toMatch('Error: intentional unhandled error')
 })

--- a/test/reporters/tests/indicator-position.test.ts
+++ b/test/reporters/tests/indicator-position.test.ts
@@ -11,7 +11,8 @@ test('should print correct indicator position', async () => {
   expect(code).toMatch(/\r\n/)
   expect(stderr).toBeTruthy()
   expect(stderr).toMatchInlineSnapshot(`
-    "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 
      FAIL  indicator-position.test.js > 
     AssertionError: expected 2 to be 3 // Object.is equality

--- a/test/reporters/tests/merge-reports.test.ts
+++ b/test/reporters/tests/merge-reports.test.ts
@@ -34,7 +34,7 @@ test('merge reports', async () => {
     .replace(/Start at [\w\s:]+/, 'Start at <time>')
   const stderrArr = stderrDefault.split('\n')
   const stderrCheck = [
-    ...stderrArr.slice(3, 19),
+    ...stderrArr.slice(4, 19),
     ...stderrArr.slice(21, -3),
   ]
 

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -66,6 +66,10 @@ export async function runVitest(
       // "none" can be used to disable passing "reporter" option so that default value is used (it's not same as reporters: ["default"])
       ...(reporters === 'none' ? {} : reporters ? { reporters } : { reporters: ['verbose'] }),
       ...rest,
+      env: {
+        NO_COLOR: 'true',
+        ...rest.env,
+      },
     }, {
       ...viteOverrides,
       server: {

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -8,10 +8,20 @@ import { Readable, Writable } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
 import { x } from 'tinyexec'
-import { afterEach, onTestFinished, type WorkerGlobalState } from 'vitest'
+import { afterEach, onTestFinished, vi, type WorkerGlobalState } from 'vitest'
 import { startVitest } from 'vitest/node'
 import { getCurrentTest } from 'vitest/suite'
 import { Cli } from './cli'
+
+vi.mock('tinyrainbow', async (importOriginal) => {
+  const { getDefaultColors, createColors, isSupported } = await importOriginal<any>()
+  return {
+    default: getDefaultColors(),
+    getDefaultColors,
+    createColors,
+    isSupported,
+  }
+})
 
 interface VitestRunnerCLIOptions {
   std?: 'inherit'

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -8,20 +8,14 @@ import { Readable, Writable } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
 import { x } from 'tinyexec'
-import { afterEach, onTestFinished, vi, type WorkerGlobalState } from 'vitest'
+import * as tinyrainbow from 'tinyrainbow'
+import { afterEach, onTestFinished, type WorkerGlobalState } from 'vitest'
 import { startVitest } from 'vitest/node'
 import { getCurrentTest } from 'vitest/suite'
 import { Cli } from './cli'
 
-vi.mock('tinyrainbow', async (importOriginal) => {
-  const { getDefaultColors, createColors, isSupported } = await importOriginal<any>()
-  return {
-    default: getDefaultColors(),
-    getDefaultColors,
-    createColors,
-    isSupported,
-  }
-})
+// override default colors to disable them in tests
+Object.assign(tinyrainbow.default, tinyrainbow.getDefaultColors())
 
 interface VitestRunnerCLIOptions {
   std?: 'inherit'

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "tinyexec": "^0.3.0",
+    "tinyrainbow": "^1.2.0",
     "vite": "latest",
     "vite-node": "workspace:*",
     "vitest": "workspace:*"

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -90,10 +90,15 @@ TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string,
 exports[`should fail > typechecks empty "include" but with tests 1`] = `
 "Testing types with tsc and vue-tsc is an experimental feature.
 Breaking changes might not follow SemVer, please pin Vitest's version when using it.
+⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯
+
+Vitest caught 1 unhandled error during the test run.
+This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
 
 ⎯⎯⎯⎯⎯⎯ Typecheck Error ⎯⎯⎯⎯⎯⎯⎯
 Error: error TS18003: No inputs were found in config file '<root>/tsconfig.vitest-temp.json'. Specified 'include' paths were '["src"]' and 'exclude' paths were '["**/dist/**"]'.
 
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 
 "
 `;

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -92,7 +92,7 @@ describe('ignoreSourceErrors', () => {
     const vitest = await runVitest({
       root: resolve(__dirname, '../fixtures/source-error'),
     })
-    expect(vitest.stdout).toContain('Unhandled Errors')
+    expect(vitest.stderr).toContain('Unhandled Errors')
     expect(vitest.stderr).toContain('Unhandled Source Error')
     expect(vitest.stderr).toContain('TypeCheckError: Cannot find name \'thisIsSourceError\'')
   })

--- a/test/watch/test/workspaces.test.ts
+++ b/test/watch/test/workspaces.test.ts
@@ -28,7 +28,7 @@ test("dynamic test case", () => {
 
 async function startVitest() {
   const { vitest } = await runVitestCli(
-    { nodeOptions: { cwd: root, env: { TEST_WATCH: 'true' } } },
+    { nodeOptions: { cwd: root, env: { TEST_WATCH: 'true', NO_COLOR: 'true' } } },
     '--root',
     root,
     '--config',


### PR DESCRIPTION
### Description

This PR changes the output to use labels instead of `|` delimiter. We still keep the `|` delimiter if the colours are disabled to have a clear separation.

![Screenshot 2024-11-18 at 16 30 59](https://github.com/user-attachments/assets/d79f10b7-a9ef-44ed-9386-66aca49454e0)

![Screenshot 2024-11-18 at 16 32 12](https://github.com/user-attachments/assets/279173f0-e762-44b4-88b5-b2f3b4c08882)

Related #6481

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
