### PR TITLE
fix(vite-node): differentiate file url with hash and query

### DIFF
--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -36,7 +36,9 @@ export function normalizeRequestId(id: string, base?: string): string {
   }
 
   if (id.startsWith('file://')) {
-    return fileURLToPath(id)
+    // preserve hash/query
+    const { file, postfix } = splitFileAndPostfix(id)
+    return fileURLToPath(file) + postfix
   }
 
   return id
@@ -56,6 +58,14 @@ export function normalizeRequestId(id: string, base?: string): string {
 const postfixRE = /[?#].*$/
 export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '')
+}
+
+function splitFileAndPostfix(path: string): {
+  file: string
+  postfix: string
+} {
+  const file = cleanUrl(path)
+  return { file, postfix: path.slice(file.length) }
 }
 
 const internalRequests = ['@vite/client', '@vite/env']

--- a/test/core/test/resolve-file-url.test.ts
+++ b/test/core/test/resolve-file-url.test.ts
@@ -4,4 +4,12 @@ test('resolve file url', async () => {
   const fileUrl = new URL('./resolve-file-url%7Edep.js', import.meta.url).href
   const mod = await import(fileUrl)
   expect(mod.default).toMatchInlineSnapshot(`"[ok]"`)
+
+  const mod2 = await import(`${fileUrl}#hash=test`)
+  expect(mod2).toEqual(mod)
+  expect(mod2).not.toBe(mod)
+
+  const mod3 = await import(`${fileUrl}?query=test`)
+  expect(mod3).toEqual(mod)
+  expect(mod3).not.toBe(mod)
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7361

I copied `splitFileAndPostfix` from Vite https://github.com/vitejs/vite/blob/2bea7cec4b7fddbd5f2fb6090a7eaf5ae7ca0f1b/packages/vite/src/shared/utils.ts#L36-L42. Vite uses this utility to put back a hash/query for asset urls for example.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
