### PR TITLE
docs: fix shiki twoslash build error

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -103,6 +103,7 @@ export default ({ mode }: { mode: string }) => {
               },
             }),
           ],
+      languages: ['js', 'jsx', 'ts', 'tsx'],
     },
     themeConfig: {
       logo: '/logo.svg',


### PR DESCRIPTION
### Description

Netlify build is failing 
- https://github.com/vitest-dev/vitest/pull/7609/checks?check_run_id=38344680615
- https://app.netlify.com/sites/vitest-dev/deploys/67ca2d036c11e50008038553

<details>

```
8:19:24 AM:   vitepress v2.0.0-alpha.3
8:19:24 AM: - building client + server bundles...
8:19:28 AM: ✗ Build failed in 3.54s
8:19:28 AM: ✗ building client + server bundles...
8:19:30 AM: Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
8:19:30 AM: build error:
8:19:30 AM: [vite-plugin-pwa:build] Language `js` not found, you may need to load it first
8:19:30 AM: file: /opt/build/repo/docs/advanced/reporters.md
8:19:30 AM: [vite-plugin-pwa:build] Language `js` not found, you may need to load it first
8:19:30 AM: file: /opt/build/repo/docs/advanced/reporters.md
8:19:30 AM:     at Object.getLanguage (file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:1723:13)
8:19:30 AM:     at codeToTokensBase (file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:802:29)
8:19:30 AM:     at file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:1008:21
8:19:30 AM:     at Array.map (<anonymous>)
8:19:30 AM:     at codeToTokensWithThemes (file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:1007:31)
8:19:30 AM:     at codeToTokens (file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:1102:25)
8:19:30 AM:     at codeToHast (file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:1161:7)
8:19:30 AM:     at Object.codeToHast (file:///opt/build/repo/node_modules/.pnpm/@shikijs+core@3.0.0/node_modules/@shikijs/core/dist/index.mjs:1384:38)
8:19:30 AM:     at code (file:///opt/build/repo/node_modules/.pnpm/@shikijs+vitepress-twoslash@3.0.0_typescript@5.7.3/node_modules/@shikijs/vitepress-twoslash/dist/index.mjs:120:30)
8:19:30 AM:     at Object.one (file:///opt/build/repo/node_modules/.pnpm/mdast-util-to-hast@13.2.0/node_modules/mdast-util-to-hast/lib/state.js:254:14)
```

</details>

Maybe something changed on shiki twoslash. I followed the doc here https://shiki.style/packages/vitepress#twoslash to add `languages` explicitly.

Now there is a huge wall of prerendering error/warning https://app.netlify.com/sites/vitest-dev/deploys/67ca30e3b34e700008668a6a, but not sure if that's something needs fix. Preview site seems fine.

```
8:36:11 AM: - rendering pages...
8:36:11 AM: TypeError: Cannot destructure property 'popperId' of 'undefined' as it is undefined.
8:36:11 AM:     at file:///opt/build/repo/node_modules/.pnpm/floating-vue@5.2.2_vue@3.5.13_typescript@5.7.3_/node_modules/floating-vue/dist/floating-vue.mjs:1241:17
...
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
