### PR TITLE
ci: skip list-changed test on ecosystem ci

### DIFF
--- a/test/cli/test/list-changed.test.ts
+++ b/test/cli/test/list-changed.test.ts
@@ -1,5 +1,8 @@
-import { expect, test } from 'vitest'
+import { test as baseTest, expect } from 'vitest'
 import { editFile, resolvePath, runVitestCli } from '../../test-utils'
+
+// ecosystem-ci updated package.json and make this test fail
+const test = baseTest.skipIf(!!process.env.ECOSYSTEM_CI)
 
 test('list command with --changed flag shows only changed tests', async () => {
   const sourceFile = resolvePath(import.meta.url, '../fixtures/git-changed/related/src/sourceA.ts')


### PR DESCRIPTION
### Description

Fixes https://discord.com/channels/804011606160703521/1401797257246015550

`list --changed` tests are added recently https://github.com/vitest-dev/vitest/pull/8272, but this doesn't work on ecosystem ci. The other `--changed` has been already skipped in a similar way.

https://github.com/vitest-dev/vitest/blob/7b9f58ba663dedc0775b266a94ca5c4496b4f7ba/test/cli/test/git-changed.test.ts#L11-L12


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
