### PR TITLE
chore(ui): use `@vitest/runner` types

### DIFF
--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { File } from 'vitest'
+import type { File } from '@vitest/runner'
 import { Tooltip as VueTooltip } from 'floating-vue'
 import { isDark, toggleDark } from '~/composables'
 import { client, isReport, runAll, runFiles } from '~/composables/client'

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import type { File } from '@vitest/runner'
 import type CodeMirror from 'codemirror'
-import type { ErrorWithDiff, File } from 'vitest'
+import type { ErrorWithDiff } from 'vitest'
 import { createTooltip, destroyTooltip } from 'floating-vue'
 import { client, isReport } from '~/composables/client'
 import { finished } from '~/composables/client/state'
@@ -102,7 +103,7 @@ function clearListeners() {
   listeners.length = 0
 }
 
-useResizeObserver(editor, () => {
+useResizeObserver(() => editor.value, () => {
   codemirrorRef.value?.refresh()
 })
 

--- a/packages/ui/client/components/views/ViewReport.spec.ts
+++ b/packages/ui/client/components/views/ViewReport.spec.ts
@@ -1,4 +1,4 @@
-import type { File } from 'vitest'
+import type { File } from '@vitest/runner'
 import { faker } from '@faker-js/faker'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { config } from '~/composables/client'
@@ -27,7 +27,7 @@ const textStacks = Array.from({ length: 5 }, makeTextStack)
 const diff = `
   \x1B[32m- Expected\x1B[39m
   \x1B[31m+ Received\x1B[39m
-  
+
   \x1B[2m  Object {\x1B[22m
   \x1B[2m    "a": 1,\x1B[22m
   \x1B[32m-   "b": 2,\x1B[39m

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import type { File, Suite, Task } from '@vitest/runner'
 import type Convert from 'ansi-to-html'
-import type { ErrorWithDiff, File, Suite, Task } from 'vitest'
+import type { ErrorWithDiff } from 'vitest'
 import { browserState, config } from '~/composables/client'
 import { isDark } from '~/composables/dark'
 import { createAnsiToHtmlFilter } from '~/composables/error'

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -1,5 +1,6 @@
+import type { File, Task, TaskResultPack } from '@vitest/runner'
 import type { WebSocketStatus } from '@vueuse/core'
-import type { File, SerializedConfig, Task, TaskResultPack } from 'vitest'
+import type { SerializedConfig } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
 import { createFileTask } from '@vitest/runner/utils'
 import { createClient, getTasks } from '@vitest/ws-client'

--- a/packages/ui/client/utils/task.ts
+++ b/packages/ui/client/utils/task.ts
@@ -1,4 +1,4 @@
-import type { Suite, Task } from 'vitest'
+import type { Suite, Task } from '@vitest/runner'
 
 export function isSuite(task: Task): task is Suite {
   return Object.hasOwnProperty.call(task, 'tasks')


### PR DESCRIPTION
### Description

This PR replaces all deprecated imports from `vitest` with `@vitest/runner` and updates `useResizeObserver` usage.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
