### PR TITLE
fix: don't use `Custom` type internally

### DIFF
--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -60,7 +60,7 @@ export async function collectTests(
       mergeHooks(fileHooks, getHooks(defaultTasks))
 
       for (const c of [...defaultTasks.tasks, ...collectorContext.tasks]) {
-        if (c.type === 'test' || c.type === 'custom' || c.type === 'suite') {
+        if (c.type === 'test' || c.type === 'suite') {
           file.tasks.push(c)
         }
         else if (c.type === 'collector') {

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -2,7 +2,6 @@ import type { Awaitable } from '@vitest/utils'
 import type { DiffOptions } from '@vitest/utils/diff'
 import type { FileSpec, VitestRunner } from './types/runner'
 import type {
-  Custom,
   File,
   HookCleanupCallback,
   HookListener,
@@ -177,7 +176,7 @@ async function callCleanupHooks(cleanups: HookCleanupCallback[]) {
   )
 }
 
-export async function runTest(test: Test | Custom, runner: VitestRunner): Promise<void> {
+export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   await runner.onBeforeRunTask?.(test)
 
   if (test.mode !== 'run') {
@@ -471,7 +470,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner): Promise<void
 let limitMaxConcurrency: ReturnType<typeof limitConcurrency>
 
 async function runSuiteChild(c: Task, runner: VitestRunner) {
-  if (c.type === 'test' || c.type === 'custom') {
+  if (c.type === 'test') {
     return limitMaxConcurrency(() => runTest(c, runner))
   }
   else if (c.type === 'suite') {

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -1,7 +1,6 @@
 import type { FixtureItem } from './fixture'
 import type { VitestRunner } from './types/runner'
 import type {
-  CustomAPI,
   File,
   Fixtures,
   RunMode,
@@ -608,7 +607,7 @@ function createSuite() {
 export function createTaskCollector(
   fn: (...args: any[]) => any,
   context?: Record<string, unknown>,
-): CustomAPI {
+): TestAPI {
   const taskFn = fn as any
 
   taskFn.each = function <T>(
@@ -729,7 +728,7 @@ export function createTaskCollector(
   const _test = createChainable(
     ['concurrent', 'sequential', 'skip', 'only', 'todo', 'fails'],
     taskFn,
-  ) as CustomAPI
+  ) as TestAPI
 
   if (context) {
     (_test as any).mergeContext(context)

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -1,7 +1,6 @@
 import type { FixtureItem } from './fixture'
 import type { VitestRunner } from './types/runner'
 import type {
-  Custom,
   CustomAPI,
   File,
   Fixtures,
@@ -294,7 +293,7 @@ function createSuiteCollector(
   each?: boolean,
   suiteOptions?: TestOptions,
 ) {
-  const tasks: (Test | Custom | Suite | SuiteCollector)[] = []
+  const tasks: (Test | Suite | SuiteCollector)[] = []
   const factoryQueue: (Test | Suite | SuiteCollector)[] = []
 
   let suite: Suite

--- a/packages/runner/src/test-state.ts
+++ b/packages/runner/src/test-state.ts
@@ -1,11 +1,11 @@
-import type { Custom, Test } from './types/tasks.ts'
+import type { Test } from './types/tasks.ts'
 
-let _test: Test | Custom | undefined
+let _test: Test | undefined
 
-export function setCurrentTest<T extends Test | Custom>(test: T | undefined): void {
+export function setCurrentTest<T extends Test>(test: T | undefined): void {
   _test = test
 }
 
-export function getCurrentTest<T extends Test | Custom | undefined>(): T {
+export function getCurrentTest<T extends Test | undefined>(): T {
   return _test as T
 }

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -12,6 +12,7 @@ export type {
   BeforeAllListener,
   BeforeEachListener,
   Custom,
+  /** @deprecated use `TestAPI` instead */
   CustomAPI,
   DoneCallback,
   ExtendedContext,

--- a/packages/runner/src/types/runner.ts
+++ b/packages/runner/src/types/runner.ts
@@ -1,6 +1,5 @@
 import type { DiffOptions } from '@vitest/utils/diff'
 import type {
-  Custom,
   ExtendedContext,
   File,
   SequenceHooks,
@@ -91,7 +90,7 @@ export interface VitestRunner {
   /**
    * When the task has finished running, but before cleanup hooks are called
    */
-  onTaskFinished?: (test: Test | Custom) => unknown
+  onTaskFinished?: (test: Test) => unknown
   /**
    * Called after result and state are set.
    */

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -234,7 +234,7 @@ export interface Custom<ExtraContext = object> extends TaskPopulated {
   context: TaskContext<Test> & ExtraContext & TestContext
 }
 
-export type Task = Test | Suite | Custom | File
+export type Task = Test | Suite | File
 
 /**
  * @deprecated Vitest doesn't provide `done()` anymore
@@ -578,8 +578,6 @@ export interface SuiteCollector<ExtraContext = object> {
   test: TestAPI<ExtraContext>
   tasks: (
     | Suite
-    // TODO: remove in Vitest 3
-    | Custom<ExtraContext>
     | Test<ExtraContext>
     | SuiteCollector<ExtraContext>
   )[]

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -223,16 +223,7 @@ export interface Test<ExtraContext = object> extends TaskPopulated {
 /**
  * @deprecated Use `Test` instead. `type: 'custom'` is not used since 2.2
  */
-export interface Custom<ExtraContext = object> extends TaskPopulated {
-  /**
-   * @deprecated use `test` instead. `custom` is not used since 2.2
-   */
-  type: 'custom'
-  /**
-   * Task context that will be passed to the test function.
-   */
-  context: TaskContext<Test> & ExtraContext & TestContext
-}
+export type Custom<ExtraContext = object> = Test<ExtraContext>
 
 export type Task = Test | Suite | File
 
@@ -441,6 +432,7 @@ export type TestAPI<ExtraContext = object> = ChainableTestAPI<ExtraContext> &
     }>
   }
 
+/** @deprecated use `TestAPI` instead */
 export type { TestAPI as CustomAPI }
 
 export interface FixtureOptions {

--- a/packages/runner/src/utils/index.ts
+++ b/packages/runner/src/utils/index.ts
@@ -18,4 +18,5 @@ export {
   hasFailed,
   hasTests,
   isAtomTest,
+  isTestCase,
 } from './tasks'

--- a/packages/runner/src/utils/tasks.ts
+++ b/packages/runner/src/utils/tasks.ts
@@ -1,19 +1,19 @@
-import type { Custom, Suite, Task, Test } from '../types/tasks'
+import type { Suite, Task, Test } from '../types/tasks'
 import { type Arrayable, toArray } from '@vitest/utils'
 
 /**
  * @deprecated use `isTestCase` instead
  */
-export function isAtomTest(s: Task): s is Test | Custom {
+export function isAtomTest(s: Task): s is Test {
   return isTestCase(s)
 }
 
-export function isTestCase(s: Task): s is Test | Custom {
-  return s.type === 'test' || s.type === 'custom'
+export function isTestCase(s: Task): s is Test {
+  return s.type === 'test'
 }
 
-export function getTests(suite: Arrayable<Task>): (Test | Custom)[] {
-  const tests: (Test | Custom)[] = []
+export function getTests(suite: Arrayable<Task>): Test[] {
+  const tests: Test[] = []
   const arraySuites = toArray(suite)
   for (const s of arraySuites) {
     if (isTestCase(s)) {

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -19,7 +19,7 @@ function collectFailed(task: Task, level: number): LeveledTask[] {
     return []
   }
 
-  if (task.type === 'test' || task.type === 'custom') {
+  if (task.type === 'test') {
     return [{ ...task, level }]
   }
   else {

--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -1,7 +1,7 @@
-import type { Custom, File, Task, TaskResultPack, Test } from '@vitest/runner'
+import type { File, Task, TaskResultPack, Test } from '@vitest/runner'
 import type { Arrayable } from '@vitest/utils'
 import type { CollectFilteredTests, CollectorInfo, Filter, FilteredTests } from '~/composables/explorer/types'
-import { isAtomTest } from '@vitest/runner/utils'
+import { isTestCase } from '@vitest/runner/utils'
 import { toArray } from '@vitest/utils'
 import { hasFailedSnapshot } from '@vitest/ws-client'
 import { client, findById } from '~/composables/client'
@@ -460,12 +460,12 @@ export function collectTestsTotalData(
   return filesSummary
 }
 
-function* testsCollector(suite: Arrayable<Task>): Generator<Test | Custom> {
+function* testsCollector(suite: Arrayable<Task>): Generator<Test> {
   const arraySuites = toArray(suite)
   let s: Task
   for (let i = 0; i < arraySuites.length; i++) {
     s = arraySuites[i]
-    if (isAtomTest(s)) {
+    if (isTestCase(s)) {
       yield s
     }
     else {

--- a/packages/ui/client/composables/explorer/types.ts
+++ b/packages/ui/client/composables/explorer/types.ts
@@ -25,7 +25,7 @@ export interface RootTreeNode extends TaskTreeNode {
   tasks: FileTreeNode[]
 }
 
-export type TaskTreeNodeType = 'file' | 'suite' | 'test' | 'custom'
+export type TaskTreeNodeType = 'file' | 'suite' | 'test'
 
 export interface UITaskTreeNode extends TaskTreeNode {
   type: TaskTreeNodeType
@@ -40,11 +40,6 @@ export interface UITaskTreeNode extends TaskTreeNode {
 export interface TestTreeNode extends UITaskTreeNode {
   fileId: string
   type: 'test'
-}
-
-export interface CustomTestTreeNode extends UITaskTreeNode {
-  fileId: string
-  type: 'custom'
 }
 
 export interface ParentTreeNode extends UITaskTreeNode {

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -1,6 +1,5 @@
 import type { File, Task } from '@vitest/runner'
 import type {
-  CustomTestTreeNode,
   FileTreeNode,
   ParentTreeNode,
   SuiteTreeNode,
@@ -13,12 +12,12 @@ import { explorerTree } from '~/composables/explorer/index'
 import { openedTreeItemsSet } from '~/composables/explorer/state'
 import { getProjectNameColor, isSuite as isTaskSuite } from '~/utils/task'
 
-export function isTestNode(node: UITaskTreeNode): node is TestTreeNode | CustomTestTreeNode {
-  return node.type === 'test' || node.type === 'custom'
+export function isTestNode(node: UITaskTreeNode): node is TestTreeNode {
+  return node.type === 'test'
 }
 
-export function isRunningTestNode(node: UITaskTreeNode): node is TestTreeNode | CustomTestTreeNode {
-  return node.mode === 'run' && (node.type === 'test' || node.type === 'custom')
+export function isRunningTestNode(node: UITaskTreeNode): node is TestTreeNode {
+  return node.mode === 'run' && (node.type === 'test')
 }
 
 export function isFileNode(node: UITaskTreeNode): node is FileTreeNode {
@@ -161,7 +160,7 @@ export function createOrUpdateNode(
           indent: node.indent + 1,
           duration,
           state: task.result?.state,
-        } as TestTreeNode | CustomTestTreeNode
+        } as TestTreeNode
       }
       else {
         taskNode = {

--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -1,4 +1,4 @@
-import type { Custom, File, TaskResultPack, TaskState, Test } from '@vitest/runner'
+import type { File, TaskResultPack, TaskState, Test } from '@vitest/runner'
 import type { Vitest } from '../core'
 import { getTests } from '@vitest/runner/utils'
 import c from 'tinyrainbow'
@@ -78,7 +78,7 @@ class DotSummary extends TaskParser {
     }
   }
 
-  onTestStart(test: Test | Custom) {
+  onTestStart(test: Test) {
     if (this.finishedTests.has(test.id)) {
       return
     }
@@ -86,7 +86,7 @@ class DotSummary extends TaskParser {
     this.tests.set(test.id, test.mode || 'run')
   }
 
-  onTestFinished(test: Test | Custom) {
+  onTestFinished(test: Test) {
     if (this.finishedTests.has(test.id)) {
       return
     }

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -1,5 +1,4 @@
 import type {
-  Custom as RunnerCustomCase,
   Task as RunnerTask,
   Test as RunnerTestCase,
   File as RunnerTestFile,
@@ -56,7 +55,7 @@ class ReportedTaskImplementation {
 export class TestCase extends ReportedTaskImplementation {
   #fullName: string | undefined
 
-  declare public readonly task: RunnerTestCase | RunnerCustomCase
+  declare public readonly task: RunnerTestCase
   public readonly type = 'test'
 
   /**
@@ -79,7 +78,7 @@ export class TestCase extends ReportedTaskImplementation {
    */
   public readonly parent: TestSuite | TestModule
 
-  protected constructor(task: RunnerTestCase | RunnerCustomCase, project: TestProject) {
+  protected constructor(task: RunnerTestCase, project: TestProject) {
     super(task, project)
 
     this.name = task.name
@@ -405,7 +404,7 @@ export interface TaskOptions {
 }
 
 function buildOptions(
-  task: RunnerTestCase | RunnerCustomCase | RunnerTestFile | RunnerTestSuite,
+  task: RunnerTestCase | RunnerTestFile | RunnerTestSuite,
 ): TaskOptions {
   return {
     each: task.each,

--- a/packages/vitest/src/node/reporters/summary.ts
+++ b/packages/vitest/src/node/reporters/summary.ts
@@ -1,4 +1,4 @@
-import type { Custom, File, Test } from '@vitest/runner'
+import type { File, Test } from '@vitest/runner'
 import type { Vitest } from '../core'
 import type { Reporter } from '../types/reporter'
 import type { HookOptions } from './task-parser'
@@ -169,7 +169,7 @@ export class SummaryReporter extends TaskParser implements Reporter {
     stats.hook.visible = false
   }
 
-  onTestStart(test: Test | Custom) {
+  onTestStart(test: Test) {
     // Track slow running tests only on verbose mode
     if (!this.options.verbose) {
       return
@@ -200,7 +200,7 @@ export class SummaryReporter extends TaskParser implements Reporter {
     stats.tests.set(test.id, slowTest)
   }
 
-  onTestFinished(test: Test | Custom) {
+  onTestFinished(test: Test) {
     const stats = this.getTestStats(test)
 
     if (!stats) {
@@ -262,7 +262,7 @@ export class SummaryReporter extends TaskParser implements Reporter {
     }
   }
 
-  private getTestStats(test: Test | Custom) {
+  private getTestStats(test: Test) {
     const file = test.file
     let stats = this.runningTests.get(file.id)
 

--- a/packages/vitest/src/node/reporters/task-parser.ts
+++ b/packages/vitest/src/node/reporters/task-parser.ts
@@ -1,4 +1,4 @@
-import type { Custom, File, Task, TaskResultPack, Test } from '@vitest/runner'
+import type { File, Task, TaskResultPack, Test } from '@vitest/runner'
 import type { Vitest } from '../core'
 import { getTests } from '@vitest/runner/utils'
 
@@ -19,8 +19,8 @@ export class TaskParser {
   onHookStart(_options: HookOptions) {}
   onHookEnd(_options: HookOptions) {}
 
-  onTestStart(_test: Test | Custom) {}
-  onTestFinished(_test: Test | Custom) {}
+  onTestStart(_test: Test) {}
+  onTestFinished(_test: Test) {}
 
   onTestFilePrepare(_file: File) {}
   onTestFileFinished(_file: File) {}
@@ -29,8 +29,8 @@ export class TaskParser {
     const startingTestFiles: File[] = []
     const finishedTestFiles: File[] = []
 
-    const startingTests: (Test | Custom)[] = []
-    const finishedTests: (Test | Custom)[] = []
+    const startingTests: Test[] = []
+    const finishedTests: Test[] = []
 
     const startingHooks: HookOptions[] = []
     const endingHooks: HookOptions[] = []
@@ -54,7 +54,7 @@ export class TaskParser {
         }
       }
 
-      if (task?.type === 'test' || task?.type === 'custom') {
+      if (task?.type === 'test') {
         if (task.result?.state === 'run') {
           startingTests.push(task)
         }

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -161,7 +161,7 @@ export type Suite = Suite_
 export type File = File_
 /** @deprecated use `RunnerTestCase` instead */
 export type Test = Test_
-/** @deprecated use `RunnerCustomCase` instead */
+/** @deprecated do not use `Custom`, use `RunnerTestCase` instead */
 export type Custom = Custom_
 /** @deprecated use `RunnerTask` instead */
 export type Task = Task_


### PR DESCRIPTION
### Description

The `Custom` has beed scheduled for deprecation, but it's not used much. Vitest 3 is a good opportunity to remove it.

Let's remove the type itself in Vitest 4, so it's easier to migrate (the deprecation message is visible in the IDE)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
