### PR TITLE
fix(web-worker): ensure `removeEventListener` is bound to worker

### DIFF
--- a/packages/web-worker/src/shared-worker.ts
+++ b/packages/web-worker/src/shared-worker.ts
@@ -97,7 +97,9 @@ export function createSharedWorkerConstructor(): typeof SharedWorker {
         addEventListener: (...args: any[]) => {
           return this._vw_workerTarget.addEventListener(...args as [any, any])
         },
-        removeEventListener: this._vw_workerTarget.removeEventListener,
+        removeEventListener: (...args: any[]) => {
+          return this._vw_workerTarget.removeEventListener(...args as [any, any])
+        },
         get self() {
           return selfProxy
         },

--- a/packages/web-worker/src/worker.ts
+++ b/packages/web-worker/src/worker.ts
@@ -75,7 +75,9 @@ export function createWorkerConstructor(
           }
           return this._vw_workerTarget.addEventListener(...args as [any, any])
         },
-        removeEventListener: this._vw_workerTarget.removeEventListener,
+        removeEventListener: (...args: any[]) => {
+          return this._vw_workerTarget.removeEventListener(...args as [any, any])
+        },
         postMessage: (...args: any[]) => {
           if (!args.length) {
             throw new SyntaxError(

--- a/test/core/src/web-worker/eventListenerWorker.ts
+++ b/test/core/src/web-worker/eventListenerWorker.ts
@@ -1,3 +1,6 @@
-self.addEventListener('message', (e) => {
+function callback(e: MessageEvent) {
   self.postMessage(`${e.data} world`)
-})
+  self.removeEventListener('message', callback)
+}
+
+self.addEventListener('message', callback)


### PR DESCRIPTION
### Description
In jsdom + vitest web-workers, I get issues when calling `removeEventListener` from `self`.

`'removeEventListener' called on an object that is not a valid instance of EventTarget`

I tracked this down to the inserted `context` that web-worker inserts. This PR fixes it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

![Screenshot From 2025-03-07 11-40-31](https://github.com/user-attachments/assets/d880169b-3f49-4b39-b7c8-5a1b8d2a684c)

^ Test that fails before my patch

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
