### PR TITLE
fix(vite-node): Boolean options in CLI

### DIFF
--- a/packages/vite-node/src/types.ts
+++ b/packages/vite-node/src/types.ts
@@ -6,6 +6,13 @@ export type Nullable<T> = T | null | undefined
 export type Arrayable<T> = T | Array<T>
 export type Awaitable<T> = T | PromiseLike<T>
 
+export type ChangeTypeDeep<T, From, To> = T extends From ? To :
+  T extends (infer U)[] ? ChangeTypeDeep<U, From, To>[] :
+    T extends object ? {
+      [K in keyof T]: ChangeTypeDeep<T[K], From, To>
+    } :
+      T
+
 export interface DepsHandlingOptions {
   external?: (string | RegExp)[]
   inline?: (string | RegExp)[] | true

--- a/test/vite-node/test/cli.test.ts
+++ b/test/vite-node/test/cli.test.ts
@@ -45,6 +45,14 @@ it('exposes .env variables', async () => {
   expect(env.MY_TEST_ENV).toBe('hello')
 })
 
+it.only('script options convert boolean strings to booleans', async () => {
+  const cliNoConfig = await runViteNodeCli(entryPath)
+  expect(cliNoConfig.stdout).not.toContain(`dump modules to`)
+
+  const { viteNode } = await runViteNodeCli('--options.debug.dumpModules=true', entryPath)
+  await viteNode.waitForStdout(/\[vite-node\] \[debug\] dump modules to.*\.vite-node\/dump/)
+})
+
 it.each(['index.js', 'index.cjs', 'index.mjs'])('correctly runs --watch %s', async (file) => {
   const entryPath = resolve(__dirname, '../src/watch', file)
   const { viteNode } = await runViteNodeCli('--watch', entryPath)

--- a/test/vite-node/test/cli.test.ts
+++ b/test/vite-node/test/cli.test.ts
@@ -45,7 +45,7 @@ it('exposes .env variables', async () => {
   expect(env.MY_TEST_ENV).toBe('hello')
 })
 
-it.only('script options convert boolean strings to booleans', async () => {
+it('script options convert boolean strings to booleans', async () => {
   const cliNoConfig = await runViteNodeCli(entryPath)
   expect(cliNoConfig.stdout).not.toContain(`dump modules to`)
 


### PR DESCRIPTION
### Description

`cac` package actually does not parse things like `--options.deps.inline=true` as boolean, it passes it as a string, because this can be a `string | boolean`. So, convert option args like `"true"` (as string) to `true` (as boolean).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [N/A] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [N/A] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
