### PR TITLE
docs: Fix documentation default value for the --pool option

### DIFF
--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -395,7 +395,7 @@ Should browser test files run in parallel. Use `--browser.fileParallelism=false`
 - **CLI:** `--pool <pool>`
 - **Config:** [pool](/config/#pool)
 
-Specify pool, if not running in the browser (default: `threads`)
+Specify pool, if not running in the browser (default: `forks`)
 
 ### poolOptions.threads.isolate
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -420,7 +420,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   pool: {
     description:
-      'Specify pool, if not running in the browser (default: `threads`)',
+      'Specify pool, if not running in the browser (default: `forks`)',
     argument: '<pool>',
     subcommands: null, // don't support custom objects
   },


### PR DESCRIPTION
### Description

Fixes #7035
The CLI docs state the wrong default value for the --pool option. It was changed from threads to forks in 2.0:
https://vitest.dev/guide/migration.html 
https://vitest.dev/guide/cli.html#pool

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
