### PR TITLE
fix: screenshot masks with Playwright provider

### DIFF
--- a/packages/browser/providers/playwright.d.ts
+++ b/packages/browser/providers/playwright.d.ts
@@ -12,6 +12,7 @@ import { Protocol } from 'playwright-core/types/protocol'
 import '../matchers.js'
 import type {} from "vitest/node"
 import type {
+  Locator,
   ScreenshotComparatorRegistry,
   ScreenshotMatcherOptions,
 } from "@vitest/browser/context"
@@ -71,7 +72,9 @@ declare module '@vitest/browser/context' {
   export interface UserEventDragAndDropOptions extends PWDragAndDropOptions {}
   export interface UserEventUploadOptions extends PWSetInputFiles {}
 
-  export interface ScreenshotOptions extends PWScreenshotOptions {}
+  export interface ScreenshotOptions extends Omit<PWScreenshotOptions, 'mask'> {
+    mask?: ReadonlyArray<Element | Locator> | undefined
+  }
 
   export interface CDPSession {
     send<T extends keyof Protocol.CommandParameters>(

--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -40,16 +40,19 @@ export default async function toMatchScreenshot(
     ? nameOrOptions
     : `${this.currentTestName} ${counter.current}`
 
-  const normalizedOptions = options.screenshotOptions && 'mask' in options.screenshotOptions
-    ? {
-        ...options,
-        screenshotOptions: {
-          ...options.screenshotOptions,
-          mask: (options.screenshotOptions.mask as Array<Element | Locator>)
-            .map(convertToSelector),
-        },
-      }
-    : options
+  const normalizedOptions: Omit<ScreenshotMatcherArguments[2], 'element'> = (
+    options.screenshotOptions && 'mask' in options.screenshotOptions
+      ? {
+          ...options,
+          screenshotOptions: {
+            ...options.screenshotOptions,
+            mask: (options.screenshotOptions.mask as Array<Element | Locator>)
+              .map(convertToSelector),
+          },
+        }
+      // TS believes `mask` to still be defined as `ReadonlyArray<Element | Locator>`
+      : options as any
+  )
 
   const result = await getBrowserState().commands.triggerCommand<ScreenshotMatcherOutput>(
     '__vitest_screenshotMatcher',

--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -3,8 +3,7 @@ import type { ScreenshotMatcherOptions } from '../../../../context'
 import type { ScreenshotMatcherArguments, ScreenshotMatcherOutput } from '../../../shared/screenshotMatcher/types'
 import type { Locator } from '../locators'
 import { getBrowserState, getWorkerState } from '../../utils'
-import { convertElementToCssSelector } from '../utils'
-import { getElementFromUserInput } from './utils'
+import { convertToSelector } from '../utils'
 
 const counters = new Map<string, { current: number }>([])
 
@@ -41,17 +40,25 @@ export default async function toMatchScreenshot(
     ? nameOrOptions
     : `${this.currentTestName} ${counter.current}`
 
-  const result = await
-  getBrowserState().commands.triggerCommand<ScreenshotMatcherOutput>(
+  const normalizedOptions = options.screenshotOptions && 'mask' in options.screenshotOptions
+    ? {
+        ...options,
+        screenshotOptions: {
+          ...options.screenshotOptions,
+          mask: (options.screenshotOptions.mask as Array<Element | Locator>)
+            .map(convertToSelector),
+        },
+      }
+    : options
+
+  const result = await getBrowserState().commands.triggerCommand<ScreenshotMatcherOutput>(
     '__vitest_screenshotMatcher',
     [
       name,
       this.currentTestName,
       {
-        element: convertElementToCssSelector(
-          getElementFromUserInput(actual, toMatchScreenshot, this),
-        ),
-        ...options,
+        element: convertToSelector(actual),
+        ...normalizedOptions,
       },
     ] satisfies ScreenshotMatcherArguments,
   )

--- a/packages/browser/src/client/tester/utils.ts
+++ b/packages/browser/src/client/tester/utils.ts
@@ -1,3 +1,4 @@
+import type { Locator } from '@vitest/browser/context'
 import type { BrowserRPC } from '../client'
 import { getBrowserState, getWorkerState } from '../utils'
 
@@ -196,4 +197,17 @@ export function escapeForTextSelector(text: string | RegExp, exact: boolean): st
     return escapeRegexForSelector(text)
   }
   return `${JSON.stringify(text)}${exact ? 's' : 'i'}`
+}
+
+export function convertToSelector(elementOrLocator: Element | Locator): string {
+  if (!elementOrLocator) {
+    throw new Error('Expected element or locator to be defined.')
+  }
+  if (elementOrLocator instanceof Element) {
+    return convertElementToCssSelector(elementOrLocator)
+  }
+  if ('selector' in elementOrLocator) {
+    return (elementOrLocator as any).selector
+  }
+  throw new Error('Expected element or locator to be an instance of Element or Locator.')
 }

--- a/packages/browser/src/node/commands/screenshot.ts
+++ b/packages/browser/src/node/commands/screenshot.ts
@@ -53,11 +53,14 @@ export async function takeScreenshot(
   await mkdir(dirname(path), { recursive: true })
 
   if (context.provider instanceof PlaywrightBrowserProvider) {
+    const mask = options.mask?.map(selector => context.iframe.locator(`${selector}`))
+
     if (options.element) {
       const { element: selector, ...config } = options
       const element = context.iframe.locator(`${selector}`)
       const buffer = await element.screenshot({
         ...config,
+        mask,
         path: options.save ? savePath : undefined,
       })
       return { buffer, path }
@@ -65,6 +68,7 @@ export async function takeScreenshot(
 
     const buffer = await context.iframe.locator('body').screenshot({
       ...options,
+      mask,
       path: options.save ? savePath : undefined,
     })
     return { buffer, path }

--- a/packages/browser/src/node/commands/screenshot.ts
+++ b/packages/browser/src/node/commands/screenshot.ts
@@ -6,8 +6,9 @@ import { basename, dirname, relative, resolve } from 'pathe'
 import { PlaywrightBrowserProvider } from '../providers/playwright'
 import { WebdriverBrowserProvider } from '../providers/webdriver'
 
-interface ScreenshotCommandOptions extends Omit<ScreenshotOptions, 'element'> {
+interface ScreenshotCommandOptions extends Omit<ScreenshotOptions, 'element' | 'mask'> {
   element?: string
+  mask?: readonly string[]
 }
 
 export const screenshot: BrowserCommand<[string, ScreenshotCommandOptions]> = async (
@@ -53,11 +54,11 @@ export async function takeScreenshot(
   await mkdir(dirname(path), { recursive: true })
 
   if (context.provider instanceof PlaywrightBrowserProvider) {
-    const mask = options.mask?.map(selector => context.iframe.locator(`${selector}`))
+    const mask = options.mask?.map(selector => context.iframe.locator(selector))
 
     if (options.element) {
       const { element: selector, ...config } = options
-      const element = context.iframe.locator(`${selector}`)
+      const element = context.iframe.locator(selector)
       const buffer = await element.screenshot({
         ...config,
         mask,

--- a/packages/browser/src/node/commands/screenshotMatcher/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/index.ts
@@ -199,7 +199,7 @@ async function getStableScreenshots({
   element: string
   name: string
   reference: ReturnType<AnyCodec['decode']> | null
-  screenshotOptions: ScreenshotMatcherOptions['screenshotOptions']
+  screenshotOptions: ScreenshotMatcherArguments[2]['screenshotOptions']
   signal: AbortSignal
 }) {
   const screenshotArgument = {

--- a/packages/browser/src/node/commands/screenshotMatcher/utils.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/utils.ts
@@ -1,5 +1,6 @@
 import type { BrowserCommandContext, BrowserConfigOptions } from 'vitest/node'
 import type { ScreenshotMatcherOptions } from '../../../../context'
+import type { ScreenshotMatcherArguments } from '../../../shared/screenshotMatcher/types'
 import type { AnyCodec } from './codecs'
 import { platform } from 'node:os'
 import { deepMerge } from '@vitest/utils'
@@ -11,6 +12,7 @@ import { getComparator } from './comparators'
 type GlobalOptions = Required<
   NonNullable<
     NonNullable<BrowserConfigOptions['expect']>['toMatchScreenshot']
+    & NonNullable<Pick<ScreenshotMatcherArguments[2], 'screenshotOptions'>>
   >
 >
 
@@ -234,7 +236,7 @@ export function takeDecodedScreenshot({
   context: BrowserCommandContext
   element: string
   name: string
-  screenshotOptions: ScreenshotMatcherOptions['screenshotOptions']
+  screenshotOptions: ScreenshotMatcherArguments[2]['screenshotOptions']
 }): ReturnType<AnyCodec['decode']> {
   return takeScreenshot(
     context,

--- a/packages/browser/src/shared/screenshotMatcher/types.ts
+++ b/packages/browser/src/shared/screenshotMatcher/types.ts
@@ -5,7 +5,11 @@ export type ScreenshotMatcherArguments<
 > = [
   name: string,
   testName: string,
-  options: ScreenshotMatcherOptions<ComparatorName> & { element: string },
+  options: ScreenshotMatcherOptions<ComparatorName>
+    & {
+      element: string
+      screenshotOptions?: ScreenshotMatcherOptions<ComparatorName>['screenshotOptions'] & { mask?: readonly string[] }
+    },
 ]
 
 export type ScreenshotMatcherOutput = Promise<


### PR DESCRIPTION
### Description

This PR fixes the issue of masks not being applied correctly when taking a screenshot, as previously discussed in the context of #8041.

Masking elements is an important feature when handling dynamic content in Visual Regression Testing.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
