### PR TITLE
Fix Typos in Documentation: "replaying" and "infering"

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -56,7 +56,7 @@ With the new `browser.instances` field you can also specify multiple browser con
 
 ### `spy.mockReset` Now Restores the Original Implementation
 
-There was no good way to reset the spy to the original implementation without replaying the spy. Now, `spy.mockReset` will reset the implementation function to the original one instead of a fake noop.
+There was no good way to reset the spy to the original implementation without reapplying the spy. Now, `spy.mockReset` will reset the implementation function to the original one instead of a fake noop.
 
 ```ts
 const foo = {

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -56,7 +56,7 @@ With the new `browser.instances` field you can also specify multiple browser con
 
 ### `spy.mockReset` Now Restores the Original Implementation
 
-There was no good way to reset the spy to the original implementation without reaplying the spy. Now, `spy.mockReset` will reset the implementation function to the original one instead of a fake noop.
+There was no good way to reset the spy to the original implementation without replaying the spy. Now, `spy.mockReset` will reset the implementation function to the original one instead of a fake noop.
 
 ```ts
 const foo = {

--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -434,7 +434,7 @@ test('types are defined correctly', ({ todos, archive }) => {
 })
 ```
 
-::: info Type inferring
+::: info Type Inferring
 Note that Vitest doesn't support infering the types when the `use` function is called. It is always preferable to pass down the whole context type as the generic type when `test.extend` is called:
 
 ```ts

--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -434,7 +434,7 @@ test('types are defined correctly', ({ todos, archive }) => {
 })
 ```
 
-::: info Type Infering
+::: info Type inferring
 Note that Vitest doesn't support infering the types when the `use` function is called. It is always preferable to pass down the whole context type as the generic type when `test.extend` is called:
 
 ```ts


### PR DESCRIPTION
### Description


This pull request corrects minor typos in the documentation:
- Replaces "replaying" with "replaying" in migration guide.
- Fixes "Infering" to "inferring" in test context guide.
