### PR TITLE
feat: Introduce `%$` option to add number of the test to its title

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -311,6 +311,7 @@ You can inject parameters with [printf formatting](https://nodejs.org/api/util.h
 - `%j`: json
 - `%o`: object
 - `%#`: index of the test case
+- `%$`: number of the test case
 - `%%`: single percent sign ('%')
 
 ```ts

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -310,8 +310,8 @@ You can inject parameters with [printf formatting](https://nodejs.org/api/util.h
 - `%f`: floating point value
 - `%j`: json
 - `%o`: object
-- `%#`: index of the test case
-- `%$`: number of the test case
+- `%#`: 0-based index of the test case
+- `%$`: 1-based index of the test case
 - `%%`: single percent sign ('%')
 
 ```ts

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -793,7 +793,7 @@ function formatTitle(template: string, items: any[], idx: number) {
     template = template
       .replace(/%%/g, '__vitest_escaped_%__')
       .replace(/%#/g, `${idx}`)
-      .replace(/%$/g, `${idx + 1}`)
+      .replace(/%\$/g, `${idx + 1}`)
       .replace(/__vitest_escaped_%__/g, '%%')
   }
   const count = template.split('%').length - 1

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -788,11 +788,12 @@ function formatName(name: string | Function) {
 }
 
 function formatTitle(template: string, items: any[], idx: number) {
-  if (template.includes('%#')) {
+  if (template.includes('%#') || template.includes('%$')) {
     // '%#' match index of the test case
     template = template
       .replace(/%%/g, '__vitest_escaped_%__')
       .replace(/%#/g, `${idx}`)
+      .replace(/%$/g, `${idx + 1}`)
       .replace(/__vitest_escaped_%__/g, '%%')
   }
   const count = template.split('%').length - 1

--- a/test/core/test/each.test.ts
+++ b/test/core/test/each.test.ts
@@ -98,6 +98,28 @@ test.each([
   expect(result).toBe(expected)
 })
 
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('the number of the test case is %$', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})
+
+test.each([
+  [1, 2, 3],
+  [4, 5, 9],
+])('return a promise like result %$', async (a, b, expected) => {
+  const promiseResolver = (first: number, second: number) => {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(first + second), 1)
+    })
+  }
+
+  const result = await promiseResolver(a, b)
+  expect(result).toBe(expected)
+})
+
 describe('context on test and describe - todo/skip', () => {
   let count = 0
 

--- a/test/reporters/fixtures/default/print-index.test.ts
+++ b/test/reporters/fixtures/default/print-index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+
+describe('passed', () => {
+  test.each([4, 5, 6])('0-based index of the test case is %#', (d) => {
+    expect(d).toBe(d)
+  })
+
+  test.each([4, 5, 6])('1-based index of the test case is %$', (d) => {
+    expect(d).toBe(d)
+  })
+})

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -131,4 +131,20 @@ describe('default reporter', async () => {
     expect(stdout).toContain('1 passed')
     expect(stdout).toContain('✓ repeat couple of times (repeat x3)')
   })
+
+  test('prints 0-based index and 1-based index of the test case', async () => {
+    const { stdout } = await runVitest({
+      include: ['print-index.test.ts'],
+      root: 'fixtures/default',
+      reporters: 'none',
+    })
+
+    expect(stdout).toContain('✓ passed > 0-based index of the test case is 0')
+    expect(stdout).toContain('✓ passed > 0-based index of the test case is 1')
+    expect(stdout).toContain('✓ passed > 0-based index of the test case is 2')
+
+    expect(stdout).toContain('✓ passed > 1-based index of the test case is 1')
+    expect(stdout).toContain('✓ passed > 1-based index of the test case is 2')
+    expect(stdout).toContain('✓ passed > 1-based index of the test case is 3')
+  })
 }, 120000)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Jest v30 planned to introduce `%$` option which adds the number of the test to its title within `each()` method by https://github.com/jestjs/jest/pull/14710. This PR imports this feature into Vitest.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
