### PR TITLE
fix: fix `toHaveBeenCalledWith(asymmetricMatcher)` with `undefined` arguments

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -630,7 +630,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const callCount = spy.mock.calls.length
       const isCalled = times <= callCount
       this.assert(
-        isCalled && equalsArgumentArray(nthCall, args),
+        nthCall && equalsArgumentArray(nthCall, args),
         `expected ${ordinalOf(
           times,
         )} "${spyName}" call to have been called with #{exp}${
@@ -653,7 +653,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const lastCall = spy.mock.calls[spy.mock.calls.length - 1]
 
       this.assert(
-        equalsArgumentArray(lastCall, args),
+        lastCall && equalsArgumentArray(lastCall, args),
         `expected last "${spyName}" call to have been called with #{exp}`,
         `expected last "${spyName}" call to not have been called with #{exp}`,
         args,

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -715,6 +715,26 @@ describe('toHaveBeenCalled', () => {
       }).toThrow(/^expected "spy" to not be called at all[^e]/)
     })
   })
+
+  it('undefined argument', () => {
+    const fn = vi.fn()
+    fn(undefined)
+    expect(fn).not.toHaveBeenCalledWith()
+    expect(fn).toHaveBeenCalledWith(undefined)
+    expect(fn).toHaveBeenCalledWith(expect.toSatisfy(() => true))
+    expect(fn).toHaveBeenCalledWith(expect.not.toSatisfy(() => false))
+    expect(fn).toHaveBeenCalledWith(expect.toBeOneOf([undefined, null]))
+  })
+
+  it('no argument', () => {
+    const fn = vi.fn()
+    fn()
+    expect(fn).toHaveBeenCalledWith()
+    expect(fn).not.toHaveBeenCalledWith(undefined)
+    expect(fn).not.toHaveBeenCalledWith(expect.toSatisfy(() => true))
+    expect(fn).not.toHaveBeenCalledWith(expect.not.toSatisfy(() => false))
+    expect(fn).not.toHaveBeenCalledWith(expect.toBeOneOf([undefined, null]))
+  })
 })
 
 describe('toHaveBeenCalledWith', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -735,6 +735,12 @@ describe('toHaveBeenCalled', () => {
     expect(fn).not.toHaveBeenCalledWith(expect.not.toSatisfy(() => false))
     expect(fn).not.toHaveBeenCalledWith(expect.toBeOneOf([undefined, null]))
   })
+
+  it('no strict equal check for each argument', () => {
+    const fn = vi.fn()
+    fn({ x: undefined, z: 123 })
+    expect(fn).toHaveBeenCalledWith({ y: undefined, z: 123 })
+  })
 })
 
 describe('toHaveBeenCalledWith', () => {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7573#issuecomment-2705573743


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
