### PR TITLE
fix(reporters): render tasks in tree when in TTY

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -144,9 +144,13 @@ export abstract class BaseReporter implements Reporter {
         if (test.result?.state === 'fail') {
           this.log(c.red(` ${padding}${taskFail} ${this.getTestName(test, c.dim(' > '))}${this.getDurationPrefix(test)}`) + suffix)
 
-          test.result?.errors?.forEach((e) => {
           // print short errors, full errors will be at the end in summary
-            this.log(c.red(`   ${padding}${F_RIGHT} ${e?.message}`))
+          test.result?.errors?.forEach((error) => {
+            const message = this.formatShortError(error)
+
+            if (message) {
+              this.log(c.red(`   ${padding}${message}`))
+            }
           })
         }
 
@@ -180,6 +184,10 @@ export abstract class BaseReporter implements Reporter {
 
   protected getTestName(test: Task, separator?: string): string {
     return getTestName(test, separator)
+  }
+
+  protected formatShortError(error: ErrorWithDiff): string {
+    return `${F_RIGHT} ${error.message}`
   }
 
   protected getTestIndentation(_test: Task) {

--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -1,5 +1,5 @@
 import type { Task } from '@vitest/runner'
-import { getFullName } from '@vitest/runner/utils'
+import { getFullName, getTests } from '@vitest/runner/utils'
 import c from 'tinyrainbow'
 import { DefaultReporter } from './default'
 import { F_RIGHT } from './renderers/figures'
@@ -48,9 +48,10 @@ export class VerboseReporter extends DefaultReporter {
 
   protected printSuite(task: Task): void {
     const indentation = '  '.repeat(getIndentation(task))
+    const tests = getTests(task)
     const state = getStateSymbol(task)
 
-    this.log(` ${indentation}${state} ${task.name}`)
+    this.log(` ${indentation}${state} ${task.name} ${c.dim(`(${tests.length})`)}`)
   }
 
   protected getTestName(test: Task): string {
@@ -63,7 +64,7 @@ export class VerboseReporter extends DefaultReporter {
 }
 
 function getIndentation(suite: Task, level = 1): number {
-  if (suite.suite) {
+  if (suite.suite && !('filepath' in suite.suite)) {
     return getIndentation(suite.suite, level + 1)
   }
 

--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -61,6 +61,11 @@ export class VerboseReporter extends DefaultReporter {
   protected getTestIndentation(test: Task): string {
     return '  '.repeat(getIndentation(test))
   }
+
+  protected formatShortError(): string {
+    // Short errors are not shown in tree-view
+    return ''
+  }
 }
 
 function getIndentation(suite: Task, level = 1): number {

--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -45,4 +45,27 @@ export class VerboseReporter extends DefaultReporter {
       task.result.errors?.forEach(error => this.log(c.red(`   ${F_RIGHT} ${error?.message}`)))
     }
   }
+
+  protected printSuite(task: Task): void {
+    const indentation = '  '.repeat(getIndentation(task))
+    const state = getStateSymbol(task)
+
+    this.log(` ${indentation}${state} ${task.name}`)
+  }
+
+  protected getTestName(test: Task): string {
+    return test.name
+  }
+
+  protected getTestIndentation(test: Task): string {
+    return '  '.repeat(getIndentation(test))
+  }
+}
+
+function getIndentation(suite: Task, level = 1): number {
+  if (suite.suite) {
+    return getIndentation(suite.suite, level + 1)
+  }
+
+  return level
 }

--- a/test/reporters/fixtures/verbose/example-1.test.ts
+++ b/test/reporters/fixtures/verbose/example-1.test.ts
@@ -1,0 +1,35 @@
+import { test, describe, expect } from "vitest";
+
+test("test pass in root", () => {});
+
+test.skip("test skip in root", () => {});
+
+describe("suite in root", () => {
+  test("test pass in 1. suite (1)", () => {});
+
+  test("test pass in 1. suite (2)", () => {});
+
+  describe("suite in suite", () => {
+    test("test pass in nested suite (1)", () => {});
+
+    test("test pass in nested suite (2)", () => {});
+
+    describe("suite in nested suite", () => {
+      test("test failure in 2x nested suite", () => {
+        expect("should fail").toBe("as expected");
+      });
+    });
+  });
+});
+
+describe.skip("suite skip in root", () => {
+  test("test 1.3", () => {});
+
+  describe("suite in suite", () => {
+    test("test in nested suite", () => {});
+
+    test("test failure in nested suite of skipped suite", () => {
+      expect("should fail").toBe("but should not run");
+    });
+  });
+});

--- a/test/reporters/fixtures/verbose/example-1.test.ts
+++ b/test/reporters/fixtures/verbose/example-1.test.ts
@@ -5,14 +5,14 @@ test("test pass in root", () => {});
 test.skip("test skip in root", () => {});
 
 describe("suite in root", () => {
-  test("test pass in 1. suite (1)", () => {});
+  test("test pass in 1. suite #1", () => {});
 
-  test("test pass in 1. suite (2)", () => {});
+  test("test pass in 1. suite #2", () => {});
 
   describe("suite in suite", () => {
-    test("test pass in nested suite (1)", () => {});
+    test("test pass in nested suite #1", () => {});
 
-    test("test pass in nested suite (2)", () => {});
+    test("test pass in nested suite #2", () => {});
 
     describe("suite in nested suite", () => {
       test("test failure in 2x nested suite", () => {

--- a/test/reporters/fixtures/verbose/example-2.test.ts
+++ b/test/reporters/fixtures/verbose/example-2.test.ts
@@ -1,0 +1,15 @@
+import { test, describe } from "vitest";
+
+test("test 0.1", () => {
+  //
+});
+
+test.skip("test 0.2", () => {
+  //
+});
+
+describe("suite 1.1", () => {
+  test("test 1.1", () => {
+    //
+  });
+});

--- a/test/reporters/fixtures/verbose/example-2.test.ts
+++ b/test/reporters/fixtures/verbose/example-2.test.ts
@@ -1,15 +1,9 @@
 import { test, describe } from "vitest";
 
-test("test 0.1", () => {
-  //
-});
+test("test 0.1", () => {});
 
-test.skip("test 0.2", () => {
-  //
-});
+test.skip("test 0.2", () => {});
 
 describe("suite 1.1", () => {
-  test("test 1.1", () => {
-    //
-  });
+  test("test 1.1", () => {});
 });

--- a/test/reporters/tests/merge-reports.test.ts
+++ b/test/reporters/tests/merge-reports.test.ts
@@ -100,8 +100,8 @@ test('merge reports', async () => {
      ❯ second.test.ts (3 tests | 1 failed) <time>
        × test 2-1 <time>
          → expected 1 to be 2 // Object.is equality
-       ✓ group > test 2-2
-       ✓ group > test 2-3
+         ✓ group > test 2-2
+         ✓ group > test 2-3
 
      Test Files  2 failed (2)
           Tests  2 failed | 3 passed (5)

--- a/test/reporters/tests/merge-reports.test.ts
+++ b/test/reporters/tests/merge-reports.test.ts
@@ -100,8 +100,8 @@ test('merge reports', async () => {
      ❯ second.test.ts (3 tests | 1 failed) <time>
        × test 2-1 <time>
          → expected 1 to be 2 // Object.is equality
-         ✓ group > test 2-2
-         ✓ group > test 2-3
+       ✓ group > test 2-2
+       ✓ group > test 2-3
 
      Test Files  2 failed (2)
           Tests  2 failed | 3 passed (5)

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -104,7 +104,6 @@ test('renders tree when in TTY', async () => {
            ✓ test pass in nested suite #2
            ❯ suite in nested suite (1)
              × test failure in 2x nested suite [...]ms
-               → expected 'should fail' to be 'as expected' // Object.is equality
        ↓ suite skip in root (3)
          ↓ test 1.3
          ↓ suite in suite (2)

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -96,24 +96,24 @@ test('renders tree when in TTY', async () => {
     "❯ fixtures/verbose/example-1.test.ts (10 tests | 1 failed | 4 skipped) [...]ms
        ✓ test pass in root
        ↓ test skip in root
-       ❯ suite in root
-         ✓ test pass in 1. suite (1)
-         ✓ test pass in 1. suite (2)
-         ❯ suite in suite
-           ✓ test pass in nested suite (1)
-           ✓ test pass in nested suite (2)
-           ❯ suite in nested suite
+       ❯ suite in root (5)
+         ✓ test pass in 1. suite #1
+         ✓ test pass in 1. suite #2
+         ❯ suite in suite (3)
+           ✓ test pass in nested suite #1
+           ✓ test pass in nested suite #2
+           ❯ suite in nested suite (1)
              × test failure in 2x nested suite [...]ms
                → expected 'should fail' to be 'as expected' // Object.is equality
-       ↓ suite skip in root
+       ↓ suite skip in root (3)
          ↓ test 1.3
-         ↓ suite in suite
+         ↓ suite in suite (2)
            ↓ test in nested suite
            ↓ test failure in nested suite of skipped suite
      ✓ fixtures/verbose/example-2.test.ts (3 tests | 1 skipped) [...]ms
        ✓ test 0.1
        ↓ test 0.2
-       ✓ suite 1.1
+       ✓ suite 1.1 (1)
          ✓ test 1.1"
   `)
 })
@@ -139,10 +139,10 @@ test('does not render tree when in non-TTY', async () => {
 
   expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
     "✓ fixtures/verbose/example-1.test.ts > test pass in root
-     ✓ fixtures/verbose/example-1.test.ts > suite in root > test pass in 1. suite (1)
-     ✓ fixtures/verbose/example-1.test.ts > suite in root > test pass in 1. suite (2)
-     ✓ fixtures/verbose/example-1.test.ts > suite in root > suite in suite > test pass in nested suite (1)
-     ✓ fixtures/verbose/example-1.test.ts > suite in root > suite in suite > test pass in nested suite (2)
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > test pass in 1. suite #1
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > test pass in 1. suite #2
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > suite in suite > test pass in nested suite #1
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > suite in suite > test pass in nested suite #2
      × fixtures/verbose/example-1.test.ts > suite in root > suite in suite > suite in nested suite > test failure in 2x nested suite
        → expected 'should fail' to be 'as expected' // Object.is equality
      ✓ fixtures/verbose/example-2.test.ts > test 0.1

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -1,18 +1,18 @@
+import type { TestSpecification } from 'vitest/node'
 import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 
 test('duration', async () => {
-  const result = await runVitest({
+  const { stdout } = await runVitest({
     root: 'fixtures/duration',
     reporters: 'verbose',
     env: { CI: '1' },
   })
 
-  const output = result.stdout.replace(/\d+ms/g, '[...]ms')
-  expect(output).toContain(`
+  expect(trimReporterOutput(stdout)).toContain(`
  ✓ basic.test.ts > fast
- ✓ basic.test.ts > slow [...]ms
-`)
+ ✓ basic.test.ts > slow [...]ms`,
+  )
 })
 
 test('prints error properties', async () => {
@@ -72,3 +72,90 @@ test('prints repeat count', async () => {
   expect(stdout).toContain('1 passed')
   expect(stdout).toContain('✓ repeat couple of times (repeat x3)')
 })
+
+test('renders tree when in TTY', async () => {
+  const { stdout } = await runVitest({
+    include: ['fixtures/verbose/*.test.ts'],
+    reporters: [['verbose', { isTTY: true, summary: false }]],
+    config: false,
+    fileParallelism: false,
+    sequence: {
+      sequencer: class StableTestFileOrderSorter {
+        sort(files: TestSpecification[]) {
+          return files.sort((a, b) => a.moduleId.localeCompare(b.moduleId))
+        }
+
+        shard(files: TestSpecification[]) {
+          return files
+        }
+      },
+    },
+  })
+
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    "❯ fixtures/verbose/example-1.test.ts (10 tests | 1 failed | 4 skipped) [...]ms
+       ✓ test pass in root
+       ↓ test skip in root
+       ❯ suite in root
+         ✓ test pass in 1. suite (1)
+         ✓ test pass in 1. suite (2)
+         ❯ suite in suite
+           ✓ test pass in nested suite (1)
+           ✓ test pass in nested suite (2)
+           ❯ suite in nested suite
+             × test failure in 2x nested suite [...]ms
+               → expected 'should fail' to be 'as expected' // Object.is equality
+       ↓ suite skip in root
+         ↓ test 1.3
+         ↓ suite in suite
+           ↓ test in nested suite
+           ↓ test failure in nested suite of skipped suite
+     ✓ fixtures/verbose/example-2.test.ts (3 tests | 1 skipped) [...]ms
+       ✓ test 0.1
+       ↓ test 0.2
+       ✓ suite 1.1
+         ✓ test 1.1"
+  `)
+})
+
+test('does not render tree when in non-TTY', async () => {
+  const { stdout } = await runVitest({
+    include: ['fixtures/verbose/*.test.ts'],
+    reporters: [['verbose', { isTTY: false, summary: false }]],
+    config: false,
+    fileParallelism: false,
+    sequence: {
+      sequencer: class StableTestFileOrderSorter {
+        sort(files: TestSpecification[]) {
+          return files.sort((a, b) => a.moduleId.localeCompare(b.moduleId))
+        }
+
+        shard(files: TestSpecification[]) {
+          return files
+        }
+      },
+    },
+  })
+
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    "✓ fixtures/verbose/example-1.test.ts > test pass in root
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > test pass in 1. suite (1)
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > test pass in 1. suite (2)
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > suite in suite > test pass in nested suite (1)
+     ✓ fixtures/verbose/example-1.test.ts > suite in root > suite in suite > test pass in nested suite (2)
+     × fixtures/verbose/example-1.test.ts > suite in root > suite in suite > suite in nested suite > test failure in 2x nested suite
+       → expected 'should fail' to be 'as expected' // Object.is equality
+     ✓ fixtures/verbose/example-2.test.ts > test 0.1
+     ✓ fixtures/verbose/example-2.test.ts > suite 1.1 > test 1.1"
+  `)
+})
+
+function trimReporterOutput(report: string) {
+  const rows = report.replace(/\d+ms/g, '[...]ms').split('\n')
+
+  // Trim start and end, capture just rendered tree
+  rows.splice(0, rows.findIndex(row => row.includes('fixtures/verbose/example-')))
+  rows.splice(rows.findIndex(row => row.includes('Test Files')))
+
+  return rows.join('\n').trim()
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Fixes https://github.com/vitest-dev/vitest/issues/7435

<!-- You can also add additional context here -->

Before-after:
<img src="https://github.com/user-attachments/assets/058196fe-f5e3-444a-83c1-d4f4ce39b5e8" width="600" />

Note that this is how it looked like in V2:
<img src="https://github.com/user-attachments/assets/74e22089-2bc4-4469-9d95-a16e6c15a4e2" width="400" />

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
