### PR TITLE
fix(typecheck): fix error test case mapping for `@ts-expect-error`

### DIFF
--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -5,6 +5,8 @@ import { resolve } from 'pathe'
 import { isPrimitive, notNullish } from './helpers'
 
 export {
+  eachMapping,
+  type EachMapping,
   generatedPositionFor,
   originalPositionFor,
   TraceMap,

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -1,6 +1,7 @@
 import type { RawSourceMap } from '@ampproject/remapping'
 import type { File, Task, TaskResultPack, TaskState } from '@vitest/runner'
 import type { ParsedStack } from '@vitest/utils'
+import type { EachMapping } from '@vitest/utils/source-map'
 import type { ChildProcess } from 'node:child_process'
 import type { Vitest } from '../node/core'
 import type { TestProject } from '../node/project'
@@ -10,7 +11,7 @@ import type { TscErrorInfo } from './types'
 import { rm } from 'node:fs/promises'
 import { performance } from 'node:perf_hooks'
 import { getTasks } from '@vitest/runner/utils'
-import { generatedPositionFor, TraceMap } from '@vitest/utils/source-map'
+import { eachMapping, generatedPositionFor, TraceMap } from '@vitest/utils/source-map'
 import { basename, extname, resolve } from 'pathe'
 import { x } from 'tinyexec'
 import { collectTests } from './collect'
@@ -161,7 +162,7 @@ export class Typechecker {
       }
       errors.forEach(({ error, originalError }) => {
         const processedPos = traceMap
-          ? generatedPositionFor(traceMap, {
+          ? findGeneratePosition(traceMap, {
             line: originalError.line,
             column: originalError.column,
             source: basename(path),
@@ -363,4 +364,32 @@ export class Typechecker {
       .flat()
       .map<TaskResultPack>(i => [i.id, i.result, { typecheck: true }])
   }
+}
+
+function findGeneratePosition(traceMap: TraceMap, { line, column, source }: { line: number; column: number; source: string }) {
+  const found = generatedPositionFor(traceMap, {
+    line,
+    column,
+    source,
+  })
+  if (found.line !== null) {
+    return found
+  }
+  // find the next source token position when the exact error position doesn't exist in source map.
+  // this can happen, for example, when the type error is in the comment "// @ts-expect-error"
+  // and comments are stripped away in the generated code.
+  const mappings: (EachMapping & { originalLine: number })[] = []
+  eachMapping(traceMap, (m) => {
+    if (m.source === source && m.originalLine !== null && m.originalColumn !== null && (line < m.originalLine || (line === m.originalLine && column <= m.originalColumn))) {
+      mappings.push(m)
+    }
+  })
+  const next = mappings.sort((a, b) => a.originalLine === b.originalLine ? a.originalColumn - b.originalColumn : a.originalLine - b.originalLine).at(0)
+  if (next) {
+    return {
+      line: next.generatedLine,
+      column: next.generatedColumn,
+    }
+  }
+  return { line: null, column: null }
 }

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -162,7 +162,7 @@ export class Typechecker {
       }
       errors.forEach(({ error, originalError }) => {
         const processedPos = traceMap
-          ? findGeneratePosition(traceMap, {
+          ? findGeneratedPosition(traceMap, {
             line: originalError.line,
             column: originalError.column,
             source: basename(path),
@@ -366,7 +366,7 @@ export class Typechecker {
   }
 }
 
-function findGeneratePosition(traceMap: TraceMap, { line, column, source }: { line: number; column: number; source: string }) {
+function findGeneratedPosition(traceMap: TraceMap, { line, column, source }: { line: number; column: number; source: string }) {
   const found = generatedPositionFor(traceMap, {
     line,
     column,

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -380,11 +380,20 @@ function findGeneratePosition(traceMap: TraceMap, { line, column, source }: { li
   // and comments are stripped away in the generated code.
   const mappings: (EachMapping & { originalLine: number })[] = []
   eachMapping(traceMap, (m) => {
-    if (m.source === source && m.originalLine !== null && m.originalColumn !== null && (line < m.originalLine || (line === m.originalLine && column <= m.originalColumn))) {
+    if (
+      m.source === source
+      && m.originalLine !== null
+      && m.originalColumn !== null
+      && (line === m.originalLine ? column < m.originalColumn : line < m.originalLine)
+    ) {
       mappings.push(m)
     }
   })
-  const next = mappings.sort((a, b) => a.originalLine === b.originalLine ? a.originalColumn - b.originalColumn : a.originalLine - b.originalLine).at(0)
+  const next = mappings
+    .sort((a, b) =>
+      a.originalLine === b.originalLine ? a.originalColumn - b.originalColumn : a.originalLine - b.originalLine,
+    )
+    .at(0)
   if (next) {
     return {
       line: next.generatedLine,

--- a/test/typescript/failing/expect-error.test-d.ts
+++ b/test/typescript/failing/expect-error.test-d.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 
+
 test('failing test with expect-error', () => {
   // @ts-expect-error expect nothing
   expectTypeOf(1).toEqualTypeOf<number>()

--- a/test/typescript/failing/expect-error.test-d.ts
+++ b/test/typescript/failing/expect-error.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 
-
+//
 test('failing test with expect-error', () => {
   // @ts-expect-error expect nothing
   expectTypeOf(1).toEqualTypeOf<number>()

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -24,12 +24,12 @@ TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has n
 exports[`should fail > typecheck files 3`] = `
 " FAIL  expect-error.test-d.ts > failing test with expect-error
 TypeCheckError: Unused '@ts-expect-error' directive.
- ❯ expect-error.test-d.ts:4:3
-      2| 
-      3| test('failing test with expect-error', () => {
-      4|   // @ts-expect-error expect nothing
+ ❯ expect-error.test-d.ts:5:3
+      3| 
+      4| test('failing test with expect-error', () => {
+      5|   // @ts-expect-error expect nothing
        |   ^
-      5|   expectTypeOf(1).toEqualTypeOf<number>()"
+      6|   expectTypeOf(1).toEqualTypeOf<number>()"
 `;
 
 exports[`should fail > typecheck files 4`] = `

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -25,7 +25,7 @@ exports[`should fail > typecheck files 3`] = `
 " FAIL  expect-error.test-d.ts > failing test with expect-error
 TypeCheckError: Unused '@ts-expect-error' directive.
  ❯ expect-error.test-d.ts:5:3
-      3| 
+      3| //
       4| test('failing test with expect-error', () => {
       5|   // @ts-expect-error expect nothing
        |   ^

--- a/test/typescript/vitest.config.fails.ts
+++ b/test/typescript/vitest.config.fails.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+// pnpm -C test/typescript test -- -c vitest.config.fails.ts
+export default defineConfig({
+  test: {
+    dir: './failing',
+    typecheck: {
+      enabled: true,
+      allowJs: true,
+      include: ['**/*.test-d.*'],
+      tsconfig: './tsconfig.fails.json',
+    },
+  },
+})


### PR DESCRIPTION
### Description

- Cherry-picked a fix from https://github.com/vitest-dev/vitest/pull/7124

The bugs is reproducible on Vite 5 as well, so I extracted the fix in a separate PR.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
