### PR TITLE
test: re-enable skipped test for Vite 6

### DIFF
--- a/test/cli/test/__snapshots__/stacktraces.test.ts.snap
+++ b/test/cli/test/__snapshots__/stacktraces.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`stacktrace filtering > filters stacktraces > stacktrace-filtering 1`] = `
+exports[`stacktrace filtering > filters stacktraces 1`] = `
 "
 ⎯⎯ Failed Tests 1 ⎯⎯
 
@@ -45,27 +45,27 @@ Error: Something truly horrible has happened!
 "
 `;
 
-exports[`stacktrace should print error frame source file correctly > error-in-deps > error-in-deps 1`] = `
+exports[`stacktrace should print error frame source file correctly > error-in-deps 1`] = `
 "
 ⎯⎯ Failed Tests 1 ⎯⎯
 
  FAIL  error-in-deps.test.js > error in deps
 ReferenceError: bar is not defined
- ❯ Module.add foo.js:3:3
+ ❯ add foo.js:3:3
       1| export function add() {
       2|   // eslint-disable-next-line no-undef
       3|   return bar()
        |   ^
       4| }
       5| 
- ❯ error-in-deps.test.js:5:3
+ ❯ error-in-deps.test.js:5:6
 
 ⎯⎯[1/1]⎯
 
 "
 `;
 
-exports[`stacktraces should pick error frame if present > frame.spec.imba > frame.spec.imba 1`] = `
+exports[`stacktraces should pick error frame if present > frame.spec.imba 1`] = `
 " FAIL  frame.spec.imba [ frame.spec.imba ]
 imba-parser error: Unexpected 'CALL_END'
 4 | test("1+1") do
@@ -76,7 +76,7 @@ imba-parser error: Unexpected 'CALL_END'
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > add.test.ts > add.test.ts 1`] = `
+exports[`stacktraces should respect sourcemaps > add.test.ts 1`] = `
 " ❯ add.test.ts:12:24
      10| 
      11| it('add', () => {
@@ -87,7 +87,7 @@ exports[`stacktraces should respect sourcemaps > add.test.ts > add.test.ts 1`] =
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > add-in-imba.test.imba > add-in-imba.test.imba 1`] = `
+exports[`stacktraces should respect sourcemaps > add-in-imba.test.imba 1`] = `
 " ❯ add-in-imba.test.imba:8:17
       6| it "add", do
       7|  expect(add()).toBe 0
@@ -98,7 +98,7 @@ exports[`stacktraces should respect sourcemaps > add-in-imba.test.imba > add-in-
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > add-in-js.test.js > add-in-js.test.js 1`] = `
+exports[`stacktraces should respect sourcemaps > add-in-js.test.js 1`] = `
 " ❯ add-in-js.test.js:6:17
       4| 
       5| it('add', () => {
@@ -109,15 +109,15 @@ exports[`stacktraces should respect sourcemaps > add-in-js.test.js > add-in-js.t
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > error-in-deps.test.js > error-in-deps.test.js 1`] = `
-" ❯ error-in-deps.test.js:5:3
+exports[`stacktraces should respect sourcemaps > error-in-deps.test.js 1`] = `
+" ❯ error-in-deps.test.js:5:6
 
 ⎯⎯[1/1]⎯
 
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > error-with-stack.test.js > error-with-stack.test.js 1`] = `
+exports[`stacktraces should respect sourcemaps > error-with-stack.test.js 1`] = `
 " ❯ d error-with-stack.test.js:20:9
      18| 
      19| function d() {
@@ -128,7 +128,7 @@ exports[`stacktraces should respect sourcemaps > error-with-stack.test.js > erro
  ❯ c error-with-stack.test.js:16:3"
 `;
 
-exports[`stacktraces should respect sourcemaps > mocked-global.test.js > mocked-global.test.js 1`] = `
+exports[`stacktraces should respect sourcemaps > mocked-global.test.js 1`] = `
 " ❯ mocked-global.test.js:6:13
       4| 
       5| test('failed', () => {
@@ -139,7 +139,7 @@ exports[`stacktraces should respect sourcemaps > mocked-global.test.js > mocked-
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > mocked-imported.test.js > mocked-imported.test.js 1`] = `
+exports[`stacktraces should respect sourcemaps > mocked-imported.test.js 1`] = `
 " ❯ mocked-imported.test.js:6:13
       4| 
       5| test('failed', () => {
@@ -150,7 +150,7 @@ exports[`stacktraces should respect sourcemaps > mocked-imported.test.js > mocke
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > mocked-imported.test.ts > mocked-imported.test.ts 1`] = `
+exports[`stacktraces should respect sourcemaps > mocked-imported.test.ts 1`] = `
 " ❯ mocked-imported.test.ts:6:13
       4| 
       5| test('failed', () => {
@@ -161,18 +161,18 @@ exports[`stacktraces should respect sourcemaps > mocked-imported.test.ts > mocke
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > require-assertions.test.js > require-assertions.test.js 1`] = `
-" ❯ require-assertions.test.js:3:1
+exports[`stacktraces should respect sourcemaps > require-assertions.test.js 1`] = `
+" ❯ require-assertions.test.js:3:5
       1| import { test } from 'vitest'
       2| 
       3| test('assertion is not called', () => {
-       | ^
+       |     ^
       4|   // no expect
       5| })
 "
 `;
 
-exports[`stacktraces should respect sourcemaps > reset-modules.test.ts > reset-modules.test.ts 1`] = `
+exports[`stacktraces should respect sourcemaps > reset-modules.test.ts 1`] = `
 " ❯ reset-modules.test.ts:16:26
      14|     expect(2 + 1).eq(3)
      15|     assert.equal(Math.sqrt(4), 2)

--- a/test/cli/test/stacktraces.test.ts
+++ b/test/cli/test/stacktraces.test.ts
@@ -1,12 +1,9 @@
 import { resolve } from 'pathe'
 import { glob } from 'tinyglobby'
-import { version as viteVersion } from 'vite'
-import { describe, expect, it as vitestIt } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { runVitest } from '../../test-utils'
 
 const [major] = process.version.slice(1).split('.').map(num => Number(num))
-
-const it = viteVersion[0] >= '6' ? (vitestIt.skip as typeof vitestIt) : vitestIt
 
 // To prevent the warning coming up in snapshots
 process.setMaxListeners(20)
@@ -23,7 +20,7 @@ describe('stacktraces should respect sourcemaps', async () => {
       const lines = String(stderr).split(/\n/g)
       const index = lines.findIndex(val => val.includes(`${file}:`))
       const msg = lines.slice(index, index + 8).join('\n')
-      expect(removeLines(msg)).toMatchSnapshot(file)
+      expect(removeLines(msg)).toMatchSnapshot()
     })
   }
 })
@@ -40,7 +37,7 @@ describe('stacktraces should pick error frame if present', async () => {
       const lines = String(stderr).split(/\n/g)
       const index = lines.findIndex(val => val.includes('FAIL'))
       const msg = lines.slice(index, index + 8).join('\n')
-      expect(msg).toMatchSnapshot(file)
+      expect(msg).toMatchSnapshot()
     })
   }
 })
@@ -53,7 +50,7 @@ describe('stacktrace should print error frame source file correctly', async () =
     const { stderr } = await runVitest({ root }, [testFile])
 
     // expect to print framestack of foo.js
-    expect(removeLines(stderr)).toMatchSnapshot('error-in-deps')
+    expect(removeLines(stderr)).toMatchSnapshot()
   })
 })
 
@@ -67,7 +64,7 @@ describe('stacktrace filtering', async () => {
       onStackTrace: (_error, { method }) => method !== 'b',
     }, [testFile])
 
-    expect(removeLines(stderr)).toMatchSnapshot('stacktrace-filtering')
+    expect(removeLines(stderr)).toMatchSnapshot()
   })
 })
 


### PR DESCRIPTION
### Description

I just noticed I forgot to re-enable these skipped tests. I also replaced `toMatchSnapshot(file)` with `toMatchSnapshot()` since the former cannot track obsolete snapshots.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
