### PR TITLE
chore(deps): bump expect-type to ^1.2.0

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -163,7 +163,7 @@
     "@vitest/utils": "workspace:*",
     "chai": "^5.2.0",
     "debug": "^4.4.0",
-    "expect-type": "^1.1.0",
+    "expect-type": "^1.2.0",
     "magic-string": "^0.30.17",
     "pathe": "^2.0.3",
     "std-env": "^3.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,8 +881,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       expect-type:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       magic-string:
         specifier: ^0.30.17
         version: 0.30.17
@@ -5584,8 +5584,8 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
-  expect-type@1.1.0:
-    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+  expect-type@1.2.0:
+    resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
     engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
@@ -14204,7 +14204,7 @@ snapshots:
 
   expand-template@2.0.3: {}
 
-  expect-type@1.1.0: {}
+  expect-type@1.2.0: {}
 
   expect@29.7.0:
     dependencies:

--- a/test/config/test/config-types.test-d.ts
+++ b/test/config/test/config-types.test-d.ts
@@ -27,7 +27,7 @@ describe('merge config helper', () => {
     expectTypeOf(mergeConfig(
       defineConfig({}),
       defineProject({ test: { name: 'test' } }),
-    )).toMatchTypeOf<Record<string, unknown>>()
+    )).toExtend<Record<string, unknown>>()
   })
 })
 
@@ -77,7 +77,7 @@ describe('define workspace helper', () => {
   })
 
   test('return type matches parameters', () => {
-    expectTypeOf(defineWorkspace).returns.toMatchTypeOf<DefineWorkspaceParameter>()
+    expectTypeOf(defineWorkspace).returns.toExtend<DefineWorkspaceParameter>()
 
     expectTypeOf(defineWorkspace([
       './path/to/project',
@@ -101,6 +101,6 @@ describe('define workspace helper', () => {
           coverage: {},
         },
       },
-    ])).items.toMatchTypeOf<DefineWorkspaceParameter[number]>()
+    ])).items.toExtend<DefineWorkspaceParameter[number]>()
   })
 })


### PR DESCRIPTION
### Description

Just getting ahead of renovate-bot and bumping expect-type because there are some downstream projects I'd like to get the new features in.

New features in expect-type:

- `.map` fn: https://github.com/mmkal/expect-type/pull/98
- `.toMatchObjectType` and `.toExtend`: https://github.com/mmkal/expect-type/pull/126 - this deprecates `.toMatchTypeOf` (no plans to remove it any time soon though). I also updated the two usages of the deprecated method.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- ~[ ]~ [no issue, it's just a dependency update so hopefully fine?] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- ~[ ]~ [updated a test, but didn't see a need for a new one] Ideally, include a test that fails without this PR but passes with it.
- ~[ ]~ [lockfile was updated, because it's a deps bump] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`. [some failures on my machine, but I think unrelated]

### Documentation
- ~[ ]~ If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
