### PR TITLE
docs: remove irrelevant `vitest.config` references and update the sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,10 @@ import { withPwa } from '@vite-pwa/vitepress'
 import type { DefaultTheme } from 'vitepress'
 import { defineConfig } from 'vitepress'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
+import {
+  groupIconMdPlugin,
+  groupIconVitePlugin,
+} from 'vitepress-plugin-group-icons'
 import { version } from '../../package.json'
 import { teamMembers } from './contributors'
 import {
@@ -20,10 +24,6 @@ import {
 } from './meta'
 import { pwa } from './scripts/pwa'
 import { transformHead } from './scripts/transformHead'
-import {
-  groupIconMdPlugin,
-  groupIconVitePlugin,
-} from 'vitepress-plugin-group-icons'
 
 export default ({ mode }: { mode: string }) => {
   return withPwa(defineConfig({
@@ -145,7 +145,7 @@ export default ({ mode }: { mode: string }) => {
           text: 'Resources',
           items: [
             {
-              text: 'Advanced',
+              text: 'Advanced API',
               link: '/advanced/api',
               activeMatch: '^/advanced/',
             },
@@ -311,6 +311,10 @@ export default ({ mode }: { mode: string }) => {
                 text: 'Advanced API',
                 link: '/advanced/api',
               },
+              {
+                text: 'Comparisons',
+                link: '/guide/comparisons',
+              },
             ],
           },
         ],
@@ -360,16 +364,16 @@ function introduction(): DefaultTheme.SidebarItem[] {
 function guide(): DefaultTheme.SidebarItem[] {
   return [
     {
-      text: 'Workspace',
-      link: '/guide/workspace',
-    },
-    {
       text: 'CLI',
       link: '/guide/cli',
     },
     {
       text: 'Test Filtering',
       link: '/guide/filtering',
+    },
+    {
+      text: 'Workspace',
+      link: '/guide/workspace',
     },
     {
       text: 'Reporters',
@@ -420,10 +424,6 @@ function guide(): DefaultTheme.SidebarItem[] {
       link: '/guide/debugging',
     },
     {
-      text: 'Comparisons',
-      link: '/guide/comparisons',
-    },
-    {
       text: 'Migration Guide',
       link: '/guide/migration',
     },
@@ -432,12 +432,18 @@ function guide(): DefaultTheme.SidebarItem[] {
       link: '/guide/common-errors',
     },
     {
-      text: 'Profiling Test Performance',
-      link: '/guide/profiling-test-performance',
-    },
-    {
-      text: 'Improving Performance',
-      link: '/guide/improving-performance',
+      text: 'Performance',
+      collapsed: false,
+      items: [
+        {
+          text: 'Profiling Test Performance',
+          link: '/guide/profiling-test-performance',
+        },
+        {
+          text: 'Improving Performance',
+          link: '/guide/improving-performance',
+        },
+      ],
     },
   ]
 }

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -335,7 +335,7 @@ This option will also affect if a file should be treated as a module when extern
 
 Setting this option will _override_ the default, if you wish to still search `node_modules` for packages include it along with any other options:
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -442,7 +442,7 @@ Vitest uses Vite SSR primitives to run tests which has [certain pitfalls](https:
 
 By default, `vitest` does not provide global APIs for explicitness. If you prefer to use the APIs globally like Jest, you can pass the `--globals` option to CLI or add `globals: true` in the config.
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -607,7 +607,7 @@ Automatically assign environment based on globs. The first match will be used.
 
 For example:
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -654,7 +654,7 @@ Automatically assign pool in which tests will run based on globs. The first matc
 
 For example:
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -773,7 +773,7 @@ Similar as `vmThreads` pool but uses `child_process` instead of `worker_threads`
 
 Options for `threads` pool.
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -845,7 +845,7 @@ Be careful when using, it as some options may crash worker, e.g. --prof, --title
 
 Options for `forks` pool.
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -908,7 +908,7 @@ Be careful when using, it as some options may crash worker, e.g. --prof, --title
 
 Options for `vmThreads` pool.
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -989,7 +989,7 @@ Be careful when using, it as some options may crash worker, e.g. --prof, --title
 
 Options for `vmForks` pool.
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -1144,7 +1144,7 @@ export default defineConfig({
   },
 })
 ```
-```ts [my.test.js]
+```ts [api.test.js]
 import { expect, inject, test } from 'vitest'
 
 test('api key is defined', () => {
@@ -1334,7 +1334,7 @@ List of files excluded from coverage as glob patterns.
 
 This option overrides all default options. Extend the default options when adding new patterns to ignore:
 
-```ts [vitest.config.js]
+```ts
 import { coverageConfigDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -1623,7 +1623,7 @@ By default Vite uses ESBuild which removes comments and Typescript types from `.
 
 If you want to apply ESBuild to other files as well, define them in [`esbuild` options](https://vitejs.dev/config/shared-options.html#esbuild):
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -1829,18 +1829,20 @@ This is an advanced API for library authors. If you just need to run tests in a 
 
 Options that will be passed down to provider when calling `provider.initialize`.
 
-```ts [vitest.config.js]
-export default {
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
   test: {
     browser: {
       providerOptions: {
         launch: {
           devtools: true,
-        }
-      }
-    }
-  }
-}
+        },
+      },
+    },
+  },
+})
 ```
 
 ::: tip
@@ -2031,7 +2033,7 @@ A list of paths to snapshot serializer modules for snapshot testing, useful if y
 
 Overrides default snapshot path. For example, to store snapshots next to test files:
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -2136,7 +2138,7 @@ Use this option if you want to disable the cache feature. At the moment Vitest s
 
 The cache directory is controlled by the Vite's [`cacheDir`](https://vitejs.dev/config/shared-options.html#cachedir) option:
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -2146,7 +2148,7 @@ export default defineConfig({
 
 You can limit the directory only for Vitest by using `process.env.VITEST`:
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -2379,7 +2381,7 @@ Custom handler for `console.log` in tests. If you return `false`, Vitest will no
 
 Can be useful for filtering out logs from third-party libraries.
 
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -2399,7 +2401,7 @@ Apply a filtering function to each frame of each stack trace when handling error
 
 Can be useful for filtering out stack trace frames from third-party libraries.
 
-```ts [vitest.config.ts]
+```ts
 import type { ParsedStack } from 'vitest'
 import { defineConfig } from 'vitest/config'
 
@@ -2429,8 +2431,7 @@ export default defineConfig({
 
 For example, as a config object:
 
-:::code-group
-```ts [vitest.config.js]
+```ts
 import { defineConfig } from 'vitest/config'
 import c from 'picocolors'
 
@@ -2440,11 +2441,10 @@ export default defineConfig({
       aIndicator: c.bold('--'),
       bIndicator: c.bold('++'),
       omitAnnotationLines: true,
-    }
-  }
+    },
+  },
 })
 ```
-:::
 
 Or as a module:
 
@@ -2454,8 +2454,8 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    diff: './vitest.diff.ts'
-  }
+    diff: './vitest.diff.ts',
+  },
 })
 ```
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -41,7 +41,7 @@ Vitest requires Vite >=v5.0.0 and Node >=v18.0.0
 
 It is recommended that you install a copy of `vitest` in your `package.json`, using one of the methods listed above. However, if you would prefer to run `vitest` directly, you can use `npx vitest` (the `npx` tool comes with npm and Node.js).
 
-The `npx` tool will execute the specified command. By default, `npx` will first check if the command exists in the local project's binaries. If it is not found there, `npx` will look in the system's $PATH and execute it if found. If the command is not found in either location, `npx` will install it in a temporary location prior to execution.
+The `npx` tool will execute the specified command. By default, `npx` will first check if the command exists in the local project's binaries. If it is not found there, `npx` will look in the system's `$PATH` and execute it if found. If the command is not found in either location, `npx` will install it in a temporary location prior to execution.
 
 ## Writing Tests
 

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -4,13 +4,13 @@ title: Mocking | Guide
 
 # Mocking
 
-When writing tests it's only a matter of time before you need to create a "fake" version of an internal — or external — service. This is commonly referred to as **mocking**. Vitest provides utility functions to help you out through its **vi** helper. You can `import { vi } from 'vitest'` or access it **globally** (when [global configuration](/config/#globals) is **enabled**).
+When writing tests it's only a matter of time before you need to create a "fake" version of an internal — or external — service. This is commonly referred to as **mocking**. Vitest provides utility functions to help you out through its `vi` helper. You can import it from `vitest` or access it globally if [`global` configuration](/config/#globals) is enabled.
 
 ::: warning
 Always remember to clear or restore mocks before or after each test run to undo mock state changes between runs! See [`mockReset`](/api/mock#mockreset) docs for more info.
 :::
 
-If you wanna dive in head first, check out the [API section](/api/vi) otherwise keep reading to take a deeper dive into the world of mocking.
+If you are not familliar with `vi.fn`, `vi.mock` or `vi.spyOn` methods, check the [API section](/api/vi) first.
 
 ## Dates
 
@@ -439,7 +439,7 @@ You can use it like below in your [setup file](/config/#setupfiles)
 ```js
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { setupServer } from 'msw/node'
-import { graphql, http, HttpResponse } from 'msw'
+import { HttpResponse, graphql, http } from 'msw'
 
 const posts = [
   {

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -439,7 +439,7 @@ You can use it like below in your [setup file](/config/#setupfiles)
 ```js
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { setupServer } from 'msw/node'
-import { HttpResponse, graphql, http } from 'msw'
+import { graphql, http, HttpResponse } from 'msw'
 
 const posts = [
   {

--- a/docs/guide/testing-types.md
+++ b/docs/guide/testing-types.md
@@ -24,7 +24,7 @@ Since Vitest 2.1, if your `include` and `typecheck.include` overlap, Vitest will
 
 Using CLI flags, like `--allowOnly` and `-t` are also supported for type checking.
 
-```ts
+```ts [mount.test-d.ts]
 import { assertType, expectTypeOf } from 'vitest'
 import { mount } from './mount.js'
 


### PR DESCRIPTION
### Description

1. Remove `vitest.config` titles on the "Config Reference" page because it is implied. I kept the names in code groups where we have several files in a single code group
2. Moved Workspace guide after "CLI" and "Test Filtering" since they are arguebly more important to run tests
3. "Performance" is split in two guides in the sidebar now for better visual representation

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
