### PR TITLE
fix(browser): fix user event state on preview provider

### DIFF
--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -50,6 +50,11 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
       })
     },
     click(element: Element | Locator, options: UserEventClickOptions = {}) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return __tl_user_event__.click(
+          element instanceof Element ? element : element.element(),
+        )
+      }
       return convertToLocator(element).click(processClickOptions(options))
     },
     dblClick(element: Element | Locator, options: UserEventClickOptions = {}) {

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -128,35 +128,35 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
     async cleanup() {
       userEvent = userEventBase.setup(options ?? {})
     },
-    click(element) {
-      return userEvent.click(toElement(element))
+    async click(element) {
+      await userEvent.click(toElement(element))
     },
-    dblClick(element) {
-      return userEvent.dblClick(toElement(element))
+    async dblClick(element) {
+      await userEvent.dblClick(toElement(element))
     },
-    tripleClick(element) {
-      return userEvent.tripleClick(toElement(element))
+    async tripleClick(element) {
+      await userEvent.tripleClick(toElement(element))
     },
-    selectOptions(element, value) {
+    async selectOptions(element, value) {
       const options = (Array.isArray(value) ? value : [value]).map((option) => {
         if (typeof option !== 'string') {
           return toElement(option)
         }
         return option
       })
-      return userEvent.selectOptions(
+      await userEvent.selectOptions(
         element,
         options as string[] | HTMLElement[],
       )
     },
-    clear(element) {
-      return userEvent.clear(toElement(element))
+    async clear(element) {
+      await userEvent.clear(toElement(element))
     },
-    hover(element: Element | Locator) {
-      return userEvent.hover(toElement(element))
+    async hover(element: Element | Locator) {
+      await userEvent.hover(toElement(element))
     },
-    unhover(element: Element | Locator) {
-      return userEvent.unhover(toElement(element))
+    async unhover(element: Element | Locator) {
+      await userEvent.unhover(toElement(element))
     },
     async upload(element: Element | Locator, files: string | string[] | File | File[]) {
       const uploadPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
@@ -183,18 +183,18 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
       await userEvent.clear(toElement(element))
       return userEvent.type(toElement(element), text)
     },
-    dragAndDrop() {
+    async dragAndDrop() {
       throw new Error(`The "preview" provider doesn't support 'userEvent.dragAndDrop'`)
     },
 
     async type(element: Element | Locator, text: string, options: UserEventTypeOptions = {}) {
-      return userEvent.type(toElement(element), text, options)
+      await userEvent.type(toElement(element), text, options)
     },
-    tab(options: UserEventTabOptions = {}) {
-      return userEvent.tab(options)
+    async tab(options: UserEventTabOptions = {}) {
+      await userEvent.tab(options)
     },
     async keyboard(text: string) {
-      return userEvent.keyboard(text)
+      await userEvent.keyboard(text)
     },
   }
 }

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -153,14 +153,10 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
       return userEvent.clear(toElement(element))
     },
     hover(element: Element | Locator) {
-      return userEvent.hover(
-        element instanceof Element ? element : element.element(),
-      )
+      return userEvent.hover(toElement(element))
     },
     unhover(element: Element | Locator) {
-      return userEvent.unhover(
-        element instanceof Element ? element : element.element(),
-      )
+      return userEvent.unhover(toElement(element))
     },
     async upload(element: Element | Locator, files: string | string[] | File | File[]) {
       const uploadPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
@@ -180,7 +176,7 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
         return fileInstance
       })
       const uploadFiles = await Promise.all(uploadPromise)
-      return userEvent.upload((element instanceof Element ? element : element.element()) as HTMLElement, uploadFiles)
+      return userEvent.upload(toElement(element) as HTMLElement, uploadFiles)
     },
 
     async fill(element: Element | Locator, text: string) {

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -39,8 +39,8 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
   }
 
   return {
-    setup(options?: any) {
-      return createUserEvent(__tl_user_event_base__, options)
+    setup() {
+      return createUserEvent()
     },
     async cleanup() {
       return ensureAwaited(async () => {
@@ -121,7 +121,7 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
     return element instanceof Element ? element : element.element()
   }
 
-  return {
+  const vitestUserEvent: UserEvent = {
     setup(options?: any) {
       return createPreviewUserEvent(userEventBase, options)
     },
@@ -197,6 +197,16 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
       await userEvent.keyboard(text)
     },
   }
+
+  for (const [name, fn] of Object.entries(vitestUserEvent)) {
+    if (name !== 'setup') {
+      (vitestUserEvent as any)[name] = function (this: any, ...args: any[]) {
+        return ensureAwaited(() => fn.apply(this, args))
+      }
+    }
+  }
+
+  return vitestUserEvent
 }
 
 export function cdp() {

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -30,7 +30,10 @@ function triggerCommand<T>(command: string, ...args: any[]) {
 }
 
 export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent, options?: TestingLibraryOptions): UserEvent {
-  let __tl_user_event__ = __tl_user_event_base__?.setup(options ?? {})
+  if (__tl_user_event_base__) {
+    return createPreviewUserEvent(__tl_user_event_base__, options ?? {})
+  }
+
   const keyboard = {
     unreleased: [] as string[],
   }
@@ -41,112 +44,37 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     },
     async cleanup() {
       return ensureAwaited(async () => {
-        if (typeof __tl_user_event_base__ !== 'undefined') {
-          __tl_user_event__ = __tl_user_event_base__?.setup(options ?? {})
-          return
-        }
         await triggerCommand('__vitest_cleanup', keyboard)
         keyboard.unreleased = []
       })
     },
     click(element: Element | Locator, options: UserEventClickOptions = {}) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.click(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).click(processClickOptions(options))
     },
     dblClick(element: Element | Locator, options: UserEventClickOptions = {}) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.dblClick(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).dblClick(processClickOptions(options))
     },
     tripleClick(element: Element | Locator, options: UserEventClickOptions = {}) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.tripleClick(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).tripleClick(processClickOptions(options))
     },
     selectOptions(element, value) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        const options = (Array.isArray(value) ? value : [value]).map((option) => {
-          if (typeof option !== 'string' && 'element' in option) {
-            return option.element() as HTMLElement
-          }
-          return option
-        })
-        return __tl_user_event__.selectOptions(
-          element,
-          options as string[] | HTMLElement[],
-        )
-      }
       return convertToLocator(element).selectOptions(value)
     },
     clear(element: Element | Locator) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.clear(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).clear()
     },
     hover(element: Element | Locator, options: UserEventHoverOptions = {}) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.hover(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).hover(processHoverOptions(options))
     },
     unhover(element: Element | Locator, options: UserEventHoverOptions = {}) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.unhover(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).unhover(options)
     },
     async upload(element: Element | Locator, files: string | string[] | File | File[]) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        const uploadPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
-          if (typeof file !== 'string') {
-            return file
-          }
-
-          const { content: base64, basename, mime } = await triggerCommand<{
-            content: string
-            basename: string
-            mime: string
-          }>('__vitest_fileInfo', file, 'base64')
-
-          const fileInstance = fetch(`data:${mime};base64,${base64}`)
-            .then(r => r.blob())
-            .then(blob => new File([blob], basename, { type: mime }))
-          return fileInstance
-        })
-        const uploadFiles = await Promise.all(uploadPromise)
-        return __tl_user_event__.upload((element instanceof Element ? element : element.element()) as HTMLElement, uploadFiles)
-      }
       return convertToLocator(element).upload(files)
     },
 
     // non userEvent events, but still useful
     async fill(element: Element | Locator, text: string, options) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        await __tl_user_event__.clear(
-          element instanceof Element ? element : element.element(),
-        )
-        return __tl_user_event__.type(
-          element instanceof Element ? element : element.element(),
-          text,
-        )
-      }
       return convertToLocator(element).fill(text, options)
     },
     dragAndDrop(source: Element | Locator, target: Element | Locator, options = {}) {
@@ -158,14 +86,6 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     // testing-library user-event
     async type(element: Element | Locator, text: string, options: UserEventTypeOptions = {}) {
       return ensureAwaited(async () => {
-        if (typeof __tl_user_event__ !== 'undefined') {
-          return __tl_user_event__.type(
-            element instanceof Element ? element : element.element(),
-            text,
-            options,
-          )
-        }
-
         const selector = convertToSelector(element)
         const { unreleased } = await triggerCommand<{ unreleased: string[] }>(
           '__vitest_type',
@@ -178,17 +98,11 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     },
     tab(options: UserEventTabOptions = {}) {
       return ensureAwaited(() => {
-        if (typeof __tl_user_event__ !== 'undefined') {
-          return __tl_user_event__.tab(options)
-        }
         return triggerCommand('__vitest_tab', options)
       })
     },
     async keyboard(text: string) {
       return ensureAwaited(async () => {
-        if (typeof __tl_user_event__ !== 'undefined') {
-          return __tl_user_event__.keyboard(text)
-        }
         const { unreleased } = await triggerCommand<{ unreleased: string[] }>(
           '__vitest_keyboard',
           text,
@@ -196,6 +110,95 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
         )
         keyboard.unreleased = unreleased
       })
+    },
+  }
+}
+
+function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options: TestingLibraryOptions): UserEvent {
+  let userEvent = userEventBase.setup(options)
+
+  function toElement(element: Element | Locator) {
+    return element instanceof Element ? element : element.element()
+  }
+
+  return {
+    setup(options?: any) {
+      return createPreviewUserEvent(userEventBase, options)
+    },
+    async cleanup() {
+      userEvent = userEventBase.setup(options ?? {})
+    },
+    click(element) {
+      return userEvent.click(toElement(element))
+    },
+    dblClick(element) {
+      return userEvent.dblClick(toElement(element))
+    },
+    tripleClick(element) {
+      return userEvent.tripleClick(toElement(element))
+    },
+    selectOptions(element, value) {
+      const options = (Array.isArray(value) ? value : [value]).map((option) => {
+        if (typeof option !== 'string') {
+          return toElement(option)
+        }
+        return option
+      })
+      return userEvent.selectOptions(
+        element,
+        options as string[] | HTMLElement[],
+      )
+    },
+    clear(element) {
+      return userEvent.clear(toElement(element))
+    },
+    hover(element: Element | Locator) {
+      return userEvent.hover(
+        element instanceof Element ? element : element.element(),
+      )
+    },
+    unhover(element: Element | Locator) {
+      return userEvent.unhover(
+        element instanceof Element ? element : element.element(),
+      )
+    },
+    async upload(element: Element | Locator, files: string | string[] | File | File[]) {
+      const uploadPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
+        if (typeof file !== 'string') {
+          return file
+        }
+
+        const { content: base64, basename, mime } = await triggerCommand<{
+          content: string
+          basename: string
+          mime: string
+        }>('__vitest_fileInfo', file, 'base64')
+
+        const fileInstance = fetch(`data:${mime};base64,${base64}`)
+          .then(r => r.blob())
+          .then(blob => new File([blob], basename, { type: mime }))
+        return fileInstance
+      })
+      const uploadFiles = await Promise.all(uploadPromise)
+      return userEvent.upload((element instanceof Element ? element : element.element()) as HTMLElement, uploadFiles)
+    },
+
+    async fill(element: Element | Locator, text: string) {
+      await userEvent.clear(toElement(element))
+      return userEvent.type(toElement(element), text)
+    },
+    dragAndDrop() {
+      throw new Error(`The "preview" provider doesn't support 'userEvent.dragAndDrop'`)
+    },
+
+    async type(element: Element | Locator, text: string, options: UserEventTypeOptions = {}) {
+      return userEvent.type(toElement(element), text, options)
+    },
+    tab(options: UserEventTabOptions = {}) {
+      return userEvent.tab(options)
+    },
+    async keyboard(text: string) {
+      return userEvent.keyboard(text)
     },
   }
 }

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -69,12 +69,12 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     unhover(element: Element | Locator, options: UserEventHoverOptions = {}) {
       return convertToLocator(element).unhover(options)
     },
-    async upload(element: Element | Locator, files: string | string[] | File | File[]) {
+    upload(element: Element | Locator, files: string | string[] | File | File[]) {
       return convertToLocator(element).upload(files)
     },
 
     // non userEvent events, but still useful
-    async fill(element: Element | Locator, text: string, options) {
+    fill(element: Element | Locator, text: string, options) {
       return convertToLocator(element).fill(text, options)
     },
     dragAndDrop(source: Element | Locator, target: Element | Locator, options = {}) {

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -58,29 +58,95 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
       return convertToLocator(element).click(processClickOptions(options))
     },
     dblClick(element: Element | Locator, options: UserEventClickOptions = {}) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return __tl_user_event__.dblClick(
+          element instanceof Element ? element : element.element(),
+        )
+      }
       return convertToLocator(element).dblClick(processClickOptions(options))
     },
     tripleClick(element: Element | Locator, options: UserEventClickOptions = {}) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return __tl_user_event__.tripleClick(
+          element instanceof Element ? element : element.element(),
+        )
+      }
       return convertToLocator(element).tripleClick(processClickOptions(options))
     },
     selectOptions(element, value) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        const options = (Array.isArray(value) ? value : [value]).map((option) => {
+          if (typeof option !== 'string' && 'element' in option) {
+            return option.element() as HTMLElement
+          }
+          return option
+        })
+        return __tl_user_event__.selectOptions(
+          element,
+          options as string[] | HTMLElement[],
+        )
+      }
       return convertToLocator(element).selectOptions(value)
     },
     clear(element: Element | Locator) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return __tl_user_event__.clear(
+          element instanceof Element ? element : element.element(),
+        )
+      }
       return convertToLocator(element).clear()
     },
     hover(element: Element | Locator, options: UserEventHoverOptions = {}) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return __tl_user_event__.hover(
+          element instanceof Element ? element : element.element(),
+        )
+      }
       return convertToLocator(element).hover(processHoverOptions(options))
     },
     unhover(element: Element | Locator, options: UserEventHoverOptions = {}) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        return __tl_user_event__.unhover(
+          element instanceof Element ? element : element.element(),
+        )
+      }
       return convertToLocator(element).unhover(options)
     },
-    upload(element: Element | Locator, files: string | string[] | File | File[]) {
+    async upload(element: Element | Locator, files: string | string[] | File | File[]) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        const uploadPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
+          if (typeof file !== 'string') {
+            return file
+          }
+
+          const { content: base64, basename, mime } = await triggerCommand<{
+            content: string
+            basename: string
+            mime: string
+          }>('__vitest_fileInfo', file, 'base64')
+
+          const fileInstance = fetch(`data:${mime};base64,${base64}`)
+            .then(r => r.blob())
+            .then(blob => new File([blob], basename, { type: mime }))
+          return fileInstance
+        })
+        const uploadFiles = await Promise.all(uploadPromise)
+        return __tl_user_event__.upload((element instanceof Element ? element : element.element()) as HTMLElement, uploadFiles)
+      }
       return convertToLocator(element).upload(files)
     },
 
     // non userEvent events, but still useful
-    fill(element: Element | Locator, text: string, options) {
+    async fill(element: Element | Locator, text: string, options) {
+      if (typeof __tl_user_event__ !== 'undefined') {
+        await __tl_user_event__.clear(
+          element instanceof Element ? element : element.element(),
+        )
+        return __tl_user_event__.type(
+          element instanceof Element ? element : element.element(),
+          text,
+        )
+      }
       return convertToLocator(element).fill(text, options)
     },
     dragAndDrop(source: Element | Locator, target: Element | Locator, options = {}) {

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -50,11 +50,6 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
       })
     },
     click(element: Element | Locator, options: UserEventClickOptions = {}) {
-      if (typeof __tl_user_event__ !== 'undefined') {
-        return __tl_user_event__.click(
-          element instanceof Element ? element : element.element(),
-        )
-      }
       return convertToLocator(element).click(processClickOptions(options))
     },
     dblClick(element: Element | Locator, options: UserEventClickOptions = {}) {

--- a/packages/browser/src/client/tester/locators/preview.ts
+++ b/packages/browser/src/client/tester/locators/preview.ts
@@ -8,7 +8,7 @@ import {
   getByTextSelector,
   getByTitleSelector,
 } from 'ivya'
-import { convertElementToCssSelector, ensureAwaited } from '../../utils'
+import { convertElementToCssSelector } from '../../utils'
 import { getElementError } from '../public-utils'
 import { Locator, selectorEngine } from './index'
 
@@ -57,39 +57,39 @@ class PreviewLocator extends Locator {
   }
 
   click(): Promise<void> {
-    return ensureAwaited(() => userEvent.click(this.element()))
+    return userEvent.click(this.element())
   }
 
   dblClick(): Promise<void> {
-    return ensureAwaited(() => userEvent.dblClick(this.element()))
+    return userEvent.dblClick(this.element())
   }
 
   tripleClick(): Promise<void> {
-    return ensureAwaited(() => userEvent.tripleClick(this.element()))
+    return userEvent.tripleClick(this.element())
   }
 
   hover(): Promise<void> {
-    return ensureAwaited(() => userEvent.hover(this.element()))
+    return userEvent.hover(this.element())
   }
 
   unhover(): Promise<void> {
-    return ensureAwaited(() => userEvent.unhover(this.element()))
+    return userEvent.unhover(this.element())
   }
 
   async fill(text: string): Promise<void> {
-    return ensureAwaited(() => userEvent.fill(this.element(), text))
+    return userEvent.fill(this.element(), text)
   }
 
   async upload(file: string | string[] | File | File[]): Promise<void> {
-    return ensureAwaited(() => userEvent.upload(this.element(), file))
+    return userEvent.upload(this.element(), file)
   }
 
   selectOptions(options: string | string[] | HTMLElement | HTMLElement[] | Locator | Locator[]): Promise<void> {
-    return ensureAwaited(() => userEvent.selectOptions(this.element(), options))
+    return userEvent.selectOptions(this.element(), options)
   }
 
   clear(): Promise<void> {
-    return ensureAwaited(() => userEvent.clear(this.element()))
+    return userEvent.clear(this.element())
   }
 
   protected locator(selector: string) {

--- a/packages/browser/src/client/tester/locators/preview.ts
+++ b/packages/browser/src/client/tester/locators/preview.ts
@@ -1,4 +1,5 @@
-import { page, server, userEvent } from '@vitest/browser/context'
+import { userEvent } from '@testing-library/user-event'
+import { page, server } from '@vitest/browser/context'
 import {
   getByAltTextSelector,
   getByLabelSelector,

--- a/packages/browser/src/client/tester/locators/preview.ts
+++ b/packages/browser/src/client/tester/locators/preview.ts
@@ -77,51 +77,19 @@ class PreviewLocator extends Locator {
   }
 
   async fill(text: string): Promise<void> {
-    await this.clear()
-    return ensureAwaited(() => userEvent.type(this.element(), text))
+    return ensureAwaited(() => userEvent.fill(this.element(), text))
   }
 
   async upload(file: string | string[] | File | File[]): Promise<void> {
-    const uploadPromise = (Array.isArray(file) ? file : [file]).map(async (file) => {
-      if (typeof file !== 'string') {
-        return file
-      }
-
-      const { content: base64, basename, mime } = await this.triggerCommand<{
-        content: string
-        basename: string
-        mime: string
-      }>('__vitest_fileInfo', file, 'base64')
-
-      const fileInstance = fetch(`data:${mime};base64,${base64}`)
-        .then(r => r.blob())
-        .then(blob => new File([blob], basename, { type: mime }))
-      return fileInstance
-    })
-    const uploadFiles = await Promise.all(uploadPromise)
-    return ensureAwaited(() => userEvent.upload(this.element() as HTMLElement, uploadFiles))
+    return ensureAwaited(() => userEvent.upload(this.element(), file))
   }
 
-  selectOptions(options_: string | string[] | HTMLElement | HTMLElement[] | Locator | Locator[]): Promise<void> {
-    const options = (Array.isArray(options_) ? options_ : [options_]).map((option) => {
-      if (typeof option !== 'string' && 'element' in option) {
-        return option.element() as HTMLElement
-      }
-      return option
-    })
-    return ensureAwaited(() => userEvent.selectOptions(this.element(), options as string[] | HTMLElement[]))
-  }
-
-  async dropTo(): Promise<void> {
-    throw new Error('The "preview" provider doesn\'t support `dropTo` method.')
+  selectOptions(options: string | string[] | HTMLElement | HTMLElement[] | Locator | Locator[]): Promise<void> {
+    return ensureAwaited(() => userEvent.selectOptions(this.element(), options))
   }
 
   clear(): Promise<void> {
     return ensureAwaited(() => userEvent.clear(this.element()))
-  }
-
-  async screenshot(): Promise<never> {
-    throw new Error('The "preview" provider doesn\'t support `screenshot` method.')
   }
 
   protected locator(selector: string) {

--- a/packages/browser/src/client/tester/locators/preview.ts
+++ b/packages/browser/src/client/tester/locators/preview.ts
@@ -1,5 +1,4 @@
-import { userEvent } from '@testing-library/user-event'
-import { page, server } from '@vitest/browser/context'
+import { page, server, userEvent } from '@vitest/browser/context'
 import {
   getByAltTextSelector,
   getByLabelSelector,

--- a/packages/browser/src/client/tester/locators/preview.ts
+++ b/packages/browser/src/client/tester/locators/preview.ts
@@ -84,8 +84,8 @@ class PreviewLocator extends Locator {
     return userEvent.upload(this.element(), file)
   }
 
-  selectOptions(options: string | string[] | HTMLElement | HTMLElement[] | Locator | Locator[]): Promise<void> {
-    return userEvent.selectOptions(this.element(), options)
+  selectOptions(options_: string | string[] | HTMLElement | HTMLElement[] | Locator | Locator[]): Promise<void> {
+    return userEvent.selectOptions(this.element(), options_)
   }
 
   clear(): Promise<void> {

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -35,7 +35,7 @@ test('non US keys', async () => {
   }
 })
 
-test.only('click with modifier', async () => {
+test('click with modifier', async () => {
   document.body.innerHTML = `
     <div id="test">test shift and click</div>
   `

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { userEvent, page, server } from '@vitest/browser/context'
+import { userEvent, page } from '@vitest/browser/context'
 
 test('non US keys', async () => {
   document.body.innerHTML = `
@@ -33,4 +33,21 @@ test('non US keys', async () => {
   } catch (e) {
     console.error(e)
   }
+})
+
+test.only('click with modifier', async () => {
+  document.body.innerHTML = `
+    <div id="test">test shift and click</div>
+  `
+  const el = document.getElementById("test")
+  el.addEventListener("pointerup", (e) => {
+    if (e.shiftKey && e.type === 'pointerup') {
+      el.textContent += " [ok]"
+    }
+  });
+
+  await userEvent.keyboard('{Shift>}')
+  await userEvent.click(el)
+  await userEvent.keyboard('{/Shift}')
+  await expect.poll(() => el.textContent).toContain("[ok]")
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7007

I moved a preview user event wrapper as `createPreviewUserEvent`, which is uniformly used for `userEvent` API and `Locator` API.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
