### PR TITLE
feat(coverage): add sourceFinder property to coverage options

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1543,6 +1543,26 @@ Sets thresholds to 100 for files matching the glob pattern.
 Set to array of class method names to ignore for coverage.
 See [istanbul documentation](https://github.com/istanbuljs/nyc#ignoring-methods) for more information.
 
+#### coverage.sourceFinder
+
+- **Type:** `(path: string) => string`
+- **Available for providers:** `'v8' | 'istanbul'`
+
+<!-- eslint-skip -->
+```ts
+sourceFinder: (path: string): string => {
+  try {
+      const content = fs.readFileSync(path, 'utf8');
+      // If you need to transform the content, do it here
+      return content;
+  } catch (ex: Error) {
+      throw new Error(`Unable to lookup source: ${path} (${ex.message})`);
+  }
+}
+```
+
+The sourceFinder function is responsible for taking a file path and finding the corresponding actual source file given the path as parameter
+
 #### coverage.watermarks
 
 - **Type:**

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -131,6 +131,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider<ResolvedCover
       dir: this.options.reportsDirectory,
       coverageMap,
       watermarks: this.options.watermarks,
+      sourceFinder: this.options.sourceFinder,
     })
 
     if (this.hasTerminalReporter(this.options.reporter)) {

--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -116,6 +116,7 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
       dir: this.options.reportsDirectory,
       coverageMap,
       watermarks: this.options.watermarks,
+      sourceFinder: this.options.sourceFinder,
     })
 
     if (this.hasTerminalReporter(this.options.reporter)) {

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -266,7 +266,7 @@ export interface BaseCoverageOptions {
    * sourceFinder: (path: string): string => {
    *   try {
    *       const content = fs.readFileSync(path, 'utf8');
-   *       // If you need to transform the content, do it here
+   *       // Transform the content here.
    *       return content;
    *   } catch (ex: Error) {
    *       throw new Error(`Unable to lookup source: ${path} (${ex.message})`);

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -255,6 +255,26 @@ export interface BaseCoverageOptions {
    * @default []
    */
   ignoreClassMethods?: string[]
+
+  /**
+   * Function that returns source code given a file path and is able to modify the content or path.
+   * Defaults to filesystem lookups based on path.
+   *
+   * @example
+   *
+   * ```ts
+   * sourceFinder: (path: string): string => {
+   *   try {
+   *       const content = fs.readFileSync(path, 'utf8');
+   *       // If you need to transform the content, do it here
+   *       return content;
+   *   } catch (ex: Error) {
+   *       throw new Error(`Unable to lookup source: ${path} (${ex.message})`);
+   *   }
+   * }
+   * ```
+   */
+  sourceFinder?: (path: string) => string
 }
 
 export interface CoverageIstanbulOptions extends BaseCoverageOptions {}

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -216,3 +216,11 @@ test('reporters, mixed variations', () => {
     ],
   })
 })
+
+test('rewriting file content with sourceFinder', () => {
+  assertType<Coverage>({
+    sourceFinder: (path: string) => {
+      return `New file content for ${path}`
+    },
+  })
+})


### PR DESCRIPTION
### Description

This PR introduces a new feature that addresses [#8324](https://github.com/vitest-dev/vitest/issues/8324) by exposing a function through the coverage configuration, allowing users to modify the file path and content used by `istanbul-lib-coverage`. 

The function returns file path and can be customized to alter the content or path as needed. By default, it performs filesystem lookups based on the provided path.

This change also resolves an issue with Angular 20 projects using Vitest, where source paths are not correctly resolved trough `istanbul-lib-coverage`. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [X] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
