### PR TITLE
fix(runner): mark tests of `describe.todo` as `'todo'`

### DIFF
--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -65,6 +65,9 @@ export function interpretTaskModes(
         if (t.mode === 'skip') {
           skipAllTasks(t)
         }
+        else if (t.mode === 'todo') {
+          todoAllTasks(t)
+        }
         else {
           traverseSuite(t, includeTask, hasLocationMatch)
         }
@@ -119,6 +122,16 @@ function skipAllTasks(suite: Suite) {
       t.mode = 'skip'
       if (t.type === 'suite') {
         skipAllTasks(t)
+      }
+    }
+  })
+}
+function todoAllTasks(suite: Suite) {
+  suite.tasks.forEach((t) => {
+    if (t.mode === 'run' || t.mode === 'queued') {
+      t.mode = 'todo'
+      if (t.type === 'suite') {
+        todoAllTasks(t)
       }
     }
   })

--- a/test/cli/fixtures/reported-tasks/1_first.test.ts
+++ b/test/cli/fixtures/reported-tasks/1_first.test.ts
@@ -61,6 +61,14 @@ describe('a group', () => {
   })
 })
 
+describe.todo('todo group', () => {
+  it('test inside todo group', () => {})
+})
+
+describe.skip('skipped group', () => {
+  it('test inside skipped group', () => {})
+})
+
 describe.shuffle('shuffled group', () => {
   it('runs a test in a shuffled group', () => {
     expect(1).toBe(1)

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -56,22 +56,22 @@ it('correctly reports a file', () => {
   expect(testModule.location).toBeUndefined()
   expect(testModule.moduleId).toBe(resolve(root, './1_first.test.ts'))
   expect(testModule.project).toBe(project)
-  expect(testModule.children.size).toBe(14)
+  expect(testModule.children.size).toBe(16)
 
   const tests = [...testModule.children.tests()]
   expect(tests).toHaveLength(11)
   const deepTests = [...testModule.children.allTests()]
-  expect(deepTests).toHaveLength(19)
+  expect(deepTests).toHaveLength(21)
 
-  expect([...testModule.children.allTests('skipped')]).toHaveLength(5)
-  expect([...testModule.children.allTests('passed')]).toHaveLength(9)
-  expect([...testModule.children.allTests('failed')]).toHaveLength(5)
-  expect([...testModule.children.allTests('running')]).toHaveLength(0)
+  expect.soft([...testModule.children.allTests('skipped')]).toHaveLength(7)
+  expect.soft([...testModule.children.allTests('passed')]).toHaveLength(9)
+  expect.soft([...testModule.children.allTests('failed')]).toHaveLength(5)
+  expect.soft([...testModule.children.allTests('running')]).toHaveLength(0)
 
   const suites = [...testModule.children.suites()]
-  expect(suites).toHaveLength(3)
+  expect(suites).toHaveLength(5)
   const deepSuites = [...testModule.children.allSuites()]
-  expect(deepSuites).toHaveLength(4)
+  expect(deepSuites).toHaveLength(6)
 
   const diagnostic = testModule.diagnostic()
   expect(diagnostic).toBeDefined()
@@ -187,6 +187,12 @@ it('correctly reports test assigned options', () => {
   expect(testOptionTodo.options.mode).toBe('todo')
   const testModifierTodo = findTest(testModule.children, 'todos a .modifier test')
   expect(testModifierTodo.options.mode).toBe('todo')
+
+  const testInsideTodoDescribe = findTest(testModule.children, 'test inside todo group')
+  expect(testInsideTodoDescribe.options.mode).toBe('todo')
+
+  const testInsideSkippedDescribe = findTest(testModule.children, 'test inside skipped group')
+  expect(testInsideSkippedDescribe.options.mode).toBe('skip')
 })
 
 it('correctly reports retried tests', () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Test cases inside `describe.todo` have `options.mode` as `'run'` after tests have finished. Tests inside `describe.skip` have correct `'skip'` mode. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
