### PR TITLE
fix: return test fn result to runner

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -479,7 +479,7 @@ function createSuiteCollector(
 
 function withAwaitAsyncAssertions<T extends (...args: any[]) => any>(fn: T, task: TaskPopulated): T {
   return (async (...args: any[]) => {
-    await fn(...args)
+    const fnResult = await fn(...args)
     // some async expect will be added to this array, in case user forget to await them
     if (task.promises) {
       const result = await Promise.allSettled(task.promises)
@@ -490,6 +490,7 @@ function withAwaitAsyncAssertions<T extends (...args: any[]) => any>(fn: T, task
         throw errors
       }
     }
+    return fnResult
   }) as T
 }
 


### PR DESCRIPTION
### Description

We're using a custom runner that stores test function results and allows using them in different tests. This works great but recently it stopped working.

I looked into adding a test but couldn't find where the runner is tested. Please let me know.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
