### PR TITLE
test: fix async assertion warning

### DIFF
--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -917,14 +917,14 @@ describe('async expect', () => {
     await expect((async () => {
       throw new Error('err')
     })()).rejects.toThrow('err')
-    expect((async () => {
+    await expect((async () => {
       throw new TestError('error')
     })()).rejects.toThrow(TestError)
     const err = new Error('hello world')
-    expect((async () => {
+    await expect((async () => {
       throw err
     })()).rejects.toThrow(err)
-    expect((async () => {
+    await expect((async () => {
       throw new Error('message')
     })()).rejects.toThrow(expect.objectContaining({
       message: expect.stringContaining('mes'),

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -3,7 +3,7 @@ import { AssertionError } from 'node:assert'
 import { stripVTControlCharacters } from 'node:util'
 import { generateToBeMessage } from '@vitest/expect'
 import { processError } from '@vitest/utils/error'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 class TestError extends Error {}
 
@@ -1011,6 +1011,12 @@ describe('async expect', () => {
   })
 
   describe('promise auto queuing', () => {
+    // silence warning
+    beforeAll(() => {
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      return () => spy.mockRestore()
+    })
+
     it.fails('fails', () => {
       expect(new Promise((resolve, reject) => setTimeout(reject, 500)))
         .resolves

--- a/test/core/test/mocked.test.ts
+++ b/test/core/test/mocked.test.ts
@@ -129,11 +129,11 @@ describe('default exported classes', () => {
   })
 })
 
-test('async functions should be mocked', () => {
+test('async functions should be mocked', async () => {
   expect(asyncFunc()).toBeUndefined()
   expect(vi.mocked(asyncFunc).mockResolvedValue).toBeDefined()
   vi.mocked(asyncFunc).mockResolvedValue('foo')
-  expect(asyncFunc()).resolves.toBe('foo')
+  await expect(asyncFunc()).resolves.toBe('foo')
 })
 
 function getError(cb: () => void): string {

--- a/test/core/test/snapshot-file.test.ts
+++ b/test/core/test/snapshot-file.test.ts
@@ -13,12 +13,12 @@ describe('snapshots', () => {
   for (const [path, file] of Object.entries(files)) {
     test(path, async () => {
       const entries = JSON.parse(await file()) as any[]
-      expect(entries.map(i => objectToCSS(i[0], i[1])).join('\n'))
+      await expect(entries.map(i => objectToCSS(i[0], i[1])).join('\n'))
         .toMatchFileSnapshot(path.replace('input.json', 'output.css'))
     })
   }
 })
 
-test('handle empty file', () => {
-  expect('').toMatchFileSnapshot('./fixtures/snapshot-empty.txt')
+test('handle empty file', async () => {
+  await expect('').toMatchFileSnapshot('./fixtures/snapshot-empty.txt')
 })

--- a/test/core/test/wait.test.ts
+++ b/test/core/test/wait.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from 'vitest'
 describe('waitFor', () => {
   describe('options', () => {
     test('timeout', async () => {
-      expect(async () => {
+      await expect(async () => {
         await vi.waitFor(() => {
           return new Promise((resolve) => {
             setTimeout(() => {
@@ -125,7 +125,7 @@ describe('waitFor', () => {
 describe('waitUntil', () => {
   describe('options', () => {
     test('timeout', async () => {
-      expect(async () => {
+      await expect(async () => {
         await vi.waitUntil(() => {
           return new Promise((resolve) => {
             setTimeout(() => {


### PR DESCRIPTION
### Description

I fixed the warning in core test suite.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
