### PR TITLE
fix(reporter): `--hideSkippedTests` should hide suites too

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -149,6 +149,11 @@ export abstract class BaseReporter implements Reporter {
     this.log(` ${title} ${task.name} ${suffix}`)
 
     for (const suite of suites) {
+      if (this.ctx.config.hideSkippedTests && (suite.mode === 'skip' || suite.result?.state === 'skip')) {
+        // Skipped suites are hidden when --hideSkippedTests
+        continue
+      }
+
       const tests = suite.tasks.filter(task => task.type === 'test')
 
       if (!('filepath' in suite)) {

--- a/test/reporters/fixtures/pass-and-skip-test-suites.test.ts
+++ b/test/reporters/fixtures/pass-and-skip-test-suites.test.ts
@@ -1,0 +1,13 @@
+import { expect, describe, test } from 'vitest'
+
+test('passing test #1', () => {})
+
+describe("passing suite", () => {
+  test('passing test #2', () => {})
+})
+
+test.skip('skipped test #1', () => {})
+
+describe.skip("skipped suite", () => {
+  test('skipped test #2', () => {})
+})

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -130,27 +130,33 @@ describe('default reporter', async () => {
 
   test('prints skipped tests by default when a single file is run', async () => {
     const { stdout } = await runVitest({
-      include: ['fixtures/all-passing-or-skipped.test.ts'],
+      include: ['fixtures/pass-and-skip-test-suites.test.ts'],
       reporters: [['default', { isTTY: true, summary: false }]],
       config: 'fixtures/vitest.config.ts',
     })
 
-    expect(stdout).toContain('✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped)')
-    expect(stdout).toContain('✓ 2 + 3 = 5')
-    expect(stdout).toContain('↓ 3 + 3 = 6')
+    expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+      "✓ fixtures/pass-and-skip-test-suites.test.ts (4 tests | 2 skipped) [...]ms
+         ✓ passing test #1 [...]ms
+         ↓ skipped test #1
+         ✓ passing suite > passing test #2 [...]ms
+         ↓ skipped suite > skipped test #2"
+    `)
   })
 
   test('hides skipped tests when --hideSkippedTests and a single file is run', async () => {
     const { stdout } = await runVitest({
-      include: ['fixtures/all-passing-or-skipped.test.ts'],
+      include: ['fixtures/pass-and-skip-test-suites.test.ts'],
       reporters: [['default', { isTTY: true, summary: false }]],
       hideSkippedTests: true,
       config: false,
     })
 
-    expect(stdout).toContain('✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped)')
-    expect(stdout).toContain('✓ 2 + 3 = 5')
-    expect(stdout).not.toContain('↓ 3 + 3 = 6')
+    expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+      "✓ fixtures/pass-and-skip-test-suites.test.ts (4 tests | 2 skipped) [...]ms
+         ✓ passing test #1 [...]ms
+         ✓ passing suite > passing test #2 [...]ms"
+    `)
   })
 
   test('prints retry count', async () => {

--- a/test/reporters/tests/verbose.test.ts
+++ b/test/reporters/tests/verbose.test.ts
@@ -27,29 +27,35 @@ test('prints error properties', async () => {
 
 test('prints skipped tests by default', async () => {
   const { stdout } = await runVitest({
-    include: ['fixtures/all-passing-or-skipped.test.ts'],
+    include: ['fixtures/pass-and-skip-test-suites.test.ts'],
     reporters: [['verbose', { isTTY: true, summary: false }]],
     config: false,
   })
 
   expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
-    "✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped) [...]ms
-       ✓ 2 + 3 = 5 [...]ms
-       ↓ 3 + 3 = 6"
+    "✓ fixtures/pass-and-skip-test-suites.test.ts (4 tests | 2 skipped) [...]ms
+       ✓ passing test #1 [...]ms
+       ↓ skipped test #1
+       ✓ passing suite (1)
+         ✓ passing test #2 [...]ms
+       ↓ skipped suite (1)
+         ↓ skipped test #2"
   `)
 })
 
 test('hides skipped tests when --hideSkippedTests', async () => {
   const { stdout } = await runVitest({
-    include: ['fixtures/all-passing-or-skipped.test.ts'],
+    include: ['fixtures/pass-and-skip-test-suites.test.ts'],
     reporters: [['verbose', { isTTY: true, summary: false }]],
     hideSkippedTests: true,
     config: false,
   })
 
   expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
-    "✓ fixtures/all-passing-or-skipped.test.ts (2 tests | 1 skipped) [...]ms
-       ✓ 2 + 3 = 5 [...]ms"
+    "✓ fixtures/pass-and-skip-test-suites.test.ts (4 tests | 2 skipped) [...]ms
+       ✓ passing test #1 [...]ms
+       ✓ passing suite (1)
+         ✓ passing test #2 [...]ms"
   `)
 })
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Skipped suites should be hidden when `--hideSkippedTests` is used.

Noticed this verbose noise in my project even when using `hideSkippedTests: true`:

<img src="https://github.com/user-attachments/assets/5f757138-e19e-419f-8a48-3dfaf61bc347" width="400" />

With this fix it becomes much easier to read:

<img src="https://github.com/user-attachments/assets/028073ea-0990-4380-8d48-f0bd828842aa" width="400" />

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
