### PR TITLE
refactor!: require fake timers for mocking date

### DIFF
--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -12,13 +12,15 @@ import type {
 } from '@sinonjs/fake-timers'
 import { withGlobal } from '@sinonjs/fake-timers'
 import { isChildProcess } from '../../runtime/utils'
-import { mockDate, RealDate, resetDate } from './date'
+// import { mockDate, RealDate, resetDate } from './date'
+
+const RealDate = Date
 
 export class FakeTimers {
   private _global: typeof globalThis
   private _clock!: InstalledClock
   private _fakingTime: boolean
-  private _fakingDate: boolean
+  // private _fakingDate: boolean
   private _fakeTimers: FakeTimerWithContext
   private _userConfig?: FakeTimerInstallOpts
   private _now = RealDate.now
@@ -32,7 +34,7 @@ export class FakeTimers {
   }) {
     this._userConfig = config
 
-    this._fakingDate = false
+    // this._fakingDate = false
 
     this._fakingTime = false
     this._fakeTimers = withGlobal(global)
@@ -127,10 +129,10 @@ export class FakeTimers {
   }
 
   useRealTimers(): void {
-    if (this._fakingDate) {
-      resetDate()
-      this._fakingDate = false
-    }
+    // if (this._fakingDate) {
+    //   resetDate()
+    //   this._fakingDate = false
+    // }
 
     if (this._fakingTime) {
       this._clock.uninstall()
@@ -139,11 +141,11 @@ export class FakeTimers {
   }
 
   useFakeTimers(): void {
-    if (this._fakingDate) {
-      throw new Error(
-        '"setSystemTime" was called already and date was mocked. Reset timers using `vi.useRealTimers()` if you want to use fake timers again.',
-      )
-    }
+    // if (this._fakingDate) {
+    //   throw new Error(
+    //     '"setSystemTime" was called already and date was mocked. Reset timers using `vi.useRealTimers()` if you want to use fake timers again.',
+    //   )
+    // }
 
     if (!this._fakingTime) {
       const toFake = Object.keys(this._fakeTimers.timers)
@@ -178,17 +180,20 @@ export class FakeTimers {
   }
 
   setSystemTime(now?: number | Date): void {
-    if (this._fakingTime) {
-      this._clock.setSystemTime(now)
-    }
-    else {
-      mockDate(now ?? this.getRealSystemTime())
-      this._fakingDate = true
-    }
+    this._checkFakeTimers()
+    this._clock.setSystemTime(now)
+    // if (this._fakingTime) {
+    //   this._clock.setSystemTime(now)
+    // }
+    // else {
+    //   mockDate(now ?? this.getRealSystemTime())
+    //   this._fakingDate = true
+    // }
   }
 
   getRealSystemTime(): number {
-    return this._now()
+    return RealDate.now()
+    // return this._now()
   }
 
   getTimerCount(): number {

--- a/test/core/test/date-mock.test.ts
+++ b/test/core/test/date-mock.test.ts
@@ -1,6 +1,11 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 describe('testing date mock functionality', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ['Date'],
+    })
+  })
   afterEach(() => {
     vi.useRealTimers()
   })

--- a/test/core/test/fixtures/timers.suite.ts
+++ b/test/core/test/fixtures/timers.suite.ts
@@ -1487,18 +1487,20 @@ describe('FakeTimers', () => {
     it('throws when using useFakeTimers after setSystemTime', () => {
       const timers = new FakeTimers({ global })
 
+      timers.useFakeTimers()
+
       const timeStr = 'Fri Feb 20 2015 19:29:31 GMT+0530'
       const timeStrMs = 1424440771000
 
-      timers.setSystemTime(timeStr)
+      // timers.setSystemTime(timeStr)
 
-      expect(Date.now()).toBe(timeStrMs)
+      // expect(Date.now()).toBe(timeStrMs)
 
-      expect(() => timers.useFakeTimers()).toThrowError(/date was mocked/)
+      // // expect(() => timers.useFakeTimers()).toThrowError(/date was mocked/)
 
-      // Some test
+      // // Some test
 
-      timers.useRealTimers()
+      // timers.useRealTimers()
     })
   })
 })


### PR DESCRIPTION
### Description

WIP

While checking https://github.com/vitest-dev/vitest/issues/7329, I was slightly confused about this feature allowing mocking date `vi.setSystemTime` without `vi.useFakeTimers`. I'd assume historically Vitest had "mockdate" feature (`vi.mockCurrentDate`), which is later replaced with Jest-like API `vi.setSystemTime` https://github.com/vitest-dev/vitest/pull/531, but then that required `vi.useFakeTimers`, so `vi.setSystemTime` only mocking is added back in https://github.com/vitest-dev/vitest/pull/639.

Having two system internally (and two flags `_fakingTime` and `_fakingDate`) looks confusing and maybe removing this is fine later time on breaking change. Users can probably migrate to `vi.useFakeTimers({ toFake: ["Date"] })`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
