### PR TITLE
fix(browser): fix webdriverio `switchToFrame` deprecation notice

### DIFF
--- a/packages/browser/src/node/providers/webdriver.ts
+++ b/packages/browser/src/node/providers/webdriver.ts
@@ -43,7 +43,7 @@ export class WebdriverBrowserProvider implements BrowserProvider {
       'css selector',
       'iframe[data-vitest]',
     )
-    await page.switchToFrame(iframe)
+    await page.switchFrame(iframe)
   }
 
   async afterCommand(): Promise<void> {


### PR DESCRIPTION
### Description

Just recently my curiousity drove me to try run browser test using `webdriverio` and I expect everything should work the same as when I use `playwright`, right? then I did feryardiant/poc-brackets#31

In my [ci](https://github.com/feryardiant/poc-brackets/actions/runs/13330004325/job/37231636226) I saw bunch of `[WEBDRIVERIO DEPRECATION NOTICE]` as described #6804

```
⚠️ [WEBDRIVERIO DEPRECATION NOTICE] The "switchToFrame" command is deprecated and we encourage everyone to use `switchFrame` instead for switching into frames. Read more about this command at https://webdriver.io/docs/api/browser/switchFrame.
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Unfortunately I'm unable to link my fork to see it on github actions since vitest is monorepo and as my understanding using [github url](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#github-urls) as dependency only work on root `package.json` in `npm`.

```
npm error code 1
npm error git dep preparation failed
npm error command /opt/homebrew/Cellar/node/23.7.0/bin/node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js install --force --cache=~/.npm --prefer-offline=fa
lse --prefer-online=false --offline=false --no-progress --no-save --no-audit --include=dev --include=peer --include=optional --no-package-lock-only --no-dry-run
npm error npm warn using --force Recommended protections disabled.
npm error npm error code EUNSUPPORTEDPROTOCOL
npm error npm error Unsupported URL Type "workspace:": workspace:*
npm error npm error A complete log of this run can be found in: ~/.npm/_logs/2025-02-14T14_30_09_058Z-debug-0.log
npm error A complete log of this run can be found in: ~/.npm/_logs/2025-02-14T14_28_51_970Z-debug-0.log
```

All I can do for now is link it with my local clone as suggested in the [contribution](https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md#testing-vitest-against-external-packages) guideline

```jsonc
{
  // ...
  "devDependencies": {
    // ...
    "@vitest/browser": "file:~/path/to/vitest/packages/browser",
    // ...
  },
}
```

I'll figure out another workaround later.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
