### PR TITLE
Fix/to equal undefined comparison

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -39,7 +39,7 @@ export function equals(
     [],
     [],
     customTesters,
-    strictCheck ? hasKey : hasDefinedKey
+    strictCheck ? hasKey : hasDefinedKey,
   )
 }
 

--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -33,7 +33,14 @@ export function equals(
   strictCheck?: boolean,
 ): boolean {
   customTesters = customTesters || []
-  return eq(a, b, [], [], customTesters, strictCheck ? hasKey : hasDefinedKey)
+  return eq(
+    filterUndefined(a),
+    filterUndefined(b),
+    [],
+    [],
+    customTesters,
+    strictCheck ? hasKey : hasDefinedKey
+  )
 }
 
 const functionToString = Function.prototype.toString
@@ -787,4 +794,22 @@ export function getObjectSubset(
       }
 
   return { subset: getObjectSubsetWithContext()(object, subset), stripped }
+}
+
+function filterUndefined(obj: any): any {
+  if (!isObject(obj)) {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(filterUndefined)
+  }
+
+  const result: any = {}
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = filterUndefined(obj[key])
+    }
+  }
+  return result
 }

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1849,3 +1849,21 @@ it('diff', () => {
   snapshotError(() => expect({ hello: 'world' }).toBeUndefined())
   snapshotError(() => expect({ hello: 'world' }).toBeNull())
 })
+
+snapshotError(() =>
+  expect({
+    x: 'foo',
+    y: undefined,
+  }).toEqual({
+    x: 'bar',
+  }),
+)
+
+snapshotError(() =>
+  expect({
+    x: 'foo',
+  }).toEqual({
+    x: 'bar',
+    y: undefined,
+  }),
+)


### PR DESCRIPTION
Fixes #7083 

### Description

This PR fixes the toEqual matcher to consistently ignore undefined properties when comparing objects. Previously, undefined properties were inconsistently highlighted in error messages, leading to confusion. The fix ensures predictable behavior and clearer error messages. Unit tests have been added to validate the changes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
