### PR TITLE
fix(browser): fix `toHaveClass` typing

### DIFF
--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -260,8 +260,7 @@ declare namespace matchers {
      * @see
      * [testing-library/jest-dom#tohaveclass](https://github.com/testing-library/jest-dom#tohaveclass)
      */
-    toHaveClass(classNames: string, options?: {exact: boolean}): R
-    toHaveClass(...classNames: Array<string | RegExp>): R
+    toHaveClass(...classNames: (string | RegExp)[] | [string, options?: {exact: boolean}]): R
     /**
      * @description
      * This allows you to check whether the given form element has the specified displayed value (the one the

--- a/test/browser/test/dom.test.ts
+++ b/test/browser/test/dom.test.ts
@@ -31,6 +31,20 @@ describe('dom related activity', () => {
     expect(screenshotPath).toMatch(
       /__screenshots__\/dom.test.ts\/dom-related-activity-renders-div-1.png/,
     )
+
+    // test typing
+    if (0) {
+      await expect.element(div).toHaveClass('x', { exact: true })
+      await expect.element(div).toHaveClass('x', 'y')
+      await expect.element(div).toHaveClass('x', /y/)
+      await expect.element(div).toHaveClass(/x/, 'y')
+      await expect.element(div).toHaveClass('x', /y/, 'z')
+      await expect.element(div).toHaveClass(/x/, 'y', /z/)
+      // @ts-expect-error error
+      await expect.element(div).toHaveClass('x', { exact: 1234 })
+      // @ts-expect-error error
+      await expect.element(div).toHaveClass('x', 1234)
+    }
   })
 
   test('resolves base64 screenshot', async () => {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7380

I think there's some dts specific magic going on as to why standard overload is not working. I couldn't figure that out, so I went for a different way and made a union on argument types, which should achieves the same for user's type safety.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
