### PR TITLE
fix(reporter): skipped tests to have `"skipped"` state

### DIFF
--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -126,6 +126,15 @@ export class TestCase extends ReportedTaskImplementation {
    */
   public result(): TestResult | undefined {
     const result = this.task.result
+
+    if (!result && this.skipped()) {
+      return {
+        state: 'skipped',
+        errors: undefined,
+        note: undefined,
+      }
+    }
+
     if (!result || result.state === 'run' || result.state === 'queued') {
       return undefined
     }

--- a/test/cli/fixtures/reported-tasks/1_first.test.ts
+++ b/test/cli/fixtures/reported-tasks/1_first.test.ts
@@ -82,3 +82,7 @@ declare module 'vitest' {
     key?: string
   }
 }
+
+it("skipped by testname filter", () => {
+  expect(1).toBe(2)
+})

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -20,6 +20,7 @@ beforeAll(async () => {
   const { ctx } = await runVitest({
     root,
     include: ['**/*.test.ts'],
+    testNamePattern: '^((?!skipped by testname filter).)*$',
     reporters: [
       'verbose',
       {
@@ -56,14 +57,14 @@ it('correctly reports a file', () => {
   expect(testModule.location).toBeUndefined()
   expect(testModule.moduleId).toBe(resolve(root, './1_first.test.ts'))
   expect(testModule.project).toBe(project)
-  expect(testModule.children.size).toBe(14)
+  expect(testModule.children.size).toBe(15)
 
   const tests = [...testModule.children.tests()]
-  expect(tests).toHaveLength(11)
+  expect(tests).toHaveLength(12)
   const deepTests = [...testModule.children.allTests()]
-  expect(deepTests).toHaveLength(19)
+  expect(deepTests).toHaveLength(20)
 
-  expect([...testModule.children.allTests('skipped')]).toHaveLength(5)
+  expect([...testModule.children.allTests('skipped')]).toHaveLength(6)
   expect([...testModule.children.allTests('passed')]).toHaveLength(9)
   expect([...testModule.children.allTests('failed')]).toHaveLength(5)
   expect([...testModule.children.allTests('running')]).toHaveLength(0)
@@ -161,6 +162,17 @@ it('correctly reports failed test', () => {
   expect(diagnostic.flaky).toBe(false)
   expect(diagnostic.repeatCount).toBe(0)
   expect(diagnostic.repeatCount).toBe(0)
+})
+
+it('correctly reports a skipped test', () => {
+  const skippedByModified = findTest(testModule.children, 'skips a .modifier test')
+  expect(skippedByModified.result()?.state).toBe('skipped')
+
+  const skippedByPattern = findTest(testModule.children, 'skipped by testname filter')
+  expect(skippedByPattern.result()?.state).toBe('skipped')
+
+  const skippedByTodo = findTest(testModule.children, 'todos a .modifier test')
+  expect(skippedByTodo.result()?.state).toBe('skipped')
 })
 
 it('correctly reports multiple failures', () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Noticed in https://github.com/vitest-dev/vitest/pull/7069 that `testCase.result().state` was not correct for skipped tests. All skipped tests were reported as `"pending"`:

https://github.com/vitest-dev/vitest/blob/506cec5cd2adf9982937cb2fe5c56102940d1285/packages/vitest/src/node/reporters/reported-tasks.ts#L132-L138

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
