### PR TITLE
fix(expect): Correct generic MatchersObject this type in expect.extend

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -92,7 +92,7 @@ export interface RawMatcherFn<T extends MatcherState = MatcherState> {
 export type MatchersObject<T extends MatcherState = MatcherState> = Record<
   string,
   RawMatcherFn<T>
->
+> & ThisType<T>
 
 export interface ExpectStatic
   extends Chai.ExpectStatic,

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -246,6 +246,15 @@ describe('jest-expect', () => {
           message: () => '',
         }
       },
+      toBeTestedMatcherContext<T>(received: unknown, expected: T) {
+        if (typeof this.utils?.stringify !== 'function') {
+          throw new TypeError('this.utils.stringify is not available.')
+        }
+        return {
+          pass: received === expected,
+          message: () => 'toBeTestedMatcherContext',
+        }
+      },
     })
 
     expect(5).toBeDividedBy(5)


### PR DESCRIPTION
### Description
fixes #6967 

 This PR fixes a TypeScript error where generic functions passed to `expect.extend` receive an incorrect `this` type. The issue was caused by the missing `& ThisType<T>` in the `MatchersObject` type definition.
 I try to add a regression test, but I couldn't find an appropriate test example, so I've attached an image below.

<table>
  <tr>
    <td align="center"><strong>Current</strong></td>
  </tr>
  <tr>
    <td align="center">
      <img width="830" alt="Current image" src="https://github.com/user-attachments/assets/b3f56a95-1bcb-47da-9bf3-d1618728cc97" />
    </td>
  </tr>
  <tr>
    <td align="center"><strong>Fixed</strong></td>
  </tr>
  <tr>
    <td align="center">
      <img width="830" alt="Fixed image" src="https://github.com/user-attachments/assets/2f7fac37-eb63-4244-b9de-0dbf6e51de5f" />
    </td>
  </tr>
</table>



---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
