### PR TITLE
fix(reporter): invisible CLI menus when `vitest --standalone`

### DIFF
--- a/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
@@ -30,6 +30,7 @@ export class WindowRenderer {
   private renderScheduled = false
 
   private windowHeight = 0
+  private started = false
   private finished = false
   private cleanups: (() => void)[] = []
 
@@ -54,11 +55,10 @@ export class WindowRenderer {
       this.flushBuffer()
       this.stop()
     })
-
-    this.start()
   }
 
   start(): void {
+    this.started = true
     this.finished = false
     this.renderInterval = setInterval(() => this.schedule(), this.options.interval).unref()
   }
@@ -171,7 +171,7 @@ export class WindowRenderer {
     // @ts-expect-error -- not sure how 2 overloads should be typed
     stream.write = (chunk, _, callback) => {
       if (chunk) {
-        if (this.finished) {
+        if (this.finished || !this.started) {
           this.write(chunk.toString(), type)
         }
         else {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

- Fixes bug where CLI menus would not render correctly when `--standalone` was passed.

To repro, use Vitest monorepo with `pnpm run test --standalone` at `test/core`. This is how it looks before the fix:


https://github.com/user-attachments/assets/f377d3c8-bfe9-4956-a4ec-58a308403fb5



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
