### PR TITLE
fix: correctly resolve vitest import if inline: true is set

### DIFF
--- a/packages/vitest/src/runtime/execute.ts
+++ b/packages/vitest/src/runtime/execute.ts
@@ -91,6 +91,36 @@ function listenForErrors(state: () => WorkerGlobalState) {
   })
 }
 
+const relativeIds: Record<string, string> = {}
+
+function getVitestImport(id: string, state: () => WorkerGlobalState) {
+  if (externalizeMap.has(id)) {
+    return { externalize: externalizeMap.get(id)! }
+  }
+  // always externalize Vitest because we import from there before running tests
+  // so we already have it cached by Node.js
+  if (bareVitestRegexp.test(id)) {
+    externalizeMap.set(id, id)
+    return { externalize: id }
+  }
+  const root = state().config.root
+  const relativeRoot = relativeIds[id] || (relativeIds[id] = normalizedDistDir.slice(root.length))
+  if (
+    // full dist path
+    id.includes(distDir)
+    || id.includes(normalizedDistDir)
+    // "relative" to root path:
+    // /node_modules/.pnpm/vitest/dist
+    || id.startsWith(relativeRoot)
+  ) {
+    const { path } = toFilePath(id, root)
+    const externalize = pathToFileURL(path).toString()
+    externalizeMap.set(id, externalize)
+    return { externalize }
+  }
+  return null
+}
+
 export async function startVitestExecutor(options: ContextExecutorOptions): Promise<VitestExecutor> {
   const state = (): WorkerGlobalState =>
     // @ts-expect-error injected untyped global
@@ -109,20 +139,9 @@ export async function startVitestExecutor(options: ContextExecutorOptions): Prom
 
   return await createVitestExecutor({
     async fetchModule(id) {
-      if (externalizeMap.has(id)) {
-        return { externalize: externalizeMap.get(id)! }
-      }
-      // always externalize Vitest because we import from there before running tests
-      // so we already have it cached by Node.js
-      if (id.includes(distDir) || id.includes(normalizedDistDir)) {
-        const { path } = toFilePath(id, state().config.root)
-        const externalize = pathToFileURL(path).toString()
-        externalizeMap.set(id, externalize)
-        return { externalize }
-      }
-      if (bareVitestRegexp.test(id)) {
-        externalizeMap.set(id, id)
-        return { externalize: id }
+      const vitest = getVitestImport(id, state)
+      if (vitest) {
+        return vitest
       }
 
       const result = await rpc().fetch(id, getTransformMode())


### PR DESCRIPTION
### Description
Fixes #7748

We can't really add a test because it needs to run against a Vitest package in `node_modules`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
