### PR TITLE
test: flaky test-run timing

### DIFF
--- a/test/reporters/tests/test-run.test.ts
+++ b/test/reporters/tests/test-run.test.ts
@@ -161,7 +161,7 @@ describe('TestCase', () => {
     const report = await run({
       'example.test.ts': ts`
         test('single test case', async () => {
-          await new Promise(resolve => setTimeout(resolve, 150))
+          await new Promise(resolve => setTimeout(resolve, 300))
           console.log("Test running!")
         });
       `,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Related to https://github.com/vitest-dev/vitest/pull/8121, especially this part:

> Note:
> - As `onUserConsoleLog` is not throttled, it's still possible that reporters see test case's console logs before `onTestCaseReady`, if logs happen 100ms within the start. 
> 

This seems to be happening on CI. Let's increase the timeout a bit.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
