### PR TITLE
fix(coverage): in-source test cases excluded

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -75,11 +75,12 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider<ResolvedCover
     const sourceMap = pluginCtx.getCombinedSourcemap()
     sourceMap.sources = sourceMap.sources.map(removeQueryParameters)
 
-    // Exclude SWC's decorators that are left in source maps
-    sourceCode = sourceCode.replaceAll(
-      '_ts_decorate',
-      '/* istanbul ignore next */_ts_decorate',
-    )
+    sourceCode = sourceCode
+      // Exclude SWC's decorators that are left in source maps
+      .replaceAll('_ts_decorate', '/* istanbul ignore next */_ts_decorate')
+
+      // Exclude in-source test's test cases
+      .replaceAll(/(if +\(import\.meta\.vitest\))/g, '/* istanbul ignore next */ $1')
 
     const code = this.instrumenter.instrumentSync(
       sourceCode,

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -292,6 +292,20 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
           ) {
             return true
           }
+
+          // Browser mode's "import.meta.env ="
+          if (
+            type === 'statement'
+            && node.type === 'ExpressionStatement'
+            && node.expression.type === 'AssignmentExpression'
+            && node.expression.left.type === 'MemberExpression'
+            && node.expression.left.object.type === 'MetaProperty'
+            && node.expression.left.object.meta.name === 'import'
+            && node.expression.left.object.property.name === 'meta'
+            && node.expression.left.property.type === 'Identifier'
+            && node.expression.left.property.name === 'env') {
+            return true
+          }
         },
       },
       )

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -293,6 +293,32 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
             return true
           }
 
+          // in-source test with "if (import.meta.vitest)"
+          if (
+            (type === 'branch' || type === 'statement')
+            && node.type === 'IfStatement'
+            && node.test.type === 'MemberExpression'
+            && node.test.property.type === 'Identifier'
+            && node.test.property.name === 'vitest'
+          ) {
+            // SSR
+            if (
+              node.test.object.type === 'Identifier'
+              && node.test.object.name === '__vite_ssr_import_meta__'
+            ) {
+              return 'ignore-this-and-nested-nodes'
+            }
+
+            // Web
+            if (
+              node.test.object.type === 'MetaProperty'
+              && node.test.object.meta.name === 'import'
+              && node.test.object.property.name === 'meta'
+            ) {
+              return 'ignore-this-and-nested-nodes'
+            }
+          }
+
           // Browser mode's "import.meta.env ="
           if (
             type === 'statement'

--- a/test/coverage-test/fixtures/src/in-source.ts
+++ b/test/coverage-test/fixtures/src/in-source.ts
@@ -11,7 +11,8 @@ export function add(a: number, b: number) {
 if (import.meta.vitest) {
   const { test, expect } = import.meta.vitest
 
-  test('in source test running add function', () => {
+  // Name of the callback test function is checked in tests
+  test('in source test running add function', function customNamedTestFunction() {
     expect(add(10, 19)).toBe(29)
   })
 }

--- a/test/coverage-test/test/in-source.test.ts
+++ b/test/coverage-test/test/in-source.test.ts
@@ -19,7 +19,8 @@ test('in-source tests work', async () => {
     ]
   `)
 
-  const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/in-source.ts')
+  const fileCoverage = coverageMap.fileCoverageFor(files[0])
+  const functions = Object.values(fileCoverage.fnMap).map(fn => fn.name)
 
   // If-branch is not taken - makes sure source maps are correct in in-source testing too
   expect(fileCoverage.getUncoveredLines()).toContain('5')
@@ -28,7 +29,7 @@ test('in-source tests work', async () => {
     expect(fileCoverage).toMatchInlineSnapshot(`
       {
         "branches": "2/4 (50%)",
-        "functions": "1/1 (100%)",
+        "functions": "2/2 (100%)",
         "lines": "10/12 (83.33%)",
         "statements": "10/12 (83.33%)",
       }
@@ -37,11 +38,23 @@ test('in-source tests work', async () => {
   else {
     expect(fileCoverage).toMatchInlineSnapshot(`
       {
-        "branches": "3/6 (50%)",
-        "functions": "2/2 (100%)",
-        "lines": "6/7 (85.71%)",
-        "statements": "6/7 (85.71%)",
+        "branches": "2/4 (50%)",
+        "functions": "1/1 (100%)",
+        "lines": "2/3 (66.66%)",
+        "statements": "2/3 (66.66%)",
       }
     `)
   }
+
+  // v8-to-istanbul cannot exclude whole if-block
+  if (isV8Provider()) {
+    return
+  }
+
+  // The "customNamedTestFunction" should be excluded by auto-generated ignore hints
+  expect(functions).toMatchInlineSnapshot(`
+    [
+      "add",
+    ]
+  `)
 })

--- a/test/coverage-test/test/vue.test.ts
+++ b/test/coverage-test/test/vue.test.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { beforeAll, expect } from 'vitest'
-import { isBrowser, isV8Provider, readCoverageMap, runVitest, test } from '../utils'
+import { isV8Provider, readCoverageMap, runVitest, test } from '../utils'
 
 beforeAll(async () => {
   await runVitest({
@@ -23,17 +23,7 @@ test('files should not contain query parameters', () => {
 test('coverage results matches snapshot', async () => {
   const coverageMap = await readCoverageMap()
 
-  if (isV8Provider() && isBrowser()) {
-    expect(coverageMap).toMatchInlineSnapshot(`
-      {
-        "branches": "5/7 (71.42%)",
-        "functions": "3/5 (60%)",
-        "lines": "37/46 (80.43%)",
-        "statements": "37/46 (80.43%)",
-      }
-    `)
-  }
-  else if (isV8Provider()) {
+  if (isV8Provider()) {
     expect(coverageMap).toMatchInlineSnapshot(`
       {
         "branches": "5/7 (71.42%)",

--- a/test/coverage-test/vitest.workspace.custom.ts
+++ b/test/coverage-test/vitest.workspace.custom.ts
@@ -108,7 +108,7 @@ export default defineWorkspace([
     test: {
       ...config.test,
       name: { label: 'v8-browser', color: 'red' },
-      env: { COVERAGE_PROVIDER: 'v8', COVERAGE_BROWSER: 'true' },
+      env: { COVERAGE_PROVIDER: 'v8-ast-aware', COVERAGE_BROWSER: 'true' },
       include: [
         BROWSER_TESTS,
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Exclude in-source tests' `if (import.meta.vitest)` contents from coverage
- Applied to Istanbul and AST-aware V8 only
  - the old V8 would require hacky solutions and is being deprecated soon so leaving it out of scope

Before-after:

![image](https://github.com/user-attachments/assets/ff47c2fa-265a-42c0-b6aa-724beb1158c3)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
