### PR TITLE
fix(typecheck): use unique temp and tsbuildinfo file for each tsconfig file (fix #7107)

### DIFF
--- a/packages/vitest/src/typecheck/parse.ts
+++ b/packages/vitest/src/typecheck/parse.ts
@@ -75,9 +75,13 @@ export async function getTsconfig(root: string, config: TypecheckConfig) {
     throw new Error('no tsconfig.json found')
   }
 
+  const tsconfigName = basename(tsconfig.path, '.json')
+  const tempTsConfigName = `${tsconfigName}.vitest-temp.json`
+  const tempTsbuildinfoName = `${tsconfigName}.tmp.tsbuildinfo`
+
   const tempConfigPath = join(
     dirname(tsconfig.path),
-    'tsconfig.vitest-temp.json',
+    tempTsConfigName,
   )
 
   try {
@@ -88,7 +92,7 @@ export async function getTsconfig(root: string, config: TypecheckConfig) {
     tmpTsConfig.compilerOptions.incremental = true
     tmpTsConfig.compilerOptions.tsBuildInfoFile = join(
       process.versions.pnp ? join(os.tmpdir(), 'vitest') : __dirname,
-      'tsconfig.tmp.tsbuildinfo',
+      tempTsbuildinfoName,
     )
 
     const tsconfigFinalContent = JSON.stringify(tmpTsConfig, null, 2)
@@ -96,7 +100,7 @@ export async function getTsconfig(root: string, config: TypecheckConfig) {
     return { path: tempConfigPath, config: tmpTsConfig }
   }
   catch (err) {
-    throw new Error('failed to write tsconfig.temp.json', { cause: err })
+    throw new Error(`failed to write ${tempTsConfigName}`, { cause: err })
   }
 }
 

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -96,7 +96,7 @@ Vitest caught 1 unhandled error during the test run.
 This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
 
 ⎯⎯⎯⎯⎯⎯ Typecheck Error ⎯⎯⎯⎯⎯⎯⎯
-Error: error TS18003: No inputs were found in config file '<root>/tsconfig.vitest-temp.json'. Specified 'include' paths were '["src"]' and 'exclude' paths were '["**/dist/**"]'.
+Error: error TS18003: No inputs were found in config file '<root>/tsconfig.empty.vitest-temp.json'. Specified 'include' paths were '["src"]' and 'exclude' paths were '["**/dist/**"]'.
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

**Context:**

This PR addresses an edge case outlined in issue #7107 (which also contains a reproduction example). The issue arises when a directory contains multiple tsconfig*.json files, each corresponding to different test workspaces. Merging this may fix #7107 

Example:
 
<img width="341" alt="image" src="https://github.com/user-attachments/assets/dc9b6a24-040f-4585-a8da-6ca703c1a76c" />

In this scenario, each tsconfig file is linked to a separate workspace. However, Vitest might behave undeterministically, because for each tsconfig file found in the same directory, it attempts to write to the same temporary configuration file, `tsconfig.vitest-temp.json`.

This can lead to flaky test results due to broken temp tsconfig files (different content written on top of each other) or wrong config being applied.

<img width="350" alt="397438346-009cbc69-1549-4411-ad47-1636d65f975f (1)" src="https://github.com/user-attachments/assets/4a203ca6-fca2-4299-9a3c-61730f985e8f" />

---

This PR changes Vitest's temp tsconfig and tsbuildinfo files generation to be unique for each tsconfig file it encounters.

- file: `tsconfig.json`
  temp config: `tsconfig.vitest-temp.json`
  tsbuildinfo: `tsconfig.tmp.tsbuildinfo`
- file: `tsconfig.noStrict.json`
  temp config: `tsconfig.noStrict.vitest-temp.json`
  tsbuildinfo: `tsconfig.noStrict.tmp.tsbuildinfo`

This change doesn't really introduce any new functionality, but helps ensure consistency in test behavior. As part of this change, I updated a test snapshot.

If there's something that I missed, please let me know.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. (updated a snapshot)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
