### PR TITLE
test: test hook cleanup timeout correctly

### DIFF
--- a/test/cli/fixtures/fails/hooks-timeout-before-hook-cleanup-callback.test.ts
+++ b/test/cli/fixtures/fails/hooks-timeout-before-hook-cleanup-callback.test.ts
@@ -1,11 +1,15 @@
-import { beforeEach, beforeAll, describe, test } from 'vitest';
+import { beforeEach, beforeAll, describe, test, expect } from 'vitest';
 
 describe('beforeEach cleanup timeout', () => {
-  beforeEach(() => new Promise(() => {}), 101)
-  test("ok", () => {})
+  beforeEach(() => () => new Promise(() => {}), 101)
+  test("ok", () => {
+    expect(0).toBe(0)
+  })
 })
 
 describe('beforeAll cleanup timeout', () => {
-  beforeAll(() => new Promise(() => {}), 102)
-  test("ok", () => {})
+  beforeAll(() => () => new Promise(() => {}), 102)
+  test("ok", () => {
+    expect(0).toBe(0)
+  })
 })


### PR DESCRIPTION
### Description

- Related https://github.com/vitest-dev/vitest/pull/7500

Oops, I just noticed the test case added in https://github.com/vitest-dev/vitest/pull/7500 wasn't actually timing out during cleanup.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
