### PR TITLE
feat: allow array element for `test.each/for` title formatting

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -330,17 +330,29 @@ test.each([
 // ✓ add(2, 1) -> 3
 ```
 
-You can also access object properties with `$` prefix, if you are using objects as arguments:
+You can also access object properties and array elements with `$` prefix:
 
-  ```ts
-  test.each([
-    { a: 1, b: 1, expected: 2 },
-    { a: 1, b: 2, expected: 3 },
-    { a: 2, b: 1, expected: 3 },
-  ])('add($a, $b) -> $expected', ({ a, b, expected }) => {
-    expect(a + b).toBe(expected)
-  })
+```ts
+test.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('add($a, $b) -> $expected', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected)
+})
 
+// this will return
+// ✓ add(1, 1) -> 2
+// ✓ add(1, 2) -> 3
+// ✓ add(2, 1) -> 3
+
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('add($0, $1) -> $2', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})
 // this will return
 // ✓ add(1, 1) -> 2
 // ✓ add(1, 2) -> 3

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -353,6 +353,7 @@ test.each([
 ])('add($0, $1) -> $2', (a, b, expected) => {
   expect(a + b).toBe(expected)
 })
+
 // this will return
 // ✓ add(1, 1) -> 2
 // ✓ add(1, 2) -> 3

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -819,6 +819,13 @@ function formatTitle(template: string, items: any[], idx: number) {
         }) as unknown as string,
     )
   }
+  formatted = formatted.replace(
+    /\$(\d+)/g,
+    (_, key) =>
+      objDisplay(objectAttr(items, key), {
+        truncate: runner?.config?.chaiConfig?.truncateThreshold,
+      }) as unknown as string,
+  )
   return formatted
 }
 

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -809,22 +809,20 @@ function formatTitle(template: string, items: any[], idx: number) {
   }
 
   let formatted = format(template, ...items.slice(0, count))
-  if (isObject(items[0])) {
-    formatted = formatted.replace(
-      /\$([$\w.]+)/g,
-      // https://github.com/chaijs/chai/pull/1490
-      (_, key) =>
-        objDisplay(objectAttr(items[0], key), {
-          truncate: runner?.config?.chaiConfig?.truncateThreshold,
-        }) as unknown as string,
-    )
-  }
+  const isObjectItem = isObject(items[0])
   formatted = formatted.replace(
-    /\$(\d+)/g,
-    (_, key) =>
-      objDisplay(objectAttr(items, key), {
+    /\$([$\w.]+)/g,
+    (_, key: string) => {
+      const isArrayKey = /^\d+$/.test(key)
+      if (!isObjectItem && !isArrayKey) {
+        return `$${key}`
+      }
+      const arrayElement = isArrayKey ? objectAttr(items, key) : undefined
+      const value = isObjectItem ? objectAttr(items[0], key, arrayElement) : arrayElement
+      return objDisplay(value, {
         truncate: runner?.config?.chaiConfig?.truncateThreshold,
-      }) as unknown as string,
+      }) as unknown as string
+    },
   )
   return formatted
 }

--- a/test/reporters/fixtures/test-for-title.test.ts
+++ b/test/reporters/fixtures/test-for-title.test.ts
@@ -39,3 +39,12 @@ test.each([
 test.for([
   [{ k1: "v1" }, { k2: "v2" }],
 ])('first array element is object: 0 = $0, 1 = $1, k1 = $k1, k2 = $k2', () => {})
+
+test.for([
+  ["foo", "bar"],
+])('first array element is not object: 0 = $0, 1 = $1, k = $k', () => {})
+
+test.for([
+  { k: "v1" },
+  { k: "v2" },
+])('not array: 0 = $0, 1 = $1, k = $k', () => {})

--- a/test/reporters/fixtures/test-for-title.test.ts
+++ b/test/reporters/fixtures/test-for-title.test.ts
@@ -1,0 +1,21 @@
+import { test } from "vitest"
+
+test.for([
+  { 0: 'a', 1: {}, 2: { te: "st" } },
+  { "0": 'b', "1": [], "2": ["test"] },
+])('test.for object (0 = $0, 2 = $2)', () => {});
+
+test.each([
+  { 0: 'a', 1: {}, 2: { te: "st" } },
+  { "0": 'b', "1": [], "2": ["test"] },
+])('test.each object (0 = $0, 2 = $2)', () => {});
+
+test.for([
+  ['a', {}, { te: "st" }],
+  ['b', [], [ "test" ]],
+])('test.for array (0 = $0, 2 = $2)', () => {});
+
+test.each([
+  ['a', {}, { te: "st" }],
+  ['b', [], [ "test" ]],
+])('test.each array (0 = $0, 2 = $2)', () => {});

--- a/test/reporters/fixtures/test-for-title.test.ts
+++ b/test/reporters/fixtures/test-for-title.test.ts
@@ -35,3 +35,7 @@ test.each([
 ])('array : add($0, $1) -> $2', (a, b, expected) => {
   expect(a + b).toBe(expected)
 })
+
+test.for([
+  [{ k1: "v1" }, { k2: "v2" }],
+])('first array element is object: 0 = $0, 1 = $1, k1 = $k1, k2 = $k2', () => {})

--- a/test/reporters/fixtures/test-for-title.test.ts
+++ b/test/reporters/fixtures/test-for-title.test.ts
@@ -1,21 +1,37 @@
-import { test } from "vitest"
+import { expect, test } from "vitest"
 
 test.for([
   { 0: 'a', 1: {}, 2: { te: "st" } },
   { "0": 'b', "1": [], "2": ["test"] },
-])('test.for object (0 = $0, 2 = $2)', () => {});
+])('test.for object : 0 = $0, 2 = $2', () => {});
 
 test.each([
   { 0: 'a', 1: {}, 2: { te: "st" } },
   { "0": 'b', "1": [], "2": ["test"] },
-])('test.each object (0 = $0, 2 = $2)', () => {});
+])('test.each object : 0 = $0, 2 = $2 ', () => {});
 
 test.for([
   ['a', {}, { te: "st" }],
   ['b', [], [ "test" ]],
-])('test.for array (0 = $0, 2 = $2)', () => {});
+])('test.for array : 0 = $0, 2 = $2', () => {});
 
 test.each([
   ['a', {}, { te: "st" }],
   ['b', [], [ "test" ]],
-])('test.each array (0 = $0, 2 = $2)', () => {});
+])('test.each array : 0 = $0, 2 = $2', () => {});
+
+test.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 1, expected: 3 },
+])('object : add($a, $b) -> $expected', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected)
+})
+
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('array : add($0, $1) -> $2', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -202,7 +202,7 @@ describe('default reporter', async () => {
         "✓ array : add(1, 1) -> 2",
         "✓ array : add(1, 2) -> 3",
         "✓ array : add(2, 1) -> 3",
-        "✓ first array element is object: 0 = undefined, 1 = undefined, k1 = 'v1', k2 = undefined",
+        "✓ first array element is object: 0 = { k1: 'v1' }, 1 = { k2: 'v2' }, k1 = 'v1', k2 = undefined",
       ]
     `)
   })

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -178,24 +178,30 @@ describe('default reporter', async () => {
     expect(stdout).toContain('✓ repeat couple of times (repeat x3)')
   })
 
-  test('test.each/for title format', async () => {
+  test.only('test.each/for title format', async () => {
     const { stdout } = await runVitest({
       include: ['fixtures/test-for-title.test.ts'],
       reporters: [['default', { isTTY: true, summary: false }]],
       config: false,
     })
     expect(
-      [...stdout.matchAll(/(✓ test.*)$/gm)].map(v => v[0]),
+      [...stdout.matchAll(/(✓ .*)$/gm)].map(v => v[0]).filter(v => !v.includes('ms')),
     ).toMatchInlineSnapshot(`
       [
-        "✓ test.for object (0 = 'a', 2 = { te: 'st' })",
-        "✓ test.for object (0 = 'b', 2 = [ 'test' ])",
-        "✓ test.each object (0 = 'a', 2 = { te: 'st' })",
-        "✓ test.each object (0 = 'b', 2 = [ 'test' ])",
-        "✓ test.for array (0 = 'a', 2 = { te: 'st' })",
-        "✓ test.for array (0 = 'b', 2 = [ 'test' ])",
-        "✓ test.each array (0 = 'a', 2 = { te: 'st' })",
-        "✓ test.each array (0 = 'b', 2 = [ 'test' ])",
+        "✓ test.for object : 0 = 'a', 2 = { te: 'st' }",
+        "✓ test.for object : 0 = 'b', 2 = [ 'test' ]",
+        "✓ test.each object : 0 = 'a', 2 = { te: 'st' } ",
+        "✓ test.each object : 0 = 'b', 2 = [ 'test' ] ",
+        "✓ test.for array : 0 = 'a', 2 = { te: 'st' }",
+        "✓ test.for array : 0 = 'b', 2 = [ 'test' ]",
+        "✓ test.each array : 0 = 'a', 2 = { te: 'st' }",
+        "✓ test.each array : 0 = 'b', 2 = [ 'test' ]",
+        "✓ object : add(1, 1) -> 2",
+        "✓ object : add(1, 2) -> 3",
+        "✓ object : add(2, 1) -> 3",
+        "✓ array : add(1, 1) -> 2",
+        "✓ array : add(1, 2) -> 3",
+        "✓ array : add(2, 1) -> 3",
       ]
     `)
   })

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -177,4 +177,26 @@ describe('default reporter', async () => {
     expect(stdout).toContain('1 passed')
     expect(stdout).toContain('✓ repeat couple of times (repeat x3)')
   })
+
+  test('test.each/for title format', async () => {
+    const { stdout } = await runVitest({
+      include: ['fixtures/test-for-title.test.ts'],
+      reporters: [['default', { isTTY: true, summary: false }]],
+      config: false,
+    })
+    expect(
+      [...stdout.matchAll(/(✓ test.*)$/gm)].map(v => v[0])
+    ).toMatchInlineSnapshot(`
+      [
+        "✓ test.for object (0 = 'a', 2 = { te: 'st' })",
+        "✓ test.for object (0 = 'b', 2 = [ 'test' ])",
+        "✓ test.each object (0 = 'a', 2 = { te: 'st' })",
+        "✓ test.each object (0 = 'b', 2 = [ 'test' ])",
+        "✓ test.for array (0 = 'a', 2 = { te: 'st' })",
+        "✓ test.for array (0 = 'b', 2 = [ 'test' ])",
+        "✓ test.each array (0 = 'a', 2 = { te: 'st' })",
+        "✓ test.each array (0 = 'b', 2 = [ 'test' ])",
+      ]
+    `)
+  })
 }, 120000)

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -185,7 +185,7 @@ describe('default reporter', async () => {
       config: false,
     })
     expect(
-      [...stdout.matchAll(/(✓ test.*)$/gm)].map(v => v[0])
+      [...stdout.matchAll(/(✓ test.*)$/gm)].map(v => v[0]),
     ).toMatchInlineSnapshot(`
       [
         "✓ test.for object (0 = 'a', 2 = { te: 'st' })",

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -203,6 +203,9 @@ describe('default reporter', async () => {
         "✓ array : add(1, 2) -> 3",
         "✓ array : add(2, 1) -> 3",
         "✓ first array element is object: 0 = { k1: 'v1' }, 1 = { k2: 'v2' }, k1 = 'v1', k2 = undefined",
+        "✓ first array element is not object: 0 = 'foo', 1 = 'bar', k = $k",
+        "✓ not array: 0 = { k: 'v1' }, 1 = undefined, k = 'v1'",
+        "✓ not array: 0 = { k: 'v2' }, 1 = undefined, k = 'v2'",
       ]
     `)
   })

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -178,7 +178,7 @@ describe('default reporter', async () => {
     expect(stdout).toContain('✓ repeat couple of times (repeat x3)')
   })
 
-  test.only('test.each/for title format', async () => {
+  test('test.each/for title format', async () => {
     const { stdout } = await runVitest({
       include: ['fixtures/test-for-title.test.ts'],
       reporters: [['default', { isTTY: true, summary: false }]],

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -202,6 +202,7 @@ describe('default reporter', async () => {
         "✓ array : add(1, 1) -> 2",
         "✓ array : add(1, 2) -> 3",
         "✓ array : add(2, 1) -> 3",
+        "✓ first array element is object: 0 = undefined, 1 = undefined, k1 = 'v1', k2 = undefined",
       ]
     `)
   })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7511

This would be a bit of breaking change since `$0`, `$1`, ... weren't replaced previously.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
