### PR TITLE
fix(browser): fix transform error before browser server initialization

### DIFF
--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -516,13 +516,20 @@ export class TestProject {
       this.vitest.version,
     )
     const { createBrowserServer, distRoot } = await import('@vitest/browser')
+    let cacheDir: string
     const browser = await createBrowserServer(
       this,
       this.vite.config.configFile,
       [
+        {
+          name: 'vitest:browser-cacheDir',
+          configResolved(config) {
+            cacheDir = config.cacheDir
+          },
+        },
         ...MocksPlugins({
           filter(id) {
-            if (id.includes(distRoot) || id.includes(browser.vite.config.cacheDir)) {
+            if (id.includes(distRoot) || id.includes(cacheDir)) {
               return false
             }
             return true

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -117,5 +117,11 @@ export default defineConfig({
         }
       },
     },
+    {
+      name: 'test-early-transform',
+      async configureServer(server) {
+        await server.ssrLoadModule('/package.json')
+      },
+    },
   ],
 })


### PR DESCRIPTION
### Description

Fixes https://discord.com/channels/917386801235247114/1356658374317445311
Fixes #7784

The following code (introduced in https://github.com/vitest-dev/vitest/pull/7605) fails when `transform` is called before full server initialization (e.g. `configureServer(server) { server.ssrLoadModule }` like sveltekit https://github.com/sveltejs/kit/blob/f4ce1856ad9ea446c424bd818b25ae89e34a0692/packages/kit/src/exports/vite/dev/index.js#L400).

```js
const browser = await createBrowserServer({
  ...
  filter() {
    // Cannot access 'browser' before initialization
    id.includes(browser.vite.config.cacheDir))
  }
})
```

I changed this to obtain `cacheDir` through a separate `configResolved` hook, which should be guaranteed to be defined earlier.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
