### PR TITLE
fix(utils): remove ast export

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,9 +47,6 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
-      "ast": [
-        "dist/ast.d.ts"
-      ],
       "source-map": [
         "dist/source-map.d.ts"
       ]

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,10 +24,6 @@
       "types": "./dist/diff.d.ts",
       "default": "./dist/diff.js"
     },
-    "./ast": {
-      "types": "./dist/ast.d.ts",
-      "default": "./dist/ast.js"
-    },
     "./resolver": {
       "types": "./dist/resolver.d.ts",
       "default": "./dist/resolver.js"

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -80,7 +80,6 @@ const external = [
   '@vitest/mocker',
   '@vitest/mocker/node',
   '@vitest/utils/diff',
-  '@vitest/utils/ast',
   '@vitest/utils/error',
   '@vitest/utils/source-map',
   '@vitest/runner/utils',


### PR DESCRIPTION
### Description

`@vitest/utils` seem to no longer export any files for the `./ast` subpath since https://github.com/vitest-dev/vitest/pull/6289/files#diff-129321e289be10e893aad151367c2631a4cb303e6a5498794777b53bdd767b88L16

I noticed it in https://publint.dev/@vitest/utils@3.2.4



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
