### PR TITLE
fix(pool): auto-adjust `minThreads` when only `maxThreads` specified

### DIFF
--- a/packages/vitest/src/node/pools/forks.ts
+++ b/packages/vitest/src/node/pools/forks.ts
@@ -65,7 +65,7 @@ export function createForksPool(
   const maxThreads
     = poolOptions.maxForks ?? vitest.config.maxWorkers ?? threadsCount
   const minThreads
-    = poolOptions.minForks ?? vitest.config.minWorkers ?? threadsCount
+    = poolOptions.minForks ?? vitest.config.minWorkers ?? Math.min(threadsCount, maxThreads)
 
   const worker = resolve(vitest.distPath, 'workers/forks.js')
 

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -57,7 +57,7 @@ export function createThreadsPool(
   const maxThreads
     = poolOptions.maxThreads ?? vitest.config.maxWorkers ?? threadsCount
   const minThreads
-    = poolOptions.minThreads ?? vitest.config.minWorkers ?? threadsCount
+    = poolOptions.minThreads ?? vitest.config.minWorkers ?? Math.min(threadsCount, maxThreads)
 
   const worker = resolve(vitest.distPath, 'workers/threads.js')
 

--- a/packages/vitest/src/node/pools/vmForks.ts
+++ b/packages/vitest/src/node/pools/vmForks.ts
@@ -71,7 +71,7 @@ export function createVmForksPool(
   const maxThreads
     = poolOptions.maxForks ?? vitest.config.maxWorkers ?? threadsCount
   const minThreads
-    = poolOptions.maxForks ?? vitest.config.minWorkers ?? threadsCount
+    = poolOptions.maxForks ?? vitest.config.minWorkers ?? Math.min(threadsCount, maxThreads)
 
   const worker = resolve(vitest.distPath, 'workers/vmForks.js')
 

--- a/packages/vitest/src/node/pools/vmThreads.ts
+++ b/packages/vitest/src/node/pools/vmThreads.ts
@@ -60,7 +60,7 @@ export function createVmThreadsPool(
   const maxThreads
     = poolOptions.maxThreads ?? vitest.config.maxWorkers ?? threadsCount
   const minThreads
-    = poolOptions.minThreads ?? vitest.config.minWorkers ?? threadsCount
+    = poolOptions.minThreads ?? vitest.config.minWorkers ?? Math.min(threadsCount, maxThreads)
 
   const worker = resolve(vitest.distPath, 'workers/vmThreads.js')
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/7974

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
