### PR TITLE
fix: configure `oxc` instead of `esbuild` on `rolldown-vite`

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -25,6 +25,7 @@ import {
   resolveFsAllow,
 } from './utils'
 import { VitestCoreResolver } from './vitestResolver'
+import * as vite from "vite"
 
 export async function VitestPlugin(
   options: UserConfig = {},
@@ -76,22 +77,12 @@ export async function VitestPlugin(
 
         const resolveOptions = getDefaultResolveOptions()
 
-        const config: ViteConfig = {
+        let config: ViteConfig = {
           root: viteConfig.test?.root || options.root,
           define: {
             // disable replacing `process.env.NODE_ENV` with static string by vite:client-inject
             'process.env.NODE_ENV': 'process.env.NODE_ENV',
           },
-          esbuild:
-            viteConfig.esbuild === false
-              ? false
-              : {
-                  // Lowest target Vitest supports is Node18
-                  target: viteConfig.esbuild?.target || 'node18',
-                  sourcemap: 'external',
-                  // Enables using ignore hint for coverage providers with @preserve keyword
-                  legalComments: 'inline',
-                },
           resolve: {
             ...resolveOptions,
             alias: testConfig.alias,
@@ -145,6 +136,30 @@ export async function VitestPlugin(
             root: testConfig.root ?? viteConfig.test?.root,
             deps: testConfig.deps ?? viteConfig.test?.deps,
           },
+        }
+
+        if ('rolldownVersion' in vite) {
+          config = {
+            ...config,
+            oxc: viteConfig.oxc === false
+              ? false
+              : {
+                  target: viteConfig.oxc?.target || 'node18',
+                },
+          };
+        } else {
+          config = {
+            ...config,
+            esbuild: viteConfig.esbuild === false
+              ? false
+              : {
+                  // Lowest target Vitest supports is Node18
+                  target: viteConfig.esbuild?.target || 'node18',
+                  sourcemap: 'external',
+                  // Enables using ignore hint for coverage providers with @preserve keyword
+                  legalComments: 'inline',
+                },
+          }
         }
 
         // inherit so it's available in VitestOptimizer

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -6,6 +6,7 @@ import {
   notNullish,
 } from '@vitest/utils'
 import { relative } from 'pathe'
+import * as vite from 'vite'
 import { defaultPort } from '../../constants'
 import { configDefaults } from '../../defaults'
 import { generateScopedClassName } from '../../integrations/css/css-modules'
@@ -25,7 +26,6 @@ import {
   resolveFsAllow,
 } from './utils'
 import { VitestCoreResolver } from './vitestResolver'
-import * as vite from "vite"
 
 export async function VitestPlugin(
   options: UserConfig = {},
@@ -146,8 +146,9 @@ export async function VitestPlugin(
               : {
                   target: viteConfig.oxc?.target || 'node18',
                 },
-          };
-        } else {
+          }
+        }
+        else {
           config = {
             ...config,
             esbuild: viteConfig.esbuild === false

--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -141,9 +141,13 @@ export async function VitestPlugin(
         if ('rolldownVersion' in vite) {
           config = {
             ...config,
+            // eslint-disable-next-line ts/ban-ts-comment
+            // @ts-ignore rolldown-vite only
             oxc: viteConfig.oxc === false
               ? false
               : {
+                  // eslint-disable-next-line ts/ban-ts-comment
+                  // @ts-ignore rolldown-vite only
                   target: viteConfig.oxc?.target || 'node18',
                 },
           }

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -4,6 +4,7 @@ import type { ResolvedConfig, TestProjectInlineConfiguration } from '../types/co
 import { existsSync, readFileSync } from 'node:fs'
 import { deepMerge } from '@vitest/utils'
 import { basename, dirname, relative, resolve } from 'pathe'
+import * as vite from 'vite'
 import { configDefaults } from '../../defaults'
 import { generateScopedClassName } from '../../integrations/css/css-modules'
 import { VitestFilteredOutProjectError } from '../errors'
@@ -21,7 +22,6 @@ import {
   resolveFsAllow,
 } from './utils'
 import { VitestProjectResolver } from './vitestResolver'
-import * as vite from "vite";
 
 interface WorkspaceOptions extends TestProjectInlineConfiguration {
   root?: string
@@ -162,8 +162,9 @@ export function WorkspaceVitestPlugin(
               : {
                   target: viteConfig.oxc?.target || 'node18',
                 },
-          };
-        } else {
+          }
+        }
+        else {
           config = {
             ...config,
             esbuild: viteConfig.esbuild === false

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -21,6 +21,7 @@ import {
   resolveFsAllow,
 } from './utils'
 import { VitestProjectResolver } from './vitestResolver'
+import * as vite from "vite";
 
 interface WorkspaceOptions extends TestProjectInlineConfiguration {
   root?: string
@@ -117,7 +118,7 @@ export function WorkspaceVitestPlugin(
         const root = testConfig.root || viteConfig.root || options.root
 
         const resolveOptions = getDefaultResolveOptions()
-        const config: ViteConfig = {
+        let config: ViteConfig = {
           root,
           define: {
             // disable replacing `process.env.NODE_ENV` with static string by vite:client-inject
@@ -127,15 +128,6 @@ export function WorkspaceVitestPlugin(
             ...resolveOptions,
             alias: testConfig.alias,
           },
-          esbuild: viteConfig.esbuild === false
-            ? false
-            : {
-                // Lowest target Vitest supports is Node18
-                target: viteConfig.esbuild?.target || 'node18',
-                sourcemap: 'external',
-                // Enables using ignore hint for coverage providers with @preserve keyword
-                legalComments: 'inline',
-              },
           server: {
             // disable watch mode in workspaces,
             // because it is handled by the top-level watcher
@@ -160,6 +152,30 @@ export function WorkspaceVitestPlugin(
             },
           },
           test: {},
+        }
+
+        if ('rolldownVersion' in vite) {
+          config = {
+            ...config,
+            oxc: viteConfig.oxc === false
+              ? false
+              : {
+                  target: viteConfig.oxc?.target || 'node18',
+                },
+          };
+        } else {
+          config = {
+            ...config,
+            esbuild: viteConfig.esbuild === false
+              ? false
+              : {
+                  // Lowest target Vitest supports is Node18
+                  target: viteConfig.esbuild?.target || 'node18',
+                  sourcemap: 'external',
+                  // Enables using ignore hint for coverage providers with @preserve keyword
+                  legalComments: 'inline',
+                },
+          }
         }
 
         ;(config.test as ResolvedConfig).defines = defines

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -157,9 +157,11 @@ export function WorkspaceVitestPlugin(
         if ('rolldownVersion' in vite) {
           config = {
             ...config,
+            // @ts-ignore
             oxc: viteConfig.oxc === false
               ? false
               : {
+                  // @ts-ignore
                   target: viteConfig.oxc?.target || 'node18',
                 },
           }

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -157,11 +157,13 @@ export function WorkspaceVitestPlugin(
         if ('rolldownVersion' in vite) {
           config = {
             ...config,
-            // @ts-ignore
+            // eslint-disable-next-line ts/ban-ts-comment
+            // @ts-ignore rolldown-vite only
             oxc: viteConfig.oxc === false
               ? false
               : {
-                  // @ts-ignore
+                  // eslint-disable-next-line ts/ban-ts-comment
+                  // @ts-ignore rolldown-vite only
                   target: viteConfig.oxc?.target || 'node18',
                 },
           }

--- a/test/core/test/esnext-decorator.test.ts
+++ b/test/core/test/esnext-decorator.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest'
+
+it('decorators work', () => {
+  expect(Sut.mocked).toBe(true)
+  expect(new Sut()).toBeInstanceOf(Sut)
+})
+
+function exampleDecorator(ClassExample: any, context: ClassDecoratorContext): any {
+  if (context.kind !== 'class') {
+    throw new Error('not a class to decorate')
+  }
+  ClassExample.mocked = true
+  return ClassExample
+}
+
+@exampleDecorator
+class Sut {
+  static mocked = false
+}

--- a/test/core/test/esnext.test.ts
+++ b/test/core/test/esnext.test.ts
@@ -7,11 +7,6 @@ it.skipIf(Number(version) < 20)('"v" flag in regexp', () => {
   expect('👍🏼👍🏼👍🏼'.match(regexp)).toEqual(['👍🏼', '👍🏼', '👍🏼'])
 })
 
-it('decorators work', () => {
-  expect(Sut.mocked).toBe(true)
-  expect(new Sut()).toBeInstanceOf(Sut)
-})
-
 it('new "using" feature', () => {
   let getResource = (): any => {
     throw new Error('don\'t call me')
@@ -36,17 +31,4 @@ function resourceful(resourceDefault: string) {
       resource = null
     },
   }
-}
-
-function exampleDecorator(ClassExample: any, context: ClassDecoratorContext): any {
-  if (context.kind !== 'class') {
-    throw new Error('not a class to decorate')
-  }
-  ClassExample.mocked = true
-  return ClassExample
-}
-
-@exampleDecorator
-class Sut {
-  static mocked = false
 }

--- a/test/core/vite.config.ts
+++ b/test/core/vite.config.ts
@@ -73,7 +73,7 @@ export default defineConfig({
       ...defaultExclude,
       // FIXME: wait for ecma decorator support in rolldown/oxc
       // https://github.com/oxc-project/oxc/issues/9170
-      ...(rolldownVersion ? ['**/esnext.test.ts'] : []),
+      ...(rolldownVersion ? ['**/esnext-decorator.test.ts'] : []),
     ],
     slowTestThreshold: 1000,
     testTimeout: process.env.CI ? 10_000 : 5_000,


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/discussions/8375

Vitest should avoid settings `esbuild` on rolldown-vite since that would be overwritten by users or other plugins `oxc` and it causes noisy warning as more plugins started to adopt `oxc` option. When Vitest configures `oxc`, it overwrites user's `esbuild` option instead, but that's probably fine since `rolldown-vite` is opt-in and users (and ecosystem in general) should adopt to `oxc` option.

Regarding `oxc.target`, I just found it doesn't seem to affect `using` transpilation https://github.com/vitejs/rolldown-vite/issues/352. We should wait until if the behavior is expected there.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
