### PR TITLE
fix: support custom toString method in %s format

### DIFF
--- a/packages/utils/src/display.ts
+++ b/packages/utils/src/display.ts
@@ -110,6 +110,9 @@ export function format(...args: unknown[]): string {
           return '-0'
         }
         if (typeof value === 'object' && value !== null) {
+          if (typeof value.toString === 'function' && value.toString !== Object.prototype.toString) {
+            return value.toString()
+          }
           return inspect(value, { depth: 0, colors: false })
         }
         return String(value)

--- a/test/core/test/utils-display.spec.ts
+++ b/test/core/test/utils-display.spec.ts
@@ -18,6 +18,15 @@ describe('format', () => {
     ['%s', -0],
     ['%s', null],
     ['%s', null, 'next'],
+    [
+      '%s',
+      new (class {
+        constructor(public value: string) {}
+        toString() {
+          return this.value
+        }
+      })('string value'),
+    ],
     ['%d', 100],
     ['%d', 100n],
     ['%d', null],


### PR DESCRIPTION
Closes #7634

### Description
- [x] Aligned `format`(vitest) with utils.format(Node.js) [spec](https://nodejs.org/api/util.html#utilformatformat-args) (respecting custom `toString` methods)

```bash
%s: Objects that have no user defined toString function are inspected using util.inspect() 
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
