### PR TITLE
feat: support `vi.setConfig({ sequence: { shuffle }})`

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -1019,8 +1019,9 @@ vi.setConfig({
   },
   maxConcurrency: 10,
   sequence: {
-    hooks: 'stack'
-    // supports only "sequence.hooks"
+    hooks: 'stack',
+    shuffle: true,
+    // supports only "sequence.hooks" and "sequence.suffle"
   }
 })
 ```

--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -32,7 +32,7 @@ export async function collectTests(
     const testLocations = typeof spec === 'string' ? undefined : spec.testLocations
 
     const file = createFileTask(filepath, config.root, config.name, runner.pool)
-    file.shuffle = config.sequence.shuffle
+    // file.shuffle = config.sequence.shuffle
 
     runner.onCollectStart?.(file)
 

--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -32,7 +32,6 @@ export async function collectTests(
     const testLocations = typeof spec === 'string' ? undefined : spec.testLocations
 
     const file = createFileTask(filepath, config.root, config.name, runner.pool)
-    // file.shuffle = config.sequence.shuffle
 
     runner.onCollectStart?.(file)
 

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -457,7 +457,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner): Promise<void
           }
           else {
             const { sequence } = runner.config
-            if (suite.shuffle) {
+            if (suite.shuffle ?? sequence.shuffle) {
               // run describe block independently from tests
               const suites = tasksGroup.filter(
                 group => group.type === 'suite',

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -522,7 +522,7 @@ function createSuite() {
     options = {
       ...currentSuite?.options,
       ...options,
-      shuffle: this.shuffle ?? options.shuffle ?? currentSuite?.options?.shuffle ?? runner?.config.sequence.shuffle,
+      shuffle: this.shuffle ?? options.shuffle ?? currentSuite?.options?.shuffle,
     }
 
     // inherit concurrent / sequential from suite

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -703,6 +703,7 @@ function createVitest(): VitestUtils {
       if (!_config) {
         _config = { ...workerState.config }
       }
+      // TODO: deep merge for `config.sequence`
       Object.assign(workerState.config, config)
     },
 

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -160,6 +160,7 @@ export type RuntimeConfig = Pick<
 > & {
   sequence?: {
     hooks?: SequenceHooks
+    shuffle?: boolean
   }
 }
 

--- a/test/config/fixtures/shuffle-setConfig/basic.test.ts
+++ b/test/config/fixtures/shuffle-setConfig/basic.test.ts
@@ -1,0 +1,19 @@
+import { afterAll, test, vi } from 'vitest'
+
+if (process.env.SET_CONFIG_SHUFFLE) {
+  vi.setConfig({
+    sequence: {
+      shuffle: process.env.SET_CONFIG_SHUFFLE === 'true',
+    },
+  })
+}
+
+const numbers: number[] = []
+
+test.for([1, 2, 3, 4, 5])('test %s', (v) => {
+  numbers.push(v)
+})
+
+afterAll(() => {
+  console.log(numbers)
+})

--- a/test/config/fixtures/shuffle-setConfig/vitest.config.ts
+++ b/test/config/fixtures/shuffle-setConfig/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    sequence: {
+      seed: 101,
+    }
+  }
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7199

Currently this is not working, but it should be possible to adjust the internal https://github.com/vitest-dev/vitest/pull/6670 to support this case.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
