### PR TITLE
refactor(ws-client): remove utils re-export

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { ModuleGraph } from '~/composables/module-graph'
 import type { Params } from '~/composables/params'
-import { hasFailedSnapshot } from '@vitest/ws-client'
 import { toJSON } from 'flatted'
 import {
   browserState,
@@ -10,6 +9,7 @@ import {
   currentLogs,
   isReport,
 } from '~/composables/client'
+import { hasFailedSnapshot } from '~/composables/explorer/collector'
 import { getModuleGraph } from '~/composables/module-graph'
 import { viewMode } from '~/composables/params'
 import { getProjectNameColor } from '~/utils/task'

--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { Task, TaskState } from '@vitest/runner'
 import type { TaskTreeNodeType } from '~/composables/explorer/types'
-import { hasFailedSnapshot } from '@vitest/ws-client'
 import { Tooltip as VueTooltip } from 'floating-vue'
 import { nextTick } from 'vue'
 import { client, isReport, runFiles, runTask } from '~/composables/client'
 import { showSource } from '~/composables/codemirror'
 import { explorerTree } from '~/composables/explorer'
+import { hasFailedSnapshot } from '~/composables/explorer/collector'
 import { escapeHtml, highlightRegex } from '~/composables/explorer/state'
 import { coverageEnabled } from '~/composables/navigation'
 

--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -3,7 +3,6 @@ import type { Arrayable } from '@vitest/utils'
 import type { CollectFilteredTests, CollectorInfo, Filter, FilteredTests } from '~/composables/explorer/types'
 import { isTestCase } from '@vitest/runner/utils'
 import { toArray } from '@vitest/utils'
-import { hasFailedSnapshot } from '@vitest/ws-client'
 import { client, findById } from '~/composables/client'
 import { testRunState } from '~/composables/client/state'
 import { expandNodesOnEndRun } from '~/composables/explorer/expand'
@@ -23,6 +22,9 @@ import {
   isRunningTestNode,
 } from '~/composables/explorer/utils'
 import { isSuite } from '~/utils/task'
+import { hasFailedSnapshot } from '../../../../vitest/src/utils/tasks'
+
+export { hasFailedSnapshot }
 
 export function runLoadFiles(
   remoteFiles: File[],

--- a/packages/ws-client/rollup.config.js
+++ b/packages/ws-client/rollup.config.js
@@ -1,8 +1,8 @@
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import resolve from '@rollup/plugin-node-resolve'
-import dts from 'rollup-plugin-dts'
 import esbuild from 'rollup-plugin-esbuild'
+import { createDtsUtils } from '../../scripts/build-utils.js'
 
 const entry = ['src/index.ts']
 
@@ -19,6 +19,8 @@ const external = [
   '@vitest/snapshot/manager',
 ]
 
+const dtsUtils = createDtsUtils()
+
 export default () => [
   {
     input: entry,
@@ -28,6 +30,7 @@ export default () => [
     },
     external,
     plugins: [
+      ...dtsUtils.isolatedDecl(),
       resolve({
         preferBuiltins: true,
       }),
@@ -39,12 +42,13 @@ export default () => [
     ],
   },
   {
-    input: ['src/index.ts'],
+    input: dtsUtils.dtsInput('src/index.ts'),
     output: {
-      file: 'dist/index.d.ts',
+      dir: 'dist',
+      entryFileNames: '[name].d.ts',
       format: 'esm',
     },
     external,
-    plugins: [dts()],
+    plugins: dtsUtils.dts(),
   },
 ]

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -6,7 +6,6 @@ import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
 import { StateManager } from './state'
 
-export * from '../../vitest/src/utils/tasks'
 export * from '@vitest/runner/utils'
 
 export interface VitestClientOptions {


### PR DESCRIPTION
### Description

- Related https://github.com/vitest-dev/vitest/pull/7609

`export * from '../../vitest/src/utils/tasks'` was the blocker, but the usage seems pretty low, so it's probably fine to remove it. Not sure if this should be marked as breaking change though. At least, there's no package level dependent on npm https://www.npmjs.com/package/@vitest/ws-client?activeTab=dependents.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
