### PR TITLE
fix(vite-node): named export should overwrite export all

### DIFF
--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -625,7 +625,7 @@ function exportAll(exports: any, sourceModule: any) {
   }
 
   for (const key in sourceModule) {
-    if (key !== 'default') {
+    if (key !== 'default' && !(key in exports)) {
       try {
         defineExport(exports, key, () => sourceModule[key])
       }

--- a/test/core/test/fixtures/named-overwrite-all/dep1.js
+++ b/test/core/test/fixtures/named-overwrite-all/dep1.js
@@ -1,0 +1,4 @@
+export const a = 'dep1-a'
+export const b = 'dep1-b'
+export const c = 'dep1-c'
+export const d = 'dep1-d'

--- a/test/core/test/fixtures/named-overwrite-all/dep2.js
+++ b/test/core/test/fixtures/named-overwrite-all/dep2.js
@@ -1,0 +1,1 @@
+export const d = 'dep2-d'

--- a/test/core/test/fixtures/named-overwrite-all/main.js
+++ b/test/core/test/fixtures/named-overwrite-all/main.js
@@ -1,0 +1,4 @@
+export const a = 'main-a'
+export * from './dep1.js'
+export const c = 'main-c'
+export * from './dep2.js'

--- a/test/core/test/named-overwrite-all.test.ts
+++ b/test/core/test/named-overwrite-all.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+// @ts-expect-error no type
+import * as lib from './fixtures/named-overwrite-all/main.js'
+
+test('named exports overwrite export all', async () => {
+  expect(lib).toMatchInlineSnapshot(`
+    {
+      "a": "main-a",
+      "b": "dep1-b",
+      "c": "main-c",
+      "d": "dep1-d",
+    }
+  `)
+})


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite/pull/19534
- Closes https://discord.com/channels/804011606160703521/1362130204595720343/1362130204595720343

Porting https://github.com/vitejs/vite/pull/19534 to fix https://github.com/vitejs/vite/issues/19525 on Vite-node. I forgot we need to have the same thing here when the fix is in runtime but not in transform.

The bug is now always happen when ssr transform hoists each named export https://github.com/vitejs/vite/pull/18983.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
