### PR TITLE
fix(expect): fix chai import in dts

### DIFF
--- a/packages/expect/index.d.ts
+++ b/packages/expect/index.d.ts
@@ -1,3 +1,0 @@
-import './dist/chai.cjs'
-
-export * from './dist/index.js'

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -17,16 +17,15 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./index.d.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./*": "./*"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
-  "types": "./index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
-    "*.d.ts",
     "dist"
   ],
   "scripts": {

--- a/test/dts-config/tsconfig.json
+++ b/test/dts-config/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": ["./tsconfig.patch.json"],
   "compilerOptions": {
+    "noUncheckedSideEffectImports": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/8076

I forgot about chai import when removing chai patch https://github.com/vitest-dev/vitest/pull/7937. We have `test/dts-config`, but it didn't catch without `compilerOptions.noUncheckedSideEffectImports`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
