### PR TITLE
fix(coverage): prevent encoding filenames of uncovered files

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -5,7 +5,7 @@ import type { EncodedSourceMap, FetchResult } from 'vite-node'
 import type { AfterSuiteRunMeta } from 'vitest'
 import type { CoverageProvider, ReportContext, ResolvedCoverageOptions, TestProject, Vitest } from 'vitest/node'
 import { promises as fs } from 'node:fs'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 // @ts-expect-error -- untyped
 import { mergeProcessCovs } from '@bcoe/v8-coverage'
 import astV8ToIstanbul from 'ast-v8-to-istanbul'
@@ -173,15 +173,17 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
           timeout = setTimeout(() => debug(c.bgRed(`File "${filename}" is taking longer than 3s`)), 3_000)
         }
 
-        const url = pathToFileURL(filename)
+        // Do not use pathToFileURL to avoid encoding filename parts
+        const url = `file://${filename.startsWith('/') ? '' : '/'}${filename}`
+
         const sources = await this.getSources(
-          url.href,
+          url,
           transformResults,
           transform,
         )
 
         coverageMap.merge(await this.remapCoverage(
-          url.href,
+          url,
           0,
           sources,
           [],

--- a/test/coverage-test/fixtures/src/tested-with-]-in-filename.ts
+++ b/test/coverage-test/fixtures/src/tested-with-]-in-filename.ts
@@ -1,0 +1,15 @@
+export default function covered(a: number, b: number) {
+  if(a === 2 && b === 3) {
+    return 5
+  }
+
+  return a + b
+}
+
+export function uncovered(a: number, b: number) {
+  if(a === 2 && b === 3) {
+    return 5
+  }
+
+  return a + b
+}

--- a/test/coverage-test/fixtures/src/untested-with-]-in-filename.ts
+++ b/test/coverage-test/fixtures/src/untested-with-]-in-filename.ts
@@ -1,0 +1,47 @@
+/*
+ * Some top level comment which adds some padding. This helps us see
+ * if sourcemaps are off.
+*/
+
+/* eslint-disable unused-imports/no-unused-vars -- intentional */
+
+export default function untestedFile() {
+  return 'Untetsted'
+}
+
+function add(a: number, b: number) {
+  // This line should NOT be covered
+  return a + b
+}
+
+type TypescriptTypings = 1 | 2
+
+function multiply(a: number, b: number) {
+  // This line should NOT be covered
+  return a * b
+}
+
+export function math(a: number, b: number, operator: '*' | '+') {
+  interface MoreCompileTimeCode {
+    should: {
+      be: {
+        excluded: true
+      }
+    }
+  }
+
+  if (operator === '*') {
+    // This line should NOT be covered
+    return multiply(a, b)
+  }
+
+  /* v8 ignore start */
+  if (operator === '+') {
+  // This line should be excluded
+    return add(a, b)
+  }
+  /* v8 ignore stop */
+
+  // This line should NOT be covered
+  throw new Error('Unsupported operator')
+}

--- a/test/coverage-test/fixtures/test/sources-with-]-in-filenames.test.ts
+++ b/test/coverage-test/fixtures/test/sources-with-]-in-filenames.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest"
+
+test("cover lines", async () => {
+  const mod = await import("../src/tested-with-]-in-filename")
+
+  expect(mod.default(100, 2)).toBe(102)
+})

--- a/test/coverage-test/test/include-exclude.test.ts
+++ b/test/coverage-test/test/include-exclude.test.ts
@@ -332,3 +332,22 @@ test('files included and excluded in project\'s plugin\'s configureVitest are ex
     ]
   `)
 })
+
+test('includes covered and uncovered with ] in filenames', async () => {
+  await runVitest({
+    include: ['fixtures/test/sources-with-]-in-filenames.test.ts'],
+    coverage: {
+      reporter: 'json',
+      include: ['**/untested-with-*', '**/tested-with-*'],
+
+    },
+  })
+
+  const coverageMap = await readCoverageMap()
+  expect(coverageMap.files()).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/tested-with-]-in-filename.ts",
+      "<process-cwd>/fixtures/src/untested-with-]-in-filename.ts",
+    ]
+  `)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/8238

Node's documentation for `pathToFileURL` describes this case: https://nodejs.org/api/url.html#urlpathtofileurlpath-options

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
