### PR TITLE
fix: process sourcemaps for stack traces from `globalSetup` files

### DIFF
--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -26,6 +26,7 @@ import mm from 'micromatch'
 import { isAbsolute, join, relative } from 'pathe'
 import { ViteNodeRunner } from 'vite-node/client'
 import { ViteNodeServer } from 'vite-node/server'
+import { installSourcemapsSupport } from 'vite-node/source-map'
 import { setup } from '../api/setup'
 import { isBrowserEnabled, resolveConfig } from './config/resolveConfig'
 import { serializeConfig } from './config/serializeConfig'
@@ -220,6 +221,12 @@ export class TestProject {
     if (this._globalSetups) {
       return
     }
+
+    // Since globalSetup files are executed with vm.runInContext, and Node.js doesn't read VM
+    // sourcemaps, we need source-map-support to ensure useful stack traces.
+    installSourcemapsSupport({
+      getSourceMap: source => this.runner.moduleCache.getSourceMap(source),
+    })
 
     this._globalSetups = await loadGlobalSetupFiles(
       this.runner,


### PR DESCRIPTION
### Description

When a `globalSetup` file (or a module imported as a result of a `globalSetup` file's execution) has an error at runtime, the sourcemaps were not being used, because globalSetup files are executed with `node:vm` (which doesn't read sourcemaps).

In my manual testing, calling `installSourcemapsSupport` before loading the globalSetup files will fix the issue.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
