### PR TITLE
docs: Fix typo in Runner API page

### DIFF
--- a/docs/advanced/runner.md
+++ b/docs/advanced/runner.md
@@ -139,7 +139,7 @@ If you don't have a custom runner or didn't define `runTest` method, Vitest will
 :::
 
 ::: tip
-Snapshot support and some other features depend on the runner. If you don't want to lose it, you can extend your runner from `VitestTestRunner` imported from `vitest/runners`. It also exposes `BenchmarkNodeRunner`, if you want to extend benchmark functionality.
+Snapshot support and some other features depend on the runner. If you don't want to lose it, you can extend your runner from `VitestTestRunner` imported from `vitest/runners`. It also exposes `NodeBenchmarkRunner`, if you want to extend benchmark functionality.
 :::
 
 ## Tasks


### PR DESCRIPTION

### Description

The page mentions `BenchmarkNodeRunner`, but the exported class is actually called `NodeBenchmarkRunner`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Source: https://github.com/vitest-dev/vitest/blob/c1f78d2adc78ef08ef8b61b0dd6a925fb08f20b6/packages/vitest/src/runtime/runners/benchmark.ts#L152


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
