### PR TITLE
chore(ui): fix static ui client types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ test/browser/fixtures/update-snapshot/basic.test.ts
 test/cli/fixtures/browser-multiple/basic-*
 .vitest-reports
 *.tsbuildinfo
+# exclude static html reporter folder
+test/browser/html/
+test/core/html/

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -58,6 +58,7 @@ export function createStaticClient(): VitestClient {
     onTaskUpdate: noop,
     writeFile: asyncNoop,
     rerun: asyncNoop,
+    rerunTask: asyncNoop,
     updateSnapshot: asyncNoop,
     resolveSnapshotPath: asyncNoop,
     snapshotSaved: asyncNoop,
@@ -80,7 +81,7 @@ export function createStaticClient(): VitestClient {
 
   ctx.rpc = rpc as any as BirpcReturn<WebSocketHandlers, WebSocketEvents>
 
-  let openPromise: Promise<void>
+  const openPromise = Promise.resolve()
 
   function reconnect() {
     registerMetadata()

--- a/packages/ui/client/composables/explorer/search.ts
+++ b/packages/ui/client/composables/explorer/search.ts
@@ -24,7 +24,7 @@ export function useSearch(searchBox: Ref<HTMLDivElement | undefined>) {
   const disableClearSearch = computed(() => search.value === '')
   const debouncedSearch = ref(search.value)
 
-  debouncedWatch(search, (value) => {
+  debouncedWatch(() => search.value, (value) => {
     debouncedSearch.value = value?.trim() ?? ''
   }, { debounce: 256 })
 

--- a/packages/ui/client/global-setup.ts
+++ b/packages/ui/client/global-setup.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite-plugin-pages/client" />
 
-import FloatingVue, { VTooltip } from 'floating-vue'
+import type { Directive } from 'vue'
+import FloatingVue, { vTooltip } from 'floating-vue'
 import routes from 'virtual:generated-pages'
 import {
   createRouter as _createRouter,
@@ -15,8 +16,8 @@ import './styles/main.css'
 import 'floating-vue/dist/style.css'
 import 'uno.css'
 
-export const directives = {
-  tooltip: VTooltip,
+export const directives: Record<string, Directive> = {
+  tooltip: vTooltip,
 }
 
 FloatingVue.options.instantMove = true

--- a/packages/ui/client/test.ts
+++ b/packages/ui/client/test.ts
@@ -3,15 +3,15 @@ import {
   cleanup,
   type RenderOptions,
 } from '@testing-library/vue'
-import { VTooltip } from 'floating-vue'
+import { vTooltip } from 'floating-vue'
 import { afterEach } from 'vitest'
 
-export function render(component: any, options?: RenderOptions) {
+export function render<C>(component: C, options?: RenderOptions<C>) {
   return _render(component, {
     ...options,
     global: {
       directives: {
-        tooltip: VTooltip,
+        tooltip: vTooltip,
       },
     },
   })

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -19,7 +19,7 @@
     "test:browser:preview": "PROVIDER=preview vitest",
     "test:browser:playwright": "PROVIDER=playwright vitest",
     "test:browser:webdriverio": "PROVIDER=webdriverio vitest",
-    "test:browser:playwright:html": "HTML_REPORTER=true PROVIDER=playwright vitest --reporter=html"
+    "test:browser:playwright:html": "PROVIDER=playwright vitest --reporter=html"
   },
   "devDependencies": {
     "@testing-library/react": "^13.2.0",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -19,7 +19,7 @@
     "test:browser:preview": "PROVIDER=preview vitest",
     "test:browser:playwright": "PROVIDER=playwright vitest",
     "test:browser:webdriverio": "PROVIDER=webdriverio vitest",
-    "test:browser:playwright:html": "PROVIDER=playwright vitest --reporter=html --outputFile=./html/index.html"
+    "test:browser:playwright:html": "HTML_REPORTER=true PROVIDER=playwright vitest --reporter=html"
   },
   "devDependencies": {
     "@testing-library/react": "^13.2.0",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -19,7 +19,7 @@
     "test:browser:preview": "PROVIDER=preview vitest",
     "test:browser:playwright": "PROVIDER=playwright vitest",
     "test:browser:webdriverio": "PROVIDER=webdriverio vitest",
-    "test:browser:playwright:html": "PROVIDER=playwright pnpm vitest --reporter=html --outputFile=./html/index.html"
+    "test:browser:playwright:html": "PROVIDER=playwright vitest --reporter=html --outputFile=./html/index.html"
   },
   "devDependencies": {
     "@testing-library/react": "^13.2.0",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -18,7 +18,8 @@
     "coverage": "vitest --coverage.enabled --coverage.provider=istanbul --browser.headless=yes",
     "test:browser:preview": "PROVIDER=preview vitest",
     "test:browser:playwright": "PROVIDER=playwright vitest",
-    "test:browser:webdriverio": "PROVIDER=webdriverio vitest"
+    "test:browser:webdriverio": "PROVIDER=webdriverio vitest",
+    "test:browser:playwright:html": "PROVIDER=playwright pnpm vitest --reporter=html --outputFile=./html/index.html"
   },
   "devDependencies": {
     "@testing-library/react": "^13.2.0",

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -10,6 +10,7 @@ function noop() {}
 
 const provider = process.env.PROVIDER || 'playwright'
 const browser = process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome')
+const outputFile = process.env.HTML_REPORTER ? undefined : './browser.json'
 
 const myCustomCommand: BrowserCommand<[arg1: string, arg2: string]> = ({ testPath }, arg1, arg2) => {
   return { testPath, arg1, arg2 }
@@ -102,8 +103,8 @@ export default defineConfig({
     },
     open: false,
     diff: './custom-diff-config.ts',
-    outputFile: './browser.json',
-    reporters: ['json', {
+    outputFile,
+    reporters: [outputFile ? 'json' : undefined, {
       onInit: noop,
       onPathsCollected: noop,
       onCollected: noop,
@@ -114,7 +115,7 @@ export default defineConfig({
       onWatcherRerun: noop,
       onServerRestart: noop,
       onUserConsoleLog: noop,
-    }, 'default'],
+    }, 'default'].filter(Boolean),
     env: {
       BROWSER: browser,
     },

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -10,7 +10,6 @@ function noop() {}
 
 const provider = process.env.PROVIDER || 'playwright'
 const browser = process.env.BROWSER || (provider === 'playwright' ? 'chromium' : 'chrome')
-const outputFile = process.env.HTML_REPORTER ? undefined : './browser.json'
 
 const myCustomCommand: BrowserCommand<[arg1: string, arg2: string]> = ({ testPath }, arg1, arg2) => {
   return { testPath, arg1, arg2 }
@@ -103,8 +102,11 @@ export default defineConfig({
     },
     open: false,
     diff: './custom-diff-config.ts',
-    outputFile,
-    reporters: [outputFile ? 'json' : undefined, {
+    outputFile: {
+      html: './html/index.html',
+      json: './browser.json',
+    },
+    reporters: ['json', {
       onInit: noop,
       onPathsCollected: noop,
       onCollected: noop,
@@ -115,7 +117,7 @@ export default defineConfig({
       onWatcherRerun: noop,
       onServerRestart: noop,
       onUserConsoleLog: noop,
-    }, 'default'].filter(Boolean),
+    }, 'default'],
     env: {
       BROWSER: browser,
     },

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "vitest",
+    "test:html": "pnpm vitest --reporter=html",
     "test:threads": "vitest --project threads",
     "test:forks": "vitest --project forks",
     "test:vmThreads": "vitest --project vmThreads",

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test": "vitest",
-    "test:html": "pnpm vitest --reporter=html",
+    "test:html": "vitest --reporter=html",
     "test:threads": "vitest --project threads",
     "test:forks": "vitest --project forks",
     "test:vmThreads": "vitest --project vmThreads",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -11,7 +11,6 @@
     "./packages/vitest/dist/**",
     "./packages/*/*.d.ts",
     "./packages/*/*.d.cts",
-    "./packages/ui/client/**",
     "./examples/**/*.*",
     "./bench/**",
     "./test/benchmark/fixtures/**",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
The static module doesn't include the new `rerunTask` added to run individual tests in the new UI, and the `openPromise` not being initialized (`Variable openPromise is used before being assigned.`).

This PR also includes:
- html reporter script in `test/core` and `test/browser`
- add `test/core/html` and `test/browser/html` to `.gitignore`
- include `packages/ui/client` folder in `tsc` typecheck script: fixed failing modules

**FIXED**: We need to check why running the html reporter on `test/browser` doesn't generate the html folder, it is generating the app inside the `test/browser` folder. using `json` reporter and `outputFile: './browser.json`

I'm going to send 2 new PR for:
- ~~fix html reporter output folder when running browser mode~~
- use `vue-tsc` to validate also vue files in `packages/ui/client`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
