### PR TITLE
feat(browser): support `toBeInViewport` utility method to assert element is in viewport or not

### DIFF
--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -16,6 +16,35 @@ export interface TestingLibraryMatchers<E, R> {
   toBeInTheDocument(): R
   /**
    * @description
+   * Assert whether an element is within the viewport or not.
+   *
+   * An element is considered to be in the viewport if any part of it is visible within the current viewport bounds.
+   * This matcher checks the element's position relative to the viewport, not just its CSS visibility.
+   *
+   * The element must be in the document, have visible dimensions, and not be hidden by CSS properties like 
+   * display: none, visibility: hidden, or opacity: 0.
+   * @example
+   * <div
+   *   data-testid="visible-element"
+   *   style="position: absolute; top: 10px; left: 10px; width: 50px; height: 50px;"
+   * >
+   *   Visible Element
+   * </div>
+   *
+   * <div
+   *   data-testid="hidden-element"
+   *   style="position: fixed; top: -100px; left: 10px; width: 50px; height: 50px;"
+   * >
+   *   Hidden Element
+   * </div>
+   *
+   * await expect.element(page.getByTestId('visible-element')).toBeInViewport()
+   * await expect.element(page.getByTestId('hidden-element')).not.toBeInViewport()
+   * @see https://vitest.dev/guide/browser/assertion-api#tobeinviewport
+   */
+  toBeInViewport(): R
+  /**
+   * @description
    * This allows you to check if an element is currently visible to the user.
    *
    * An element is visible if **all** the following conditions are met:

--- a/packages/browser/src/client/tester/expect/index.ts
+++ b/packages/browser/src/client/tester/expect/index.ts
@@ -4,6 +4,7 @@ import toBeEmptyDOMElement from './toBeEmptyDOMElement'
 import { toBeDisabled, toBeEnabled } from './toBeEnabled'
 import toBeInTheDocument from './toBeInTheDocument'
 import { toBeInvalid, toBeValid } from './toBeInvalid'
+import toBeInViewport from './toBeInViewport'
 import toBePartiallyChecked from './toBePartiallyChecked'
 import toBeRequired from './toBeRequired'
 import toBeVisible from './toBeVisible'
@@ -28,6 +29,7 @@ export const matchers: MatchersObject = {
   toBeEnabled,
   toBeEmptyDOMElement,
   toBeInTheDocument,
+  toBeInViewport,
   toBeInvalid,
   toBeRequired,
   toBeValid,

--- a/packages/browser/src/client/tester/expect/toBeInViewport.ts
+++ b/packages/browser/src/client/tester/expect/toBeInViewport.ts
@@ -1,0 +1,82 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Kent C. Dodds
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+
+import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { Locator } from '../locators'
+import { getElementFromUserInput } from './utils'
+
+export default function toBeInViewport(
+  this: MatcherState,
+  actual: Element | Locator,
+): ExpectationResult {
+  const htmlElement = getElementFromUserInput(actual, toBeInViewport, this)
+
+  const pass = isElementInViewport(htmlElement)
+
+  return {
+    pass,
+    message: () => {
+      const is = pass ? 'is' : 'is not'
+      return [
+        this.utils.matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeInViewport`,
+          'element',
+          '',
+        ),
+        '',
+        `Received element ${is} in viewport:`,
+        `  ${this.utils.printReceived(htmlElement.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}
+
+function isElementInViewport(element: HTMLElement | SVGElement): boolean {
+  // First check if element is in the document
+  const isInDocument = element.ownerDocument === element.getRootNode({ composed: true })
+  if (!isInDocument) {
+    return false
+  }
+
+  // Check basic visibility properties that would make element invisible
+  const style = window.getComputedStyle(element)
+  if (
+    style.display === 'none'
+    || style.visibility === 'hidden'
+    || Number.parseFloat(style.opacity) === 0
+  ) {
+    return false
+  }
+
+  // Get bounding rectangle
+  const rect = element.getBoundingClientRect()
+
+  // Check if element has dimensions
+  if (rect.width === 0 || rect.height === 0) {
+    return false
+  }
+
+  // Check if element intersects with viewport
+  const viewportWidth = window.innerWidth
+    || document.documentElement.clientWidth
+  const viewportHeight = window.innerHeight
+    || document.documentElement.clientHeight
+
+  // Element is in viewport if any part of it is visible
+  const isHorizontallyVisible = rect.right > 0 && rect.left < viewportWidth
+  const isVerticallyVisible = rect.bottom > 0 && rect.top < viewportHeight
+
+  return isHorizontallyVisible && isVerticallyVisible
+}

--- a/test/browser/fixtures/expect-dom/toBeInViewport.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeInViewport.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { render } from './utils'
+
+describe('toBeInViewport', () => {
+  let cleanupFunctions: Array<() => void> = []
+
+  afterEach(() => {
+    cleanupFunctions.forEach(cleanup => cleanup())
+    cleanupFunctions = []
+  })
+
+  it('should pass when element is visible in document viewport', () => {
+    const { container } = render(`
+      <div data-testid="visible-element" style="width: 50px; height: 50px; background: red; position: absolute; top: 10px; left: 10px;">
+        Visible Element
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="visible-element"]')).toBeInViewport()
+  })
+
+  it('should fail when element is positioned outside document viewport (right)', () => {
+    const { container } = render(`
+      <div data-testid="hidden-right" style="width: 50px; height: 50px; background: red; position: fixed; top: 10px; left: ${window.innerWidth + 100}px;">
+        Hidden Right
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="hidden-right"]')).not.toBeInViewport()
+  })
+
+  it('should fail when element is positioned outside document viewport (bottom)', () => {
+    const { container } = render(`
+      <div data-testid="hidden-bottom" style="width: 50px; height: 50px; background: red; position: fixed; top: ${window.innerHeight + 100}px; left: 10px;">
+        Hidden Bottom
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="hidden-bottom"]')).not.toBeInViewport()
+  })
+
+  it('should fail when element is positioned outside document viewport (negative coordinates)', () => {
+    const { container } = render(`
+      <div data-testid="hidden-negative" style="width: 50px; height: 50px; background: red; position: fixed; top: -100px; left: 10px;">
+        Hidden Above
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="hidden-negative"]')).not.toBeInViewport()
+  })
+
+  it('should handle partially visible elements - default behavior should pass', () => {
+    const { container } = render(`
+      <div data-testid="partially-visible" style="width: 100px; height: 100px; background: red; position: fixed; top: ${window.innerHeight - 50}px; left: 10px;">
+        Partially Visible
+      </div>
+    `)
+
+    // By default, partially visible should be considered "in viewport"
+    expect(container.querySelector('[data-testid="partially-visible"]')).toBeInViewport()
+  })
+
+  it('should fail when element is completely hidden by display:none', () => {
+    const { container } = render(`
+      <div data-testid="display-none" style="width: 50px; height: 50px; background: red; position: absolute; top: 10px; left: 10px; display: none;">
+        Display None
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="display-none"]')).not.toBeInViewport()
+  })
+
+  it('should fail when element is completely hidden by visibility:hidden', () => {
+    const { container } = render(`
+      <div data-testid="visibility-hidden" style="width: 50px; height: 50px; background: red; position: absolute; top: 10px; left: 10px; visibility: hidden;">
+        Visibility Hidden
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="visibility-hidden"]')).not.toBeInViewport()
+  })
+
+  it('should fail when element has zero dimensions', () => {
+    const { container } = render(`
+      <div data-testid="zero-dimensions" style="width: 0px; height: 0px; background: red; position: absolute; top: 10px; left: 10px;">
+        Zero Dimensions
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="zero-dimensions"]')).not.toBeInViewport()
+  })
+
+  it('should handle elements with scrollable parent containers', () => {
+    // Create a scrollable container programmatically since we need to test scrolling behavior
+    const scrollContainer = document.createElement('div')
+    scrollContainer.style.width = '200px'
+    scrollContainer.style.height = '200px'
+    scrollContainer.style.overflow = 'auto'
+    scrollContainer.style.border = '1px solid black'
+    scrollContainer.style.position = 'relative'
+    
+    const tallContent = document.createElement('div')
+    tallContent.style.height = '400px'
+    tallContent.style.width = '100%'
+    
+    const testElement = document.createElement('div')
+    testElement.setAttribute('data-testid', 'scrollable-element')
+    testElement.style.width = '50px'
+    testElement.style.height = '50px'
+    testElement.style.backgroundColor = 'red'
+    testElement.style.position = 'absolute'
+    testElement.style.top = '300px'
+    testElement.style.left = '10px'
+    testElement.textContent = 'Scrollable Element'
+    
+    scrollContainer.appendChild(tallContent)
+    scrollContainer.appendChild(testElement)
+    document.body.appendChild(scrollContainer)
+    
+    cleanupFunctions.push(() => {
+      if (scrollContainer.parentNode) {
+        scrollContainer.parentNode.removeChild(scrollContainer)
+      }
+    })
+
+    // Initially not in viewport due to scrolling
+    expect(testElement).not.toBeInViewport()
+    
+    // Scroll to make element visible
+    scrollContainer.scrollTop = 150
+    
+    // Now should be in viewport
+    expect(testElement).toBeInViewport()
+  })
+
+  it('should handle elements with CSS transforms', () => {
+    const { container } = render(`
+      <div data-testid="transformed-visible" style="width: 50px; height: 50px; background: red; position: absolute; top: 10px; left: 10px; transform: translateX(50px);">
+        Transformed Visible
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="transformed-visible"]')).toBeInViewport()
+  })
+
+  it('should fail when elements are transformed outside viewport', () => {
+    const { container } = render(`
+      <div data-testid="transformed-hidden" style="width: 50px; height: 50px; background: red; position: fixed; top: 10px; left: 10px; transform: translateX(${window.innerWidth}px);">
+        Transformed Hidden
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="transformed-hidden"]')).not.toBeInViewport()
+  })
+
+  it('should handle nested scrollable containers', () => {
+    const { container } = render(`
+      <div style="width: 300px; height: 300px; overflow: auto; border: 1px solid blue;">
+        <div style="width: 200px; height: 200px; overflow: auto; border: 1px solid green; margin: 10px;">
+          <div data-testid="nested-element" style="width: 50px; height: 50px; background: red; position: absolute; top: 10px; left: 10px;">
+            Nested Element
+          </div>
+        </div>
+      </div>
+    `)
+
+    expect(container.querySelector('[data-testid="nested-element"]')).toBeInViewport()
+  })
+
+  it('should handle elements that are detached from DOM', () => {
+    const detachedElement = document.createElement('div')
+    detachedElement.style.width = '50px'
+    detachedElement.style.height = '50px'
+    detachedElement.style.backgroundColor = 'red'
+    
+    expect(detachedElement).not.toBeInViewport()
+  })
+
+  it('should work with different element types', () => {
+    const { container } = render(`
+      <button data-testid="button-element" style="position: absolute; top: 10px; left: 10px;">
+        Button Element
+      </button>
+      <img data-testid="img-element" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" style="position: absolute; top: 70px; left: 10px; width: 50px; height: 50px;" alt="test image" />
+      <input data-testid="input-element" type="text" style="position: absolute; top: 130px; left: 10px;" />
+    `)
+
+    expect(container.querySelector('[data-testid="button-element"]')).toBeInViewport()
+    expect(container.querySelector('[data-testid="img-element"]')).toBeInViewport()
+    expect(container.querySelector('[data-testid="input-element"]')).toBeInViewport()
+  })
+
+  it('should handle elements with opacity', () => {
+    const { container } = render(`
+      <div data-testid="transparent" style="width: 50px; height: 50px; background: red; position: absolute; top: 10px; left: 10px; opacity: 0;">
+        Transparent Element
+      </div>
+      <div data-testid="semi-transparent" style="width: 50px; height: 50px; background: red; position: absolute; top: 70px; left: 10px; opacity: 0.5;">
+        Semi-transparent Element
+      </div>
+    `)
+
+    // Elements with opacity 0 or low opacity should still be considered in viewport if positioned correctly
+    // This differs from toBeVisible which might consider opacity
+    expect(container.querySelector('[data-testid="transparent"]')).toBeInViewport()
+    expect(container.querySelector('[data-testid="semi-transparent"]')).toBeInViewport()
+  })
+})


### PR DESCRIPTION
### Description

Close: https://github.com/vitest-dev/vitest/issues/7650

This is a suggested feature in that ticket. toBeInViewport is implemented in playwright, and this is port to vitest

Hi team 👋 I am a one of vitest fun, and I wanted to enhance vitest feature. 
As a first step, I implemented `toBeInViewport` feature in `vitest/browser` package which is suggested in https://github.com/vitest-dev/vitest/issues/7650

Perhaps, I could overtake some context, so please feel free to point out that if there is something I overtake. Additionaly, regarding issue https://github.com/vitest-dev/vitest/issues/7650, some time has passed since its creation. If there has been an internal decision not to proceed with this feature, please don't hesitate to close the issue.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
