### PR TITLE
test: reduce max thread count when vitest-in-vitest

### DIFF
--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -83,6 +83,10 @@ export async function runVitest(
         NO_COLOR: 'true',
         ...rest.env,
       },
+
+      // Test cases are already run with multiple forks/threads
+      maxWorkers: 1,
+      minWorkers: 1,
     }, {
       ...viteOverrides,
       server: {
@@ -147,12 +151,17 @@ interface CliOptions extends Partial<Options> {
   earlyReturn?: boolean
 }
 
-export async function runCli(command: string, _options?: CliOptions | string, ...args: string[]) {
+async function runCli(command: 'vitest' | 'vite-node', _options?: CliOptions | string, ...args: string[]) {
   let options = _options
 
   if (typeof _options === 'string') {
     args.unshift(_options)
     options = undefined
+  }
+
+  if (command === 'vitest') {
+    args.push('--maxWorkers=1')
+    args.push('--minWorkers=1')
   }
 
   const subprocess = x(command, args, options as Options).process!


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- This mostly affects local usage where CPU count is higher than CI's 2 cores
- Vitest spawns max amount of workers always. When we run Vitest inside Vitest, we are running 2*`CPU_COUNT` the amount of workers the CPU count should handle.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
