### PR TITLE
feat(reporters): customize project name colors through options

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -115,7 +115,7 @@ export abstract class BaseReporter implements Reporter {
     }
 
     if (task.projectName) {
-      title += ` ${formatProjectName(task.projectName, '')}`
+      title += ` ${formatProjectName(task.projectName, { suffix: '' })}`
     }
 
     this.log(` ${title} ${task.name} ${suffix}`)

--- a/packages/vitest/src/node/reporters/benchmark/reporter.ts
+++ b/packages/vitest/src/node/reporters/benchmark/reporter.ts
@@ -56,7 +56,7 @@ export class BenchmarkReporter extends DefaultReporter {
     const duration = task.result.duration
 
     if (benches.length > 0 && benches.every(t => t.result?.state !== 'run' && t.result?.state !== 'queued')) {
-      let title = `\n ${getStateSymbol(task)} ${formatProjectName(task.file.projectName)}${getFullName(task, c.dim(' > '))}`
+      let title = `\n ${getStateSymbol(task)} ${formatProjectName(task.file.projectName, { colors: this.colors })}${getFullName(task, c.dim(' > '))}`
 
       if (duration != null && duration > this.ctx.config.slowTestThreshold) {
         title += c.yellow(` ${Math.round(duration)}${c.dim('ms')}`)

--- a/packages/vitest/src/node/reporters/default.ts
+++ b/packages/vitest/src/node/reporters/default.ts
@@ -1,17 +1,21 @@
 import type { Vitest } from '../core'
 import type { TestSpecification } from '../spec'
 import type { BaseOptions } from './base'
+import type { ReporterColors } from './renderers/utils'
 import type { ReportedHookContext, TestCase, TestModule } from './reported-tasks'
 import { BaseReporter } from './base'
 import { SummaryReporter } from './summary'
 
 export interface DefaultReporterOptions extends BaseOptions {
+  colors?: ReporterColors
   summary?: boolean
 }
 
 export class DefaultReporter extends BaseReporter {
   private options: DefaultReporterOptions
   private summary?: SummaryReporter
+
+  protected colors: DefaultReporterOptions['colors']
 
   constructor(options: DefaultReporterOptions = {}) {
     super(options)
@@ -26,6 +30,10 @@ export class DefaultReporter extends BaseReporter {
 
     if (this.options.summary) {
       this.summary = new SummaryReporter()
+    }
+
+    if (this.options.colors) {
+      this.colors = this.options.colors
     }
   }
 

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -1,5 +1,6 @@
 import type { Task } from '@vitest/runner'
 import type { SnapshotSummary } from '@vitest/snapshot'
+import type { Colors, Formatter } from 'tinyrainbow'
 import { stripVTControlCharacters } from 'node:util'
 import { slash } from '@vitest/utils'
 import { basename, dirname, isAbsolute, relative } from 'pathe'
@@ -13,6 +14,8 @@ import {
   F_LONG_DASH,
   F_POINTER,
 } from './figures'
+
+export type ReporterColors = ((c: Colors) => Formatter[]) | Formatter[]
 
 export const pointer = c.yellow(F_POINTER)
 export const skipped = c.dim(c.gray(F_DOWN))
@@ -212,7 +215,13 @@ export function formatTime(time: number) {
   return `${Math.round(time)}ms`
 }
 
-export function formatProjectName(name: string | undefined, suffix = ' ') {
+export function formatProjectName(name: string | undefined, {
+  colors = [c.black, c.yellow, c.cyan, c.green, c.magenta],
+  suffix = ' ',
+}: {
+  colors?: ReporterColors
+  suffix?: string
+} = {}) {
   if (!name) {
     return ''
   }
@@ -223,7 +232,7 @@ export function formatProjectName(name: string | undefined, suffix = ' ') {
     .split('')
     .reduce((acc, v, idx) => acc + v.charCodeAt(0) + idx, 0)
 
-  const colors = [c.black, c.yellow, c.cyan, c.green, c.magenta]
+  colors = typeof colors === 'function' ? colors(c) : colors
 
   return c.inverse(colors[index % colors.length](` ${name} `)) + suffix
 }

--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -22,7 +22,7 @@ export class VerboseReporter extends DefaultReporter {
     let title = ` ${getStateSymbol(task)} `
 
     if (task.file.projectName) {
-      title += formatProjectName(task.file.projectName)
+      title += formatProjectName(task.file.projectName, { colors: this.colors })
     }
 
     title += getFullName(task, c.dim(' > '))


### PR DESCRIPTION
### Description

Fixes https://github.com/vitest-dev/vitest/issues/6481
Follows #7371 

Introduce a `colors` reporter option to be able to customize what colors are used when formatting reporter outputs.

Maybe what we would to introduce instead is the whole `formatProjectName` function override.

### Tests

I'd like some help to writing tests for this.

### Documentation

Needs to be discussed, the option name is subject to change.
