### PR TITLE
fix(junit): fix testsuites time to be sum of all testsuite items

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -335,6 +335,7 @@ export class JUnitReporter implements Reporter {
       (stats, file) => {
         stats.tests += file.tasks.length
         stats.failures += file.stats.failures
+        stats.time += file.result?.duration || 0
         return stats
       },
       {
@@ -342,11 +343,11 @@ export class JUnitReporter implements Reporter {
         tests: 0,
         failures: 0,
         errors: 0, // we cannot detect those
-        time: executionTime(new Date().getTime() - this._timeStart.getTime()),
+        time: 0,
       },
     )
 
-    await this.writeElement('testsuites', stats, async () => {
+    await this.writeElement('testsuites', { ...stats, time: executionTime(stats.time) }, async () => {
       for (const file of transformed) {
         const filename = relative(this.ctx.config.root, file.filepath)
         await this.writeElement(

--- a/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
+++ b/test/reporters/tests/__snapshots__/reporters.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`JUnit reporter 1`] = `
 
 exports[`JUnit reporter with custom function classnameTemplate 1`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0.145992842">
     <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
         <testcase classname="filename:basic.test.ts - filepath:/vitest/test/core/test/basic.test.ts" name="Math.sqrt()" time="0.001442286">
         </testcase>
@@ -27,7 +27,7 @@ exports[`JUnit reporter with custom function classnameTemplate 1`] = `
 
 exports[`JUnit reporter with custom string classname 1`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0.145992842">
     <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
         <testcase classname="my-custom-classname" name="Math.sqrt()" time="0.001442286">
         </testcase>
@@ -38,7 +38,7 @@ exports[`JUnit reporter with custom string classname 1`] = `
 
 exports[`JUnit reporter with custom string classnameTemplate 1`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0.145992842">
     <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
         <testcase classname="filename:basic.test.ts - filepath:/vitest/test/core/test/basic.test.ts" name="Math.sqrt()" time="0.001442286">
         </testcase>
@@ -97,7 +97,7 @@ exports[`JUnit reporter with outputFile object in non-existing directory 2`] = `
 
 exports[`JUnit reporter without classname 1`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0">
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0.145992842">
     <testsuite name="test/core/test/basic.test.ts" timestamp="2022-01-19T10:10:01.759Z" hostname="hostname" tests="1" failures="0" errors="0" skipped="0" time="0.145992842">
         <testcase classname="test/core/test/basic.test.ts" name="Math.sqrt()" time="0.001442286">
         </testcase>


### PR DESCRIPTION
not the total time of execution

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This addresses 2 problems, one that is general to junit reporter itself, but more debatable, and the other one is merge-reports specific, but is clearly a bug. Let's start with the first one.

1. I haven't found an official junit.xml spec (and I'm not sure if it exists at all), but this document https://github.com/testmoapp/junitxml?tab=readme-ov-file#complete-junit-xml-example suggests that `testsuites.time` is an
> time        Aggregated time of all tests in this file in seconds

which makes sense
But the current implementation uses `new Date().getTime() - this._timeStart.getTime()`, so like, total execution time, including transform, prepare and so on. Which IMO should be changed to aggregated sum

2. When using `--merge-reports --reporter=junit` the `testsuites.time` would be completely wrong (due to it being execution time of reports merging, not the tests times aggregation). This is not a junit-only problem, it also affect text reporters, but I'm not sure what is the correct behaviour for them, so I focused on junit here.

I specifically found it when merging reports, since we calculate mean test time by doing `testsuites.time / (testsuites.total - testsuites.skipped)`, and noticed that mean time suddenly dropped down to nanoseconds (I wish it would, though!)

<!-- You can also add additional context here -->

Xml tests are just best-effort, I'd like to use a proper parser, so let me know if they will suffice or not

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
