### PR TITLE
fix(browser): fix mocking modules out of root

### DIFF
--- a/packages/mocker/src/browser/interceptor-msw.ts
+++ b/packages/mocker/src/browser/interceptor-msw.ts
@@ -99,12 +99,13 @@ export class ModuleMockerMSWInterceptor implements ModuleMockerInterceptor {
     ]).then(([{ setupWorker }, { http }]) => {
       const worker = setupWorker(
         http.get(/.+/, async ({ request }) => {
-          let path = cleanQuery(request.url.slice(location.origin.length))
-          // TODO: where should we normalize /@fs/?
-          if (path.startsWith('/@fs/')) {
-            path = path.slice('/@fs'.length)
-          }
           // path = /@fs/abs-path/out-side-of-root/index.js
+          const path = cleanQuery(request.url.slice(location.origin.length))
+          // let path = cleanQuery(request.url.slice(location.origin.length))
+          // TODO: where should we normalize /@fs/?
+          // if (path.startsWith('/@fs/')) {
+          //   path = path.slice('/@fs'.length)
+          // }
           if (!this.mocks.has(path)) {
             return passthrough()
           }

--- a/packages/mocker/src/browser/interceptor-msw.ts
+++ b/packages/mocker/src/browser/interceptor-msw.ts
@@ -99,7 +99,11 @@ export class ModuleMockerMSWInterceptor implements ModuleMockerInterceptor {
     ]).then(([{ setupWorker }, { http }]) => {
       const worker = setupWorker(
         http.get(/.+/, async ({ request }) => {
-          const path = cleanQuery(request.url.slice(location.origin.length))
+          let path = cleanQuery(request.url.slice(location.origin.length))
+          // TODO: where should we normalize /@fs/?
+          if (path.startsWith('/@fs/')) {
+            path = path.slice('/@fs'.length)
+          }
           // path = /@fs/abs-path/out-side-of-root/index.js
           if (!this.mocks.has(path)) {
             return passthrough()

--- a/packages/mocker/src/browser/interceptor-msw.ts
+++ b/packages/mocker/src/browser/interceptor-msw.ts
@@ -100,6 +100,7 @@ export class ModuleMockerMSWInterceptor implements ModuleMockerInterceptor {
       const worker = setupWorker(
         http.get(/.+/, async ({ request }) => {
           const path = cleanQuery(request.url.slice(location.origin.length))
+          // path = /@fs/abs-path/out-side-of-root/index.js
           if (!this.mocks.has(path)) {
             return passthrough()
           }

--- a/packages/mocker/src/browser/interceptor-msw.ts
+++ b/packages/mocker/src/browser/interceptor-msw.ts
@@ -99,13 +99,7 @@ export class ModuleMockerMSWInterceptor implements ModuleMockerInterceptor {
     ]).then(([{ setupWorker }, { http }]) => {
       const worker = setupWorker(
         http.get(/.+/, async ({ request }) => {
-          // path = /@fs/abs-path/out-side-of-root/index.js
           const path = cleanQuery(request.url.slice(location.origin.length))
-          // let path = cleanQuery(request.url.slice(location.origin.length))
-          // TODO: where should we normalize /@fs/?
-          // if (path.startsWith('/@fs/')) {
-          //   path = path.slice('/@fs'.length)
-          // }
           if (!this.mocks.has(path)) {
             return passthrough()
           }

--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -141,12 +141,13 @@ export class ModuleMocker {
           ? 'factory'
           : factoryOrOptions?.spy ? 'spy' : 'auto',
       })
-      .then(async ({ redirectUrl, resolvedId, needsInterop, mockType }) => {
+      .then(async ({ redirectUrl, resolvedId, resolvedUrl, needsInterop, mockType }) => {
         // TODO: does this have /@fs prefixed?
         // resolvedId = /abs-path/out-side-of-root/index.js
         // mockUrl = /abs-path/out-side-of-root/index.js
-        const mockUrl = this.resolveMockPath(cleanVersion(resolvedId))
+        // const mockUrl = this.resolveMockPath(cleanVersion(resolvedId))
         // console.log('[queueMock]', { resolvedId, mockUrl })
+        const mockUrl = cleanVersion(resolvedUrl)
         this.mockedIds.add(resolvedId)
         const factory = typeof factoryOrOptions === 'function'
           ? async () => {
@@ -247,6 +248,7 @@ export interface ResolveIdResult {
 export interface ResolveMockResult {
   mockType: MockedModuleType
   resolvedId: string
+  resolvedUrl: string
   redirectUrl?: string | null
   needsInterop?: boolean
 }

--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -134,6 +134,7 @@ export class ModuleMocker {
 
   public queueMock(rawId: string, importer: string, factoryOrOptions?: ModuleMockOptions | (() => any)): void {
     // rawId = /@fs/abs-path/out-side-of-root/index.js
+    // console.log('[queueMock]', { rawId })
     const promise = this.rpc
       .resolveMock(rawId, importer, {
         mock: typeof factoryOrOptions === 'function'
@@ -145,6 +146,7 @@ export class ModuleMocker {
         // resolvedId = /abs-path/out-side-of-root/index.js
         // mockUrl = /abs-path/out-side-of-root/index.js
         const mockUrl = this.resolveMockPath(cleanVersion(resolvedId))
+        // console.log('[queueMock]', { resolvedId, mockUrl })
         this.mockedIds.add(resolvedId)
         const factory = typeof factoryOrOptions === 'function'
           ? async () => {

--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -133,6 +133,7 @@ export class ModuleMocker {
   }
 
   public queueMock(rawId: string, importer: string, factoryOrOptions?: ModuleMockOptions | (() => any)): void {
+    // rawId = /@fs/abs-path/out-side-of-root/index.js
     const promise = this.rpc
       .resolveMock(rawId, importer, {
         mock: typeof factoryOrOptions === 'function'
@@ -140,6 +141,9 @@ export class ModuleMocker {
           : factoryOrOptions?.spy ? 'spy' : 'auto',
       })
       .then(async ({ redirectUrl, resolvedId, needsInterop, mockType }) => {
+        // TODO: does this have /@fs prefixed?
+        // resolvedId = /abs-path/out-side-of-root/index.js
+        // mockUrl = /abs-path/out-side-of-root/index.js
         const mockUrl = this.resolveMockPath(cleanVersion(resolvedId))
         this.mockedIds.add(resolvedId)
         const factory = typeof factoryOrOptions === 'function'

--- a/packages/mocker/src/node/resolver.ts
+++ b/packages/mocker/src/node/resolver.ts
@@ -70,34 +70,6 @@ export class ServerMockResolver {
       return null
     }
     return this.normalizeResolveIdToUrl(resolved)
-    // const isOptimized = resolved.id.startsWith(withTrailingSlash(this.server.config.cacheDir))
-    // let url: string
-    // // normalise the URL to be acceptable by the browser
-    // // https://github.com/vitejs/vite/blob/e833edf026d495609558fd4fb471cf46809dc369/packages/vite/src/node/plugins/importAnalysis.ts#L335
-    // const root = this.server.config.root
-    // if (resolved.id.startsWith(withTrailingSlash(root))) {
-    //   url = resolved.id.slice(root.length)
-    // }
-    // else if (
-    //   resolved.id !== '/@react-refresh'
-    //   && isAbsolute(resolved.id)
-    //   && existsSync(cleanUrl(resolved.id))
-    // ) {
-    //   url = join('/@fs/', resolved.id)
-    // }
-    // else {
-    //   url = resolved.id
-    // }
-    // if (url[0] !== '.' && url[0] !== '/') {
-    //   url = id.startsWith(VALID_ID_PREFIX)
-    //     ? id
-    //     : VALID_ID_PREFIX + id.replace('\0', '__x00__')
-    // }
-    // return {
-    //   id: resolved.id,
-    //   url,
-    //   optimized: isOptimized,
-    // }
   }
 
   private normalizeResolveIdToUrl(resolved: { id: string }) {

--- a/packages/mocker/src/node/resolver.ts
+++ b/packages/mocker/src/node/resolver.ts
@@ -26,15 +26,16 @@ export class ServerMockResolver {
     options: { mock: 'spy' | 'factory' | 'auto' },
   ): Promise<ServerMockResolution> {
     const { id, fsPath, external } = await this.resolveMockId(rawId, importer)
+    const resolvedUrl = this.normalizeResolveIdToUrl({ id }).url
 
     if (options.mock === 'factory') {
       const manifest = getViteDepsManifest(this.server.config)
       const needsInterop = manifest?.[fsPath]?.needsInterop ?? false
-      return { mockType: 'manual', resolvedId: id, needsInterop }
+      return { mockType: 'manual', resolvedId: id, resolvedUrl, needsInterop }
     }
 
     if (options.mock === 'spy') {
-      return { mockType: 'autospy', resolvedId: id }
+      return { mockType: 'autospy', resolvedId: id, resolvedUrl }
     }
 
     const redirectUrl = findMockRedirect(this.server.config.root, fsPath, external)
@@ -43,6 +44,7 @@ export class ServerMockResolver {
       mockType: redirectUrl === null ? 'automock' : 'redirect',
       redirectUrl,
       resolvedId: id,
+      resolvedUrl,
     }
   }
 
@@ -67,10 +69,42 @@ export class ServerMockResolver {
     if (!resolved) {
       return null
     }
+    return this.normalizeResolveIdToUrl(resolved)
+    // const isOptimized = resolved.id.startsWith(withTrailingSlash(this.server.config.cacheDir))
+    // let url: string
+    // // normalise the URL to be acceptable by the browser
+    // // https://github.com/vitejs/vite/blob/e833edf026d495609558fd4fb471cf46809dc369/packages/vite/src/node/plugins/importAnalysis.ts#L335
+    // const root = this.server.config.root
+    // if (resolved.id.startsWith(withTrailingSlash(root))) {
+    //   url = resolved.id.slice(root.length)
+    // }
+    // else if (
+    //   resolved.id !== '/@react-refresh'
+    //   && isAbsolute(resolved.id)
+    //   && existsSync(cleanUrl(resolved.id))
+    // ) {
+    //   url = join('/@fs/', resolved.id)
+    // }
+    // else {
+    //   url = resolved.id
+    // }
+    // if (url[0] !== '.' && url[0] !== '/') {
+    //   url = id.startsWith(VALID_ID_PREFIX)
+    //     ? id
+    //     : VALID_ID_PREFIX + id.replace('\0', '__x00__')
+    // }
+    // return {
+    //   id: resolved.id,
+    //   url,
+    //   optimized: isOptimized,
+    // }
+  }
+
+  private normalizeResolveIdToUrl(resolved: { id: string }) {
     const isOptimized = resolved.id.startsWith(withTrailingSlash(this.server.config.cacheDir))
     let url: string
     // normalise the URL to be acceptable by the browser
-    // https://github.com/vitejs/vite/blob/e833edf026d495609558fd4fb471cf46809dc369/packages/vite/src/node/plugins/importAnalysis.ts#L335
+    // https://github.com/vitejs/vite/blob/14027b0f2a9b01c14815c38aab22baf5b29594bb/packages/vite/src/node/plugins/importAnalysis.ts#L103
     const root = this.server.config.root
     if (resolved.id.startsWith(withTrailingSlash(root))) {
       url = resolved.id.slice(root.length)
@@ -86,9 +120,9 @@ export class ServerMockResolver {
       url = resolved.id
     }
     if (url[0] !== '.' && url[0] !== '/') {
-      url = id.startsWith(VALID_ID_PREFIX)
-        ? id
-        : VALID_ID_PREFIX + id.replace('\0', '__x00__')
+      url = resolved.id.startsWith(VALID_ID_PREFIX)
+        ? resolved.id
+        : VALID_ID_PREFIX + resolved.id.replace('\0', '__x00__')
     }
     return {
       id: resolved.id,
@@ -177,6 +211,7 @@ function withTrailingSlash(path: string): string {
 export interface ServerMockResolution {
   mockType: 'manual' | 'redirect' | 'automock' | 'autospy'
   resolvedId: string
+  resolvedUrl: string
   needsInterop?: boolean
   redirectUrl?: string | null
 }

--- a/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
@@ -6,5 +6,5 @@ vi.mock("../project2/index.js", () => ({
 }))
 
 test("basic", () => {
-  expect(project2).toMatchInlineSnapshot(`"project2"`)
+  expect(project2).toMatchInlineSnapshot(`"project2-mocked"`)
 })

--- a/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
@@ -1,0 +1,10 @@
+import { test, expect, vi } from 'vitest';
+import project2 from "../project2/index.js"
+
+vi.mock("../project2/index.js", () => ({
+  default: 'project2-mocked'
+}))
+
+test("basic", () => {
+  expect(project2).toMatchInlineSnapshot(`"project2"`)
+})

--- a/test/browser/fixtures/mocking-out-of-root/project1/vitest.config.ts
+++ b/test/browser/fixtures/mocking-out-of-root/project1/vitest.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from 'vitest/config';
 import { fileURLToPath } from 'node:url'
+import { instances, provider } from '../../../settings'
 
-// pnpm -C test/browser test-fixtures --root fixtures/mocking-out-of-root/project1
-
-const provider = process.env.PROVIDER || 'playwright'
+// BROWSER=chromium pnpm -C test/browser test-fixtures --root fixtures/mocking-out-of-root/project1
 
 export default defineConfig({
   cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
@@ -13,12 +12,7 @@ export default defineConfig({
       enabled: true,
       provider: provider,
       screenshotFailures: false,
-      instances: [
-        {
-          name: 'chromium',
-          browser: provider === 'playwright' ? 'chromium' : 'chrome',
-        },
-      ],
+      instances,
     },
   },
 })

--- a/test/browser/fixtures/mocking-out-of-root/project1/vitest.config.ts
+++ b/test/browser/fixtures/mocking-out-of-root/project1/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url'
+
+// pnpm -C test/browser test-fixtures --root fixtures/mocking-out-of-root/project1
+
+const provider = process.env.PROVIDER || 'playwright'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  root: import.meta.dirname,
+  test: {
+    browser: {
+      enabled: true,
+      provider: provider,
+      screenshotFailures: false,
+      instances: [
+        {
+          name: 'chromium',
+          browser: provider === 'playwright' ? 'chromium' : 'chrome',
+        },
+      ],
+    },
+  },
+})

--- a/test/browser/fixtures/mocking-out-of-root/project2/index.js
+++ b/test/browser/fixtures/mocking-out-of-root/project2/index.js
@@ -1,0 +1,1 @@
+export default "project2"

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -63,3 +63,16 @@ test('mocking dependency correctly invalidates it on rerun', async () => {
     expect(vitest.stdout).not.toReportPassedTest('2_not-mocked-import.test.ts', browser)
   })
 })
+
+test('mocking out of root', async () => {
+  const { vitest, ctx } = await runVitest({
+    root: 'fixtures/mocking-out-of-root/project1',
+  })
+  onTestFinished(async () => {
+    await ctx.close()
+  })
+  expect(vitest.stderr).toReportNoErrors()
+  instances.forEach(({ browser }) => {
+    expect(vitest.stdout).toReportPassedTest('basic.test.js', browser)
+  })
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7411

Vite import analysis rewrites workspace linked dep into `/@fs/abs-path/out-side-of-root/some-file.js`, but mock registry contains `/abs-path/out-side-of-root/some-file.js` and thus MSW skips mocking. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
