### PR TITLE
fix: Race condition in RPC filesystem cache.

### DIFF
--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -65,7 +65,11 @@ export function createMethodsRPC(project: TestProject, options: MethodsOptions =
       }
       promises.set(
         tmp,
-        atomicWriteFile(tmp, code).finally(() => promises.delete(tmp)),
+
+        atomicWriteFile(tmp, code)
+        // Fallback to non-atomic write for windows case where file already exists:
+          .catch(() => writeFile(tmp, code, 'utf-8'))
+          .finally(() => promises.delete(tmp)),
       )
       await promises.get(tmp)
       Object.assign(result, { id: tmp })

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -161,6 +161,6 @@ async function atomicWriteFile(realFilePath: string, data: string): Promise<void
         await unlink(tmpFilePath)
       }
     }
-    catch () {}
+    catch {}
   }
 }

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -151,6 +151,20 @@ function handleRollupError(e: unknown): never {
   throw e
 }
 
+/**
+ * Performs an atomic write operation using the write-then-rename pattern.
+ *
+ * Why we need this:
+ * - Ensures file integrity by never leaving partially written files on disk
+ * - Prevents other processes from reading incomplete data during writes
+ * - Particularly important for test files where incomplete writes could cause test failures
+ *
+ * The implementation writes to a temporary file first, then renames it to the target path.
+ * This rename operation is atomic on most filesystems (including POSIX-compliant ones),
+ * guaranteeing that other processes will only ever see the complete file.
+ *
+ * Added in https://github.com/vitest-dev/vitest/pull/7531
+ */
 async function atomicWriteFile(realFilePath: string, data: string): Promise<void> {
   const dir = dirname(realFilePath)
   const tmpFilePath = join(dir, `.tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`)


### PR DESCRIPTION
### Description

This fixes https://github.com/vitest-dev/vitest/issues/6976. `writeFile` does not atomically write the file, and when the file is read by the other thread, it can (if the timing is _just wrong_), read an empty file. In the most common case, the `/@vite/env` module empty, and defines don't show up. In principle, however, I believe it can happen with any file.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - There is a test case repository (https://github.com/timothympace/vitest-define-bug), which fails on master, and runs for hours and hours with this fix. I don't think it'll be easy to create a test case that causes the error reliably in this repository.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.
  - there are some errors locally that appear to be environment related, not related to my change.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
