### PR TITLE
fix(browser): resolve thread count from `maxWorkers`

### DIFF
--- a/packages/browser/src/node/pool.ts
+++ b/packages/browser/src/node/pool.ts
@@ -155,6 +155,10 @@ export function createBrowserPool(vitest: Vitest): ProcessPool {
       return 1
     }
 
+    if (project.config.maxWorkers) {
+      return project.config.maxWorkers
+    }
+
     return vitest.config.watch
       ? Math.max(Math.floor(numCpus / 2), 1)
       : Math.max(numCpus - 1, 1)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Fixes #7446 
<!-- You can also add additional context here -->

Allow users to define thread count in browser mode. This is useful when you don't want to allocate all CPUs to Vitest, see linked issue. 

```ts
import { defineConfig } from "vitest/config";

export default defineConfig({
  test: {
    minWorkers: 4,
    maxWorkers: 4,

    browser: {
      enabled: true,
      headless: true,
      provider: "playwright",
      instances: [{ browser: "chromium" }],
    },
  },
});
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
