### PR TITLE
fix(types): ensure Chai declaration merge works with TS-Go

### DIFF
--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -7,11 +7,17 @@ import type { UserConsoleLog } from './general'
 declare global {
   // eslint-disable-next-line ts/no-namespace
   namespace Chai {
-    interface Assertion {
-      containSubset: (expected: any) => Assertion
+    interface ContainSubset {
+      (expected: any): Assertion
     }
+
+    interface Assertion {
+      containSubset: ContainSubset
+    }
+
     interface Assert {
-      containSubset: (val: any, exp: any, msg?: string) => void
+      // eslint-disable-next-line ts/method-signature-style
+      containSubset(val: any, exp: any, msg?: string): void
     }
   }
 }


### PR DESCRIPTION
### Description

Context: Currently TypeScript accepts code like this:
```ts
interface Foo {
    foo(x: any): void;
    foo: (x: any) => void;
}
```

While it does not accept code like this:
```ts
interface Foo {
    foo: (x: any) => void;
    foo(x: any): void;
}
```

The only difference being the ordering.

By comparison, in TypeScript Go neither of these are accepted. See https://github.com/microsoft/typescript-go/issues/1192#issuecomment-2976459707 for official confirmation by Anders Hejlsberg (lead architect of TypeScript). I noticed this effected Vitest due to its merge of `Chai.Assert.containSubset` as a callback instead of as a method, leading to a conflict with `@types/chai`.

No associated issue because it's a small types-only fix.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
