### PR TITLE
fix(cli): add built-in reporters list to --help output

### DIFF
--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -89,7 +89,9 @@ Hide logs for skipped tests
 - **CLI:** `--reporter <name>`
 - **Config:** [reporters](/config/#reporters)
 
-Specify reporters
+Specify which reporter(s) to use. Available values:
+
+`default`, `basic`, `blob`, `verbose`, `dot`, `json`, `tap`, `tap-flat`, `junit`, `hanging-process`, `github-actions`.
 
 ### outputFile
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types/pool-options'
 import type { CliOptions } from './cli-api'
 import { defaultBrowserPort, defaultPort } from '../../constants'
+import { ReportersMap } from '../reporters'
 
 type NestedOption<T, V = Extract<T, Record<string, any>>> = V extends
   | never
@@ -160,7 +161,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   reporters: {
     alias: 'reporter',
-    description: 'Specify reporters',
+    description: `Specify reporters (${Object.keys(ReportersMap).join(', ')})`,
     argument: '<name>',
     subcommands: null, // don't support custom objects
     array: true,

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -31,8 +31,8 @@ export {
 }
 export type { BaseReporter, Reporter, TestRunEndReason }
 
+export type { BenchmarkBuiltinReporters } from './benchmark'
 export {
-  BenchmarkBuiltinReporters,
   BenchmarkReporter,
   BenchmarkReportsMap,
   VerboseBenchmarkReporter,

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -1,5 +1,6 @@
 import { resolveConfig as viteResolveConfig } from 'vite'
 import { expect, test } from 'vitest'
+import { ReportersMap } from 'vitest/reporters'
 import { createCLI, parseCLI } from '../../../packages/vitest/src/node/cli/cac.js'
 import { resolveConfig } from '../../../packages/vitest/src/node/config/resolveConfig.js'
 
@@ -464,4 +465,20 @@ test('public parseCLI works correctly', () => {
       'color': true,
     },
   })
+})
+
+test('should include builtin reporters list', () => {
+  let helpText = ''
+  vitestCli.help((sections) => {
+    for (const section of sections) {
+      helpText += section.body
+    }
+  })
+  vitestCli.parse(['node', '/index.js', '--help'], { run: false })
+  const match = helpText.match(/--reporter[^(]*\(([^)]+)\)/)
+  expect(match).not.toBeNull()
+
+  const listed = match![1].split(',').map(s => s.trim()).filter(Boolean)
+  const expected = Object.keys(ReportersMap)
+  expect(new Set(listed)).toEqual(new Set(expected))
 })


### PR DESCRIPTION
### Description
closes #7907

### Changed
- dynamically pulls the names of all build-in reporters from the `ReportersMap`

<div align="center">
  <table>
    <tr>
      <th>--reporter <name></th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/0f84d6b5-435d-461e-8659-a9b29ac329a7" />
      </td>
    </tr>
  </table>
</div>

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
