### PR TITLE
fix(dot): allow dot reporter to work in non interactive terminals

### DIFF
--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -1,4 +1,5 @@
 import type { File, Test } from '@vitest/runner'
+import type { Writable } from 'node:stream'
 import type { Vitest } from '../core'
 import type { TestCase, TestModule } from './reported-tasks'
 import c from 'tinyrainbow'
@@ -30,11 +31,8 @@ export class DotReporter extends BaseReporter {
     }
   }
 
-  printTestModule(testModule: TestModule): void {
-    if (!this.isTTY) {
-      super.printTestModule(testModule)
-    }
-  }
+  // ignore base reporter
+  printTestModule(): void {}
 
   onWatcherRerun(files: string[], trigger?: string): void {
     this.tests.clear()
@@ -46,6 +44,9 @@ export class DotReporter extends BaseReporter {
     if (this.isTTY) {
       const finalLog = formatTests(Array.from(this.tests.values()))
       this.ctx.logger.log(finalLog)
+    }
+    else {
+      this.ctx.logger.log()
     }
 
     this.tests.clear()
@@ -70,10 +71,15 @@ export class DotReporter extends BaseReporter {
   }
 
   onTestCaseResult(test: TestCase): void {
+    const result = test.result().state
+    if (!this.isTTY && result !== 'pending') {
+      (this.ctx.logger.outputStream as Writable).write(formatTests([result]))
+    }
+
     super.onTestCaseResult(test)
 
     this.finishedTests.add(test.id)
-    this.tests.set(test.id, test.result().state || 'skipped')
+    this.tests.set(test.id, result || 'skipped')
     this.renderer?.schedule()
   }
 

--- a/test/reporters/tests/dot.test.ts
+++ b/test/reporters/tests/dot.test.ts
@@ -56,9 +56,8 @@ describe('{ isTTY: false }', () => {
       typecheck: undefined,
     })
 
-    expect(stdout).toContain('✓ fixtures/ok.test.ts')
+    expect(stdout).toContain('\n·\n')
     expect(stdout).toContain('Test Files  1 passed (1)')
-    expect(stdout).not.toContain('·')
 
     expect(stderr).toBe('')
   })
@@ -70,11 +69,7 @@ describe('{ isTTY: false }', () => {
       typecheck: undefined,
     })
 
-    expect(stdout).toContain('❯ fixtures/some-failing.test.ts (2 tests | 1 failed)')
-    expect(stdout).toContain('✓ 2 + 3 = 5')
-    expect(stdout).toContain('× 3 + 3 = 7')
-    expect(stdout).not.toContain('\n·x\n')
-
+    expect(stdout).toContain('\n·x\n')
     expect(stdout).toContain('Test Files  1 failed (1)')
     expect(stdout).toContain('Tests  1 failed | 1 passed')
 
@@ -88,10 +83,9 @@ describe('{ isTTY: false }', () => {
       typecheck: undefined,
     })
 
-    expect(stdout).toContain('↓ fixtures/all-skipped.test.ts (2 tests | 2 skipped)')
+    expect(stdout).toContain('\n--\n')
     expect(stdout).toContain('Test Files  1 skipped (1)')
     expect(stdout).toContain('Tests  1 skipped | 1 todo')
-    expect(stdout).not.toContain('\n--\n')
 
     expect(stderr).toContain('')
   })


### PR DESCRIPTION
### Description

Updates dot reporter to support non-TTY terminals instead of silently switching to basic reporter. Closes #3932

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
