### PR TITLE
fix: apply browser CLI options only if the project has the browser set in the config already

### DIFF
--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -361,7 +361,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
         return { enabled: browser === 'yes' }
       }
       if (typeof browser === 'string') {
-        return { enabled: true, name: browser }
+        return { name: browser }
       }
       return browser
     },

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -1,6 +1,7 @@
 import type { ResolvedConfig as ResolvedViteConfig } from 'vite'
 import type { Vitest } from '../core'
 import type { BenchmarkBuiltinReporters } from '../reporters'
+import type { ResolvedBrowserOptions } from '../types/browser'
 import type {
   ApiConfig,
   ResolvedConfig,
@@ -13,6 +14,7 @@ import { toArray } from '@vitest/utils'
 import { resolveModule } from 'local-pkg'
 import { normalize, relative, resolve } from 'pathe'
 import c from 'tinyrainbow'
+import { mergeConfig } from 'vite'
 import {
   defaultBrowserPort,
   defaultInspectPort,
@@ -205,8 +207,6 @@ export function resolveConfig(
     resolved.minWorkers = resolveInlineWorkerOption(resolved.minWorkers)
   }
 
-  resolved.browser ??= {} as any
-
   // run benchmark sequentially by default
   resolved.fileParallelism ??= mode !== 'benchmark'
 
@@ -238,10 +238,18 @@ export function resolveConfig(
     }
   }
 
+  // apply browser CLI options only if the config already has the browser config and not disabled manually
+  if (vitest._cliOptions.browser && resolved.browser && resolved.browser.enabled !== false) {
+    resolved.browser = mergeConfig(
+      resolved.browser,
+      vitest._cliOptions.browser,
+    ) as ResolvedBrowserOptions
+  }
+
+  resolved.browser ??= {} as any
   const browser = resolved.browser
 
-  // if browser was enabled via CLI and it's configured by the user, then validate the input
-  if (browser.enabled && viteConfig.test?.browser) {
+  if (browser.enabled) {
     if (!browser.name && !browser.instances) {
       throw new Error(`Vitest Browser Mode requires "browser.name" (deprecated) or "browser.instances" options, none were set.`)
     }

--- a/packages/vitest/src/node/create.ts
+++ b/packages/vitest/src/node/create.ts
@@ -6,7 +6,7 @@ import type { CliOptions } from './cli/cli-api'
 import type { VitestOptions } from './core'
 import type { VitestRunMode } from './types/config'
 import { resolve } from 'node:path'
-import { slash } from '@vitest/utils'
+import { deepClone, slash } from '@vitest/utils'
 import { findUp } from 'find-up'
 import { mergeConfig } from 'vite'
 import { configFiles } from '../constants'
@@ -20,7 +20,7 @@ export async function createVitest(
   viteOverrides: ViteUserConfig = {},
   vitestOptions: VitestOptions = {},
 ): Promise<Vitest> {
-  const ctx = new Vitest(mode, vitestOptions)
+  const ctx = new Vitest(mode, deepClone(options), vitestOptions)
   const root = slash(resolve(options.root || process.cwd()))
 
   const configPath
@@ -32,12 +32,14 @@ export async function createVitest(
 
   options.config = configPath
 
+  const { browser: _removeBrowser, ...restOptions } = options
+
   const config: ViteInlineConfig = {
     configFile: configPath,
     configLoader: options.configLoader,
     // this will make "mode": "test" | "benchmark" inside defineConfig
     mode: options.mode || mode,
-    plugins: await VitestPlugin(options, ctx),
+    plugins: await VitestPlugin(restOptions, ctx),
   }
 
   const server = await createViteServer(

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -4,7 +4,6 @@ import type { ResolvedConfig, TestProjectInlineConfiguration } from '../types/co
 import { existsSync, readFileSync } from 'node:fs'
 import { deepMerge } from '@vitest/utils'
 import { basename, dirname, relative, resolve } from 'pathe'
-import { mergeConfig } from 'vite'
 import { configDefaults } from '../../defaults'
 import { generateScopedClassName } from '../../integrations/css/css-modules'
 import { VitestFilteredOutProjectError } from '../errors'
@@ -116,16 +115,7 @@ export function WorkspaceVitestPlugin(
           },
         }
 
-        // if this project defines a browser configuration, respect --browser flag
-        // otherwise if we always override the configuration, every project will run in browser mode
-        if (project.vitest._options.browser && viteConfig.test?.browser) {
-          viteConfig.test.browser = mergeConfig(
-            viteConfig.test.browser,
-            project.vitest._options.browser,
-          )
-        }
-
-        (config.test as ResolvedConfig).defines = defines
+        ;(config.test as ResolvedConfig).defines = defines
 
         // keep project names to potentially filter it out
         const workspaceNames = [name]


### PR DESCRIPTION
### Description

Fixes https://github.com/vitest-dev/vitest/issues/7944
Fixes https://github.com/vitest-dev/vitest/issues/7964

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
