### PR TITLE
fix: prevent modifying `test.exclude` when same object passed in `coverage.exclude`

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -349,7 +349,12 @@ export function resolveConfig(
   resolved.globalSetup = toArray(resolved.globalSetup || []).map(file =>
     resolvePath(file, resolved.root),
   )
-  resolved.coverage.exclude.push(
+
+  // override original exclude array for cases where user re-uses same object in test.exclude
+  resolved.coverage.exclude = [
+    ...resolved.coverage.exclude,
+
+    // Exclude setup files
     ...resolved.setupFiles.map(
       file =>
         `${resolved.coverage.allowExternal ? '**/' : ''}${relative(
@@ -357,8 +362,10 @@ export function resolveConfig(
           file,
         )}`,
     ),
-  )
-  resolved.coverage.exclude.push(...resolved.include)
+
+    // Exclude test files
+    ...resolved.include,
+  ]
 
   resolved.forceRerunTriggers = [
     ...resolved.forceRerunTriggers,

--- a/test/config/test/public.test.ts
+++ b/test/config/test/public.test.ts
@@ -42,3 +42,21 @@ test('respects custom config', async () => {
   expect(vitestConfig.name).toBe('custom config')
   expect(vitestConfig.reporters).toEqual([['default', {}]])
 })
+
+test('default value changes of coverage.exclude do not reflect to test.exclude', async () => {
+  const exclude = ['**/custom-exclude/**']
+
+  const { vitestConfig } = await resolveConfig({
+    include: ['**/example.test.ts'],
+    exclude,
+    coverage: {
+      exclude,
+    },
+  })
+
+  expect(exclude).toStrictEqual(['**/custom-exclude/**'])
+
+  expect(vitestConfig.include).toStrictEqual(['**/example.test.ts'])
+  expect(vitestConfig.exclude).toStrictEqual(['**/custom-exclude/**'])
+  expect(vitestConfig.coverage.exclude).toStrictEqual(['**/custom-exclude/**', '**/example.test.ts'])
+})


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/7772


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
