### PR TITLE
docs: improve mocking classes section

### DIFF
--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -703,19 +703,19 @@ test('can feed dogs', () => {
 Now, when we create a new instance of the `Dog` class its `speak` method (alongside `feed` and `greet`) is already mocked:
 
 ```ts
-const dog = new Dog('Cooper')
-dog.speak() // loud bark!
-dog.greet() // Hi! My name is Cooper!
+const Cooper = new Dog('Cooper')
+Cooper.speak() // loud bark!
+Cooper.greet() // Hi! My name is Cooper!
 
 // you can use built-in assertions to check the validity of the call
-expect(dog.speak).toHaveBeenCalled()
-expect(dog.greet).toHaveBeenCalled()
+expect(Cooper.speak).toHaveBeenCalled()
+expect(Cooper.greet).toHaveBeenCalled()
 
-const dog2 = new Dog('Max')
+const Max = new Dog('Max')
 
 // methods assigned to the prototype are shared between instances
-expect(dog2.speak).toHaveBeenCalled()
-expect(dog2.greet).not.toHaveBeenCalled()
+expect(Max.speak).toHaveBeenCalled()
+expect(Max.greet).not.toHaveBeenCalled()
 ```
 
 We can reassign the return value for a specific instance:

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -656,7 +656,7 @@ const IncorrectDogClass = vi.fn(name => ({
 const Marti = new CorrectDogClass('Marti')
 const Newt = new IncorrectDogClass('Newt')
 
-Marti instanceof CorrectDogClass // true
+Marti instanceof CorrectDogClass // ✅ true
 Newt instanceof IncorrectDogClass // false!
 ```
 :::

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -657,7 +657,7 @@ const Marti = new CorrectDogClass('Marti')
 const Newt = new IncorrectDogClass('Newt')
 
 Marti instanceof CorrectDogClass // ✅ true
-Newt instanceof IncorrectDogClass // false!
+Newt instanceof IncorrectDogClass // ❌ false!
 ```
 :::
 

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -602,14 +602,13 @@ class Dog {
 
   constructor(name: string) {
     this.name = name
-    this.greet = this.greet.bind(this)
   }
 
   static getType(): string {
     return 'animal'
   }
 
-  greet(): string {
+  greet = (): string => {
     return `Hi! My name is ${this.name}!`
   }
 
@@ -627,8 +626,8 @@ We can re-create this class with ES5 functions:
 ```ts
 const Dog = vi.fn(function (name) {
   this.name = name
-  // mock bound methods in the constructor, each instance will have its own spy
-  this.greet = vi.fn(() => `Hi! My name is ${name}!`)
+  // mock instance methods in the constructor, each instance will have its own spy
+  this.greet = vi.fn(() => `Hi! My name is ${this.name}!`)
 })
 
 // notice that static methods are mocked directly on the function,

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -620,19 +620,18 @@ class Dog {
 We can re-create this class with ES5 functions:
 
 ```ts
-// constructor parameters are passed to the mock implementation
-const Dog = vi.fn(name => ({
-  // assign class fields to the returned object
-  name,
-  // mock the "speak" and "feed" methods on every instance of a class
-  speak: vi.fn(() => 'loud bark!'),
-  feed: vi.fn(),
-}))
+const Dog = vi.fn(function (name) {
+  this.name = name
+})
 
-// notice that static methods are mocked directly on the function prototype,
+// notice that static methods are mocked directly on the function,
 // not on the instance of the class
-// all `new Dog()` instances will inherit and share this mock
-Dog.prototype.getType = vi.fn(() => 'mocked animal')
+Dog.getType = vi.fn(() => 'mocked animal')
+
+// mock the "speak" and "feed" methods on every instance of a class
+// all `new Dog()` instances will inherit these spies
+Dog.prototype.speak = vi.fn(() => 'loud bark!')
+Dog.prototype.feed = vi.fn()
 ```
 
 ::: tip WHEN TO USE?
@@ -641,13 +640,12 @@ Generally speaking, you would re-create a class like this inside the module fact
 ```ts
 import { Dog } from './dog.js'
 
-vi.mock('./dog.js', () => ({
-  Dog: vi.fn(name => ({
-    name,
-    feed: vi.fn(),
-    // ... other mocks
-  }))
-}))
+vi.mock(import('./dog.js'), () => {
+  const Dog = vi.fn()
+  Dog.prototype.feed = vi.fn()
+  // ... other mocks
+  return { Dog }
+})
 ```
 
 This method can also be used to pass an instance of a class to a function that accepts the same interface:
@@ -661,10 +659,8 @@ function feed(dog: Dog) {
 import { expect, test, vi } from 'vitest'
 import { feed } from '../src/feed.js'
 
-const Dog = vi.fn(name => ({
-  name,
-  feed: vi.fn(),
-}))
+const Dog = vi.fn()
+Dog.prototype.feed = vi.fn()
 
 test('can feed dogs', () => {
   const dogMax = new Dog('Max')
@@ -769,12 +765,9 @@ export class SomeClass {}
 ```ts
 import { SomeClass } from './example.js'
 
-vi.mock('./example.js', () => {
-  const SomeClass = vi.fn(someConstructorParameter => ({
-    someInstanceField: someConstructorParameter,
-    someInstanceMethod: vi.fn(),
-  }))
-  SomeClass.prototype.someStaticMethod = vi.fn()
+vi.mock(import('./example.js'), () => {
+  const SomeClass = vi.fn()
+  SomeClass.prototype.someMethod = vi.fn()
   return { SomeClass }
 })
 // SomeClass.mock.instances will have SomeClass


### PR DESCRIPTION
There are no issues open for this PR, I opened it directly to suggest some changes to the docs, I hope this approach is ok.  

### Description

When I was checking the documentation for mocking classes, I found out that some recommendations are incorrect, and in general, I found it a bit more convoluted than the recommendation from Jest.  
Because of that, I always refer to the [Jest docs for mocking classes](https://jestjs.io/docs/es6-class-mocks).  
I opened this PR to try to improve the docs.

When I mention "convoluted", it's more a matter of taste, and I could remove the changes from this PR if the maintainers don't think it's useful.   
What I changed is removing references to `this` and `prototype` as much as possible, which can be confusing topics in JS in general, and used a more explicit and inline recommendation for mocking classes.

The other part of the PR is fixing some incorrect suggestions in https://github.com/vitest-dev/vitest/blob/main/docs/guide/mocking.md, the following part:

```js
const Dog = vi.fn(function (name) {
  this.name = name
})

// notice that static methods are mocked directly on the function,
// not on the instance of the class
Dog.getType = vi.fn(() => 'mocked animal')

// mock the "speak" and "feed" methods on every instance of a class
// all `new Dog()` instances will inherit these spies
Dog.prototype.speak = vi.fn(() => 'loud bark!')
Dog.prototype.feed = vi.fn()
```

The correct recommendation is that static methods are added to the `prototype` and the instance methods are directly set as properties of the object instance.

Adding a property to the original function and not the `prototype` will not be shared across the class instances, and trying to call it throws an error.

Adding the instance methods to the `prototype` will cause those methods to be shared across all instances, which can cause issues if trying to assert mock calls between different tests.