### PR TITLE
perf!: remove `minWorkers` and set it automatically to 0 in non watch mode

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -750,13 +750,6 @@ export default defineConfig({
 
 Maximum number or percentage of threads. You can also use `VITEST_MAX_THREADS` environment variable.
 
-##### poolOptions.threads.minThreads<NonProjectOption />
-
-- **Type:** `number | string`
-- **Default:** _available CPUs_
-
-Minimum number or percentage of threads. You can also use `VITEST_MIN_THREADS` environment variable.
-
 ##### poolOptions.threads.singleThread
 
 - **Type:** `boolean`
@@ -822,13 +815,6 @@ export default defineConfig({
 
 Maximum number or percentage of forks. You can also use `VITEST_MAX_FORKS` environment variable.
 
-##### poolOptions.forks.minForks<NonProjectOption />
-
-- **Type:** `number | string`
-- **Default:** _available CPUs_
-
-Minimum number or percentage of forks. You can also use `VITEST_MIN_FORKS` environment variable.
-
 ##### poolOptions.forks.isolate
 
 - **Type:** `boolean`
@@ -884,13 +870,6 @@ export default defineConfig({
 - **Default:** _available CPUs_
 
 Maximum number or percentage of threads. You can also use `VITEST_MAX_THREADS` environment variable.
-
-##### poolOptions.vmThreads.minThreads<NonProjectOption />
-
-- **Type:** `number | string`
-- **Default:** _available CPUs_
-
-Minimum number or percentage of threads. You can also use `VITEST_MIN_THREADS` environment variable.
 
 ##### poolOptions.vmThreads.memoryLimit<NonProjectOption />
 
@@ -966,13 +945,6 @@ export default defineConfig({
 
 Maximum number or percentage of forks. You can also use `VITEST_MAX_FORKS` environment variable.
 
-##### poolOptions.vmForks.minForks<NonProjectOption />
-
-- **Type:** `number | string`
-- **Default:** _available CPUs_
-
-Minimum number or percentage of forks. You can also use `VITEST_MIN_FORKS` environment variable.
-
 ##### poolOptions.vmForks.memoryLimit<NonProjectOption />
 
 - **Type:** `string | number`
@@ -997,7 +969,7 @@ Be careful when using, it as some options may crash worker, e.g. --prof, --title
 - **Default:** `true`
 - **CLI:** `--no-file-parallelism`, `--fileParallelism=false`
 
-Should all test files run in parallel. Setting this to `false` will override `maxWorkers` and `minWorkers` options to `1`.
+Should all test files run in parallel. Setting this to `false` will override `maxWorkers` option to `1`.
 
 ::: tip
 This option doesn't affect tests running in the same file. If you want to run those in parallel, use `concurrent` option on [describe](/api/#describe-concurrent) or via [a config](#sequence-concurrent).
@@ -1008,12 +980,6 @@ This option doesn't affect tests running in the same file. If you want to run th
 - **Type:** `number | string`
 
 Maximum number or percentage of workers to run tests in. `poolOptions.{threads,vmThreads}.maxThreads`/`poolOptions.forks.maxForks` has higher priority.
-
-### minWorkers<NonProjectOption /> {#minworkers}
-
-- **Type:** `number | string`
-
-Minimum number or percentage of workers to run tests in. `poolOptions.{threads,vmThreads}.minThreads`/`poolOptions.forks.minForks` has higher priority.
 
 ### testTimeout
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -411,13 +411,6 @@ Run tests inside a single thread (default: `false`)
 
 Maximum number or percentage of threads to run tests in
 
-### poolOptions.threads.minThreads
-
-- **CLI:** `--poolOptions.threads.minThreads <workers>`
-- **Config:** [poolOptions.threads.minThreads](/config/#pooloptions-threads-minthreads)
-
-Minimum number or percentage of threads to run tests in
-
 ### poolOptions.threads.useAtomics
 
 - **CLI:** `--poolOptions.threads.useAtomics`
@@ -445,13 +438,6 @@ Run tests inside a single thread (default: `false`)
 - **Config:** [poolOptions.vmThreads.maxThreads](/config/#pooloptions-vmthreads-maxthreads)
 
 Maximum number or percentage of threads to run tests in
-
-### poolOptions.vmThreads.minThreads
-
-- **CLI:** `--poolOptions.vmThreads.minThreads <workers>`
-- **Config:** [poolOptions.vmThreads.minThreads](/config/#pooloptions-vmthreads-minthreads)
-
-Minimum number or percentage of threads to run tests in
 
 ### poolOptions.vmThreads.useAtomics
 
@@ -488,13 +474,6 @@ Run tests inside a single child_process (default: `false`)
 
 Maximum number or percentage of processes to run tests in
 
-### poolOptions.forks.minForks
-
-- **CLI:** `--poolOptions.forks.minForks <workers>`
-- **Config:** [poolOptions.forks.minForks](/config/#pooloptions-forks-minforks)
-
-Minimum number or percentage of processes to run tests in
-
 ### poolOptions.vmForks.isolate
 
 - **CLI:** `--poolOptions.vmForks.isolate`
@@ -515,13 +494,6 @@ Run tests inside a single child_process (default: `false`)
 - **Config:** [poolOptions.vmForks.maxForks](/config/#pooloptions-vmforks-maxforks)
 
 Maximum number or percentage of processes to run tests in
-
-### poolOptions.vmForks.minForks
-
-- **CLI:** `--poolOptions.vmForks.minForks <workers>`
-- **Config:** [poolOptions.vmForks.minForks](/config/#pooloptions-vmforks-minforks)
-
-Minimum number or percentage of processes to run tests in
 
 ### poolOptions.vmForks.memoryLimit
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -544,13 +544,6 @@ Should all test files run in parallel. Use `--no-file-parallelism` to disable (d
 
 Maximum number or percentage of workers to run tests in
 
-### minWorkers
-
-- **CLI:** `--minWorkers <workers>`
-- **Config:** [minWorkers](/config/#minworkers)
-
-Minimum number or percentage of workers to run tests in
-
 ### environment
 
 - **CLI:** `--environment <name>`

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -238,6 +238,7 @@ Vitest 4.0 removes some deprecated APIs, including:
 - Reporter APIs `onCollected`, `onSpecsCollected`, `onPathsCollected`, `onTaskUpdate` and `onFinished`. See [`Reporters API`](/advanced/api/reporters) for new alternatives. These APIs were introduced in Vitest `v3.0.0`.
 - `deps.external`, `deps.inline`, `deps.fallbackCJS` config options. Use `server.deps.external`, `server.deps.inline`, or `server.deps.fallbackCJS` instead.
 - `browser.testerScripts` config option. Use [`browser.testerHtmlPath`](/guide/browser/config#browser-testerhtmlpath) instead.
+- `minWorkers` config option. Only `maxWorkers` has any effect on how tests are running, so we are removing this public option.
 
 This release also removes all deprecated types. This finally fixes an issue where Vitest accidentally pulled in `@types/node` (see [#5481](https://github.com/vitest-dev/vitest/issues/5481) and [#6141](https://github.com/vitest-dev/vitest/issues/6141)).
 

--- a/docs/guide/parallelism.md
+++ b/docs/guide/parallelism.md
@@ -12,7 +12,7 @@ By default, Vitest runs _test files_ in parallel. Depending on the specified `po
 - `forks` (the default) and `vmForks` run tests in different [child processes](https://nodejs.org/api/child_process.html)
 - `threads` and `vmThreads` run tests in different [worker threads](https://nodejs.org/api/worker_threads.html)
 
-Both "child processes" and "worker threads" are refered to as "workers". You can configure the number of running workers with [`minWorkers`](/config/#minworkers) and [`maxWorkers`](/config/#maxworkers) options. Or more granually with [`poolOptions`](/config/#pooloptions) configuration.
+Both "child processes" and "worker threads" are refered to as "workers". You can configure the number of running workers with [`maxWorkers`](/config/#maxworkers) option. Or more granually with [`poolOptions`](/config/#pooloptions) configuration.
 
 If you have a lot of tests, it is usually faster to run them in parallel, but it also depends on the project, the environment and [isolation](/config/#isolate) state. To disable file parallelisation, you can set [`fileParallelism`](/config/#fileparallelism) to `false`. To learn more about possible performance improvements, read the [Performance Guide](/guide/improving-performance).
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -66,10 +66,6 @@ const poolThreadsCommands: CLIOptions<ThreadsOptions & WorkerContextOptions> = {
     description: 'Maximum number or percentage of threads to run tests in',
     argument: '<workers>',
   },
-  minThreads: {
-    description: 'Minimum number or percentage of threads to run tests in',
-    argument: '<workers>',
-  },
   useAtomics: {
     description:
       'Use Atomics to synchronize threads. This can improve performance in some cases, but might cause segfault in older Node versions (default: `false`)',
@@ -86,10 +82,6 @@ const poolForksCommands: CLIOptions<ForksOptions & WorkerContextOptions> = {
   },
   maxForks: {
     description: 'Maximum number or percentage of processes to run tests in',
-    argument: '<workers>',
-  },
-  minForks: {
-    description: 'Minimum number or percentage of processes to run tests in',
     argument: '<workers>',
   },
   execArgv: null,
@@ -479,10 +471,6 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   maxWorkers: {
     description: 'Maximum number or percentage of workers to run tests in',
-    argument: '<workers>',
-  },
-  minWorkers: {
-    description: 'Minimum number or percentage of workers to run tests in',
     argument: '<workers>',
   },
   environment: {

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -206,17 +206,12 @@ export function resolveConfig(
     resolved.maxWorkers = resolveInlineWorkerOption(resolved.maxWorkers)
   }
 
-  if (resolved.minWorkers) {
-    resolved.minWorkers = resolveInlineWorkerOption(resolved.minWorkers)
-  }
-
   // run benchmark sequentially by default
   resolved.fileParallelism ??= mode !== 'benchmark'
 
   if (!resolved.fileParallelism) {
     // ignore user config, parallelism cannot be implemented without limiting workers
     resolved.maxWorkers = 1
-    resolved.minWorkers = 1
   }
 
   if (resolved.maxConcurrency === 0) {
@@ -482,20 +477,6 @@ export function resolveConfig(
     }
   }
 
-  if (process.env.VITEST_MIN_THREADS) {
-    resolved.poolOptions = {
-      ...resolved.poolOptions,
-      threads: {
-        ...resolved.poolOptions?.threads,
-        minThreads: Number.parseInt(process.env.VITEST_MIN_THREADS),
-      },
-      vmThreads: {
-        ...resolved.poolOptions?.vmThreads,
-        minThreads: Number.parseInt(process.env.VITEST_MIN_THREADS),
-      },
-    }
-  }
-
   if (process.env.VITEST_MAX_FORKS) {
     resolved.poolOptions = {
       ...resolved.poolOptions,
@@ -510,24 +491,8 @@ export function resolveConfig(
     }
   }
 
-  if (process.env.VITEST_MIN_FORKS) {
-    resolved.poolOptions = {
-      ...resolved.poolOptions,
-      forks: {
-        ...resolved.poolOptions?.forks,
-        minForks: Number.parseInt(process.env.VITEST_MIN_FORKS),
-      },
-      vmForks: {
-        ...resolved.poolOptions?.vmForks,
-        minForks: Number.parseInt(process.env.VITEST_MIN_FORKS),
-      },
-    }
-  }
-
   const poolThreadsOptions = [
-    ['threads', 'minThreads'],
     ['threads', 'maxThreads'],
-    ['vmThreads', 'minThreads'],
     ['vmThreads', 'maxThreads'],
   ] as const satisfies [keyof PoolOptions, keyof ThreadsOptions][]
 
@@ -538,9 +503,7 @@ export function resolveConfig(
   }
 
   const poolForksOptions = [
-    ['forks', 'minForks'],
     ['forks', 'maxForks'],
-    ['vmForks', 'minForks'],
     ['vmForks', 'maxForks'],
   ] as const satisfies [keyof PoolOptions, keyof ForksOptions][]
 

--- a/packages/vitest/src/node/pools/forks.ts
+++ b/packages/vitest/src/node/pools/forks.ts
@@ -85,8 +85,10 @@ export function createForksPool(
 
   const maxThreads
     = poolOptions.maxForks ?? vitest.config.maxWorkers ?? recommendedCount
-  const minThreads
-    = poolOptions.minForks ?? vitest.config.minWorkers ?? Math.min(recommendedCount, maxThreads)
+  const minThreads = vitest.config.watch
+    ? Math.min(recommendedCount, maxThreads)
+    // avoid recreating threads when tests are finished
+    : 0
 
   const worker = resolve(vitest.distPath, 'workers/forks.js')
 

--- a/packages/vitest/src/node/pools/threads.ts
+++ b/packages/vitest/src/node/pools/threads.ts
@@ -66,8 +66,10 @@ export function createThreadsPool(
 
   const maxThreads
     = poolOptions.maxThreads ?? vitest.config.maxWorkers ?? recommendedCount
-  const minThreads
-    = poolOptions.minThreads ?? vitest.config.minWorkers ?? Math.min(recommendedCount, maxThreads)
+  const minThreads = vitest.config.watch
+    ? Math.min(recommendedCount, maxThreads)
+    // avoid recreating forks when tests are finished
+    : 0
 
   const worker = resolve(vitest.distPath, 'workers/threads.js')
 

--- a/packages/vitest/src/node/pools/vmForks.ts
+++ b/packages/vitest/src/node/pools/vmForks.ts
@@ -92,8 +92,10 @@ export function createVmForksPool(
 
   const maxThreads
     = poolOptions.maxForks ?? vitest.config.maxWorkers ?? recommendedCount
-  const minThreads
-    = poolOptions.maxForks ?? vitest.config.minWorkers ?? Math.min(recommendedCount, maxThreads)
+  const minThreads = vitest.config.watch
+    ? Math.min(recommendedCount, maxThreads)
+    // avoid recreating forks when tests are finished
+    : 0
 
   const worker = resolve(vitest.distPath, 'workers/vmForks.js')
 

--- a/packages/vitest/src/node/pools/vmThreads.ts
+++ b/packages/vitest/src/node/pools/vmThreads.ts
@@ -69,8 +69,10 @@ export function createVmThreadsPool(
 
   const maxThreads
     = poolOptions.maxThreads ?? vitest.config.maxWorkers ?? recommendedCount
-  const minThreads
-    = poolOptions.minThreads ?? vitest.config.minWorkers ?? Math.min(recommendedCount, maxThreads)
+  const minThreads = vitest.config.watch
+    ? Math.min(recommendedCount, maxThreads)
+    // avoid recreating threads when tests are finished
+    : 0
 
   const worker = resolve(vitest.distPath, 'workers/vmThreads.js')
 

--- a/packages/vitest/src/node/test-run.ts
+++ b/packages/vitest/src/node/test-run.ts
@@ -105,7 +105,7 @@ export class TestRun {
       process.exitCode = 1
     }
 
-    this.vitest.report('onTestRunEnd', modules, [...errors] as SerializedError[], state)
+    await this.vitest.report('onTestRunEnd', modules, [...errors] as SerializedError[], state)
   }
 
   private hasFailed(modules: TestModule[]) {

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -304,14 +304,10 @@ export interface InlineConfig {
    * Maximum number or percentage of workers to run tests in. `poolOptions.{threads,vmThreads}.maxThreads`/`poolOptions.forks.maxForks` has higher priority.
    */
   maxWorkers?: number | string
-  /**
-   * Minimum number or percentage of workers to run tests in. `poolOptions.{threads,vmThreads}.minThreads`/`poolOptions.forks.minForks` has higher priority.
-   */
-  minWorkers?: number | string
 
   /**
    * Should all test files run in parallel. Doesn't affect tests running in the same file.
-   * Setting this to `false` will override `maxWorkers` and `minWorkers` options to `1`.
+   * Setting this to `false` will override `maxWorkers` option to `1`.
    *
    * @default true
    */
@@ -1014,7 +1010,6 @@ export interface ResolvedConfig
   runner?: string
 
   maxWorkers: number
-  minWorkers: number
 }
 
 type NonProjectOptions
@@ -1044,7 +1039,6 @@ type NonProjectOptions
     | 'inspectBrk'
     | 'coverage'
     | 'maxWorkers'
-    | 'minWorkers'
     | 'fileParallelism'
     | 'watchTriggerPatterns'
 

--- a/packages/vitest/src/node/types/pool-options.ts
+++ b/packages/vitest/src/node/types/pool-options.ts
@@ -50,9 +50,6 @@ export interface ResolvedPoolOptions extends PoolOptions {
 }
 
 export interface ThreadsOptions {
-  /** Minimum amount of threads to use */
-  minThreads?: number | string
-
   /** Maximum amount of threads to use */
   maxThreads?: number | string
 
@@ -74,14 +71,10 @@ export interface ThreadsOptions {
 }
 
 export interface ResolvedThreadsOptions extends ThreadsOptions {
-  minThreads?: number
   maxThreads?: number
 }
 
 export interface ForksOptions {
-  /** Minimum amount of child processes to use */
-  minForks?: number | string
-
   /** Maximum amount of child processes to use */
   maxForks?: number | string
 
@@ -94,7 +87,6 @@ export interface ForksOptions {
 }
 
 export interface ResolvedForksOptions extends ForksOptions {
-  minForks?: number
   maxForks?: number
 }
 

--- a/test/cli/test/scoped-fixtures.test.ts
+++ b/test/cli/test/scoped-fixtures.test.ts
@@ -253,7 +253,6 @@ test('worker fixtures in isolated tests init and teardown twice', async () => {
   }, {
     globals: true,
     maxWorkers: 1,
-    minWorkers: 1,
     pool: 'vmThreads',
   })
 
@@ -291,7 +290,6 @@ test('worker fixture initiates and torn down in different workers', async () => 
     globals: true,
     isolate: false,
     maxWorkers: 2,
-    minWorkers: 2,
     pool: 'threads',
   })
 
@@ -329,7 +327,6 @@ test('worker fixture initiates and torn down in one non-isolated worker', async 
     globals: true,
     isolate: false,
     maxWorkers: 1,
-    minWorkers: 1,
     pool: 'threads',
   })
 

--- a/test/config/fixtures/get-state/vitest.config.ts
+++ b/test/config/fixtures/get-state/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     isolate: false,
-    minWorkers: 1,
     maxWorkers: 1,
   }
 })

--- a/test/config/test/failures.test.ts
+++ b/test/config/test/failures.test.ts
@@ -1,7 +1,6 @@
 import type { UserConfig as ViteUserConfig } from 'vite'
 import type { TestUserConfig } from 'vitest/node'
 import type { VitestRunnerCLIOptions } from '../../test-utils'
-import { cpus } from 'node:os'
 import { normalize, resolve } from 'pathe'
 import { beforeEach, expect, test } from 'vitest'
 import { version } from 'vitest/package.json'
@@ -575,26 +574,6 @@ test('non existing project name will throw', async () => {
 test('non existing project name array will throw', async () => {
   const { stderr } = await runVitest({ project: ['non-existing-project', 'also-non-existing'] })
   expect(stderr).toMatch('No projects matched the filter "non-existing-project", "also-non-existing".')
-})
-
-test('minWorkers must be smaller than maxWorkers', async () => {
-  const { stderr } = await runVitest({ minWorkers: 2, maxWorkers: 1 })
-
-  expect(stderr).toMatch('RangeError: options.minThreads and options.maxThreads must not conflict')
-})
-
-test('minWorkers higher than maxWorkers does not crash', async ({ skip }) => {
-  skip(cpus().length < 2, 'Test requires +2 CPUs')
-
-  const { stdout, stderr } = await runVitest({
-    maxWorkers: 1,
-
-    // Overrides defaults of "runVitest" of "test-utils"
-    minWorkers: undefined,
-  })
-
-  expect(stdout).toMatch('✓ example.test.ts > it works')
-  expect(stderr).toBe('')
 })
 
 test('cannot set the `workspace` options', async () => {

--- a/test/config/test/get-state.test.ts
+++ b/test/config/test/get-state.test.ts
@@ -4,7 +4,7 @@ import { runVitest } from '../../test-utils'
 
 test.for([
   { isolate: true },
-  { isolate: false, minWorkers: 1, maxWorkers: 1 },
+  { isolate: false, maxWorkers: 1 },
   { isolate: false, fileParallelism: false },
   { isolate: false, poolOptions: { forks: { singleFork: true } } },
 ] satisfies TestUserConfig[])(`getState().testPath during collection %s`, async (config) => {

--- a/test/config/test/mixed-environments.test.ts
+++ b/test/config/test/mixed-environments.test.ts
@@ -6,7 +6,7 @@ import { runVitest } from '../../test-utils'
 const configs: TestUserConfig[] = [
   { pool: 'threads', poolOptions: { threads: { isolate: false, singleThread: true } } },
   { pool: 'threads', poolOptions: { threads: { isolate: false, singleThread: false } } },
-  { pool: 'threads', poolOptions: { threads: { isolate: false, minThreads: 1, maxThreads: 1 } } },
+  { pool: 'threads', poolOptions: { threads: { isolate: false, maxThreads: 1 } } },
   { pool: 'forks', poolOptions: { forks: { isolate: true } } },
   { pool: 'forks', poolOptions: { forks: { isolate: false } } },
 ]

--- a/test/config/test/workers-option.test.ts
+++ b/test/config/test/workers-option.test.ts
@@ -45,11 +45,11 @@ test.each([
   let workerOptions = {}
 
   if (poolOption.toLowerCase().includes('threads')) {
-    workerOptions = { maxThreads: '100%', minThreads: '10%' }
+    workerOptions = { maxThreads: '100%' }
   }
 
   if (poolOption.toLowerCase().includes('forks')) {
-    workerOptions = { maxForks: '100%', minForks: '10%' }
+    workerOptions = { maxForks: '100%' }
   }
 
   const { stderr } = await runVitest({ poolOptions: { [poolOption]: workerOptions } })

--- a/test/config/test/workers-option.test.ts
+++ b/test/config/test/workers-option.test.ts
@@ -31,7 +31,7 @@ function runVitest(config: TestUserConfig) {
 }
 
 test('workers percent argument should not throw error', async () => {
-  const { stderr } = await runVitest({ maxWorkers: '100%', minWorkers: '10%' })
+  const { stderr } = await runVitest({ maxWorkers: '100%' })
 
   expect(stderr).toBe('')
 })

--- a/test/core/test/web-worker-node.test.ts
+++ b/test/core/test/web-worker-node.test.ts
@@ -222,9 +222,13 @@ it('throws syntax error if no arguments are provided', () => {
 
 function sendEventMessage(worker: SharedWorker, msg: any) {
   worker.port.postMessage(msg)
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Failed to send the message ${msg} to the SharedWorker.`))
+    }, 5_000)
     worker.port.addEventListener('message', function onmessage(e) {
       worker.port.removeEventListener('message', onmessage)
+      clearTimeout(timeout)
       resolve(e.data as string)
     })
   })
@@ -232,9 +236,13 @@ function sendEventMessage(worker: SharedWorker, msg: any) {
 
 function sendOnMessage(worker: SharedWorker, msg: any) {
   worker.port.postMessage(msg)
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Failed to send the message ${msg} to the SharedWorker.`))
+    }, 5_000)
     worker.port.onmessage = function onmessage(e) {
       worker.port.onmessage = null
+      clearTimeout(timeout)
       resolve(e.data as string)
     }
   })

--- a/test/reporters/tests/html.test.ts
+++ b/test/reporters/tests/html.test.ts
@@ -31,6 +31,7 @@ describe('html reporter', async () => {
     const resultJson = parse(metaJson.replace(new RegExp(vitestRoot, 'g'), '<rootDir>'))
     resultJson.config = {} // doesn't matter for a test
     const file = resultJson.files[0]
+    // reset durations and id
     file.id = 0
     file.collectDuration = 0
     file.environmentLoad = 0
@@ -39,12 +40,15 @@ describe('html reporter', async () => {
     file.importDurations = {}
     file.result.duration = 0
     file.result.startTime = 0
+
     const task = file.tasks[0]
     task.id = 0
     task.result.duration = 0
     task.result.startTime = 0
+
     expect(task.result.errors).not.toBeDefined()
     expect(task.result.logs).not.toBeDefined()
+
     expect(resultJson).toMatchSnapshot(`tests are passing`)
     expect(indexHtml).toMatch('window.METADATA_PATH="html.meta.json.gz"')
   }, 120000)
@@ -70,6 +74,7 @@ describe('html reporter', async () => {
     const resultJson = parse(metaJson.replace(new RegExp(vitestRoot, 'g'), '<rootDir>'))
     resultJson.config = {} // doesn't matter for a test
     const file = resultJson.files[0]
+    // reset durations and id
     file.id = 0
     file.collectDuration = 0
     file.environmentLoad = 0
@@ -78,16 +83,19 @@ describe('html reporter', async () => {
     file.importDurations = {}
     file.result.duration = 0
     file.result.startTime = 0
+
     const task = file.tasks[0]
     task.id = 0
     task.result.duration = 0
     task.result.startTime = 0
+
     expect(task.result.errors).toBeDefined()
     task.result.errors[0].stack = task.result.errors[0].stack.split('\n')[0]
     expect(task.logs).toBeDefined()
     expect(task.logs).toHaveLength(1)
     task.logs[0].taskId = 0
     task.logs[0].time = 0
+
     expect(resultJson).toMatchSnapshot(`tests are failing`)
     expect(indexHtml).toMatch('window.METADATA_PATH="html.meta.json.gz"')
   }, 120000)

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -79,7 +79,6 @@ export async function runVitest(
     ctx = await startVitest(mode, cliFilters, {
       // Test cases are already run with multiple forks/threads
       maxWorkers: 1,
-      minWorkers: 1,
 
       watch: false,
       // "none" can be used to disable passing "reporter" option so that default value is used (it's not same as reporters: ["default"])
@@ -164,7 +163,6 @@ async function runCli(command: 'vitest' | 'vite-node', _options?: CliOptions | s
 
   if (command === 'vitest') {
     args.push('--maxWorkers=1')
-    args.push('--minWorkers=1')
   }
 
   const subprocess = x(command, args, options as Options).process!


### PR DESCRIPTION
### Description

Vitest tries to always keep `minWorkers` workers alive even after all tests have finished running. This adds unnecessary time at the end of the run. It also doesn't make a lot of sense to expose as an option to the users, unlike `maxWorkers` that actually has an impact on test performance.

This PR sets `minWorkers` to 0 during the run mode, reducing the time it takes for Vitest to exit the process after tests have finished running. This PR also removes the public `minWorkers` option.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
