### PR TITLE
test: fix some types in `test/browser`

### DIFF
--- a/test/browser/fixtures/mocking/import-actual-in-mock.test.ts
+++ b/test/browser/fixtures/mocking/import-actual-in-mock.test.ts
@@ -5,11 +5,11 @@ vi.mock(import('./src/mocks_factory'), async (importOriginal) => {
   const original = await importOriginal()
   return {
     ...original,
-    mocked: 'mocked!',
+    mocked: true,
   }
 })
 
 test('actual is overriding import', () => {
-  expect(mocked).toBe('mocked!')
+  expect(mocked).toBe(true)
   expect(calculator('plus', 1, 2)).toBe(3)
 })

--- a/test/browser/tsconfig.json
+++ b/test/browser/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "noEmit": true,
-    "jsx": "react-jsx",
     "target": "ESNext",
+    "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
@@ -14,6 +13,7 @@
       "vitest-browser-react",
       "vitest/import-meta"
     ],
+    "noEmit": true,
     "esModuleInterop": true
   },
   "include": [

--- a/test/browser/tsconfig.json
+++ b/test/browser/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "jsx": "react-jsx",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
@@ -15,9 +17,9 @@
     "esModuleInterop": true
   },
   "include": [
-    "fixtures/**/*.ts",
-    "test/**/*.ts",
-    "specs/**/*.ts",
+    "fixtures",
+    "test",
+    "specs",
     "./vitest.config.*",
     "./setup.unit.ts"
   ]


### PR DESCRIPTION
### Description

Related https://github.com/vitest-dev/vitest/pull/7176

On my vscode, `blog.tsx` was all red as `.tsx` wasn't included. 

<details>

![image](https://github.com/user-attachments/assets/0244e7b3-53d4-4d52-9f72-98febd3d7bed)

</details>

After changing `include`, there's still some issues with `pnpm exec tsx` probably because it references internal types. Hopefully they aren't visible to users.

<details>

```
../../packages/browser/utils.d.ts:12:18 - error TS2304: Cannot find name 'Locator'.

12   el?: Element | Locator | null | (Element | Locator)[],
                    ~~~~~~~

../../packages/browser/utils.d.ts:12:46 - error TS2304: Cannot find name 'Locator'.

12   el?: Element | Locator | null | (Element | Locator)[],
                                                ~~~~~~~

../../packages/browser/utils.d.ts:17:19 - error TS2304: Cannot find name 'Locator'.

17   dom?: Element | Locator | undefined | null,
                     ~~~~~~~

../test-utils/index.ts:133:19 - error TS2339: Property 'closingPromise' does not exist on type 'Vitest'.

133       return ctx?.closingPromise
                      ~~~~~~~~~~~~~~

../test-utils/index.ts:213:3 - error TS2578: Unused '@ts-expect-error' directive.

213   // @ts-expect-error untyped global
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 5 errors.
```

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
