### PR TITLE
fix(vitest): override `config.include` option with `config.browser.instances[].include` option if it is specified

### DIFF
--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -322,8 +322,10 @@ function cloneConfig(project: TestProject, { browser, ...config }: BrowserInstan
       providerOptions: config,
       instances: undefined, // projects cannot spawn more configs
     },
-    // If there is no include pattern in browser.instances[], we should use the include pattern from the parent project
+    // If there is no include or exclude or includeSource pattern in browser.instances[], we should use the that's pattern from the parent project
     include: (overrideConfig.include && overrideConfig.include.length > 0) ? [] : clonedConfig.include,
+    exclude: (overrideConfig.exclude && overrideConfig.exclude.length > 0) ? [] : clonedConfig.exclude,
+    includeSource: (overrideConfig.includeSource && overrideConfig.includeSource.length > 0) ? [] : clonedConfig.includeSource,
     // TODO: should resolve, not merge/override
   } satisfies ResolvedConfig, overrideConfig) as ResolvedConfig
 }

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -234,39 +234,60 @@ test('coverage provider v8 works correctly in workspaced browser mode if instanc
   ])
 })
 
-test('browser instances with include option override parent include patterns', async () => {
+test('browser instances with include/exclude/includeSource option override parent that patterns', async () => {
   const { projects } = await vitest({}, {
     include: ['**/*.global.test.{js,ts}', '**/*.shared.test.{js,ts}'],
+    exclude: ['**/*.skip.test.{js,ts}'],
+    includeSource: ['src/**/*.{js,ts}'],
     browser: {
       enabled: true,
       headless: true,
       instances: [
         { browser: 'chromium' },
-        { browser: 'firefox', include: ['test/firefox-specific.test.ts'] },
-        { browser: 'webkit', include: ['test/webkit-only.test.ts', 'test/webkit-extra.test.ts'] },
+        { browser: 'firefox', include: ['test/firefox-specific.test.ts'], exclude: ['test/webkit-only.test.ts', 'test/webkit-extra.test.ts'], includeSource: ['src/firefox-compat.ts'] },
+        { browser: 'webkit', include: ['test/webkit-only.test.ts', 'test/webkit-extra.test.ts'], exclude: ['test/firefox-specific.test.ts'], includeSource: ['src/webkit-compat.ts'] },
       ],
     },
   })
 
-  // Chromium should inherit parent include patterns (plus default test pattern)
+  // Chromium should inherit parent include/exclude/includeSource patterns (plus default test pattern)
   expect(projects[0].name).toEqual('chromium')
   expect(projects[0].config.include).toEqual([
     'test/**.test.ts',
     '**/*.global.test.{js,ts}',
     '**/*.shared.test.{js,ts}',
   ])
+  expect(projects[0].config.exclude).toEqual([
+    '**/*.skip.test.{js,ts}',
+  ])
+  expect(projects[0].config.includeSource).toEqual([
+    'src/**/*.{js,ts}',
+  ])
 
-  // Firefox should only have its specific include pattern (not parent patterns)
+  // Firefox should only have its specific include/exclude/includeSource pattern (not parent patterns)
   expect(projects[1].name).toEqual('firefox')
   expect(projects[1].config.include).toEqual([
     'test/firefox-specific.test.ts',
   ])
+  expect(projects[1].config.exclude).toEqual([
+    'test/webkit-only.test.ts',
+    'test/webkit-extra.test.ts',
+  ])
+  expect(projects[1].config.includeSource).toEqual([
+    'src/firefox-compat.ts',
+  ])
 
-  // Webkit should only have its specific include patterns (not parent patterns)
+  // Webkit should only have its specific include/exclude/includeSource patterns (not parent patterns)
   expect(projects[2].name).toEqual('webkit')
   expect(projects[2].config.include).toEqual([
     'test/webkit-only.test.ts',
     'test/webkit-extra.test.ts',
+  ])
+  expect(projects[2].config.exclude).toEqual([
+    'test/firefox-specific.test.ts',
+  ])
+  expect(projects[2].config.includeSource).toEqual([
+    'src/webkit-compat.ts',
   ])
 })
 


### PR DESCRIPTION
### Description

Close: #7914 

Hi Team 👋 

As described in https://github.com/vitest-dev/vitest/issues/7914#issuecomment-2847037046, I understand that #7914 happens because `mergeConfig` merges array in config object instead of overriding it.

As mentioned in [docs](https://vitest.dev/config/#include), vitest config root's `include` option has `['**/*.{test,spec}.?(c|m)[jt]s?(x)']` as default value, and config which is calculated per browser instance configuration will be like below:

```typescript
// input vitest.config.ts

export default defineConfig({
  test: {
    browser: {
      enabled: true,
      provider: 'playwright',

      instances: [
        // Run all tests with Chromium, it's stable
        { browser: "chromium" },

        // Firefox is flaky, run just one test 
        { browser: "firefox", include: ["test/something-simple.test.ts"] },
      ],
    },
    // include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'] as default value
  },
});

// output config for chromium
export default defineConfig({
  test: {
    ...config,
    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)']
});

// output config for firefox
export default defineConfig({
  test: {
    ...config,
    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', "test/something-simple.test.ts"]
});
```

and so, `'**/*.{test,spec}.?(c|m)[jt]s?(x)'` pattern in firefox's config will match test files which should be ignored by `config.browsers.instances[firefox].include`.

I thought vitest user expect include config in deeper will be prioritized than the root that, so I fixed this issue by ignoreing project root's include value if `config.browser.instances[].include` is specified.
 
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
