### PR TITLE
feat(api)!: report test file also as a suite

### DIFF
--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -120,10 +120,9 @@ export class TestCase extends ReportedTaskImplementation {
    */
   public get fullName(): string {
     if (this.#fullName === undefined) {
-      if (this.parent.task !== this.module.task) {
+      if (!this.parent.isTestModule()) {
         this.#fullName = `${this.parent.fullName} > ${this.name}`
-      }
-      else {
+      } else {
         this.#fullName = this.name
       }
     }
@@ -399,10 +398,20 @@ export class TestSuite extends SuiteImplementation {
     this.options = buildOptions(task)
   }
 
+  /** @internal */
   static fromTestModule(testModule: TestModule): TestSuite {
     return new this(testModule.task, testModule.project, testModule, {
       register: false,
     })
+  }
+
+  /**
+   * Returns true if the current test suite is a test module.
+   * Test module suite is a "virtual" suite that wraps all tests in the module,
+   * it is not defined by the user manually.
+   */
+  isTestModule(): boolean {
+    return 'filepath' in this.task
   }
 
   /**
@@ -423,10 +432,9 @@ export class TestSuite extends SuiteImplementation {
    */
   public get fullName(): string {
     if (this.#fullName === undefined) {
-      if (this.parent) {
+      if (this.parent && !this.parent?.isTestModule()) {
         this.#fullName = `${this.parent.fullName} > ${this.name}`
-      }
-      else {
+      } else {
         this.#fullName = this.name
       }
     }

--- a/packages/vitest/src/node/test-run.ts
+++ b/packages/vitest/src/node/test-run.ts
@@ -95,7 +95,8 @@ export class TestRun {
     }
 
     if (event === 'suite-prepare' && entity.type === 'module') {
-      return await this.vitest.report('onTestModuleStart', entity)
+      await this.vitest.report('onTestModuleStart', entity)
+      return await this.vitest.report('onTestSuiteReady', entity.suite)
     }
 
     if (event === 'suite-finished') {
@@ -120,6 +121,7 @@ export class TestRun {
       }
 
       if (entity.type === 'module') {
+        await this.vitest.report('onTestSuiteResult', entity.suite)
         await this.vitest.report('onTestModuleEnd', entity)
       }
       else {

--- a/test/reporters/tests/test-run.test.ts
+++ b/test/reporters/tests/test-run.test.ts
@@ -89,8 +89,10 @@ describe('TestModule', () => {
       onTestModuleQueued    (test-module.test.ts)
       onTestModuleCollected (test-module.test.ts)
       onTestModuleStart     (test-module.test.ts)
-        onTestCaseReady     (test-module.test.ts) |example|
-        onTestCaseResult    (test-module.test.ts) |example|
+        onTestSuiteReady    (test-module.test.ts) |test-module.test.ts|
+          onTestCaseReady   (test-module.test.ts) |example|
+          onTestCaseResult  (test-module.test.ts) |example|
+        onTestSuiteResult   (test-module.test.ts) |test-module.test.ts|
       onTestModuleEnd       (test-module.test.ts)"
     `)
   })
@@ -110,15 +112,19 @@ describe('TestModule', () => {
       onTestModuleQueued    (first.test.ts)
       onTestModuleCollected (first.test.ts)
       onTestModuleStart     (first.test.ts)
-        onTestCaseReady     (first.test.ts) |first test case|
-        onTestCaseResult    (first.test.ts) |first test case|
+        onTestSuiteReady    (first.test.ts) |first.test.ts|
+          onTestCaseReady   (first.test.ts) |first test case|
+          onTestCaseResult  (first.test.ts) |first test case|
+        onTestSuiteResult   (first.test.ts) |first.test.ts|
       onTestModuleEnd       (first.test.ts)
 
       onTestModuleQueued    (second.test.ts)
       onTestModuleCollected (second.test.ts)
       onTestModuleStart     (second.test.ts)
-        onTestCaseReady     (second.test.ts) |second test case|
-        onTestCaseResult    (second.test.ts) |second test case|
+        onTestSuiteReady    (second.test.ts) |second.test.ts|
+          onTestCaseReady   (second.test.ts) |second test case|
+          onTestCaseResult  (second.test.ts) |second test case|
+        onTestSuiteResult   (second.test.ts) |second.test.ts|
       onTestModuleEnd       (second.test.ts)"
     `)
   })
@@ -140,15 +146,19 @@ describe('TestModule', () => {
       onTestModuleQueued    (first.test.ts)
       onTestModuleCollected (first.test.ts)
       onTestModuleStart     (first.test.ts)
-        onTestCaseReady     (first.test.ts) |first test case|
-        onTestCaseResult    (first.test.ts) |first test case|
+        onTestSuiteReady    (first.test.ts) |first.test.ts|
+          onTestCaseReady   (first.test.ts) |first test case|
+          onTestCaseResult  (first.test.ts) |first test case|
+        onTestSuiteResult   (first.test.ts) |first.test.ts|
       onTestModuleEnd       (first.test.ts)
 
       onTestModuleQueued    (second.test.ts)
       onTestModuleCollected (second.test.ts)
       onTestModuleStart     (second.test.ts)
-        onTestCaseReady     (second.test.ts) |second test case|
-        onTestCaseResult    (second.test.ts) |second test case|
+        onTestSuiteReady    (second.test.ts) |second.test.ts|
+          onTestCaseReady   (second.test.ts) |second test case|
+          onTestCaseResult  (second.test.ts) |second test case|
+        onTestSuiteResult   (second.test.ts) |second.test.ts|
       onTestModuleEnd       (second.test.ts)"
     `)
   })
@@ -167,8 +177,10 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |single test case|
-        onTestCaseResult    (example.test.ts) |single test case|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |single test case|
+          onTestCaseResult  (example.test.ts) |single test case|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -187,12 +199,14 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-        onTestCaseResult    (example.test.ts) |second|
-        onTestCaseReady     (example.test.ts) |third|
-        onTestCaseResult    (example.test.ts) |third|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+          onTestCaseResult  (example.test.ts) |second|
+          onTestCaseReady   (example.test.ts) |third|
+          onTestCaseResult  (example.test.ts) |third|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -212,12 +226,14 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-        onTestCaseResult    (example.test.ts) |second|
-        onTestCaseReady     (example.test.ts) |third|
-        onTestCaseResult    (example.test.ts) |third|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+          onTestCaseResult  (example.test.ts) |second|
+          onTestCaseReady   (example.test.ts) |third|
+          onTestCaseResult  (example.test.ts) |third|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -236,8 +252,10 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |failing test case|
-        onTestCaseResult    (example.test.ts) |failing test case|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |failing test case|
+          onTestCaseResult  (example.test.ts) |failing test case|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -255,10 +273,12 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |running|
-        onTestCaseResult    (example.test.ts) |running|
-        onTestCaseReady     (example.test.ts) |skipped|
-        onTestCaseResult    (example.test.ts) |skipped|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |running|
+          onTestCaseResult  (example.test.ts) |running|
+          onTestCaseReady   (example.test.ts) |skipped|
+          onTestCaseResult  (example.test.ts) |skipped|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -276,10 +296,12 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |running|
-        onTestCaseResult    (example.test.ts) |running|
-        onTestCaseReady     (example.test.ts) |skipped|
-        onTestCaseResult    (example.test.ts) |skipped|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |running|
+          onTestCaseResult  (example.test.ts) |running|
+          onTestCaseReady   (example.test.ts) |skipped|
+          onTestCaseResult  (example.test.ts) |skipped|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -297,10 +319,12 @@ describe('TestCase', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-        onTestCaseResult    (example.test.ts) |second|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+          onTestCaseResult  (example.test.ts) |second|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -321,10 +345,12 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |example suite|
           onTestCaseReady   (example.test.ts) |first test case|
           onTestCaseResult  (example.test.ts) |first test case|
         onTestSuiteResult   (example.test.ts) |example suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -347,6 +373,7 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |first suite|
           onTestCaseReady   (example.test.ts) |first test case|
           onTestCaseResult  (example.test.ts) |first test case|
@@ -355,6 +382,7 @@ describe('TestSuite', () => {
           onTestCaseReady   (example.test.ts) |second test case|
           onTestCaseResult  (example.test.ts) |second test case|
         onTestSuiteResult   (example.test.ts) |second suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -380,6 +408,7 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |first suite|
           onTestCaseReady   (example.test.ts) |first test case|
           onTestCaseResult  (example.test.ts) |first test case|
@@ -388,6 +417,7 @@ describe('TestSuite', () => {
           onTestCaseReady   (example.test.ts) |second test case|
           onTestCaseResult  (example.test.ts) |second test case|
         onTestSuiteResult   (example.test.ts) |second suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -414,6 +444,7 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |first suite|
           onTestCaseReady   (example.test.ts) |first test case|
           onTestCaseResult  (example.test.ts) |first test case|
@@ -426,6 +457,7 @@ describe('TestSuite', () => {
             onTestSuiteResult (example.test.ts) |third suite|
           onTestSuiteResult (example.test.ts) |second suite|
         onTestSuiteResult   (example.test.ts) |first suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -444,10 +476,12 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |skipped suite|
           onTestCaseReady   (example.test.ts) |first test case|
           onTestCaseResult  (example.test.ts) |first test case|
         onTestSuiteResult   (example.test.ts) |skipped suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -470,14 +504,16 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |skipped suite|
           onTestSuiteReady  (example.test.ts) |nested skipped suite|
             onTestCaseReady (example.test.ts) |first nested case|
             onTestCaseResult (example.test.ts) |first nested case|
           onTestSuiteResult (example.test.ts) |nested skipped suite|
         onTestSuiteResult   (example.test.ts) |skipped suite|
-        onTestCaseReady     (example.test.ts) |first test case|
-        onTestCaseResult    (example.test.ts) |first test case|
+          onTestCaseReady   (example.test.ts) |first test case|
+          onTestCaseResult  (example.test.ts) |first test case|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -500,6 +536,7 @@ describe('TestSuite', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |first suite|
           onTestCaseReady   (example.test.ts) |first test case|
           onTestCaseResult  (example.test.ts) |first test case|
@@ -508,6 +545,7 @@ describe('TestSuite', () => {
             onTestCaseResult (example.test.ts) |second test case|
           onTestSuiteResult (example.test.ts) |skipped suite|
         onTestSuiteResult   (example.test.ts) |first suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -529,14 +567,16 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-          onHookStart       (example.test.ts) |first| [beforeEach]
-          onHookEnd         (example.test.ts) |first| [beforeEach]
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-          onHookStart       (example.test.ts) |second| [beforeEach]
-          onHookEnd         (example.test.ts) |second| [beforeEach]
-        onTestCaseResult    (example.test.ts) |second|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+            onHookStart     (example.test.ts) |first| [beforeEach]
+            onHookEnd       (example.test.ts) |first| [beforeEach]
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+            onHookStart     (example.test.ts) |second| [beforeEach]
+            onHookEnd       (example.test.ts) |second| [beforeEach]
+          onTestCaseResult  (example.test.ts) |second|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -556,14 +596,16 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-          onHookStart       (example.test.ts) |first| [afterEach]
-          onHookEnd         (example.test.ts) |first| [afterEach]
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-          onHookStart       (example.test.ts) |second| [afterEach]
-          onHookEnd         (example.test.ts) |second| [afterEach]
-        onTestCaseResult    (example.test.ts) |second|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+            onHookStart     (example.test.ts) |first| [afterEach]
+            onHookEnd       (example.test.ts) |first| [afterEach]
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+            onHookStart     (example.test.ts) |second| [afterEach]
+            onHookEnd       (example.test.ts) |second| [afterEach]
+          onTestCaseResult  (example.test.ts) |second|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -584,18 +626,20 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-          onHookStart       (example.test.ts) |first| [beforeEach]
-          onHookEnd         (example.test.ts) |first| [beforeEach]
-          onHookStart       (example.test.ts) |first| [afterEach]
-          onHookEnd         (example.test.ts) |first| [afterEach]
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-          onHookStart       (example.test.ts) |second| [beforeEach]
-          onHookEnd         (example.test.ts) |second| [beforeEach]
-          onHookStart       (example.test.ts) |second| [afterEach]
-          onHookEnd         (example.test.ts) |second| [afterEach]
-        onTestCaseResult    (example.test.ts) |second|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+            onHookStart     (example.test.ts) |first| [beforeEach]
+            onHookEnd       (example.test.ts) |first| [beforeEach]
+            onHookStart     (example.test.ts) |first| [afterEach]
+            onHookEnd       (example.test.ts) |first| [afterEach]
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+            onHookStart     (example.test.ts) |second| [beforeEach]
+            onHookEnd       (example.test.ts) |second| [beforeEach]
+            onHookStart     (example.test.ts) |second| [afterEach]
+            onHookEnd       (example.test.ts) |second| [afterEach]
+          onTestCaseResult  (example.test.ts) |second|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -615,12 +659,14 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onHookStart         (example.test.ts) [beforeAll]
         onHookEnd           (example.test.ts) [beforeAll]
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-        onTestCaseResult    (example.test.ts) |second|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+          onTestCaseResult  (example.test.ts) |second|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -640,12 +686,14 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-        onTestCaseResult    (example.test.ts) |second|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+          onTestCaseResult  (example.test.ts) |second|
         onHookStart         (example.test.ts) [afterAll]
         onHookEnd           (example.test.ts) [afterAll]
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -666,14 +714,16 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onHookStart         (example.test.ts) [beforeAll]
         onHookEnd           (example.test.ts) [beforeAll]
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-        onTestCaseResult    (example.test.ts) |second|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+          onTestCaseResult  (example.test.ts) |second|
         onHookStart         (example.test.ts) [afterAll]
         onHookEnd           (example.test.ts) [afterAll]
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -697,22 +747,24 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onHookStart         (example.test.ts) [beforeAll]
         onHookEnd           (example.test.ts) [beforeAll]
-        onTestCaseReady     (example.test.ts) |first|
-          onHookStart       (example.test.ts) |first| [beforeEach]
-          onHookEnd         (example.test.ts) |first| [beforeEach]
-          onHookStart       (example.test.ts) |first| [afterEach]
-          onHookEnd         (example.test.ts) |first| [afterEach]
-        onTestCaseResult    (example.test.ts) |first|
-        onTestCaseReady     (example.test.ts) |second|
-          onHookStart       (example.test.ts) |second| [beforeEach]
-          onHookEnd         (example.test.ts) |second| [beforeEach]
-          onHookStart       (example.test.ts) |second| [afterEach]
-          onHookEnd         (example.test.ts) |second| [afterEach]
-        onTestCaseResult    (example.test.ts) |second|
+          onTestCaseReady   (example.test.ts) |first|
+            onHookStart     (example.test.ts) |first| [beforeEach]
+            onHookEnd       (example.test.ts) |first| [beforeEach]
+            onHookStart     (example.test.ts) |first| [afterEach]
+            onHookEnd       (example.test.ts) |first| [afterEach]
+          onTestCaseResult  (example.test.ts) |first|
+          onTestCaseReady   (example.test.ts) |second|
+            onHookStart     (example.test.ts) |second| [beforeEach]
+            onHookEnd       (example.test.ts) |second| [beforeEach]
+            onHookStart     (example.test.ts) |second| [afterEach]
+            onHookEnd       (example.test.ts) |second| [afterEach]
+          onTestCaseResult  (example.test.ts) |second|
         onHookStart         (example.test.ts) [afterAll]
         onHookEnd           (example.test.ts) [afterAll]
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -734,6 +786,7 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |example|
           onHookStart       (example.test.ts) |example| [beforeAll]
           onHookEnd         (example.test.ts) |example| [beforeAll]
@@ -742,6 +795,7 @@ describe('hooks', () => {
           onTestCaseReady   (example.test.ts) |second|
           onTestCaseResult  (example.test.ts) |second|
         onTestSuiteResult   (example.test.ts) |example|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -763,6 +817,7 @@ describe('hooks', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
         onTestSuiteReady    (example.test.ts) |example|
           onTestCaseReady   (example.test.ts) |first|
           onTestCaseResult  (example.test.ts) |first|
@@ -771,12 +826,13 @@ describe('hooks', () => {
           onHookStart       (example.test.ts) |example| [afterAll]
           onHookEnd         (example.test.ts) |example| [afterAll]
         onTestSuiteResult   (example.test.ts) |example|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
 })
 
-describe('merge reports', () => {
+describe.only('merge reports', () => {
   test('correctly reports events for a single test module', async () => {
     const blobsOutputDirectory = resolve(import.meta.dirname, 'fixtures-blobs')
     const blobOutputFile = resolve(blobsOutputDirectory, 'blob.json')
@@ -811,12 +867,14 @@ describe('merge reports', () => {
       onTestModuleQueued    (example.test.ts)
       onTestModuleCollected (example.test.ts)
       onTestModuleStart     (example.test.ts)
-        onTestCaseReady     (example.test.ts) |first|
-        onTestCaseResult    (example.test.ts) |first|
-        onTestSuiteReady    (example.test.ts) |suite|
-          onTestCaseReady   (example.test.ts) |second|
-          onTestCaseResult  (example.test.ts) |second|
-        onTestSuiteResult   (example.test.ts) |suite|
+        onTestSuiteReady    (example.test.ts) |example.test.ts|
+          onTestCaseReady   (example.test.ts) |first|
+          onTestCaseResult  (example.test.ts) |first|
+          onTestSuiteReady  (example.test.ts) |suite|
+            onTestCaseReady (example.test.ts) |second|
+            onTestCaseResult (example.test.ts) |second|
+          onTestSuiteResult (example.test.ts) |suite|
+        onTestSuiteResult   (example.test.ts) |example.test.ts|
       onTestModuleEnd       (example.test.ts)"
     `)
   })
@@ -868,35 +926,39 @@ describe('merge reports', () => {
       onTestModuleQueued    (example-1.test.ts)
       onTestModuleCollected (example-1.test.ts)
       onTestModuleStart     (example-1.test.ts)
-        onTestCaseReady     (example-1.test.ts) |first|
-        onTestCaseResult    (example-1.test.ts) |first|
-        onTestSuiteReady    (example-1.test.ts) |suite|
-          onTestCaseReady   (example-1.test.ts) |second|
-          onTestCaseResult  (example-1.test.ts) |second|
-        onTestSuiteResult   (example-1.test.ts) |suite|
+        onTestSuiteReady    (example-1.test.ts) |example-1.test.ts|
+          onTestCaseReady   (example-1.test.ts) |first|
+          onTestCaseResult  (example-1.test.ts) |first|
+          onTestSuiteReady  (example-1.test.ts) |suite|
+            onTestCaseReady (example-1.test.ts) |second|
+            onTestCaseResult (example-1.test.ts) |second|
+          onTestSuiteResult (example-1.test.ts) |suite|
+        onTestSuiteResult   (example-1.test.ts) |example-1.test.ts|
       onTestModuleEnd       (example-1.test.ts)
 
       onTestModuleQueued    (example-2.test.ts)
       onTestModuleCollected (example-2.test.ts)
       onTestModuleStart     (example-2.test.ts)
-        onTestCaseReady     (example-2.test.ts) |first|
-        onTestCaseResult    (example-2.test.ts) |first|
-        onTestSuiteReady    (example-2.test.ts) |suite|
-          onTestCaseReady   (example-2.test.ts) |second|
-          onTestCaseResult  (example-2.test.ts) |second|
-          onTestCaseReady   (example-2.test.ts) |third|
-          onTestCaseResult  (example-2.test.ts) |third|
-        onTestSuiteResult   (example-2.test.ts) |suite|
-        onTestCaseReady     (example-2.test.ts) |fifth|
-        onTestCaseResult    (example-2.test.ts) |fifth|
-        onTestCaseReady     (example-2.test.ts) |fourth|
-        onTestCaseResult    (example-2.test.ts) |fourth|
+        onTestSuiteReady    (example-2.test.ts) |example-2.test.ts|
+          onTestCaseReady   (example-2.test.ts) |first|
+          onTestCaseResult  (example-2.test.ts) |first|
+          onTestSuiteReady  (example-2.test.ts) |suite|
+            onTestCaseReady (example-2.test.ts) |second|
+            onTestCaseResult (example-2.test.ts) |second|
+            onTestCaseReady (example-2.test.ts) |third|
+            onTestCaseResult (example-2.test.ts) |third|
+          onTestSuiteResult (example-2.test.ts) |suite|
+          onTestCaseReady   (example-2.test.ts) |fifth|
+          onTestCaseResult  (example-2.test.ts) |fifth|
+          onTestCaseReady   (example-2.test.ts) |fourth|
+          onTestCaseResult  (example-2.test.ts) |fourth|
+        onTestSuiteResult   (example-2.test.ts) |example-2.test.ts|
       onTestModuleEnd       (example-2.test.ts)"
     `)
   })
 })
 
-describe('type checking', () => {
+describe.skip('type checking', () => {
   test('typechecking is reported correctly', async () => {
     const report = await run({
       'example-1.test-d.ts': ts`
@@ -1090,17 +1152,12 @@ function getDepth(entity: TestSuite | TestCase | TestModule) {
     return 0
   }
 
-  let depth = 0
+  let depth = 2
   let parent = entity.parent
 
   while (parent) {
     depth += 2
-    if (parent.type !== 'module') {
-      parent = parent.parent
-    }
-    else {
-      break
-    }
+    parent = parent.parent
   }
 
   return depth


### PR DESCRIPTION
### Description

An idea I had while working on #7738. It felt weird that `onTestSuiteReady`/`onTestSuiteResult` are never called if test files doesn't have any suites. This PR makes it so the test file is also treated as a suite by the reporter. It means:

- `testCase.parent` will always be a `TestSuite`
- `testSuite.parent` is now `TestSuite | undefined`. If it's `undefined`, then the current suite is the same as the `TestModule`
- `onTestSuiteReady`/`onTestSuiteResult` is always called

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
