### PR TITLE
fix: fix `vi.importMock` to work as `vi.importActual` + automocking

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -603,8 +603,11 @@ function createVitest(): VitestUtils {
     },
 
     async importMock<T>(path: string): Promise<MaybeMockedDeep<T>> {
-      // return _mocker().importMock(path, getImporter('importMock'))
-      const mod = await utils.importActual(path)
+      const mod = await _mocker().importActual<any>(
+        path,
+        getImporter('importMock'),
+        _mocker().getMockContext().callstack,
+      )
       return _mocker().mockObject(mod, {}, 'automock') as any
     },
 

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -603,7 +603,9 @@ function createVitest(): VitestUtils {
     },
 
     async importMock<T>(path: string): Promise<MaybeMockedDeep<T>> {
-      return _mocker().importMock(path, getImporter('importMock'))
+      // return _mocker().importMock(path, getImporter('importMock'))
+      const mod = await utils.importActual(path)
+      return _mocker().mockObject(mod, {}, 'automock') as any
     },
 
     // this is typed in the interface so it's not necessary to type it here


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/5482

From the description of documentation, it sounds like `vi.importMock` should work like this and thus it's mostly an async version of `jest.createMockFromModule`. Apparently this change breaks some test though.

_todo_

- compare with `jest.createMockFromModule`
  - I just noticed they actually have `jest.requireMock` https://jestjs.io/docs/29.6/jest-object#jestrequiremockmodulename. I guess we can just keep `vi.importMock` and add `vi.createMockFromModule` separately.
- test

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
