### PR TITLE
fix(cli): throw error when `--shard x/<count>` exceeds count of test files

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -224,6 +224,13 @@ export function createPool(ctx: Vitest): ProcessPool {
 
     async function sortSpecs(specs: TestSpecification[]) {
       if (ctx.config.shard) {
+        if (ctx.config.shard.count > specs.length) {
+          throw new Error(
+            '--shard <count> must be a smaller than count of test files. '
+            + `Resolved ${specs.length} test files for --shard=${ctx.config.shard.index}/${ctx.config.shard.count}.`,
+          )
+        }
+
         specs = await sequencer.shard(specs)
       }
       return sequencer.sort(specs)

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -224,7 +224,7 @@ export function createPool(ctx: Vitest): ProcessPool {
 
     async function sortSpecs(specs: TestSpecification[]) {
       if (ctx.config.shard) {
-        if (ctx.config.shard.count > specs.length) {
+        if (!ctx.config.passWithNoTests && ctx.config.shard.count > specs.length) {
           throw new Error(
             '--shard <count> must be a smaller than count of test files. '
             + `Resolved ${specs.length} test files for --shard=${ctx.config.shard.index}/${ctx.config.shard.count}.`,

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -51,6 +51,12 @@ test('shard index must be smaller than count', async () => {
   expect(stderr).toMatch('Error: --shard <index> must be a positive number less then <count>')
 })
 
+test('shard count must be smaller than count of test files', async () => {
+  const { stderr } = await runVitest({ root: './fixtures/shard', shard: '1/4' })
+
+  expect(stderr).toMatch('Error: --shard <count> must be a smaller than count of test files. Resolved 3 test files for --shard=1/4.')
+})
+
 test('inspect requires changing pool and singleThread/singleFork', async () => {
   const { stderr } = await runVitest({ inspect: true })
 

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -52,9 +52,15 @@ test('shard index must be smaller than count', async () => {
 })
 
 test('shard count must be smaller than count of test files', async () => {
-  const { stderr } = await runVitest({ root: './fixtures/shard', shard: '1/4' })
+  const { stderr } = await runVitest({ root: './fixtures/shard', shard: '1/4', include: ['**/*.test.js'] })
 
   expect(stderr).toMatch('Error: --shard <count> must be a smaller than count of test files. Resolved 3 test files for --shard=1/4.')
+})
+
+test('shard count can be smaller than count of test files when passWithNoTests', async () => {
+  const { stderr } = await runVitest({ root: './fixtures/shard', shard: '1/4', passWithNoTests: true, include: ['**/*.test.js'] })
+
+  expect(stderr).toMatch('')
 })
 
 test('inspect requires changing pool and singleThread/singleFork', async () => {

--- a/test/coverage-test/test/shard.test.ts
+++ b/test/coverage-test/test/shard.test.ts
@@ -2,16 +2,16 @@ import { readdirSync } from 'node:fs'
 import { expect } from 'vitest'
 import { coverageTest, normalizeURL, runVitest, test } from '../utils'
 
-test('{ shard: 1/4 }', async () => {
+test('{ shard: 1/3 }', async () => {
   await runVitest({
-    include: [normalizeURL(import.meta.url)],
-    shard: '1/4',
+    include: [normalizeURL(import.meta.url), 'fixtures/test/math.test.ts', 'fixtures/test/even.test.ts'],
+    shard: '1/3',
   })
 })
 
 coverageTest('temporary directory is postfixed with --shard value', () => {
   const files = readdirSync('./coverage')
 
-  expect(files).toContain('.tmp-1-4')
+  expect(files).toContain('.tmp-1-3')
   expect(files).not.toContain('.tmp')
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/8100

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
