### PR TITLE
Revert "fix(browser): remove @testing-library/dom from dependencies #7555)"

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -88,6 +88,7 @@
     }
   },
   "dependencies": {
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitest/mocker": "workspace:*",
     "@vitest/utils": "workspace:*",

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -242,6 +242,7 @@ export default (parentServer: ParentBrowserProject, base = '/'): Plugin[] => {
           'vitest > chai > loupe',
           'vitest > @vitest/utils > loupe',
           '@vitest/browser > @testing-library/user-event',
+          '@vitest/browser > @testing-library/dom',
         ]
 
         const fileRoot = browserTestFiles[0] ? dirname(browserTestFiles[0]) : project.config.root

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
 
   packages/browser:
     dependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.0
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)


### PR DESCRIPTION
This reverts commit 5387a5b3bfc62048dd5210bd65f894b43367563a.

It is actually used by `user-event`. Removing it from dependencies breaks certain package managers like Yarn PnP even if preview provider is not used.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
