### PR TITLE
feat(cli): Support location filters for suites

### DIFF
--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -51,10 +51,8 @@ export function interpretTaskModes(
         else if (parentMatchedWithLocation) {
           t.mode = 'run'
         }
-        else {
-          if (t.type === 'test') {
-            t.mode = 'skip'
-          }
+        else if (t.type === 'test') {
+          t.mode = 'skip'
         }
       }
 

--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -15,7 +15,7 @@ export function interpretTaskModes(
 ): void {
   const matchedLocations: number[] = []
 
-  const traverseSuite = (suite: Suite, parentIsOnly?: boolean) => {
+  const traverseSuite = (suite: Suite, parentIsOnly?: boolean, parentMatchedWithLocation?: boolean) => {
     const suiteIsOnly = parentIsOnly || suite.mode === 'only'
 
     suite.tasks.forEach((t) => {
@@ -37,22 +37,30 @@ export function interpretTaskModes(
           t.mode = 'run'
         }
       }
+
+      let hasLocationMatch = parentMatchedWithLocation
+      // Match test location against provided locations, only run if present
+      // in `testLocations`. Note: if `includeTaskLocations` is not enabled,
+      // all test will be skipped.
+      if (testLocations !== undefined && testLocations.length !== 0) {
+        if (t.location && testLocations?.includes(t.location.line)) {
+          t.mode = 'run'
+          matchedLocations.push(t.location.line)
+          hasLocationMatch = true
+        }
+        else if (parentMatchedWithLocation) {
+          t.mode = 'run'
+        }
+        else {
+          if (t.type === 'test') {
+            t.mode = 'skip'
+          }
+        }
+      }
+
       if (t.type === 'test') {
         if (namePattern && !getTaskFullName(t).match(namePattern)) {
           t.mode = 'skip'
-        }
-
-        // Match test location against provided locations, only run if present
-        // in `testLocations`.  Note: if `includeTaskLocations` is not enabled,
-        // all test will be skipped.
-        if (testLocations !== undefined && testLocations.length !== 0) {
-          if (t.location && testLocations?.includes(t.location.line)) {
-            t.mode = 'run'
-            matchedLocations.push(t.location.line)
-          }
-          else {
-            t.mode = 'skip'
-          }
         }
       }
       else if (t.type === 'suite') {
@@ -60,7 +68,7 @@ export function interpretTaskModes(
           skipAllTasks(t)
         }
         else {
-          traverseSuite(t, includeTask)
+          traverseSuite(t, includeTask, hasLocationMatch)
         }
       }
     })
@@ -73,7 +81,7 @@ export function interpretTaskModes(
     }
   }
 
-  traverseSuite(file, parentIsOnly)
+  traverseSuite(file, parentIsOnly, false)
 
   const nonMatching = testLocations?.filter(loc => !matchedLocations.includes(loc))
   if (nonMatching && nonMatching.length !== 0) {

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -931,6 +931,23 @@ Repository: micromatch/micromatch
 
 ---------------------------------------
 
+## mimic-fn
+License: MIT
+By: Sindre Sorhus
+Repository: sindresorhus/mimic-fn
+
+> MIT License
+>
+> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------
+
 ## mlly
 License: MIT
 Repository: unjs/mlly
@@ -956,6 +973,23 @@ Repository: unjs/mlly
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
+
+---------------------------------------
+
+## onetime
+License: MIT
+By: Sindre Sorhus
+Repository: sindresorhus/onetime
+
+> MIT License
+>
+> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
 
@@ -1137,6 +1171,23 @@ Repository: privatenumber/resolve-pkg-maps
 
 ---------------------------------------
 
+## restore-cursor
+License: MIT
+By: Sindre Sorhus
+Repository: sindresorhus/restore-cursor
+
+> MIT License
+>
+> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------
+
 ## reusify
 License: MIT
 By: Matteo Collina
@@ -1191,6 +1242,30 @@ Repository: git://github.com/feross/run-parallel.git
 > COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 > IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 > CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------
+
+## signal-exit
+License: ISC
+By: Ben Coe
+Repository: https://github.com/tapjs/signal-exit.git
+
+> The ISC License
+>
+> Copyright (c) 2015, Contributors
+>
+> Permission to use, copy, modify, and/or distribute this software
+> for any purpose with or without fee is hereby granted, provided
+> that the above copyright notice and this permission notice
+> appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+> OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
+> LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+> OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+> WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+> ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
 

--- a/test/cli/test/location-filters.test.ts
+++ b/test/cli/test/location-filters.test.ts
@@ -18,6 +18,54 @@ describe('location filter with list command', () => {
     expect(stderr).toEqual('')
   })
 
+  test('finds "basic suite" at correct line number', async () => {
+    const { stdout, stderr } = await runVitestCli(
+      'list',
+      `-r=${fixturePath}`,
+      `${fixturePath}/basic.test.ts:3`,
+    )
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "basic.test.ts > basic suite > inner suite > some test
+      basic.test.ts > basic suite > inner suite > another test
+      basic.test.ts > basic suite > basic test
+      "
+    `)
+    expect(stderr).toEqual('')
+  })
+
+  test('finds "inner suite" at correct line number', async () => {
+    const { stdout, stderr } = await runVitestCli(
+      'list',
+      `-r=${fixturePath}`,
+      `${fixturePath}/basic.test.ts:4`,
+    )
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "basic.test.ts > basic suite > inner suite > some test
+      basic.test.ts > basic suite > inner suite > another test
+      "
+    `)
+    expect(stderr).toEqual('')
+  })
+
+  test('handles matching test inside a suite', async () => {
+    const { stdout, stderr } = await runVitestCli(
+      'list',
+      `-r=${fixturePath}`,
+      `${fixturePath}/basic.test.ts:3`,
+      `${fixturePath}/basic.test.ts:9`,
+    )
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "basic.test.ts > basic suite > inner suite > some test
+      basic.test.ts > basic suite > inner suite > another test
+      basic.test.ts > basic suite > basic test
+      "
+    `)
+    expect(stderr).toEqual('')
+  })
+
   test('handles file with a dash in the name', async () => {
     const { stdout, stderr } = await runVitestCli(
       'list',
@@ -120,9 +168,44 @@ describe('location filter with run command', () => {
       `${fixturePath}/math.test.ts:3`,
     )
 
-    // expect(`${stdout}\n--------------------\n${stderr}`).toEqual('')
-
     expect(stdout).contain('1 passed')
+    expect(stdout).contain('1 skipped')
+    expect(stderr).toEqual('')
+  })
+
+  test('finds "basic suite" at correct line number', async () => {
+    const { stdout, stderr } = await runVitestCli(
+      'run',
+      `-r=${fixturePath}`,
+      `${fixturePath}/basic.test.ts:3`,
+    )
+
+    expect(stdout).contain('3 passed')
+    expect(stdout).contain('1 skipped')
+    expect(stderr).toEqual('')
+  })
+
+  test('finds "inner suite" at correct line number', async () => {
+    const { stdout, stderr } = await runVitestCli(
+      'run',
+      `-r=${fixturePath}`,
+      `${fixturePath}/basic.test.ts:4`,
+    )
+
+    expect(stdout).contain('2 passed')
+    expect(stdout).contain('2 skipped')
+    expect(stderr).toEqual('')
+  })
+
+  test('handles matching test inside a suite', async () => {
+    const { stdout, stderr } = await runVitestCli(
+      'run',
+      `-r=${fixturePath}`,
+      `${fixturePath}/basic.test.ts:3`,
+      `${fixturePath}/basic.test.ts:9`,
+    )
+
+    expect(stdout).contain('3 passed')
     expect(stdout).contain('1 skipped')
     expect(stderr).toEqual('')
   })


### PR DESCRIPTION
### Description

Closes #5445.

This is a continuation on my previous PR #6411, with support for matching location of suite.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
