### PR TITLE
docs: Add sync-only info to `expect.toThrowError` TIP

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -701,6 +701,8 @@ You can provide an optional argument to test that a specific error is thrown:
 
 :::tip
 You must wrap the code in a function, otherwise the error will not be caught, and test will fail.
+
+> _This only applies to the synchronous usage !_
 :::
 
 For example, if we want to test that `getFruitStock('pineapples')` throws, we could write:

--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -705,9 +705,9 @@ You must wrap the code in a function, otherwise the error will not be caught, an
 This does not apply for async calls as [rejects](#rejects) correctly unwraps the promise:
 ```ts
 test('expect rejects toThrow', async ({ expect }) => {
-  const promise = Promise.reject(new Error('Test'));
-  await expect(promise).rejects.toThrowError();
-});
+  const promise = Promise.reject(new Error('Test'))
+  await expect(promise).rejects.toThrowError()
+})
 ```
 :::
 

--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -702,7 +702,13 @@ You can provide an optional argument to test that a specific error is thrown:
 :::tip
 You must wrap the code in a function, otherwise the error will not be caught, and test will fail.
 
-> _This only applies to the synchronous usage !_
+This does not apply for async calls as [rejects](#rejects) correctly unwraps the promise:
+```ts
+test('expect rejects toThrow', async ({ expect }) => {
+  const promise = Promise.reject(new Error('Test'));
+  await expect(promise).rejects.toThrowError();
+});
+```
 :::
 
 For example, if we want to test that `getFruitStock('pineapples')` throws, we could write:


### PR DESCRIPTION
close #6558

### Description

In #6558 it was mentioned to add a note to `expect.toThrowError`([live](https://vitest.dev/api/expect.html#tothrowerror), [preview](https://deploy-preview-7381--vitest-dev.netlify.app/api/expect.html#tothrowerror)) about the TIP being "sync only".

<img width="735" alt="image" src="https://github.com/user-attachments/assets/0eb6b842-ac16-49e3-bab7-1c5e61254569" />



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
