### PR TITLE
fix(coverage): prevent crash when v8 incorrectly merges static_initializer's

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@ampproject/remapping": "^2.3.0",
-    "@bcoe/v8-coverage": "^0.2.3",
+    "@bcoe/v8-coverage": "^1.0.1",
     "debug": "^4.4.0",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -6,6 +6,7 @@ import type { CoverageProvider, ReportContext, ResolvedCoverageOptions, TestProj
 import { promises as fs } from 'node:fs'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import remapping from '@ampproject/remapping'
+// @ts-expect-error -- untyped
 import { mergeProcessCovs } from '@bcoe/v8-coverage'
 import createDebug from 'debug'
 import libCoverage from 'istanbul-lib-coverage'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,8 +498,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       '@bcoe/v8-coverage':
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^1.0.1
+        version: 1.0.1
       debug:
         specifier: ^4.4.0
         version: 4.4.0
@@ -2281,8 +2281,9 @@ packages:
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
-  '@bcoe/v8-coverage@0.2.3':
-    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+  '@bcoe/v8-coverage@1.0.1':
+    resolution: {integrity: sha512-W+a0/JpU28AqH4IKtwUPcEUnUyXMDLALcn5/JLczGGT9fHE2sIby/xP/oQnx3nxkForzgzPy201RAKcB4xPAFQ==}
+    engines: {node: '>=18'}
 
   '@bundled-es-modules/cookie@2.0.1':
     resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
@@ -10877,7 +10878,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@bcoe/v8-coverage@0.2.3': {}
+  '@bcoe/v8-coverage@1.0.1': {}
 
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:


### PR DESCRIPTION
### Description

- Fixes https://github.com/vitest-dev/vitest/issues/5329

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
