### PR TITLE
fix: revert `expect.any` return type

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -108,8 +108,8 @@ export interface ExpectStatic
   AsymmetricMatchersContaining {
   <T>(actual: T, message?: string): Assertion<T>
   extend: (expects: MatchersObject) => void
-  anything: () => AsymmetricMatcher<unknown>
-  any: (constructor: unknown) => AsymmetricMatcher<unknown>
+  anything: () => any
+  any: (constructor: unknown) => any
   getState: () => MatcherState
   setState: (state: Partial<MatcherState>) => void
   not: AsymmetricMatchersContaining
@@ -202,7 +202,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(user).toEqual({ name: 'Alice', age: 30 });
    */
-  toEqual: <E>(expected: DeeplyAllowMatchers<E>) => void
+  toEqual: <E>(expected: E) => void
 
   /**
    * Use to test that objects have the same types as well as structure.
@@ -210,7 +210,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(user).toStrictEqual({ name: 'Alice', age: 30 });
    */
-  toStrictEqual: <E>(expected: DeeplyAllowMatchers<E>) => void
+  toStrictEqual: <E>(expected: E) => void
 
   /**
    * Checks that a value is what you expect. It calls `Object.is` to compare values.
@@ -240,7 +240,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *   address: { city: 'Wonderland' }
    * });
    */
-  toMatchObject: <E extends object | any[]>(expected: DeeplyAllowMatchers<E>) => void
+  toMatchObject: <E extends object | any[]>(expected: E) => void
 
   /**
    * Used when you want to check that an item is in a list.


### PR DESCRIPTION
Fixes #8082
Fixes #8079

### Description

The team decided to revert the change until the next major version.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
