### PR TITLE
docs: typos in docs/guide/browser/index.md

### DIFF
--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -544,7 +544,7 @@ test('shows the children when the checkbox is checked', async () => {
 })
 ```
 ```tsx [solid]
-// baed on @testing-library/solid API
+// based on @testing-library/solid API
 // https://testing-library.com/docs/solid-testing-library/api
 
 import { render } from '@testing-library/solid'
@@ -571,7 +571,7 @@ it('uses params', async () => {
 })
 ```
 ```ts [marko]
-// baed on @testing-library/marko API
+// based on @testing-library/marko API
 // https://testing-library.com/docs/marko-testing-library/api
 
 import { render, screen } from '@marko/testing-library'


### PR DESCRIPTION
### Description

There are two typos in `docs/guide/browser/index.md` where it says ~~baed~~ instead of **based**.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.


----

### Screenshots

From the [deploy preview](https://deploy-preview-7983--vitest-dev.netlify.app/)

<img width="748" alt="image" src="https://github.com/user-attachments/assets/1a6bf7dc-3dab-4829-882c-3a8c2b454d36" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/5fa37419-968f-46b8-8650-5118265ca467" />

