### PR TITLE
feat: Explicit Resource Management support in mocked functions

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -460,6 +460,19 @@ expect(spy).toHaveReturnedWith(1)
 ```
 
 ::: tip
+In environments that support [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management), you can use `using` instead of `const` to automatically call `mockRestore` on any mocked function when the containing block is exited. This is especially useful for spied methods:
+
+```ts
+it('calls console.log', () => {
+  using spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  debug('message')
+  expect(spy).toHaveBeenCalled()
+})
+// console.log is restored here
+```
+:::
+
+::: tip
 You can call [`vi.restoreAllMocks`](#vi-restoreallmocks) inside [`afterEach`](/api/#aftereach) (or enable [`test.restoreMocks`](/config/#restoreMocks)) to restore all methods to their original implementations. This will restore the original [object descriptor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty), so you won't be able to change method's implementation:
 
 ```ts

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -175,7 +175,7 @@ Jest uses the latter for `MockInstance.mockImplementation` etc... and it allows 
   const boolFn: Jest.Mock<() => boolean> = jest.fn<() => true>(() => true)
 */
 /* eslint-disable ts/method-signature-style */
-export interface MockInstance<T extends Procedure = Procedure> {
+export interface MockInstance<T extends Procedure = Procedure> extends Disposable {
   /**
    * Use it to return the name assigned to the mock with the `.mockName(name)` method. By default, it will return `vi.fn()`.
    * @see https://vitest.dev/api/mock#getmockname
@@ -547,6 +547,10 @@ function enhanceSpy<T extends Procedure>(
     stub.mockReset()
     state.restore()
     return stub
+  }
+
+  if (Symbol.dispose) {
+    stub[Symbol.dispose] = stub.mockRestore
   }
 
   stub.getMockImplementation = () =>

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -550,7 +550,7 @@ function enhanceSpy<T extends Procedure>(
   }
 
   if (Symbol.dispose) {
-    stub[Symbol.dispose] = stub.mockRestore
+    stub[Symbol.dispose] = () => stub.mockRestore()
   }
 
   stub.getMockImplementation = () =>

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -567,7 +567,9 @@ describe('jest mock compat layer', () => {
     it('calls mockRestore when disposing', () => {
       const fn = vi.fn()
       const restoreSpy = vi.spyOn(fn, 'mockRestore')
-      fn[Symbol.dispose]()
+      {
+        using _fn2 = fn
+      }
       expect(restoreSpy).toHaveBeenCalled()
     })
     it('allows disposal when using mockImplementation', () => {

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -561,19 +561,26 @@ describe('jest mock compat layer', () => {
   })
 
   describe('is disposable', () => {
-    it('has dispose property', () => {
-      expect(vi.fn()[Symbol.dispose]).toBeTypeOf('function')
+    describe.runIf(Symbol.dispose)('in environments supporting it', () => {
+      it('has dispose property', () => {
+        expect(vi.fn()[Symbol.dispose]).toBeTypeOf('function')
+      })
+      it('calls mockRestore when disposing', () => {
+        const fn = vi.fn()
+        const restoreSpy = vi.spyOn(fn, 'mockRestore')
+        {
+          using _fn2 = fn
+        }
+        expect(restoreSpy).toHaveBeenCalled()
+      })
+      it('allows disposal when using mockImplementation', () => {
+        expect(vi.fn().mockImplementation(() => {})[Symbol.dispose]).toBeTypeOf('function')
+      })
     })
-    it('calls mockRestore when disposing', () => {
-      const fn = vi.fn()
-      const restoreSpy = vi.spyOn(fn, 'mockRestore')
-      {
-        using _fn2 = fn
-      }
-      expect(restoreSpy).toHaveBeenCalled()
-    })
-    it('allows disposal when using mockImplementation', () => {
-      expect(vi.fn().mockImplementation(() => {})[Symbol.dispose]).toBeTypeOf('function')
+    describe.skipIf(Symbol.dispose)('in environments not supporting it', () => {
+      it('does not have dispose property', () => {
+        expect(vi.fn()[Symbol.dispose]).toBeUndefined()
+      })
     })
   })
 

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -560,6 +560,21 @@ describe('jest mock compat layer', () => {
     expect(fn.getMockImplementation()).toBe(temporaryMockImplementation)
   })
 
+  describe('is disposable', () => {
+    it('has dispose property', () => {
+      expect(vi.fn()[Symbol.dispose]).toBeTypeOf('function')
+    })
+    it('calls mockRestore when disposing', () => {
+      const fn = vi.fn()
+      const restoreSpy = vi.spyOn(fn, 'mockRestore')
+      fn[Symbol.dispose]()
+      expect(restoreSpy).toHaveBeenCalled()
+    })
+    it('allows disposal when using mockImplementation', () => {
+      expect(vi.fn().mockImplementation(() => {})[Symbol.dispose]).toBeTypeOf('function')
+    })
+  })
+
   describe('docs example', () => {
     it('mockClear', () => {
       const person = {


### PR DESCRIPTION
### Description

Support [explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) with mocked functions, meaning mockRestore can be called automatically once scope is exited.

```ts
using consoleSpy = vi.spyOn(console, "spy")
// is like
const consoleSpy = vi.spyOn(console, "spy")
try {
  // ...
} finally {
  consoleSpy.mockRestore()
}
```

This is very convenient, but also good for Jest parity - Jest added it here https://github.com/jestjs/jest/pull/14895 and released in [v30.0.0-alpha.3](https://github.com/jestjs/jest/releases/tag/v30.0.0-alpha.3).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
