### PR TITLE
fix: use correct path for optimisation of strip-literal

### DIFF
--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -241,7 +241,7 @@ export default (parentServer: ParentBrowserProject, base = '/'): Plugin[] => {
           'vitest > @vitest/snapshot > magic-string',
           'vitest > chai',
           'vitest > chai > loupe',
-          'vitest > strip-literal',
+          'vitest > @vitest/runner > strip-literal',
           'vitest > @vitest/utils > loupe',
           '@vitest/browser > @testing-library/user-event',
           '@vitest/browser > @testing-library/dom',


### PR DESCRIPTION
### Description

https://github.com/vitest-dev/vitest/pull/8127 added `vitest > strip-literal` to optimisedeps.include, but strip-literal is actually a dependency of @vitest/runner

On package managers with strict module resolution, this dependency chain doesn't exist, so is skipped, and js-tokens isn't transpiled causing many explosions.

This PR adds the correct path, to reduce explosions.

- fixes #8138

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
