### PR TITLE
test(vite-node): test css import

### DIFF
--- a/test/vite-node/src/deps.ts
+++ b/test/vite-node/src/deps.ts
@@ -1,7 +1,7 @@
 import './deps.css'
 
 // eslint-disable-next-line no-console
-console.log('deps')
+console.log('[deps.ts] imported')
 
 export {}
 

--- a/test/vite-node/test/hmr.test.ts
+++ b/test/vite-node/test/hmr.test.ts
@@ -28,3 +28,8 @@ test('can handle top-level throw in self-accepting module', async () => {
   await viteNode.waitForStderr('some error')
   await viteNode.waitForStderr(`[hmr] Failed to reload ${scriptFile}. This could be due to syntax errors or importing non-existent modules. (see errors above)`)
 })
+
+test('basic', async () => {
+  const { viteNode } = await runViteNodeCli('--watch', resolve(__dirname, '../src/testMod.ts'))
+  await viteNode.waitForStdout('[deps.ts] imported')
+})


### PR DESCRIPTION
### Description

Related
- https://github.com/vitest-dev/vitest/pull/7480
- https://github.com/vitejs/vite/pull/19624
- https://github.com/vitest-dev/vitest/pull/7652

There were some files importing css, but weren't used as tests. This verifies css import is working on vite-node.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
