### PR TITLE
fix: add global `chai` variable in `vitest/globals` (fix: #7474)

### DIFF
--- a/packages/vitest/globals.d.ts
+++ b/packages/vitest/globals.d.ts
@@ -1,6 +1,7 @@
 declare global {
   const suite: typeof import('vitest')['suite']
   const test: typeof import('vitest')['test']
+  const chai: typeof import("vitest")["chai"]
   const describe: typeof import('vitest')['describe']
   const it: typeof import('vitest')['it']
   const expectTypeOf: typeof import('vitest')['expectTypeOf']


### PR DESCRIPTION
### Description

Adds a new global variable `chai` declared inside `packages/vitest/globals.d.ts`

Closes #7474 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
