### PR TITLE
fix(coverage)!: always exclude test files

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1351,7 +1351,8 @@ export default defineConfig({
 ```
 
 ::: tip NOTE
-Vitest automatically adds test files `include` patterns to the default value of `coverage.exclude`.
+Vitest automatically adds test files `include` patterns to the `coverage.exclude`.
+It's not possible to show coverage of test files.
 :::
 
 #### coverage.all

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -85,6 +85,10 @@ This function is not used internally and exposed exclusively as a public API.
 
 The `vitest/reporters` entrypoint now only exports reporters implementations and options types. If you need access to `TestCase`/`TestSuite` and other task related types, import them additionally from `vitest/node`.
 
+### Coverage ignores test files even when `coverage.excludes` is overwritten.
+
+It is no longer possible to include test files in coverage report by overwriting `coverage.excludes`. Test files are now always excluded.
+
 ## Migrating to Vitest 2.0 {#vitest-2}
 
 ### Default Pool is `forks`

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -344,6 +344,7 @@ export function resolveConfig(
         )}`,
     ),
   )
+  resolved.coverage.exclude.push(...resolved.include)
 
   resolved.forceRerunTriggers = [
     ...resolved.forceRerunTriggers,

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@vitest/utils'
 import { relative } from 'pathe'
 import { defaultPort } from '../../constants'
-import { configDefaults, coverageConfigDefaults } from '../../defaults'
+import { configDefaults } from '../../defaults'
 import { generateScopedClassName } from '../../integrations/css/css-modules'
 import { resolveApiServerConfig } from '../config/resolveConfig'
 import { Vitest } from '../core'
@@ -153,13 +153,6 @@ export async function VitestPlugin(
           },
         )
         config.customLogger = silenceImportViteIgnoreWarning(config.customLogger)
-
-        // If "coverage.exclude" is not defined by user, add "test.include" to "coverage.exclude" automatically
-        if (userConfig.coverage?.enabled && !userConfig.coverage.exclude && userConfig.include && config.test) {
-          config.test.coverage = {
-            exclude: [...coverageConfigDefaults.exclude, ...userConfig.include],
-          }
-        }
 
         // we want inline dependencies to be resolved by analyser plugin so module graph is populated correctly
         if (viteConfig.ssr?.noExternal !== true) {

--- a/test/coverage-test/test/include-exclude.test.ts
+++ b/test/coverage-test/test/include-exclude.test.ts
@@ -16,7 +16,7 @@ test('default exclude should ignore test files', async () => {
   expect(coverageMap.files()).toMatchInlineSnapshot(`[]`)
 })
 
-test('overridden exclude should not apply defaults', async () => {
+test('overridden exclude should still apply defaults', async () => {
   await runVitest({
     include: ['fixtures/test/math.test.ts'],
     coverage: {
@@ -28,11 +28,7 @@ test('overridden exclude should not apply defaults', async () => {
   })
 
   const coverageMap = await readCoverageMap()
-  expect(coverageMap.files()).toMatchInlineSnapshot(`
-    [
-      "<process-cwd>/fixtures/test/math.test.ts",
-    ]
-  `)
+  expect(coverageMap.files()).toMatchInlineSnapshot(`[]`)
 })
 
 test('test file is excluded from report when excludes is not set', async () => {
@@ -49,7 +45,7 @@ test('test file is excluded from report when excludes is not set', async () => {
   expect(files.find(file => file.includes('test-that-looks-like-source-file'))).toBeFalsy()
 })
 
-test('test files are not automatically excluded from report when excludes is set', async () => {
+test('test files are automatically excluded from report when excludes is set', async () => {
   await runVitest({
     include: ['fixtures/src/test-that-looks-like-source-file.ts'],
     coverage: {
@@ -61,5 +57,5 @@ test('test files are not automatically excluded from report when excludes is set
 
   const coverageMap = await readCoverageMap()
   const files = coverageMap.files()
-  expect(files).toContain('<process-cwd>/fixtures/src/test-that-looks-like-source-file.ts')
+  expect(files.find(file => file.includes('test-that-looks-like-source-file'))).toBeFalsy()
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Exclude test files from coverage even when custom `coverage.excludes` is set

cc. @yannbf 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
