### PR TITLE
feat: add resolved project names to the reporter API

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -153,10 +153,11 @@ watch(
     ws.addEventListener('open', async () => {
       status.value = 'OPEN'
       client.state.filesMap.clear()
-      let [files, _config, errors] = await Promise.all([
+      let [files, _config, errors, projects] = await Promise.all([
         client.rpc.getFiles(),
         client.rpc.getConfig(),
         client.rpc.getUnhandledErrors(),
+        client.rpc.getResolvedProjectNames(),
       ])
       if (_config.standalone) {
         const filenames = await client.rpc.getTestFiles()
@@ -166,7 +167,7 @@ watch(
           return file
         })
       }
-      explorerTree.loadFiles(files)
+      explorerTree.loadFiles(files, projects)
       client.state.collectFiles(files)
       explorerTree.startRun()
       unhandledErrors.value = (errors || []).map(parseError)

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -15,6 +15,7 @@ interface HTMLReportMetadata {
   paths: string[]
   files: File[]
   config: SerializedConfig
+  projects: string[]
   moduleGraph: Record<string, Record<string, ModuleGraphData>>
   unhandledErrors: unknown[]
   // filename -> source
@@ -46,6 +47,9 @@ export function createStaticClient(): VitestClient {
     },
     getConfig: () => {
       return metadata.config
+    },
+    getResolvedProjectNames: () => {
+      return metadata.projects
     },
     getModuleGraph: async (projectName, id) => {
       return metadata.moduleGraph[projectName]?.[id]

--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -18,6 +18,7 @@ export class ExplorerTree {
   private rafCollector: ReturnType<typeof useRafFn>
   private resumeEndRunId: ReturnType<typeof setTimeout> | undefined
   constructor(
+    public projects: string[] = [],
     private onTaskUpdateCalled: boolean = false,
     private resumeEndTimeout = 500,
     public root = <RootTreeNode>{
@@ -53,7 +54,8 @@ export class ExplorerTree {
     this.rafCollector = useRafFn(this.runCollect.bind(this), { fpsLimit: 10, immediate: false })
   }
 
-  loadFiles(remoteFiles: File[]) {
+  loadFiles(remoteFiles: File[], projects: string[]) {
+    this.projects.splice(0, this.projects.length, ...projects)
     runLoadFiles(
       remoteFiles,
       true,

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -66,7 +66,7 @@ export default class HTMLReporter implements Reporter {
       files: this.ctx.state.getFiles(),
       config: this.ctx.getRootProject().serializedConfig,
       unhandledErrors: this.ctx.state.getUnhandledErrors(),
-      projects: (this.ctx as any).resolvedProjects.map((p: { name?: string }) => p.name),
+      projects: this.ctx.resolvedProjects.map(p => p.name),
       moduleGraph: {},
       sources: {},
     }

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -66,7 +66,7 @@ export default class HTMLReporter implements Reporter {
       files: this.ctx.state.getFiles(),
       config: this.ctx.getRootProject().serializedConfig,
       unhandledErrors: this.ctx.state.getUnhandledErrors(),
-      projects: this.ctx.getResolvedProjectNames(),
+      projects: (this.ctx as any).resolvedProjects.map((p: { name?: string }) => p.name),
       moduleGraph: {},
       sources: {},
     }

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -36,6 +36,7 @@ interface HTMLReportData {
   paths: string[]
   files: File[]
   config: SerializedConfig
+  projects: string[]
   moduleGraph: Record<string, Record<string, ModuleGraphData>>
   unhandledErrors: unknown[]
   // filename -> source
@@ -65,6 +66,7 @@ export default class HTMLReporter implements Reporter {
       files: this.ctx.state.getFiles(),
       config: this.ctx.getRootProject().serializedConfig,
       unhandledErrors: this.ctx.state.getUnhandledErrors(),
+      projects: this.ctx.getResolvedProjectNames(),
       moduleGraph: {},
       sources: {},
     }

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -81,6 +81,9 @@ export function setup(ctx: Vitest, _server?: ViteDevServer) {
         getConfig() {
           return ctx.getRootProject().serializedConfig
         },
+        getResolvedProjectNames(): string[] {
+          return ctx.getResolvedProjectNames()
+        },
         async getTransformResult(projectName: string, id, browser = false) {
           const project = ctx.getProjectByName(projectName)
           const result: TransformResultWithSource | null | undefined = browser

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -82,7 +82,7 @@ export function setup(ctx: Vitest, _server?: ViteDevServer) {
           return ctx.getRootProject().serializedConfig
         },
         getResolvedProjectNames(): string[] {
-          return ctx.getResolvedProjectNames()
+          return ctx.resolvedProjects.map(p => p.name)
         },
         async getTransformResult(projectName: string, id, browser = false) {
           const project = ctx.getProjectByName(projectName)

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -32,6 +32,7 @@ export interface WebSocketHandlers {
   getTestFiles: () => Promise<SerializedTestSpecification[]>
   getPaths: () => string[]
   getConfig: () => SerializedConfig
+  getResolvedProjectNames: () => string[]
   getModuleGraph: (
     projectName: string,
     id: string,

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -329,6 +329,13 @@ export class Vitest {
   }
 
   /**
+   * Get project names.
+   */
+  public getResolvedProjectNames(): string[] {
+    return this.resolvedProjects.map(p => p.name)
+  }
+
+  /**
    * @deprecated use Reported Task API instead
    */
   public getProjectByTaskId(taskId: string): TestProject {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -329,13 +329,6 @@ export class Vitest {
   }
 
   /**
-   * Get project names.
-   */
-  public getResolvedProjectNames(): string[] {
-    return this.resolvedProjects.map(p => p.name)
-  }
-
-  /**
    * @deprecated use Reported Task API instead
    */
   public getProjectByTaskId(taskId: string): TestProject {

--- a/test/reporters/tests/__snapshots__/html.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/html.test.ts.snap
@@ -98,6 +98,9 @@ exports[`html reporter > resolves to "failing" status for test file "json-fail" 
   "paths": [
     "<rootDir>/test/reporters/fixtures/json-fail.test.ts",
   ],
+  "projects": [
+    "",
+  ],
   "sources": {
     "<rootDir>/test/reporters/fixtures/json-fail.test.ts": "import { expect, test } from 'vitest'
 
@@ -194,6 +197,9 @@ exports[`html reporter > resolves to "passing" status for test file "all-passing
   },
   "paths": [
     "<rootDir>/test/reporters/fixtures/all-passing-or-skipped.test.ts",
+  ],
+  "projects": [
+    "",
   ],
   "sources": {
     "<rootDir>/test/reporters/fixtures/all-passing-or-skipped.test.ts": "import { expect, test } from 'vitest'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

The changes in the UI will require the project names in this PR #7157, right now we need to traverse all the files to collect the project names, with this PR we can get them without any async operation.

This PR includes the project names in the UI statically, if there is some change (adding/removing/updating workspace/project), the UI will not reflect the changes (will require page refresh), maybe we can check later if we can expose some method.

**NOTE**: on my local running `test:ci` is failing

![image](https://github.com/user-attachments/assets/aeee4441-5f34-4ec7-a1aa-264e97f1e608)

![image](https://github.com/user-attachments/assets/4af34974-8630-4fd5-894c-ea79488030ab)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
