### PR TITLE
fix(snapshot): preserve white space of `toMatchFileSnapshot`

### DIFF
--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -164,8 +164,8 @@ export class SnapshotClient {
       throw createMismatchError(
         `Snapshot \`${key || 'unknown'}\` mismatched`,
         snapshotState.expand,
-        actual?.trim(),
-        expected?.trim(),
+        rawSnapshot ? actual : actual?.trim(),
+        rawSnapshot ? expected : expected?.trim(),
       )
     }
   }

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -391,11 +391,11 @@ export default class SnapshotState {
       if (!pass) {
         this.unmatched.increment(testId)
         return {
-          actual: removeExtraLineBreaks(receivedSerialized),
+          actual: rawSnapshot ? receivedSerialized : removeExtraLineBreaks(receivedSerialized),
           count,
           expected:
             expectedTrimmed !== undefined
-              ? removeExtraLineBreaks(expectedTrimmed)
+              ? rawSnapshot ? expectedTrimmed : removeExtraLineBreaks(expectedTrimmed)
               : undefined,
           key,
           pass: false,

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -291,8 +291,7 @@ export default class SnapshotState {
         ? rawSnapshot.content
         : this._snapshotData[key]
     const expectedTrimmed = rawSnapshot ? expected : prepareExpected(expected)
-    const receivedSerializedTrimmed = rawSnapshot ? receivedSerialized : prepareExpected(receivedSerialized)
-    const pass = expectedTrimmed === receivedSerializedTrimmed
+    const pass = expectedTrimmed === (rawSnapshot ? receivedSerialized : prepareExpected(receivedSerialized))
     const hasSnapshot = expected !== undefined
     const snapshotIsPersisted
       = isInline

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -290,8 +290,9 @@ export default class SnapshotState {
       : rawSnapshot
         ? rawSnapshot.content
         : this._snapshotData[key]
-    const expectedTrimmed = prepareExpected(expected)
-    const pass = expectedTrimmed === prepareExpected(receivedSerialized)
+    const expectedTrimmed = rawSnapshot ? expected : prepareExpected(expected)
+    const receivedSerializedTrimmed = rawSnapshot ? receivedSerialized : prepareExpected(receivedSerialized)
+    const pass = expectedTrimmed === receivedSerializedTrimmed
     const hasSnapshot = expected !== undefined
     const snapshotIsPersisted
       = isInline

--- a/test/core/test/snapshot-1.txt
+++ b/test/core/test/snapshot-1.txt
@@ -1,0 +1,2 @@
+
+  white space

--- a/test/core/test/snapshot-2.txt
+++ b/test/core/test/snapshot-2.txt
@@ -1,0 +1,10 @@
+example: |
+  {
+    echo "hello"
+  }
+some:
+  nesting:
+    - "hello world"
+even:
+  more:
+    nesting: true

--- a/test/core/test/snapshot.test.ts
+++ b/test/core/test/snapshot.test.ts
@@ -161,3 +161,21 @@ my string
   "
 `)
 })
+
+test('toMatchFileSnapshot preserves white spaces', async () => {
+  await expect(`
+  white space
+`).toMatchFileSnapshot('snapshot-1.txt')
+  await expect(`\
+example: |
+  {
+    echo "hello"
+  }
+some:
+  nesting:
+    - "hello world"
+even:
+  more:
+    nesting: true
+`).toMatchFileSnapshot('snapshot-2.txt')
+})

--- a/test/core/test/snapshot.test.ts
+++ b/test/core/test/snapshot.test.ts
@@ -161,21 +161,3 @@ my string
   "
 `)
 })
-
-test('toMatchFileSnapshot preserves white spaces', async () => {
-  await expect(`
-  white space
-`).toMatchFileSnapshot('snapshot-1.txt')
-  await expect(`\
-example: |
-  {
-    echo "hello"
-  }
-some:
-  nesting:
-    - "hello world"
-even:
-  more:
-    nesting: true
-`).toMatchFileSnapshot('snapshot-2.txt')
-})

--- a/test/snapshots/test/file.test.ts
+++ b/test/snapshots/test/file.test.ts
@@ -1,0 +1,28 @@
+import { join } from 'node:path'
+import { expect, test } from 'vitest'
+import { editFile, runVitest } from '../../test-utils'
+
+test('white space sensitive', async () => {
+  const root = join(import.meta.dirname, 'fixtures/file')
+
+  // check correct snapshot
+  let vitest = await runVitest({ root })
+  expect(vitest.exitCode).toBe(0)
+
+  // check diff of wrong snapshot
+  editFile(join(root, 'snapshot-1.txt'), s => s.trim())
+  editFile(join(root, 'snapshot-2.txt'), s => s.replace('echo', 'ECHO'))
+  vitest = await runVitest({ root })
+  expect(vitest.stderr).toContain(`
+- white space
++
++
++   white space
++
+`)
+  expect(vitest.stderr).toContain(`
+-     ECHO "hello"
++     echo "hello"
+`)
+  expect(vitest.exitCode).toBe(1)
+})

--- a/test/snapshots/test/fixtures/file/basic.test.ts
+++ b/test/snapshots/test/fixtures/file/basic.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "vitest"
+
+// pnpm -C test/snapshots test:fixtures --root test/fixtures/file
+
+test('white space', async () => {
+  await expect(`
+
+  white space
+`).toMatchFileSnapshot('snapshot-1.txt')
+})
+
+test('indent', async () => {
+  await expect(`\
+example: |
+  {
+    echo "hello"
+  }
+some:
+  nesting:
+    - "hello world"
+even:
+  more:
+    nesting: true
+`).toMatchFileSnapshot('snapshot-2.txt')
+})

--- a/test/snapshots/test/fixtures/file/snapshot-1.txt
+++ b/test/snapshots/test/fixtures/file/snapshot-1.txt
@@ -1,0 +1,3 @@
+
+
+  white space

--- a/test/snapshots/test/fixtures/file/snapshot-2.txt
+++ b/test/snapshots/test/fixtures/file/snapshot-2.txt
@@ -1,0 +1,10 @@
+example: |
+  {
+    echo "hello"
+  }
+some:
+  nesting:
+    - "hello world"
+even:
+  more:
+    nesting: true


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6107

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
