### PR TITLE
fix(coverage): preserve moduleExecutionInfo in non-isolated runs

### DIFF
--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -7,6 +7,7 @@ import { provideWorkerState } from '../utils'
 let _viteNode: VitestExecutor
 
 const moduleCache = new ModuleCacheMap()
+const moduleExecutionInfo = new Map()
 
 async function startViteNode(options: ContextExecutorOptions) {
   if (_viteNode) {
@@ -21,6 +22,7 @@ export async function runBaseTests(method: 'run' | 'collect', state: WorkerGloba
   const { ctx } = state
   // state has new context, but we want to reuse existing ones
   state.moduleCache = moduleCache
+  state.moduleExecutionInfo = moduleExecutionInfo
 
   provideWorkerState(globalThis, state)
 

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -48,9 +48,8 @@ for (const isolate of [true, false]) {
       if (isV8Provider()) {
         expect(summary).toStrictEqual({
           '<process-cwd>/fixtures/src/branch.ts': {
-            // FIXME: this should specify exact numbers
-            branches: expect.any(String),
-            functions: expect.any(String),
+            branches: '3/3 (100%)',
+            functions: '1/1 (100%)',
             lines: '6/6 (100%)',
             statements: '6/6 (100%)',
           },


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Reverts https://github.com/vitest-dev/vitest/pull/7485

Caused by https://github.com/vitest-dev/vitest/pull/7417. Luckily the completely extra test refactoring PR https://github.com/vitest-dev/vitest/pull/7482 made the summary comparisons more accurate - without this I would have completely missed this. 😰 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
