### PR TITLE
test: remove redundant snapshot name

### DIFF
--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -1,42 +1,42 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`should fail .dot-folder/dot-test.test.ts > .dot-folder/dot-test.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
+exports[`should fail .dot-folder/dot-test.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
 
-exports[`should fail async-assertion.test.ts > async-assertion.test.ts 1`] = `
+exports[`should fail async-assertion.test.ts 1`] = `
 "AssertionError: expected 'xx' to be 'zz' // Object.is equality
 AssertionError: expected 'xx' to be 'yy' // Object.is equality"
 `;
 
-exports[`should fail concurrent-suite-deadlock.test.ts > concurrent-suite-deadlock.test.ts 1`] = `"Error: Test timed out in 500ms."`;
+exports[`should fail concurrent-suite-deadlock.test.ts 1`] = `"Error: Test timed out in 500ms."`;
 
-exports[`should fail concurrent-test-deadlock.test.ts > concurrent-test-deadlock.test.ts 1`] = `"Error: Test timed out in 500ms."`;
+exports[`should fail concurrent-test-deadlock.test.ts 1`] = `"Error: Test timed out in 500ms."`;
 
-exports[`should fail each-timeout.test.ts > each-timeout.test.ts 1`] = `"Error: Test timed out in 10ms."`;
+exports[`should fail each-timeout.test.ts 1`] = `"Error: Test timed out in 10ms."`;
 
-exports[`should fail empty.test.ts > empty.test.ts 1`] = `"Error: No test suite found in file <rootDir>/empty.test.ts"`;
+exports[`should fail empty.test.ts 1`] = `"Error: No test suite found in file <rootDir>/empty.test.ts"`;
 
-exports[`should fail expect.test.ts > expect.test.ts 1`] = `"AssertionError: expected 2 to deeply equal 3"`;
+exports[`should fail expect.test.ts 1`] = `"AssertionError: expected 2 to deeply equal 3"`;
 
-exports[`should fail expect-soft.test.ts > expect-soft.test.ts 1`] = `"Error: expect.soft() can only be used inside a test"`;
+exports[`should fail expect-soft.test.ts 1`] = `"Error: expect.soft() can only be used inside a test"`;
 
-exports[`should fail expect-unreachable.test.ts > expect-unreachable.test.ts 1`] = `"AssertionError: expected "hi" not to be reached"`;
+exports[`should fail expect-unreachable.test.ts 1`] = `"AssertionError: expected "hi" not to be reached"`;
 
-exports[`should fail hook-timeout.test.ts > hook-timeout.test.ts 1`] = `"Error: Hook timed out in 10ms."`;
+exports[`should fail hook-timeout.test.ts 1`] = `"Error: Hook timed out in 10ms."`;
 
-exports[`should fail hooks-called.test.ts > hooks-called.test.ts 1`] = `
+exports[`should fail hooks-called.test.ts 1`] = `
 "Error: after all
 Error: before all"
 `;
 
-exports[`should fail hooks-fail-afterAll.test.ts > hooks-fail-afterAll.test.ts 1`] = `"TypeError: "afterAll" callback value must be function, received "string""`;
+exports[`should fail hooks-fail-afterAll.test.ts 1`] = `"TypeError: "afterAll" callback value must be function, received "string""`;
 
-exports[`should fail hooks-fail-afterEach.test.ts > hooks-fail-afterEach.test.ts 1`] = `"TypeError: "afterEach" callback value must be function, received "string""`;
+exports[`should fail hooks-fail-afterEach.test.ts 1`] = `"TypeError: "afterEach" callback value must be function, received "string""`;
 
-exports[`should fail hooks-fail-beforeAll.test.ts > hooks-fail-beforeAll.test.ts 1`] = `"TypeError: "beforeAll" callback value must be function, received "string""`;
+exports[`should fail hooks-fail-beforeAll.test.ts 1`] = `"TypeError: "beforeAll" callback value must be function, received "string""`;
 
-exports[`should fail hooks-fail-beforeEach.test.ts > hooks-fail-beforeEach.test.ts 1`] = `"TypeError: "beforeEach" callback value must be function, received "string""`;
+exports[`should fail hooks-fail-beforeEach.test.ts 1`] = `"TypeError: "beforeEach" callback value must be function, received "string""`;
 
-exports[`should fail inline-snapshop-inside-each.test.ts > inline-snapshop-inside-each.test.ts 1`] = `
+exports[`should fail inline-snapshop-inside-each.test.ts 1`] = `
 "Error: InlineSnapshot cannot be used inside of test.each or describe.each
 Error: InlineSnapshot cannot be used inside of test.each or describe.each
 Error: InlineSnapshot cannot be used inside of test.each or describe.each
@@ -44,7 +44,7 @@ Error: InlineSnapshot cannot be used inside of test.each or describe.each
 Error: InlineSnapshot cannot be used inside of test.each or describe.each"
 `;
 
-exports[`should fail inline-snapshop-inside-loop.test.ts > inline-snapshop-inside-loop.test.ts 1`] = `
+exports[`should fail inline-snapshop-inside-loop.test.ts 1`] = `
 "Error: toMatchInlineSnapshot cannot be called multiple times at the same location.
 Error: toMatchInlineSnapshot cannot be called multiple times at the same location.
 Error: toMatchInlineSnapshot cannot be called multiple times at the same location.
@@ -52,15 +52,15 @@ Error: toMatchInlineSnapshot cannot be called multiple times at the same locatio
 Error: toMatchInlineSnapshot cannot be called multiple times at the same location."
 `;
 
-exports[`should fail mock-import-proxy-module.test.ts > mock-import-proxy-module.test.ts 1`] = `"Error: There are some problems in resolving the mocks API."`;
+exports[`should fail mock-import-proxy-module.test.ts 1`] = `"Error: There are some problems in resolving the mocks API."`;
 
-exports[`should fail nested-suite.test.ts > nested-suite.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
+exports[`should fail nested-suite.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
 
-exports[`should fail no-assertions.test.ts > no-assertions.test.ts 1`] = `"Error: expected any number of assertion, but got none"`;
+exports[`should fail no-assertions.test.ts 1`] = `"Error: expected any number of assertion, but got none"`;
 
-exports[`should fail node-browser-context.test.ts > node-browser-context.test.ts 1`] = `"Error: @vitest/browser/context can be imported only inside the Browser Mode. Your test is running in forks pool. Make sure your regular tests are excluded from the "test.include" glob pattern."`;
+exports[`should fail node-browser-context.test.ts 1`] = `"Error: @vitest/browser/context can be imported only inside the Browser Mode. Your test is running in forks pool. Make sure your regular tests are excluded from the "test.include" glob pattern."`;
 
-exports[`should fail poll-no-awaited.test.ts > poll-no-awaited.test.ts 1`] = `
+exports[`should fail poll-no-awaited.test.ts 1`] = `
 "Error: expect.poll(assertion).toBe() was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not executed to avoid unhandled rejections:
 AssertionError: expected 3 to be 4 // Object.is equality
 Error: expect.poll(assertion).toBe() was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not executed to avoid unhandled rejections:
@@ -69,9 +69,9 @@ Error: expect.poll(assertion).not.toBe() was not awaited. This assertion is asyn
 Error: expect.poll(assertion).toBe() was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not executed to avoid unhandled rejections:"
 `;
 
-exports[`should fail primitive-error.test.ts > primitive-error.test.ts 1`] = `"Unknown Error: 42"`;
+exports[`should fail primitive-error.test.ts 1`] = `"Unknown Error: 42"`;
 
-exports[`should fail snapshot-with-not.test.ts > snapshot-with-not.test.ts 1`] = `
+exports[`should fail snapshot-with-not.test.ts 1`] = `
 "Error: toThrowErrorMatchingInlineSnapshot cannot be used with "not"
 Error: toThrowErrorMatchingSnapshot cannot be used with "not"
 Error: toMatchInlineSnapshot cannot be used with "not"
@@ -79,16 +79,16 @@ Error: toMatchFileSnapshot cannot be used with "not"
 Error: toMatchSnapshot cannot be used with "not""
 `;
 
-exports[`should fail stall.test.ts > stall.test.ts 1`] = `
+exports[`should fail stall.test.ts 1`] = `
 "TypeError: failure
 TypeError: failure
 TypeError: failure
 TypeError: failure"
 `;
 
-exports[`should fail test-extend/circular-dependency.test.ts > test-extend/circular-dependency.test.ts 1`] = `"Error: Circular fixture dependency detected: a <- b <- a"`;
+exports[`should fail test-extend/circular-dependency.test.ts 1`] = `"Error: Circular fixture dependency detected: a <- b <- a"`;
 
-exports[`should fail test-extend/fixture-error.test.ts > test-extend/fixture-error.test.ts 1`] = `
+exports[`should fail test-extend/fixture-error.test.ts 1`] = `
 "Error: Error fixture teardown
 Error: Test timed out in 20ms.
 Error: Error thrown in test fixture
@@ -96,19 +96,19 @@ Error: Error thrown in afterEach fixture
 Error: Error thrown in beforeEach fixture"
 `;
 
-exports[`should fail test-extend/fixture-rest-params.test.ts > test-extend/fixture-rest-params.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "...rest"."`;
+exports[`should fail test-extend/fixture-rest-params.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "...rest"."`;
 
-exports[`should fail test-extend/fixture-rest-props.test.ts > test-extend/fixture-rest-props.test.ts 1`] = `"Error: Rest parameters are not supported in fixtures, received "...rest"."`;
+exports[`should fail test-extend/fixture-rest-props.test.ts 1`] = `"Error: Rest parameters are not supported in fixtures, received "...rest"."`;
 
-exports[`should fail test-extend/fixture-without-destructuring.test.ts > test-extend/fixture-without-destructuring.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "context"."`;
+exports[`should fail test-extend/fixture-without-destructuring.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "context"."`;
 
-exports[`should fail test-extend/test-rest-params.test.ts > test-extend/test-rest-params.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "...rest"."`;
+exports[`should fail test-extend/test-rest-params.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "...rest"."`;
 
-exports[`should fail test-extend/test-rest-props.test.ts > test-extend/test-rest-props.test.ts 1`] = `"Error: Rest parameters are not supported in fixtures, received "...rest"."`;
+exports[`should fail test-extend/test-rest-props.test.ts 1`] = `"Error: Rest parameters are not supported in fixtures, received "...rest"."`;
 
-exports[`should fail test-extend/test-without-destructuring.test.ts > test-extend/test-without-destructuring.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "context"."`;
+exports[`should fail test-extend/test-without-destructuring.test.ts 1`] = `"Error: The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "context"."`;
 
-exports[`should fail test-timeout.test.ts > test-timeout.test.ts 1`] = `
+exports[`should fail test-timeout.test.ts 1`] = `
 "Error: Test timed out in 20ms.
 Error: Test timed out in 200ms.
 Error: Test timed out in 100ms.
@@ -116,7 +116,7 @@ Error: Test timed out in 15ms.
 Error: Test timed out in 10ms."
 `;
 
-exports[`should fail unhandled.test.ts > unhandled.test.ts 1`] = `
+exports[`should fail unhandled.test.ts 1`] = `
 "Error: some error
 Error: Uncaught [Error: some error]"
 `;

--- a/test/cli/test/fails.test.ts
+++ b/test/cli/test/fails.test.ts
@@ -22,7 +22,7 @@ it.each(files)('should fail %s', async (file) => {
     .map(i => i.trim().replace(root, '<rootDir>'),
     )
     .join('\n')
-  expect(msg).toMatchSnapshot(file)
+  expect(msg).toMatchSnapshot()
 }, 30_000)
 
 it('should report coverage when "coverag.reportOnFailure: true" and tests fail', async () => {


### PR DESCRIPTION
### Description

I replaced `toMatchSnapshot(file)` with a simpler `toMatchSnapshot()` since `file` already appears in a `test.each` title.

Also, `toMatchSnapshot("...")` API has an issue with skipped tests (see https://github.com/vitest-dev/vitest/issues/7113), so it's better to avoid that for now.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
