### PR TITLE
fix(mocker)!: don't reset or clear automocks when restoreAllMocks is called

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -145,6 +145,10 @@ $ pnpm run test:dev math.test.ts
 ```
 :::
 
+### `restoreAllMocks` no longer resets automocks
+
+Previously, all automocks created by `vi.mock('./path')` would reset their state if `vi.restoreAllMocks` was called or if [`restoreMocks`](/config/#restoreMocks) was set in the config.
+
 ### Deprecated APIs are Removed
 
 Vitest 4.0 removes some deprecated APIs, including:

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -147,7 +147,7 @@ $ pnpm run test:dev math.test.ts
 
 ### `restoreAllMocks` no longer resets automocks
 
-Previously, all automocks created by `vi.mock('./path')` would reset their state if `vi.restoreAllMocks` was called or if [`restoreMocks`](/config/#restoreMocks) was set in the config.
+Previously, all automocks created by `vi.mock('./path')` would reset their state if `vi.restoreAllMocks` was called or if [`restoreMocks`](/config/#restoreMocks) was set in the config. Now they don't affect automocked mocks at all.
 
 ### Deprecated APIs are Removed
 

--- a/packages/mocker/src/automocker.ts
+++ b/packages/mocker/src/automocker.ts
@@ -8,6 +8,9 @@ export interface MockObjectOptions {
   spyOn: (obj: any, prop: Key) => any
 }
 
+// not definined the Spy type to avoid recursive definition
+export const moduleSpies: Set<any> = new Set()
+
 export function mockObject(
   options: MockObjectOptions,
   object: Record<Key, any>,
@@ -120,6 +123,7 @@ export function mockObject(
                 const original = this[key]
                 const mock = spyOn(this, key as string)
                   .mockImplementation(original)
+                moduleSpies.add(mock)
                 const origMockReset = mock.mockReset
                 mock.mockRestore = mock.mockReset = () => {
                   origMockReset.call(mock)
@@ -131,6 +135,7 @@ export function mockObject(
           }
         }
         const mock = spyOn(newContainer, property)
+        moduleSpies.add(mock)
         if (options.type === 'automock') {
           mock.mockImplementation(mockFunction)
           const origMockReset = mock.mockReset

--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -2,7 +2,7 @@ import type { MockedModule, MockedModuleType } from '../registry'
 import type { ModuleMockOptions } from '../types'
 import type { ModuleMockerInterceptor } from './interceptor'
 import { extname, join } from 'pathe'
-import { mockObject } from '../automocker'
+import { mockObject, moduleSpies } from '../automocker'
 import { AutomockedModule, MockerRegistry, RedirectedModule } from '../registry'
 
 const { now } = Date
@@ -113,6 +113,10 @@ export class ModuleMocker {
     }
 
     return import(/* @vite-ignore */ mock.redirect)
+  }
+
+  public moduleSpies(): Set<any> {
+    return moduleSpies
   }
 
   public mockObject(

--- a/packages/mocker/src/index.ts
+++ b/packages/mocker/src/index.ts
@@ -1,4 +1,4 @@
-export { mockObject } from './automocker'
+export { mockObject, moduleSpies } from './automocker'
 export type { GlobalConstructors, MockObjectOptions } from './automocker'
 
 export {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -90,10 +90,6 @@
     "./snapshot": {
       "types": "./dist/snapshot.d.ts",
       "default": "./dist/snapshot.js"
-    },
-    "./mocker": {
-      "types": "./dist/mocker.d.ts",
-      "default": "./dist/mocker.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -25,7 +25,6 @@ const entries = {
   'browser': 'src/public/browser.ts',
   'runners': 'src/public/runners.ts',
   'environments': 'src/public/environments.ts',
-  'mocker': 'src/public/mocker.ts',
   'spy': 'src/integrations/spy.ts',
   'coverage': 'src/public/coverage.ts',
   'execute': 'src/public/execute.ts',
@@ -56,7 +55,6 @@ const dtsEntries = {
   coverage: 'src/public/coverage.ts',
   execute: 'src/public/execute.ts',
   reporters: 'src/public/reporters.ts',
-  mocker: 'src/public/mocker.ts',
   workers: 'src/public/workers.ts',
   snapshot: 'src/public/snapshot.ts',
 }

--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -666,7 +666,8 @@ function createVitest(): VitestUtils {
     },
 
     restoreAllMocks() {
-      [...mocks].reverse().forEach(spy => spy.mockRestore())
+      const moduleSpies = _mocker().moduleSpies();
+      [...mocks].reverse().forEach(spy => !moduleSpies.has(spy) && spy.mockRestore())
       return utils
     },
 

--- a/packages/vitest/src/public/mocker.ts
+++ b/packages/vitest/src/public/mocker.ts
@@ -1,1 +1,0 @@
-export * from '@vitest/mocker'

--- a/packages/vitest/src/runtime/mocker.ts
+++ b/packages/vitest/src/runtime/mocker.ts
@@ -1,9 +1,10 @@
 import type { ManualMockedModule, MockedModule, MockedModuleType } from '@vitest/mocker'
+import type { MockInstance } from '../integrations/spy'
 import type { MockFactory, MockOptions, PendingSuiteMock } from '../types/mocker'
 import type { VitestExecutor } from './execute'
 import { isAbsolute, resolve } from 'node:path'
 import vm from 'node:vm'
-import { AutomockedModule, MockerRegistry, mockObject, RedirectedModule } from '@vitest/mocker'
+import { AutomockedModule, MockerRegistry, mockObject, moduleSpies, RedirectedModule } from '@vitest/mocker'
 import { findMockRedirect } from '@vitest/mocker/redirect'
 import { highlight } from '@vitest/utils'
 import { distDir } from '../paths'
@@ -252,6 +253,10 @@ export class VitestMocker {
 
   public resolveMockPath(mockPath: string, external: string | null): string | null {
     return findMockRedirect(this.root, mockPath, external)
+  }
+
+  public moduleSpies(): Set<MockInstance> {
+    return moduleSpies
   }
 
   public mockObject(

--- a/test/core/test/exports.test.ts
+++ b/test/core/test/exports.test.ts
@@ -77,14 +77,6 @@ it('exports snapshot', async ({ skip, task }) => {
           "stringify": "function",
           "takeCoverageInsideWorker": "function",
         },
-        "./mocker": {
-          "AutomockedModule": "function",
-          "AutospiedModule": "function",
-          "ManualMockedModule": "function",
-          "MockerRegistry": "function",
-          "RedirectedModule": "function",
-          "mockObject": "function",
-        },
         "./node": {
           "BaseSequencer": "function",
           "GitNotFoundError": "function",
@@ -229,14 +221,6 @@ it('exports snapshot', async ({ skip, task }) => {
             "stopCoverageInsideWorker": "function",
             "stringify": "function",
             "takeCoverageInsideWorker": "function",
-          },
-          "./mocker": {
-            "AutomockedModule": "function",
-            "AutospiedModule": "function",
-            "ManualMockedModule": "function",
-            "MockerRegistry": "function",
-            "RedirectedModule": "function",
-            "mockObject": "function",
           },
           "./node": {
             "BaseSequencer": "function",

--- a/test/core/test/mocked-class-restore-all.test.ts
+++ b/test/core/test/mocked-class-restore-all.test.ts
@@ -29,12 +29,18 @@ test(`mocked class are not affected by restoreAllMocks`, () => {
   expect(vi.mocked(instance0.testFn).mock.calls).toMatchInlineSnapshot(`
     [
       [
+        "a",
+      ],
+      [
         "b",
       ],
     ]
   `)
   expect(vi.mocked(MockedE.prototype.testFn).mock.calls).toMatchInlineSnapshot(`
     [
+      [
+        "a",
+      ],
       [
         "b",
       ],
@@ -53,6 +59,9 @@ test(`mocked class are not affected by restoreAllMocks`, () => {
   expect(vi.mocked(instance0.testFn).mock.calls).toMatchInlineSnapshot(`
     [
       [
+        "a",
+      ],
+      [
         "b",
       ],
     ]
@@ -67,6 +76,9 @@ test(`mocked class are not affected by restoreAllMocks`, () => {
   expect(vi.mocked(instance2.testFn).mock.calls).toMatchInlineSnapshot(`[]`)
   expect(vi.mocked(MockedE.prototype.testFn).mock.calls).toMatchInlineSnapshot(`
     [
+      [
+        "a",
+      ],
       [
         "b",
       ],


### PR DESCRIPTION
### Description

TODO
- [x] Test

Fixes #7942

This PR also removes the `vitest/mocker` entry point. It was never documented and not used internally now.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
