### PR TITLE
fix(docs): remove falsy comment on test execution speed

### DIFF
--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -55,8 +55,6 @@ bun add -D vitest @vitest/browser
 ::: warning
 However, to run tests in CI you need to install either [`playwright`](https://npmjs.com/package/playwright) or [`webdriverio`](https://www.npmjs.com/package/webdriverio). We also recommend switching to either one of them for testing locally instead of using the default `preview` provider since it relies on simulating events instead of using Chrome DevTools Protocol.
 
-If you don't already use one of these tools, we recommend starting with Playwright because it supports parallel execution, which makes your tests run faster. Additionally, Playwright uses [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) which is generally faster than WebDriver.
-
 ::: tabs key:provider
 == Playwright
 [Playwright](https://npmjs.com/package/playwright) is a framework for Web Testing and Automation.


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR removes a wrong statement from the docs that WebdriverIO doesn't support parallel tests and is slower than PW. Both statements are wrong. You can run as many parallel browser sessions as your system allows you. Furthermore, WebdriverIO is mostly relying on WebDriver Bidi these days which is the same communication method than CDP is using. You may technically argue that WebDriver Bidi messages go through a browser driver which is another hop and can potentially be slower than sending a socket message directly to the browser but I would argue that this doesn't impact test execution time a lot and I would love to see someone challenging this.

On contrary I can put in a statement saying that Playwright browser are not real browser used by users in the real world given they are patched to accomodate Playwrights proprietary automation approach.

I think generally we should stay away from making judgements about what is better for the user to use. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
