### PR TITLE
feat: add `getTestFilepath` export to runner and suite modules

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -12,6 +12,7 @@ export {
   createTaskCollector,
   describe,
   getCurrentSuite,
+  getTestFilepath,
   it,
   suite,
   test,

--- a/packages/vitest/src/public/suite.ts
+++ b/packages/vitest/src/public/suite.ts
@@ -5,6 +5,7 @@ export {
   getCurrentTest,
   getFn,
   getHooks,
+  getTestFilepath,
   setFn,
   setHooks,
 } from '@vitest/runner'


### PR DESCRIPTION
### Description

I want to be able to generate folders based on the current running test, which works fine due to being able to access the `file` property from `getCurrentTest`. But when you want to do it from a describe, or suite you can't.

```typescript
// test/index.test.ts
import { it, describe } from "vitest";
import { getCurrentTest, getCurrentSuite } from "vitest/suite";

it("expect filename to be test/index.test.ts", () => {
  expect(getCurrentTest().file.name).toBe("test/index.test.ts");
}); // this doesn't fail

describe("expect filename", () => {
  // not possible to get the filename from a describe
  console.log(getCurrentSuite()) // there is no file or anything like.
})
```

This PR will fix that by exporting `getTestFilePath` which returns the current test file path.

I didn't make an issue for this, as this is a very small change. So sorry in advance  🙇🏻

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
