### PR TITLE
feat: Add `deps.includeSourcemap`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -207,6 +207,13 @@ Vite will process inlined modules. This could be helpful to handle packages that
 
 If `true`, every dependency will be inlined. All dependencies, specified in [`ssr.noExternal`](https://vitejs.dev/guide/ssr.html#ssr-externals) will be inlined by default.
 
+#### server.deps.includeSourcemap
+
+- **Type:** `(string | RegExp)[]`
+- **Default:** `[]`
+
+Vitest will include inline source maps for any dependency specified in `inlineSourcemap`.
+
 #### server.deps.fallbackCJS
 
 - **Type** `boolean`

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -194,6 +194,9 @@ function parseServerOptions(
       external: toArray(serverOptions.deps?.external).map((dep) => {
         return dep.startsWith('/') && dep.endsWith('/') ? new RegExp(dep) : dep
       }),
+      includeSourcemap: toArray(serverOptions.deps?.includeSourcemap).map((dep) => {
+        return dep.startsWith('/') && dep.endsWith('/') ? new RegExp(dep) : dep
+      }),
       moduleDirectories: serverOptions.deps?.moduleDirectories
         ? toArray(serverOptions.deps?.moduleDirectories)
         : undefined,

--- a/packages/vite-node/src/externalize.ts
+++ b/packages/vite-node/src/externalize.ts
@@ -118,13 +118,13 @@ async function _shouldExternalize(
 
   const moduleDirectories = options?.moduleDirectories || ['/node_modules/']
 
-  if (matchExternalizePattern(id, moduleDirectories, options?.inline)) {
+  if (matchDependencyPattern(id, moduleDirectories, options?.inline)) {
     return false
   }
   if (options?.inlineFiles && options?.inlineFiles.includes(id)) {
     return false
   }
-  if (matchExternalizePattern(id, moduleDirectories, options?.external)) {
+  if (matchDependencyPattern(id, moduleDirectories, options?.external)) {
     return id
   }
 
@@ -138,10 +138,10 @@ async function _shouldExternalize(
   const guessCJS = isLibraryModule && options?.fallbackCJS
   id = guessCJS ? guessCJSversion(id) || id : id
 
-  if (matchExternalizePattern(id, moduleDirectories, defaultInline)) {
+  if (matchDependencyPattern(id, moduleDirectories, defaultInline)) {
     return false
   }
-  if (matchExternalizePattern(id, moduleDirectories, depsExternal)) {
+  if (matchDependencyPattern(id, moduleDirectories, depsExternal)) {
     return id
   }
 
@@ -152,7 +152,7 @@ async function _shouldExternalize(
   return false
 }
 
-function matchExternalizePattern(
+export function matchDependencyPattern(
   id: string,
   moduleDirectories: string[],
   patterns?: (string | RegExp)[] | true,
@@ -163,14 +163,14 @@ function matchExternalizePattern(
   if (patterns === true) {
     return true
   }
-  for (const ex of patterns) {
-    if (typeof ex === 'string') {
-      if (moduleDirectories.some(dir => id.includes(join(dir, ex)))) {
+  for (const pattern of patterns) {
+    if (typeof pattern === 'string') {
+      if (moduleDirectories.some(dir => id.includes(join(dir, pattern)))) {
         return true
       }
     }
     else {
-      if (ex.test(id)) {
+      if (pattern.test(id)) {
         return true
       }
     }
@@ -178,7 +178,7 @@ function matchExternalizePattern(
   return false
 }
 
-function patchWindowsImportPath(path: string) {
+export function patchWindowsImportPath(path: string) {
   if (path.match(/^\w:\\/)) {
     return `file:///${slash(path)}`
   }

--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -10,6 +10,7 @@ export interface DepsHandlingOptions {
   external?: (string | RegExp)[]
   inline?: (string | RegExp)[] | true
   inlineFiles?: string[]
+  includeSourcemap?: (string | RegExp)[]
   /**
    * A list of directories that are considered to hold Node.js modules
    * Have to include "/" at the start and end of the path


### PR DESCRIPTION
This option allows to control if inline source maps should be included in dependencies. This is useful when debugging inline dependencies. It was discussed in https://github.com/vitest-dev/vitest/pull/6041#discussion_r1668253799

To get correct line numbers you need to specify dependencies you wish to debug in `deps.includeSourcemap` and configure `outFiles` in `.vscode/launch.json` like this:

```diff
 {
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
       "type": "node",
       "request": "launch",
       // ...
       "outFiles": [
         "${workspaceFolder}/**/*.(m|c|)js",
         "!**/node_modules/**",
+        "${workspaceFolder}/node_modules/**/date-fns/**/*.js"
       ]
     }
   ]
 }
```


fixes #5605

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
