### PR TITLE
feat(vitest): allow conditional `context.skip(boolean)`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -129,6 +129,18 @@ test('skipped test', (context) => {
 })
 ```
 
+Since Vitest 3.1, if the condition is unknonwn, you can provide it to the `skip` method as the first arguments:
+
+```ts
+import { assert, test } from 'vitest'
+
+test('skipped test', (context) => {
+  context.skip(Math.random() < 0.5, 'optional message')
+  // Test skipped, no error
+  assert.equal(Math.sqrt(4), 3)
+})
+```
+
 ### test.skipIf
 
 - **Alias:** `it.skipIf`

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -104,10 +104,18 @@ export function createTestContext(
 
   context.task = test
 
-  context.skip = (note?: string) => {
+  context.skip = (condition?: boolean | string, note?: string): never => {
+    if (typeof condition === 'boolean' && !condition) {
+      // do nothing
+      return undefined as never
+    }
     test.result ??= { state: 'skip' }
     test.result.pending = true
-    throw new PendingError('test is skipped; abort execution', test, note)
+    throw new PendingError(
+      'test is skipped; abort execution',
+      test,
+      typeof condition === 'string' ? condition : note,
+    )
   }
 
   context.onTestFailed = (handler, timeout) => {

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -105,7 +105,7 @@ export function createTestContext(
   context.task = test
 
   context.skip = (condition?: boolean | string, note?: string): never => {
-    if (typeof condition === 'boolean' && !condition) {
+    if (condition === false) {
       // do nothing
       return undefined as never
     }

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -658,7 +658,10 @@ export interface TestContext {
    * Mark tests as skipped. All execution after this call will be skipped.
    * This function throws an error, so make sure you are not catching it accidentally.
    */
-  skip: (note?: string) => never
+  skip: {
+    (note?: string): never
+    (condition: boolean, note?: string): void
+  }
 }
 
 /**

--- a/test/cli/fixtures/fails/skip-conditional.test.ts
+++ b/test/cli/fixtures/fails/skip-conditional.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+
+it('skips correctly', (t) => {
+  t.skip(true)
+  expect.unreachable()
+})
+
+it('doesnt skip correctly', (t) => {
+  t.skip(false)
+  throw new Error('doesnt skip')
+})

--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -74,6 +74,8 @@ Error: expect.poll(assertion).toBe() was not awaited. This assertion is asynchro
 
 exports[`should fail primitive-error.test.ts 1`] = `"Unknown Error: 42"`;
 
+exports[`should fail skip-conditional.test.ts 1`] = `"Error: doesnt skip"`;
+
 exports[`should fail snapshot-with-not.test.ts 1`] = `
 "Error: toThrowErrorMatchingInlineSnapshot cannot be used with "not"
 Error: toThrowErrorMatchingSnapshot cannot be used with "not"

--- a/test/reporters/fixtures/default/a.test.ts
+++ b/test/reporters/fixtures/default/a.test.ts
@@ -24,3 +24,17 @@ describe('a failed', () => {
     })
   })
 })
+
+describe('a skipped', () => {
+  test('skipped with note', (t) => {
+    t.skip('reason')
+  })
+
+  test('condition', (t) => {
+    t.skip(true)
+  })
+
+  test('condition with note', (t) => {
+    t.skip(true, 'note')
+  })
+})

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -67,10 +67,12 @@ describe('default reporter', async () => {
       reporters: 'none',
     })
 
-    expect(stdout).contain('✓ a passed > a1 test')
-    expect(stdout).contain('✓ a passed > nested a > nested a3 test')
-    expect(stdout).contain('× a failed > a failed test')
-    expect(stdout).contain('nested a failed 1 test')
+    expect(stdout).toContain('✓ a passed > a1 test')
+    expect(stdout).toContain('✓ a passed > nested a > nested a3 test')
+    expect(stdout).toContain('× a failed > a failed test')
+    expect(stdout).toContain('nested a failed 1 test')
+    expect(stdout).toContain('[note]')
+    expect(stdout).toContain('[reason]')
   })
 
   test('rerun should undo', async () => {

--- a/test/reporters/tests/junit.test.ts
+++ b/test/reporters/tests/junit.test.ts
@@ -120,8 +120,8 @@ test('options.classname changes classname property', async () => {
 
   // All classname attributes should have the custom value
   expect(xml.match(/<testcase classname="a\.test\.ts"/g)).toBeNull()
-  expect(xml.match(/<testcase classname="/g)).toHaveLength(13)
-  expect(xml.match(/<testcase classname="some-custom-classname"/g)).toHaveLength(13)
+  expect(xml.match(/<testcase classname="/g)).toHaveLength(16)
+  expect(xml.match(/<testcase classname="some-custom-classname"/g)).toHaveLength(16)
 })
 
 test('options.suiteName changes name property', async () => {


### PR DESCRIPTION
### Description

I was writing tests and notice that it would be nice to have this during the test in case users provide `text.extend` overrides and can't use `test.skipIf()` during collection:

```ts
test('some test', { custom, skip } => {
  skip(custom === 'value', 'not supported')
})
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
