### PR TITLE
Changed readHelloWorld in exampele 3 to return a string

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -385,7 +385,7 @@ module.exports = fs.promises
 import { readFileSync } from 'node:fs'
 
 export function readHelloWorld(path) {
-  return readFileSync(path)
+  return readFileSync(path, { encoding: 'utf8', flag: 'r' })
 }
 ```
 

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -385,7 +385,7 @@ module.exports = fs.promises
 import { readFileSync } from 'node:fs'
 
 export function readHelloWorld(path) {
-  return readFileSync(path, { encoding: 'utf8', flag: 'r' })
+  return readFileSync(path, 'utf-8')
 }
 ```
 


### PR DESCRIPTION
### Description

File system mocking example would not run as `readHelloWorld` returns a buffer with test assertions expecting a text instead. It seems that the returned value should be a string, which is a simpler solution that to call `.toString()` in the tests. The name of the variable also suggests that text is expected to be returned.


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
