### PR TITLE
fix(browser): fix matchers.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ test/**/__screenshots__/**/*
 test/browser/fixtures/update-snapshot/basic.test.ts
 test/cli/fixtures/browser-multiple/basic-*
 .vitest-reports
+*.tsbuildinfo

--- a/packages/browser/matchers.d.ts
+++ b/packages/browser/matchers.d.ts
@@ -1,6 +1,6 @@
 import type { Locator } from '@vitest/browser/context'
 import type jsdomMatchers from './jest-dom.js'
-import type { Assertion } from 'vitest'
+import type { Assertion, ExpectPollOptions } from 'vitest'
 
 declare module 'vitest' {
   interface JestAssertion<T = any> extends jsdomMatchers.default.TestingLibraryMatchers<void, T> {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1283,6 +1283,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest
 
+  test/dts-playwright:
+    devDependencies:
+      '@vitest/browser':
+        specifier: workspace:*
+        version: link:../../packages/browser
+      vitest:
+        specifier: workspace:*
+        version: link:../../packages/vitest
+
   test/global-setup:
     devDependencies:
       vitest:

--- a/test/dts-playwright/package.json
+++ b/test/dts-playwright/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-dts-fixture",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "tsc -b"
+  },
+  "devDependencies": {
+    "@vitest/browser": "workspace:*",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/dts-playwright/package.json
+++ b/test/dts-playwright/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/test-dts-fixture",
+  "name": "@vitest/test-dts-playwright",
   "type": "module",
   "private": true,
   "scripts": {

--- a/test/dts-playwright/src/basic.test.ts
+++ b/test/dts-playwright/src/basic.test.ts
@@ -1,8 +1,8 @@
+import { page, userEvent } from '@vitest/browser/context'
 /// <reference types="@vitest/browser/providers/playwright" />
 import { test } from 'vitest'
-import { userEvent, page } from "@vitest/browser/context"
 
-test("basic", async () => {
-  document.body.innerHTML = `<button>hello</button>`;
-  await userEvent.click(page.getByRole('button'), { force: true });
+test('basic', async () => {
+  document.body.innerHTML = `<button>hello</button>`
+  await userEvent.click(page.getByRole('button'), { force: true })
 })

--- a/test/dts-playwright/src/basic.test.ts
+++ b/test/dts-playwright/src/basic.test.ts
@@ -1,5 +1,5 @@
-import { page, userEvent } from '@vitest/browser/context'
 /// <reference types="@vitest/browser/providers/playwright" />
+import { page, userEvent } from '@vitest/browser/context'
 import { test } from 'vitest'
 
 test('basic', async () => {

--- a/test/dts-playwright/src/basic.test.ts
+++ b/test/dts-playwright/src/basic.test.ts
@@ -1,0 +1,8 @@
+/// <reference types="@vitest/browser/providers/playwright" />
+import { test } from 'vitest'
+import { userEvent, page } from "@vitest/browser/context"
+
+test("basic", async () => {
+  document.body.innerHTML = `<button>hello</button>`;
+  await userEvent.click(page.getByRole('button'), { force: true });
+})

--- a/test/dts-playwright/tsconfig.json
+++ b/test/dts-playwright/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/test/dts-playwright/tsconfig.json
+++ b/test/dts-playwright/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "strict": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "strict": true,
     "noEmit": true
   },
   "include": ["src"]

--- a/test/dts-playwright/tsconfig.json
+++ b/test/dts-playwright/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "noEmit": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "noEmit": true
   },
   "include": ["src"]
 }

--- a/test/dts-playwright/tsconfig.json
+++ b/test/dts-playwright/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Description

While checking the repro for https://github.com/vitest-dev/vitest/pull/6989, I spotted another red squiggles:

![image](https://github.com/user-attachments/assets/79a35676-4ba8-4042-bf1c-99a720813c2f)

It looks like we can catch this issue by tsc without `skipLibCheck`, so I added `test/dts-playwright` for this:

```
$ pnpm -C test/dts-playwright test

> @vitest/test-dts-fixture@ test /home/hiroshi/code/others/vitest/test/dts-playwright
> tsc -b

../../packages/browser/matchers.d.ts:20:66 - error TS2304: Cannot find name 'ExpectPollOptions'.

20     element: <T extends Element | Locator>(element: T, options?: ExpectPollOptions) => PromisifyDomAssertion<Awaited<Element | null>>
                                                                    ~~~~~~~~~~~~~~~~~


Found 1 error.
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
