### PR TITLE
fix(runner): show stacktrace on test timeout error

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -342,22 +342,26 @@ function createSuiteCollector(
     })
     setTestFixture(context, options.fixtures)
 
+    // custom can be called from any place, let's assume the limit is 15 stacks
+    const limit = Error.stackTraceLimit
+    Error.stackTraceLimit = 15
+    const stackTraceError = new Error('STACK_TRACE_ERROR')
+    Error.stackTraceLimit = limit
+
     if (handler) {
       setFn(
         task,
         withTimeout(
           withAwaitAsyncAssertions(withFixtures(handler, context), task),
           timeout,
+          false,
+          stackTraceError,
         ),
       )
     }
 
     if (runner.config.includeTaskLocation) {
-      const limit = Error.stackTraceLimit
-      // custom can be called from any place, let's assume the limit is 15 stacks
-      Error.stackTraceLimit = 15
-      const error = new Error('stacktrace').stack!
-      Error.stackTraceLimit = limit
+      const error = stackTraceError.stack!
       const stack = findTestFileStackTrace(error, task.each ?? false)
       if (stack) {
         task.location = stack

--- a/test/config/fixtures/hook-timeout/basic.test.ts
+++ b/test/config/fixtures/hook-timeout/basic.test.ts
@@ -48,3 +48,5 @@ describe('onFinished', () => {
     ctx.onTestFinished(() => new Promise(() => {}), 80)
   })
 })
+
+it("test timeout", () => new Promise(() => {}), 123)

--- a/test/config/test/__snapshots__/hook-timeout.test.ts.snap
+++ b/test/config/test/__snapshots__/hook-timeout.test.ts.snap
@@ -15,7 +15,7 @@ If this is a long-running hook, pass a timeout value as the last argument or con
       5| 
       6|   it('ok', () => {})
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/10]⎯
 
  FAIL  basic.test.ts > afterAll
 Error: Hook timed out in 30ms.
@@ -28,7 +28,7 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      17| 
      18|   it('ok', () => {})
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/10]⎯
 
  FAIL  basic.test.ts > cleanup-beforeAll
 Error: Hook timed out in 50ms.
@@ -41,10 +41,10 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      29| 
      30|   it('ok', () => {})
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/10]⎯
 
 
-⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
 
  FAIL  basic.test.ts > beforeEach > ok
 Error: Hook timed out in 20ms.
@@ -57,7 +57,7 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      11| 
      12|   it('ok', () => {})
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/10]⎯
 
  FAIL  basic.test.ts > afterEach > ok
 Error: Hook timed out in 40ms.
@@ -70,7 +70,7 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      23| 
      24|   it('ok', () => {})
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/10]⎯
 
  FAIL  basic.test.ts > cleanup-beforeEach > ok
 Error: Hook timed out in 60ms.
@@ -83,7 +83,7 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      35| 
      36|   it('ok', () => {})
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/10]⎯
 
  FAIL  basic.test.ts > onFailed > fail
 Error: fail
@@ -95,7 +95,7 @@ Error: fail
      43|   })
      44| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/10]⎯
 
  FAIL  basic.test.ts > onFailed > fail
 Error: Hook timed out in 70ms.
@@ -108,7 +108,7 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      42|     throw new Error('fail')
      43|   })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/10]⎯
 
  FAIL  basic.test.ts > onFinished > ok
 Error: Hook timed out in 80ms.
@@ -121,7 +121,19 @@ If this is a long-running hook, pass a timeout value as the last argument or con
      49|   })
      50| })
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/9]⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/10]⎯
+
+ FAIL  basic.test.ts > test timeout
+Error: Test timed out in 123ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+ ❯ basic.test.ts:52:1
+     50| })
+     51| 
+     52| it("test timeout", () => new Promise(() => {}), 123)
+       | ^
+     53| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/10]⎯
 
 "
 `;


### PR DESCRIPTION
### Description

- Related https://github.com/vitest-dev/vitest/pull/7502

https://github.com/vitest-dev/vitest/pull/7502 added error stack for hooks, but I forgot to use it for test function. This still avoids unconditionally accessing `stackTraceError.stack` since that's where custom `prepareStackTrace` kicks in and it might be costly. It's only accessed either when `includeTaskLocation` enabled or actually timeout error occurs.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
