### PR TITLE
fix(reporter): `task.meta` should be available in custom reporter's errors

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -249,6 +249,10 @@ export abstract class BaseReporter implements Reporter {
     return getTestName(test, separator)
   }
 
+  protected getFullName(test: Task, separator?: string): string {
+    return getFullName(test, separator)
+  }
+
   protected formatShortError(error: ErrorWithDiff): string {
     return `${F_RIGHT} ${error.message}`
   }
@@ -374,7 +378,7 @@ export abstract class BaseReporter implements Reporter {
     const task = log.taskId ? this.ctx.state.idMap.get(log.taskId) : undefined
 
     if (task) {
-      headerText = getFullName(task, c.dim(' > '))
+      headerText = this.getFullName(task, c.dim(' > '))
     }
     else if (log.taskId && log.taskId !== '__vitest__unknown_test__') {
       headerText = log.taskId
@@ -579,7 +583,7 @@ export abstract class BaseReporter implements Reporter {
         continue
       }
 
-      const groupName = getFullName(group, c.dim(' > '))
+      const groupName = this.getFullName(group, c.dim(' > '))
       const project = this.ctx.projects.find(p => p.name === bench.file.projectName)
 
       this.log(`  ${formatProjectName(project)}${bench.name}${c.dim(` - ${groupName}`)}`)
@@ -636,7 +640,7 @@ export abstract class BaseReporter implements Reporter {
         const projectName = (task as File)?.projectName || task.file?.projectName || ''
         const project = this.ctx.projects.find(p => p.name === projectName)
 
-        let name = getFullName(task, c.dim(' > '))
+        let name = this.getFullName(task, c.dim(' > '))
 
         if (filepath) {
           name += c.dim(` [ ${this.relative(filepath)} ]`)

--- a/test/reporters/fixtures/metadata/metadata.test.ts
+++ b/test/reporters/fixtures/metadata/metadata.test.ts
@@ -1,0 +1,12 @@
+import {expect, test } from 'vitest';
+
+test('pass', ( { task }) => {
+  task.meta.custom = "Passing test added this"
+});
+
+
+test('fails', ( { task }) => {
+  task.meta.custom = "Failing test added this"
+
+  expect(true).toBe(false)
+});

--- a/test/reporters/fixtures/metadata/vitest.config.ts
+++ b/test/reporters/fixtures/metadata/vitest.config.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -1,5 +1,6 @@
-import type { TestSpecification } from 'vitest/node'
+import type { RunnerTask, TestSpecification } from 'vitest/node'
 import { describe, expect, test } from 'vitest'
+import { DefaultReporter } from 'vitest/reporters'
 import { runVitest, runVitestCli } from '../../test-utils'
 
 describe('default reporter', async () => {
@@ -237,6 +238,21 @@ describe('default reporter', async () => {
 
     expect(stdout).toContain('Example project')
     expect(stdout).toContain('\x1B[30m\x1B[45m Example project \x1B[49m\x1B[39m')
+  })
+
+  test('extended reporter can override getFullName', async () => {
+    class Custom extends DefaultReporter {
+      getFullName(test: RunnerTask, separator?: string): string {
+        return `${separator}{ name: ${test.name}, meta: ${test.meta.custom} } (Custom getFullName here)`
+      }
+    }
+
+    const { stderr } = await runVitest({
+      root: 'fixtures/metadata',
+      reporters: new Custom(),
+    })
+
+    expect(stderr).toMatch('FAIL   > { name: fails, meta: Failing test added this } (Custom getFullName here')
   })
 }, 120000)
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/8018

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
