### PR TITLE
chore: ignore react-is-18 on renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,7 +35,8 @@
     // Transitive dependency that we patch
     "acorn",
     // Keep using codemirror 5
-    "codemirror"
+    "codemirror",
+    "react-is-18"
   ],
   "ignorePaths": [
     "**/node_modules/**"


### PR DESCRIPTION
### Description

This should not be picked up by renovate. see https://github.com/vitest-dev/vitest/pull/7180

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
