### PR TITLE
test: use `tinyexec` for `execArgv` tests

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -164,7 +164,7 @@
     "pathe": "^1.1.2",
     "std-env": "^3.8.0",
     "tinybench": "^2.9.0",
-    "tinyexec": "^0.3.1",
+    "tinyexec": "^0.3.2",
     "tinypool": "^1.0.2",
     "tinyrainbow": "^1.2.0",
     "vite": "^5.0.0 || ^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,8 +896,8 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       tinyexec:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.3.2
+        version: 0.3.2
       tinypool:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1124,8 +1124,8 @@ importers:
   test/config:
     devDependencies:
       tinyexec:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.2
+        version: 0.3.2
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.10.2)(terser@5.36.0)
@@ -1346,8 +1346,8 @@ importers:
   test/test-utils:
     devDependencies:
       tinyexec:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.2
+        version: 0.3.2
       tinyrainbow:
         specifier: ^1.2.0
         version: 1.2.0
@@ -8746,11 +8746,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.0:
-    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
-
-  tinyexec@0.3.1:
-    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
@@ -9904,12 +9901,12 @@ snapshots:
   '@antfu/install-pkg@0.4.1':
     dependencies:
       package-manager-detector: 0.2.6
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
 
   '@antfu/install-pkg@0.5.0':
     dependencies:
       package-manager-detector: 0.2.6
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
 
   '@antfu/ni@0.23.2': {}
 
@@ -13434,7 +13431,7 @@ snapshots:
       jsonc-parser: 3.3.1
       prompts: 2.4.2
       semver: 7.6.3
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinyglobby: 0.2.10
     transitivePeerDependencies:
       - magicast
@@ -18291,9 +18288,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.0: {}
-
-  tinyexec@0.3.1: {}
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.10:
     dependencies:

--- a/test/config/package.json
+++ b/test/config/package.json
@@ -6,7 +6,7 @@
     "test": "vitest --typecheck.enabled"
   },
   "devDependencies": {
-    "tinyexec": "^0.3.0",
+    "tinyexec": "^0.3.2",
     "vite": "latest",
     "vitest": "workspace:*"
   }

--- a/test/config/test/exec-args.test.ts
+++ b/test/config/test/exec-args.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { x } from 'tinyexec'
 import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 
@@ -35,19 +35,20 @@ test.each([
 })
 
 test('should not pass execArgv to workers when not specified in the config', async () => {
-  const { stdout, stderr } = spawnSync('node', [
+  const { stdout, stderr } = await x('node', [
     '--title',
     'this-works-only-on-main-thread',
     '../../../../node_modules/vitest/vitest.mjs',
     '--run',
   ], {
-    encoding: 'utf-8',
-    cwd: `${process.cwd()}/fixtures/no-exec-args-fixtures`,
-    env: {
-      ...process.env,
-      VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
-      NO_COLOR: '1',
+    nodeOptions: {
+      cwd: `${process.cwd()}/fixtures/no-exec-args-fixtures`,
+      env: {
+        VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
+        NO_COLOR: '1',
+      },
     },
+    throwOnError: false,
   })
 
   expect(stderr).not.toContain('Error: Initiated Worker with invalid execArgv flags: --title')
@@ -56,20 +57,21 @@ test('should not pass execArgv to workers when not specified in the config', asy
 })
 
 test('should let allowed args pass to workers', async () => {
-  const { stdout, stderr } = spawnSync('node', [
+  const { stdout, stderr } = await x('node', [
     '--heap-prof',
     '--diagnostic-dir=/tmp/vitest-diagnostics',
     '--heap-prof-name=heap.prof',
     '../../../../node_modules/vitest/vitest.mjs',
     '--run',
   ], {
-    encoding: 'utf-8',
-    cwd: `${process.cwd()}/fixtures/allowed-exec-args-fixtures`,
-    env: {
-      ...process.env,
-      VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
-      NO_COLOR: '1',
+    nodeOptions: {
+      cwd: `${process.cwd()}/fixtures/allowed-exec-args-fixtures`,
+      env: {
+        VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
+        NO_COLOR: '1',
+      },
     },
+    throwOnError: false,
   })
 
   expect(stderr).toBe('')

--- a/test/test-utils/package.json
+++ b/test/test-utils/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"No tests\""
   },
   "devDependencies": {
-    "tinyexec": "^0.3.0",
+    "tinyexec": "^0.3.2",
     "tinyrainbow": "^1.2.0",
     "vite": "latest",
     "vite-node": "workspace:*",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- In https://github.com/vitest-dev/vitest/pull/7019/commits/9c9e69b1f6b089555e5d7ffb570e5efd9f688c9b I had to replace `tinyexec` with `node:child_process`. This PR reverts the change.
- Related upstream fix: https://github.com/tinylibs/tinyexec/pull/41


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
