### PR TITLE
fix(core): Fix `objectContaining` expect utility to have more compatibility to jest's one

### DIFF
--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -147,6 +147,10 @@ describe('jest-expect', () => {
     expect(undefined).not.toEqual(expect.anything())
     expect({ a: 0, b: 0 }).toEqual(expect.objectContaining({ a: 0 }))
     expect({ a: 0, b: 0 }).not.toEqual(expect.objectContaining({ z: 0 }))
+    // objectContaining with symbol key
+    const symbolForObjectContaining = Symbol('symbolForObjectContaining')
+    expect({ [symbolForObjectContaining]: 0 }).toEqual(expect.objectContaining({ [symbolForObjectContaining]: 0 }))
+    expect({ [symbolForObjectContaining]: 0 }).not.toEqual(expect.objectContaining({ [symbolForObjectContaining]: 1 }))
     expect(0).toEqual(expect.any(Number))
     expect('string').toEqual(expect.any(String))
     expect('string').not.toEqual(expect.any(Number))


### PR DESCRIPTION
### Description

Closes: #8170

As the above issue mentions, `objectContaining` cannot check equality of object which has symbol key correctly.
This is because the current implementation of `objectContaining` is based on simple iterator and `Object.hasOwnProperty`, and symbolic keys are not enumerated in simple iterator.

In jest's implementation(ref: https://github.com/jestjs/jest/blob/7250950f1385cff688bfef514ea50eb2ffa6495d/packages/expect-utils/src/utils.ts#L46-L57), this is considered so jest's `objectContaining` works fine with object which has symbol key.

This PR fixes #8170 and accomplish more compatibility of `objectContaining` expect utility to jest's one by adding `Object.getOwnPropertySymbols` and `Object.hasOwn` based property checking for symbol key consideration

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
