### PR TITLE
fix(ui,browser): load panel sizes from storage on initial load

### DIFF
--- a/packages/ui/client/components/BrowserIframe.vue
+++ b/packages/ui/client/components/BrowserIframe.vue
@@ -59,7 +59,7 @@ const marginLeft = computed(() => {
   <div h="full" flex="~ col">
     <div p="3" h-10 flex="~ gap-2" items-center bg-header border="b base">
       <IconButton
-        v-show="panels.navigation <= 2"
+        v-show="panels.navigation <= 15"
         v-tooltip.bottom="'Show Navigation Panel'"
         title="Show Navigation Panel"
         rotate-180

--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -8,7 +8,6 @@ import { RecycleScroller } from 'vue-virtual-scroller'
 import { config } from '~/composables/client'
 import { useSearch } from '~/composables/explorer/search'
 
-import { panels } from '~/composables/navigation'
 import { activeFileId } from '~/composables/params'
 
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
@@ -46,12 +45,10 @@ const {
 
 const filterClass = ref<string>('grid-cols-2')
 const filterHeaderClass = ref<string>('grid-col-span-2')
-const testExplorerRef = ref<HTMLInputElement | undefined>()
 
-const { width: windowWidth } = useWindowSize()
-
-watch(() => windowWidth.value * (panels.navigation / 100), (width) => {
-  if (width < 420) {
+const testExplorerRef = ref<HTMLElement | undefined>()
+useResizeObserver(() => testExplorerRef.value, ([{ contentRect }]) => {
+  if (contentRect.width < 420) {
     filterClass.value = 'grid-cols-2'
     filterHeaderClass.value = 'grid-col-span-2'
   }

--- a/packages/ui/client/composables/navigation.ts
+++ b/packages/ui/client/composables/navigation.ts
@@ -19,16 +19,10 @@ export const coverageEnabled = computed(() => {
 export const mainSizes = useLocalStorage<[left: number, right: number]>(
   'vitest-ui_splitpanes-mainSizes',
   [33, 67],
-  {
-    initOnMounted: true,
-  },
 )
 export const detailSizes = useLocalStorage<[left: number, right: number]>(
   'vitest-ui_splitpanes-detailSizes',
   [33, 67],
-  {
-    initOnMounted: true,
-  },
 )
 
 // live sizes of panels in percentage

--- a/packages/ui/client/pages/index.vue
+++ b/packages/ui/client/pages/index.vue
@@ -39,17 +39,6 @@ const resizingMain = useDebounceFn((event: { size: number }[]) => {
   preventBrowserEvents()
 }, 0)
 
-function resizeMain() {
-  const width = window.innerWidth
-  const panelWidth = Math.min(width / 3, 300)
-  mainSizes.value[0] = (100 * panelWidth) / width
-  mainSizes.value[1] = 100 - mainSizes.value[0]
-  recordMainResize([
-    { size: mainSizes.value[0] },
-    { size: mainSizes.value[1] },
-  ])
-}
-
 function recordMainResize(event: { size: number }[]) {
   panels.navigation = event[0].size
   panels.details.size = event[1].size
@@ -82,7 +71,6 @@ function allowBrowserEvents() {
       class="pt-4px"
       @resized="onMainResized"
       @resize="resizingMain"
-      @ready="resizeMain"
     >
       <Pane :size="mainSizes[0]">
         <Navigation />


### PR DESCRIPTION
### Description

The problem was about restoring the sizes using `@ready` event in the root split pane: there was some race condition between local storage and the event handling.

There is also similar problem with the `Hide/Show Right Panel` button in browser mode when hidding the right panel and initial load or page refresh: showing `Hide Right Panel` button instead `Show Right Panel`.

This PR also includes:
- use resize observer in Explorer.vue to change the filter based on its width instead on main and panels sizes: on initial load or page refresh sometimes the filter with wrong grid columns (the filter will not change while resizing until resized).
- increase the navigator percentage to 15% in BrowserIFrame.vue to show the `Show Navigation Panel` button (browser mode).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
closes #6678
supersedes #6679

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
