### PR TITLE
fix(coverage): expose profiling timers

### DIFF
--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -215,6 +215,10 @@ if (condition) {
 
 To see all configurable options for coverage, see the [coverage Config Reference](https://vitest.dev/config/#coverage).
 
+## Coverage performance
+
+If code coverage generation is slow on your project, see [Profiling Test Performance | Code coverage](/guide/profiling-test-performance.html#code-coverage).
+
 ## Vitest UI
 
 You can check your coverage report in [Vitest UI](/guide/ui).

--- a/docs/guide/profiling-test-performance.md
+++ b/docs/guide/profiling-test-performance.md
@@ -178,6 +178,32 @@ _x_examples_profiling_test_prime-number_test_ts-1413378098.js
 _src_prime-number_ts-525172412.js
 ```
 
+## Code coverage
+
+If code coverage generation is slow on your project you can use `DEBUG=vitest:coverage` environment variable to enable performance logging.
+
+```bash
+$ DEBUG=vitest:coverage vitest --run --coverage
+
+ RUN  v3.1.1 /x/vitest-example
+
+  vitest:coverage Reading coverage results 2/2
+  vitest:coverage Converting 1/2
+  vitest:coverage 4 ms /x/src/multiply.ts
+  vitest:coverage Converting 2/2
+  vitest:coverage 552 ms /x/src/add.ts
+  vitest:coverage Uncovered files 1/2
+  vitest:coverage File "/x/src/large-file.ts" is taking longer than 3s # [!code error]
+  vitest:coverage 3027 ms /x/src/large-file.ts
+  vitest:coverage Uncovered files 2/2
+  vitest:coverage 4 ms /x/src/untested-file.ts
+  vitest:coverage Generate coverage total time 3521 ms
+```
+
+This profiling approach is great for detecting large files that are accidentally picked by coverage providers.
+For example if your configuration is accidentally including large built minified Javascript files in code coverage, they should appear in logs.
+In these cases you might want to adjust your [`coverage.include`](/config/#coverage-include) and [`coverage.exclude`](/config/#coverage-exclude) options.
+
 ## Inspecting profiling records
 
 You can inspect the contents of `*.cpuprofile` and `*.heapprofile` with various tools. See list below for examples.

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -217,7 +217,7 @@ export class BaseCoverageProvider<Options extends ResolvedCoverageOptions<'istan
         for (const chunk of this.toSlices(filenames, this.options.processingConcurrency)) {
           if (onDebug.enabled) {
             index += chunk.length
-            onDebug('Covered files %d/%d', index, total)
+            onDebug(`Reading coverage results ${index}/${total}`)
           }
 
           await Promise.all(chunk.map(async (filename) => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Expose code coverage debug timers via `DEBUG=vitest:coverage` environment variable
- Adds documentation for code coverage performance profiling

<!-- You can also add additional context here -->

I've seen and heard reports about slow code coverage report generation in past. Always user's projects have been picking some minified JS due to agressive `coverage.all` (to be fixed in https://github.com/vitest-dev/vitest/issues/6956), and processing those makes Vite transform and other processing really slow.

With `DEBUG=vitest:coverage` users should be able to detect such files when Vitest seems to be "stuck".

<img src="https://github.com/user-attachments/assets/a3dce54d-a5a3-4d60-9052-8876d9ddf962" width="600" />


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
