### PR TITLE
fix: only use locator.element on last expect.element attempt (fix #7139)

### DIFF
--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -18,6 +18,9 @@ export async function setupExpectDom() {
 
       const isNot = chai.util.flag(this, 'negate') as boolean
       const name = chai.util.flag(this, '_name') as string
+      // element selector uses prettyDOM under the hood, which is an expensive call
+      // that should not be called on each failed locator attempt to avoid memory leak:
+      // https://github.com/vitest-dev/vitest/issues/7139
       const isLastPollAttempt = chai.util.flag(this, '_isLastPollAttempt')
       // special case for `toBeInTheDocument` matcher
       if (isNot && name === 'toBeInTheDocument') {

--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -18,11 +18,23 @@ export async function setupExpectDom() {
 
       const isNot = chai.util.flag(this, 'negate') as boolean
       const name = chai.util.flag(this, '_name') as string
+      const isLastPollAttempt = chai.util.flag(this, "_isLastPollAttempt")
       // special case for `toBeInTheDocument` matcher
       if (isNot && name === 'toBeInTheDocument') {
         return elementOrLocator.query()
       }
-      return elementOrLocator.element()
+
+      if (isLastPollAttempt) {
+        return elementOrLocator.element()
+      }
+  
+      const result = elementOrLocator.query()
+  
+      if (!result) {
+        throw new Error(`Cannot find element with locator: ${JSON.stringify(elementOrLocator)}`)
+      }
+  
+      return result
     }, options)
   }
 }

--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -18,7 +18,7 @@ export async function setupExpectDom() {
 
       const isNot = chai.util.flag(this, 'negate') as boolean
       const name = chai.util.flag(this, '_name') as string
-      const isLastPollAttempt = chai.util.flag(this, "_isLastPollAttempt")
+      const isLastPollAttempt = chai.util.flag(this, '_isLastPollAttempt')
       // special case for `toBeInTheDocument` matcher
       if (isNot && name === 'toBeInTheDocument') {
         return elementOrLocator.query()
@@ -27,13 +27,13 @@ export async function setupExpectDom() {
       if (isLastPollAttempt) {
         return elementOrLocator.element()
       }
-  
+
       const result = elementOrLocator.query()
-  
+
       if (!result) {
         throw new Error(`Cannot find element with locator: ${JSON.stringify(elementOrLocator)}`)
       }
-  
+
       return result
     }, options)
   }

--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -88,19 +88,19 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
             timeoutId = setTimeout(() => {
               clearTimeout(intervalId)
               chai.util.flag(assertion, '_isLastPollAttempt', true)
-              check().then(() => {
-                if (!lastError) {
-                  return
-                }
+              const rejectWithCause = (cause: any) => {
                 reject(
                   copyStackTrace(
                     new Error(`Matcher did not succeed in ${timeout}ms`, {
-                      cause: lastError,
+                      cause,
                     }),
                     STACK_TRACE_ERROR,
                   ),
                 )
-              })
+              }
+              check()
+                .then(() => rejectWithCause(lastError))
+                .catch(e => rejectWithCause(e))
             }, timeout)
             check()
           })

--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -85,18 +85,22 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                 }
               }
             }
-            timeoutId = setTimeout(async () => {
+            timeoutId = setTimeout(() => {
               clearTimeout(intervalId)
               chai.util.flag(assertion, '_isLastPollAttempt', true)
-              await check()
-              reject(
-                copyStackTrace(
-                  new Error(`Matcher did not succeed in ${timeout}ms`, {
-                    cause: lastError,
-                  }),
-                  STACK_TRACE_ERROR,
-                ),
-              )
+              check().then(() => {
+                if (!lastError) {
+                  return
+                }
+                reject(
+                  copyStackTrace(
+                    new Error(`Matcher did not succeed in ${timeout}ms`, {
+                      cause: lastError,
+                    }),
+                    STACK_TRACE_ERROR,
+                  ),
+                )
+              })
             }, timeout)
             check()
           })

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -28,8 +28,8 @@ describe('running browser tests', async () => {
       console.error(stderr)
     })
 
-    expect(browserResultJson.testResults).toHaveLength(19 * instances.length)
-    expect(passedTests).toHaveLength(17 * instances.length)
+    expect(browserResultJson.testResults).toHaveLength(20 * instances.length)
+    expect(passedTests).toHaveLength(18 * instances.length)
     expect(failedTests).toHaveLength(2 * instances.length)
 
     expect(stderr).not.toContain('optimized dependencies changed')

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -28,6 +28,9 @@ describe('running browser tests', async () => {
       console.error(stderr)
     })
 
+    // This should match the number of actual tests from browser.json
+    // if you added new tests, these assertion will fail and you should
+    // update the numbers
     expect(browserResultJson.testResults).toHaveLength(20 * instances.length)
     expect(passedTests).toHaveLength(18 * instances.length)
     expect(failedTests).toHaveLength(2 * instances.length)

--- a/test/browser/test/expect-element.test.ts
+++ b/test/browser/test/expect-element.test.ts
@@ -1,5 +1,5 @@
 import { page } from '@vitest/browser/context'
-import { test, expect, vi } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
 // element selector uses prettyDOM under the hood, which is an expensive call
 // that should not be called on each failed locator attempt to avoid memory leak:
@@ -18,7 +18,8 @@ test('should only use element selector on last expect.element attempt', async ()
 
   try {
     await expect.element(locator, { timeout: 500, interval: 100 }).toBeInTheDocument()
-  } catch {}
+  }
+  catch {}
 
   expect(locatorElementMock).toBeCalledTimes(1)
   expect(locatorElementMock).toHaveBeenCalledAfter(locatorQueryMock)

--- a/test/browser/test/expect-element.test.ts
+++ b/test/browser/test/expect-element.test.ts
@@ -11,10 +11,8 @@ test('should only use element selector on last expect.element attempt', async ()
   document.body.append(div)
 
   const locator = page.getByText('non-existent')
-  const locatorElementMock = vi.fn(locator.element)
-  locator.element = locatorElementMock
-  const locatorQueryMock = vi.fn(locator.query)
-  locator.query = locatorQueryMock
+  const locatorElementMock = vi.spyOn(locator, 'element')
+  const locatorQueryMock = vi.spyOn(locator, 'query')
 
   try {
     await expect.element(locator, { timeout: 500, interval: 100 }).toBeInTheDocument()

--- a/test/browser/test/expect-element.test.ts
+++ b/test/browser/test/expect-element.test.ts
@@ -1,0 +1,25 @@
+import { page } from '@vitest/browser/context'
+import { test, expect, vi } from 'vitest'
+
+// element selector uses prettyDOM under the hood, which is an expensive call
+// that should not be called on each failed locator attempt to avoid memory leak:
+// https://github.com/vitest-dev/vitest/issues/7139
+test('should only use element selector on last expect.element attempt', async () => {
+  const div = document.createElement('div')
+  const spanString = '<span>test</span>'
+  div.innerHTML = spanString
+  document.body.append(div)
+
+  const locator = page.getByText('non-existent')
+  const locatorElementMock = vi.fn(locator.element)
+  locator.element = locatorElementMock
+  const locatorQueryMock = vi.fn(locator.query)
+  locator.query = locatorQueryMock
+
+  try {
+    await expect.element(locator, { timeout: 500, interval: 100 }).toBeInTheDocument()
+  } catch {}
+
+  expect(locatorElementMock).toBeCalledTimes(1)
+  expect(locatorElementMock).toHaveBeenCalledAfter(locatorQueryMock)
+})

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -130,7 +130,6 @@ test('should handle success on last attempt', async () => {
   await expect.poll(fn, { interval: 100, timeout: 500 }).toBe(1)
 })
 
-
 test('should handle failure on last attempt', async () => {
   const fn = vi.fn(function (this: object) {
     if (chai.util.flag(this, '_isLastPollAttempt')) {

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest'
+import { expect, test, vi, chai } from 'vitest'
 
 test('simple usage', async () => {
   await expect.poll(() => false).toBe(false)
@@ -105,4 +105,17 @@ test('toBeDefined', async () => {
       message: 'expected undefined to be defined',
     }),
   }))
+})
+
+test('should set _isLastPollAttempt flag on last call', async () => {
+  const fn = vi.fn(function(this: object) {
+    return chai.util.flag(this, '_isLastPollAttempt')
+  })
+  await expect(async () => {
+    await expect.poll(fn, { interval: 100, timeout: 500 }).toBe(false)
+  }).rejects.toThrowError()
+  fn.mock.results.forEach((result, index) => {
+    const isLastCall = index === fn.mock.results.length - 1
+    expect(result.value).toBe(isLastCall ? true : undefined)
+  })
 })

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi, chai } from 'vitest'
+import { chai, expect, test, vi } from 'vitest'
 
 test('simple usage', async () => {
   await expect.poll(() => false).toBe(false)
@@ -108,7 +108,7 @@ test('toBeDefined', async () => {
 })
 
 test('should set _isLastPollAttempt flag on last call', async () => {
-  const fn = vi.fn(function(this: object) {
+  const fn = vi.fn(function (this: object) {
     return chai.util.flag(this, '_isLastPollAttempt')
   })
   await expect(async () => {


### PR DESCRIPTION
### Description

Fixes memory leak caused by multiple prettyDOM calls during expect.element retries.

ref: https://github.com/vitest-dev/vitest/issues/7139

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
