### PR TITLE
docs: add mockClear/mockReset/mockRestore examples

### DIFF
--- a/docs/api/mock.md
+++ b/docs/api/mock.md
@@ -54,17 +54,17 @@ Clears all information about every call. After calling it, all properties on `.m
 
 ```ts
 const person = {
-  greet: (name: string) => `hello ${name}`,
+  greet: (name: string) => `Hello ${name}`,
 }
-const spy = vi.spyOn(obj, 'greet').mockImplementation(() => 'mocked')
-person.greet('alice') // => 'mocked'
-spy.mock.calls // => [['alice']]
+const spy = vi.spyOn(person, 'greet').mockImplementation(() => 'mocked')
+expect(person.greet('Alice')).toBe('mocked')
+expect(spy.mock.calls).toEqual([['Alice']])
 
 // clear call history but keep mock implementation
 spy.mockClear()
-spy.mock.calls // => []
-person.greet('bob') // => 'mocked'
-spy.mock.calls // => [['bob']]
+expect(spy.mock.calls).toEqual([])
+expect(person.greet('Bob')).toBe('mocked')
+expect(spy.mock.calls).toEqual([['Bob']])
 ```
 
 To automatically call this method before each test, enable the [`clearMocks`](/config/#clearmocks) setting in the configuration.
@@ -222,17 +222,18 @@ This is useful when you want to reset a mock to its original state.
 
 ```ts
 const person = {
-  greet: (name: string) => `hello ${name}`,
+  greet: (name: string) => `Hello ${name}`,
 }
-const spy = vi.spyOn(obj, 'greet').mockImplementation(() => 'mocked')
-person.greet('alice') // => 'mocked'
-spy.mock.calls // => [['alice']]
+const spy = vi.spyOn(person, 'greet').mockImplementation(() => 'mocked')
+expect(person.greet('Alice')).toBe('mocked')
+expect(spy.mock.calls).toEqual([['Alice']])
 
-// clear call history and reset implementation, but it's still spied
+// clear call history and reset implementation, but method is still spied
 spy.mockReset()
-spy.mock.calls // => []
-person.greet('bob') // => 'hello bob'
-spy.mock.calls // => [['bob']]
+expect(spy.mock.calls).toEqual([])
+expect(person.greet).toBe(spy)
+expect(person.greet('Bob')).toBe('Hello Bob')
+expect(spy.mock.calls).toEqual([['Bob']])
 ```
 
 To automatically call this method before each test, enable the [`mockReset`](/config/#mockreset) setting in the configuration.
@@ -250,17 +251,18 @@ Restoring a mock from `vi.fn(impl)` will restore implementation to `impl`.
 
 ```ts
 const person = {
-  greet: (name: string) => `hello ${name}`,
+  greet: (name: string) => `Hello ${name}`,
 }
-const spy = vi.spyOn(obj, 'greet').mockImplementation(() => 'mocked')
-person.greet('alice') // => 'mocked'
-spy.mock.calls // => [['alice']]
+const spy = vi.spyOn(person, 'greet').mockImplementation(() => 'mocked')
+expect(person.greet('Alice')).toBe('mocked')
+expect(spy.mock.calls).toEqual([['Alice']])
 
 // clear call history and restore spied object method
-spy.mockClear()
-spy.mock.calls // => []
-person.greet('bob') // => 'hello bob'
-spy.mock.calls // => []
+spy.mockRestore()
+expect(spy.mock.calls).toEqual([])
+expect(person.greet).not.toBe(spy)
+expect(person.greet('Bob')).toBe('Hello Bob')
+expect(spy.mock.calls).toEqual([])
 ```
 
 To automatically call this method before each test, enable the [`restoreMocks`](/config/#restoremocks) setting in the configuration.

--- a/docs/api/mock.md
+++ b/docs/api/mock.md
@@ -52,6 +52,21 @@ function mockClear(): MockInstance<T>
 
 Clears all information about every call. After calling it, all properties on `.mock` will return to their initial state. This method does not reset implementations. It is useful for cleaning up mocks between different assertions.
 
+```ts
+const person = {
+  greet: (name: string) => `hello ${name}`,
+}
+const spy = vi.spyOn(obj, 'greet').mockImplementation(() => 'mocked')
+person.greet('alice') // => 'mocked'
+spy.mock.calls // => [['alice']]
+
+// clear call history but keep mock implementation
+spy.mockClear()
+spy.mock.calls // => []
+person.greet('bob') // => 'mocked'
+spy.mock.calls // => [['bob']]
+```
+
 To automatically call this method before each test, enable the [`clearMocks`](/config/#clearmocks) setting in the configuration.
 
 ## mockName
@@ -197,13 +212,28 @@ await asyncMock() // throws Error<'Async error'>
 function mockReset(): MockInstance<T>
 ```
 
-Does what `mockClear` does and resets inner implementation to the original function.
+Does what [`mockClear`](#mockClear) does and resets inner implementation to the original function.
 This also resets all "once" implementations.
 
 Note that resetting a mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
 resetting a mock from `vi.fn(impl)` will restore implementation to `impl`.
 
 This is useful when you want to reset a mock to its original state.
+
+```ts
+const person = {
+  greet: (name: string) => `hello ${name}`,
+}
+const spy = vi.spyOn(obj, 'greet').mockImplementation(() => 'mocked')
+person.greet('alice') // => 'mocked'
+spy.mock.calls // => [['alice']]
+
+// clear call history and reset implementation, but it's still spied
+spy.mockReset()
+spy.mock.calls // => []
+person.greet('bob') // => 'hello bob'
+spy.mock.calls // => [['bob']]
+```
 
 To automatically call this method before each test, enable the [`mockReset`](/config/#mockreset) setting in the configuration.
 
@@ -213,10 +243,25 @@ To automatically call this method before each test, enable the [`mockReset`](/co
 function mockRestore(): MockInstance<T>
 ```
 
-Does what `mockReset` does and restores original descriptors of spied-on objects.
+Does what [`mockReset`](#mockReset) does and restores original descriptors of spied-on objects.
 
 Note that restoring a mock from `vi.fn()` will set implementation to an empty function that returns `undefined`.
 Restoring a mock from `vi.fn(impl)` will restore implementation to `impl`.
+
+```ts
+const person = {
+  greet: (name: string) => `hello ${name}`,
+}
+const spy = vi.spyOn(obj, 'greet').mockImplementation(() => 'mocked')
+person.greet('alice') // => 'mocked'
+spy.mock.calls // => [['alice']]
+
+// clear call history and restore spied object method
+spy.mockClear()
+spy.mock.calls // => []
+person.greet('bob') // => 'hello bob'
+spy.mock.calls // => []
+```
 
 To automatically call this method before each test, enable the [`restoreMocks`](/config/#restoremocks) setting in the configuration.
 

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -559,4 +559,53 @@ describe('jest mock compat layer', () => {
     fn.mockImplementationOnce(temporaryMockImplementation)
     expect(fn.getMockImplementation()).toBe(temporaryMockImplementation)
   })
+
+  describe('docs example', () => {
+    it('mockClear', () => {
+      const person = {
+        greet: (name: string) => `Hello ${name}`,
+      }
+      const spy = vi.spyOn(person, 'greet').mockImplementation(() => 'mocked')
+      expect(person.greet('Alice')).toBe('mocked')
+      expect(spy.mock.calls).toEqual([['Alice']])
+
+      // clear call history but keep mock implementation
+      spy.mockClear()
+      expect(spy.mock.calls).toEqual([])
+      expect(person.greet('Bob')).toBe('mocked')
+      expect(spy.mock.calls).toEqual([['Bob']])
+    })
+
+    it('mockReset', () => {
+      const person = {
+        greet: (name: string) => `Hello ${name}`,
+      }
+      const spy = vi.spyOn(person, 'greet').mockImplementation(() => 'mocked')
+      expect(person.greet('Alice')).toBe('mocked')
+      expect(spy.mock.calls).toEqual([['Alice']])
+
+      // clear call history and reset implementation, but method is still spied
+      spy.mockReset()
+      expect(spy.mock.calls).toEqual([])
+      expect(person.greet).toBe(spy)
+      expect(person.greet('Bob')).toBe('Hello Bob')
+      expect(spy.mock.calls).toEqual([['Bob']])
+    })
+
+    it('mockRestore', () => {
+      const person = {
+        greet: (name: string) => `Hello ${name}`,
+      }
+      const spy = vi.spyOn(person, 'greet').mockImplementation(() => 'mocked')
+      expect(person.greet('Alice')).toBe('mocked')
+      expect(spy.mock.calls).toEqual([['Alice']])
+
+      // clear call history and restore spied object method
+      spy.mockRestore()
+      expect(spy.mock.calls).toEqual([])
+      expect(person.greet).not.toBe(spy)
+      expect(person.greet('Bob')).toBe('Hello Bob')
+      expect(spy.mock.calls).toEqual([])
+    })
+  })
 })


### PR DESCRIPTION
### Description

I got still confused with the difference between `mockReset` and `mockRestore`, so I added an example to highlight the difference.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
