### PR TITLE
fix: correctly report "skipped" result in TestCase

### DIFF
--- a/docs/advanced/api/test-suite.md
+++ b/docs/advanced/api/test-suite.md
@@ -189,5 +189,5 @@ describe('collection failed', () => {
 ```
 
 ::: warning
-Note that errors are serialized into simple object: `instanceof Error` will always return `false`.
+Note that errors are serialized into simple objects: `instanceof Error` will always return `false`.
 :::

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -126,7 +126,17 @@ export class TestCase extends ReportedTaskImplementation {
    */
   public result(): TestResult | undefined {
     const result = this.task.result
-    if (!result || result.state === 'run') {
+    if (!result) {
+      if (this.skipped()) {
+        return {
+          state: 'skipped',
+          errors: undefined,
+          note: undefined,
+        }
+      }
+      return undefined
+    }
+    if (result.state === 'run') {
       return undefined
     }
     const state = result.state === 'fail'

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -163,6 +163,24 @@ it('correctly reports failed test', () => {
   expect(diagnostic.repeatCount).toBe(0)
 })
 
+it('correctly reports a skipped test', () => {
+  const optionTestCase = findTest(testModule.children, 'skips an option test')
+  expect(optionTestCase.skipped()).toBe(true)
+  expect(optionTestCase.result()).toEqual({
+    state: 'skipped',
+    note: undefined,
+    errors: undefined,
+  })
+
+  const modifierTestCase = findTest(testModule.children, 'skips a .modifier test')
+  expect(modifierTestCase.skipped()).toBe(true)
+  expect(modifierTestCase.result()).toEqual({
+    state: 'skipped',
+    note: undefined,
+    errors: undefined,
+  })
+})
+
 it('correctly reports multiple failures', () => {
   const testCase = findTest(testModule.children, 'fails multiple times')
   const result = testCase.result()!


### PR DESCRIPTION
### Description

I'm also wondering if we should remove the skipped state altogether from the `result()` and only keep `pass` and `fail` 🤔 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
