### PR TITLE
feat(coverage): v8 experimental AST-aware remapping

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1642,7 +1642,7 @@ Sets thresholds to 100 for files matching the glob pattern.
 - **Available for providers:** `'v8'`
 - **CLI:** `--coverage.ignoreEmptyLines=<boolean>`
 
-Ignore empty lines, comments and other non-runtime code, e.g. Typescript types.
+Ignore empty lines, comments and other non-runtime code, e.g. Typescript types. Requires `experimentalAstAwareRemapping: false`.
 
 This option works only if the used compiler removes comments and other non-runtime code from the transpiled code.
 By default Vite uses ESBuild which removes comments and Typescript types from `.ts`, `.tsx` and `.jsx` files.
@@ -1666,6 +1666,14 @@ export default defineConfig({
   },
 })
 ```
+#### coverage.experimentalAstAwareRemapping
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Available for providers:** `'v8'`
+- **CLI:** `--coverage.experimentalAstAwareRemapping=<boolean>`
+
+Remap coverage with experimental AST based analysis. Provides more accurate results compared to default mode.
 
 #### coverage.ignoreClassMethods
 

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -190,24 +190,21 @@ Both coverage providers have their own ways how to ignore code from coverage rep
 
 - [`v8`](https://github.com/istanbuljs/v8-to-istanbul#ignoring-uncovered-lines)
 - [`ìstanbul`](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines)
+- `v8` with [`experimentalAstAwareRemapping: true`](https://vitest.dev/config/#coverage-experimentalAstAwareRemapping) see [ast-v8-to-istanbul | Ignoring code](https://github.com/AriPerkkio/ast-v8-to-istanbul?tab=readme-ov-file#ignoring-code)
 
 When using TypeScript the source codes are transpiled using `esbuild`, which strips all comments from the source codes ([esbuild#516](https://github.com/evanw/esbuild/issues/516)).
 Comments which are considered as [legal comments](https://esbuild.github.io/api/#legal-comments) are preserved.
 
-For `istanbul` provider you can include a `@preserve` keyword in the ignore hint.
+You can include a `@preserve` keyword in the ignore hint.
 Beware that these ignore hints may now be included in final production build as well.
 
 ```diff
 -/* istanbul ignore if */
 +/* istanbul ignore if -- @preserve */
 if (condition) {
-```
 
-For `v8` this does not cause any issues. You can use `v8 ignore` comments with Typescript as usual:
-
-<!-- eslint-skip -->
-```ts
-/* v8 ignore next 3 */
+-/* v8 ignore if */
++/* v8 ignore if -- @preserve */
 if (condition) {
 ```
 

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@ampproject/remapping": "catalog:",
     "@bcoe/v8-coverage": "^1.0.2",
+    "ast-v8-to-istanbul": "^0.3.1",
     "debug": "catalog:",
     "istanbul-lib-coverage": "catalog:",
     "istanbul-lib-report": "catalog:",

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -275,8 +275,23 @@ export interface CoverageIstanbulOptions extends BaseCoverageOptions {
 export interface CoverageV8Options extends BaseCoverageOptions {
   /**
    * Ignore empty lines, comments and other non-runtime code, e.g. Typescript types
+   * - Requires `experimentalAstAwareRemapping: false`
    */
   ignoreEmptyLines?: boolean
+
+  /**
+   * Remap coverage with experimental AST based analysis
+   * - Provides more accurate results compared to default mode
+   */
+  experimentalAstAwareRemapping?: boolean
+
+  /**
+   * Set to array of class method names to ignore for coverage.
+   * - Requires `experimentalAstAwareRemapping: true`
+   *
+   * @default []
+   */
+  ignoreClassMethods?: string[]
 }
 
 export interface CustomProviderOptions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@bcoe/v8-coverage':
         specifier: ^1.0.2
         version: 1.0.2
+      ast-v8-to-istanbul:
+        specifier: ^0.3.1
+        version: 0.3.1
       debug:
         specifier: 'catalog:'
         version: 4.4.0
@@ -4835,6 +4838,9 @@ packages:
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@0.3.1:
+    resolution: {integrity: sha512-JTXdVVvDN2GYU99F33hyGP1etlltAqV3bk6LRepl5twqAxGAL02VDAEKuckemYBxlND+Gic3Gf9sT3f8UxTPRw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -12808,6 +12814,12 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.1:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   async@3.2.6: {}
 

--- a/test/coverage-test/fixtures/src/ignore-hints.ts
+++ b/test/coverage-test/fixtures/src/ignore-hints.ts
@@ -11,7 +11,7 @@ export function second() {
 // Covered line
 second()
 
-/* v8 ignore next -- Uncovered line v8 */
+/* v8 ignore next -- @preserve, Uncovered line v8 */
 second()
 
 /* istanbul ignore next -- @preserve, Uncovered line istanbul */

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -75,8 +75,7 @@ test('provider options, generic', () => {
 test('provider specific options, v8', () => {
   assertType<Coverage>({
     provider: 'v8',
-    // @ts-expect-error -- Istanbul-only option is not allowed
-    ignoreClassMethods: ['string'],
+    experimentalAstAwareRemapping: true,
   })
 })
 
@@ -84,6 +83,9 @@ test('provider specific options, istanbul', () => {
   assertType<Coverage>({
     provider: 'istanbul',
     ignoreClassMethods: ['string'],
+
+    // @ts-expect-error -- v8 specific error
+    experimentalAstAwareRemapping: true,
   })
 })
 

--- a/test/coverage-test/test/file-outside-vite.test.ts
+++ b/test/coverage-test/test/file-outside-vite.test.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import { expect } from 'vitest'
-import { coverageTest, isV8Provider, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
+import { coverageTest, isExperimentalV8Provider, isV8Provider, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
 
 test('does not crash when file outside Vite is loaded (#5639)', async () => {
   await runVitest({
@@ -11,7 +11,7 @@ test('does not crash when file outside Vite is loaded (#5639)', async () => {
   const coverageMap = await readCoverageMap()
   const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/load-outside-vite.cjs')
 
-  if (isV8Provider()) {
+  if (isV8Provider() || isExperimentalV8Provider()) {
     expect(fileCoverage).toMatchInlineSnapshot(`
       {
         "branches": "0/0 (100%)",
@@ -22,6 +22,8 @@ test('does not crash when file outside Vite is loaded (#5639)', async () => {
     `)
   }
   else {
+    // On istanbul the instrumentation happens on Vite plugin, so files
+    // loaded outsite Vite should have 0% coverage
     expect(fileCoverage).toMatchInlineSnapshot(`
       {
         "branches": "0/0 (100%)",

--- a/test/coverage-test/test/ignore-hints.test.ts
+++ b/test/coverage-test/test/ignore-hints.test.ts
@@ -4,7 +4,7 @@
 */
 
 import { expect } from 'vitest'
-import { isV8Provider, readCoverageMap, runVitest, test } from '../utils'
+import { isExperimentalV8Provider, isV8Provider, readCoverageMap, runVitest, test } from '../utils'
 
 test('ignore hints work', async () => {
   await runVitest({
@@ -22,6 +22,10 @@ test('ignore hints work', async () => {
   if (isV8Provider()) {
     expect(lines[15]).toBeUndefined()
     expect(lines[18]).toBeGreaterThanOrEqual(1)
+  }
+  else if (isExperimentalV8Provider()) {
+    expect(lines[15]).toBeUndefined()
+    expect(lines[18]).toBeUndefined()
   }
   else {
     expect(lines[15]).toBeGreaterThanOrEqual(1)

--- a/test/coverage-test/utils.ts
+++ b/test/coverage-test/utils.ts
@@ -43,7 +43,8 @@ export async function runVitest(config: UserConfig, options = { throwOnError: tr
       enabled: true,
       reporter: [],
       ...config.coverage,
-      provider,
+      provider: provider === 'v8-ast-aware' ? 'v8' : provider,
+      experimentalAstAwareRemapping: provider === 'v8-ast-aware',
       customProviderModule: provider === 'custom' ? 'fixtures/custom-provider' : undefined,
     },
     browser: {
@@ -104,6 +105,10 @@ export function normalizeFilename(filename: string) {
 
 export function isV8Provider() {
   return process.env.COVERAGE_PROVIDER === 'v8'
+}
+
+export function isExperimentalV8Provider() {
+  return process.env.COVERAGE_PROVIDER === 'v8-ast-aware'
 }
 
 export function isBrowser() {

--- a/test/coverage-test/vitest.workspace.custom.ts
+++ b/test/coverage-test/vitest.workspace.custom.ts
@@ -31,6 +31,25 @@ export default defineWorkspace([
     },
   },
 
+  // Test cases for experimental AST aware v8-provider
+  {
+    test: {
+      ...config.test,
+      name: 'v8-ast-aware',
+      env: { COVERAGE_PROVIDER: 'v8-ast-aware' },
+
+      // Intentionally run Istanbul tests too
+      include: [GENERIC_TESTS, ISTANBUL_TESTS, V8_TESTS],
+      exclude: [
+        UNIT_TESTS,
+        CUSTOM_TESTS,
+        BROWSER_TESTS,
+        // Not using original v8-to-istanbul that has patch applied: github.com/istanbuljs/v8-to-istanbul/pull/244
+        'test/empty-lines.v8.test.ts',
+      ],
+    },
+  },
+
   // Test cases for istanbul-provider
   {
     test: {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Adds support for experimental AST-aware V8 coverage remapping
- Vitest v3 will default to old `v8-to-istanbul`, but switches to `ast-v8-to-istanbul` when `experimentalAstAwareRemapping: true` is set.
- If all goes well, we can remove `v8-to-istanbul` in Vitest v4 (https://github.com/vitest-dev/vitest/issues/7928)
- Right now the `provider.ts` is a bit of mess as it supports both remappers. Once `v8-to-istanbul` can be dropped, it will simplify quite much
- Tests start and run as fast as with previous `@vitest/coverage-v8`. Report accuracy is as good as with `@vitest/coverage-istanbul`. Report generation is slightly slower than with previous `@vitest/coverage-v8`, but faster than overall istanbul provider run. 
- Fixes https://github.com/vitest-dev/vitest/issues/6300
- Fixes https://github.com/vitest-dev/vitest/issues/5783
- Fixes https://github.com/vitest-dev/vitest/issues/7130
- Fixes https://github.com/vitest-dev/vitest/discussions/7587

Testing: 

- `vuejs/core`: 100% match with `@vitest/coverage-istanbul`, except branch coverage is `87.69% 12059/13751` vs `87.46% 12047/13773`. There are couple of uncovered function default arguments that are not reported by V8 at all. These are marked as covered.
- `vitejs/vite`: Close to 100% match with `@vitest/coverage-istanbul`. Differences coming from V8 limitations, e.g. uncovered default parameters.
- Self-test: 100% match https://github.com/AriPerkkio/ast-v8-to-istanbul/pull/31

<img src="https://github.com/user-attachments/assets/9a4356e9-c1c5-49d2-a5ba-2ed58513c250" width="400" />

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
