### PR TITLE
fix(expect): Ensure we can always self `toEqual`

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -186,13 +186,13 @@ export interface AsymmetricMatchersContaining extends CustomMatcher {
   closeTo: (expected: number, precision?: number) => any
 }
 
+type WithAsymmetricMatcher<T> = T | AsymmetricMatcher<unknown>
+
 export type DeeplyAllowMatchers<T> = T extends Array<infer Element>
-  ? (DeeplyAllowMatchers<Element> | Element)[]
+  ? WithAsymmetricMatcher<T> | DeeplyAllowMatchers<Element>[]
   : T extends object
-    ? {
-        [K in keyof T]: DeeplyAllowMatchers<T[K]> | AsymmetricMatcher<unknown>
-      }
-    : T
+    ? WithAsymmetricMatcher<T> | { [K in keyof T]: DeeplyAllowMatchers<T[K]> }
+    : WithAsymmetricMatcher<T>
 
 export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMatcher {
   /**

--- a/test/core/test/expect.test-d.ts
+++ b/test/core/test/expect.test-d.ts
@@ -111,4 +111,12 @@ test('expect.* allows asymmetrict mattchers with different types', () => {
   // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62831/files#diff-ff7b882e4a29e7fe0e348a6bdf8b11774d606eaa221009b166b01389576d921fR1237
   expect({ list: [1, 2, 3] }).toMatchObject({ list: expect.any(Array) })
   expect({ list: [1, 2, 3] }).toMatchObject<{ list: number[] }>({ list: expect.any(Array) })
+
+  // expect<T>
+  // https://github.com/vitest-dev/vitest/issues/8081
+  function expectMany<T>(value: ({ enabled: false } | { enabled: true; data: T })) {
+    expect(value).toEqual(value)
+    expect(value).toMatchObject(value)
+  }
+  expectMany({ enabled: true, data: 'ok' })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This Pull Request proposes a fix for the issue #8081. It fixes a typing issue making `expect(self).toEqual(self)` unable to compile for some types.

Example:

```ts
function expectMany<T>(value: { enabled: false } | { enable: true; data: T }) {
  // In Vitest 3.2:
  //
  // Argument of type '{ enabled: false; } | { enable: true; data: T; }' is not assignable to parameter of type '{ enabled: false | AsymmetricMatcher<unknown, MatcherState>; } | { enable: true | AsymmetricMatcher<unknown, MatcherState>; data: AsymmetricMatcher<...> | DeeplyAllowMatchers<...>; }'.
  //   Type '{ enable: true; data: T; }' is not assignable to type '{ enabled: false | AsymmetricMatcher<unknown, MatcherState>; } | { enable: true | AsymmetricMatcher<unknown, MatcherState>; data: AsymmetricMatcher<...> | DeeplyAllowMatchers<...>; }'.
  //     Type '{ enable: true; data: T; }' is not assignable to type '{ enable: true | AsymmetricMatcher<unknown, MatcherState>; data: AsymmetricMatcher<unknown, MatcherState> | DeeplyAllowMatchers<T>; }'.
  //       Types of property 'data' are incompatible.
  //         Type 'T' is not assignable to type 'AsymmetricMatcher<unknown, MatcherState> | DeeplyAllowMatchers<T>'.
  //           Type 'T' is not assignable to type 'AsymmetricMatcher<unknown, MatcherState>'.ts(2345)
  expect(value).toEqual(value);
}
```

Fixes #8081

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
