### PR TITLE
docs: Typo in doc for `watchTriggerPatterns`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -724,7 +724,7 @@ export default defineConfig({
     watchTriggerPatterns: [
       {
         pattern: /^src\/(mailers|templates)\/(.*)\.(ts|html|txt)$/,
-        testToRun: (id, match) => {
+        testsToRun: (id, match) => {
           // relative to the root value
           return `./api/tests/mailers/${match[2]}.test.ts`
         },


### PR DESCRIPTION
### Description
This fixes the tiniest typo in the documentation (`testToRun` => `testsToRun`).

Since this is in a copy-pasteable code block, it is still annoying for users to debug why their copy-pasted config isn't working.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
