### PR TITLE
fix: exclude `queueMicrotask` from default fake timers to not break node fetch

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -818,8 +818,8 @@ Mocking `nextTick` is not supported when running Vitest inside `node:child_proce
 The implementation is based internally on [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
 
 ::: tip
-`vi.useFakeTimers()` does not automatically mock `process.nextTick`.
-But you can enable it by specifying the option in `toFake` argument: `vi.useFakeTimers({ toFake: ['nextTick'] })`.
+`vi.useFakeTimers()` does not automatically mock `process.nextTick` and `queueMicrotask`.
+But you can enable it by specifying the option in `toFake` argument: `vi.useFakeTimers({ toFake: ['nextTick', 'queueMicrotask'] })`.
 :::
 
 ### vi.isFakeTimers {#vi-isfaketimers}

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2345,7 +2345,7 @@ Installs fake timers with the specified Unix epoch.
 #### fakeTimers.toFake
 
 - **Type:** `('setTimeout' | 'clearTimeout' | 'setImmediate' | 'clearImmediate' | 'setInterval' | 'clearInterval' | 'Date' | 'nextTick' | 'hrtime' | 'requestAnimationFrame' | 'cancelAnimationFrame' | 'requestIdleCallback' | 'cancelIdleCallback' | 'performance' | 'queueMicrotask')[]`
-- **Default:** everything available globally except `nextTick`
+- **Default:** everything available globally except `nextTick` and `queueMicrotask`
 
 An array with names of global methods and APIs to fake.
 

--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -153,9 +153,9 @@ export class FakeTimers {
 
     if (!this._fakingTime) {
       const toFake = Object.keys(this._fakeTimers.timers)
-        // Do not mock nextTick by default. It can still be mocked through userConfig.
+        // Do not mock timers internally used by node by default. It can still be mocked through userConfig.
         .filter(
-          timer => timer !== 'nextTick',
+          timer => timer !== 'nextTick' && timer !== 'queueMicrotask',
         ) as (keyof FakeTimerWithContext['timers'])[]
 
       if (this._userConfig?.toFake?.includes('nextTick') && isChildProcess()) {

--- a/test/core/test/timers-queueMicrotask.test.ts
+++ b/test/core/test/timers-queueMicrotask.test.ts
@@ -14,7 +14,8 @@ test(`node fetch works with fake timers`, async () => {
   expect(await response.json()).toBe('ok')
 })
 
-test(`node fetch timeouts with fake queueMicrotask`, async () => {
+// skipped since this might cause a weird OOM on CI
+test.skip(`node fetch timeouts with fake queueMicrotask`, async () => {
   vi.useFakeTimers({ toFake: ['queueMicrotask'] })
   onTestFinished(() => {
     vi.useRealTimers()

--- a/test/core/test/timers-queueMicrotask.test.ts
+++ b/test/core/test/timers-queueMicrotask.test.ts
@@ -2,7 +2,7 @@ import { expect, onTestFinished, test, vi } from 'vitest'
 
 test(`node fetch works without fake timers`, async () => {
   const response = Response.json('ok')
-  expect(await response.json()).toMatchInlineSnapshot(`"ok"`)
+  expect(await response.json()).toBe('ok')
 })
 
 test(`node fetch works with fake timers`, async () => {
@@ -10,7 +10,20 @@ test(`node fetch works with fake timers`, async () => {
   onTestFinished(() => {
     vi.useRealTimers()
   })
-
   const response = Response.json('ok')
-  expect(await response.json()).toMatchInlineSnapshot(`"ok"`)
+  expect(await response.json()).toBe('ok')
+})
+
+test(`node fetch timeouts with fake queueMicrotask`, async () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] })
+  onTestFinished(() => {
+    vi.useRealTimers()
+  })
+  const response = Response.json('ok')
+  expect(
+    await Promise.race([
+      new Promise(r => setTimeout(() => r('timeout'), 200)),
+      response.json(),
+    ]),
+  ).toBe('timeout')
 })

--- a/test/core/test/timers-queueMicrotask.test.ts
+++ b/test/core/test/timers-queueMicrotask.test.ts
@@ -1,0 +1,16 @@
+import { expect, onTestFinished, test, vi } from 'vitest'
+
+test(`node fetch works without fake timers`, async () => {
+  const response = Response.json('ok')
+  expect(await response.json()).toMatchInlineSnapshot(`"ok"`)
+})
+
+test(`node fetch works with fake timers`, async () => {
+  vi.useFakeTimers()
+  onTestFinished(() => {
+    vi.useRealTimers()
+  })
+
+  const response = Response.json('ok')
+  expect(await response.json()).toMatchInlineSnapshot(`"ok"`)
+})

--- a/test/core/test/timers-queueMicrotask.test.ts
+++ b/test/core/test/timers-queueMicrotask.test.ts
@@ -1,8 +1,7 @@
 import { expect, onTestFinished, test, vi } from 'vitest'
 
 test(`node fetch works without fake timers`, async () => {
-  const response = Response.json('ok')
-  expect(await response.json()).toBe('ok')
+  expect(await Response.json('ok').json()).toBe('ok')
 })
 
 test(`node fetch works with fake timers`, async () => {
@@ -10,8 +9,7 @@ test(`node fetch works with fake timers`, async () => {
   onTestFinished(() => {
     vi.useRealTimers()
   })
-  const response = Response.json('ok')
-  expect(await response.json()).toBe('ok')
+  expect(await Response.json('ok').json()).toBe('ok')
 })
 
 // skipped since this might cause a weird OOM on CI
@@ -20,11 +18,10 @@ test.skip(`node fetch timeouts with fake queueMicrotask`, async () => {
   onTestFinished(() => {
     vi.useRealTimers()
   })
-  const response = Response.json('ok')
   expect(
     await Promise.race([
       new Promise(r => setTimeout(() => r('timeout'), 200)),
-      response.json(),
+      Response.json('ok').json(),
     ]),
   ).toBe('timeout')
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7288

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
