### PR TITLE
fix(benchmark): disable type testing while benchmarking

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -557,6 +557,7 @@ export function resolveConfig(
     }
     // override test config
     resolved.coverage.enabled = false
+    resolved.typecheck.enabled = false
     resolved.include = resolved.benchmark.include
     resolved.exclude = resolved.benchmark.exclude
     resolved.includeSource = resolved.benchmark.includeSource

--- a/test/benchmark/fixtures/basic/should-not-run.test-d.ts
+++ b/test/benchmark/fixtures/basic/should-not-run.test-d.ts
@@ -1,0 +1,7 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+describe('test', () => {
+  test('some-test', () => {
+    expectTypeOf({ a: 1 }).toEqualTypeOf({ a: "should not match" })
+  })
+})

--- a/test/benchmark/test/basic.test.ts
+++ b/test/benchmark/test/basic.test.ts
@@ -13,6 +13,9 @@ it('basic', { timeout: 60_000 }, async () => {
     root,
     allowOnly: true,
     outputJson: 'bench.json',
+
+    // Verify that type testing cannot be used with benchmark
+    typecheck: { enabled: true },
   }, [], 'benchmark')
   expect(result.exitCode).toBe(0)
 

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -14,6 +14,7 @@
     "./packages/ui/client/**",
     "./examples/**/*.*",
     "./bench/**",
+    "./test/benchmark/fixtures/**",
     "./test/typescript/**",
     "./test/browser/**",
     "**/coverage/fixtures/**",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Type tests should be disabled when running `vitest bench`
- Noticed while testing https://github.com/vitest-dev/vitest/pull/7019 against https://github.com/radashi-org/radashi

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
