### PR TITLE
refactor(coverage): remove unnecessary `__vite_ssr_exports__` manipulation

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -399,7 +399,7 @@ function excludeGeneratedCode(
   }
 
   const trimmed = new MagicString(source)
-  trimmed.replaceAll(VITE_EXPORTS_LINE_PATTERN, '\n')
+  // trimmed.replaceAll(VITE_EXPORTS_LINE_PATTERN, '\n')
   trimmed.replaceAll(DECORATOR_METADATA_PATTERN, match =>
     '\n'.repeat(match.split('\n').length - 1))
 

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -30,9 +30,6 @@ type RawCoverage = Profiler.TakePreciseCoverageReturnType
 // TODO: vite-node should export this
 const WRAPPER_LENGTH = 185
 
-// Note that this needs to match the line ending as well
-const VITE_EXPORTS_LINE_PATTERN
-  = /Object\.defineProperty\(__vite_ssr_exports__.*\n/g
 const DECORATOR_METADATA_PATTERN
   = /_ts_metadata\("design:paramtypes", \[[^\]]*\]\),*/g
 const FILE_PROTOCOL = 'file://'
@@ -391,15 +388,11 @@ function excludeGeneratedCode(
     return map
   }
 
-  if (
-    !source.match(VITE_EXPORTS_LINE_PATTERN)
-    && !source.match(DECORATOR_METADATA_PATTERN)
-  ) {
+  if (!source.match(DECORATOR_METADATA_PATTERN)) {
     return map
   }
 
   const trimmed = new MagicString(source)
-  // trimmed.replaceAll(VITE_EXPORTS_LINE_PATTERN, '\n')
   trimmed.replaceAll(DECORATOR_METADATA_PATTERN, match =>
     '\n'.repeat(match.split('\n').length - 1))
 


### PR DESCRIPTION
### Description

- Related https://github.com/vitest-dev/vitest/issues/7130

Vite SSR doesn't create a mapping for `Object.defineProperty(__vite_ssr_exports__, ...)` (as they are simply injected by `MagicString.appendLeft`), so I'm not sure what this replacement on v8 coverage is for.

It looks like `test/coverage-test` is passing locally. Let me check others on CI.

Sadly, this doesn't seem to entirely help https://github.com/vitest-dev/vitest/issues/7130. There's still some odd changes (namely export getter `get` appears in function coverage) in https://github.com/vitest-dev/vitest/pull/7096 after applying the same patch.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
