### PR TITLE
fix(ui):  config option: `{ ui: true }`

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -290,7 +290,7 @@ export async function VitestPlugin(
     ...CSSEnablerPlugin(ctx),
     CoverageTransform(ctx),
     VitestCoreResolver(ctx),
-    options.ui ? await UIPlugin() : null,
+    await UIPlugin(),
     ...MocksPlugins(),
     VitestOptimizer(),
     NormalizeURLPlugin(),


### PR DESCRIPTION
### Description

Now the config option: ` test: { ui: true } ` works.

Have removed the condition `options.ui ? await UIPlugin() : null`, because at the time of code execution, `options.ui` will be always `undefined` unless the CLI option `--ui` is given.

If `ui` is `false` then it would not trigger Vitest UI (as expected) .

---

Closes #7321

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
