### PR TITLE
fix: make sure test errors always have `stacks` property in Node.js context

### DIFF
--- a/packages/ui/client/components/views/ViewReport.spec.ts
+++ b/packages/ui/client/components/views/ViewReport.spec.ts
@@ -104,6 +104,7 @@ describe('ViewReport', () => {
         errors: [
           {
             name: 'Do some test',
+            stacks: [],
             stack: '\x1B[33mtest/plain-stack-trace.ts\x1B[0m',
             message: 'Error: Transform failed with 1 error:',
             diff,
@@ -163,6 +164,7 @@ describe('ViewReport', () => {
           {
             name: 'Do some test',
             stack: '\x1B[33mtest/plain-stack-trace.ts\x1B[0m',
+            stacks: [],
             message: '\x1B[44mError: Transform failed with 1 error:\x1B[0m',
             diff,
           },

--- a/packages/ui/client/composables/error.ts
+++ b/packages/ui/client/composables/error.ts
@@ -40,6 +40,7 @@ export function parseError(e: unknown) {
       message: String(error).split(/\n/g)[0],
       stack: String(error),
       name: '',
+      stacks: [],
     }
   }
 
@@ -49,6 +50,7 @@ export function parseError(e: unknown) {
       message: err.message,
       stack: err.stack,
       name: '',
+      stacks: [],
     }
   }
 

--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -23,7 +23,7 @@ export interface StackTraceParserOptions {
 const CHROME_IE_STACK_REGEXP = /^\s*at .*(?:\S:\d+|\(native\))/m
 const SAFARI_NATIVE_CODE_REGEXP = /^(?:eval@)?(?:\[native code\])?$/
 
-const stackIgnorePatterns = [
+const stackIgnorePatterns: (string | RegExp)[] = [
   'node:internal',
   /\/packages\/\w+\/dist\//,
   /\/@vitest\/\w+\/dist\//,
@@ -46,6 +46,8 @@ const stackIgnorePatterns = [
   /__vitest_browser__/,
   /\/deps\/vitest_/,
 ]
+
+export { stackIgnorePatterns as defaultStackIgnorePatterns }
 
 function extractLocation(urlLike: string) {
   // Fail-fast but return locations like "(native)"

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -30,9 +30,9 @@ export interface ParsedStack {
 
 export interface SerializedError {
   message: string
+  stacks?: ParsedStack[]
   stack?: string
   name?: string
-  stacks?: ParsedStack[]
   cause?: SerializedError
   [key: string]: unknown
 }

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -256,7 +256,7 @@ export class Logger {
     )
   }
 
-  printUnhandledErrors(errors: unknown[]): void {
+  printUnhandledErrors(errors: ReadonlyArray<unknown>): void {
     const errorMessage = c.red(
       c.bold(
         `\nVitest caught ${errors.length} unhandled error${

--- a/packages/vitest/src/node/test-run.ts
+++ b/packages/vitest/src/node/test-run.ts
@@ -126,12 +126,12 @@ export class TestRun {
           return
         }
 
+        const project = this.vitest.getProjectByName(task!.file.projectName || '')
         if (isBrowser) {
-          const project = this.vitest.getProjectByName(task!.file.projectName || '')
-          error.stacks = project.browser?.parseErrorStacktrace(error) || []
+          error.stacks = project.browser?.parseErrorStacktrace(error, { frameFilter: project.config.onStackTrace }) || []
         }
         else {
-          error.stacks = parseErrorStacktrace(error)
+          error.stacks = parseErrorStacktrace(error, { frameFilter: project.config.onStackTrace })
         }
       })
     })

--- a/packages/vitest/src/utils/source-map.ts
+++ b/packages/vitest/src/utils/source-map.ts
@@ -4,6 +4,7 @@ export {
   positionToOffset,
 } from '@vitest/utils'
 export {
+  defaultStackIgnorePatterns,
   parseErrorStacktrace,
   parseSingleStack,
   parseStacktrace,

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -170,8 +170,29 @@ error with a stack
 })
 
 test(`stack trace points to correct file in every browser when failed`, async () => {
+  expect.assertions(15)
   const { stderr } = await runBrowserTests({
     root: './fixtures/failing',
+    reporters: [
+      'default',
+      {
+        onTestCaseReady(testCase) {
+          if (testCase.name !== 'correctly fails and prints a diff') {
+            return
+          }
+          if (testCase.project.name === 'chromium' || testCase.project.name === 'chrome') {
+            expect(testCase.result().errors[0].stacks).toEqual([
+              {
+                line: 11,
+                column: 12,
+                file: testCase.module.moduleId,
+                method: '',
+              },
+            ])
+          }
+        },
+      },
+    ],
   })
 
   expect(stderr).toContain('expected 1 to be 2')

--- a/test/reporters/src/data.ts
+++ b/test/reporters/src/data.ts
@@ -54,6 +54,7 @@ const error: TestError = {
   actual: '2.23606797749979',
   expected: '2',
   operator: 'strictEqual',
+  stacks: undefined!,
 }
 error.showDiff = true
 error.stack = 'AssertionError: expected 2.23606797749979 to equal 2\n'

--- a/test/reporters/tests/__snapshots__/html.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/html.test.ts.snap
@@ -62,6 +62,14 @@ exports[`html reporter > resolves to "failing" status for test file "json-fail" 
                 "operator": "strictEqual",
                 "showDiff": true,
                 "stack": "AssertionError: expected 2 to deeply equal 1",
+                "stacks": [
+                  {
+                    "column": 13,
+                    "file": "<rootDir>/test/reporters/fixtures/json-fail.test.ts",
+                    "line": 8,
+                    "method": "",
+                  },
+                ],
               },
             ],
             "repeatCount": 0,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
