### PR TITLE
fix(coverage): correct coverage when `isolate: false` is used

### DIFF
--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -122,7 +122,7 @@ async function executeTests(method: 'run' | 'collect', files: string[]) {
   try {
     await Promise.all([
       setupCommonEnv(config),
-      startCoverageInsideWorker(config.coverage, executor),
+      startCoverageInsideWorker(config.coverage, executor, { isolate: config.browser.isolate }),
       (async () => {
         const VitestIndex = await import('vitest')
         Object.defineProperty(window, '__vitest_index__', {
@@ -160,7 +160,7 @@ async function executeTests(method: 'run' | 'collect', files: string[]) {
       }, 'Cleanup Error')
     }
     state.environmentTeardownRun = true
-    await stopCoverageInsideWorker(config.coverage, executor).catch((error) => {
+    await stopCoverageInsideWorker(config.coverage, executor, { isolate: config.browser.isolate }).catch((error) => {
       client.rpc.onUnhandledError({
         name: error.name,
         message: error.message,

--- a/packages/coverage-istanbul/src/index.ts
+++ b/packages/coverage-istanbul/src/index.ts
@@ -3,7 +3,7 @@ import type { CoverageProviderModule } from 'vitest/node'
 import type { IstanbulCoverageProvider } from './provider'
 import { COVERAGE_STORE_KEY } from './constants'
 
-export default <CoverageProviderModule>{
+export default {
   takeCoverage() {
     // @ts-expect-error -- untyped global
     return globalThis[COVERAGE_STORE_KEY]
@@ -46,4 +46,4 @@ export default <CoverageProviderModule>{
 
     return new IstanbulCoverageProvider()
   },
-}
+} satisfies CoverageProviderModule

--- a/packages/coverage-istanbul/src/index.ts
+++ b/packages/coverage-istanbul/src/index.ts
@@ -1,33 +1,49 @@
+import type { CoverageMapData } from 'istanbul-lib-coverage'
+import type { CoverageProviderModule } from 'vitest/node'
 import type { IstanbulCoverageProvider } from './provider'
 import { COVERAGE_STORE_KEY } from './constants'
 
-export async function getProvider(): Promise<IstanbulCoverageProvider> {
-  // to not bundle the provider
-  const providerPath = './provider.js'
-  const { IstanbulCoverageProvider } = (await import(
-    /* @vite-ignore */
-    providerPath
-  )) as typeof import('./provider')
-  return new IstanbulCoverageProvider()
-}
-
-export function takeCoverage(): any {
-  // @ts-expect-error -- untyped global
-  const coverage = globalThis[COVERAGE_STORE_KEY]
+export default <CoverageProviderModule>{
+  takeCoverage() {
+    // @ts-expect-error -- untyped global
+    return globalThis[COVERAGE_STORE_KEY]
+  },
 
   // Reset coverage map to prevent duplicate results if this is called twice in row
-  // @ts-expect-error -- untyped global
-  globalThis[COVERAGE_STORE_KEY] = {}
+  startCoverage() {
+    // @ts-expect-error -- untyped global
+    const coverageMap = globalThis[COVERAGE_STORE_KEY] as CoverageMapData
 
-  return coverage
+    // When isolated, there are no previous results
+    if (!coverageMap) {
+      return
+    }
+
+    for (const filename in coverageMap) {
+      const branches = coverageMap[filename].b
+
+      for (const key in branches) {
+        branches[key] = branches[key].map(() => 0)
+      }
+
+      for (const metric of ['f', 's'] as const) {
+        const entry = coverageMap[filename][metric]
+
+        for (const key in entry) {
+          entry[key] = 0
+        }
+      }
+    }
+  },
+
+  async getProvider(): Promise<IstanbulCoverageProvider> {
+    // to not bundle the provider
+    const providerPath = './provider.js'
+    const { IstanbulCoverageProvider } = (await import(
+      /* @vite-ignore */
+      providerPath
+    )) as typeof import('./provider')
+
+    return new IstanbulCoverageProvider()
+  },
 }
-
-const _default: {
-  getProvider: () => Promise<IstanbulCoverageProvider>
-  takeCoverage: () => any
-} = {
-  getProvider,
-  takeCoverage,
-}
-
-export default _default

--- a/packages/coverage-v8/src/browser.ts
+++ b/packages/coverage-v8/src/browser.ts
@@ -8,7 +8,7 @@ let enabled = false
 
 type ScriptCoverage = Awaited<ReturnType<typeof session.send<'Profiler.takePreciseCoverage'>>>
 
-export default <CoverageProviderModule>{
+export default {
   async startCoverage() {
     if (enabled) {
       return
@@ -47,7 +47,7 @@ export default <CoverageProviderModule>{
   async getProvider(): Promise<V8CoverageProvider> {
     return loadProvider()
   },
-}
+} satisfies CoverageProviderModule
 
 function filterResult(coverage: ScriptCoverage['result'][number]): boolean {
   if (!coverage.url.startsWith(window.location.origin)) {

--- a/packages/coverage-v8/src/browser.ts
+++ b/packages/coverage-v8/src/browser.ts
@@ -1,13 +1,21 @@
+import type { CoverageProviderModule } from 'vitest/node'
 import type { V8CoverageProvider } from './provider'
 import { cdp } from '@vitest/browser/context'
 import { loadProvider } from './load-provider'
 
 const session = cdp()
+let enabled = false
 
 type ScriptCoverage = Awaited<ReturnType<typeof session.send<'Profiler.takePreciseCoverage'>>>
 
-export default {
+export default <CoverageProviderModule>{
   async startCoverage() {
+    if (enabled) {
+      return
+    }
+
+    enabled = true
+
     await session.send('Profiler.enable')
     await session.send('Profiler.startPreciseCoverage', {
       callCount: true,
@@ -32,9 +40,8 @@ export default {
     return { result }
   },
 
-  async stopCoverage() {
-    await session.send('Profiler.stopPreciseCoverage')
-    await session.send('Profiler.disable')
+  stopCoverage() {
+    // Browser mode should not stop coverage as same V8 instance is shared between tests
   },
 
   async getProvider(): Promise<V8CoverageProvider> {

--- a/packages/coverage-v8/src/index.ts
+++ b/packages/coverage-v8/src/index.ts
@@ -1,12 +1,20 @@
+import type { CoverageProviderModule } from 'vitest/node'
 import type { V8CoverageProvider } from './provider'
 import inspector, { type Profiler } from 'node:inspector'
 import { provider } from 'std-env'
 import { loadProvider } from './load-provider'
 
 const session = new inspector.Session()
+let enabled = false
 
-export default {
-  startCoverage(): void {
+export default <CoverageProviderModule>{
+  startCoverage({ isolate }) {
+    if (isolate === false && enabled) {
+      return
+    }
+
+    enabled = true
+
     session.connect()
     session.post('Profiler.enable')
     session.post('Profiler.startPreciseCoverage', {
@@ -34,7 +42,11 @@ export default {
     })
   },
 
-  stopCoverage(): void {
+  stopCoverage({ isolate }) {
+    if (isolate === false) {
+      return
+    }
+
     session.post('Profiler.stopPreciseCoverage')
     session.post('Profiler.disable')
     session.disconnect()

--- a/packages/coverage-v8/src/index.ts
+++ b/packages/coverage-v8/src/index.ts
@@ -7,7 +7,7 @@ import { loadProvider } from './load-provider'
 const session = new inspector.Session()
 let enabled = false
 
-export default <CoverageProviderModule>{
+export default {
   startCoverage({ isolate }) {
     if (isolate === false && enabled) {
       return
@@ -55,7 +55,7 @@ export default <CoverageProviderModule>{
   async getProvider(): Promise<V8CoverageProvider> {
     return loadProvider()
   },
-}
+} satisfies CoverageProviderModule
 
 function filterResult(coverage: Profiler.ScriptCoverage): boolean {
   if (!coverage.url.startsWith('file://')) {

--- a/packages/vitest/src/integrations/coverage.ts
+++ b/packages/vitest/src/integrations/coverage.ts
@@ -79,11 +79,12 @@ export async function getCoverageProvider(
 export async function startCoverageInsideWorker(
   options: SerializedCoverageConfig | undefined,
   loader: Loader,
+  runtimeOptions: { isolate: boolean },
 ) {
   const coverageModule = await resolveCoverageProviderModule(options, loader)
 
   if (coverageModule) {
-    return coverageModule.startCoverage?.()
+    return coverageModule.startCoverage?.(runtimeOptions)
   }
 
   return null
@@ -105,11 +106,12 @@ export async function takeCoverageInsideWorker(
 export async function stopCoverageInsideWorker(
   options: SerializedCoverageConfig | undefined,
   loader: Loader,
+  runtimeOptions: { isolate: boolean },
 ) {
   const coverageModule = await resolveCoverageProviderModule(options, loader)
 
   if (coverageModule) {
-    return coverageModule.stopCoverage?.()
+    return coverageModule.stopCoverage?.(runtimeOptions)
   }
 
   return null

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -66,7 +66,7 @@ export interface CoverageProviderModule {
   /**
    * Executed before tests are run in the worker thread.
    */
-  startCoverage?: () => unknown | Promise<unknown>
+  startCoverage?: (runtimeOptions: { isolate: boolean }) => unknown | Promise<unknown>
 
   /**
    * Executed on after each run in the worker thread. Possible to return a payload passed to the provider
@@ -76,7 +76,7 @@ export interface CoverageProviderModule {
   /**
    * Executed after all tests have been run in the worker thread.
    */
-  stopCoverage?: () => unknown | Promise<unknown>
+  stopCoverage?: (runtimeOptions: { isolate: boolean }) => unknown | Promise<unknown>
 }
 
 export type CoverageReporter = keyof ReportOptions | (string & {})

--- a/packages/vitest/src/runtime/runVmTests.ts
+++ b/packages/vitest/src/runtime/runVmTests.ts
@@ -62,7 +62,7 @@ export async function run(
     getSourceMap: source => workerState.moduleCache.getSourceMap(source),
   })
 
-  await startCoverageInsideWorker(config.coverage, executor)
+  await startCoverageInsideWorker(config.coverage, executor, { isolate: false })
 
   if (config.chaiConfig) {
     setupChaiConfig(config.chaiConfig)
@@ -101,7 +101,7 @@ export async function run(
     vi.restoreAllMocks()
   }
 
-  await stopCoverageInsideWorker(config.coverage, executor)
+  await stopCoverageInsideWorker(config.coverage, executor, { isolate: false })
 }
 
 function resolveCss(mod: NodeJS.Module) {

--- a/test/coverage-test/fixtures/setup.isolation.ts
+++ b/test/coverage-test/fixtures/setup.isolation.ts
@@ -1,0 +1,6 @@
+import { beforeAll } from "vitest";
+import { branch } from "./src/branch";
+
+beforeAll(() => {
+  branch(1);
+});

--- a/test/coverage-test/fixtures/src/branch.ts
+++ b/test/coverage-test/fixtures/src/branch.ts
@@ -1,0 +1,7 @@
+export const branch = async (a: number) => {
+  if (a === 15) {
+    return true;
+  }
+
+  return false;
+};

--- a/test/coverage-test/fixtures/test/isolation-1-fixture.test.ts
+++ b/test/coverage-test/fixtures/test/isolation-1-fixture.test.ts
@@ -1,0 +1,9 @@
+import { test } from "vitest";
+import { multiply, remainder, subtract, sum } from "../src/math";
+
+test("Should run function sucessfully", async () => {
+  sum(1, 1);
+  subtract(1,2)
+  multiply(3,4)
+  remainder(6,7)
+});

--- a/test/coverage-test/fixtures/test/isolation-2-fixture.test.ts
+++ b/test/coverage-test/fixtures/test/isolation-2-fixture.test.ts
@@ -1,0 +1,10 @@
+import { test } from "vitest";
+import { branch } from "../src/branch";
+
+test("cover some lines", async () => {
+  branch(15);
+});
+
+test("cover lines", async () => {
+  branch(2);
+});

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -14,7 +14,12 @@ for (const isolate of [true, false]) {
 
       coverage: {
         all: false,
-        reporter: 'json',
+        reporter: ['json', 'html'],
+      },
+
+      // @ts-expect-error -- merged in runVitest
+      browser: {
+        isolate,
       },
     })
 
@@ -33,6 +38,7 @@ for (const isolate of [true, false]) {
     expect(math.toSummary().branches.pct).toBe(100)
   })
 }
+
 class Sorter {
   sort(files: WorkspaceSpec[]) {
     return files.sort((a) => {

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -1,0 +1,49 @@
+import type { WorkspaceSpec } from 'vitest/node'
+import { expect } from 'vitest'
+import { readCoverageMap, runVitest, test } from '../utils'
+
+for (const isolate of [true, false]) {
+  test(`{ isolate: ${isolate} }`, async () => {
+    await runVitest({
+      include: ['fixtures/test/isolation-*'],
+      setupFiles: ['fixtures/setup.isolation.ts'],
+      sequence: { sequencer: Sorter },
+
+      isolate,
+      fileParallelism: false,
+
+      coverage: {
+        all: false,
+        reporter: 'json',
+      },
+    })
+
+    const coverageMap = await readCoverageMap()
+
+    const branches = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/branch.ts')
+    expect(branches.toSummary().lines.pct).toBe(100)
+    expect(branches.toSummary().statements.pct).toBe(100)
+    expect(branches.toSummary().functions.pct).toBe(100)
+    expect(branches.toSummary().branches.pct).toBe(100)
+
+    const math = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/math.ts')
+    expect(math.toSummary().lines.pct).toBe(100)
+    expect(math.toSummary().statements.pct).toBe(100)
+    expect(math.toSummary().functions.pct).toBe(100)
+    expect(math.toSummary().branches.pct).toBe(100)
+  })
+}
+class Sorter {
+  sort(files: WorkspaceSpec[]) {
+    return files.sort((a) => {
+      if (a.moduleId.includes('isolation-1')) {
+        return -1
+      }
+      return 1
+    })
+  }
+
+  shard(files: WorkspaceSpec[]) {
+    return files
+  }
+}

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -1,12 +1,9 @@
 import type { WorkspaceSpec } from 'vitest/node'
 import { expect, test } from 'vitest'
-import { isV8Provider, readCoverageMap, runVitest } from '../utils'
+import { readCoverageMap, runVitest } from '../utils'
 
 for (const isolate of [true, false]) {
-  // TODO: Requires #6736
-  const fails = isV8Provider() && isolate === false
-
-  test(`{ isolate: ${isolate} }`, { fails }, async () => {
+  test(`{ isolate: ${isolate} }`, async () => {
     await runVitest({
       include: ['fixtures/test/isolation-*'],
       setupFiles: ['fixtures/setup.isolation.ts'],

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -2,41 +2,56 @@ import type { WorkspaceSpec } from 'vitest/node'
 import { expect, test } from 'vitest'
 import { readCoverageMap, runVitest } from '../utils'
 
+const pools = ['forks']
+
+if (!process.env.COVERAGE_BROWSER) {
+  pools.push('threads')
+
+  const [major] = process.version.slice(1).split('.').map(num => Number(num))
+
+  if (major < 22) {
+    pools.push('vmForks', 'vmThreads')
+  }
+}
+
 for (const isolate of [true, false]) {
-  test(`{ isolate: ${isolate} }`, async () => {
-    await runVitest({
-      include: ['fixtures/test/isolation-*'],
-      setupFiles: ['fixtures/setup.isolation.ts'],
-      sequence: { sequencer: Sorter },
+  for (const pool of pools) {
+    test(`{ isolate: ${isolate}, pool: "${pool}" }`, async () => {
+      await runVitest({
+        include: ['fixtures/test/isolation-*'],
+        setupFiles: ['fixtures/setup.isolation.ts'],
+        sequence: { sequencer: Sorter },
 
-      isolate,
-      fileParallelism: false,
-
-      coverage: {
-        all: false,
-        reporter: ['json', 'html'],
-      },
-
-      // @ts-expect-error -- merged in runVitest
-      browser: {
+        pool,
         isolate,
-      },
+        fileParallelism: false,
+
+        coverage: {
+          all: false,
+          reporter: ['json', 'html'],
+        },
+
+        // @ts-expect-error -- merged in runVitest
+        browser: {
+          isolate,
+        },
+      })
+
+      const coverageMap = await readCoverageMap()
+
+      const branches = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/branch.ts')
+      expect(branches.toSummary().lines.pct).toBe(100)
+      expect(branches.toSummary().statements.pct).toBe(100)
+      expect(branches.toSummary().functions.pct).toBe(100)
+      expect(branches.toSummary().branches.pct).toBe(100)
+
+      const math = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/math.ts')
+      expect(math.toSummary().lines.pct).toBe(100)
+      expect(math.toSummary().statements.pct).toBe(100)
+      expect(math.toSummary().functions.pct).toBe(100)
+      expect(math.toSummary().branches.pct).toBe(100)
     })
-
-    const coverageMap = await readCoverageMap()
-
-    const branches = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/branch.ts')
-    expect(branches.toSummary().lines.pct).toBe(100)
-    expect(branches.toSummary().statements.pct).toBe(100)
-    expect(branches.toSummary().functions.pct).toBe(100)
-    expect(branches.toSummary().branches.pct).toBe(100)
-
-    const math = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/math.ts')
-    expect(math.toSummary().lines.pct).toBe(100)
-    expect(math.toSummary().statements.pct).toBe(100)
-    expect(math.toSummary().functions.pct).toBe(100)
-    expect(math.toSummary().branches.pct).toBe(100)
-  })
+  }
 }
 
 class Sorter {

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -1,9 +1,12 @@
 import type { WorkspaceSpec } from 'vitest/node'
-import { expect } from 'vitest'
-import { readCoverageMap, runVitest, test } from '../utils'
+import { expect, test } from 'vitest'
+import { isV8Provider, readCoverageMap, runVitest } from '../utils'
 
 for (const isolate of [true, false]) {
-  test(`{ isolate: ${isolate} }`, async () => {
+  // TODO: Requires #6736
+  const fails = isV8Provider() && isolate === false
+
+  test(`{ isolate: ${isolate} }`, { fails }, async () => {
     await runVitest({
       include: ['fixtures/test/isolation-*'],
       setupFiles: ['fixtures/setup.isolation.ts'],

--- a/test/coverage-test/utils.ts
+++ b/test/coverage-test/utils.ts
@@ -51,6 +51,7 @@ export async function runVitest(config: UserConfig, options = { throwOnError: tr
       headless: true,
       name: 'chromium',
       provider: 'playwright',
+      ...config.browser,
     },
   })
 

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    reporters: 'basic',
+    reporters: 'verbose',
     isolate: false,
     poolOptions: {
       threads: {

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  server: {
+    watch: null,
+  },
   test: {
     reporters: 'verbose',
     isolate: false,

--- a/test/coverage-test/vitest.workspace.custom.ts
+++ b/test/coverage-test/vitest.workspace.custom.ts
@@ -66,6 +66,7 @@ export default defineWorkspace([
         BROWSER_TESTS,
 
         // Other non-provider-specific tests that should be run on browser mode as well
+        '**/isolation.test.ts',
         '**/include-exclude.test.ts',
         '**/allow-external.test.ts',
         '**/ignore-hints.test.ts',
@@ -90,6 +91,7 @@ export default defineWorkspace([
         BROWSER_TESTS,
 
         // Other non-provider-specific tests that should be run on browser mode as well
+        '**/isolation.test.ts',
         '**/include-exclude.test.ts',
         '**/allow-external.test.ts',
         '**/ignore-hints.test.ts',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/6736
- Istanbul: Preserve files in coverage state, reset just the counters
- V8: Don't restart coverage collection when same runtime instance is re-used between tests 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
