### PR TITLE
fix: set `diff.expand: false` as default

### DIFF
--- a/packages/utils/src/diff/normalizeDiffOptions.ts
+++ b/packages/utils/src/diff/normalizeDiffOptions.ts
@@ -30,7 +30,7 @@ function getDefaultOptions(): DiffOptionsNormalized {
     compareKeys: undefined,
     contextLines: DIFF_CONTEXT_DEFAULT,
     emptyFirstOrLastLinePlaceholder: '',
-    expand: true,
+    expand: false,
     includeChangeCounts: false,
     omitAnnotationLines: false,
     patchColor: c.yellow,

--- a/test/config/test/__snapshots__/diff.test.ts.snap
+++ b/test/config/test/__snapshots__/diff.test.ts.snap
@@ -1,59 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`inline diff options: { expand: false, printBasicPrototype: true } 1`] = `
-[
-  "- Expected
-+ Received
-
-@@ -1,7 +1,7 @@
-  Array [
--   1000,
-+   0,
-    1,
-    2,
-    3,
-    4,
-    5,
-@@ -12,11 +12,11 @@
-    10,
-    11,
-    12,
-    13,
-    14,
--   2000,
-+   15,
-    16,
-    17,
-    18,
-    19,
-    20,
-@@ -26,7 +26,7 @@
-    24,
-    25,
-    26,
-    27,
-    28,
--   3000,
-+   29,
-  ]",
-  "- Expected
-+ Received
-
-  Object {
-    "arr": Array [
-      1,
--     3,
-+     2,
-    ],
-    "obj": Object {
--     "k": "bar",
-+     "k": "foo",
-    },
-  }",
-]
-`;
-
-exports[`inline diff options: undefined 1`] = `
+exports[`inline diff options: { expand: true } 1`] = `
 [
   "- Expected
 + Received
@@ -103,6 +50,59 @@ exports[`inline diff options: undefined 1`] = `
 +     2,
     ],
     "obj": {
+-     "k": "bar",
++     "k": "foo",
+    },
+  }",
+]
+`;
+
+exports[`inline diff options: { printBasicPrototype: true } 1`] = `
+[
+  "- Expected
++ Received
+
+@@ -1,7 +1,7 @@
+  Array [
+-   1000,
++   0,
+    1,
+    2,
+    3,
+    4,
+    5,
+@@ -12,11 +12,11 @@
+    10,
+    11,
+    12,
+    13,
+    14,
+-   2000,
++   15,
+    16,
+    17,
+    18,
+    19,
+    20,
+@@ -26,7 +26,7 @@
+    24,
+    25,
+    26,
+    27,
+    28,
+-   3000,
++   29,
+  ]",
+  "- Expected
++ Received
+
+  Object {
+    "arr": Array [
+      1,
+-     3,
++     2,
+    ],
+    "obj": Object {
 -     "k": "bar",
 +     "k": "foo",
     },

--- a/test/config/test/diff.test.ts
+++ b/test/config/test/diff.test.ts
@@ -3,8 +3,8 @@ import { expect, test } from 'vitest'
 import { runVitest } from '../../test-utils'
 
 test.for([
-  [undefined],
-  [{ expand: false, printBasicPrototype: true }],
+  [{ expand: true }],
+  [{ printBasicPrototype: true }],
 ])(`inline diff options: %o`, async ([options]) => {
   const { ctx } = await runVitest({
     root: './fixtures/diff',

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -1618,7 +1618,7 @@ function snapshotError(f: () => unknown) {
     f()
   }
   catch (error) {
-    const e = processError(error)
+    const e = processError(error, { expand: true })
     expect({
       message: stripVTControlCharacters(e.message),
       diff: e.diff ? stripVTControlCharacters(e.diff) : e.diff,


### PR DESCRIPTION
### Description

- https://github.com/vitest-dev/vitest/issues/4385
- follow up to https://github.com/vitest-dev/vitest/pull/6740

I just saw a huge useless diff and remembered we didn't change the default yet. I'm not sure if we discussed about the default. Starting this PR to revive the discussion if we haven't.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
