### PR TITLE
fix: filter projects eagerly during config resolution

### DIFF
--- a/packages/browser/src/node/pool.ts
+++ b/packages/browser/src/node/pool.ts
@@ -133,6 +133,9 @@ export function createBrowserPool(vitest: Vitest): ProcessPool {
       }
       await project._initBrowserProvider()
 
+      if (!project.browser) {
+        throw new TypeError(`The browser server was not initialized for the ${project.name} project. This is a bug in Vitest. Please, open a new issue with reproduction.`)
+      }
       await executeTests(method, project, files)
     }
   }

--- a/packages/browser/src/node/pool.ts
+++ b/packages/browser/src/node/pool.ts
@@ -134,7 +134,7 @@ export function createBrowserPool(vitest: Vitest): ProcessPool {
       await project._initBrowserProvider()
 
       if (!project.browser) {
-        throw new TypeError(`The browser server was not initialized for the ${project.name} project. This is a bug in Vitest. Please, open a new issue with reproduction.`)
+        throw new TypeError(`The browser server was not initialized${project.name ? ` for the "${project.name}" project` : ''}. This is a bug in Vitest. Please, open a new issue with reproduction.`)
       }
       await executeTests(method, project, files)
     }

--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -167,7 +167,9 @@ export function parseSingleV8Stack(raw: string): ParsedStack | null {
   }
 
   // normalize Windows path (\ -> /)
-  file = resolve(file)
+  file = file.startsWith('node:') || file.startsWith('internal:')
+    ? file
+    : resolve(file)
 
   if (method) {
     method = method.replace(/__vite_ssr_import_\d+__\./g, '')

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -266,7 +266,7 @@ export function resolveConfig(
       browser: {
         provider: browser.provider,
         name: browser.name,
-        instances: browser.instances,
+        instances: browser.instances?.map(i => ({ browser: i.browser })),
       },
     }
 

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -231,6 +231,8 @@ export function resolveConfig(
     }
   }
 
+  resolved.project = toArray(options.project || []).map(project => wildcardPatternToRegExp(project))
+
   const browser = resolved.browser
 
   if (browser.enabled) {
@@ -469,7 +471,7 @@ export function resolveConfig(
   resolved.forceRerunTriggers.push(...resolved.snapshotSerializers)
 
   if (options.resolveSnapshotPath) {
-    delete (resolved as UserConfig).resolveSnapshotPath
+    delete (resolved as any).resolveSnapshotPath
   }
 
   resolved.pool ??= 'threads'
@@ -908,11 +910,10 @@ function isPlaywrightChromiumOnly(config: ResolvedConfig) {
   if (!browser.instances) {
     return false
   }
-  const filteredProjects = toArray(config.project).map(p => wildcardPatternToRegExp(p))
   for (const instance of browser.instances) {
     const name = instance.name || (config.name ? `${config.name} (${instance.browser})` : instance.browser)
     // browser config is filtered out
-    if (filteredProjects.length && !filteredProjects.every(p => p.test(name))) {
+    if (config.project.length && !config.project.every(p => p.test(name))) {
       continue
     }
     if (instance.browser !== 'chromium') {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -869,10 +869,7 @@ export class Vitest {
       this._projectFilter = pattern
     }
 
-    // TODO: restart the whole vitest server, not just filter projects
-    this.projects = this.resolvedProjects.filter(p => p.name === pattern)
-    const files = (await this.globTestSpecifications()).map(spec => spec.moduleId)
-    await this.rerunFiles(files, 'change project filter', pattern === '')
+    await this.vite.restart()
   }
 
   /** @internal */

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -276,15 +276,9 @@ export class Vitest {
     const projects = await this.resolveWorkspace(cliOptions)
     this.resolvedProjects = projects
     this.projects = projects
-    // const filters = toArray(resolved.project).map(s => wildcardPatternToRegExp(s))
-    // if (filters.length > 0) {
-    //   this.projects = this.projects.filter(p =>
-    //     filters.some(pattern => pattern.test(p.name)),
-    //   )
     if (!this.projects.length) {
       throw new Error(`No projects matched the filter "${toArray(resolved.project).join('", "')}".`)
     }
-    // }
     if (!this.coreWorkspaceProject) {
       this.coreWorkspaceProject = TestProject._createBasicProject(this)
     }
@@ -404,7 +398,7 @@ export class Vitest {
     // user doesn't have a workspace config, return default project
     if (!workspaceConfigPath) {
       // user can filter projects with --project flag, `getDefaultTestProject`
-      // return the project only if it matches the filter
+      // returns the project only if it matches the filter
       const project = getDefaultTestProject(this)
       if (!project) {
         return []

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -39,7 +39,7 @@ import { VitestSpecifications } from './specifications'
 import { StateManager } from './state'
 import { TestRun } from './test-run'
 import { VitestWatcher } from './watcher'
-import { resolveBrowserWorkspace, resolveWorkspace } from './workspace/resolveWorkspace'
+import { getDefaultTestProject, resolveBrowserWorkspace, resolveWorkspace } from './workspace/resolveWorkspace'
 
 const WATCHER_DEBOUNCE = 100
 
@@ -401,8 +401,15 @@ export class Vitest {
 
     this._workspaceConfigPath = workspaceConfigPath
 
+    // user doesn't have a workspace config, return default project
     if (!workspaceConfigPath) {
-      return resolveBrowserWorkspace(this, new Set(), [this._ensureRootProject()])
+      // user can filter projects with --project flag, `getDefaultTestProject`
+      // return the project only if it matches the filter
+      const project = getDefaultTestProject(this)
+      if (!project) {
+        return []
+      }
+      return resolveBrowserWorkspace(this, new Set(), [project])
     }
 
     const workspaceModule = await this.import<{

--- a/packages/vitest/src/node/errors.ts
+++ b/packages/vitest/src/node/errors.ts
@@ -39,3 +39,11 @@ export class RangeLocationFilterProvidedError extends Error {
       + `are not supported.  Consider specifying the exact line numbers of your tests.`)
   }
 }
+
+export class VitestFilteredOutProjectError extends Error {
+  code = 'VITEST_FILTERED_OUT_PROJECT'
+
+  constructor() {
+    super('VITEST_FILTERED_OUT_PROJECT')
+  }
+}

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -262,8 +262,8 @@ export async function VitestPlugin(
         })
 
         const originalName = viteConfigTest.name
-        if (viteConfigTest.browser?.enabled && viteConfigTest.browser?.instances) {
-          viteConfigTest.browser.instances.forEach((instance) => {
+        if (options.browser?.enabled && options.browser?.instances) {
+          options.browser.instances.forEach((instance) => {
             instance.name ??= originalName ? `${originalName} (${instance.browser})` : instance.browser
           })
         }

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -145,6 +145,11 @@ export async function VitestPlugin(
           },
         }
 
+        if (ctx._projectFilter) {
+          // project filter was set by the user, so we need to filter the project
+          options.project = ctx._projectFilter
+        }
+
         config.customLogger = createViteLogger(
           ctx.logger,
           viteConfig.logLevel || 'warn',

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -73,15 +73,6 @@ export async function VitestPlugin(
           open = testConfig.uiBase ?? '/__vitest__/'
         }
 
-        const originalName = testConfig.name
-        const workspaceNames = originalName ? [originalName] : []
-        if (testConfig.browser?.enabled && testConfig.browser?.instances) {
-          testConfig.browser.instances.forEach((instance) => {
-            instance.name ??= originalName ? `${originalName} (${instance.browser})` : instance.browser
-            workspaceNames.push(instance.name)
-          })
-        }
-
         const config: ViteConfig = {
           root: viteConfig.test?.root || options.root,
           esbuild:
@@ -226,9 +217,9 @@ export async function VitestPlugin(
         return config
       },
       async configResolved(viteConfig) {
-        const viteConfigTest = (viteConfig.test as any) || {}
+        const viteConfigTest = (viteConfig.test as UserConfig) || {}
         if (viteConfigTest.watch === false) {
-          viteConfigTest.run = true
+          ;(viteConfigTest as any).run = true
         }
 
         if ('alias' in viteConfigTest) {
@@ -264,6 +255,13 @@ export async function VitestPlugin(
           enumerable: false,
           configurable: true,
         })
+
+        const originalName = viteConfigTest.name
+        if (viteConfigTest.browser?.enabled && viteConfigTest.browser?.instances) {
+          viteConfigTest.browser.instances.forEach((instance) => {
+            instance.name ??= originalName ? `${originalName} (${instance.browser})` : instance.browser
+          })
+        }
       },
       configureServer: {
         // runs after vite:import-analysis as it relies on `server` instance on Vite 5

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -145,9 +145,9 @@ export async function VitestPlugin(
           },
         }
 
-        if (ctx._projectFilter) {
+        if (ctx.configOverride.project) {
           // project filter was set by the user, so we need to filter the project
-          options.project = ctx._projectFilter
+          options.project = ctx.configOverride.project
         }
 
         config.customLogger = createViteLogger(
@@ -261,7 +261,7 @@ export async function VitestPlugin(
           configurable: true,
         })
 
-        const originalName = viteConfigTest.name
+        const originalName = options.name
         if (options.browser?.enabled && options.browser?.instances) {
           options.browser.instances.forEach((instance) => {
             instance.name ??= originalName ? `${originalName} (${instance.browser})` : instance.browser

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -63,14 +63,23 @@ export async function VitestPlugin(
 
         // store defines for globalThis to make them
         // reassignable when running in worker in src/runtime/setup.ts
-        const defines: Record<string, any> = deleteDefineConfig(viteConfig);
+        const defines: Record<string, any> = deleteDefineConfig(viteConfig)
 
-        (options as ResolvedConfig).defines = defines
+        ;(options as unknown as ResolvedConfig).defines = defines
 
         let open: string | boolean | undefined = false
 
         if (testConfig.ui && testConfig.open) {
           open = testConfig.uiBase ?? '/__vitest__/'
+        }
+
+        const originalName = testConfig.name
+        const workspaceNames = originalName ? [originalName] : []
+        if (testConfig.browser?.enabled && testConfig.browser?.instances) {
+          testConfig.browser.instances.forEach((instance) => {
+            instance.name ??= originalName ? `${originalName} (${instance.browser})` : instance.browser
+            workspaceNames.push(instance.name)
+          })
         }
 
         const config: ViteConfig = {

--- a/packages/vitest/src/node/plugins/publicConfig.ts
+++ b/packages/vitest/src/node/plugins/publicConfig.ts
@@ -45,10 +45,9 @@ export async function resolveConfig(
   // Reflect just to avoid type error
   const updatedOptions = Reflect.get(config, '_vitest') as UserConfig
   const vitestConfig = resolveVitestConfig(
-    'test',
+    vitest,
     updatedOptions,
     config,
-    vitest.logger,
   )
   return {
     viteConfig: config,

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -84,10 +84,10 @@ export function WorkspaceVitestPlugin(
         // if projects don't match, we ignore the test project altogether
         // if some of them match, they will later be filtered again by `resolveWorkspace`
         if (filters.length) {
-          const filteredNames = workspaceNames.filter((name) => {
+          const hasProject = workspaceNames.some((name) => {
             return project.vitest._matchesProjectFilter(name)
           })
-          if (!filteredNames.length) {
+          if (!hasProject) {
             throw new VitestFilteredOutProjectError()
           }
         }

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -85,7 +85,7 @@ export function WorkspaceVitestPlugin(
         // if some of them match, they will later be filtered again by `resolveWorkspace`
         if (filters.length) {
           const filteredNames = workspaceNames.filter((name) => {
-            return filters.some(n => n.test(name))
+            return project.vitest._matchesProjectFilter(name)
           })
           if (!filteredNames.length) {
             throw new VitestFilteredOutProjectError()

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -63,20 +63,26 @@ export function WorkspaceVitestPlugin(
           }
         }
 
+        // keep project names to potentially filter it out
         const workspaceNames = [name]
         if (viteConfig.test?.browser?.enabled) {
           if (viteConfig.test.browser.name) {
             const browser = viteConfig.test.browser.name
+            // vitest injects `instances` in this case later on
             workspaceNames.push(name ? `${name} (${browser})` : browser)
           }
 
           viteConfig.test.browser.instances?.forEach((instance) => {
+            // every instance is a potential project
             instance.name ??= name ? `${name} (${instance.browser})` : instance.browser
             workspaceNames.push(instance.name)
           })
         }
 
         const filters = project.vitest.config.project
+        // if there is `--project=...` filter, check if any of the potential projects match
+        // if projects don't match, we ignore the test project altogether
+        // if some of them match, they will later be filtered again by `resolveWorkspace`
         if (filters.length) {
           const filteredNames = workspaceNames.filter((name) => {
             return filters.some(n => n.test(name))

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -64,8 +64,13 @@ export function WorkspaceVitestPlugin(
         }
 
         const workspaceNames = [name]
-        if (viteConfig.test?.browser?.enabled && viteConfig.test?.browser?.instances) {
-          viteConfig.test.browser.instances.forEach((instance) => {
+        if (viteConfig.test?.browser?.enabled) {
+          if (viteConfig.test.browser.name) {
+            const browser = viteConfig.test.browser.name
+            workspaceNames.push(name ? `${name} (${browser})` : browser)
+          }
+
+          viteConfig.test.browser.instances?.forEach((instance) => {
             instance.name ??= name ? `${name} (${instance.browser})` : instance.browser
             workspaceNames.push(instance.name)
           })

--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -577,13 +577,12 @@ export class TestProject {
   /** @internal */
   async _configureServer(options: UserConfig, server: ViteDevServer): Promise<void> {
     this._config = resolveConfig(
-      this.vitest.mode,
+      this.vitest,
       {
         ...options,
         coverage: this.vitest.config.coverage,
       },
       server.config,
-      this.vitest.logger,
     )
     for (const _providedKey in this.config.provide) {
       const providedKey = _providedKey as keyof ProvidedContext

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -181,7 +181,7 @@ export function registerConsoleShortcuts(
         name: 'filter',
         type: 'text',
         message: 'Input a single project name',
-        initial: ctx._projectFilter || '',
+        initial: ctx.config.project[0] || '',
       },
     ])
     on()

--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -2,7 +2,6 @@ import type { Writable } from 'node:stream'
 import type { Vitest } from './core'
 import readline from 'node:readline'
 import { getTests } from '@vitest/runner/utils'
-import { toArray } from '@vitest/utils'
 import { relative, resolve } from 'pathe'
 import prompt from 'prompts'
 import c from 'tinyrainbow'
@@ -182,7 +181,7 @@ export function registerConsoleShortcuts(
         name: 'filter',
         type: 'text',
         message: 'Input a single project name',
-        initial: toArray(ctx.configOverride.project)[0] || '',
+        initial: ctx._projectFilter || '',
       },
     ])
     on()

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -965,6 +965,7 @@ export interface UserConfig extends InlineConfig {
 export interface ResolvedConfig
   extends Omit<
     Required<UserConfig>,
+    | 'project'
     | 'config'
     | 'filters'
     | 'browser'
@@ -1015,6 +1016,8 @@ export interface ResolvedConfig
 
   api?: ApiConfig
   cliExclude?: string[]
+
+  project: RegExp[]
 
   benchmark?: Required<
     Omit<BenchmarkUserOptions, 'outputFile' | 'compare' | 'outputJson'>

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -1017,8 +1017,7 @@ export interface ResolvedConfig
   api?: ApiConfig
   cliExclude?: string[]
 
-  project: RegExp[]
-
+  project: string[]
   benchmark?: Required<
     Omit<BenchmarkUserOptions, 'outputFile' | 'compare' | 'outputJson'>
   > &

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -101,7 +101,13 @@ export async function resolveWorkspace(
 
   // pretty rare case - the glob didn't match anything and there are no inline configs
   if (!projectPromises.length) {
-    throw new Error(`No projects were found. Make sure your configuration is correct. The workspace: ${JSON.stringify(workspaceDefinition)}`)
+    throw new Error(
+      [
+        'No projects were found. Make sure your configuration is correct. ',
+        vitest.config.project.length ? `The filter matched no projects: ${vitest.config.project.map(p => p.toString()).join(', ')}. ` : '',
+        `The workspace: ${JSON.stringify(workspaceDefinition, null, 4)}.`,
+      ].join(''),
+    )
   }
 
   const resolvedProjectsPromises = await Promise.allSettled(projectPromises)
@@ -445,7 +451,10 @@ export function getDefaultTestProject(vitest: Vitest): TestProject | null {
   if (!filter.length) {
     return project
   }
-  const hasProjects = getPotentialProjectNames(project).some(p => filter.some(pattern => pattern.test(p)))
+  // check for the project name and browser names
+  const hasProjects = getPotentialProjectNames(project).some(p =>
+    filter.some(pattern => pattern.test(p)),
+  )
   if (hasProjects) {
     return project
   }

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -173,8 +173,12 @@ export async function resolveBrowserWorkspace(
     }
     const configs = project.config.browser.instances || []
     if (configs.length === 0) {
+      const name = project.config.browser.name
       // browser.name should be defined, otherwise the config fails in "resolveConfig"
-      configs.push({ browser: project.config.browser.name })
+      configs.push({
+        browser: name,
+        name: project.name ? `${project.name} (${name})` : name,
+      })
       console.warn(
         withLabel(
           'yellow',

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -174,11 +174,11 @@ export async function resolveBrowserWorkspace(
     }
     const instances = project.config.browser.instances || []
     if (instances.length === 0) {
-      const name = project.config.browser.name
+      const browser = project.config.browser.name
       // browser.name should be defined, otherwise the config fails in "resolveConfig"
       instances.push({
-        browser: name,
-        name: project.name ? `${project.name} (${name})` : name,
+        browser,
+        name: project.name ? `${project.name} (${browser})` : browser,
       })
       console.warn(
         withLabel(
@@ -196,15 +196,15 @@ export async function resolveBrowserWorkspace(
     }
     const originalName = project.config.name
     // if original name is in the --project=name filter, keep all instances
-    const filteredConfigs = !filters.length || filters.some(pattern => pattern.test(originalName))
+    const filteredInstances = !filters.length || filters.some(pattern => pattern.test(originalName))
       ? instances
-      : instances.filter((config) => {
-        const newName = config.name! // name is set in "workspace" plugin
+      : instances.filter((instance) => {
+        const newName = instance.name! // name is set in "workspace" plugin
         return filters.some(pattern => pattern.test(newName))
       })
 
     // every project was filtered out
-    if (!filteredConfigs.length) {
+    if (!filteredInstances.length) {
       removeProjects.add(project)
       return
     }
@@ -215,7 +215,7 @@ export async function resolveBrowserWorkspace(
       )
     }
 
-    filteredConfigs.forEach((config, index) => {
+    filteredInstances.forEach((config, index) => {
       const browser = config.browser
       if (!browser) {
         const nth = index + 1
@@ -239,6 +239,7 @@ export async function resolveBrowserWorkspace(
       }
       names.add(name)
       const clonedConfig = cloneConfig(project, config)
+      clonedConfig.name = name
       const clone = TestProject._cloneBrowserProject(project, clonedConfig)
       resolvedProjects.push(clone)
     })

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -83,6 +83,8 @@ export async function resolveWorkspace(
       if (
         !vitest.config.project.length
         // only include the root project if it wasn't filtered out
+        // TODO: browser.instances might not be filtered out -- test it out
+        // workspaces: [{ extends: true }]
         || vitest.config.project.some(pattern => pattern.test(vitest.config.name || ''))
       ) {
         projectPromises.push(Promise.resolve(vitest._ensureRootProject()))

--- a/packages/vitest/src/node/workspace/resolveWorkspace.ts
+++ b/packages/vitest/src/node/workspace/resolveWorkspace.ts
@@ -172,11 +172,11 @@ export async function resolveBrowserWorkspace(
     if (!project.config.browser.enabled) {
       return
     }
-    const configs = project.config.browser.instances || []
-    if (configs.length === 0) {
+    const instances = project.config.browser.instances || []
+    if (instances.length === 0) {
       const name = project.config.browser.name
       // browser.name should be defined, otherwise the config fails in "resolveConfig"
-      configs.push({
+      instances.push({
         browser: name,
         name: project.name ? `${project.name} (${name})` : name,
       })
@@ -197,8 +197,8 @@ export async function resolveBrowserWorkspace(
     const originalName = project.config.name
     // if original name is in the --project=name filter, keep all instances
     const filteredConfigs = !filters.length || filters.some(pattern => pattern.test(originalName))
-      ? configs
-      : configs.filter((config) => {
+      ? instances
+      : instances.filter((config) => {
         const newName = config.name! // name is set in "workspace" plugin
         return filters.some(pattern => pattern.test(newName))
       })
@@ -224,6 +224,10 @@ export async function resolveBrowserWorkspace(
       }
       const name = config.name!
 
+      if (name == null) {
+        throw new Error(`The browser configuration must have a "name" property. This is a bug in Vitest. Please, open a new issue with reproduction`)
+      }
+
       if (names.has(name)) {
         throw new Error(
           [
@@ -235,7 +239,6 @@ export async function resolveBrowserWorkspace(
       }
       names.add(name)
       const clonedConfig = cloneConfig(project, config)
-      clonedConfig.name = name
       const clone = TestProject._cloneBrowserProject(project, clonedConfig)
       resolvedProjects.push(clone)
     })

--- a/test/browser/specs/browser-crash.test.ts
+++ b/test/browser/specs/browser-crash.test.ts
@@ -13,5 +13,5 @@ test.runIf(provider === 'playwright')('fails gracefully when browser crashes', a
     },
   })
 
-  expect(stderr).contains('Page crashed when executing tests')
+  expect(stderr).toContain('Page crashed when executing tests')
 })

--- a/test/cli/fixtures/git-changed/workspace/vitest.workspace.js
+++ b/test/cli/fixtures/git-changed/workspace/vitest.workspace.js
@@ -1,3 +1,3 @@
 export default [
-  "packages/*/vitest.config.js",
+  "packages/*/vitest.config.mjs",
 ];

--- a/test/cli/test/list.test.ts
+++ b/test/cli/test/list.test.ts
@@ -2,13 +2,14 @@ import { readFileSync, rmSync } from 'node:fs'
 import { expect, onTestFinished, test } from 'vitest'
 import { runVitestCli } from '../../test-utils'
 
-test.each([
-  ['--pool=threads'],
-  ['--pool=forks'],
-  ['--pool=vmForks'],
+test.only.each([
+  // ['--pool=threads'],
+  // ['--pool=forks'],
+  // ['--pool=vmForks'],
   ['--browser.enabled'],
 ])('correctly outputs all tests with args: "%s"', async (...args) => {
-  const { stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)
+  const { stdout, stderr, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)
+  console.log(stderr)
   expect(stdout).toMatchSnapshot()
   expect(exitCode).toBe(0)
 })

--- a/test/cli/test/list.test.ts
+++ b/test/cli/test/list.test.ts
@@ -8,8 +8,7 @@ test.each([
   ['--pool=vmForks'],
   ['--browser.enabled'],
 ])('correctly outputs all tests with args: "%s"', async (...args) => {
-  const { stdout, stderr, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)
-  console.log(stderr)
+  const { stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)
   expect(stdout).toMatchSnapshot()
   expect(exitCode).toBe(0)
 })

--- a/test/cli/test/list.test.ts
+++ b/test/cli/test/list.test.ts
@@ -2,10 +2,10 @@ import { readFileSync, rmSync } from 'node:fs'
 import { expect, onTestFinished, test } from 'vitest'
 import { runVitestCli } from '../../test-utils'
 
-test.only.each([
-  // ['--pool=threads'],
-  // ['--pool=forks'],
-  // ['--pool=vmForks'],
+test.each([
+  ['--pool=threads'],
+  ['--pool=forks'],
+  ['--pool=vmForks'],
   ['--browser.enabled'],
 ])('correctly outputs all tests with args: "%s"', async (...args) => {
   const { stdout, stderr, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)

--- a/test/config/fixtures/workspace/config-empty/vitest.config.js
+++ b/test/config/fixtures/workspace/config-empty/vitest.config.js
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({})

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -198,7 +198,7 @@ test('coverage provider v8 works correctly in browser mode if instances are filt
   ])
 })
 
-test.only('filter for the global browser project includes all browser instances', async () => {
+test('filter for the global browser project includes all browser instances', async () => {
   const { projects } = await vitest({
     project: 'myproject',
     workspace: [

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -198,6 +198,35 @@ test('coverage provider v8 works correctly in browser mode if instances are filt
   ])
 })
 
+test('coverage provider v8 works correctly in workspaced browser mode if instances are filtered', async () => {
+  const { projects } = await vitest({
+    project: 'browser (chromium)',
+    workspace: [
+      {
+        test: {
+          name: 'browser',
+          browser: {
+            enabled: true,
+            provider: 'playwright',
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+              { browser: 'webkit' },
+            ],
+          },
+        },
+      },
+    ],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+    },
+  })
+  expect(projects.map(p => p.name)).toEqual([
+    'browser (chromium)',
+  ])
+})
+
 test('filter for the global browser project includes all browser instances', async () => {
   const { projects } = await vitest({
     project: 'myproject',

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -198,6 +198,39 @@ test('coverage provider v8 works correctly in browser mode if instances are filt
   ])
 })
 
+test.only('filter for the global browser project includes all browser instances', async () => {
+  const { projects } = await vitest({
+    project: 'myproject',
+    workspace: [
+      {
+        test: {
+          name: 'myproject',
+          browser: {
+            enabled: true,
+            provider: 'playwright',
+            headless: true,
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+              { browser: 'webkit' },
+            ],
+          },
+        },
+      },
+      {
+        test: {
+          name: 'skip',
+        },
+      },
+    ],
+  })
+  expect(projects.map(p => p.name)).toEqual([
+    'myproject (chromium)',
+    'myproject (firefox)',
+    'myproject (webkit)',
+  ])
+})
+
 test('can enable browser-cli options for multi-project workspace', async () => {
   const { projects } = await vitest(
     {

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -1,7 +1,8 @@
 import type { UserConfig } from 'vitest/node'
+import type { VitestRunnerCLIOptions } from '../../test-utils'
 import { normalize, resolve } from 'pathe'
-import { beforeEach, expect, test } from 'vitest'
 
+import { beforeEach, expect, test } from 'vitest'
 import { version } from 'vitest/package.json'
 import * as testUtils from '../../test-utils'
 
@@ -9,8 +10,8 @@ const providers = ['playwright', 'webdriverio', 'preview'] as const
 const names = ['edge', 'chromium', 'webkit', 'chrome', 'firefox', 'safari'] as const
 const browsers = providers.map(provider => names.map(name => ({ name, provider }))).flat()
 
-function runVitest(config: NonNullable<UserConfig> & { shard?: any }) {
-  return testUtils.runVitest({ root: './fixtures/test', ...config }, [])
+function runVitest(config: NonNullable<UserConfig> & { shard?: any }, runnerOptions?: VitestRunnerCLIOptions) {
+  return testUtils.runVitest({ root: './fixtures/test', ...config }, [], undefined, {}, runnerOptions)
 }
 
 function runVitestCli(...cliArgs: string[]) {
@@ -286,19 +287,22 @@ Use either:
 })
 
 test('v8 coverage provider cannot be used in workspace without playwright + chromium', async () => {
-  const { stderr } = await runVitest({ coverage: { enabled: true }, workspace: './fixtures/workspace/browser/workspace-with-browser.ts' })
+  const { stderr } = await runVitest({
+    coverage: { enabled: true },
+    workspace: './fixtures/workspace/browser/workspace-with-browser.ts',
+  }, { fails: true })
   expect(stderr).toMatch(
     `Error: @vitest/coverage-v8 does not work with
-{
-  "browser": {
-    "provider": "webdriverio",
-    "instances": [
-      {
-        "browser": "chrome"
+    {
+      "browser": {
+        "provider": "webdriverio",
+        "instances": [
+          {
+            "browser": "chrome"
+          }
+        ]
       }
-    ]
-  }
-}`,
+    }`,
   )
 })
 

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -175,7 +175,7 @@ Use either:
   }
 })
 
-test.only('v8 coverage provider throws when not playwright + chromium (browser.instances)', async () => {
+test('v8 coverage provider throws when not playwright + chromium (browser.instances)', async () => {
   for (const { provider, name } of browsers) {
     if (provider === 'playwright' && name === 'chromium') {
       continue

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -175,7 +175,7 @@ Use either:
   }
 })
 
-test('v8 coverage provider throws when not playwright + chromium (browser.instances)', async () => {
+test.only('v8 coverage provider throws when not playwright + chromium (browser.instances)', async () => {
   for (const { provider, name } of browsers) {
     if (provider === 'playwright' && name === 'chromium') {
       continue

--- a/test/config/test/workspace.test.ts
+++ b/test/config/test/workspace.test.ts
@@ -134,3 +134,24 @@ it('correctly inherits the root config', async () => {
   expect(stderr).toBe('')
   expect(stdout).toContain('repro.test.js > importing a virtual module')
 })
+
+it('fails if workspace is empty', async () => {
+  const { stderr } = await runVitest({
+    workspace: [],
+  })
+  expect(stderr).toContain('No projects were found. Make sure your configuration is correct. The workspace: [].')
+})
+
+it('fails if workspace is filtered by the project', async () => {
+  const { stderr } = await runVitest({
+    project: 'non-existing',
+    root: 'fixtures/workspace/config-empty',
+    config: './vitest.config.js',
+    workspace: [
+      './vitest.config.js',
+    ],
+  })
+  expect(stderr).toContain(`No projects were found. Make sure your configuration is correct. The filter matched no projects: /^non-existing$/i. The workspace: [
+    "./vitest.config.js"
+].`)
+})

--- a/test/config/test/workspace.test.ts
+++ b/test/config/test/workspace.test.ts
@@ -151,7 +151,7 @@ it('fails if workspace is filtered by the project', async () => {
       './vitest.config.js',
     ],
   })
-  expect(stderr).toContain(`No projects were found. Make sure your configuration is correct. The filter matched no projects: /^non-existing$/i. The workspace: [
+  expect(stderr).toContain(`No projects were found. Make sure your configuration is correct. The filter matched no projects: non-existing. The workspace: [
     "./vitest.config.js"
 ].`)
 })

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -292,7 +292,7 @@ test('clearScreen', async () => {
       clearScreen: viteClearScreen,
     }
     const vitestConfig = getCLIOptions(vitestClearScreen)
-    const config = resolveConfig('test', vitestConfig, viteConfig, undefined as any)
+    const config = resolveConfig({ logger: undefined, mode: 'test' } as any, vitestConfig, viteConfig)
     return config.clearScreen
   })
   expect(results).toMatchInlineSnapshot(`

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -294,13 +294,14 @@ export function useFS(root: string, structure: Record<string, string | ViteUserC
 export async function runInlineTests(
   structure: Record<string, string | ViteUserConfig | WorkspaceProjectConfiguration[]>,
   config?: UserConfig,
+  options?: VitestRunnerCLIOptions,
 ) {
   const root = resolve(process.cwd(), `vitest-test-${crypto.randomUUID()}`)
   const fs = useFS(root, structure)
   const vitest = await runVitest({
     root,
     ...config,
-  })
+  }, [], 'test', {}, options)
   return {
     fs,
     root,

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -6,6 +6,7 @@ import { webcrypto as crypto } from 'node:crypto'
 import fs from 'node:fs'
 import { Readable, Writable } from 'node:stream'
 import { fileURLToPath } from 'node:url'
+import { inspect } from 'node:util'
 import { dirname, resolve } from 'pathe'
 import { x } from 'tinyexec'
 import * as tinyrainbow from 'tinyrainbow'
@@ -17,7 +18,7 @@ import { Cli } from './cli'
 // override default colors to disable them in tests
 Object.assign(tinyrainbow.default, tinyrainbow.getDefaultColors())
 
-interface VitestRunnerCLIOptions {
+export interface VitestRunnerCLIOptions {
   std?: 'inherit'
   fails?: boolean
   preserveAnsi?: boolean
@@ -101,7 +102,7 @@ export async function runVitest(
       console.error(e)
     }
     thrown = true
-    cli.stderr += e.stack
+    cli.stderr += inspect(e)
   }
   finally {
     exitCode = process.exitCode

--- a/test/watch/test/change-project.test.ts
+++ b/test/watch/test/change-project.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
+
+test('reruns tests when config changes', async () => {
+  const { vitest, ctx } = await runInlineTests({
+    'vitest.config.ts': `
+
+    process.stdin.isTTY = true
+    process.stdin.setRawMode = () => process.stdin
+
+    export default {
+      test: {
+        workspace: [
+          './project-1',
+          './project-2',
+        ],
+      },
+    }`,
+    'project-1/vitest.config.ts': { test: { name: 'project-1' } },
+    'project-1/basic-1.test.ts': /* ts */`
+      import { test } from 'vitest'
+      test('basic test 1', () => {})
+    `,
+    'project-2/vitest.config.ts': { test: { name: 'project-2' } },
+    'project-2/basic-2.test.ts': /* ts */`
+      import { test } from 'vitest'
+      test('basic test 2', () => {})
+    `,
+  }, { watch: true })
+
+  await vitest.waitForStdout('Waiting for file changes')
+
+  expect(vitest.stdout).toContain('2 passed')
+  expect(vitest.stdout).toContain('basic-1.test.ts')
+  expect(vitest.stdout).toContain('basic-2.test.ts')
+  vitest.resetOutput()
+
+  await ctx!.changeProjectName('project-2')
+
+  await vitest.waitForStdout('Waiting for file changes')
+
+  expect(vitest.stdout).toContain('1 passed')
+  expect(vitest.stdout).toContain('basic-2.test.ts')
+})


### PR DESCRIPTION
### Description

Fixes #7303
Fixes #7308
Fixes #7286

Accidentally fixes #7131
Closes #7146

The idea is to filter out the project during its `config` resolution instead of creating a project and then filtering it. This should make `vitest --project={name}` run faster if you have a lot of projects. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
