### PR TITLE
fix(watch): filename filter runs duplicate tests in workspaces

### DIFF
--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -199,7 +199,10 @@ export function registerConsoleShortcuts(
 
     const filter = await watchFilter.filter(async (str: string) => {
       const files = await ctx.globTestFiles([str])
-      return files.map(file => relative(ctx.config.root, file[1]))
+
+      return files
+        .map(file => relative(ctx.config.root, file[1]))
+        .filter((file, index, all) => all.indexOf(file) === index)
     })
 
     on()

--- a/test/watch/test/stdin.test.ts
+++ b/test/watch/test/stdin.test.ts
@@ -34,6 +34,41 @@ describe.each([true, false])('standalone mode is %s', (standalone) => {
     await vitest.waitForStdout('1 passed')
   })
 
+  test('filter by filename when multiple projects match same file', async () => {
+    const { vitest } = await runVitest({
+      ...options,
+      projects: [
+        {
+          test: {
+            name: 'First',
+            root: options.root,
+          },
+        },
+        {
+          test: {
+            name: 'Second',
+            root: options.root,
+          },
+        },
+      ],
+    })
+
+    vitest.write('p')
+
+    await vitest.waitForStdout('Input filename pattern')
+
+    vitest.write('math')
+
+    await vitest.waitForStdout('Pattern matches 1 result')
+    await vitest.waitForStdout('› math.test.ts')
+
+    vitest.write('\n')
+
+    // 2 due to count of projects
+    await vitest.waitForStdout('2 passed')
+    await vitest.waitForStdout('Filename pattern: math')
+  })
+
   test('filter by test name', async () => {
     const { vitest } = await runVitest(options)
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/8249


[vitest-workspace-watch-mode-fixed.webm](https://github.com/user-attachments/assets/393e5ba0-b6f9-4f9b-87d7-c308ebcf504b)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
