### PR TITLE
fix(snapshot): fix obsoleteness check of `toMatchSnapshot("...")`

### DIFF
--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -109,7 +109,10 @@ export default class SnapshotState {
 
   markSnapshotsAsCheckedForTest(testName: string): void {
     this._uncheckedKeys.forEach((uncheckedKey) => {
-      if (keyToTestName(uncheckedKey) === testName) {
+      // skip snapshots with following keys
+      //   testName n
+      //   testName > xxx n (this is for toMatchSnapshot("xxx") API)
+      if (/ \d+$| > /.test(uncheckedKey.slice(testName.length))) {
         this._uncheckedKeys.delete(uncheckedKey)
       }
     })

--- a/test/snapshots/test/fixtures/skip-test-custom/__snapshots__/basic.test.ts.snap
+++ b/test/snapshots/test/fixtures/skip-test-custom/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`custom a > x 1`] = `0`;
+
+exports[`custom a > y 1`] = `0`;
+
+exports[`custom b > w 1`] = `0`;
+
+exports[`custom b > z 1`] = `0`;

--- a/test/snapshots/test/fixtures/skip-test-custom/basic.test.ts
+++ b/test/snapshots/test/fixtures/skip-test-custom/basic.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+
+test('custom a', () => {
+  expect(0).toMatchSnapshot('x');
+  expect(0).toMatchSnapshot('y');
+});
+
+test('custom b', () => {
+  expect(0).toMatchSnapshot('z');
+  expect(0).toMatchSnapshot('w');
+});


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7113

Previously only `... \d+` (e.g. `test name 1`) is skipped. I added `... > ...` (e.g. `test name > custom message`) to cover `toMatchSnapshot("...")` case.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
