### PR TITLE
feat: Implement connect option for playwright browser provider

### DIFF
--- a/docs/guide/browser/playwright.md
+++ b/docs/guide/browser/playwright.md
@@ -66,7 +66,7 @@ Vitest will ignore `launch.headless` option. Instead, use [`test.browser.headles
 Note that Vitest will push debugging flags to `launch.args` if [`--inspect`](/guide/cli#inspect) is enabled.
 :::
 
-## connect
+## connect <Version>3.2.0</Version> {#connect}
 
 These options are directly passed down to `playwright[browser].connect` command. You can read more about the command and available arguments in the [Playwright documentation](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
 

--- a/docs/guide/browser/playwright.md
+++ b/docs/guide/browser/playwright.md
@@ -16,9 +16,9 @@ Alternatively, you can also add it to `compilerOptions.types` field in your `tsc
 }
 ```
 
-Vitest opens a single page to run all tests in the same file. You can configure the `launch` and `context` properties in `instances`:
+Vitest opens a single page to run all tests in the same file. You can configure the `launch`, `connect` and `context` properties in `instances`:
 
-```ts{9-10} [vitest.config.ts]
+```ts{9-11} [vitest.config.ts]
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -28,6 +28,7 @@ export default defineConfig({
         {
           browser: 'firefox',
           launch: {},
+          connect: {},
           context: {},
         },
       ],
@@ -63,6 +64,14 @@ These options are directly passed down to `playwright[browser].launch` command. 
 Vitest will ignore `launch.headless` option. Instead, use [`test.browser.headless`](/guide/browser/config#browser-headless).
 
 Note that Vitest will push debugging flags to `launch.args` if [`--inspect`](/guide/cli#inspect) is enabled.
+:::
+
+## connect
+
+These options are directly passed down to `playwright[browser].connect` command. You can read more about the command and available arguments in the [Playwright documentation](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).
+
+::: warning
+Since this command connects to an existing Playwright server, any `launch` options will be ignored.
 :::
 
 ## context

--- a/packages/browser/providers/playwright.d.ts
+++ b/packages/browser/providers/playwright.d.ts
@@ -5,7 +5,8 @@ import type {
   FrameLocator,
   LaunchOptions,
   Page,
-  CDPSession
+  CDPSession,
+  ConnectOptions
 } from 'playwright'
 import { Protocol } from 'playwright-core/types/protocol'
 import '../matchers.js'
@@ -14,6 +15,10 @@ import type {} from "vitest/node"
 declare module 'vitest/node' {
   export interface BrowserProviderOptions {
     launch?: LaunchOptions
+    connect?: {
+      wsEndpoint: string
+      options?: ConnectOptions
+    }
     context?: Omit<
       BrowserContextOptions,
       'ignoreHTTPSErrors' | 'serviceWorkers'

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -3,6 +3,7 @@ import type {
   Browser,
   BrowserContext,
   BrowserContextOptions,
+  ConnectOptions,
   Frame,
   FrameLocator,
   LaunchOptions,
@@ -41,6 +42,10 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
   private options?: {
     launch?: LaunchOptions
+    connect?: {
+      wsEndpoint: string
+      options?: ConnectOptions
+    }
     context?: BrowserContextOptions & { actionTimeout?: number }
   }
 
@@ -85,6 +90,13 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
       const options = this.project.config.browser
 
       const playwright = await import('playwright')
+
+      if (this.options?.connect) {
+        const browser = await playwright[this.browserName].connect(this.options.connect.wsEndpoint, this.options.connect.options)
+        this.browser = browser
+        this.browserPromise = null
+        return this.browser
+      }
 
       const launchOptions = {
         ...this.options?.launch,

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -19,6 +19,7 @@ import type {
   TestProject,
 } from 'vitest/node'
 import { createManualModuleSource } from '@vitest/mocker/node'
+import c from 'tinyrainbow'
 import { createDebugger } from 'vitest/node'
 
 const debug = createDebugger('vitest:browser:playwright')
@@ -92,6 +93,13 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
       const playwright = await import('playwright')
 
       if (this.options?.connect) {
+        if (this.options.launch) {
+          this.project.vitest.logger.warn(
+            c.yellow(`Found both ${c.bold(c.italic(c.yellow('connect')))} and ${c.bold(c.italic(c.yellow('launch')))} options in browser instance configuration.
+          Ignoring ${c.bold(c.italic(c.yellow('launch')))} options and using ${c.bold(c.italic(c.yellow('connect')))} mode.
+          You probably want to remove one of the two options and keep only the one you want to use.`),
+          )
+        }
         const browser = await playwright[this.browserName].connect(this.options.connect.wsEndpoint, this.options.connect.options)
         this.browser = browser
         this.browserPromise = null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1156,6 +1156,9 @@ importers:
       '@vitest/injected-lib':
         specifier: link:./injected-lib
         version: link:injected-lib
+      playwright:
+        specifier: ^1.52.0
+        version: 1.52.0
       react:
         specifier: ^19.1.0
         version: 19.1.0

--- a/test/browser/fixtures/playwright-connect/basic.test.js
+++ b/test/browser/fixtures/playwright-connect/basic.test.js
@@ -1,0 +1,12 @@
+import { test, expect } from 'vitest';
+
+test('[playwright] Run basic test in browser via connect mode', () => {
+  expect(1).toBe(1)
+})
+
+test('[playwright] Run browser-only test in browser via connect mode', () => {
+  const element = document.createElement("div")
+  expect(element instanceof HTMLDivElement).toBe(true)
+  expect(element instanceof HTMLElement).toBe(true)
+  expect(element instanceof HTMLInputElement).not.toBe(true)
+})

--- a/test/browser/fixtures/playwright-connect/vitest.config.js
+++ b/test/browser/fixtures/playwright-connect/vitest.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url'
+
+const provider = process.env.PROVIDER || 'playwright'
+
+export default defineConfig({
+  clearScreen: false,
+  cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  test: {
+    browser: {
+      provider: provider,
+      enabled: true,
+      headless: true,
+      screenshotFailures: false,
+    },
+  },
+})

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -31,6 +31,7 @@
     "@vitest/bundled-lib": "link:./bundled-lib",
     "@vitest/cjs-lib": "link:./cjs-lib",
     "@vitest/injected-lib": "link:./injected-lib",
+    "playwright": "^1.52.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "url": "^0.11.4",

--- a/test/browser/specs/playwright-connect.test.ts
+++ b/test/browser/specs/playwright-connect.test.ts
@@ -1,0 +1,57 @@
+import { chromium } from 'playwright'
+import { expect, test } from 'vitest'
+import { provider } from '../settings'
+import { runBrowserTests } from './utils'
+
+test.runIf(provider === 'playwright')('[playwright] runs in connect mode', async () => {
+  const browserServer = await chromium.launchServer()
+  const wsEndpoint = browserServer.wsEndpoint()
+
+  const { stdout, exitCode, stderr } = await runBrowserTests({
+    root: './fixtures/playwright-connect',
+    browser: {
+      instances: [
+        {
+          browser: 'chromium',
+          name: 'chromium',
+          connect: {
+            wsEndpoint,
+          },
+        },
+      ],
+    },
+  })
+
+  await browserServer.close()
+
+  expect(stdout).toContain('Tests  2 passed')
+  expect(exitCode).toBe(0)
+  expect(stderr).toBe('')
+})
+
+test.runIf(provider === 'playwright')('[playwright] warns if both connect and launch mode are configured', async () => {
+  const browserServer = await chromium.launchServer()
+  const wsEndpoint = browserServer.wsEndpoint()
+
+  const { stdout, exitCode, stderr } = await runBrowserTests({
+    root: './fixtures/playwright-connect',
+    browser: {
+      instances: [
+        {
+          browser: 'chromium',
+          name: 'chromium',
+          connect: {
+            wsEndpoint,
+          },
+          launch: {},
+        },
+      ],
+    },
+  })
+
+  await browserServer.close()
+
+  expect(stdout).toContain('Tests  2 passed')
+  expect(exitCode).toBe(0)
+  expect(stderr).toContain('Found both connect and launch options in browser instance configuration.')
+})


### PR DESCRIPTION
### Description

This PR adds the ability to use the Playwright browser provider with remote Playwright servers. Playwright itself doesn't support running on all distributions, it is primarily tested against Debian-based distributions. Notably Playwright doesn't support running on Red Hat Enterprise Linux and derived distributions. To solve this use case Playwright allows its client and server to run on different hosts, so the server may be launched on a supported distribution (see https://playwright.dev/docs/docker#remote-connection). By offering the client connect mode as an alternative to the launch mode we make browser mode available for more distributions.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
