### PR TITLE
fix: remove vestigial spy stub, import directly from `@vitest/spy`

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -1,19 +1,19 @@
 import type { FakeTimerInstallOpts } from '@sinonjs/fake-timers'
-import type { RuntimeOptions, SerializedConfig } from '../runtime/config'
-import type { VitestMocker } from '../runtime/mocker'
-import type { MockFactoryWithHelper, MockOptions } from '../types/mocker'
 import type {
   MaybeMocked,
   MaybeMockedDeep,
   MaybePartiallyMocked,
   MaybePartiallyMockedDeep,
   MockInstance,
-} from './spy'
+} from '@vitest/spy'
+import type { RuntimeOptions, SerializedConfig } from '../runtime/config'
+import type { VitestMocker } from '../runtime/mocker'
+import type { MockFactoryWithHelper, MockOptions } from '../types/mocker'
+import { fn, isMockFunction, mocks, spyOn } from '@vitest/spy'
 import { assertTypes, createSimpleStackTrace } from '@vitest/utils'
 import { getWorkerState, isChildProcess, resetModules, waitForImportsToResolve } from '../runtime/utils'
 import { parseSingleStack } from '../utils/source-map'
 import { FakeTimers } from './mock/timers'
-import { fn, isMockFunction, mocks, spyOn } from './spy'
 import { waitFor, waitUntil } from './wait'
 
 type ESModuleExports = Record<string, unknown>

--- a/packages/vitest/src/public/browser.ts
+++ b/packages/vitest/src/public/browser.ts
@@ -4,10 +4,11 @@ export {
   stopCoverageInsideWorker,
   takeCoverageInsideWorker,
 } from '../integrations/coverage'
-export * as SpyModule from '../integrations/spy'
+
 export {
   loadDiffConfig,
   loadSnapshotSerializers,
   setupCommonEnv,
 } from '../runtime/setup-common'
 export { collectTests, processError, startTests } from '@vitest/runner'
+export * as SpyModule from '@vitest/spy'

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -109,15 +109,6 @@ export { assert, chai, createExpect, expect, should } from '../integrations/chai
 export { inject } from '../integrations/inject'
 export { isFirstRun, runOnce } from '../integrations/run-once'
 
-export type {
-  Mock,
-  MockContext,
-  Mocked,
-  MockedClass,
-  MockedFunction,
-  MockedObject,
-  MockInstance,
-} from '../integrations/spy'
 export { getRunningMode, isWatchMode } from '../integrations/utils'
 export { vi, vitest } from '../integrations/vi'
 export type { VitestUtils } from '../integrations/vi'
@@ -318,6 +309,16 @@ export type {
   SnapshotUpdateState,
   UncheckedSnapshot,
 } from '@vitest/snapshot'
+
+export type {
+  Mock,
+  MockContext,
+  Mocked,
+  MockedClass,
+  MockedFunction,
+  MockedObject,
+  MockInstance,
+} from '@vitest/spy'
 
 /** @deprecated import from `vitest/node` instead */
 export type BrowserScript = BrowserScript_


### PR DESCRIPTION
### Description

- Fixes #7571

The `integration/spy.ts` file has been vestigial since #2575. It seems to be confusing `rollup-dts-plugin`. Rather than bang our heads against a wall fixing that, remove it and just import/export from `@vitest/spy` directly where referenced.

This appears to fix the output `.d.ts` files.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
