### PR TITLE
chore(snapshots): rename `message` to `hint` in method signatures

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -771,7 +771,7 @@ test('throws on pineapples', async () => {
 
 ## toMatchSnapshot
 
-- **Type:** `<T>(shape?: Partial<T> | string, message?: string) => void`
+- **Type:** `<T>(shape?: Partial<T> | string, hint?: string) => void`
 
 This ensures that a value matches the most recent snapshot.
 
@@ -803,7 +803,7 @@ test('matches snapshot', () => {
 
 ## toMatchInlineSnapshot
 
-- **Type:** `<T>(shape?: Partial<T> | string, snapshot?: string, message?: string) => void`
+- **Type:** `<T>(shape?: Partial<T> | string, snapshot?: string, hint?: string) => void`
 
 This ensures that a value matches the most recent snapshot.
 
@@ -846,7 +846,7 @@ test('matches snapshot', () => {
 
 ## toMatchFileSnapshot {#tomatchfilesnapshot}
 
-- **Type:** `<T>(filepath: string, message?: string) => Promise<void>`
+- **Type:** `<T>(filepath: string, hint?: string) => Promise<void>`
 
 Compare or update the snapshot with the content of a file explicitly specified (instead of the `.snap` file).
 
@@ -863,13 +863,13 @@ Note that since file system operation is async, you need to use `await` with `to
 
 ## toThrowErrorMatchingSnapshot
 
-- **Type:** `(message?: string) => void`
+- **Type:** `(hint?: string) => void`
 
 The same as [`toMatchSnapshot`](#tomatchsnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
 
 ## toThrowErrorMatchingInlineSnapshot
 
-- **Type:** `(snapshot?: string, message?: string) => void`
+- **Type:** `(snapshot?: string, hint?: string) => void`
 
 The same as [`toMatchInlineSnapshot`](#tomatchinlinesnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
 

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -19,18 +19,18 @@ declare global {
 interface SnapshotMatcher<T> {
   <U extends { [P in keyof T]: any }>(
     snapshot: Partial<U>,
-    message?: string
+    hint?: string
   ): void
-  (message?: string): void
+  (hint?: string): void
 }
 
 interface InlineSnapshotMatcher<T> {
   <U extends { [P in keyof T]: any }>(
     properties: Partial<U>,
     snapshot?: string,
-    message?: string
+    hint?: string
   ): void
-  (message?: string): void
+  (hint?: string): void
 }
 
 declare module '@vitest/expect' {
@@ -67,19 +67,19 @@ declare module '@vitest/expect' {
     /**
      * Checks that an error thrown by a function matches a previously recorded snapshot.
      *
-     * @param message - Optional custom error message.
+     * @param hint - Optional custom error message.
      *
      * @example
      * expect(functionWithError).toThrowErrorMatchingSnapshot();
      */
-    toThrowErrorMatchingSnapshot: (message?: string) => void
+    toThrowErrorMatchingSnapshot: (hint?: string) => void
 
     /**
      * Checks that an error thrown by a function matches an inline snapshot within the test file.
      * Useful for keeping snapshots close to the test code.
      *
      * @param snapshot - Optional inline snapshot string to match.
-     * @param message - Optional custom error message.
+     * @param hint - Optional custom error message.
      *
      * @example
      * const throwError = () => { throw new Error('Error occurred') };
@@ -87,7 +87,7 @@ declare module '@vitest/expect' {
      */
     toThrowErrorMatchingInlineSnapshot: (
       snapshot?: string,
-      message?: string
+      hint?: string
     ) => void
 
     /**
@@ -95,12 +95,12 @@ declare module '@vitest/expect' {
      * Useful for cases where snapshot content is large or needs to be shared across tests.
      *
      * @param filepath - Path to the snapshot file.
-     * @param message - Optional custom error message.
+     * @param hint - Optional custom error message.
      *
      * @example
      * await expect(largeData).toMatchFileSnapshot('path/to/snapshot.json');
      */
-    toMatchFileSnapshot: (filepath: string, message?: string) => Promise<void>
+    toMatchFileSnapshot: (filepath: string, hint?: string) => Promise<void>
   }
 }
 


### PR DESCRIPTION
### Description

The vitest docs use the term _"hint"_ in several places<sup>[[1]](https://vitest.dev/api/expect.html#tomatchsnapshot)[[2]](https://vitest.dev/guide/snapshot.html#_3-chevron-is-used-as-a-separator-instead-of-colon-for-custom-messages)</sup>, and other libraries like [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest) also use _"hint"_<sup>[[3]](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-snapshot-hint.md)</sup>. 

However, the method signatures currently use `message` instead of `hint`. This can be a source a confusion, since IDEs show the parameter names as you type, and it's not clear if `message` and `hint` are the same thing.

This PR aligns the wording in the method signature with the documentation.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] ~~Ideally, include a test that fails without this PR but passes with it.~~ _Not applicable_
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] ~~If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.~~ _Not applicable_

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
