### PR TITLE
feat: make json reporter easier to extend

### DIFF
--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -88,7 +88,7 @@ export class JsonReporter implements Reporter {
     this.start = Date.now()
   }
 
-  protected async logTasks(files: File[], coverageMap?: CoverageMap | null): JsonTestResults {
+  protected async logTasks(files: File[], coverageMap?: CoverageMap | null): Promise<JsonTestResults> {
     const suites = getSuites(files)
     const numTotalTestSuites = suites.length
     const tests = getTests(files)

--- a/packages/vitest/src/node/reporters/json.ts
+++ b/packages/vitest/src/node/reporters/json.ts
@@ -88,7 +88,7 @@ export class JsonReporter implements Reporter {
     this.start = Date.now()
   }
 
-  protected async logTasks(files: File[], coverageMap?: CoverageMap | null) {
+  protected async logTasks(files: File[], coverageMap?: CoverageMap | null): JsonTestResults {
     const suites = getSuites(files)
     const numTotalTestSuites = suites.length
     const tests = getTests(files)
@@ -176,7 +176,7 @@ export class JsonReporter implements Reporter {
       })
     }
 
-    const result: JsonTestResults = {
+    return {
       numTotalTestSuites,
       numPassedTestSuites,
       numFailedTestSuites,
@@ -192,12 +192,11 @@ export class JsonReporter implements Reporter {
       testResults,
       coverageMap,
     }
-
-    await this.writeReport(JSON.stringify(result))
   }
 
   async onFinished(files = this.ctx.state.getFiles(), _errors: unknown[] = [], coverageMap?: unknown) {
-    await this.logTasks(files, coverageMap as CoverageMap)
+    const results = await this.logTasks(files, coverageMap as CoverageMap)
+    await this.writeReport(JSON.stringify(results))
   }
 
   /**


### PR DESCRIPTION
### Description

Separates concerns : generating results and writing results should be separate functions.
This way we can extend the logtasks function to change the coverage map results without touching the write logic.
Or the other way, change the writing logic without touching the coverage map logic.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
