### PR TITLE
fix(diff): truncate to avoid crash on diff large objects

### DIFF
--- a/test/core/test/diff.test.ts
+++ b/test/core/test/diff.test.ts
@@ -331,7 +331,13 @@ test('getter only property', () => {
   `)
 })
 
-function getErrorDiff(actual: unknown, expected: unknown, options?: DiffOptions) {
+test('truncate large diff', () => {
+  const diff = getErrorDiff(Array.from({ length: 500_000 }).fill(0), 1234)
+  expect(diff.length).lessThan(200_000)
+  expect(diff.trim()).toMatch(/\.\.\.$/)
+})
+
+function getErrorDiff(actual: unknown, expected: unknown, options?: DiffOptions): string {
   try {
     expect(actual).toEqual(expected)
   }
@@ -339,5 +345,5 @@ function getErrorDiff(actual: unknown, expected: unknown, options?: DiffOptions)
     const error = processError(e, options)
     return error.diff
   }
-  expect.unreachable()
+  return expect.unreachable()
 }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7009

This isn't fool-proof for all situations, but it seems to help dealing with some cases.

For playwright's case, the large formatting happens because of `callToJSON: false`, which is used only when comparing against two different "types" of objects (`ElementHandle` vs `null` in the repro's case). `ElementHandle.toJSON` is something compact like this:

```
Object {
  "_guid": "handle@c697bfba7ffbd40d2511ee19416963a8",
  "_type": "ElementHandle",
}
```

https://github.com/vitest-dev/vitest/blob/f9a628438a5462436b59dd9bdeffddada19a9e81/packages/utils/src/diff/index.ts#L58-L62

I also noticed `prettyFormat` actually succeeds, but large memory consumption happens probably later when going through RPC etc... So the fix here is to just truncate beforehand for `FALLBACK_FORMAT_OPTIONS` case and also reduce the default `FALLBACK_FORMAT_OPTIONS.maxDepth` a little.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
