### PR TITLE
fix: remove pointer-events-none after resizing the left panel

### DIFF
--- a/packages/ui/client/pages/index.vue
+++ b/packages/ui/client/pages/index.vue
@@ -24,6 +24,7 @@ const onMainResized = useDebounceFn((event: { size: number }[]) => {
     mainSizes.value[i] = e.size
   })
   recordMainResize(event)
+  allowBrowserEvents()
 }, 0)
 
 const onModuleResized = useDebounceFn((event: { size: number }[]) => {


### PR DESCRIPTION
### Description

This PR fixes a bug I just found where if you resize the left panel (the one with the list of tests), it adds pointer-events: none; to the tester-ui div which removes the ability to click on whatever you are testing. I have not tested this but I think this change will fix it. 

To reproduce :
1. Open vitest browser UI with a clickable component (like the react example) 
2. Click on the component (should work)
3. Resize the left panel
4. Click on the component (should not work since there is a pointer-events: none; )

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
