### PR TITLE
feat: `diff.printBasicPrototype: false` by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2507,7 +2507,7 @@ Color of truncate annotation, default is output with no color.
 #### diff.printBasicPrototype
 
 - **Type**: `boolean`
-- **Default**: `true`
+- **Default**: `false`
 
 Print basic prototype `Object` and `Array` in diff output
 

--- a/packages/utils/src/diff/normalizeDiffOptions.ts
+++ b/packages/utils/src/diff/normalizeDiffOptions.ts
@@ -34,7 +34,7 @@ function getDefaultOptions(): DiffOptionsNormalized {
     includeChangeCounts: false,
     omitAnnotationLines: false,
     patchColor: c.yellow,
-    printBasicPrototype: true,
+    printBasicPrototype: false,
     truncateThreshold: DIFF_TRUNCATE_THRESHOLD_DEFAULT,
     truncateAnnotation: '... Diff result is truncated',
     truncateAnnotationColor: noColor,

--- a/test/config/test/__snapshots__/diff.test.ts.snap
+++ b/test/config/test/__snapshots__/diff.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`inline diff options: { expand: false, printBasicPrototype: false } 1`] = `
+exports[`inline diff options: { expand: false, printBasicPrototype: true } 1`] = `
 [
   "- Expected
 + Received
 
 @@ -1,7 +1,7 @@
-  [
+  Array [
 -   1000,
 +   0,
     1,
@@ -39,13 +39,13 @@ exports[`inline diff options: { expand: false, printBasicPrototype: false } 1`] 
   "- Expected
 + Received
 
-  {
-    "arr": [
+  Object {
+    "arr": Array [
       1,
 -     3,
 +     2,
     ],
-    "obj": {
+    "obj": Object {
 -     "k": "bar",
 +     "k": "foo",
     },
@@ -58,7 +58,7 @@ exports[`inline diff options: undefined 1`] = `
   "- Expected
 + Received
 
-  Array [
+  [
 -   1000,
 +   0,
     1,
@@ -96,13 +96,13 @@ exports[`inline diff options: undefined 1`] = `
   "- Expected
 + Received
 
-  Object {
-    "arr": Array [
+  {
+    "arr": [
       1,
 -     3,
 +     2,
     ],
-    "obj": Object {
+    "obj": {
 -     "k": "bar",
 +     "k": "foo",
     },

--- a/test/config/test/diff.test.ts
+++ b/test/config/test/diff.test.ts
@@ -4,7 +4,7 @@ import { runVitest } from '../../test-utils'
 
 test.for([
   [undefined],
-  [{ expand: false, printBasicPrototype: false }],
+  [{ expand: false, printBasicPrototype: true }],
 ])(`inline diff options: %o`, async ([options]) => {
   const { ctx } = await runVitest({
     root: './fixtures/diff',

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -26,7 +26,7 @@ exports[`asymmetric matcher error 3`] = `
   "diff": "- Expected
 + Received
 
-  Object {
+  {
 -   "foo": StringContaining "xx",
 +   "foo": "hello",
   }",
@@ -45,7 +45,7 @@ exports[`asymmetric matcher error 4`] = `
   "diff": "- Expected
 + Received
 
-  Object {
+  {
 -   "foo": StringNotContaining "ll",
 +   "foo": "hello",
   }",
@@ -90,7 +90,7 @@ exports[`asymmetric matcher error 7`] = `
   "diff": "- Expected
 + Received
 
-  Object {
+  {
 -   "foo": stringContainingCustom<xx>,
 +   "foo": "hello",
   }",
@@ -109,7 +109,7 @@ exports[`asymmetric matcher error 8`] = `
   "diff": "- Expected
 + Received
 
-  Object {
+  {
 -   "foo": not.stringContainingCustom<ll>,
 +   "foo": "hello",
   }",
@@ -161,7 +161,7 @@ exports[`asymmetric matcher error 12`] = `
 + Received
 
 - ObjectContaining {
-+ Object {
++ {
     "k": "v",
 -   "k3": "v3",
 +   "k2": "v2",
@@ -184,7 +184,7 @@ exports[`asymmetric matcher error 13`] = `
 + Received
 
 - ArrayContaining [
-+ Array [
++ [
     "a",
 -   "c",
 +   "b",
@@ -333,7 +333,7 @@ exports[`diff 2`] = `
 false
 
 + Received: 
-Object {
+{
   "hello": "world",
 }",
   "expected": "false",
@@ -350,7 +350,7 @@ exports[`diff 3`] = `
 NaN
 
 + Received: 
-Object {
+{
   "hello": "world",
 }",
   "expected": "NaN",
@@ -367,7 +367,7 @@ exports[`diff 4`] = `
 undefined
 
 + Received: 
-Object {
+{
   "hello": "world",
 }",
   "expected": "undefined",
@@ -384,7 +384,7 @@ exports[`diff 5`] = `
 null
 
 + Received: 
-Object {
+{
   "hello": "world",
 }",
   "expected": "null",
@@ -400,7 +400,7 @@ exports[`toHaveBeenNthCalledWith error 1`] = `
   "diff": "- Expected
 + Received
 
-  Array [
+  [
 -   "hey",
 +   "Hi",
   ]",

--- a/test/core/test/__snapshots__/mocked.test.ts.snap
+++ b/test/core/test/__snapshots__/mocked.test.ts.snap
@@ -47,21 +47,21 @@ Received:
 
   1st spy call return:
 
-  Object {
+  {
 -   "a": "4",
 +   "a": "1",
   }
 
   2nd spy call return:
 
-  Object {
+  {
 -   "a": "4",
 +   "a": "1",
   }
 
   3rd spy call return:
 
-  Object {
+  {
 -   "a": "4",
 +   "a": "1",
   }

--- a/test/core/test/diff.test.ts
+++ b/test/core/test/diff.test.ts
@@ -28,7 +28,7 @@ test('displays object diff', () => {
     - Expected
     + Received
 
-      Object {
+      {
         "a": 1,
     -   "b": 2,
     +   "b": 3,
@@ -47,7 +47,7 @@ test('display truncated object diff', () => {
     - Expected
     + Received
 
-      Object {
+      {
         "a": 1,
     -   "b": 2,
     -   "c": 3,
@@ -137,7 +137,7 @@ test('display truncated multiple items array diff', () => {
     - Expected
     + Received
 
-      Array [
+      [
     -   "foo",
     -   "foo",
     +   "bar",
@@ -152,7 +152,7 @@ test('asymmetric matcher in object', () => {
     "- Expected
     + Received
 
-      Object {
+      {
     -   "x": 1,
     +   "x": 0,
         "y": Anything,
@@ -171,7 +171,7 @@ test('asymmetric matcher in object with truncated diff', () => {
     "- Expected
     + Received
 
-      Object {
+      {
         "w": Anything,
     -   "x": 1,
     +   "x": 0,
@@ -184,7 +184,7 @@ test('asymmetric matcher in array', () => {
     "- Expected
     + Received
 
-      Array [
+      [
     -   1,
     +   0,
         Anything,
@@ -203,7 +203,7 @@ test('asymmetric matcher in array  with truncated diff', () => {
     "- Expected
     + Received
 
-      Array [
+      [
     -   1,
     +   0,
     ... Diff result is truncated"
@@ -220,13 +220,13 @@ test('asymmetric matcher in nested', () => {
     "- Expected
     + Received
 
-      Array [
-        Object {
+      [
+        {
     -     "x": 1,
     +     "x": 0,
           "y": Anything,
         },
-        Array [
+        [
     -     1,
     +     0,
           Anything,
@@ -246,8 +246,8 @@ test('asymmetric matcher in nested with truncated diff', () => {
     "- Expected
     + Received
 
-      Array [
-        Object {
+      [
+        {
     -     "x": 1,
     +     "x": 0,
           "y": Anything,
@@ -321,8 +321,8 @@ test('getter only property', () => {
     "- Expected
     + Received
 
-      Object {
-        "getOnlyProp": Object {
+      {
+        "getOnlyProp": {
           "a": "b",
         },
     -   "normalProp": 2,

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1139,7 +1139,7 @@ it('correctly prints diff with asymmetric matchers', () => {
       "- Expected
       + Received
 
-        Object {
+        {
           "a": Any<Number>,
       -   "b": Any<Function>,
       +   "b": "string",
@@ -1173,7 +1173,7 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
+      {
     -   "c": 4,
     +   "c": 3,
       }",
@@ -1188,7 +1188,7 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
+      {
     -   "b": 3,
     +   "b": 2,
       }",
@@ -1203,8 +1203,8 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
-        "c": Object {
+      {
+        "c": {
     -     "d": 5,
     +     "d": 4,
         },
@@ -1219,7 +1219,7 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
+      {
         "a": 1,
         "b": 2,
     -   "c": 4,
@@ -1236,9 +1236,9 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
+      {
         "a": 1,
-        "c": Object {
+        "c": {
     -     "d": 4,
     +     "d": 3,
         },
@@ -1254,12 +1254,12 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
-        "c": Object {
+      {
+        "c": {
     -     "d": 5,
     +     "d": 4,
         },
-        "foo": Object {
+        "foo": {
     -     "value": "biz",
     +     "value": "bar",
         },
@@ -1276,9 +1276,9 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
-        "children": Array [
-          Object {
+      {
+        "children": [
+          {
     -       "firstName": "Paul",
     +       "firstName": "Jessica",
           },
@@ -1322,7 +1322,7 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-    - Object {
+    - {
     -   "value": 1,
     + Foo {
     +   "value": 0,
@@ -1338,7 +1338,7 @@ it('toMatchObject error diff', () => {
 
     - Bar {
     -   "value": 1,
-    + Object {
+    + {
     +   "value": 0,
       }",
     ]
@@ -1358,7 +1358,7 @@ it('toMatchObject error diff', () => {
       "- Expected
     + Received
 
-      Object {
+      {
     -   "bad": Bar {
     -     "value": 2,
     +   "bad": Foo {

--- a/test/reporters/tests/__snapshots__/junit.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/junit.test.ts.snap
@@ -78,7 +78,7 @@ AssertionError: expected { hello: &apos;x&apos; } to deeply equal { hello: &apos
 - Expected
 + Received
 
-  Object {
+  {
 -   &quot;hello&quot;: &quot;y&quot;,
 +   &quot;hello&quot;: &quot;x&quot;,
   }


### PR DESCRIPTION
### Description

- follow up to https://github.com/vitest-dev/vitest/pull/6504#discussion_r1764478255

We've been using `printBasicPrototype: false` for snapshot, but diff formatting was still `true` for some reason.

Before

![image](https://github.com/user-attachments/assets/3b72382a-5a8e-4f97-9b26-ba65986afacd)

After

![image](https://github.com/user-attachments/assets/95cfe09e-ad30-4a1f-9589-af01d04b4878)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
