### PR TITLE
docs: use `extends` instead of `configFile` in `injectTestProjects`

### DIFF
--- a/docs/advanced/api/plugin.md
+++ b/docs/advanced/api/plugin.md
@@ -93,10 +93,10 @@ This methods accepts a config glob pattern, a filepath to the config or an inlin
 ```ts
 // inject a single project with a custom alias
 const newProjects = await injectTestProjects({
-  // you can inherit the current project config by referencing `configFile`
+  // you can inherit the current project config by referencing `extends`
   // note that you cannot have a project with the name that already exists,
   // so it's a good practice to define a custom name
-  configFile: project.vite.config.configFile,
+  extends: project.vite.config.configFile,
   test: {
     name: 'my-custom-alias',
     alias: {
@@ -117,7 +117,7 @@ Note that this will only affect projects injected with [`injectTestProjects`](#i
 :::
 
 ::: tip Referencing the Current Config
-If you want to keep the user configuration, you can specify the `configFile` property. All other properties will be merged with the user defined config.
+If you want to keep the user configuration, you can specify the `extends` property. All other properties will be merged with the user defined config.
 
 The project's `configFile` can be accessed in Vite's config: `project.vite.config.configFile`.
 


### PR DESCRIPTION
### Description

This fixes a typo in the `injectTestProjects` documentation which was referencing the `configFile` attribute instead of `extends` in the instructions to inherit the user's config.

See: https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/types/config.ts#L1134

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
