### PR TITLE
fix: don't await an empty timeout after every test

### DIFF
--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -72,6 +72,7 @@ export function withTimeout<T extends (...args: any[]) => any>(
           })
       }
       catch (error) {
+        clearTimeout(timer)
         reject(error)
       }
     })

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -52,7 +52,7 @@ export function withTimeout<T extends (...args: any[]) => any>(
       // `unref` might not exist in browser
       timer.unref?.()
 
-      /// sync fn will be caught by try/catch
+      // sync fn will be caught by try/catch
       try {
         Promise.resolve(fn(...args))
           .then((result) => {

--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -7,9 +7,15 @@ exports[`should fail async-assertion.test.ts 1`] = `
 AssertionError: expected 'xx' to be 'yy' // Object.is equality"
 `;
 
-exports[`should fail concurrent-suite-deadlock.test.ts 1`] = `"Error: Test timed out in 500ms."`;
+exports[`should fail concurrent-suite-deadlock.test.ts 1`] = `
+"Error: Test timed out in 500ms.
+Error: Test timed out in 500ms."
+`;
 
-exports[`should fail concurrent-test-deadlock.test.ts 1`] = `"Error: Test timed out in 500ms."`;
+exports[`should fail concurrent-test-deadlock.test.ts 1`] = `
+"Error: Test timed out in 500ms.
+Error: Test timed out in 500ms."
+`;
 
 exports[`should fail each-timeout.test.ts 1`] = `"Error: Test timed out in 10ms."`;
 

--- a/test/cli/test/fails.test.ts
+++ b/test/cli/test/fails.test.ts
@@ -18,7 +18,7 @@ it.each(files)('should fail %s', async (file) => {
   const msg = String(stderr)
     .split(/\n/g)
     .reverse()
-    .filter(i => i.includes('Error: ') && !i.includes('Command failed') && !i.includes('stackStr') && !i.includes('at runTest') && !i.includes('at runWithTimeout'))
+    .filter(i => i.includes('Error: ') && !i.includes('Command failed') && !i.includes('stackStr') && !i.includes('at runTest') && !i.includes('at runWithTimeout') && !i.includes('file:'))
     .map(i => i.trim().replace(root, '<rootDir>'),
     )
     .join('\n')


### PR DESCRIPTION
### Description

Fixes #7275

- reduce the amount of promises created form 4 to 1
- remove empty `setTimeout`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
