### PR TITLE
docs: suggest `vitest run` in `--merge-reports` usage

### DIFF
--- a/docs/guide/improving-performance.md
+++ b/docs/guide/improving-performance.md
@@ -88,7 +88,7 @@ vitest run --reporter=blob --shard=3/3 # 3rd machine
 Collect the results stored in `.vitest-reports` directory from each machine and merge them with [`--merge-reports`](/guide/cli#merge-reports) option:
 
 ```sh
-vitest --merge-reports
+vitest run --merge-reports
 ```
 
 ::: details Github action example
@@ -180,7 +180,7 @@ VITEST_MAX_THREADS=7 vitest run --reporter=blob --shard=3/4 & \
 VITEST_MAX_THREADS=7 vitest run --reporter=blob --shard=4/4 & \
 wait # https://man7.org/linux/man-pages/man2/waitpid.2.html
 
-vitest --merge-reports
+vitest run --merge-reports
 ```
 
 :::


### PR DESCRIPTION
## The problem

The docs suggest running `vitest --merge-reports` but since the `vitest` command runs test in _watch mode_ by default, you are getting the following error:

```
Error: Cannot merge reports with --watch enabled
```

The solution here is either use explicit `vitest run` or make the `--merge-reports` flag turn off the watch mode implicitly. 

I am generally not a fan of implicit magic, so I'm proposing an easier solution to update the docs so merging the reports works as expected. This is also an incremental solution to the broken suggestion, and it doesn't require any work on Vitest itself.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
