### PR TITLE
fix: do not strip git hash when resolving module path

### DIFF
--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -53,7 +53,7 @@ export function normalizeRequestId(id: string, base?: string): string {
     .replace(/\?+$/, '') // remove end query mark
 }
 
-const postfixRE = /[?#].*$/
+const postfixRE = /(?<!\.git)[?#].*$/
 export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '')
 }

--- a/test/vite-node/src/test@git+https+++git@github.com+test+module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey/index.mjs
+++ b/test/vite-node/src/test@git+https+++git@github.com+test+module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey/index.mjs
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log('test 1')

--- a/test/vite-node/test/server.test.ts
+++ b/test/vite-node/test/server.test.ts
@@ -228,6 +228,16 @@ describe('server correctly caches data', () => {
     expect(ssrFiles).toHaveLength(1)
     expect(webFiles).toHaveLength(1)
   })
+
+  it('correctly processes path containing git hash', async ({ viteNode, root }) => {
+    const gitPath = '/src/test@git+https+++git@github.com+test+module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey/index.mjs'
+    
+    await viteNode.fetchModule(gitPath, 'web')
+   
+    const fsPath = join(root, gitPath)
+
+    expect(viteNode.fetchCaches.web.has(fsPath)).toBe(true)
+  })
 })
 
 describe('externalize', () => {

--- a/test/vite-node/test/server.test.ts
+++ b/test/vite-node/test/server.test.ts
@@ -231,9 +231,9 @@ describe('server correctly caches data', () => {
 
   it('correctly processes path containing git hash', async ({ viteNode, root }) => {
     const gitPath = '/src/test@git+https+++git@github.com+test+module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey/index.mjs'
-    
+
     await viteNode.fetchModule(gitPath, 'web')
-   
+
     const fsPath = join(root, gitPath)
 
     expect(viteNode.fetchCaches.web.has(fsPath)).toBe(true)


### PR DESCRIPTION
### Description

Using `pnpm` and including a private git dependency can prevent vitest from resolving the module path.

```JSON
{
  "dependencies": {
    "private-module": "github:garymathews/private-module#4d28af3d661d5c8b7b23"
  }
}
```

`pnpm` caches dependencies under `node_modules/.pnpm/<modules>`, when defining a module in `package.json` from a git source pnpm will include its git hash in the folder name.

The path of a public git dependency looks like this:
```
node_modules/.pnpm/kysely@https+++codeload.github.com+kysely+kysely+tar.gz+3c2f063125ed786651e95870388c3b0633c3833b
```

However, including a private git dependency looks like this:
```
node_modules/.pnpm/private-module@git+https+++git@github.com+garymathews+private-module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey

FAIL  src/test/index.test.ts [ src/test/index.test.ts ]
Error: Failed to load url /Users/gmathews/github/test/node_modules/.pnpm/private-module@git+https+++git@github.com+garymathews+private-module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey/node_modules/private-module/dist/index.mjs (resolved id: /Users/gmathews/github/test/node_modules/.pnpm/private-module@git+https+++git@github.com+garymathews+private-module.git#4d28af3d661d5c8b7b23_bibis5ubruacouaifyvvr7mcey/node_modules/private-module/dist/index.mjs). Does the file exist?
 ❯ loadAndTransform ../../node_modules/.pnpm/vite@5.4.11_@types+node@22.10.5_terser@5.34.1/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:51920:17
```

Note how this folder ends with `.git#<hash>`; vite-node will strip the hash from this path due to [cleanUrl](https://github.com/vitest-dev/vitest/blob/main/packages/vite-node/src/utils.ts#L57)

This method strips query parameters from the passed in url, which would invalidate any paths containing `?#` characters; which pnpm uses to reference git modules. This PR adjusts the regex to not strip any parameters if prefixed by `.git`. Although, maybe there's a better way of handling this?

Also, for anyone wanting to include git dependencies, you may also need to force your git dependencies to be inlined, not doing so may display `Error: Cannot find module ...`. Not sure why this is necessary?
```JS
export default defineConfig({
    test: {
        ...
        server: {
            deps: {
                inline: [/\.git#/]
            }
        },
    },
   ...
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
