### PR TITLE
fix: persist cli filters as watch mode file filter

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -65,7 +65,7 @@ export class Vitest {
   invalidates: Set<string> = new Set()
   changedTests: Set<string> = new Set()
   watchedTests: Set<string> = new Set()
-  filenamePattern?: string
+  filenamePattern?: string[]
   runningPromise?: Promise<void>
   closingPromise?: Promise<void>
   isCancelling = false
@@ -414,6 +414,7 @@ export class Vitest {
       await this.report('onInit', this)
     }
 
+    this.filenamePattern = filters && filters?.length > 0 ? filters : undefined
     const files = await this.filterTestsBySource(
       await this.globTestFiles(filters),
     )
@@ -710,7 +711,7 @@ export class Vitest {
     }
 
     if (this.filenamePattern) {
-      const filteredFiles = await this.globTestFiles([this.filenamePattern])
+      const filteredFiles = await this.globTestFiles(this.filenamePattern)
       files = files.filter(file => filteredFiles.some(f => f[1] === file))
     }
 
@@ -774,9 +775,9 @@ export class Vitest {
   }
 
   async changeFilenamePattern(pattern: string, files: string[] = this.state.getFilepaths()) {
-    this.filenamePattern = pattern
+    this.filenamePattern = pattern ? [pattern] : []
 
-    const trigger = this.filenamePattern ? 'change filename pattern' : 'reset filename pattern'
+    const trigger = this.filenamePattern.length ? 'change filename pattern' : 'reset filename pattern'
 
     await this.rerunFiles(files, trigger, pattern === '')
   }
@@ -844,7 +845,7 @@ export class Vitest {
       let files = Array.from(this.changedTests)
 
       if (this.filenamePattern) {
-        const filteredFiles = await this.globTestFiles([this.filenamePattern])
+        const filteredFiles = await this.globTestFiles(this.filenamePattern)
         files = files.filter(file => filteredFiles.some(f => f[1] === file))
 
         // A file that does not match the current filename pattern was changed

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -209,7 +209,7 @@ export abstract class BaseReporter implements Reporter {
     }
 
     if (this.ctx.filenamePattern) {
-      this.log(BADGE_PADDING + c.dim(' Filename pattern: ') + c.blue(this.ctx.filenamePattern))
+      this.log(BADGE_PADDING + c.dim(' Filename pattern: ') + c.blue(this.ctx.filenamePattern.join(', ')))
     }
 
     if (this.ctx.configOverride.testNamePattern) {

--- a/test/watch/test/stdin.test.ts
+++ b/test/watch/test/stdin.test.ts
@@ -103,3 +103,13 @@ test('rerun current pattern tests', async () => {
   await vitest.waitForStdout('Test name pattern: /sum/')
   await vitest.waitForStdout('1 passed')
 })
+
+test('cli filter as watch filename pattern', async () => {
+  const { vitest } = await runVitest(_options, ['math'])
+
+  vitest.write('r')
+
+  await vitest.waitForStdout('RERUN')
+  await vitest.waitForStdout('Filename pattern: math')
+  await vitest.waitForStdout('1 passed')
+})


### PR DESCRIPTION
### Description

- fixes https://github.com/vitest-dev/vitest/discussions/6954

Probably this behavior makes more sense? Currently `-t` cli option also becomes `this.testNamePattern`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
