### PR TITLE
refactor: use `isBuiltin` to replace `isNodeBuiltin`

### DIFF
--- a/packages/mocker/src/node/redirect.ts
+++ b/packages/mocker/src/node/redirect.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { builtinModules } from 'node:module'
+import nodeModule from 'node:module'
 import { basename, dirname, extname, join, resolve } from 'pathe'
 
 const { existsSync, readdirSync, statSync } = fs
@@ -55,7 +55,7 @@ export function findMockRedirect(
 }
 
 const builtins = new Set([
-  ...builtinModules,
+  ...nodeModule.builtinModules,
   'assert/strict',
   'diagnostics_channel',
   'dns/promises',
@@ -80,6 +80,10 @@ const prefixedBuiltins = new Set([
 ])
 const NODE_BUILTIN_NAMESPACE = 'node:'
 function isNodeBuiltin(id: string): boolean {
+  // Added in v18.6.0
+  if (nodeModule.isBuiltin) {
+    return nodeModule.isBuiltin(id)
+  }
   if (prefixedBuiltins.has(id)) {
     return true
   }

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Arrayable, Nullable } from './types'
 import { existsSync, promises as fsp } from 'node:fs'
-import { builtinModules } from 'node:module'
+import nodeModule from 'node:module'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, join, resolve } from 'pathe'
 
@@ -87,7 +87,7 @@ const prefixedBuiltins = new Set([
 ])
 
 const builtins = new Set([
-  ...builtinModules,
+  ...nodeModule.builtinModules,
   'assert/strict',
   'diagnostics_channel',
   'dns/promises',
@@ -162,6 +162,10 @@ export function toFilePath(
 
 const NODE_BUILTIN_NAMESPACE = 'node:'
 export function isNodeBuiltin(id: string): boolean {
+  // Added in v18.6.0
+  if (nodeModule.isBuiltin) {
+    return nodeModule.isBuiltin(id)
+  }
   if (prefixedBuiltins.has(id)) {
     return true
   }


### PR DESCRIPTION
### Description
https://nodejs.org/docs/latest-v20.x/api/module.html#moduleisbuiltinmodulename
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
