### PR TITLE
chore: improve inline snapshot error msg

### DIFF
--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -146,7 +146,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
       const isInsideEach = test.each || test.suite?.each
       if (isInsideEach) {
         throw new Error(
-          'InlineSnapshot cannot be used inside of test.each or describe.each. Use `toMatchSnapshot` instead',
+          'InlineSnapshot cannot be used inside of test.each or describe.each. Use toMatchSnapshot instead',
         )
       }
       const expected = utils.flag(this, 'object')

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -146,7 +146,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
       const isInsideEach = test.each || test.suite?.each
       if (isInsideEach) {
         throw new Error(
-          'InlineSnapshot cannot be used inside of test.each or describe.each',
+          'InlineSnapshot cannot be used inside of test.each or describe.each. Use `toMatchSnapshot` instead',
         )
       }
       const expected = utils.flag(this, 'object')

--- a/test/cli/test/__snapshots__/fails.test.ts.snap
+++ b/test/cli/test/__snapshots__/fails.test.ts.snap
@@ -48,11 +48,11 @@ Error: Hook timed out in 102ms."
 `;
 
 exports[`should fail inline-snapshop-inside-each.test.ts 1`] = `
-"Error: InlineSnapshot cannot be used inside of test.each or describe.each
-Error: InlineSnapshot cannot be used inside of test.each or describe.each
-Error: InlineSnapshot cannot be used inside of test.each or describe.each
-Error: InlineSnapshot cannot be used inside of test.each or describe.each
-Error: InlineSnapshot cannot be used inside of test.each or describe.each"
+"Error: InlineSnapshot cannot be used inside of test.each or describe.each. Use toMatchSnapshot instead
+Error: InlineSnapshot cannot be used inside of test.each or describe.each. Use toMatchSnapshot instead
+Error: InlineSnapshot cannot be used inside of test.each or describe.each. Use toMatchSnapshot instead
+Error: InlineSnapshot cannot be used inside of test.each or describe.each. Use toMatchSnapshot instead
+Error: InlineSnapshot cannot be used inside of test.each or describe.each. Use toMatchSnapshot instead"
 `;
 
 exports[`should fail mock-import-proxy-module.test.ts 1`] = `"Error: There are some problems in resolving the mocks API."`;


### PR DESCRIPTION
### Description

This PR improves the error message about inline snapshots and `.each`. While it is obvious when thinking about it, a more "actionable" error message could help people not used to snapshot testing.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
