### PR TITLE
fix(ui): add errors and draft state (*) to the code editor

### DIFF
--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -4,6 +4,7 @@ import { codemirrorRef } from '~/composables/codemirror'
 const { mode, readOnly } = defineProps<{
   mode?: string
   readOnly?: boolean
+  saving?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -53,7 +54,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div relative font-mono text-sm class="codemirror-scrolls">
+  <div relative font-mono text-sm class="codemirror-scrolls" :class="saving ? 'codemirror-busy' : undefined">
     <textarea ref="el" />
   </div>
 </template>

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -39,10 +39,16 @@ onMounted(async () => {
     readOnly: readOnly ? true : undefined,
     extraKeys: {
       'Cmd-S': function (cm) {
-        emit('save', cm.getValue())
+        const isReadonly = cm.getOption('readOnly')
+        if (!isReadonly) {
+          emit('save', cm.getValue())
+        }
       },
       'Ctrl-S': function (cm) {
-        emit('save', cm.getValue())
+        const isReadonly = cm.getOption('readOnly')
+        if (!isReadonly) {
+          emit('save', cm.getValue())
+        }
       },
     },
   })

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -228,7 +228,7 @@ const projectNameTextColor = computed(() => {
       </div>
       <ViewEditor
         v-if="viewMode === 'editor'"
-        :key="current.filepath"
+        :key="current.id"
         :file="current"
         data-testid="editor"
         @draft="onDraft"

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -35,6 +35,7 @@ watch(
         code.value = ''
         serverCode.value = code.value
         draft.value = false
+        loading.value = false
         return
       }
 
@@ -214,6 +215,11 @@ async function onSave(content: string) {
 
   // clear previous state
   const cmValue = codemirrorRef.value
+  if (cmValue) {
+    cmValue.setOption('readOnly', true)
+    await nextTick()
+    cmValue.refresh()
+  }
   // save cursor position
   currentPosition.value = cmValue?.getCursor()
   cmValue?.off('changes', codemirrorChanges)
@@ -263,6 +269,11 @@ async function onSave(content: string) {
 
   saving.value = false
   await nextTick()
+  if (cmValue) {
+    cmValue.setOption('readOnly', false)
+    await nextTick()
+    cmValue.refresh()
+  }
   // activate watcher
   resume()
 }

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -3,6 +3,7 @@ import type CodeMirror from 'codemirror'
 import type { ErrorWithDiff, File } from 'vitest'
 import { createTooltip, destroyTooltip } from 'floating-vue'
 import { client, isReport } from '~/composables/client'
+import { finished } from '~/composables/client/state'
 import { codemirrorRef } from '~/composables/codemirror'
 import { openInEditor } from '~/composables/error'
 import { lineNumber } from '~/composables/params'
@@ -17,6 +18,9 @@ const code = ref('')
 const serverCode = shallowRef<string | undefined>(undefined)
 const draft = ref(false)
 const loading = ref(true)
+// finished.value is true when saving the file, we need it to restore the caret position
+const saving = ref(true)
+const currentPosition = ref<CodeMirror.Position | undefined>()
 
 watch(
   () => props.file,
@@ -34,10 +38,15 @@ watch(
       serverCode.value = code.value
       draft.value = false
     }
-    finally {
-      // fire focusing editor after loading
-      nextTick(() => (loading.value = false))
+    catch (e) {
+      console.error('cannot fetch file', e)
     }
+
+    await nextTick()
+
+    // fire focusing editor after loading
+    loading.value = false
+    saving.value = false
   },
   { immediate: true },
 )
@@ -65,13 +74,9 @@ watch(() => [loading.value, props.file, lineNumber.value] as const, ([loadingFil
 const ext = computed(() => props.file?.filepath?.split(/\./g).pop() || 'js')
 const editor = ref<any>()
 
-const cm = computed<CodeMirror.EditorFromTextArea | undefined>(
-  () => editor.value?.cm,
-)
 const failed = computed(
   () => props.file?.tasks.filter(i => i.result?.state === 'fail') || [],
 )
-
 const widgets: CodeMirror.LineWidget[] = []
 const handles: CodeMirror.LineHandle[] = []
 const listeners: [el: HTMLSpanElement, l: EventListener, t: () => void][] = []
@@ -134,46 +139,103 @@ function createErrorElement(e: ErrorWithDiff) {
   const el: EventListener = async () => {
     await openInEditor(stack.file, stack.line, stack.column)
   }
+  span.addEventListener('click', el)
   div.appendChild(span)
   listeners.push([span, el, () => destroyTooltip(span)])
   handles.push(codemirrorRef.value!.addLineClass(stack.line - 1, 'wrap', 'bg-red-500/10'))
   widgets.push(codemirrorRef.value!.addLineWidget(stack.line - 1, div))
 }
 
-watch(
-  [cm, failed],
-  ([cmValue]) => {
+const { pause, resume } = watch(
+  [codemirrorRef, failed, finished, saving] as const,
+  ([cmValue, f, end, s]) => {
     if (!cmValue) {
+      widgets.length = 0
+      handles.length = 0
       clearListeners()
       return
     }
 
-    setTimeout(() => {
-      clearListeners()
-      widgets.forEach(widget => widget.clear())
-      handles.forEach(h => codemirrorRef.value?.removeLineClass(h, 'wrap'))
-      widgets.length = 0
-      handles.length = 0
+    // if still running or saving return
+    if (!end || s) {
+      return
+    }
 
-      cmValue.on('changes', codemirrorChanges)
+    cmValue.off('changes', codemirrorChanges)
 
-      failed.value.forEach((i) => {
-        i.result?.errors?.forEach(createErrorElement)
-      })
-      if (!hasBeenEdited.value) {
-        cmValue.clearHistory()
-      } // Prevent getting access to initial state
-    }, 100)
+    // cleanup previous data
+    clearListeners()
+    widgets.forEach(widget => widget.clear())
+    handles.forEach(h => cmValue?.removeLineClass(h, 'wrap'))
+    widgets.length = 0
+    handles.length = 0
+
+    // add new data
+    f.forEach((i) => {
+      i.result?.errors?.forEach(createErrorElement)
+    })
+
+    // Prevent getting access to initial state
+    if (!hasBeenEdited.value) {
+      cmValue.clearHistory()
+    }
+
+    cmValue.on('changes', codemirrorChanges)
+
+    // restore caret position
+    const { ch, line } = currentPosition.value ?? {}
+    console.log('WTF: ', currentPosition.value)
+    console.error('WTF', new Error('WTF'))
+    if (typeof ch === 'number' && typeof line === 'number') {
+      currentPosition.value = undefined
+    }
   },
   { flush: 'post' },
 )
 
+watchDebounced(() => [finished.value, saving.value, currentPosition.value] as const, ([f, s], old) => {
+  if (f && !s && old && old[2]) {
+    codemirrorRef.value?.setCursor(old[2])
+  }
+}, { debounce: 100, flush: 'post' })
+
 async function onSave(content: string) {
-  hasBeenEdited.value = true
-  await client.rpc.saveTestFile(props.file!.filepath, content)
-  serverCode.value = content
-  draft.value = false
+  if (saving.value) {
+    return
+  }
+  pause()
+  saving.value = true
+  await nextTick()
+  try {
+    currentPosition.value = codemirrorRef.value?.getCursor()
+    hasBeenEdited.value = true
+    // save the file changes
+    await client.rpc.saveTestFile(props.file!.filepath, content)
+    // update original server code
+    serverCode.value = content
+    // update draft indicator in the tab title (</> * Code)
+    draft.value = false
+    // the server will send 3 events in a row
+    // await first change in the state
+    await until(finished).toBe(false, { flush: 'sync', timeout: 1000, throwOnTimeout: false })
+    // await second change in the state
+    await until(finished).toBe(true, { flush: 'sync', timeout: 1000, throwOnTimeout: false })
+    // await last change in the state
+    await until(finished).toBe(false, { flush: 'sync', timeout: 1000, throwOnTimeout: false })
+  }
+  catch (e) {
+    console.error('error saving file', e)
+  }
+
+  // activate watcher
+  resume()
+  await nextTick()
+  // enable adding the errors if present
+  saving.value = false
 }
+
+// we need to remove listeners before unmounting the component: the watcher will not be called
+onBeforeUnmount(clearListeners)
 </script>
 
 <template>
@@ -181,7 +243,7 @@ async function onSave(content: string) {
     ref="editor"
     v-model="code"
     h-full
-    v-bind="{ lineNumbers: true, readOnly: isReport }"
+    v-bind="{ lineNumbers: true, readOnly: isReport, saving }"
     :mode="ext"
     data-testid="code-mirror"
     @save="onSave"

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -182,11 +182,8 @@ const { pause, resume } = watch(
 
     cmValue.on('changes', codemirrorChanges)
 
-    // restore caret position
-    const { ch, line } = currentPosition.value ?? {}
-    console.log('WTF: ', currentPosition.value)
-    console.error('WTF', new Error('WTF'))
-    if (typeof ch === 'number' && typeof line === 'number') {
+    // restore caret position: the watchDebounced below will use old value
+    if (currentPosition.value) {
       currentPosition.value = undefined
     }
   },

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -32,7 +32,11 @@ export const client = (function createVitestClient() {
         },
         onFinished(_files, errors) {
           explorerTree.endRun()
-          testRunState.value = 'idle'
+          // don't change the testRunState.value here:
+          // - when saving the file in the codemirror requires explorer tree endRun to finish (multiple microtasks)
+          // - if we change here the state before the tasks states are updated, the cursor position will be lost
+          // - line moved to composables/explorer/collector.ts::refreshExplorer after calling updateRunningTodoTests
+          // testRunState.value = 'idle'
           unhandledErrors.value = (errors || []).map(parseError)
         },
         onFinishedReportCoverage() {

--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -5,6 +5,7 @@ import { isTestCase } from '@vitest/runner/utils'
 import { toArray } from '@vitest/utils'
 import { hasFailedSnapshot } from '@vitest/ws-client'
 import { client, findById } from '~/composables/client'
+import { testRunState } from '~/composables/client/state'
 import { expandNodesOnEndRun } from '~/composables/explorer/expand'
 import { runFilter, testMatcher } from '~/composables/explorer/filter'
 import { explorerTree } from '~/composables/explorer/index'
@@ -234,6 +235,7 @@ function refreshExplorer(search: string, filter: Filter, end: boolean) {
   // update only at the end
   if (end) {
     updateRunningTodoTests()
+    testRunState.value = 'idle'
   }
 }
 

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -211,3 +211,7 @@ html.dark {
 .v-popper__popper .v-popper__arrow-outer {
   border-color: var(--background-color);
 }
+
+.codemirror-busy > .CodeMirror > .CodeMirror-scroll > .CodeMirror-sizer .CodeMirror-lines {
+  cursor: wait !important;
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
We have a regression somewhere, maybe updating Vue dependency, I'm not sure. The problem is that changes included in these 2 PR missing in current version:
- https://github.com/vitest-dev/vitest/pull/1131
- https://github.com/vitest-dev/vitest/pull/1039

This PR adds the draft indicator and the line error to the code editor: tested with test/core and test/browser (only preview).

This PR also includes:
- codemirror optimizations when registering/unregistering the errors entries to remove memory leaks: looks like `destroy` method is missing in v6
- changes the cursor to `wait` when saving the file: [Video showing the cursor](https://streamable.com/27q83g)
- registers the span listener to open the file in the editor (at line and column error), missing in the original PR #1131

![imagen](https://github.com/user-attachments/assets/9d019809-6ec2-42f3-9110-6d9bb45b1e37)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
