### PR TITLE
fix(spy): fix spyOn types with optional method

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -435,8 +435,8 @@ export function spyOn<T, M extends Classes<Required<T>> | Methods<Required<T>>>(
   methodName: M
 ): Required<T>[M] extends { new (...args: infer A): infer R }
   ? MockInstance<(this: R, ...args: A) => R>
-  : T[M] extends Procedure
-    ? MockInstance<T[M]>
+  : Required<T>[M] extends Procedure
+    ? MockInstance<Required<T>[M]>
     : never
 export function spyOn<T, K extends keyof T>(
   obj: T,

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -608,4 +608,16 @@ describe('jest mock compat layer', () => {
       expect(spy.mock.calls).toEqual([])
     })
   })
+
+  it.fails('optional method type', () => {
+    interface Person {
+      greet: (name: string) => string
+    }
+    const person: Partial<Person> = {}
+    const spy = vi.spyOn(person, 'greet')
+    expect(spy).toBe(person.greet)
+    expect(person.greet?.('Alice')).toMatchInlineSnapshot()
+    spy.mockImplementation(() => 'mocked')
+    expect(person.greet?.('Bob')).toMatchInlineSnapshot()
+  })
 })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7674

It looks like opitonal key is intended to work, but `Required` wrapper is missing in a few cases. Jest does it a bit differently by moving `Required<T>` to generic side, but the idea seems same https://github.com/jestjs/jest/blob/4e7d916ec6a16de5548273c17b5d2c5761b0aebb/packages/jest-mock/src/index.ts#L1112.

On second thought, this doesn't necessary make things more type-safe. Waiting for a better use case from OP in https://github.com/vitest-dev/vitest/issues/7674#issuecomment-2727265923.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
