### PR TITLE
fix(browser): fix mocking from outside of root

### DIFF
--- a/packages/mocker/src/node/resolver.ts
+++ b/packages/mocker/src/node/resolver.ts
@@ -103,9 +103,9 @@ export class ServerMockResolver {
   }
 
   private async resolveMockId(rawId: string, importer: string) {
-    if (!importer.startsWith(this.server.config.root)) {
-      importer = join(this.server.config.root, importer)
-    }
+    // if (!importer.startsWith(this.server.config.root)) {
+    //   importer = join(this.server.config.root, importer)
+    // }
     const resolved = await this.server.pluginContainer.resolveId(
       rawId,
       importer,

--- a/packages/mocker/src/node/resolver.ts
+++ b/packages/mocker/src/node/resolver.ts
@@ -103,9 +103,16 @@ export class ServerMockResolver {
   }
 
   private async resolveMockId(rawId: string, importer: string) {
-    // if (!importer.startsWith(this.server.config.root)) {
-    //   importer = join(this.server.config.root, importer)
-    // }
+    if (!importer.startsWith(this.server.config.root)) {
+      const resolved = await this.server.pluginContainer.resolveId(
+        importer,
+        this.server.config.root,
+        {
+          ssr: false,
+        },
+      )
+      importer = resolved?.id ?? this.server.config.root
+    }
     const resolved = await this.server.pluginContainer.resolveId(
       rawId,
       importer,

--- a/packages/mocker/src/node/resolver.ts
+++ b/packages/mocker/src/node/resolver.ts
@@ -103,15 +103,11 @@ export class ServerMockResolver {
   }
 
   private async resolveMockId(rawId: string, importer: string) {
-    if (!importer.startsWith(this.server.config.root)) {
-      const resolved = await this.server.pluginContainer.resolveId(
-        importer,
-        this.server.config.root,
-        {
-          ssr: false,
-        },
-      )
-      importer = resolved?.id ?? this.server.config.root
+    if (
+      !this.server.moduleGraph.getModuleById(importer)
+      && !importer.startsWith(this.server.config.root)
+    ) {
+      importer = join(this.server.config.root, importer)
     }
     const resolved = await this.server.pluginContainer.resolveId(
       rawId,

--- a/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
@@ -1,6 +1,6 @@
 import { test, expect, vi } from 'vitest';
 import project2 from "../project2/index.js"
-import "../project3/index.js"
+import "../project3/imported-test.js"
 
 vi.mock("../project2/index.js", () => ({
   default: 'project2-mocked'

--- a/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
@@ -1,5 +1,6 @@
 import { test, expect, vi } from 'vitest';
 import project2 from "../project2/index.js"
+import "../project3/index.js"
 
 vi.mock("../project2/index.js", () => ({
   default: 'project2-mocked'

--- a/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/basic.test.js
@@ -1,5 +1,6 @@
 import { test, expect, vi } from 'vitest';
 import project2 from "../project2/index.js"
+import "./imported-test.js"
 import "../project3/imported-test.js"
 
 vi.mock("../project2/index.js", () => ({

--- a/test/browser/fixtures/mocking-out-of-root/project1/imported-test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/imported-test.js
@@ -1,0 +1,8 @@
+import { vi, test, expect } from "vitest"
+import lib from "./lib.js";
+
+vi.mock("./lib.js", () => ({ default: "mocked" }))
+
+test("project1 imported", () => {
+  expect(lib).toBe("mocked");
+})

--- a/test/browser/fixtures/mocking-out-of-root/project1/lib.js
+++ b/test/browser/fixtures/mocking-out-of-root/project1/lib.js
@@ -1,0 +1,1 @@
+export default "lib"

--- a/test/browser/fixtures/mocking-out-of-root/project3/imported-test.js
+++ b/test/browser/fixtures/mocking-out-of-root/project3/imported-test.js
@@ -3,6 +3,6 @@ import lib from "./lib.js";
 
 vi.mock("./lib.js", () => ({ default: "mocked" }))
 
-test("project3", () => {
+test("project3 imported", () => {
   expect(lib).toBe("mocked");
 })

--- a/test/browser/fixtures/mocking-out-of-root/project3/index.js
+++ b/test/browser/fixtures/mocking-out-of-root/project3/index.js
@@ -1,0 +1,8 @@
+import { vi, test, expect } from "vitest"
+import lib from "./lib.js";
+
+vi.mock("./lib.js", () => ({ default: "mocked" }))
+
+test("project3", () => {
+  expect(lib).toBe("mocked");
+})

--- a/test/browser/fixtures/mocking-out-of-root/project3/lib.js
+++ b/test/browser/fixtures/mocking-out-of-root/project3/lib.js
@@ -1,0 +1,1 @@
+export default "lib"


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7595

It seems like a very odd use case to call `vi.mock` from outside of root, but `join(root, importer)` also felt a bit odd. Not sure when that happens. If this is necessary, then we could also call another `resolveId` to resolve `importer` itself. (Well, it looks like this happens with custom mock server usage like in `teste/public-mocker`.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
