### PR TITLE
perf: avoid spawning extra workers if no tests will run there

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -175,11 +175,11 @@ export function createPool(ctx: Vitest): ProcessPool {
     const groupedSpecifications: Record<string, TestSpecification[]> = {}
     const groups = new Set<number>()
 
-    const factories: Record<LocalPool, () => ProcessPool> = {
-      vmThreads: () => createVmThreadsPool(ctx, options),
-      vmForks: () => createVmForksPool(ctx, options),
-      threads: () => createThreadsPool(ctx, options),
-      forks: () => createForksPool(ctx, options),
+    const factories: Record<LocalPool, (specs: TestSpecification[]) => ProcessPool> = {
+      vmThreads: specs => createVmThreadsPool(ctx, options, specs),
+      vmForks: specs => createVmForksPool(ctx, options, specs),
+      threads: specs => createThreadsPool(ctx, options, specs),
+      forks: specs => createForksPool(ctx, options, specs),
       typescript: () => createTypecheckPool(ctx),
     }
 
@@ -241,7 +241,7 @@ export function createPool(ctx: Vitest): ProcessPool {
 
           if (pool in factories) {
             const factory = factories[pool]
-            pools[pool] ??= factory()
+            pools[pool] ??= factory(specs)
             return pools[pool]![method](specs, invalidate)
           }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
