### PR TITLE
feat(ui): [PoC] bundle reporter ui's HTML and it's resources into single HTML file

### DIFF
--- a/packages/ui/client/constants.ts
+++ b/packages/ui/client/constants.ts
@@ -5,5 +5,5 @@ export const HOST = [location.hostname, PORT].filter(Boolean).join(':')
 export const ENTRY_URL = `${
   location.protocol === 'https:' ? 'wss:' : 'ws:'
 }//${HOST}/__vitest_api__?token=${(window as any).VITEST_API_TOKEN || '0'}`
-export const isReport = !!window.METADATA_PATH
+export const isReport = !!(window.METADATA_PATH || window.METADATA_BASE64)
 export const BASE_PATH = isReport ? import.meta.env.BASE_URL : __BASE_PATH__

--- a/packages/ui/client/shim.d.ts
+++ b/packages/ui/client/shim.d.ts
@@ -5,6 +5,7 @@ const __BASE_PATH__: string
 
 declare interface Window {
   METADATA_PATH?: string
+  METADATA_BASE64?: string
 }
 
 declare interface Error {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,9 @@
   ],
   "scripts": {
     "build": "rimraf dist && pnpm build:node && pnpm build:client",
-    "build:client": "vite build",
+    "build:client": "pnpm build:client:single && pnpm build:client:normal",
+    "build:client:single": "vite build --config vite.config.bundle-as-single-html.ts",
+    "build:client:normal": "vite build --config vite.config.ts",
     "build:node": "rollup -c",
     "typecheck": "tsc --noEmit",
     "dev:client": "vite",
@@ -85,6 +87,7 @@
     "unplugin-vue-components": "catalog:",
     "vite": "^5.0.0",
     "vite-plugin-pages": "^0.33.0",
+    "vite-plugin-singlefile": "^2.3.0",
     "vue": "catalog:",
     "vue-router": "^4.5.1",
     "vue-virtual-scroller": "2.0.0-beta.8"

--- a/packages/ui/vite.config.bundle-as-single-html.ts
+++ b/packages/ui/vite.config.bundle-as-single-html.ts
@@ -1,0 +1,117 @@
+import Vue from '@vitejs/plugin-vue'
+import { resolve } from 'pathe'
+import { presetAttributify, presetIcons, presetUno, transformerDirectives } from 'unocss'
+import Unocss from 'unocss/vite'
+import AutoImport from 'unplugin-auto-import/vite'
+import Components from 'unplugin-vue-components/vite'
+import { defineConfig } from 'vite'
+import Pages from 'vite-plugin-pages'
+import { viteSingleFile } from 'vite-plugin-singlefile'
+
+// for debug:
+// open a static file serve to share the report json
+// and ui using the link to load the report json data
+// const debugLink = 'http://127.0.0.1:4173/__vitest__'
+
+export default defineConfig({
+  root: import.meta.dirname,
+  base: './',
+  resolve: {
+    dedupe: ['vue'],
+    alias: {
+      '~/': `${resolve(import.meta.dirname, 'client')}/`,
+      '@vitest/ws-client': `${resolve(import.meta.dirname, '../ws-client/src/index.ts')}`,
+    },
+  },
+  define: {
+    __BASE_PATH__: '"/__vitest__/"',
+  },
+  plugins: [
+    Vue({
+      features: {
+        propsDestructure: true,
+      },
+      script: {
+        defineModel: true,
+      },
+    }),
+    Unocss({
+      presets: [presetUno(), presetAttributify(), presetIcons()],
+      shortcuts: {
+        'bg-base': 'bg-white dark:bg-[#111]',
+        'bg-overlay': 'bg-[#eee]:50 dark:bg-[#222]:50',
+        'bg-header': 'bg-gray-500:5',
+        'bg-active': 'bg-gray-500:8',
+        'bg-hover': 'bg-gray-500:20',
+        'border-base': 'border-gray-500:10',
+        'focus-base': 'border-gray-500 dark:border-gray-400',
+        'highlight': 'bg-[#eab306] text-[#323238] dark:bg-[#323238] dark:text-[#eab306]',
+
+        'tab-button': 'font-light op50 hover:op80 h-full px-4',
+        'tab-button-active': 'op100 bg-gray-500:10',
+      },
+      transformers: [
+        transformerDirectives(),
+      ],
+      safelist: 'absolute origin-top mt-[8px]'.split(' '),
+    }),
+    Components({
+      dirs: ['client/components'],
+      dts: resolve(import.meta.dirname, './client/components.d.ts'),
+    }),
+    Pages({
+      dirs: ['client/pages'],
+    }),
+    AutoImport({
+      dts: resolve(import.meta.dirname, './client/auto-imports.d.ts'),
+      dirs: ['./client/composables'],
+      imports: ['vue', 'vue-router', '@vueuse/core'],
+      injectAtEnd: true,
+      exclude: [
+        /node_modules/,
+        /dist/,
+        /\.git/,
+      ],
+    }),
+    viteSingleFile(),
+    // uncomment to see the HTML reporter preview
+    // {
+    //   name: 'debug-html-report',
+    //   apply: 'serve',
+    //   transformIndexHtml(html) {
+    //     return html.replace('<!-- !LOAD_METADATA! -->', `<script>window.METADATA_PATH="${debugLink}/html.meta.json.gz"</script>`)
+    //   },
+    // },
+
+    // uncomment to see the browser tab
+    // {
+    //   name: 'browser-dev-preview',
+    //   apply: 'serve',
+    //   transformIndexHtml() {
+    //     return [
+    //       { tag: 'script', attrs: { src: './browser.dev.js' } },
+    //     ]
+    //   },
+    // },
+    {
+      // workaround `crossorigin` issues on some browsers
+      // https://github.com/vitejs/vite/issues/6648
+      name: 'no-crossorigin-for-same-assets',
+      apply: 'build',
+      transformIndexHtml(html) {
+        return html
+          .replace('crossorigin src="./assets/', 'src="./assets/')
+          .replace('crossorigin href="./assets/', 'href="./assets/')
+      },
+    },
+  ],
+  build: {
+    outDir: './dist/client-for-single-html',
+  },
+  test: {
+    browser: {
+      name: 'chromium',
+      provider: 'playwright',
+    },
+  },
+})

--- a/packages/vitest/src/node/reporters/html.ts
+++ b/packages/vitest/src/node/reporters/html.ts
@@ -1,3 +1,4 @@
 export interface HTMLOptions {
   outputFile?: string
+  bundleSingleHtml?: boolean
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,9 @@ importers:
       vite-plugin-pages:
         specifier: ^0.33.0
         version: 0.33.0(@vue/compiler-sfc@3.5.17)(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0))(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))
+      vite-plugin-singlefile:
+        specifier: ^2.3.0
+        version: 2.3.0(rollup@4.44.0)(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0))
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -1326,7 +1329,7 @@ importers:
         version: 3.0.3
       '@vitejs/plugin-vue':
         specifier: latest
-        version: 5.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+        version: 6.0.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
       '@vitest/browser':
         specifier: workspace:*
         version: link:../../packages/browser
@@ -4005,6 +4008,13 @@ packages:
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^6.3.5
+      vue: ^3.2.25
+
+  '@vitejs/plugin-vue@6.0.0':
+    resolution: {integrity: sha512-iAliE72WsdhjzTOp2DtvKThq1VBC4REhwRcaA+zPAAph6I+OQhUXv+Xu2KS7ElxYtb7Zc/3R30Hwv1DxEo7NXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^6.3.5
       vue: ^3.2.25
@@ -8512,6 +8522,13 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
+  vite-plugin-singlefile@2.3.0:
+    resolution: {integrity: sha512-DAcHzYypM0CasNLSz/WG0VdKOCxGHErfrjOoyIPiNxTPTGmO6rRD/te93n1YL/s+miXq66ipF1brMBikf99c6A==}
+    engines: {node: '>18.0.0'}
+    peerDependencies:
+      rollup: ^4.44.0
+      vite: ^6.3.5
+
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -11522,6 +11539,12 @@ snapshots:
 
   '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
+      vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0)
+      vue: 3.5.17(typescript@5.8.3)
+
+  '@vitejs/plugin-vue@6.0.0(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.19
       vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0)
       vue: 3.5.17(typescript@5.8.3)
 
@@ -16745,6 +16768,12 @@ snapshots:
       '@vite-pwa/assets-generator': 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-singlefile@2.3.0(rollup@4.44.0)(vite@6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0)):
+    dependencies:
+      micromatch: 4.0.8
+      rollup: 4.44.0
+      vite: 6.3.5(@types/node@22.15.32)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0)
 
   vite@6.3.5(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:


### PR DESCRIPTION
### Description

Close: https://github.com/vitest-dev/vitest/issues/6425

**In current(25/07/04) status, this is just PoC. so I want feedback about interface, and design from maintainers 🙇**

Still this is just PoC, you can test this with the below vitest option

```ts
// vitest.config.ts
export default defineConfig({
  test: {
    reporters: [
        [
            'html',
            {
                bundleSingleHtml: true,
            }
        ]
    ],
  },
})
```

As mentioned above, this is still PoC but I would like to refine and complete this implementation if maintainers feels this is acceptable.

---

I implemented `bundleSingleHtml` option for html reporter. This enable users to output reporter's html as single HTML file instead of HTML file with it's subresources like css or js.

In my understanding, HTML reporter's frontend is implemented in `@vitest/ui`. This is implemented as SPA and built as HTML + CSS + JS + favicon in the build process of vitest itself. When a user invoke `vitest` with `--ui` or `--provider=html` option, vitest will embed user's test data as `METADATA_PATH`, which is path for test data's gzip and in frontend, vitest's ui application resolve it's `METADATA_PATH` test data and display that.

In this PoC, I implemented like below in order to accomplish to serve reporter's ui as single HTML file

- bundle `@vitest/ui` SPA application as a single HTML file with [vite-plugin-singlefile](https://www.npmjs.com/package/vite-plugin-singlefile) as separated build process of the normal `@vitest/ui` SPA application's build process(outputs HTML + CSS + JS)
- if `bundleSingleHTML` option is specified, vitest will embed user's test data as base64 encoded data instead of gzip path
- Additionaly, favicon is abandoned in single bundled HTML because it cannot be bundle into HTML

Please feel free to point out if you feel something unclear or this way is not accepatable!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
