### PR TITLE
docs: clarify that locator.nth is zero based

### DIFF
--- a/docs/guide/browser/locators.md
+++ b/docs/guide/browser/locators.md
@@ -393,7 +393,7 @@ It is recommended to use this only after the other locators don't work for your 
 function nth(index: number): Locator
 ```
 
-This method returns a new locator that matches only a specific index within a multi-element query result. Unlike `elements()[n]`, the `nth` locator will be retried until the element is present.
+This method returns a new locator that matches only a specific index within a multi-element query result. It's zero based, `nth(0)` selects the first element. Unlike `elements()[n]`, the `nth` locator will be retried until the element is present.
 
 ```html
 <div aria-label="one"><input/><input/><input/></div>


### PR DESCRIPTION
### Description

Add a note as Playwright has in [their docs for `nth`](https://playwright.dev/docs/api/class-locator#locator-nth).

I think that `nth()` should start from 1, in the same way that CSS `:nth-child` and usage in JS like `nthCalledWith`. I thought of adding an `at()` alias to avoid confusion, but I think aligning with playwright locators is more important here. Maybe the alias could first be proposed to Playwright, but I doubt they will be willing to change this.