### PR TITLE
fix: Preserve test results from previous runs

### DIFF
--- a/packages/vitest/src/node/cache/results.ts
+++ b/packages/vitest/src/node/cache/results.ts
@@ -45,8 +45,9 @@ export class ResultsCache {
 
     const resultsCache = await fs.promises.readFile(this.cachePath, 'utf8')
     const { results, version } = JSON.parse(resultsCache || '[]')
+    const [major, minor] = version.split('.')
     // handling changed in 0.30.0
-    if (Number(version.split('.')[1]) >= 30) {
+    if (major > 0 || Number(minor) >= 30) {
       this.cache = new Map(results)
       this.version = version
       results.forEach(([spec]: [string]) => {

--- a/test/config/fixtures/cache/second.test.ts
+++ b/test/config/fixtures/cache/second.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+test('', () => {
+  expect(true).toBe(true)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I want to preserve test results stored in `node_modules/.vite/results.json` so that they are not overwritten on subsequent runs of vitest, e.g. if I run vitest twice like this

```
pnpm vitest first.test
pnpm vitest second.test
```

I want results of both test runs to be recorded. Currently only results of the second.test are stored in the results.json file.

Not sure if the current behavior is desired but it looks to me like the `if` statement just didn't consider major versions at the time.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
