### PR TITLE
fix: cleanup vitest in public `resolveConfig` API

### DIFF
--- a/packages/vitest/src/node/plugins/publicConfig.ts
+++ b/packages/vitest/src/node/plugins/publicConfig.ts
@@ -49,6 +49,7 @@ export async function resolveConfig(
     updatedOptions,
     config,
   )
+  await vitest.close()
   return {
     viteConfig: config,
     vitestConfig,

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -4,9 +4,9 @@ import { expect, onTestFinished, test } from 'vitest'
 import { createVitest } from 'vitest/node'
 
 async function vitest(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}, vitestOptions: VitestOptions = {}) {
-  const result = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
-  onTestFinished(() => result.close())
-  return result
+  const vitest = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
+  onTestFinished(() => vitest.close())
+  return vitest
 }
 
 test('assignes names as browsers', async () => {

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -1,10 +1,12 @@
 import type { ViteUserConfig } from 'vitest/config'
 import type { UserConfig, VitestOptions } from 'vitest/node'
-import { expect, test } from 'vitest'
+import { expect, onTestFinished, test } from 'vitest'
 import { createVitest } from 'vitest/node'
 
 async function vitest(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}, vitestOptions: VitestOptions = {}) {
-  return await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
+  const result = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
+  onTestFinished(() => result.close())
+  return result
 }
 
 test('assignes names as browsers', async () => {

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -1,6 +1,6 @@
 import type { UserConfig as ViteUserConfig } from 'vite'
 import type { UserConfig } from 'vitest/node'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, onTestFinished } from 'vitest'
 import { extraInlineDeps } from 'vitest/config'
 import { createVitest, parseCLI } from 'vitest/node'
 
@@ -8,6 +8,7 @@ type VitestOptions = Parameters<typeof createVitest>[3]
 
 async function vitest(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}, vitestOptions: VitestOptions = {}) {
   const vitest = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
+  onTestFinished(() => vitest.close())
   return vitest
 }
 

--- a/test/config/vitest.config.ts
+++ b/test/config/vitest.config.ts
@@ -7,14 +7,15 @@ export default defineConfig({
     reporters: ['verbose'],
     testTimeout: 60_000,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-      threads: {
-        singleThread: true,
-      },
-    },
+    fileParallelism: false,
+    // poolOptions: {
+    //   forks: {
+    //     singleFork: true,
+    //   },
+    //   threads: {
+    //     singleThread: true,
+    //   },
+    // },
     chaiConfig: {
       truncateThreshold: 999,
     },

--- a/test/config/vitest.config.ts
+++ b/test/config/vitest.config.ts
@@ -7,15 +7,14 @@ export default defineConfig({
     reporters: ['verbose'],
     testTimeout: 60_000,
     pool: 'forks',
-    fileParallelism: false,
-    // poolOptions: {
-    //   forks: {
-    //     singleFork: true,
-    //   },
-    //   threads: {
-    //     singleThread: true,
-    //   },
-    // },
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+      threads: {
+        singleThread: true,
+      },
+    },
     chaiConfig: {
       truncateThreshold: 999,
     },


### PR DESCRIPTION
### Description

Currently we get a huge wall of logs like this https://github.com/vitest-dev/vitest/actions/runs/13711813132/job/38349623334?pr=7621#step:8:458

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: intentional unhandled rejection
 ❯ fixtures/unhandled-rejections/setup-unhandled-rejections.ts:2:42
 ❯ Object.setup fixtures/unhandled-rejections/setup-unhandled-rejections.ts:2:8
 ❯ TestProject._initializeGlobalSetup ../../packages/vitest/dist/chunks/cli-api.DIBEqC3b.js:10464:53
 ❯ Vitest.initializeGlobalSetup ../../packages/vitest/dist/chunks/cli-api.DIBEqC3b.js:12943:7
 ❯ ../../packages/vitest/dist/chunks/cli-api.DIBEqC3b.js:12854:9
 ❯ Vitest.runFiles ../../packages/vitest/dist/chunks/cli-api.DIBEqC3b.js:12883:12
 ❯ Vitest.start ../../packages/vitest/dist/chunks/cli-api.DIBEqC3b.js:12764:21
 ❯ startVitest ../../packages/vitest/dist/chunks/cli-api.DIBEqC3b.js:13910:7
 ❯ runVitest ../test-utils/index.ts:76:11
```

Some are due to test not doing proper cleanup. Also public `resolveConfig` API had hanging `new Vitest`, so I made it close properly.

I fixed all except these two https://github.com/vitest-dev/vitest/actions/runs/13712690144/job/38352041269?pr=7623#step:8:457, which can be reproduce by 

```
pnpm -C test/config test run /unhandled /override
...
  Error: intentional unhandled rejection
  Error: intentional unhandled rejection
```

Probably this is due to error handler not cleaned up when resolve config is throwing. It should be fixed, but I guess we can deal with this later.

https://github.com/vitest-dev/vitest/blob/cad3d75afa7156dc3842ded7a4e43f275f028076/test/config/test/override.test.ts#L304-L306

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
