### PR TITLE
feat!: remove support for Vite 5

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,7 @@
     "tinyglobby": "catalog:",
     "unocss": "catalog:",
     "unplugin-vue-components": "catalog:",
-    "vite": "^5.2.8",
+    "vite": "^6.3.5",
     "vite-plugin-pwa": "^0.21.2",
     "vitepress": "2.0.0-alpha.6",
     "vitepress-plugin-group-icons": "^1.6.0",

--- a/packages/mocker/package.json
+++ b/packages/mocker/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "msw": "^2.4.9",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    "vite": "^6.0.0 || ^7.0.0-0"
   },
   "peerDependenciesMeta": {
     "msw": {
@@ -77,6 +77,6 @@
     "acorn-walk": "catalog:",
     "msw": "catalog:",
     "pathe": "catalog:",
-    "vite": "^5.4.0"
+    "vite": "^6.3.5"
   }
 }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -170,7 +170,7 @@
     "tinyglobby": "catalog:",
     "tinypool": "^1.1.1",
     "tinyrainbow": "catalog:",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+    "vite": "^6.0.0 || ^7.0.0-0",
     "vite-node": "workspace:*",
     "why-is-node-running": "^2.3.0"
   },


### PR DESCRIPTION
### Description

Vitest 4 will use the Module Runner instead of `vite-node`, so we need at least Vite 6. I am not touching `vite-node`'s dependencies here for now, as it will be moved into a separate project before Vitest 4 is released.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
