### PR TITLE
fix: ensure project names are readable in dark terminals

### DIFF
--- a/packages/ui/client/utils/task.ts
+++ b/packages/ui/client/utils/task.ts
@@ -25,6 +25,6 @@ export function getProjectNameColor(name: string | undefined) {
   const index = name
     .split('')
     .reduce((acc, v, idx) => acc + v.charCodeAt(0) + idx, 0)
-  const colors = ['blue', 'yellow', 'cyan', 'green', 'magenta']
+  const colors = ['yellow', 'cyan', 'green', 'magenta']
   return colors[index % colors.length]
 }

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -223,9 +223,9 @@ export function formatProjectName(name: string | undefined, suffix = ' ') {
     .split('')
     .reduce((acc, v, idx) => acc + v.charCodeAt(0) + idx, 0)
 
-  const colors = [c.blue, c.yellow, c.cyan, c.green, c.magenta]
+  const colors = [c.bgYellow, c.bgCyan, c.bgGreen, c.bgMagenta]
 
-  return c.inverse(colors[index % colors.length](` ${name} `)) + suffix
+  return c.black(colors[index % colors.length](` ${name} `)) + suffix
 }
 
 export function withLabel(color: 'red' | 'green' | 'blue' | 'cyan' | 'yellow', label: string, message?: string) {

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -223,7 +223,7 @@ export function formatProjectName(name: string | undefined, suffix = ' ') {
     .split('')
     .reduce((acc, v, idx) => acc + v.charCodeAt(0) + idx, 0)
 
-  const colors = [c.black, c.yellow, c.cyan, c.green, c.magenta]
+  const colors = [c.blue, c.yellow, c.cyan, c.green, c.magenta]
 
   return c.inverse(colors[index % colors.length](` ${name} `)) + suffix
 }


### PR DESCRIPTION
### Description

In terminals using a color scheme with a dark background, project names could end up being unreadable because one of the hard-coded background colors used for project names was black. ~Replacing black with blue~ Setting an explicit foreground color as described in [this comment](https://github.com/vitest-dev/vitest/pull/7371#discussion_r1940082951) solves this problem while also ensuring that project names remain readable in terminals with light backgrounds.

This mitigates an issue that's described in the comments of #6481, although it doesn't implement fully customizable colors, which is the main topic of that issue.

**After:**

![2025-02-04 10 04 26 T57Iko8h@2x](https://github.com/user-attachments/assets/3df4a324-6f13-4c74-bea9-18d774aad555)

**Before:**

![vitest-before](https://github.com/user-attachments/assets/f1b3d887-9a6a-4b26-803e-61eb2da4486b)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.

There doesn't seem to be any existing test coverage for the colors defined in `formatProjectName()`. It's not immediately obvious to me how I might add coverage, so pointers are welcome!

- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

There's one pre-existing test failure that also occurs on `main`. It's unrelated to this change:

```
 FAIL  test/browser-multiple.test.ts > automatically assigns the port
AssertionError: expected [ 'http://localhost:63316/', 'http://localhost:63317/' ] to include 'http://localhost:63315/'
 ❯ test/browser-multiple.test.ts:33:16
     31|   expect(spy).not.toHaveBeenCalled()
     32|   expect(stderr).not.toContain('is in use, trying another one...')
     33|   expect(urls).toContain('http://localhost:63315/')
       |                ^
     34|   expect(urls).toContain('http://localhost:63316/')
     35| })
```

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
