### PR TITLE
feat(reporter): add `onWritePath` option to `github-actions`

### DIFF
--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -497,6 +497,9 @@ export default defineConfig({
 Output [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)
 to provide annotations for test failures. This reporter is automatically enabled with a [`default`](#default-reporter) reporter when `process.env.GITHUB_ACTIONS === 'true'`.
 
+<img alt="Github Actions" img-dark src="https://github.com/vitest-dev/vitest/assets/4232207/336cddc2-df6b-4b8a-8e72-4d00010e37f5">
+<img alt="Github Actions" img-light src="https://github.com/vitest-dev/vitest/assets/4232207/ce8447c1-0eab-4fe1-abef-d0d322290dca">
+
 If you configure non-default reporters, you need to explicitly add `github-actions`.
 
 ```ts
@@ -507,8 +510,22 @@ export default defineConfig({
 })
 ```
 
-<img alt="Github Actions" img-dark src="https://github.com/vitest-dev/vitest/assets/4232207/336cddc2-df6b-4b8a-8e72-4d00010e37f5">
-<img alt="Github Actions" img-light src="https://github.com/vitest-dev/vitest/assets/4232207/ce8447c1-0eab-4fe1-abef-d0d322290dca">
+You can customize the file paths that are printed in [GitHub's annotation command format](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions) by using the `onWritePath` option. This is useful when running Vitest in a containerized environment, such as Docker, where the file paths may not match the paths in the GitHub Actions environment.
+
+```ts
+export default defineConfig({
+  test: {
+    reporters: process.env.GITHUB_ACTIONS
+      ? [
+          'default',
+          ['github-actions', { onWritePath(path) {
+            return path.replace(/^\/app\//, `${process.env.GITHUB_WORKSPACE}/`)
+          } }],
+        ]
+      : ['default'],
+  },
+})
+```
 
 ### Blob Reporter
 

--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -6,8 +6,17 @@ import { stripVTControlCharacters } from 'node:util'
 import { getFullName, getTasks } from '@vitest/runner/utils'
 import { capturePrintError } from '../printError'
 
+export interface GithubActionsReporterOptions {
+  onWritePath?: (path: string) => string
+}
+
 export class GithubActionsReporter implements Reporter {
   ctx: Vitest = undefined!
+  options: GithubActionsReporterOptions
+
+  constructor(options: GithubActionsReporterOptions = {}) {
+    this.options = options
+  }
 
   onInit(ctx: Vitest): void {
     this.ctx = ctx
@@ -48,6 +57,8 @@ export class GithubActionsReporter implements Reporter {
       }
     }
 
+    const onWritePath = this.options.onWritePath ?? defaultOnWritePath
+
     // format errors via `printError`
     for (const { project, title, error, file } of projectErrors) {
       const result = capturePrintError(error, this.ctx, { project, task: file })
@@ -58,7 +69,7 @@ export class GithubActionsReporter implements Reporter {
       const formatted = formatMessage({
         command: 'error',
         properties: {
-          file: stack.file,
+          file: onWritePath(stack.file),
           title,
           line: String(stack.line),
           column: String(stack.column),
@@ -68,6 +79,10 @@ export class GithubActionsReporter implements Reporter {
       this.ctx.logger.log(`\n${formatted}`)
     }
   }
+}
+
+function defaultOnWritePath(path: string): string {
+  return path
 }
 
 // workflow command formatting based on

--- a/test/reporters/tests/github-actions.test.ts
+++ b/test/reporters/tests/github-actions.test.ts
@@ -1,17 +1,41 @@
 import { resolve } from 'pathe'
-import { expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { GithubActionsReporter } from '../../../packages/vitest/src/node/reporters'
 import { runVitest } from '../../test-utils'
 
-test(GithubActionsReporter, async () => {
-  let { stdout, stderr } = await runVitest(
-    { reporters: new GithubActionsReporter(), root: './fixtures', include: ['**/some-failing.test.ts'] },
-  )
-  stdout = stdout.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
-  expect(stdout).toMatchInlineSnapshot(`
+describe(GithubActionsReporter, () => {
+  it('uses absolute path by default', async () => {
+    let { stdout, stderr } = await runVitest(
+      { reporters: new GithubActionsReporter(), root: './fixtures', include: ['**/some-failing.test.ts'] },
+    )
+    stdout = stdout.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
+    expect(stdout).toMatchInlineSnapshot(`
     "
     ::error file=__TEST_DIR__/fixtures/some-failing.test.ts,title=some-failing.test.ts > 3 + 3 = 7,line=8,column=17::AssertionError: expected 6 to be 7 // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- 7%0A+ 6%0A%0A ❯ some-failing.test.ts:8:17%0A%0A
     "
   `)
-  expect(stderr).toBe('')
+    expect(stderr).toBe('')
+  })
+
+  it('uses onWritePath to format path', async () => {
+    let { stdout, stderr } = await runVitest(
+      {
+        reporters: new GithubActionsReporter({
+          onWritePath(path) {
+            return path.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
+          },
+        }),
+        root: './fixtures',
+        include: ['**/some-failing.test.ts'],
+        env: { GITHUB_WORKSPACE: '/home/user/workspace' },
+      },
+    )
+    stdout = stdout.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
+    expect(stdout).toMatchInlineSnapshot(`
+      "
+      ::error file=__TEST_DIR__/fixtures/some-failing.test.ts,title=some-failing.test.ts > 3 + 3 = 7,line=8,column=17::AssertionError: expected 6 to be 7 // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- 7%0A+ 6%0A%0A ❯ some-failing.test.ts:8:17%0A%0A
+      "
+    `)
+    expect(stderr).toBe('')
+  })
 })

--- a/test/reporters/tests/github-actions.test.ts
+++ b/test/reporters/tests/github-actions.test.ts
@@ -1,3 +1,4 @@
+import { sep } from 'node:path'
 import { resolve } from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { GithubActionsReporter } from '../../../packages/vitest/src/node/reporters'
@@ -22,7 +23,11 @@ describe(GithubActionsReporter, () => {
       {
         reporters: new GithubActionsReporter({
           onWritePath(path) {
-            return path.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
+            const normalized = path
+              .replace(resolve(__dirname, '..'), '')
+              .replaceAll(sep, '/')
+
+            return `/some-custom-path${normalized}`
           },
         }),
         root: './fixtures',
@@ -31,7 +36,7 @@ describe(GithubActionsReporter, () => {
     )
     expect(stdout).toMatchInlineSnapshot(`
       "
-      ::error file=__TEST_DIR__/fixtures/some-failing.test.ts,title=some-failing.test.ts > 3 + 3 = 7,line=8,column=17::AssertionError: expected 6 to be 7 // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- 7%0A+ 6%0A%0A ❯ some-failing.test.ts:8:17%0A%0A
+      ::error file=/some-custom-path/fixtures/some-failing.test.ts,title=some-failing.test.ts > 3 + 3 = 7,line=8,column=17::AssertionError: expected 6 to be 7 // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- 7%0A+ 6%0A%0A ❯ some-failing.test.ts:8:17%0A%0A
       "
     `)
     expect(stderr).toBe('')

--- a/test/reporters/tests/github-actions.test.ts
+++ b/test/reporters/tests/github-actions.test.ts
@@ -27,7 +27,6 @@ describe(GithubActionsReporter, () => {
         }),
         root: './fixtures',
         include: ['**/some-failing.test.ts'],
-        env: { GITHUB_WORKSPACE: '/home/user/workspace' },
       },
     )
     expect(stdout).toMatchInlineSnapshot(`

--- a/test/reporters/tests/github-actions.test.ts
+++ b/test/reporters/tests/github-actions.test.ts
@@ -18,7 +18,7 @@ describe(GithubActionsReporter, () => {
   })
 
   it('uses onWritePath to format path', async () => {
-    let { stdout, stderr } = await runVitest(
+    const { stdout, stderr } = await runVitest(
       {
         reporters: new GithubActionsReporter({
           onWritePath(path) {
@@ -30,7 +30,6 @@ describe(GithubActionsReporter, () => {
         env: { GITHUB_WORKSPACE: '/home/user/workspace' },
       },
     )
-    stdout = stdout.replace(resolve(__dirname, '..').replace(/:/g, '%3A'), '__TEST_DIR__')
     expect(stdout).toMatchInlineSnapshot(`
       "
       ::error file=__TEST_DIR__/fixtures/some-failing.test.ts,title=some-failing.test.ts > 3 + 3 = 7,line=8,column=17::AssertionError: expected 6 to be 7 // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- 7%0A+ 6%0A%0A ❯ some-failing.test.ts:8:17%0A%0A


### PR DESCRIPTION
### Description

This PR adds support for an `onWritePath` option for the GitHub Actions reporter. This can be used to customize the path that's written in [GitHub's annotation command format](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message). This names was taken from `vitest-sonar-reporter` as suggested by this comment: https://github.com/vitest-dev/vitest/issues/8008#issuecomment-2896741513.

This is useful for situations where tests might be run such that their paths don't match the paths that GitHub sees. For instance, if the tests are being run in a container, the paths might start with `/app/`, which GitHub can't map to a specific file in order to attach the annotation.

Closes https://github.com/vitest-dev/vitest/issues/8008.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
