### PR TITLE
feat: add `describe.for`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -948,6 +948,11 @@ describe.todo('unimplemented suite')
 
 - **Alias:** `suite.each`
 
+::: tip
+While `describe.each` is provided for Jest compatibility,
+Vitest also has [`describe.for`](#describe-for) which simplifies argument types and aligns with [`test.for`](#test-for).
+:::
+
 Use `describe.each` if you have more than one test that depends on the same data.
 
 ```ts
@@ -997,6 +1002,37 @@ describe.each`
 ::: warning
 You cannot use this syntax when using Vitest as [type checker](/guide/testing-types).
 :::
+
+### describe.for
+
+- **Alias:** `suite.for`
+
+The difference from `describe.each` is how array case is provided in the arguments.
+Other non array case (including template string usage) works exactly same.
+
+```ts
+// `each` spreads array case
+describe.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add(%i, %i) -> %i', (a, b, expected) => { // [!code --]
+  test('test', () => {
+    expect(a + b).toBe(expected)
+  })
+})
+
+// `for` doesn't spread array case
+describe.for([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add(%i, %i) -> %i', ([a, b, expected]) => { // [!code ++]
+  test('test', () => {
+    expect(a + b).toBe(expected)
+  })
+})
+```
 
 ## Setup and Teardown
 

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -594,6 +594,31 @@ function createSuite() {
     }
   }
 
+  suiteFn.for = function <T>(
+    this: {
+      withContext: () => SuiteAPI
+      setContext: (key: string, value: boolean | undefined) => SuiteAPI
+    },
+    cases: ReadonlyArray<T>,
+    ...args: any[]
+  ) {
+    if (Array.isArray(cases) && args.length) {
+      cases = formatTemplateString(cases, args)
+    }
+
+    return (
+      name: string | Function,
+      optionsOrFn: ((...args: T[]) => void) | TestOptions,
+      fnOrOptions?: ((...args: T[]) => void) | number | TestOptions,
+    ) => {
+      const name_ = formatName(name)
+      const { options, handler } = parseArguments(optionsOrFn, fnOrOptions)
+      cases.forEach((item, idx) => {
+        suite(formatTitle(name_, toArray(item), idx), options, () => handler(item))
+      })
+    }
+  }
+
   suiteFn.skipIf = (condition: any) =>
     (condition ? suite.skip : suite) as SuiteAPI
   suiteFn.runIf = (condition: any) =>

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -360,6 +360,11 @@ interface TestForFunction<ExtraContext> {
   >
 }
 
+interface SuiteForFunction {
+  <T>(cases: ReadonlyArray<T>): EachFunctionReturn<[T]>
+  (...args: [TemplateStringsArray, ...any]): EachFunctionReturn<any[]>
+}
+
 interface TestCollectorCallable<C = object> {
   /**
    * @deprecated Use options as the second argument instead
@@ -525,6 +530,7 @@ type ChainableSuiteAPI<ExtraContext = object> = ChainableFunction<
   SuiteCollectorCallable<ExtraContext>,
   {
     each: TestEachFunction
+    for: SuiteForFunction
   }
 >
 

--- a/test/core/test/__snapshots__/test-for-suite.test.ts.snap
+++ b/test/core/test/__snapshots__/test-for-suite.test.ts.snap
@@ -1,0 +1,45 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`add(1, 1) > test 1`] = `2`;
+
+exports[`add(1, 2) > test 1`] = `3`;
+
+exports[`add(2, 1) > test 1`] = `3`;
+
+exports[`basic case1 > test 1`] = `
+{
+  "args": [
+    "case1",
+  ],
+}
+`;
+
+exports[`basic case2 > test 1`] = `
+{
+  "args": [
+    "case2",
+  ],
+}
+`;
+
+exports[`template 'x' true > test 1`] = `
+{
+  "args": [
+    {
+      "a": "x",
+      "b": true,
+    },
+  ],
+}
+`;
+
+exports[`template 'y' false > test 1`] = `
+{
+  "args": [
+    {
+      "a": "y",
+      "b": false,
+    },
+  ],
+}
+`;

--- a/test/core/test/test-for-suite.test.ts
+++ b/test/core/test/test-for-suite.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, expectTypeOf, test } from 'vitest'
+
+describe.for(['case1', 'case2'])(
+  'basic %s',
+  (...args) => {
+    test('test', () => {
+      expectTypeOf(args).toEqualTypeOf<[string]>()
+      expect({ args }).matchSnapshot()
+    })
+  },
+)
+
+describe.for`
+  a         | b
+  ${'x'}    | ${true}
+  ${'y'}    | ${false}
+`(
+  'template $a $b',
+  (...args) => {
+    test('test', () => {
+      expectTypeOf(args).toEqualTypeOf<any[]>()
+      expect({ args }).toMatchSnapshot()
+    })
+  },
+)
+
+describe.for([
+  [1, 1],
+  [1, 2],
+  [2, 1],
+])('add(%i, %i)', ([a, b]) => {
+  test('test', () => {
+    expect(a + b).matchSnapshot()
+  })
+})


### PR DESCRIPTION
### Description

- Related https://github.com/vitest-dev/vitest/pull/5861

I didn't add `describe.for` initially since test context feature was irrelevant, but I think we said we can still add this for consistency. Also typing `describe.each` is more complicated and I tend to prefer simple `.for` style types.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
