### PR TITLE
fix(reporters): check `--hideSkippedTests` in base reporter

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -134,6 +134,10 @@ export abstract class BaseReporter implements Reporter {
         )
       }
 
+      else if (this.ctx.config.hideSkippedTests && (test.mode === 'skip' || test.result?.state === 'skip')) {
+        // Skipped tests are hidden when --hideSkippedTests
+      }
+
       // also print skipped tests that have notes
       else if (test.result?.state === 'skip' && test.result.note) {
         this.log(`   ${getStateSymbol(test)} ${getTestName(test)}${c.dim(c.gray(` [${test.result.note}]`))}`)

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -69,4 +69,29 @@ describe('default reporter', async () => {
     expect(result.stderr).not.toContain(`Serialized Error`)
     expect(result.stderr).not.toContain(`status: 'not found'`)
   })
+
+  test('prints skipped tests by default when a single file is run', async () => {
+    const { stdout } = await runVitest({
+      include: ['fixtures/all-passing-or-skipped.test.ts'],
+      reporters: [['default', { isTTY: true, summary: false }]],
+      config: 'fixtures/vitest.config.ts',
+    })
+
+    expect(stdout).toContain('✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped)')
+    expect(stdout).toContain('✓ 2 + 3 = 5')
+    expect(stdout).toContain('↓ 3 + 3 = 6')
+  })
+
+  test('hides skipped tests when --hideSkippedTests and a single file is run', async () => {
+    const { stdout } = await runVitest({
+      include: ['fixtures/all-passing-or-skipped.test.ts'],
+      reporters: [['default', { isTTY: true, summary: false }]],
+      hideSkippedTests: true,
+      config: false,
+    })
+
+    expect(stdout).toContain('✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped)')
+    expect(stdout).toContain('✓ 2 + 3 = 5')
+    expect(stdout).not.toContain('↓ 3 + 3 = 6')
+  })
 }, 120000)

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -24,3 +24,28 @@ test('prints error properties', async () => {
 
   expect(result.stderr).toContain(`Serialized Error: { code: 404, status: 'not found' }`)
 })
+
+test('prints skipped tests by default', async () => {
+  const { stdout } = await runVitest({
+    include: ['fixtures/all-passing-or-skipped.test.ts'],
+    reporters: [['verbose', { isTTY: true, summary: false }]],
+    config: false,
+  })
+
+  expect(stdout).toContain('✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped)')
+  expect(stdout).toContain('✓ 2 + 3 = 5')
+  expect(stdout).toContain('↓ 3 + 3 = 6')
+})
+
+test('hides skipped tests when --hideSkippedTests', async () => {
+  const { stdout } = await runVitest({
+    include: ['fixtures/all-passing-or-skipped.test.ts'],
+    reporters: [['verbose', { isTTY: true, summary: false }]],
+    hideSkippedTests: true,
+    config: false,
+  })
+
+  expect(stdout).toContain('✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped)')
+  expect(stdout).toContain('✓ 2 + 3 = 5')
+  expect(stdout).not.toContain('↓ 3 + 3 = 6')
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Fixes `--hideSkippedTests` flag that broke in https://github.com/vitest-dev/vitest/pull/6893

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
