### PR TITLE
fix: pass testTimeout as timeout to birpc (vitest-dev#8164)

### DIFF
--- a/packages/vitest/src/runtime/workers/forks.ts
+++ b/packages/vitest/src/runtime/workers/forks.ts
@@ -1,12 +1,12 @@
-import type { WorkerGlobalState } from '../../types/worker'
+import type { ContextRPC, WorkerGlobalState } from '../../types/worker'
 import type { VitestWorker, WorkerRpcOptions } from './types'
 import v8 from 'node:v8'
 import { runBaseTests } from './base'
 import { createForksRpcOptions, unwrapSerializableConfig } from './utils'
 
 class ForksBaseWorker implements VitestWorker {
-  getRpcOptions(): WorkerRpcOptions {
-    return createForksRpcOptions(v8)
+  getRpcOptions(ctx?: ContextRPC): WorkerRpcOptions {
+    return createForksRpcOptions(v8, ctx?.config?.testTimeout)
   }
 
   async executeTests(method: 'run' | 'collect', state: WorkerGlobalState): Promise<void> {

--- a/packages/vitest/src/runtime/workers/types.ts
+++ b/packages/vitest/src/runtime/workers/types.ts
@@ -5,7 +5,7 @@ import type { ContextRPC, WorkerGlobalState } from '../../types/worker'
 
 export type WorkerRpcOptions = Pick<
   BirpcOptions<RuntimeRPC>,
-  'on' | 'post' | 'serialize' | 'deserialize'
+  'on' | 'post' | 'serialize' | 'deserialize' | 'timeout'
 >
 
 export interface VitestWorker {

--- a/packages/vitest/src/runtime/workers/utils.ts
+++ b/packages/vitest/src/runtime/workers/utils.ts
@@ -37,6 +37,7 @@ export function disposeInternalListeners(): void {
 
 export function createForksRpcOptions(
   nodeV8: typeof import('v8'),
+  timeout?: number,
 ): WorkerRpcOptions {
   return {
     serialize: nodeV8.serialize,
@@ -56,6 +57,7 @@ export function createForksRpcOptions(
       processOn('message', handler)
       dispose.push(() => processOff('message', handler))
     },
+    timeout,
   }
 }
 

--- a/packages/vitest/src/runtime/workers/vmForks.ts
+++ b/packages/vitest/src/runtime/workers/vmForks.ts
@@ -1,12 +1,12 @@
-import type { WorkerGlobalState } from '../../types/worker'
+import type { ContextRPC, WorkerGlobalState } from '../../types/worker'
 import type { VitestWorker, WorkerRpcOptions } from './types'
 import v8 from 'node:v8'
 import { createForksRpcOptions, unwrapSerializableConfig } from './utils'
 import { runVmTests } from './vm'
 
 class ForksVmWorker implements VitestWorker {
-  getRpcOptions(): WorkerRpcOptions {
-    return createForksRpcOptions(v8)
+  getRpcOptions(ctx?: ContextRPC): WorkerRpcOptions {
+    return createForksRpcOptions(v8, ctx?.config?.testTimeout)
   }
 
   async executeTests(method: 'run' | 'collect', state: WorkerGlobalState): Promise<void> {


### PR DESCRIPTION
### Description

This PR allows testTimeout to be passed to birpc, so it does not issue error message.

Addresses #8164

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
