### PR TITLE
fix: use suite's timeout when `test.extend`

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -786,7 +786,7 @@ export function createTaskCollector(
         )
       }
       const { handler, options } = parseArguments(optionsOrFn, optionsOrTest)
-      const timeout = options.timeout ?? runner?.config.testTimeout
+      const timeout = options.timeout ?? collector.options?.timeout ?? runner?.config.testTimeout
       originalWrapper.call(context, formatName(name), handler, timeout)
     }, _context)
   }

--- a/test/core/test/test-extend.test.ts
+++ b/test/core/test/test-extend.test.ts
@@ -487,3 +487,17 @@ describe('test.scoped repro #7813', () => {
     })
   })
 })
+
+describe('suite with timeout', () => {
+  test.extend({}).fails('should timeout', async () => {
+    await new Promise(resolve => setTimeout(resolve, 1_000))
+  })
+
+  test.extend({})('should pass', { timeout: 1_000 }, async () => {
+    await new Promise(resolve => setTimeout(resolve, 200))
+  })
+
+  test.extend({})('should also pass', async () => {
+    await new Promise(resolve => setTimeout(resolve, 1))
+  })
+}, 100)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/8277

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
