### PR TITLE
docs(vite-node): Update programmatic usage example

### DIFF
--- a/packages/vite-node/README.md
+++ b/packages/vite-node/README.md
@@ -91,10 +91,12 @@ import { installSourcemapsSupport } from 'vite-node/source-map'
 const server = await createServer({
   optimizeDeps: {
     // It's recommended to disable deps optimization
-    disabled: true,
+    noDiscovery: true,
+    include: undefined,
   },
 })
-// For old Vite, this is need to initialize the plugins.
+
+// For old Vite, this is needed to initialize the plugins.
 if (Number(viteVersion.split('.')[0]) < 6) {
   await server.pluginContainer.buildStart({})
 }


### PR DESCRIPTION
### Description

With the example of programmatic usage in the README I get the following warning:

```
(!) Experimental optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
    To disable the deps optimizer, set optimizeDeps.noDiscovery to true and optimizeDeps.include as undefined or empty.
    Please remove optimizeDeps.disabled from your config.
```

So I updated the example to follow the advice given in the warning and set the `optimizeDeps` config to this:

```js
optimizeDeps: {
  // It's recommended to disable deps optimization
  noDiscovery: true,
  include: undefined,
},
```

This PR also fixes a grammatical error in a comment in the same programmatic usage example
 
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

I ran the tests. 8 tests failed. But I'm pretty sure that has nothing to do with this PR

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
