### PR TITLE
fix(types): Fix public types

### DIFF
--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -260,8 +260,8 @@ declare namespace matchers {
      * @see
      * [testing-library/jest-dom#tohaveclass](https://github.com/testing-library/jest-dom#tohaveclass)
      */
-    toHaveClass(...classNames: Array<string | RegExp>): R
     toHaveClass(classNames: string, options?: {exact: boolean}): R
+    toHaveClass(...classNames: Array<string | RegExp>): R
     /**
      * @description
      * This allows you to check whether the given form element has the specified displayed value (the one the

--- a/packages/browser/utils.d.ts
+++ b/packages/browser/utils.d.ts
@@ -2,7 +2,7 @@
 // we cannot bundle it because vitest depend on the @vitest/browser and vise versa
 // fortunately, the file is quite small
 
-import { LocatorSelectors } from '@vitest/browser/context'
+import { LocatorSelectors, Locator } from '@vitest/browser/context'
 import { StringifyOptions } from 'vitest/utils'
 
 export type PrettyDOMOptions = Omit<StringifyOptions, 'maxLength'>

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -123,6 +123,7 @@
   },
   "peerDependencies": {
     "@edge-runtime/vm": "*",
+    "@types/debug": "^4.1.12",
     "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
     "@vitest/browser": "workspace:*",
     "@vitest/ui": "workspace:*",
@@ -131,6 +132,9 @@
   },
   "peerDependenciesMeta": {
     "@edge-runtime/vm": {
+      "optional": true
+    },
+    "@types/debug": {
       "optional": true
     },
     "@types/node": {

--- a/packages/vitest/src/utils/debugger.ts
+++ b/packages/vitest/src/utils/debugger.ts
@@ -1,6 +1,7 @@
+import type { Debugger } from 'debug'
 import createDebug from 'debug'
 
-export function createDebugger(namespace: `vitest:${string}`) {
+export function createDebugger(namespace: `vitest:${string}`): Debugger | undefined {
   const debug = createDebug(namespace)
   if (debug.enabled) {
     return debug


### PR DESCRIPTION
### Description

I'm trying to move to vitest browser, and have encountered a few type errors in vitests types.

Some of these may have been caught with `skipLibCheck: false`; I tried that but it opened up a bit of a can of worms, as many other `.d.ts` files contain type errors, both compiled and handwritten, along with third party deps suggesting we're missing some type packages.

This PR at least fixes the issues I've encountered in the field.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
