### PR TITLE
fix: fix vm tests flakiness

### DIFF
--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -647,7 +647,7 @@ export interface TestContext {
   /**
    * Metadata of the current test
    */
-  task: Readonly<Task>
+  task: Readonly<Test<TestContext>>
 
   /**
    * Extract hooks on test failed

--- a/packages/vitest/src/runtime/external-executor.ts
+++ b/packages/vitest/src/runtime/external-executor.ts
@@ -1,18 +1,15 @@
+import type vm from 'node:vm'
 import type { RuntimeRPC } from '../types/rpc'
 import type { FileMap } from './vm/file-map'
-import type { VMModule, VMSyntheticModule } from './vm/types'
+import type { VMModule } from './vm/types'
 import fs from 'node:fs'
 import { dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import vm from 'node:vm'
 import { extname, join, normalize } from 'pathe'
 import { getCachedData, isNodeBuiltin, setCacheData } from 'vite-node/utils'
 import { CommonjsExecutor } from './vm/commonjs-executor'
 import { EsmExecutor } from './vm/esm-executor'
-import { interopCommonJsModule } from './vm/utils'
 import { ViteExecutor } from './vm/vite-executor'
-
-const SyntheticModule: typeof VMSyntheticModule = (vm as any).SyntheticModule
 
 const { existsSync, statSync } = fs
 
@@ -64,6 +61,7 @@ export class ExternalModulesExecutor {
       context: this.context,
       importModuleDynamically: this.importModuleDynamically,
       fileMap: options.fileMap,
+      interopDefault: options.interopDefault,
     })
     this.vite = new ViteExecutor({
       esmExecutor: this.esm,
@@ -156,52 +154,6 @@ export class ExternalModulesExecutor {
     return {}
   }
 
-  private wrapCoreSyntheticModule(
-    identifier: string,
-    exports: Record<string, unknown>,
-  ) {
-    const moduleKeys = Object.keys(exports)
-    const m = new SyntheticModule(
-      [...moduleKeys, 'default'],
-      function () {
-        for (const key of moduleKeys) {
-          this.setExport(key, exports[key])
-        }
-        this.setExport('default', exports)
-      },
-      {
-        context: this.context,
-        identifier,
-      },
-    )
-    return m
-  }
-
-  private wrapCommonJsSynteticModule(
-    identifier: string,
-    exports: Record<string, unknown>,
-  ) {
-    // TODO: technically module should be parsed to find static exports, implement for strict mode in #2854
-    const { keys, moduleExports, defaultExport } = interopCommonJsModule(
-      this.options.interopDefault,
-      exports,
-    )
-    const m = new SyntheticModule(
-      [...keys, 'default'],
-      function () {
-        for (const key of keys) {
-          this.setExport(key, moduleExports[key])
-        }
-        this.setExport('default', defaultExport)
-      },
-      {
-        context: this.context,
-        identifier,
-      },
-    )
-    return m
-  }
-
   private getModuleInformation(identifier: string): ModuleInformation {
     if (identifier.startsWith('data:')) {
       return { type: 'data', url: identifier, path: identifier }
@@ -248,7 +200,7 @@ export class ExternalModulesExecutor {
     return { type, path: pathUrl, url: fileUrl }
   }
 
-  private async createModule(identifier: string): Promise<VMModule> {
+  private createModule(identifier: string): VMModule | Promise<VMModule> {
     const { type, url, path } = this.getModuleInformation(identifier)
 
     // create ERR_MODULE_NOT_FOUND on our own since latest NodeJS's import.meta.resolve doesn't throw on non-existing namespace or path
@@ -264,25 +216,21 @@ export class ExternalModulesExecutor {
 
     switch (type) {
       case 'data':
-        return await this.esm.createDataModule(identifier)
-      case 'builtin': {
-        const exports = this.require(identifier)
-        return this.wrapCoreSyntheticModule(identifier, exports)
-      }
+        return this.esm.createDataModule(identifier)
+      case 'builtin':
+        return this.cjs.getCoreSyntheticModule(identifier)
       case 'vite':
-        return await this.vite.createViteModule(url)
+        return this.vite.createViteModule(url)
       case 'wasm':
-        return await this.esm.createWebAssemblyModule(url, () =>
+        return this.esm.createWebAssemblyModule(url, () =>
           this.fs.readBuffer(path))
       case 'module':
-        return await this.esm.createEsModule(url, () =>
+        return this.esm.createEsModule(url, () =>
           this.fs.readFileAsync(path))
-      case 'commonjs': {
-        const exports = this.require(path)
-        return this.wrapCommonJsSynteticModule(identifier, exports)
-      }
+      case 'commonjs':
+        return this.cjs.getCjsSyntheticModule(path, identifier)
       case 'network':
-        return await this.esm.createNetworkModule(url)
+        return this.esm.createNetworkModule(url)
       default: {
         const _deadend: never = type
         return _deadend

--- a/packages/vitest/src/runtime/external-executor.ts
+++ b/packages/vitest/src/runtime/external-executor.ts
@@ -163,11 +163,11 @@ export class ExternalModulesExecutor {
     const moduleKeys = Object.keys(exports)
     const m = new SyntheticModule(
       [...moduleKeys, 'default'],
-      () => {
+      function () {
         for (const key of moduleKeys) {
-          m.setExport(key, exports[key])
+          this.setExport(key, exports[key])
         }
-        m.setExport('default', exports)
+        this.setExport('default', exports)
       },
       {
         context: this.context,
@@ -188,11 +188,11 @@ export class ExternalModulesExecutor {
     )
     const m = new SyntheticModule(
       [...keys, 'default'],
-      () => {
+      function () {
         for (const key of keys) {
-          m.setExport(key, moduleExports[key])
+          this.setExport(key, moduleExports[key])
         }
-        m.setExport('default', defaultExport)
+        this.setExport('default', defaultExport)
       },
       {
         context: this.context,

--- a/packages/vitest/src/runtime/vm/commonjs-executor.ts
+++ b/packages/vitest/src/runtime/vm/commonjs-executor.ts
@@ -35,7 +35,6 @@ export class CommonjsExecutor {
 
   private fs: FileMap
   private Module: typeof _Module
-  private cjsNamedExportsMap = new Map<string, Set<string>>()
   private interopDefault: boolean | undefined
 
   constructor(options: CommonjsExecutorOptions) {
@@ -137,7 +136,7 @@ export class CommonjsExecutor {
       static SourceMap = _Module.SourceMap
       static syncBuiltinESMExports = _Module.syncBuiltinESMExports
 
-      static _cache = executor.builtinCache
+      static _cache = executor.publicRequireCache
       static _extensions = executor.extensions
 
       static createRequire = (filename: string | URL) => {

--- a/packages/vitest/src/runtime/vm/vite-executor.ts
+++ b/packages/vitest/src/runtime/vm/vite-executor.ts
@@ -83,9 +83,9 @@ export class ViteExecutor {
     const moduleKeys = Object.keys(stub)
     const module = new SyntheticModule(
       moduleKeys,
-      () => {
+      function () {
         moduleKeys.forEach((key) => {
-          module.setExport(key, stub[key])
+          this.setExport(key, stub[key])
         })
       },
       { context: this.options.context, identifier },

--- a/test/cli/test/setup-files.test.ts
+++ b/test/cli/test/setup-files.test.ts
@@ -2,13 +2,7 @@ import { promises as fs } from 'node:fs'
 import { describe, expect, it, test } from 'vitest'
 import { editFile, runVitest } from '../../test-utils'
 
-const [major] = process.version.slice(1).split('.').map(num => Number(num))
-
 test.each(['threads', 'vmThreads'])('%s: print stdout and stderr correctly when called in the setup file', async (pool) => {
-  if (major >= 22 && pool === 'vmThreads') {
-    return
-  }
-
   const { stdout, stderr } = await runVitest({
     root: 'fixtures/setup-files',
     include: ['empty.test.ts'],

--- a/test/cli/test/stacktraces.test.ts
+++ b/test/cli/test/stacktraces.test.ts
@@ -3,8 +3,6 @@ import { glob } from 'tinyglobby'
 import { describe, expect, it } from 'vitest'
 import { runVitest } from '../../test-utils'
 
-const [major] = process.version.slice(1).split('.').map(num => Number(num))
-
 // To prevent the warning coming up in snapshots
 process.setMaxListeners(20)
 
@@ -92,7 +90,7 @@ describe('stacktrace in dependency package', () => {
   })
 })
 
-it.runIf(major < 22)('stacktrace in vmThreads', async () => {
+it('stacktrace in vmThreads', async () => {
   const root = resolve(__dirname, '../fixtures/stacktraces')
   const testFile = resolve(root, './error-with-stack.test.js')
   const { stderr } = await runVitest({

--- a/test/cli/test/vm-threads.test.ts
+++ b/test/cli/test/vm-threads.test.ts
@@ -2,9 +2,7 @@ import { expect, test } from 'vitest'
 
 import { createFile, resolvePath, runVitest } from '../../test-utils'
 
-const [major] = process.version.slice(1).split('.').map(num => Number(num))
-
-test.runIf(major < 22)('importing files in restricted fs works correctly', async () => {
+test('importing files in restricted fs works correctly', async () => {
   createFile(
     resolvePath(import.meta.url, '../fixtures/vm-threads/src/external/package-null/package-null.json'),
     'null',

--- a/test/core/test/diff.test.ts
+++ b/test/core/test/diff.test.ts
@@ -322,7 +322,7 @@ test('truncate large diff', () => {
   const diff = getErrorDiff(Array.from({ length: 500_000 }).fill(0), 1234)
   expect(diff.length).lessThan(200_000)
   expect(diff.trim()).toMatch(/\.\.\.$/)
-})
+}, 60_000)
 
 test('diff default maxDepth', () => {
   function generateCycle(n: number) {

--- a/test/core/test/env.test.ts
+++ b/test/core/test/env.test.ts
@@ -60,15 +60,8 @@ test('PROD, DEV, SSR should be boolean', () => {
   expect(process.env.PROD).toBe('')
   expect(process.env.DEV).toBe('1')
 
-  // see https://github.com/vitest-dev/vitest/issues/5562
-  if (process.execArgv.includes('--experimental-vm-modules')) {
-    expect(import.meta.env.SSR).toBe(false)
-    expect(process.env.SSR).toBe(undefined)
-  }
-  else {
-    expect(import.meta.env.SSR).toBe(true)
-    expect(process.env.SSR).toBe('1')
-  }
+  expect(import.meta.env.SSR).toBe(true)
+  expect(process.env.SSR).toBe('1')
 
   import.meta.env.SSR = false
   expect(import.meta.env.SSR).toEqual(false)

--- a/test/core/test/timeout.spec.ts
+++ b/test/core/test/timeout.spec.ts
@@ -1,17 +1,15 @@
 import { describe, expect, test } from 'vitest'
 
 describe('suite timeout', () => {
-  test('true is true after 100ms', async () => {
-    await new Promise(resolve => setTimeout(resolve, 10))
-    expect(true).toBe(true)
+  test('timeout is inherited', async ({ task }) => {
+    expect(task.timeout).toBe(100)
   })
 }, {
   timeout: 100,
 })
 
 describe('suite timeout simple input', () => {
-  test('true is true after 100ms', async () => {
-    await new Promise(resolve => setTimeout(resolve, 10))
-    expect(true).toBe(true)
+  test('timeout is inherited', async ({ task }) => {
+    expect(task.timeout).toBe(100)
   })
 }, 100)

--- a/test/core/vitest.workspace.ts
+++ b/test/core/vitest.workspace.ts
@@ -14,6 +14,5 @@ function project(pool: Pool) {
 export default defineWorkspace([
   project('threads'),
   project('forks'),
-  // TODO: fix fail on Node 22.1
-  // project('vmThreads'),
+  project('vmThreads'),
 ])

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -6,19 +6,14 @@ const pools = ['forks']
 
 if (!process.env.COVERAGE_BROWSER) {
   pools.push('threads')
-
-  const [major] = process.version.slice(1).split('.').map(num => Number(num))
-
-  if (major < 22) {
-    pools.push('vmForks', 'vmThreads')
-  }
+  pools.push('vmForks', 'vmThreads')
 }
 
 for (const isolate of [true, false]) {
   for (const pool of pools) {
     test(`{ isolate: ${isolate}, pool: "${pool}" }`, async () => {
       await runVitest({
-        include: ['fixtures/test/isolation-*'],
+        include: ['fixtures/test/isolation-*.test.ts'],
         setupFiles: ['fixtures/setup.isolation.ts'],
         sequence: { sequencer: Sorter },
 


### PR DESCRIPTION
### Description

Vitest did not properly cache synthetic modules. After adding the cache, flakiness disappears. I wasn't able to reproduce this with a simple setup, unfortunately, so I am still not sure what exactly caused the crashes to happen.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
