### PR TITLE
feat!: support Vite 6

### DIFF
--- a/packages/vite-node/package.json
+++ b/packages/vite-node/package.json
@@ -74,7 +74,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
@@ -86,7 +86,7 @@
     "debug": "^4.3.7",
     "es-module-lexer": "^1.5.4",
     "pathe": "^1.1.2",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@jridgewell/trace-mapping": "^0.3.25",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -115,7 +115,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
@@ -123,7 +123,7 @@
   },
   "peerDependencies": {
     "@edge-runtime/vm": "*",
-    "@types/node": "^18.0.0 || >=20.0.0",
+    "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
     "@vitest/browser": "workspace:*",
     "@vitest/ui": "workspace:*",
     "happy-dom": "*",
@@ -167,7 +167,7 @@
     "tinyexec": "^0.3.1",
     "tinypool": "^1.0.2",
     "tinyrainbow": "^1.2.0",
-    "vite": "^5.0.0",
+    "vite": "^5.0.0 || ^6.0.0",
     "vite-node": "workspace:*",
     "why-is-node-running": "^2.3.0"
   },


### PR DESCRIPTION
### Description

Yet again, we are using `"^5.0.0 || ^6.0.0"` in `dependencies` because Vitest _requires_ the Vite dependency to be installed. This means that if you don't have Vite installed, Vitest will use the latest Vite 6. Otherwise, it depends on how your package manager works.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
