### PR TITLE
feat: support Vite v6 in mocker package

### DIFF
--- a/packages/mocker/package.json
+++ b/packages/mocker/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "msw": "^2.4.9",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "msw": {


### PR DESCRIPTION
### Description

This avoids warnings like:

```
└─┬ vitest 3.0.0-beta.2
  └─┬ @vitest/mocker 3.0.0-beta.2
    └── ✕ unmet peer vite@^5.0.0: found 6.0.3
```

when using v3 beta with Vite v6 and pnpm.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
