### PR TITLE
fix: Add Locator typings for nth, first and last.

### DIFF
--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -435,6 +435,21 @@ export interface Locator extends LocatorSelectors {
    * @see {@link https://vitest.dev/guide/browser/locators#all}
    */
   all(): Locator[]
+  /**
+   * Returns a locator for the nth element matching the selector.
+   * @see {@link https://vitest.dev/guide/browser/locators#nth}
+   */
+  nth(index: number): Locator
+  /**
+   * Returns a locator for the first element matching the selector.
+   * @see {@link https://vitest.dev/guide/browser/locators#first}
+   */
+  first(): Locator
+  /**
+   * Returns a locator for the last element matching the selector.
+   * @see {@link https://vitest.dev/guide/browser/locators#last}
+   */
+  last(): Locator
 }
 
 export interface UserEventTabOptions {


### PR DESCRIPTION
### Description

This is a follow-up to #7137 which adds typings to the public interfaces of `@vitest/browser`, ensuring that end users' test files will cleanly pass type checking & IDEs.

#### How to Add Test Coverage

I think we could prevent a recurrence of this by adding a type-check step to the `test/browser` job.

Currently, `pnpm exec tsc` is broken when I invoke it under `test/browser`; we would need to fix the issues listed below, which are actually type errors in various other files within the project, or possibly false errors due to local ts mis-configuration. We'd need to fix all nine existing issues, whatever the cause, before adding a type check to CI.

We would also need to add some negative test cases to ensure that _omitting_ the typing of a command actually causes errors.

```
Found 9 errors in 4 files.

Errors  Files
     3  ../../packages/browser/utils.d.ts:12
     3  ../../packages/vitest/dist/chunks/reporters.B8rK8Gbt.d.ts:55
     1  fixtures/mocking/import-actual-in-mock.test.ts:4
     2  ../test-utils/index.ts:133
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
