### PR TITLE
fix: batch console logs by microtask

### DIFF
--- a/packages/utils/src/timers.ts
+++ b/packages/utils/src/timers.ts
@@ -8,6 +8,7 @@ export interface SafeTimers {
   clearTimeout: typeof clearTimeout
   setImmediate: typeof setImmediate
   clearImmediate: typeof clearImmediate
+  queueMicrotask: typeof queueMicrotask
 }
 
 export function getSafeTimers(): SafeTimers {
@@ -18,6 +19,7 @@ export function getSafeTimers(): SafeTimers {
     clearTimeout: safeClearTimeout,
     setImmediate: safeSetImmediate,
     clearImmediate: safeClearImmediate,
+    queueMicrotask: safeQueueMicrotask,
   } = (globalThis as any)[SAFE_TIMERS_SYMBOL] || globalThis
 
   const { nextTick: safeNextTick } = (globalThis as any)[SAFE_TIMERS_SYMBOL]
@@ -31,6 +33,7 @@ export function getSafeTimers(): SafeTimers {
     clearTimeout: safeClearTimeout,
     setImmediate: safeSetImmediate,
     clearImmediate: safeClearImmediate,
+    queueMicrotask: safeQueueMicrotask,
   }
 }
 
@@ -42,6 +45,7 @@ export function setSafeTimers(): void {
     clearTimeout: safeClearTimeout,
     setImmediate: safeSetImmediate,
     clearImmediate: safeClearImmediate,
+    queueMicrotask: safeQueueMicrotask,
   } = globalThis
 
   const { nextTick: safeNextTick } = globalThis.process || {
@@ -56,6 +60,7 @@ export function setSafeTimers(): void {
     clearTimeout: safeClearTimeout,
     setImmediate: safeSetImmediate,
     clearImmediate: safeClearImmediate,
+    queueMicrotask: safeQueueMicrotask,
   };
 
   (globalThis as any)[SAFE_TIMERS_SYMBOL] = timers

--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -37,10 +37,9 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
   const stderrBuffer = new Map<string, any[]>()
   const timers = new Map<
     string,
-    { stdoutTime: number; stderrTime: number; timer: any; cancel?: () => void }
+    { stdoutTime: number; stderrTime: number; cancel?: () => void }
   >()
 
-  // const { setTimeout, clearTimeout } = getSafeTimers()
   const { queueMicrotask } = getSafeTimers()
 
   function queueCancelableMicrotask(callback: () => void) {
@@ -72,17 +71,6 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
         sendStderr(taskId)
       }
     })
-    // clearTimeout(timer.timer)
-    // timer.timer = setTimeout(() => {
-    //   if (stderrTime < stdoutTime) {
-    //     sendStderr(taskId)
-    //     sendStdout(taskId)
-    //   }
-    //   else {
-    //     sendStdout(taskId)
-    //     sendStderr(taskId)
-    //   }
-    // })
   }
   function sendStdout(taskId: string) {
     sendBuffer('stdout', taskId)
@@ -152,7 +140,6 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
         timer = {
           stdoutTime: RealDate.now(),
           stderrTime: RealDate.now(),
-          timer: 0,
         }
         timers.set(id, timer)
       }
@@ -192,7 +179,6 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
         timer = {
           stderrTime: RealDate.now(),
           stdoutTime: RealDate.now(),
-          timer: 0,
         }
         timers.set(id, timer)
       }

--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -57,7 +57,7 @@ export function createCustomConsole(defaultState?: WorkerGlobalState) {
 
   const state = () => defaultState || getWorkerState()
 
-  // group sync console.log calls with macro task
+  // group sync console.log calls with micro task
   function schedule(taskId: string) {
     const timer = timers.get(taskId)!
     const { stdoutTime, stderrTime } = timer

--- a/test/config/fixtures/console-batch/basic.test.ts
+++ b/test/config/fixtures/console-batch/basic.test.ts
@@ -1,0 +1,25 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, test } from 'vitest'
+
+beforeAll(() => {
+  console.log('[beforeAll]')
+})
+
+afterAll(() => {
+  console.log('[afterAll]')
+})
+
+beforeEach(() => {
+  console.log('[beforeEach]')
+})
+
+afterEach(() => {
+  console.log('[afterEach]')
+})
+
+test('test', async () => {
+  console.log('a')
+  console.log('b')
+  await Promise.resolve()
+  console.log('c')
+  console.log('d')
+})

--- a/test/config/fixtures/console-batch/basic.test.ts
+++ b/test/config/fixtures/console-batch/basic.test.ts
@@ -1,37 +1,37 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, test } from 'vitest'
 
 beforeAll(() => {
-  console.log('[beforeAll 1]')
+  console.log('__TEST__ [beforeAll 1]')
 })
 beforeAll(() => {
-  console.log('[beforeAll 2]')
+  console.log('__TEST__ [beforeAll 2]')
 })
 
 afterAll(() => {
-  console.log('[afterAll 1]')
+  console.log('__TEST__ [afterAll 1]')
 })
 afterAll(() => {
-  console.log('[afterAll 2]')
+  console.log('__TEST__ [afterAll 2]')
 })
 
 beforeEach(() => {
-  console.log('[beforeEach 1]')
+  console.log('__TEST__ [beforeEach 1]')
 })
 beforeEach(() => {
-  console.log('[beforeEach 2]')
+  console.log('__TEST__ [beforeEach 2]')
 })
 
 afterEach(() => {
-  console.log('[afterEach 1]')
+  console.log('__TEST__ [afterEach 1]')
 })
 afterEach(() => {
-  console.log('[afterEach 2]')
+  console.log('__TEST__ [afterEach 2]')
 })
 
 test('test', async () => {
-  console.log('[test 1]')
-  console.log('[test 2]')
+  console.log('__TEST__ [test 1]')
+  console.log('__TEST__ [test 2]')
   await Promise.resolve()
-  console.log('[test 3]')
-  console.log('[test 4]')
+  console.log('__TEST__ [test 3]')
+  console.log('__TEST__ [test 4]')
 })

--- a/test/config/fixtures/console-batch/basic.test.ts
+++ b/test/config/fixtures/console-batch/basic.test.ts
@@ -1,25 +1,37 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, test } from 'vitest'
 
 beforeAll(() => {
-  console.log('[beforeAll]')
+  console.log('[beforeAll 1]')
+})
+beforeAll(() => {
+  console.log('[beforeAll 2]')
 })
 
 afterAll(() => {
-  console.log('[afterAll]')
+  console.log('[afterAll 1]')
+})
+afterAll(() => {
+  console.log('[afterAll 2]')
 })
 
 beforeEach(() => {
-  console.log('[beforeEach]')
+  console.log('[beforeEach 1]')
+})
+beforeEach(() => {
+  console.log('[beforeEach 2]')
 })
 
 afterEach(() => {
-  console.log('[afterEach]')
+  console.log('[afterEach 1]')
+})
+afterEach(() => {
+  console.log('[afterEach 2]')
 })
 
 test('test', async () => {
-  console.log('a')
-  console.log('b')
+  console.log('[test 1]')
+  console.log('[test 2]')
   await Promise.resolve()
-  console.log('c')
-  console.log('d')
+  console.log('[test 3]')
+  console.log('[test 4]')
 })

--- a/test/config/test/console.test.ts
+++ b/test/config/test/console.test.ts
@@ -1,3 +1,4 @@
+import type { UserConsoleLog } from 'vitest'
 import { expect, test, vi } from 'vitest'
 import { runVitest } from '../../test-utils'
 
@@ -20,4 +21,37 @@ test.each(['threads', 'vmThreads'] as const)(`disable intercept pool=%s`, async 
 
   const call = spy.mock.lastCall![0]
   expect(call.toString()).toBe('__test_console__\n')
+})
+
+test('group synchronous console logs', async () => {
+  const logs: UserConsoleLog[] = []
+  await runVitest({
+    root: './fixtures/console-batch',
+    reporters: [
+      'default',
+      {
+        onUserConsoleLog(log) {
+          logs.push(log)
+        },
+      },
+    ],
+  })
+  expect(logs.map(log => log.content)).toMatchInlineSnapshot(`
+    [
+      "[beforeAll]
+    ",
+      "[beforeEach]
+    ",
+      "a
+    b
+    ",
+      "c
+    d
+    ",
+      "[afterEach]
+    ",
+      "[afterAll]
+    ",
+    ]
+  `)
 })

--- a/test/config/test/console.test.ts
+++ b/test/config/test/console.test.ts
@@ -38,19 +38,27 @@ test('group synchronous console logs', async () => {
   })
   expect(logs.map(log => log.content)).toMatchInlineSnapshot(`
     [
-      "[beforeAll]
+      "[beforeAll 1]
     ",
-      "[beforeEach]
+      "[beforeAll 2]
     ",
-      "a
-    b
+      "[beforeEach 1]
     ",
-      "c
-    d
+      "[beforeEach 2]
     ",
-      "[afterEach]
+      "[test 1]
+    [test 2]
     ",
-      "[afterAll]
+      "[test 3]
+    [test 4]
+    ",
+      "[afterEach 2]
+    ",
+      "[afterEach 1]
+    ",
+      "[afterAll 2]
+    ",
+      "[afterAll 1]
     ",
     ]
   `)


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7153

It turns out separation between `before/after/test` logs are effectively fixed by https://github.com/vitest-dev/vitest/pull/6944, which added `setTimeout` wrapper. I'm not sure whether this changes is needed but maybe we can discuss. Also having a test like this is nice to have regardless.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
