### PR TITLE
docs:  Fixed typo under vi.useRealTimers section

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -832,7 +832,7 @@ Returns `true` if fake timers are enabled.
 
 - **Type:** `() => Vitest`
 
-When timers are run out, you may call this method to return mocked timers to its original implementations. All timers that were scheduled before will be discarded.
+When timers have run out, you may call this method to return mocked timers to its original implementations. All timers that were scheduled before will be discarded.
 
 ## Miscellaneous
 


### PR DESCRIPTION
### Description

A fix for at typo under the section vi.useRealTimers section of the vi.md docs

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
