### PR TITLE
feat(bench): add hooks in bench mode

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -7,7 +7,7 @@ export {
   onTestFinished,
 } from './hooks'
 export { getFn, getHooks, setFn, setHooks } from './map'
-export { collectTests, startTests, updateTask } from './run'
+export { collectTests, startTests, updateTask, callCleanupHooks, callSuiteHook } from './run'
 export {
   createTaskCollector,
   describe,

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -200,7 +200,7 @@ async function sendTasksUpdate(runner: VitestRunner) {
   }
 }
 
-async function callCleanupHooks(cleanups: unknown[]) {
+export async function callCleanupHooks(cleanups: unknown[]): Promise<void> {
   await Promise.all(
     cleanups.map(async (fn) => {
       if (typeof fn !== 'function') {

--- a/packages/vitest/src/runtime/runners/benchmark.ts
+++ b/packages/vitest/src/runtime/runners/benchmark.ts
@@ -26,10 +26,10 @@ function createBenchmarkResult(name: string): BenchmarkResult {
   } as BenchmarkResult
 }
 
-const benchmarkTasks = new WeakMap<Benchmark, import('tinybench').Task>()
+const benchmarkTasks = new WeakMap<Benchmark, BenchTask>()
 
 async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
-  const { Task, Bench } = await runner.importTinybench()
+  const { Task: BenchTask, Bench: BenchFactory } = await runner.importTinybench()
 
   const start = performance.now()
 
@@ -63,7 +63,7 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
     updateTask('suite-prepare', suite)
 
     const addBenchTaskListener = (
-      task: InstanceType<typeof Task>,
+      task: BenchTask,
       benchmark: Benchmark,
     ) => {
       task.addEventListener(
@@ -103,7 +103,7 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
 
     benchmarkGroup.forEach((benchmark) => {
       const options = getBenchOptions(benchmark)
-      const benchmarkInstance = new Bench(options)
+      const benchmarkInstance = new BenchFactory(options)
 
       const benchmarkFn = getBenchFn(benchmark)
 
@@ -113,7 +113,7 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
         benchmark: createBenchmarkResult(benchmark.name),
       }
 
-      const task = new Task(benchmarkInstance, benchmark.name, benchmarkFn)
+      const task = new BenchTask(benchmarkInstance, benchmark.name, benchmarkFn)
       benchmarkTasks.set(benchmark, task)
       addBenchTaskListener(task, benchmark)
     })
@@ -152,7 +152,7 @@ async function runBenchmarkSuite(suite: Suite, runner: NodeBenchmarkRunner) {
 export class NodeBenchmarkRunner implements VitestRunner {
   private __vitest_executor!: VitestExecutor
 
-  constructor(public config: SerializedConfig) {}
+  constructor(public config: SerializedConfig) { }
 
   async importTinybench(): Promise<typeof import('tinybench')> {
     return await import('tinybench')

--- a/packages/vitest/src/runtime/types/benchmark.ts
+++ b/packages/vitest/src/runtime/types/benchmark.ts
@@ -5,7 +5,6 @@ import type {
   Options as BenchOptions,
   Task as BenchTask,
   TaskResult as BenchTaskResult,
-  TaskResult as TinybenchResult,
 } from 'tinybench'
 
 export interface Benchmark extends Test {
@@ -15,7 +14,7 @@ export interface Benchmark extends Test {
   }
 }
 
-export interface BenchmarkResult extends TinybenchResult {
+export interface BenchmarkResult extends BenchTaskResult {
   name: string
   rank: number
   sampleCount: number

--- a/test/benchmark/fixtures/basic/hooks.bench.ts
+++ b/test/benchmark/fixtures/basic/hooks.bench.ts
@@ -1,0 +1,60 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  bench,
+  describe,
+  expect,
+} from 'vitest'
+
+describe('hooks', () => {
+  let cleanUpCount = 0
+  describe('run', () => {
+    beforeAll(() => {
+      cleanUpCount += 10
+    })
+    beforeEach(() => {
+      cleanUpCount += 1
+    })
+    afterEach(() => {
+      cleanUpCount -= 1
+    })
+    afterAll(() => {
+      cleanUpCount -= 10
+    })
+
+    bench('one', () => {
+      expect(cleanUpCount).toBe(11)
+    })
+    bench('two', () => {
+      expect(cleanUpCount).toBe(11)
+    })
+  })
+  bench('end', () => {
+    expect(cleanUpCount).toBe(0)
+  })
+})
+
+describe('hooks-cleanup', () => {
+  let cleanUpCount = 0
+  beforeAll(() => {
+    cleanUpCount += 10
+    return () => {
+      cleanUpCount -= 10
+    }
+  })
+  beforeEach(() => {
+    cleanUpCount += 1
+    return () => {
+      cleanUpCount -= 1
+    }
+  })
+
+  bench('one', () => {
+    expect(cleanUpCount).toBe(11)
+  })
+  bench('two', () => {
+    expect(cleanUpCount).toBe(11)
+  })
+})

--- a/test/benchmark/test/basic.test.ts
+++ b/test/benchmark/test/basic.test.ts
@@ -43,6 +43,28 @@ it('basic', { timeout: 60_000 }, async () => {
           ],
         ],
       ],
+      [
+        [
+          "hooks.bench.ts > hooks",
+          [
+            "end",
+          ],
+        ],
+        [
+          "hooks.bench.ts > hooks > run",
+          [
+            "one",
+            "two",
+          ],
+        ],
+        [
+          "hooks.bench.ts > hooks-cleanup",
+          [
+            "one",
+            "two",
+          ],
+        ],
+      ],
       [],
       [
         [


### PR DESCRIPTION
### Description

1. This PR allows hooks to be used when running `vitest bench`.
2. This is essentially an updated fork of #5076.
3. Closes #5075.
4. Creating this as we'd like to use hooks in benchmarks in https://github.com/ariakit/ariakit/pull/4415

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
