### PR TITLE
Fix: Correct typos in documentation and tests

### DIFF
--- a/docs/advanced/api/vitest.md
+++ b/docs/advanced/api/vitest.md
@@ -256,7 +256,7 @@ function start(filters?: string[]): Promise<TestRunResult>
 Initialize reporters, the coverage provider, and run tests. This method accepts string filters to match the test files - these are the same filters that [CLI supports](/guide/filtering#cli).
 
 ::: warning
-This method should not be called if [`vitest.init()`](#init) is also invoked. Use [`runTestSpecifications`](#runtestspecifications) or [`rerunTestSpecifications`](#reruntestspecifications) instead if you need to run tests after Vitest was inititalised.
+This method should not be called if [`vitest.init()`](#init) is also invoked. Use [`runTestSpecifications`](#runtestspecifications) or [`rerunTestSpecifications`](#reruntestspecifications) instead if you need to run tests after Vitest was initialised.
 :::
 
 This method is called automatically by [`startVitest`](/advanced/guide/tests) if `config.mergeReports` and `config.standalone` are not set.

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -49,7 +49,7 @@ describe('running browser tests', async () => {
 
     const browserResult = await readFile('./browser.json', 'utf-8')
     browserResultJson = JSON.parse(browserResult)
-    const getPassed = results => results.filter(result => result.status === 'passed' && !result.mesage)
+    const getPassed = results => results.filter(result => result.status === 'passed' && !result.message)
     const getFailed = results => results.filter(result => result.status === 'failed')
     passedTests = getPassed(browserResultJson.testResults)
     failedTests = getFailed(browserResultJson.testResults)


### PR DESCRIPTION


### **Description:**

This PR addresses two minor typos identified in the codebase.

#### Changes:
*   Corrected `inititalised` to `initialised` in `docs/advanced/api/vitest.md`.
*   Corrected `mesage` to `message` in `test/browser/specs/runner.test.ts`.

