### PR TITLE
fix: use happy-dom/jsdom types for `envionmentOptions`

### DIFF
--- a/packages/vitest/optional-types.d.ts
+++ b/packages/vitest/optional-types.d.ts
@@ -1,0 +1,7 @@
+/* eslint-disable ts/ban-ts-comment */
+
+// @ts-ignore optional peer dep
+export type * as jsdomTypes from 'jsdom'
+
+// @ts-ignore optional peer dep
+export type * as happyDomTypes from 'happy-dom'

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -76,6 +76,7 @@ const external = [
   'node:http',
   'node:console',
   'inspector',
+  'vitest/optional-types.js',
   'vite-node/source-map',
   'vite-node/client',
   'vite-node/server',

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -1,4 +1,5 @@
 import type { Environment } from '../../types/environment'
+import type { JSDOMOptions } from '../../types/jsdom-options'
 import { populateGlobal } from './utils'
 
 function catchWindowErrors(window: Window) {
@@ -51,7 +52,7 @@ export default <Environment>{
       console = false,
       cookieJar = false,
       ...restOptions
-    } = jsdom as any
+    } = jsdom as JSDOMOptions
     let dom = new JSDOM(html, {
       pretendToBeVisual,
       resources:

--- a/packages/vitest/src/types/happy-dom-options.ts
+++ b/packages/vitest/src/types/happy-dom-options.ts
@@ -1,23 +1,8 @@
-/**
- * Happy DOM options.
- */
-export interface HappyDOMOptions {
-  width?: number
-  height?: number
-  url?: string
-  settings?: {
-    disableJavaScriptEvaluation?: boolean
-    disableJavaScriptFileLoading?: boolean
-    disableCSSFileLoading?: boolean
-    disableIframePageLoading?: boolean
-    disableComputedStyleRendering?: boolean
-    enableFileSystemHttpRequests?: boolean
-    navigator?: {
-      userAgent?: string
-    }
-    device?: {
-      prefersColorScheme?: string
-      mediaType?: string
-    }
-  }
-}
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore `happy-dom` is optional peeer dep
+import type { Window } from 'happy-dom'
+
+export type HappyDOMOptions = Omit<
+  NonNullable<ConstructorParameters<typeof Window>[0]>,
+  'console'
+>

--- a/packages/vitest/src/types/happy-dom-options.ts
+++ b/packages/vitest/src/types/happy-dom-options.ts
@@ -1,8 +1,6 @@
-// eslint-disable-next-line ts/ban-ts-comment
-// @ts-ignore `happy-dom` is optional peeer dep
-import type { Window } from 'happy-dom'
+import type { happyDomTypes } from 'vitest/optional-types.js'
 
 export type HappyDOMOptions = Omit<
-  NonNullable<ConstructorParameters<typeof Window>[0]>,
+  NonNullable<ConstructorParameters<typeof happyDomTypes.Window>[0]>,
   'console'
 >

--- a/packages/vitest/src/types/jsdom-options.ts
+++ b/packages/vitest/src/types/jsdom-options.ts
@@ -1,15 +1,16 @@
-export interface JSDOMOptions {
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore `jsdom` is optional peeer dep
+import type { ConstructorOptions } from 'jsdom'
+
+export type JSDOMOptions = ConstructorOptionsOverride & Omit<ConstructorOptions, keyof ConstructorOptionsOverride>
+
+interface ConstructorOptionsOverride {
   /**
    * The html content for the test.
    *
    * @default '<!DOCTYPE html>'
    */
   html?: string | ArrayBufferLike
-  /**
-   * referrer just affects the value read from document.referrer.
-   * It defaults to no referrer (which reflects as the empty string).
-   */
-  referrer?: string
   /**
    * userAgent affects the value read from navigator.userAgent, as well as the User-Agent header sent while fetching subresources.
    *
@@ -24,21 +25,6 @@ export interface JSDOMOptions {
    * @default 'http://localhost:3000'.
    */
   url?: string
-  /**
-   * contentType affects the value read from document.contentType, and how the document is parsed: as HTML or as XML.
-   * Values that are not "text/html" or an XML mime type will throw.
-   *
-   * @default 'text/html'.
-   */
-  contentType?: string
-  /**
-   * The maximum size in code units for the separate storage areas used by localStorage and sessionStorage.
-   * Attempts to store data larger than this limit will cause a DOMException to be thrown. By default, it is set
-   * to 5,000,000 code units per origin, as inspired by the HTML specification.
-   *
-   * @default 5_000_000
-   */
-  storageQuota?: number
   /**
    * Enable console?
    *
@@ -55,20 +41,6 @@ export interface JSDOMOptions {
    * @default true
    */
   pretendToBeVisual?: boolean
-  /**
-   * `includeNodeLocations` preserves the location info produced by the HTML parser,
-   * allowing you to retrieve it with the nodeLocation() method (described below).
-   *
-   * It defaults to false to give the best performance,
-   * and cannot be used with an XML content type since our XML parser does not support location info.
-   *
-   * @default false
-   */
-  includeNodeLocations?: boolean | undefined
-  /**
-   * @default 'dangerously'
-   */
-  runScripts?: 'dangerously' | 'outside-only'
   /**
    * Enable CookieJar
    *

--- a/packages/vitest/src/types/jsdom-options.ts
+++ b/packages/vitest/src/types/jsdom-options.ts
@@ -1,8 +1,6 @@
-// eslint-disable-next-line ts/ban-ts-comment
-// @ts-ignore `jsdom` is optional peeer dep
-import type { ConstructorOptions } from 'jsdom'
+import type { jsdomTypes } from 'vitest/optional-types.js'
 
-export type JSDOMOptions = ConstructorOptionsOverride & Omit<ConstructorOptions, keyof ConstructorOptionsOverride>
+export type JSDOMOptions = ConstructorOptionsOverride & Omit<jsdomTypes.ConstructorOptions, keyof ConstructorOptionsOverride>
 
 interface ConstructorOptionsOverride {
   /**

--- a/test/dts-config/happy-dom-patch.ts
+++ b/test/dts-config/happy-dom-patch.ts
@@ -1,0 +1,3 @@
+// happy-dom's dts will break `skipLibCheck: false`.
+// for now, override happy-dom type for the sake of testing other packages.
+export const Window = {} as any

--- a/test/dts-config/tsconfig.json
+++ b/test/dts-config/tsconfig.json
@@ -1,11 +1,9 @@
 {
+  "extends": ["./tsconfig.patch.json"],
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "paths": {
-      "happy-dom": ["./happy-dom-patch.ts"]
-    },
     "types": [],
     "strict": true,
     "noEmit": true

--- a/test/dts-config/tsconfig.json
+++ b/test/dts-config/tsconfig.json
@@ -3,6 +3,9 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "paths": {
+      "happy-dom": ["./happy-dom-patch.ts"]
+    },
     "types": [],
     "strict": true,
     "noEmit": true

--- a/test/dts-config/tsconfig.patch.json
+++ b/test/dts-config/tsconfig.patch.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "happy-dom": ["./happy-dom-patch.ts"]
+    }
+  }
+}

--- a/test/dts-fixture/tsconfig.check.json
+++ b/test/dts-fixture/tsconfig.check.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["../dts-config/tsconfig.patch.json"],
   "compilerOptions": {
     "target": "ESNext",
     "module": "NodeNext",

--- a/test/dts-fixture/tsconfig.json
+++ b/test/dts-fixture/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["../dts-config/tsconfig.patch.json"],
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",

--- a/test/dts-playwright/tsconfig.json
+++ b/test/dts-playwright/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["../dts-config/tsconfig.patch.json"],
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",


### PR DESCRIPTION
### Description

- Related https://github.com/vitest-dev/vitest/discussions/7792

Using the same idea as https://github.com/vitejs/vite/pull/18460.

It looks like happy-dom's dts includes invalid types (though largely completion should work), so it's breaking `test/dts-config` which tests with `skipLibCheck: false`.

```sh
node_modules/.pnpm/happy-dom@17.4.4/node_modules/happy-dom/lib/nodes/node/ICachedQuerySelectorResult.d.ts:4:21 - error TS2344: Type 'Element | null' does not satisfy the constraint 'WeakKey'.
  Type 'null' is not assignable to type 'WeakKey'.

4     result: WeakRef<Element | null> | null;
                      ~~~~~~~~~~~~~~
```

For now, I add a hack in `test/dts-xxx` to not pick up this error.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
