### PR TITLE
docs: update default value for --pool option to `forks`

### DIFF
--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -395,7 +395,7 @@ Should browser test files run in parallel. Use `--browser.fileParallelism=false`
 - **CLI:** `--pool <pool>`
 - **Config:** [pool](/config/#pool)
 
-Specify pool, if not running in the browser (default: `threads`)
+Specify pool, if not running in the browser (default: `forks`)
 
 ### poolOptions.threads.isolate
 


### PR DESCRIPTION
### Description

Updates the specified default value for the --pool option to be correct with the change in 2.0
https://vitest.dev/guide/migration.html 
https://vitest.dev/guide/cli.html#pool 


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
