### PR TITLE
perf: don't set `process.title`

### DIFF
--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -294,11 +294,6 @@ function normalizeCliOptions(cliFilters: string[], argv: CliOptions): CliOptions
 
 async function start(mode: VitestRunMode, cliFilters: string[], options: CliOptions): Promise<void> {
   try {
-    process.title = 'node (vitest)'
-  }
-  catch {}
-
-  try {
     const { startVitest } = await import('./cli-api')
     const ctx = await startVitest(mode, cliFilters.map(normalize), normalizeCliOptions(cliFilters, options))
     if (!ctx.shouldKeepServer()) {
@@ -330,11 +325,6 @@ async function init(project: string) {
 }
 
 async function collect(mode: VitestRunMode, cliFilters: string[], options: CliOptions): Promise<void> {
-  try {
-    process.title = 'node (vitest)'
-  }
-  catch {}
-
   try {
     const { prepareVitest, processCollected, outputFileList } = await import('./cli-api')
     const ctx = await prepareVitest(mode, {

--- a/packages/vitest/src/runtime/utils.ts
+++ b/packages/vitest/src/runtime/utils.ts
@@ -40,13 +40,6 @@ export function isChildProcess(): boolean {
   return typeof process !== 'undefined' && !!process.send
 }
 
-export function setProcessTitle(title: string): void {
-  try {
-    process.title = `node (${title})`
-  }
-  catch {}
-}
-
 export function resetModules(modules: EvaluatedModules, resetMocks = false): void {
   const skipPaths = [
     // Vitest

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -9,12 +9,10 @@ import { loadEnvironment } from '../integrations/env/loader'
 import { addCleanupListener, cleanup as cleanupWorker } from './cleanup'
 import { setupInspect } from './inspector'
 import { createRuntimeRpc, rpcDone } from './rpc'
-import { isChildProcess, setProcessTitle } from './utils'
+import { isChildProcess } from './utils'
 import { disposeInternalListeners } from './workers/utils'
 
 if (isChildProcess()) {
-  setProcessTitle(`vitest ${poolId}`)
-
   const isProfiling = process.execArgv.some(
     execArg =>
       execArg.startsWith('--prof')


### PR DESCRIPTION
### Description

`process.title` takes 10ms on my machine (MacBook Pro) and 20ms on @AriPerkkio's machine. We are considering removing this call to improve performance.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
