### PR TITLE
docs: fix typo in `skip` method usage description

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -167,7 +167,7 @@ test('skipped test', (context) => {
 })
 ```
 
-Since Vitest 3.1, if the condition is unknown, you can provide it to the `skip` method as the first arguments:
+Since Vitest 3.1, if the condition is known, you can provide it to the `skip` method as the first argument:
 
 ```ts
 import { assert, test } from 'vitest'


### PR DESCRIPTION
Corrected two grammatical errors in the documentation for the `skip` method. Changed "unknown" to "known" and "as the first arguments" to "as the first argument" for clarity and correctness.

### Description
Correct the sentence from "Since Vitest 3.1, if the condition is unknown, you can provide it to the `skip` method as the first arguments:" to "Since Vitest 3.1, if the condition is known, you can provide it to the `skip` method as the first argument:"

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
