### PR TITLE
fix(ui): wrong module graph when generating html.meta.json.gz in browser mode

### DIFF
--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -71,11 +71,14 @@ export default class HTMLReporter implements Reporter {
     await Promise.all(
       result.files.map(async (file) => {
         const projectName = file.projectName || ''
+        const resolvedConfig = this.ctx.getProjectByName(projectName).config
+        const browser = resolvedConfig.browser.enabled && resolvedConfig.browser.ui
         result.moduleGraph[projectName] ??= {}
         result.moduleGraph[projectName][file.filepath] = await getModuleGraph(
           this.ctx as any,
           projectName,
           file.filepath,
+          browser,
         )
         if (!result.sources[file.filepath]) {
           try {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
When using html reporter with browser mode, the module graph is using server instead client graph: when serving static html folder the module graph tab not displaying the graph since it is not being generated correctly.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
