### PR TITLE
docs: added more description about connecting UI with right mode.

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -19,7 +19,7 @@ vitest --ui
 Then you can visit the Vitest UI at <a href="http://localhost:51204/__vitest__/">`http://localhost:51204/__vitest__/`</a>
 
 ::: warning
-Make sure you are running it in `watch` mode as it's **not supported** for `run` mode. HTML reporter can be used instead to get generated HTML page with the same results. More details are provided in `TIP` section below.
+The UI is interactive and requires a running Vite server, so make sure to run Vitest in `watch` mode (the default). Alternatively, you can generate a static HTML report that looks identical to the Vitest UI by specifying `html` in config's `reporters` option.
 :::
 
 <img alt="Vitest UI" img-light src="/ui-1-light.png">

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -18,6 +18,10 @@ vitest --ui
 
 Then you can visit the Vitest UI at <a href="http://localhost:51204/__vitest__/">`http://localhost:51204/__vitest__/`</a>
 
+::: warning
+Make sure you are running it in `watch` mode as it's **not supported** for `run` mode. HTML reporter can be used instead to get generated HTML page with the same results. More details are provided in `TIP` section below.
+:::
+
 <img alt="Vitest UI" img-light src="/ui-1-light.png">
 <img alt="Vitest UI" img-dark src="/ui-1-dark.png">
 


### PR DESCRIPTION
Added more description for connecting UI with right mode to avoid confusion.

### Description

While reading the [guide](https://vitest.dev/guide/ui) about Vitest UI, most of us try to run it with `vitest run` and the UI never connects. It is made for `watch` mode. I have added a `warning` about this usage and also mentioned the area where information about `HTML` reported is given for `run` mode.

### Fixes
It's an old issue. I am not creating a new issue for the same. Instead, referencing the previous one which asks for a documentation update to avoid confusion.

Details: #2897

### Snapshot
![image](https://github.com/user-attachments/assets/ca79d6e8-96b9-48a5-b488-ff09cfc93dde)

<!-- You can also add additional context here -->
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
