### PR TITLE
feat(ui): insert message "no tests found" in ui

### DIFF
--- a/packages/ui/client/components/ProgressBar.vue
+++ b/packages/ui/client/components/ProgressBar.vue
@@ -4,15 +4,10 @@ import { explorerTree } from '~/composables/explorer'
 
 const { width } = useWindowSize()
 const classes = computed(() => {
-  // if there are no files and not finished, then in progress and gray
-  if (explorerTree.summary.files === 0 && !finished.value) {
-    return '!bg-gray-4 !dark:bg-gray-7 in-progress'
-  }
-  else if (!finished.value) {
-    return 'in-progress'
-  }
-
-  return null
+  return [
+    explorerTree.summary.files === 0 && '!bg-gray-4 !dark:bg-gray-7',
+    !finished.value && 'in-progress',
+  ].filter(Boolean).join(' ')
 })
 
 const widthPass = computed(() => {

--- a/packages/ui/client/components/ProgressBar.vue
+++ b/packages/ui/client/components/ProgressBar.vue
@@ -4,8 +4,8 @@ import { explorerTree } from '~/composables/explorer'
 
 const { width } = useWindowSize()
 const classes = computed(() => {
-  // if there are no files, then in progress and gray
-  if (explorerTree.summary.files === 0) {
+  // if there are no files and not finished, then in progress and gray
+  if (explorerTree.summary.files === 0 && !finished.value) {
     return '!bg-gray-4 !dark:bg-gray-7 in-progress'
   }
   else if (!finished.value) {

--- a/packages/ui/client/components/dashboard/TestsFilesContainer.vue
+++ b/packages/ui/client/components/dashboard/TestsFilesContainer.vue
@@ -1,10 +1,18 @@
+<script setup lang="ts">
+import { finished } from '~/composables/client/state'
+import { explorerTree } from '~/composables/explorer'
+</script>
+
 <template>
   <div gap-0 flex="~ col gap-4" h-full justify-center items-center>
-    <!-- <div bg-header rounded-lg p="y4 x2"> -->
+    <template v-if="explorerTree.summary.files === 0 && finished">
+      <div class="text-gray-5">
+        No tests found
+      </div>
+    </template>
     <section aria-labelledby="tests" m="y-4 x-2">
       <TestsEntry />
     </section>
     <TestFilesEntry />
-    <!-- </div> -->
   </div>
 </template>


### PR DESCRIPTION
### Description

closes #7256 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Remove progressBar when no tests found.
- Insert message "no testes found" in UI.

<!-- You can also add additional context here -->

[no_tests_found.webm](https://github.com/user-attachments/assets/ff39bc67-114a-4fdf-9ae3-639225937fed)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
