### PR TITLE
chore: remove hijackVitePluginInject

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -21,7 +21,6 @@ import { SsrReplacerPlugin } from './ssrReplacer'
 import {
   deleteDefineConfig,
   getDefaultResolveOptions,
-  hijackVitePluginInject,
   resolveFsAllow,
 } from './utils'
 import { VitestCoreResolver } from './vitestResolver'
@@ -78,6 +77,10 @@ export async function VitestPlugin(
 
         const config: ViteConfig = {
           root: viteConfig.test?.root || options.root,
+          define: {
+            // disable replacing `process.env.NODE_ENV` with static string by vite:client-inject
+            'process.env.NODE_ENV': 'process.env.NODE_ENV',
+          },
           esbuild:
             viteConfig.esbuild === false
               ? false
@@ -247,8 +250,6 @@ export async function VitestPlugin(
         if (!options.watch) {
           viteConfig.server.watch = null
         }
-
-        hijackVitePluginInject(viteConfig)
 
         Object.defineProperty(viteConfig, '_vitest', {
           value: options,

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,6 +1,5 @@
 import type {
   DepOptimizationOptions,
-  ResolvedConfig,
   UserConfig as ViteConfig,
 } from 'vite'
 import type { DepsOptimizationOptions, InlineConfig } from '../types/config'
@@ -120,19 +119,6 @@ export function deleteDefineConfig(viteConfig: ViteConfig): Record<string, any> 
     }
   }
   return defines
-}
-
-export function hijackVitePluginInject(viteConfig: ResolvedConfig): void {
-  // disable replacing `process.env.NODE_ENV` with static string
-  const processEnvPlugin = viteConfig.plugins.find(
-    p => p.name === 'vite:client-inject',
-  )
-  if (processEnvPlugin) {
-    const originalTransform = processEnvPlugin.transform as any
-    processEnvPlugin.transform = function transform(code, id, options) {
-      return originalTransform.call(this, code, id, { ...options, ssr: true })
-    }
-  }
 }
 
 export function resolveFsAllow(

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -17,7 +17,6 @@ import { SsrReplacerPlugin } from './ssrReplacer'
 import {
   deleteDefineConfig,
   getDefaultResolveOptions,
-  hijackVitePluginInject,
   resolveFsAllow,
 } from './utils'
 import { VitestProjectResolver } from './vitestResolver'
@@ -96,6 +95,10 @@ export function WorkspaceVitestPlugin(
         const resolveOptions = getDefaultResolveOptions()
         const config: ViteConfig = {
           root,
+          define: {
+            // disable replacing `process.env.NODE_ENV` with static string by vite:client-inject
+            'process.env.NODE_ENV': 'process.env.NODE_ENV',
+          },
           resolve: {
             ...resolveOptions,
             alias: testConfig.alias,
@@ -171,9 +174,6 @@ export function WorkspaceVitestPlugin(
         config.customLogger = silenceImportViteIgnoreWarning(config.customLogger)
 
         return config
-      },
-      configResolved(viteConfig) {
-        hijackVitePluginInject(viteConfig)
       },
       async configureServer(server) {
         const options = deepMerge({}, configDefaults, server.config.test || {})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Removed `hijackVitePluginInject` so that Vite can remove this compat code in the next major.
https://github.com/vitejs/vite/blob/42ff9b3562d495337036365aba7575f52c4c0209/packages/vite/src/node/plugins/clientInjections.ts#L98-L99
Instead I added `define: { 'process.env.NODE_ENV': 'process.env.NODE_ENV' }`.
Disabling the `process.env.NODE_ENV` replacement with `define: { 'process.env.NODE_ENV': 'process.env.NODE_ENV' }` is supported by Vite 3.0.0+ (https://github.com/vitejs/vite/commit/ec52baa17ef2cf35d8133ddec2a7f6970be6c913).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
