### PR TITLE
fix(snapshot): fix "obsolete" message on snapshot update re-run

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -937,6 +937,7 @@ export class Vitest {
       // environment is resolved inside a worker thread
       snapshotEnvironment: null as any,
     }
+    this.snapshot.options.updateSnapshot = 'all'
   }
 
   /**
@@ -944,6 +945,7 @@ export class Vitest {
    */
   public resetSnapshotUpdate(): void {
     delete this.configOverride.snapshotOptions
+    this.snapshot.options.updateSnapshot = this.config.snapshotOptions.updateSnapshot
   }
 
   /**

--- a/test/snapshots/test/fixtures/summary-removed/.gitignore
+++ b/test/snapshots/test/fixtures/summary-removed/.gitignore
@@ -1,0 +1,1 @@
+__snapshots__

--- a/test/snapshots/test/fixtures/summary-removed/basic.test.ts
+++ b/test/snapshots/test/fixtures/summary-removed/basic.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+test('x', () => {
+  expect(0).toMatchSnapshot()
+})
+
+// REMOVE-START
+test('y', () => {
+  expect(0).toMatchSnapshot()
+})
+// REMOVE-END

--- a/test/snapshots/test/summary.test.ts
+++ b/test/snapshots/test/summary.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import { join } from 'node:path'
-import { expect, test } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { assert, expect, onTestFailed, onTestFinished, test } from 'vitest'
+import { editFile, runVitest } from '../../test-utils'
 
 function fsUpdate(file: string, updateFn: (data: string) => string) {
   fs.writeFileSync(file, updateFn(fs.readFileSync(file, 'utf-8')))
@@ -39,4 +39,55 @@ test('summary', async () => {
     update: true,
   })
   expect(vitest.stdout).toContain('Snapshots  2 updated')
+})
+
+test('first obsolete then remove', async () => {
+  const root = join(import.meta.dirname, 'fixtures/summary-removed')
+  const testFile = join(root, 'basic.test.ts')
+  const snapshotFile = join(root, '__snapshots__/basic.test.ts.snap')
+
+  // reset snapshot
+  fs.rmSync(snapshotFile, { recursive: true, force: true })
+  await runVitest({
+    root,
+    update: true,
+  })
+  expect(fs.readFileSync(snapshotFile, 'utf-8')).toMatchInlineSnapshot(`
+    "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+    exports[\`x 1\`] = \`0\`;
+
+    exports[\`y 1\`] = \`0\`;
+    "
+  `)
+
+  // watch run
+  const { ctx, ...result } = await runVitest(
+    {
+      watch: true,
+      root,
+    },
+  )
+  assert(ctx)
+  onTestFinished(() => {
+    ctx.close()
+  })
+  onTestFailed(() => {
+    console.error(result.vitest.stdout)
+    console.error(result.vitest.stderr)
+  })
+
+  // remove `toMatchSnapshot()` and rerun -> obsolete snapshot
+  editFile(testFile, s => s.replace(/REMOVE-START.*REMOVE-END/s, ''))
+  await result.vitest.waitForStdout('1 obsolete')
+
+  // rerun with update -> remove snapshot
+  await ctx.updateSnapshot()
+  await result.vitest.waitForStdout('1 removed')
+  expect(fs.readFileSync(snapshotFile, 'utf-8')).toMatchInlineSnapshot(`
+    "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+    exports[\`x 1\`] = \`0\`;
+    "
+  `)
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7128

It looks like this is a bug since summary's option isn't updated on watch update re-run

https://github.com/vitest-dev/vitest/blob/87c3c4aff63a861431e0a2e44c58ab94aa44791f/packages/snapshot/src/manager.ts#L61

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
