### PR TITLE
feat(reporter): `--silent=passed-only` to log failed tasks only

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1089,11 +1089,13 @@ Default timeout to wait for close when Vitest shuts down, in milliseconds
 
 ### silent<NonProjectOption />
 
-- **Type:** `boolean`
+- **Type:** `boolean | 'passed-only'`
 - **Default:** `false`
 - **CLI:** `--silent`, `--silent=false`
 
-Silent console output from tests
+Silent console output from tests.
+
+Use `'passed-only'` to see logs from failing tests only. Logs from failing tests are printed after a test has finished.
 
 ### setupFiles
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -73,10 +73,10 @@ Set to true to exit if port is already in use, instead of automatically trying t
 
 ### silent
 
-- **CLI:** `--silent`
+- **CLI:** `--silent [value]`
 - **Config:** [silent](/config/#silent)
 
-Silent console output from tests
+Silent console output from tests. Use `'passed-only'` to see logs from failing tests only.
 
 ### hideSkippedTests
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -152,7 +152,8 @@ export const cliOptionsConfig: VitestCLIOptions = {
     subcommands: apiConfig(defaultPort),
   },
   silent: {
-    description: 'Silent console output from tests',
+    description: 'Silent console output from tests. Use `\'passed-only\'` to see logs from failing tests only.',
+    argument: '[value]',
   },
   hideSkippedTests: {
     description: 'Hide logs for skipped tests',

--- a/packages/vitest/src/node/reporters/default.ts
+++ b/packages/vitest/src/node/reporters/default.ts
@@ -42,6 +42,7 @@ export class DefaultReporter extends BaseReporter {
   }
 
   onTestModuleEnd(module: TestModule): void {
+    super.onTestModuleEnd(module)
     this.summary?.onTestModuleEnd(module)
   }
 
@@ -50,6 +51,7 @@ export class DefaultReporter extends BaseReporter {
   }
 
   onTestCaseResult(test: TestCase): void {
+    super.onTestCaseResult(test)
     this.summary?.onTestCaseResult(test)
   }
 

--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -70,12 +70,16 @@ export class DotReporter extends BaseReporter {
   }
 
   onTestCaseResult(test: TestCase): void {
+    super.onTestCaseResult(test)
+
     this.finishedTests.add(test.id)
     this.tests.set(test.id, test.result().state || 'skipped')
     this.renderer?.schedule()
   }
 
-  onTestModuleEnd(): void {
+  onTestModuleEnd(testModule: TestModule): void {
+    super.onTestModuleEnd(testModule)
+
     if (!this.isTTY) {
       return
     }

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -454,9 +454,11 @@ export interface InlineConfig {
   /**
    * Silent mode
    *
+   * Use `'passed-only'` to see logs from failing tests only.
+   *
    * @default false
    */
-  silent?: boolean
+  silent?: boolean | 'passed-only'
 
   /**
    * Hide logs for skipped tests

--- a/test/reporters/fixtures/console-some-failing.test.ts
+++ b/test/reporters/fixtures/console-some-failing.test.ts
@@ -1,0 +1,37 @@
+import { beforeAll, describe, expect, test } from "vitest"
+
+console.log("Log from failed file")
+
+test("passed test #1", () => {
+  console.log("Log from passed test")
+})
+
+test("failed test #1", () => {
+  console.log("Log from failed test")
+  expect(1).toBe(2)
+})
+
+describe("failed suite #1", () => {
+  beforeAll(() => {
+    console.log("Log from failed suite")
+  })
+
+  test("passed test #2", () => {
+    console.log("Log from passed test")
+  })
+
+  test("failed test #2", () => {
+    console.log("Log from failed test")
+    expect(2).toBe(3)
+  })
+})
+
+describe("passed suite #2", () => {
+  beforeAll(() => {
+    console.log("Log from passed suite")
+  })
+
+  test("passed test #3", () => {
+    console.log("Log from passed test")
+  })
+})

--- a/test/reporters/tests/github-actions.test.ts
+++ b/test/reporters/tests/github-actions.test.ts
@@ -5,8 +5,7 @@ import { runVitest } from '../../test-utils'
 
 test(GithubActionsReporter, async () => {
   let { stdout, stderr } = await runVitest(
-    { reporters: new GithubActionsReporter(), root: './fixtures' },
-    ['some-failing.test.ts'],
+    { reporters: new GithubActionsReporter(), root: './fixtures', include: ['**/some-failing.test.ts'] },
   )
   stdout = stdout.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
   expect(stdout).toMatchInlineSnapshot(`

--- a/test/reporters/tests/json.test.ts
+++ b/test/reporters/tests/json.test.ts
@@ -11,6 +11,7 @@ describe('json reporter', async () => {
     const { stdout } = await runVitest({
       reporters: 'json',
       root,
+      include: ['**/json-fail-import.test.ts', '**/json-fail.test.ts'],
       includeTaskLocation: true,
     }, ['json-fail'])
 
@@ -126,11 +127,11 @@ describe('json reporter', async () => {
   })
 
   it.each([
-    ['passed', 'all-passing-or-skipped'],
-    ['passed', 'all-skipped'],
-    ['failed', 'some-failing'],
+    ['passed', 'all-passing-or-skipped.test.ts'],
+    ['passed', 'all-skipped.test.ts'],
+    ['failed', 'some-failing.test.ts'],
   ])('resolves to "%s" status for test file "%s"', async (expected, file) => {
-    const { stdout } = await runVitest({ reporters: 'json', root }, [file])
+    const { stdout } = await runVitest({ reporters: 'json', root, include: [`**/${file}`] })
 
     const data = JSON.parse(stdout)
 

--- a/test/reporters/tests/silent.test.ts
+++ b/test/reporters/tests/silent.test.ts
@@ -49,7 +49,7 @@ Log from passed test`,
   )
 })
 
-test('{ silent: "silent-passed-tests" } shows all console logs from failed tests only', async () => {
+test('{ silent: "passed-only" } shows all console logs from failed tests only', async () => {
   const { stdout } = await runVitest({
     include: ['./fixtures/console-some-failing.test.ts'],
     silent: 'passed-only',
@@ -72,6 +72,31 @@ Log from failed file`,
 
   expect(stdout).not.toContain('Log from passed')
   expect(stdout.match(/stdout/g)).toHaveLength(4)
+})
+
+test('{ silent: "passed-only" } logs are filtered by custom onConsoleLog', async () => {
+  const { stdout } = await runVitest({
+    include: ['./fixtures/console-some-failing.test.ts'],
+    silent: 'passed-only',
+    onConsoleLog(log) {
+      if (log.includes('suite')) {
+        return true
+      }
+
+      return false
+    },
+    reporters: [new LogReporter()],
+  })
+
+  expect(stdout).toContain(`\
+stdout | fixtures/console-some-failing.test.ts > failed suite #1
+Log from failed suite`,
+  )
+
+  expect(stdout).not.toContain('Log from passed')
+  expect(stdout).not.toContain('Log from failed test')
+  expect(stdout).not.toContain('Log from failed file')
+  expect(stdout.match(/stdout/g)).toHaveLength(1)
 })
 
 class LogReporter extends DefaultReporter {

--- a/test/reporters/tests/silent.test.ts
+++ b/test/reporters/tests/silent.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from 'vitest'
+import { DefaultReporter } from 'vitest/reporters'
+import { runVitest } from '../../test-utils'
+
+test('{ silent: true } hides all console logs', async () => {
+  const { stdout } = await runVitest({
+    include: ['./fixtures/console-some-failing.test.ts'],
+    silent: true,
+    reporters: [new LogReporter()],
+  })
+
+  expect(stdout).not.toContain('stdout')
+  expect(stdout).not.toContain('Log from')
+  expect(stdout).toContain('Test Files  1 failed | 1 passed')
+})
+
+test('default value of silence shows all console logs', async () => {
+  const { stdout } = await runVitest({
+    include: ['./fixtures/console-some-failing.test.ts'],
+    reporters: [new LogReporter()],
+  })
+
+  expect(stdout.match(/stdout/g)).toHaveLength(8)
+
+  expect(stdout).toContain(`\
+stdout | fixtures/console-some-failing.test.ts
+Log from failed file
+
+stdout | fixtures/console-some-failing.test.ts > passed test #1
+Log from passed test
+
+stdout | fixtures/console-some-failing.test.ts > failed test #1
+Log from failed test
+
+stdout | fixtures/console-some-failing.test.ts > failed suite #1
+Log from failed suite
+
+stdout | fixtures/console-some-failing.test.ts > failed suite #1 > passed test #2
+Log from passed test
+
+stdout | fixtures/console-some-failing.test.ts > failed suite #1 > failed test #2
+Log from failed test
+
+stdout | fixtures/console-some-failing.test.ts > passed suite #2
+Log from passed suite
+
+stdout | fixtures/console-some-failing.test.ts > passed suite #2 > passed test #3
+Log from passed test`,
+  )
+})
+
+test('{ silent: "silent-passed-tests" } shows all console logs from failed tests only', async () => {
+  const { stdout } = await runVitest({
+    include: ['./fixtures/console-some-failing.test.ts'],
+    silent: 'passed-only',
+    reporters: [new LogReporter()],
+  })
+
+  expect(stdout).toContain(`\
+stdout | fixtures/console-some-failing.test.ts > failed test #1
+Log from failed test
+
+stdout | fixtures/console-some-failing.test.ts > failed suite #1 > failed test #2
+Log from failed test
+
+stdout | fixtures/console-some-failing.test.ts > failed suite #1
+Log from failed suite
+
+stdout | fixtures/console-some-failing.test.ts
+Log from failed file`,
+  )
+
+  expect(stdout).not.toContain('Log from passed')
+  expect(stdout.match(/stdout/g)).toHaveLength(4)
+})
+
+class LogReporter extends DefaultReporter {
+  isTTY = true
+  onTaskUpdate() {}
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Closes https://github.com/vitest-dev/vitest/issues/6272

<!-- You can also add additional context here -->
Adds `--silent=passed-only` that can be used to print logs from failing tests only.

<img src="https://github.com/user-attachments/assets/673c18cb-7e67-4f99-bbec-3575cbc2506f" width="600" />


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
