### PR TITLE
fix(types): make parameters non-nullable for Playwright options

### DIFF
--- a/packages/browser/providers/playwright.d.ts
+++ b/packages/browser/providers/playwright.d.ts
@@ -27,13 +27,13 @@ declare module 'vitest/node' {
   }
 }
 
-type PWHoverOptions = Parameters<Page['hover']>[1]
-type PWClickOptions = Parameters<Page['click']>[1]
-type PWDoubleClickOptions = Parameters<Page['dblclick']>[1]
-type PWFillOptions = Parameters<Page['fill']>[2]
-type PWScreenshotOptions = Parameters<Page['screenshot']>[0]
-type PWSelectOptions = Parameters<Page['selectOption']>[2]
-type PWDragAndDropOptions = Parameters<Page['dragAndDrop']>[2]
+type PWHoverOptions = NonNullable<Parameters<Page['hover']>[1]>
+type PWClickOptions = NonNullable<Parameters<Page['click']>[1]>
+type PWDoubleClickOptions = NonNullable<Parameters<Page['dblclick']>[1]>
+type PWFillOptions = NonNullable<Parameters<Page['fill']>[2]>
+type PWScreenshotOptions = NonNullable<Parameters<Page['screenshot']>[0]>
+type PWSelectOptions = NonNullable<Parameters<Page['selectOption']>[2]>
+type PWDragAndDropOptions = NonNullable<Parameters<Page['dragAndDrop']>[2]>
 
 declare module '@vitest/browser/context' {
   export interface UserEventHoverOptions extends PWHoverOptions {}

--- a/packages/browser/src/node/commands/hover.ts
+++ b/packages/browser/src/node/commands/hover.ts
@@ -16,7 +16,7 @@ export const hover: UserEventCommand<UserEvent['hover']> = async (
   }
   else if (context.provider instanceof WebdriverBrowserProvider) {
     const browser = context.browser
-    await browser.$(selector).moveTo(options)
+    await browser.$(selector).moveTo(options as any)
   }
   else {
     throw new TypeError(`Provider "${context.provider.name}" does not support hover`)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, when selecting Playwright as the provider, type completion for the options parameter of the click method from @vitest/browser/context's userEvent is not working. This is because when fetching the types for Playwright's options, the possibility of undefined is not eliminated, resulting in a missing interface type. Therefore, I have wrapped it with NonNullable to remove the potential for undefined, which fixes the issue so that type completion now works.

<!-- You can also add additional context here -->

before

<img width="1234" alt="スクリーンショット 2024-11-30 17 47 47" src="https://github.com/user-attachments/assets/0531ddc3-c4a9-4f6f-bdd6-560c30d8e8c2">


after

<img width="1273" alt="スクリーンショット 2024-11-30 17 46 40" src="https://github.com/user-attachments/assets/3fcd2237-bd0d-4cb0-a7e2-f1ce31a33fa8">


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
