### PR TITLE
refactor: correct argument names

### DIFF
--- a/packages/utils/src/diff/index.ts
+++ b/packages/utils/src/diff/index.ts
@@ -233,8 +233,8 @@ function isReplaceable(obj1: any, obj2: any) {
 }
 
 export function printDiffOrStringify(
-  expected: unknown,
   received: unknown,
+  expected: unknown,
   options?: DiffOptions,
 ): string | undefined {
   const { aAnnotation, bAnnotation } = normalizeDiffOptions(options)
@@ -249,10 +249,10 @@ export function printDiffOrStringify(
     && expected !== received
   ) {
     if (expected.includes('\n') || received.includes('\n')) {
-      return diffStringsUnified(received, expected, options)
+      return diffStringsUnified(expected, received, options)
     }
 
-    const [diffs] = diffStringsRaw(received, expected, true)
+    const [diffs] = diffStringsRaw(expected, received, true)
     const hasCommonDiff = diffs.some(diff => diff[0] === DIFF_EQUAL)
 
     const printLabel = getLabelPrinter(aAnnotation, bAnnotation)
@@ -273,7 +273,7 @@ export function printDiffOrStringify(
   // if (isLineDiffable(expected, received)) {
   const clonedExpected = deepClone(expected, { forceWritable: true })
   const clonedReceived = deepClone(received, { forceWritable: true })
-  const { replacedExpected, replacedActual } = replaceAsymmetricMatcher(clonedExpected, clonedReceived)
+  const { replacedExpected, replacedActual } = replaceAsymmetricMatcher(clonedReceived, clonedExpected)
   const difference = diff(replacedExpected, replacedActual, options)
 
   return difference


### PR DESCRIPTION
### Description

I fixed `printDiffOrStringify` since `received/expected` perspective is flipped compared to its usage.

https://github.com/vitest-dev/vitest/blob/a37d81c315904d0b0f87d6e6b6b8b2ce6499eab5/packages/utils/src/error.ts#L139

https://github.com/vitest-dev/vitest/blob/a37d81c315904d0b0f87d6e6b6b8b2ce6499eab5/packages/utils/src/diff/index.ts#L293-L295

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
