### PR TITLE
refactor: use bg* colors in reporter instead of reversing

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -609,7 +609,7 @@ export abstract class BaseReporter implements Reporter {
         }
 
         this.ctx.logger.error(
-          `${c.red(c.bold(c.inverse(' FAIL ')))} ${formatProjectName(projectName)}${name}`,
+          `${c.bgRed(c.bold(' FAIL '))} ${formatProjectName(projectName)}${name}`,
         )
       }
 
@@ -628,7 +628,7 @@ export abstract class BaseReporter implements Reporter {
 }
 
 function errorBanner(message: string) {
-  return c.red(divider(c.bold(c.inverse(` ${message} `))))
+  return c.bgRed(divider(c.bold(` ${message} `)))
 }
 
 function sum<T>(items: T[], cb: (_next: T) => number | undefined) {

--- a/packages/vitest/src/node/reporters/basic.ts
+++ b/packages/vitest/src/node/reporters/basic.ts
@@ -12,7 +12,7 @@ export class BasicReporter extends BaseReporter {
   onInit(ctx: Vitest): void {
     super.onInit(ctx)
 
-    ctx.logger.log(c.inverse(c.bold(c.yellow(' DEPRECATED '))), c.yellow(
+    ctx.logger.log(c.bold(c.bgYellow(' DEPRECATED ')), c.yellow(
       `'basic' reporter is deprecated and will be removed in Vitest v3.\n`
       + `Remove 'basic' from 'reporters' option. To match 'basic' reporter 100%, use configuration:\n${
         JSON.stringify({ test: { reporters: [['default', { summary: false }]] } }, null, 2)}`,

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -229,7 +229,8 @@ export function formatProjectName(name: string | undefined, suffix = ' '): strin
 }
 
 export function withLabel(color: 'red' | 'green' | 'blue' | 'cyan' | 'yellow', label: string, message?: string) {
-  return `${c.bold(c.inverse(c[color](` ${label} `)))} ${message ? c[color](message) : ''}`
+  const bgColor = `bg${color.charAt(0).toUpperCase()}${color.slice(1)}` as 'bgRed' | 'bgGreen' | 'bgBlue' | 'bgCyan' | 'bgYellow'
+  return `${c.bold(c[bgColor](` ${label} `))} ${message ? c[color](message) : ''}`
 }
 
 export function padSummaryTitle(str: string): string {


### PR DESCRIPTION
### Description

I am not familiar with _why_ we do this, but this doesn't work in CI, so why not just use `bg` colors.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
