### PR TITLE
perf(reporters): update summary only when needed

### DIFF
--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -66,11 +66,13 @@ export class DotReporter extends BaseReporter {
       return
     }
     this.tests.set(test.id, test.result().state || 'run')
+    this.renderer?.schedule()
   }
 
   onTestCaseResult(test: TestCase) {
     this.finishedTests.add(test.id)
     this.tests.set(test.id, test.result().state || 'skipped')
+    this.renderer?.schedule()
   }
 
   onTestModuleEnd() {
@@ -104,6 +106,7 @@ export class DotReporter extends BaseReporter {
     }
 
     this.ctx.logger.log(formatTests(states))
+    this.renderer?.schedule()
   }
 
   private createSummary() {

--- a/packages/vitest/src/node/reporters/summary.ts
+++ b/packages/vitest/src/node/reporters/summary.ts
@@ -109,6 +109,7 @@ export class SummaryReporter implements Reporter {
     }
 
     this.runningModules.set(module.id, initializeStats(module))
+    this.renderer.schedule()
   }
 
   onTestModuleCollected(module: TestModule) {
@@ -124,6 +125,7 @@ export class SummaryReporter implements Reporter {
     stats.total = total
 
     this.maxParallelTests = Math.max(this.maxParallelTests, this.runningModules.size)
+    this.renderer.schedule()
   }
 
   onHookStart(options: ReportedHookContext) {
@@ -213,6 +215,8 @@ export class SummaryReporter implements Reporter {
     else if (!result?.state || result?.state === 'skipped') {
       this.tests.skipped++
     }
+
+    this.renderer.schedule()
   }
 
   onTestModuleEnd(module: TestModule) {
@@ -247,6 +251,8 @@ export class SummaryReporter implements Reporter {
       // Remove finished test immediatelly.
       this.removeTestModule(module.id)
     }
+
+    this.renderer.schedule()
   }
 
   private getHookStats({ entity }: ReportedHookContext) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/7285
- Summary (and dot reporter) now instruct window renderer when an update is needed to render. Window rendered also schedules updates every 1s. In `v3.0.2` and `^v2` Vitest was updating whole terminal every 16ms. 

I'm unable to reproduce this using repro from #7285, but generated artificial test setup inside Windows VM. Using `cmd.exe` the execution time dropped from 50s to 38s in that setup. With Git Bash or Powershell there were no performance issues or any changes. On MacOS I'm unable to reproduce this at all.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
