### PR TITLE
chore: update license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-Present Vitest Team
+Copyright (c) 2021-Present VoidZero Inc. and Vitest contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Thanks to:
 - [@patak-dev](https://github.com/patak-dev) for the awesome package name!
 
 ## Contribution
+
 See [Contributing Guide](https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md).
 
 ## License
 
-[MIT](./LICENSE) License © 2021-Present [Anthony Fu](https://github.com/antfu), [Matias Capeletto](https://github.com/patak-dev)
+[MIT](./LICENSE) License © 2021-Present VoidZero Inc. and Vitest contributors

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -142,7 +142,7 @@ export default ({ mode }: { mode: string }) => {
 
       footer: {
         message: 'Released under the MIT License.',
-        copyright: 'Copyright © 2021-PRESENT Anthony Fu, Matías Capeletto and Vitest contributors',
+        copyright: 'Copyright © 2021-PRESENT VoidZero Inc. and Vitest contributors',
       },
 
       nav: [

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -3,7 +3,7 @@ Vitest is released under the MIT license:
 
 MIT License
 
-Copyright (c) 2021-Present Vitest Team
+Copyright (c) 2021-Present VoidZero Inc. and Vitest contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This change reflects that we (@sheremet-va, @antfu, @patak-dev) have assigned the copyright of our code in the Vitest project over to VoidZero Inc. Copyrights of other Vitest contributors remain unaffected and governance of the project remain unchanged. Vitest remains open source under MIT license.
