### PR TITLE
add storybook coverage exclude entries

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -39,7 +39,7 @@ const defaultCoverageExcludes = [
   '**/\x00*',
   'cypress/**',
   'storybook-static/**',
-  '*.stories.*,
+  '*.stories.*',
   'test?(s)/**',
   'test?(-*).?(c|m)[jt]s?(x)',
   '**/*{.,-}{test,spec,bench,benchmark}?(-d).?(c|m)[jt]s?(x)',

--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -38,6 +38,8 @@ const defaultCoverageExcludes = [
   '**/__x00__*',
   '**/\x00*',
   'cypress/**',
+  'storybook-static/**',
+  '*.stories.*,
   'test?(s)/**',
   'test?(-*).?(c|m)[jt]s?(x)',
   '**/*{.,-}{test,spec,bench,benchmark}?(-d).?(c|m)[jt]s?(x)',


### PR DESCRIPTION
### Description

Storybook stories can be considered test, especially with the storybook test plugin for vitest in the works, they are converted into test files.

When enabling coverage in that scenario, it's undesired to have the story files count for measuring coverage.

Therefore is useful for those files to be excluded.

It would be possible for vitest users to configure this, however we think it could be useful to add this to the default set of coverage exclude patterns inside of vitest itself.

More context here:
https://github.com/storybookjs/storybook/issues/29613

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
