### PR TITLE
feat(types): add support for generics in promise expects

### DIFF
--- a/packages/browser/matchers.d.ts
+++ b/packages/browser/matchers.d.ts
@@ -3,7 +3,7 @@ import type { TestingLibraryMatchers } from './jest-dom.js'
 import type { Assertion, ExpectPollOptions } from 'vitest'
 
 declare module 'vitest' {
-  interface JestAssertion<T = any> extends TestingLibraryMatchers<void, T> {}
+  interface JestAssertion<T = any, R = void> extends TestingLibraryMatchers<void, T> {}
   interface AsymmetricMatchersContaining extends TestingLibraryMatchers<void, void> {}
 
   type Promisify<O> = {

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -629,12 +629,6 @@ export interface JestAssertion<T = any, R = void> extends jest.Matchers<void, T>
   nthReturnedWith: <E>(nthCall: number, value: E) => R
 }
 
-type Promisify<O> = {
-  [K in keyof O]: O[K] extends (...args: infer A) => infer R
-    ? Promisify<O[K]> & ((...args: A) => Promise<R>)
-    : O[K];
-}
-
 type VitestAssertion<A, T, R = void> = {
   [K in keyof A]: A[K] extends Chai.Assertion
     ? R extends Promise<void> ? Promisify<Assertion<T, R>> : Assertion<T, R>
@@ -642,6 +636,12 @@ type VitestAssertion<A, T, R = void> = {
       ? A[K] // not converting function since they may contain overload
       : VitestAssertion<A[K], T, R>;
 } & ((type: string, message?: string) => Assertion<T, R>)
+
+type Promisify<O> = {
+  [K in keyof O]: O[K] extends (...args: infer A) => infer R
+    ? Promisify<O[K]> & ((...args: A) => Promise<R>)
+    : O[K];
+}
 
 export type PromisifyAssertion<T> = Assertion<T, Promise<void>>
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -95,11 +95,11 @@ export interface RawMatcherFn<T extends MatcherState = MatcherState, E extends A
 // eslint-disable-next-line
 export interface Matchers<T = any, R = void> {}
 
-export type MatchersObject<T extends MatcherState = MatcherState> = Record<
+export type MatchersObject<T extends MatcherState = MatcherState, R = void> = Record<
   string,
   RawMatcherFn<T>
 > & ThisType<T> & {
-  [K in keyof Matchers<T>]?: RawMatcherFn<T, Parameters<Matchers<T>[K]>>
+  [K in keyof Matchers<T, R>]?: RawMatcherFn<T, Parameters<Matchers<T, R>[K]>>
 }
 
 export interface ExpectStatic

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -93,7 +93,7 @@ export interface RawMatcherFn<T extends MatcherState = MatcherState, E extends A
 // Allow unused `T` to preserve its name for extensions.
 // Type parameter names must be identical when extending those types.
 // eslint-disable-next-line
-export interface Matchers<T = any> {}
+export interface Matchers<T = any, R = void> {}
 
 export type MatchersObject<T extends MatcherState = MatcherState> = Record<
   string,
@@ -194,7 +194,7 @@ export type DeeplyAllowMatchers<T> = T extends Array<infer Element>
     ? WithAsymmetricMatcher<T> | { [K in keyof T]: DeeplyAllowMatchers<T[K]> }
     : WithAsymmetricMatcher<T>
 
-export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMatcher {
+export interface JestAssertion<T = any, R = void> extends jest.Matchers<void, T>, CustomMatcher {
   /**
    * Used when you want to check that two objects have the same value.
    * This matcher recursively checks the equality of all fields, rather than checking for object identity.
@@ -202,7 +202,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(user).toEqual({ name: 'Alice', age: 30 });
    */
-  toEqual: <E>(expected: E) => void
+  toEqual: <E>(expected: E) => R
 
   /**
    * Use to test that objects have the same types as well as structure.
@@ -210,7 +210,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(user).toStrictEqual({ name: 'Alice', age: 30 });
    */
-  toStrictEqual: <E>(expected: E) => void
+  toStrictEqual: <E>(expected: E) => R
 
   /**
    * Checks that a value is what you expect. It calls `Object.is` to compare values.
@@ -220,7 +220,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(result).toBe(42);
    * expect(status).toBe(true);
    */
-  toBe: <E>(expected: E) => void
+  toBe: <E>(expected: E) => R
 
   /**
    * Check that a string matches a regular expression.
@@ -229,7 +229,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(message).toMatch(/hello/);
    * expect(greeting).toMatch('world');
    */
-  toMatch: (expected: string | RegExp) => void
+  toMatch: (expected: string | RegExp) => R
 
   /**
    * Used to check that a JavaScript object matches a subset of the properties of an object
@@ -240,7 +240,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *   address: { city: 'Wonderland' }
    * });
    */
-  toMatchObject: <E extends object | any[]>(expected: E) => void
+  toMatchObject: <E extends object | any[]>(expected: E) => R
 
   /**
    * Used when you want to check that an item is in a list.
@@ -250,7 +250,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(items).toContain('apple');
    * expect(numbers).toContain(5);
    */
-  toContain: <E>(item: E) => void
+  toContain: <E>(item: E) => R
 
   /**
    * Used when you want to check that an item is in a list.
@@ -260,7 +260,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(items).toContainEqual({ name: 'apple', quantity: 1 });
    */
-  toContainEqual: <E>(item: E) => void
+  toContainEqual: <E>(item: E) => R
 
   /**
    * Use when you don't care what a value is, you just want to ensure a value
@@ -270,7 +270,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(user.isActive).toBeTruthy();
    */
-  toBeTruthy: () => void
+  toBeTruthy: () => R
 
   /**
    * When you don't care what a value is, you just want to
@@ -279,7 +279,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(user.isActive).toBeFalsy();
    */
-  toBeFalsy: () => void
+  toBeFalsy: () => R
 
   /**
    * For comparing floating point numbers.
@@ -287,7 +287,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(score).toBeGreaterThan(10);
    */
-  toBeGreaterThan: (num: number | bigint) => void
+  toBeGreaterThan: (num: number | bigint) => R
 
   /**
    * For comparing floating point numbers.
@@ -295,7 +295,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(score).toBeGreaterThanOrEqual(10);
    */
-  toBeGreaterThanOrEqual: (num: number | bigint) => void
+  toBeGreaterThanOrEqual: (num: number | bigint) => R
 
   /**
    * For comparing floating point numbers.
@@ -303,7 +303,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(score).toBeLessThan(10);
    */
-  toBeLessThan: (num: number | bigint) => void
+  toBeLessThan: (num: number | bigint) => R
 
   /**
    * For comparing floating point numbers.
@@ -311,7 +311,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(score).toBeLessThanOrEqual(10);
    */
-  toBeLessThanOrEqual: (num: number | bigint) => void
+  toBeLessThanOrEqual: (num: number | bigint) => R
 
   /**
    * Used to check that a variable is NaN.
@@ -319,7 +319,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(value).toBeNaN();
    */
-  toBeNaN: () => void
+  toBeNaN: () => R
 
   /**
    * Used to check that a variable is undefined.
@@ -327,7 +327,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(value).toBeUndefined();
    */
-  toBeUndefined: () => void
+  toBeUndefined: () => R
 
   /**
    * This is the same as `.toBe(null)` but the error messages are a bit nicer.
@@ -336,7 +336,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(value).toBeNull();
    */
-  toBeNull: () => void
+  toBeNull: () => R
 
   /**
    * Ensure that a variable is not undefined.
@@ -344,7 +344,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(value).toBeDefined();
    */
-  toBeDefined: () => void
+  toBeDefined: () => R
 
   /**
    * Ensure that an object is an instance of a class.
@@ -353,7 +353,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(new Date()).toBeInstanceOf(Date);
    */
-  toBeInstanceOf: <E>(expected: E) => void
+  toBeInstanceOf: <E>(expected: E) => R
 
   /**
    * Used to check that an object has a `.length` property
@@ -363,7 +363,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect([1, 2, 3]).toHaveLength(3);
    * expect('hello').toHaveLength(5);
    */
-  toHaveLength: (length: number) => void
+  toHaveLength: (length: number) => R
 
   /**
    * Use to check if a property at the specified path exists on an object.
@@ -381,7 +381,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
   toHaveProperty: <E>(
     property: string | (string | number)[],
     value?: E
-  ) => void
+  ) => R
 
   /**
    * Using exact equality with floating point numbers is a bad idea.
@@ -391,7 +391,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(price).toBeCloseTo(9.99, 2);
    */
-  toBeCloseTo: (number: number, numDigits?: number) => void
+  toBeCloseTo: (number: number, numDigits?: number) => R
 
   /**
    * Ensures that a mock function is called an exact number of times.
@@ -401,7 +401,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveBeenCalledTimes(2);
    */
-  toHaveBeenCalledTimes: (times: number) => void
+  toHaveBeenCalledTimes: (times: number) => R
 
   /**
    * Ensures that a mock function is called an exact number of times.
@@ -411,7 +411,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toBeCalledTimes(2);
    */
-  toBeCalledTimes: (times: number) => void
+  toBeCalledTimes: (times: number) => R
 
   /**
    * Ensures that a mock function is called.
@@ -422,7 +422,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(mockFunc).toHaveBeenCalled();
    */
 
-  toHaveBeenCalled: () => void
+  toHaveBeenCalled: () => R
 
   /**
    * Ensures that a mock function is called.
@@ -432,7 +432,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toBeCalled();
    */
-  toBeCalled: () => void
+  toBeCalled: () => R
 
   /**
    * Ensure that a mock function is called with specific arguments.
@@ -442,7 +442,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveBeenCalledWith('arg1', 42);
    */
-  toHaveBeenCalledWith: <E extends any[]>(...args: E) => void
+  toHaveBeenCalledWith: <E extends any[]>(...args: E) => R
 
   /**
    * Ensure that a mock function is called with specific arguments.
@@ -452,7 +452,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toBeCalledWith('arg1', 42);
    */
-  toBeCalledWith: <E extends any[]>(...args: E) => void
+  toBeCalledWith: <E extends any[]>(...args: E) => R
 
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
@@ -462,7 +462,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveBeenNthCalledWith(2, 'secondArg');
    */
-  toHaveBeenNthCalledWith: <E extends any[]>(n: number, ...args: E) => void
+  toHaveBeenNthCalledWith: <E extends any[]>(n: number, ...args: E) => R
 
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
@@ -472,7 +472,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).nthCalledWith(2, 'secondArg');
    */
-  nthCalledWith: <E extends any[]>(nthCall: number, ...args: E) => void
+  nthCalledWith: <E extends any[]>(nthCall: number, ...args: E) => R
 
   /**
    * If you have a mock function, you can use `.toHaveBeenLastCalledWith`
@@ -483,7 +483,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveBeenLastCalledWith('lastArg');
    */
-  toHaveBeenLastCalledWith: <E extends any[]>(...args: E) => void
+  toHaveBeenLastCalledWith: <E extends any[]>(...args: E) => R
 
   /**
    * If you have a mock function, you can use `.lastCalledWith`
@@ -494,7 +494,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).lastCalledWith('lastArg');
    */
-  lastCalledWith: <E extends any[]>(...args: E) => void
+  lastCalledWith: <E extends any[]>(...args: E) => R
 
   /**
    * Used to test that a function throws when it is called.
@@ -505,7 +505,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(() => functionWithError()).toThrow('Error message');
    * expect(() => parseJSON('invalid')).toThrow(SyntaxError);
    */
-  toThrow: (expected?: string | Constructable | RegExp | Error) => void
+  toThrow: (expected?: string | Constructable | RegExp | Error) => R
 
   /**
    * Used to test that a function throws when it is called.
@@ -516,7 +516,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(() => functionWithError()).toThrowError('Error message');
    * expect(() => parseJSON('invalid')).toThrowError(SyntaxError);
    */
-  toThrowError: (expected?: string | Constructable | RegExp | Error) => void
+  toThrowError: (expected?: string | Constructable | RegExp | Error) => R
 
   /**
    * Use to test that the mock function successfully returned (i.e., did not throw an error) at least one time
@@ -526,7 +526,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toReturn();
    */
-  toReturn: () => void
+  toReturn: () => R
 
   /**
    * Use to test that the mock function successfully returned (i.e., did not throw an error) at least one time
@@ -536,7 +536,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveReturned();
    */
-  toHaveReturned: () => void
+  toHaveReturned: () => R
 
   /**
    * Use to ensure that a mock function returned successfully (i.e., did not throw an error) an exact number of times.
@@ -547,7 +547,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toReturnTimes(3);
    */
-  toReturnTimes: (times: number) => void
+  toReturnTimes: (times: number) => R
 
   /**
    * Use to ensure that a mock function returned successfully (i.e., did not throw an error) an exact number of times.
@@ -558,7 +558,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveReturnedTimes(3);
    */
-  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedTimes: (times: number) => R
 
   /**
    * Use to ensure that a mock function returned a specific value.
@@ -568,7 +568,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toReturnWith('returnValue');
    */
-  toReturnWith: <E>(value: E) => void
+  toReturnWith: <E>(value: E) => R
 
   /**
    * Use to ensure that a mock function returned a specific value.
@@ -578,7 +578,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveReturnedWith('returnValue');
    */
-  toHaveReturnedWith: <E>(value: E) => void
+  toHaveReturnedWith: <E>(value: E) => R
 
   /**
    * Use to test the specific value that a mock function last returned.
@@ -590,7 +590,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveLastReturnedWith('lastValue');
    */
-  toHaveLastReturnedWith: <E>(value: E) => void
+  toHaveLastReturnedWith: <E>(value: E) => R
 
   /**
    * Use to test the specific value that a mock function last returned.
@@ -602,7 +602,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).lastReturnedWith('lastValue');
    */
-  lastReturnedWith: <E>(value: E) => void
+  lastReturnedWith: <E>(value: E) => R
 
   /**
    * Use to test the specific value that a mock function returned for the nth call.
@@ -614,7 +614,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).toHaveNthReturnedWith(2, 'nthValue');
    */
-  toHaveNthReturnedWith: <E>(nthCall: number, value: E) => void
+  toHaveNthReturnedWith: <E>(nthCall: number, value: E) => R
 
   /**
    * Use to test the specific value that a mock function returned for the nth call.
@@ -626,7 +626,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * @example
    * expect(mockFunc).nthReturnedWith(2, 'nthValue');
    */
-  nthReturnedWith: <E>(nthCall: number, value: E) => void
+  nthReturnedWith: <E>(nthCall: number, value: E) => R
 }
 
 type VitestAssertion<A, T> = {
@@ -637,18 +637,12 @@ type VitestAssertion<A, T> = {
       : VitestAssertion<A[K], T>;
 } & ((type: string, message?: string) => Assertion)
 
-type Promisify<O> = {
-  [K in keyof O]: O[K] extends (...args: infer A) => infer R
-    ? Promisify<O[K]> & ((...args: A) => Promise<R>)
-    : O[K];
-}
+export type PromisifyAssertion<T> = Assertion<T, Promise<void>>
 
-export type PromisifyAssertion<T> = Promisify<Assertion<T>>
-
-export interface Assertion<T = any>
+export interface Assertion<T = any, R = void>
   extends VitestAssertion<Chai.Assertion, T>,
-  JestAssertion<T>,
-  Matchers<T> {
+  JestAssertion<T, R>,
+  Matchers<T, R> {
   /**
    * Ensures a value is of a specific type.
    *
@@ -666,7 +660,7 @@ export interface Assertion<T = any>
       | 'string'
       | 'symbol'
       | 'undefined'
-  ) => void
+  ) => R
 
   /**
    * Asserts that a mock function was called exactly once.
@@ -674,7 +668,7 @@ export interface Assertion<T = any>
    * @example
    * expect(mockFunc).toHaveBeenCalledOnce();
    */
-  toHaveBeenCalledOnce: () => void
+  toHaveBeenCalledOnce: () => R
 
   /**
    * Ensure that a mock function is called with specific arguments and called
@@ -683,7 +677,7 @@ export interface Assertion<T = any>
    * @example
    * expect(mockFunc).toHaveBeenCalledExactlyOnceWith('arg1', 42);
    */
-  toHaveBeenCalledExactlyOnceWith: <E extends any[]>(...args: E) => void
+  toHaveBeenCalledExactlyOnceWith: <E extends any[]>(...args: E) => R
 
   /**
    * This assertion checks if a `Mock` was called before another `Mock`.
@@ -699,7 +693,7 @@ export interface Assertion<T = any>
    *
    * expect(mock1).toHaveBeenCalledBefore(mock2)
    */
-  toHaveBeenCalledBefore: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => void
+  toHaveBeenCalledBefore: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => R
 
   /**
    * This assertion checks if a `Mock` was called after another `Mock`.
@@ -715,7 +709,7 @@ export interface Assertion<T = any>
    *
    * expect(mock1).toHaveBeenCalledAfter(mock2)
    */
-  toHaveBeenCalledAfter: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => void
+  toHaveBeenCalledAfter: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => R
 
   /**
    * Checks that a promise resolves successfully at least once.
@@ -723,7 +717,7 @@ export interface Assertion<T = any>
    * @example
    * await expect(promise).toHaveResolved();
    */
-  toHaveResolved: () => void
+  toHaveResolved: () => R
 
   /**
    * Checks that a promise resolves to a specific value.
@@ -731,7 +725,7 @@ export interface Assertion<T = any>
    * @example
    * await expect(promise).toHaveResolvedWith('success');
    */
-  toHaveResolvedWith: <E>(value: E) => void
+  toHaveResolvedWith: <E>(value: E) => R
 
   /**
    * Ensures a promise resolves a specific number of times.
@@ -739,7 +733,7 @@ export interface Assertion<T = any>
    * @example
    * expect(mockAsyncFunc).toHaveResolvedTimes(3);
    */
-  toHaveResolvedTimes: (times: number) => void
+  toHaveResolvedTimes: (times: number) => R
 
   /**
    * Asserts that the last resolved value of a promise matches an expected value.
@@ -747,7 +741,7 @@ export interface Assertion<T = any>
    * @example
    * await expect(mockAsyncFunc).toHaveLastResolvedWith('finalResult');
    */
-  toHaveLastResolvedWith: <E>(value: E) => void
+  toHaveLastResolvedWith: <E>(value: E) => R
 
   /**
    * Ensures a specific value was returned by a promise on the nth resolution.
@@ -755,7 +749,7 @@ export interface Assertion<T = any>
    * @example
    * await expect(mockAsyncFunc).toHaveNthResolvedWith(2, 'secondResult');
    */
-  toHaveNthResolvedWith: <E>(nthCall: number, value: E) => void
+  toHaveNthResolvedWith: <E>(nthCall: number, value: E) => R
 
   /**
    * Verifies that a promise resolves.

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -22,21 +22,21 @@ declare global {
   }
 }
 
-interface SnapshotMatcher<T> {
+interface SnapshotMatcher<T, R = void> {
   <U extends { [P in keyof T]: any }>(
     snapshot: Partial<U>,
     hint?: string
-  ): void
-  (hint?: string): void
+  ): R
+  (hint?: string): R
 }
 
-interface InlineSnapshotMatcher<T> {
+interface InlineSnapshotMatcher<T, R = void> {
   <U extends { [P in keyof T]: any }>(
     properties: Partial<U>,
     snapshot?: string,
     hint?: string
-  ): void
-  (hint?: string): void
+  ): R
+  (hint?: string): R
 }
 
 declare module '@vitest/expect' {
@@ -64,11 +64,11 @@ declare module '@vitest/expect' {
     addSnapshotSerializer: (plugin: PrettyFormatPlugin) => void
   }
 
-  interface Assertion<T> {
+  interface Assertion<T, R = void> {
     // Snapshots are extended in @vitest/snapshot and are not part of @vitest/expect
-    matchSnapshot: SnapshotMatcher<T>
-    toMatchSnapshot: SnapshotMatcher<T>
-    toMatchInlineSnapshot: InlineSnapshotMatcher<T>
+    matchSnapshot: SnapshotMatcher<T, R>
+    toMatchSnapshot: SnapshotMatcher<T, R>
+    toMatchInlineSnapshot: InlineSnapshotMatcher<T, R>
 
     /**
      * Checks that an error thrown by a function matches a previously recorded snapshot.
@@ -78,7 +78,7 @@ declare module '@vitest/expect' {
      * @example
      * expect(functionWithError).toThrowErrorMatchingSnapshot();
      */
-    toThrowErrorMatchingSnapshot: (hint?: string) => void
+    toThrowErrorMatchingSnapshot: (hint?: string) => R
 
     /**
      * Checks that an error thrown by a function matches an inline snapshot within the test file.
@@ -94,7 +94,7 @@ declare module '@vitest/expect' {
     toThrowErrorMatchingInlineSnapshot: (
       snapshot?: string,
       hint?: string
-    ) => void
+    ) => R
 
     /**
      * Compares the received value to a snapshot saved in a specified file.

--- a/test/core/test/expect.test-d.ts
+++ b/test/core/test/expect.test-d.ts
@@ -2,35 +2,51 @@
 
 import { expect, test } from 'vitest'
 
-test('expect.* allows asymmetrict mattchers with different types', () => {
+test('expect.* allows asymmetrict mattchers with different types', async () => {
   // types.ts examples: stringContaining
   expect('I have an apple').toEqual(expect.stringContaining('apple'))
   expect('I have an apple').toEqual<string>(expect.stringContaining('apple'))
+  await expect('I have an apple').resolves.toEqual(expect.stringContaining('apple'))
+  await expect('I have an apple').resolves.toEqual<string>(expect.stringContaining('apple'))
 
   expect({ a: 'test string' }).toEqual({ a: expect.stringContaining('test') })
   expect({ a: 'test string' }).toEqual<{ a: string }>({ a: expect.stringContaining('test') })
+  await expect({ a: 'test string' }).resolves.toEqual({ a: expect.stringContaining('test') })
+  await expect({ a: 'test string' }).resolves.toEqual<{ a: string }>({ a: expect.stringContaining('test') })
 
   // types.ts examples: objectContaining
   expect({ a: '1', b: 2 }).toEqual(expect.objectContaining({ a: '1' }))
   expect({ a: '1', b: 2 }).toEqual<{ a: string; b: string }>(expect.objectContaining({ a: '1' }))
+  await expect({ a: '1', b: 2 }).resolves.toEqual(expect.objectContaining({ a: '1' }))
+  await expect({ a: '1', b: 2 }).resolves.toEqual<{ a: string; b: string }>(expect.objectContaining({ a: '1' }))
 
   // types.ts examples: arrayContaining
   expect(['a', 'b', 'c']).toEqual(expect.arrayContaining(['b', 'a']))
   expect(['a', 'b', 'c']).toEqual<string[]>(expect.arrayContaining(['b', 'a']))
+  await expect(['a', 'b', 'c']).resolves.toEqual(expect.arrayContaining(['b', 'a']))
+  await expect(['a', 'b', 'c']).resolves.toEqual<string[]>(expect.arrayContaining(['b', 'a']))
 
   // types.ts examples: stringMatching
   expect('hello world').toEqual(expect.stringMatching(/^hello/))
   expect('hello world').toEqual<string>(expect.stringMatching(/^hello/))
+  await expect('hello world').resolves.toEqual(expect.stringMatching(/^hello/))
+  await expect('hello world').resolves.toEqual<string>(expect.stringMatching(/^hello/))
 
   expect('hello world').toEqual(expect.stringMatching('hello'))
   expect('hello world').toEqual<string>(expect.stringMatching('hello'))
+  await expect('hello world').resolves.toEqual(expect.stringMatching('hello'))
+  await expect('hello world').resolves.toEqual<string>(expect.stringMatching('hello'))
 
   // types.ts examples: closeTo
   expect(10.45).toEqual(expect.closeTo(10.5, 1))
   expect(10.45).toEqual<number>(expect.closeTo(10.5, 1))
+  await expect(10.45).resolves.toEqual(expect.closeTo(10.5, 1))
+  await expect(10.45).resolves.toEqual<number>(expect.closeTo(10.5, 1))
 
   expect(5.11).toEqual(expect.closeTo(5.12))
   expect(5.11).toEqual<number>(expect.closeTo(5.12))
+  await expect(5.11).resolves.toEqual(expect.closeTo(5.12))
+  await expect(5.11).resolves.toEqual<number>(expect.closeTo(5.12))
 
   // expect.any(String)
   // https://github.com/vitest-dev/vitest/pull/7016#issuecomment-2517674066
@@ -45,7 +61,20 @@ test('expect.* allows asymmetrict mattchers with different types', () => {
       name: 'Amelia',
     })
 
+    await expect(obj).resolves.toEqual({
+      id: expect.any(String),
+      name: 'Amelia',
+    })
+
     expect(obj).toEqual<{
+      id: string
+      name: string
+    }>({
+      id: expect.any(String),
+      name: 'Amelia',
+    })
+
+    await expect(obj).resolves.toEqual<{
       id: string
       name: string
     }>({
@@ -71,7 +100,23 @@ test('expect.* allows asymmetrict mattchers with different types', () => {
       createdAt: expect.any(Date),
     })
 
+    await expect(actual).resolves.toEqual({
+      foo: 'foo',
+      bar: 'bar',
+      createdAt: expect.any(Date),
+    })
+
     expect(actual).toEqual<{
+      foo: string
+      bar: string
+      createdAt: Date
+    }>({
+      foo: 'foo',
+      bar: 'bar',
+      createdAt: expect.any(Date),
+    })
+
+    await expect(actual).resolves.toEqual<{
       foo: string
       bar: string
       createdAt: Date
@@ -92,6 +137,18 @@ test('expect.* allows asymmetrict mattchers with different types', () => {
         createdAt: expect.any(Date),
       },
     ])
+
+    await expect(actual).resolves.toEqual<{
+      foo: string
+      bar: string
+      createdAt: Date
+    }[]>([
+      {
+        foo: 'foo',
+        bar: 'bar',
+        createdAt: expect.any(Date),
+      },
+    ])
   }
 
   // expect.arrayContaining
@@ -99,18 +156,26 @@ test('expect.* allows asymmetrict mattchers with different types', () => {
   {
     expect([1, 2, 3]).toEqual(expect.arrayContaining(['a']))
     expect([1, 2, 3]).toEqual<number[]>(expect.arrayContaining(['a']))
+    await expect([1, 2, 3]).resolves.toEqual<number[]>(expect.arrayContaining(['a']))
+    await expect([1, 2, 3]).resolves.toEqual<number[]>(expect.arrayContaining(['a']))
 
     expect([1, 2, 3]).toEqual(expect.arrayContaining([expect.any(Number)]))
     expect([1, 2, 3]).toEqual<number[]>(expect.arrayContaining([expect.any(Number)]))
+    await expect([1, 2, 3]).resolves.toEqual(expect.arrayContaining([expect.any(Number)]))
+    await expect([1, 2, 3]).resolves.toEqual<number[]>(expect.arrayContaining([expect.any(Number)]))
 
     expect([1, 2, 3]).toEqual(expect.arrayContaining([expect.anything()]))
     expect([1, 2, 3]).toEqual<number[]>(expect.arrayContaining([expect.anything()]))
+    await expect([1, 2, 3]).resolves.toEqual(expect.arrayContaining([expect.anything()]))
+    await expect([1, 2, 3]).resolves.toEqual<number[]>(expect.arrayContaining([expect.anything()]))
   }
 
   // expect.any(Array)
   // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62831/files#diff-ff7b882e4a29e7fe0e348a6bdf8b11774d606eaa221009b166b01389576d921fR1237
   expect({ list: [1, 2, 3] }).toMatchObject({ list: expect.any(Array) })
   expect({ list: [1, 2, 3] }).toMatchObject<{ list: number[] }>({ list: expect.any(Array) })
+  await expect({ list: [1, 2, 3] }).resolves.toMatchObject({ list: expect.any(Array) })
+  await expect({ list: [1, 2, 3] }).resolves.toMatchObject<{ list: number[] }>({ list: expect.any(Array) })
 
   // expect<T>
   // https://github.com/vitest-dev/vitest/issues/8081

--- a/test/core/test/snapshot-async.test.ts
+++ b/test/core/test/snapshot-async.test.ts
@@ -8,10 +8,10 @@ function reject() {
 }
 
 test('resolved inline', async () => {
-  await expect(resolve()).resolves.toMatchInlineSnapshot('"foo"')
+  await (expect(resolve()).resolves.toMatchInlineSnapshot('"foo"') satisfies Promise<void>)
 })
 
 test('rejected inline', async () => {
-  await expect(reject()).rejects.toMatchInlineSnapshot('[Error: foo]')
+  await (expect(reject()).rejects.toMatchInlineSnapshot('[Error: foo]') satisfies Promise<void>)
   await expect(reject()).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: foo]`)
 })


### PR DESCRIPTION
### Description

Resolves https://github.com/vitest-dev/vitest/issues/6279

At the moment, when you use `.resolves` or `.rejects` the type generics get lost due to the Promisify function.

```ts
import { expect } from "vitest";

interface FooBar {
  foo: string;
}

expect({ foo: "bar" }).resolves.toStrictEqual<FooBar>({ foo: "bar" });
expect({ foo: "bar" }).toStrictEqual<FooBar>({ foo: "bar" });
```

<details>
  <summary>See error</summary>
	<img width="911" alt="image" src="https://github.com/user-attachments/assets/50762624-f6cb-42a0-a8b6-9be155ae8821" />
</details>

This PR changes the types and allows us to also type-check the resolves and reject matchers.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
