### PR TITLE
fix(pool): throw if user's tests use `process.send()`

### DIFF
--- a/packages/vitest/src/node/pools/forks.ts
+++ b/packages/vitest/src/node/pools/forks.ts
@@ -30,7 +30,21 @@ function createChildProcessChannel(project: TestProject, collect = false) {
   const rpc = createBirpc<RunnerRPC, RuntimeRPC>(createMethodsRPC(project, { cacheFs: true, collect }), {
     eventNames: ['onCancel'],
     serialize: v8.serialize,
-    deserialize: v => v8.deserialize(Buffer.from(v)),
+    deserialize: (v) => {
+      try {
+        return v8.deserialize(Buffer.from(v))
+      }
+      catch (error) {
+        let stringified = ''
+
+        try {
+          stringified = `\nReceived value: ${JSON.stringify(v)}`
+        }
+        catch {}
+
+        throw new Error(`[vitest-pool]: Unexpected call to process.send(). Make sure your test cases are not interfering with process's channel.${stringified}`, { cause: error })
+      }
+    },
     post(v) {
       emitter.emit(events.message, v)
     },

--- a/packages/vitest/src/node/pools/vmForks.ts
+++ b/packages/vitest/src/node/pools/vmForks.ts
@@ -35,7 +35,21 @@ function createChildProcessChannel(project: TestProject, collect: boolean) {
     {
       eventNames: ['onCancel'],
       serialize: v8.serialize,
-      deserialize: v => v8.deserialize(Buffer.from(v)),
+      deserialize: (v) => {
+        try {
+          return v8.deserialize(Buffer.from(v))
+        }
+        catch (error) {
+          let stringified = ''
+
+          try {
+            stringified = `\nReceived value: ${JSON.stringify(v)}`
+          }
+          catch {}
+
+          throw new Error(`[vitest-pool]: Unexpected call to process.send(). Make sure your test cases are not interfering with process's channel.${stringified}`, { cause: error })
+        }
+      },
       post(v) {
         emitter.emit(events.message, v)
       },

--- a/test/cli/fixtures/forks-channel/process-send.test.ts
+++ b/test/cli/fixtures/forks-channel/process-send.test.ts
@@ -1,0 +1,9 @@
+import { test } from "vitest";
+
+test("calls IPC channel", () => {
+  if (!process.send) {
+    throw new Error("Expected test case to run inside child_process")
+  }
+
+  process.send({ "not serialized": "with v8 serializer" })
+})

--- a/test/cli/fixtures/forks-channel/vitest.config.ts
+++ b/test/cli/fixtures/forks-channel/vitest.config.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/test/cli/test/forks-channel.test.ts
+++ b/test/cli/test/forks-channel.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+test.each(['forks', 'vmForks'] as const)('test case\'s process.send() calls are handled', async (pool) => {
+  const { stderr } = await runVitest({
+    root: './fixtures/forks-channel',
+    pool,
+  })
+
+  expect(stderr).toContain('⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯')
+  expect(stderr).toContain('Error: [vitest-pool]: Unexpected call to process.send(). Make sure your test cases are not interfering with process\'s channel.')
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Closes https://github.com/vitest-dev/vitest/issues/8109

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
