### PR TITLE
fix(browser): fix `console.time` with fake timers

### DIFF
--- a/packages/browser/src/client/tester/logger.ts
+++ b/packages/browser/src/client/tester/logger.ts
@@ -71,7 +71,7 @@ export function setupConsoleLogSpy() {
     if (!(label in timeLabels)) {
       sendLog('stderr', `Timer "${label}" does not exist`)
     }
-    else if (start) {
+    else if (typeof start !== 'undefined') {
       const duration = end - start
       sendLog('stdout', `${label}: ${duration} ms`)
     }

--- a/packages/browser/src/client/tester/logger.ts
+++ b/packages/browser/src/client/tester/logger.ts
@@ -2,7 +2,7 @@ import { format, stringify } from 'vitest/utils'
 import { getConfig } from '../utils'
 import { rpc } from './rpc'
 
-const { Date, console } = globalThis
+const { Date, console, performance } = globalThis
 
 export function setupConsoleLogSpy() {
   const {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -90,8 +90,8 @@ describe('running browser tests', async () => {
     expect(stdout).toContain('count: 3')
     expect(stdout).toMatch(/default: [\d.]+ ms/)
     expect(stdout).toMatch(/time: [\d.]+ ms/)
-    expect(stdout).toContain('fake-timers-zero: 0 ms')
-    expect(stdout).toContain('fake-timers-advance: 1234 ms')
+    expect(stdout).toMatch(/\[console-time-fake\]: [\d.]+ ms/)
+    expect(stdout).not.toContain('[console-time-fake]: 0 ms')
   })
 
   test('logs are redirected to stderr', () => {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -90,6 +90,8 @@ describe('running browser tests', async () => {
     expect(stdout).toContain('count: 3')
     expect(stdout).toMatch(/default: [\d.]+ ms/)
     expect(stdout).toMatch(/time: [\d.]+ ms/)
+    expect(stdout).toContain('fake-timers-zero: 0 ms')
+    expect(stdout).toContain('fake-timers-advance: 1234 ms')
   })
 
   test('logs are redirected to stderr', () => {

--- a/test/browser/test/timers.test.ts
+++ b/test/browser/test/timers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { afterEach, expect, it, vi } from 'vitest'
 
 afterEach(() => {
@@ -16,4 +17,15 @@ it('only runs a setTimeout callback once (ever)', () => {
 
   vi.runAllTimers()
   expect(fn).toHaveBeenCalledTimes(1)
+})
+
+it('console.time', async () => {
+  vi.useFakeTimers()
+
+  console.time('fake-timers-zero')
+  console.timeEnd('fake-timers-zero')
+
+  console.time('fake-timers-advance')
+  vi.advanceTimersByTime(1234)
+  console.timeEnd('fake-timers-advance')
 })

--- a/test/browser/test/timers.test.ts
+++ b/test/browser/test/timers.test.ts
@@ -21,11 +21,6 @@ it('only runs a setTimeout callback once (ever)', () => {
 
 it('console.time', async () => {
   vi.useFakeTimers()
-
-  console.time('fake-timers-zero')
-  console.timeEnd('fake-timers-zero')
-
-  console.time('fake-timers-advance')
-  vi.advanceTimersByTime(1234)
-  console.timeEnd('fake-timers-advance')
+  console.time('[console-time-fake]')
+  console.timeEnd('[console-time-fake]')
 })

--- a/test/browser/test/timers.test.ts
+++ b/test/browser/test/timers.test.ts
@@ -20,7 +20,10 @@ it('only runs a setTimeout callback once (ever)', () => {
 })
 
 it('console.time', async () => {
-  vi.useFakeTimers()
+  vi.useFakeTimers({
+    toFake: ['Date', 'performance'],
+  })
   console.time('[console-time-fake]')
+  await new Promise(r => setTimeout(r, 500))
   console.timeEnd('[console-time-fake]')
 })


### PR DESCRIPTION
### Description

`performance` used by console wrapper is referencing a global one, which might be mocked. 

I'm not sure if this is intended and actually it might be fine either way since Node's `console.time` implementation seems to actually pick up the mocked `performance` internally (regardless of `--disable-console-intercept`) while Browser devtools console won't get affected by mock. I chose browser devtools behavior.

```js
import { vi, test } from "vitest"

test('console.time', () => {
  vi.useFakeTimers()
  console.time('test')
  console.timeEnd('test')
  // on node -> 0ms
  // on browser devtools -> 0.09999999962747097
})
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
