### PR TITLE
fix: ignore failures on writeToCache

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -746,7 +746,10 @@ export class Vitest {
         }
 
         this.cache.results.updateResults(files)
-        await this.cache.results.writeToCache()
+        try {
+          await this.cache.results.writeToCache()
+        }
+        catch {}
 
         return {
           testModules: this.state.getTestModules(),


### PR DESCRIPTION
The cache is not mandatory. No reason to abort when it fails.

This can happen when node_modules is not writable for example.

### Description

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.
