### PR TITLE
Fix wrong reference version.

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -133,7 +133,7 @@ export default defineConfig({
 })
 ```
 
-The `<reference types="vitest" />` will stop working in Vitest 4, but you can start migrating to `vitest/config` in Vitest 2.1:
+The `<reference types="vitest" />` will stop working in the next major update, but you can start migrating to `vitest/config` in Vitest 2.1:
 
 ```ts [vite.config.ts]
 /// <reference types="vitest/config" />

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -133,7 +133,7 @@ export default defineConfig({
 })
 ```
 
-The `<reference types="vitest" />` will stop working in Vitest 3, but you can start migrating to `vitest/config` in Vitest 2.1:
+The `<reference types="vitest" />` will stop working in Vitest 4, but you can start migrating to `vitest/config` in Vitest 2.1:
 
 ```ts [vite.config.ts]
 /// <reference types="vitest/config" />


### PR DESCRIPTION
According to this page it is first in Vitest 4:
https://vitest.dev/config/#configuring-vitest

