### PR TITLE
fix: expect: rejects: fix wrong Vitest version

### DIFF
--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -48,7 +48,7 @@ export function recordAsyncExpect(
         const stack = processor(error.stack)
         console.warn([
           `Promise returned by \`${assertion}\` was not awaited. `,
-          'Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. ',
+          'Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 4. ',
           'Please remember to await the assertion.\n',
           stack,
         ].join(''))

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -48,7 +48,7 @@ export function recordAsyncExpect(
         const stack = processor(error.stack)
         console.warn([
           `Promise returned by \`${assertion}\` was not awaited. `,
-          'Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 4. ',
+          'Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next major version. ',
           'Please remember to await the assertion.\n',
           stack,
         ].join(''))


### PR DESCRIPTION
Vitest 3 does not fail, but Vitest 4 will, as confirmed in practice and by this : https://vitest.dev/api/expect.html#rejects

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
