### PR TITLE
fix(runner): preserve handler wrapping on extend

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -770,7 +770,8 @@ export function createTaskCollector(
       runner,
     )
 
-    return createTest(function fn(
+    const originalWrapper = fn
+    return createTest(function (
       name: string | Function,
       optionsOrFn?: TestOptions | TestFunction,
       optionsOrTest?: number | TestOptions | TestFunction,
@@ -784,12 +785,9 @@ export function createTaskCollector(
           scopedFixtures,
         )
       }
-      collector.test.fn.call(
-        context,
-        formatName(name),
-        optionsOrFn as TestOptions,
-        optionsOrTest as TestFunction,
-      )
+      const { handler, options } = parseArguments(optionsOrFn, optionsOrTest)
+      const timeout = options.timeout ?? runner?.config.testTimeout
+      originalWrapper.call(context, formatName(name), handler, timeout)
     }, _context)
   }
 

--- a/test/core/test/task-collector.test.ts
+++ b/test/core/test/task-collector.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, vi } from 'vitest'
-import { createTaskCollector } from 'vitest/suite'
+import { assert, describe, expect, test, vi } from 'vitest'
+import { createTaskCollector, getCurrentSuite } from 'vitest/suite'
 
 test('collector keeps the order of arguments', () => {
   const fn = vi.fn()
@@ -22,4 +22,30 @@ test('collector keeps the order of arguments', () => {
   collector.each([1])('a', options, cb)
 
   expect(fn).toHaveBeenNthCalledWith(4, 'a', options, expect.any(Function))
+})
+
+describe('collector.extend should preserve handler wrapping', () => {
+  let flag = false
+
+  const flagTest = createTaskCollector(function (
+    this: object,
+    name: string,
+    fn: () => void,
+  ) {
+    const handler = async () => {
+      flag = false
+      await fn()
+      assert(flag)
+    }
+    getCurrentSuite().task(name, { ...this, handler })
+  })
+
+  const extendedTest = flagTest.extend({})
+
+  extendedTest.fails('should fail when flag is never set', {}, () => {})
+
+  flagTest('should pass when flag is set', () => {
+    flag = true
+    expect(flag).toBe(true)
+  })
 })


### PR DESCRIPTION
### Description
Closes #8117

- add regression test for extend handler wrapping
- update `createTaskCollector` > `taskFn.extend` implementation.
  - Call the original wrapper instead of the low-level `collector.test.fn.call`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
