### PR TITLE
perf: reduce the amount of dynamic imports

### DIFF
--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -11,7 +11,7 @@ import {
 import { getCurrentTest } from '@vitest/runner'
 import { getTestName } from '@vitest/runner/utils'
 import * as chai from 'chai'
-import { getCurrentEnvironment, getWorkerState } from '../../runtime/utils'
+import { getWorkerState } from '../../runtime/utils'
 import { createExpectPoll } from './poll'
 import './setup'
 
@@ -47,7 +47,6 @@ export function createExpect(test?: TaskPopulated): ExpectStatic {
       isExpectingAssertionsError: null,
       expectedAssertionsNumber: null,
       expectedAssertionsNumberErrorGen: null,
-      environment: getCurrentEnvironment(),
       get testPath() {
         return getWorkerState().filepath
       },

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -1,11 +1,9 @@
-import type { ResolvedConfig as ViteConfig } from 'vite'
-import type { ResolvedConfig, SerializedConfig } from '../types/config'
+import type { TestProject } from '../project'
+import type { SerializedConfig } from '../types/config'
 
-export function serializeConfig(
-  config: ResolvedConfig,
-  coreConfig: ResolvedConfig,
-  viteConfig: ViteConfig | undefined,
-): SerializedConfig {
+export function serializeConfig(project: TestProject): SerializedConfig {
+  const { config, globalConfig } = project
+  const viteConfig = project._vite?.config
   const optimizer = config.deps?.optimizer || {}
   const poolOptions = config.poolOptions
 
@@ -69,35 +67,35 @@ export function serializeConfig(
       forks: {
         singleFork:
           poolOptions?.forks?.singleFork
-          ?? coreConfig.poolOptions?.forks?.singleFork
+          ?? globalConfig.poolOptions?.forks?.singleFork
           ?? false,
         isolate:
           poolOptions?.forks?.isolate
           ?? isolate
-          ?? coreConfig.poolOptions?.forks?.isolate
+          ?? globalConfig.poolOptions?.forks?.isolate
           ?? true,
       },
       threads: {
         singleThread:
           poolOptions?.threads?.singleThread
-          ?? coreConfig.poolOptions?.threads?.singleThread
+          ?? globalConfig.poolOptions?.threads?.singleThread
           ?? false,
         isolate:
           poolOptions?.threads?.isolate
           ?? isolate
-          ?? coreConfig.poolOptions?.threads?.isolate
+          ?? globalConfig.poolOptions?.threads?.isolate
           ?? true,
       },
       vmThreads: {
         singleThread:
           poolOptions?.vmThreads?.singleThread
-          ?? coreConfig.poolOptions?.vmThreads?.singleThread
+          ?? globalConfig.poolOptions?.vmThreads?.singleThread
           ?? false,
       },
       vmForks: {
         singleFork:
           poolOptions?.vmForks?.singleFork
-          ?? coreConfig.poolOptions?.vmForks?.singleFork
+          ?? globalConfig.poolOptions?.vmForks?.singleFork
           ?? false,
       },
     },
@@ -113,28 +111,28 @@ export function serializeConfig(
     snapshotOptions: {
       // TODO: store it differently, not on the config
       snapshotEnvironment: undefined!,
-      updateSnapshot: coreConfig.snapshotOptions.updateSnapshot,
+      updateSnapshot: globalConfig.snapshotOptions.updateSnapshot,
       snapshotFormat: {
-        ...coreConfig.snapshotOptions.snapshotFormat,
+        ...globalConfig.snapshotOptions.snapshotFormat,
       },
       expand:
         config.snapshotOptions.expand
-        ?? coreConfig.snapshotOptions.expand,
+        ?? globalConfig.snapshotOptions.expand,
     },
     sequence: {
-      shuffle: coreConfig.sequence.shuffle,
-      concurrent: coreConfig.sequence.concurrent,
-      seed: coreConfig.sequence.seed,
-      hooks: coreConfig.sequence.hooks,
-      setupFiles: coreConfig.sequence.setupFiles,
+      shuffle: globalConfig.sequence.shuffle,
+      concurrent: globalConfig.sequence.concurrent,
+      seed: globalConfig.sequence.seed,
+      hooks: globalConfig.sequence.hooks,
+      setupFiles: globalConfig.sequence.setupFiles,
     },
-    inspect: coreConfig.inspect,
-    inspectBrk: coreConfig.inspectBrk,
-    inspector: coreConfig.inspector,
+    inspect: globalConfig.inspect,
+    inspectBrk: globalConfig.inspectBrk,
+    inspector: globalConfig.inspector,
     watch: config.watch,
     includeTaskLocation:
       config.includeTaskLocation
-      ?? coreConfig.includeTaskLocation,
+      ?? globalConfig.includeTaskLocation,
     env: {
       ...viteConfig?.env,
       ...config.env,
@@ -161,9 +159,10 @@ export function serializeConfig(
     })(config.browser),
     standalone: config.standalone,
     printConsoleTrace:
-      config.printConsoleTrace ?? coreConfig.printConsoleTrace,
+      config.printConsoleTrace ?? globalConfig.printConsoleTrace,
     benchmark: config.benchmark && {
       includeSamples: config.benchmark.includeSamples,
     },
+    serializedDefines: project._serializedDefines || '',
   }
 }

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -163,6 +163,9 @@ export function serializeConfig(project: TestProject): SerializedConfig {
     benchmark: config.benchmark && {
       includeSamples: config.benchmark.includeSamples,
     },
-    serializedDefines: project._serializedDefines || '',
+    // the browser initialized them via `@vite/env` import
+    serializedDefines: config.browser.enabled
+      ? ''
+      : project._serializedDefines || '',
   }
 }

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -130,6 +130,7 @@ export interface SerializedConfig {
   benchmark: {
     includeSamples: boolean
   } | undefined
+  serializedDefines: string
 }
 
 export interface SerializedCoverageConfig {

--- a/packages/vitest/src/runtime/moduleRunner/moduleMocker.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleMocker.ts
@@ -20,7 +20,7 @@ interface MockContext {
 
 export interface VitestMockerOptions {
   context?: vm.Context
-
+  spyModule?: typeof import('@vitest/spy')
   root: string
   moduleDirectories: string[]
   resolveId: (id: string, importer?: string) => Promise<{
@@ -70,6 +70,10 @@ export class VitestMocker {
         Array,
         Map,
       }
+    }
+
+    if (options.spyModule) {
+      this.spyModule = options.spyModule
     }
 
     const Symbol = this.primitives.Symbol

--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -143,6 +143,7 @@ export interface VitestModuleRunnerOptions {
   getWorkerState: () => WorkerGlobalState
   mocker?: VitestMocker
   vm?: VitestVmOptions
+  spyModule?: typeof import('@vitest/spy')
 }
 
 export interface VitestVmOptions {

--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -29,6 +29,7 @@ export class VitestModuleRunner extends ModuleRunner {
     )
     this.moduleExecutionInfo = options.getWorkerState().moduleExecutionInfo
     this.mocker = options.mocker || new VitestMocker(this, {
+      spyModule: options.spyModule,
       context: options.vm?.context,
       resolveId: options.transport.resolveId,
       get root() {

--- a/packages/vitest/src/runtime/moduleRunner/startModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startModuleRunner.ts
@@ -25,12 +25,13 @@ export interface ContextModuleRunnerOptions {
   context?: vm.Context
   externalModulesExecutor?: ExternalModulesExecutor
   state: WorkerGlobalState
+  spyModule?: typeof import('@vitest/spy')
 }
 
 const cwd = process.cwd()
 const isWindows = process.platform === 'win32'
 
-export async function startVitestModuleRunner(options: ContextModuleRunnerOptions): Promise<VitestModuleRunner> {
+export function startVitestModuleRunner(options: ContextModuleRunnerOptions): VitestModuleRunner {
   const state = (): WorkerGlobalState =>
     // @ts-expect-error injected untyped global
     globalThis.__vitest_worker__ || options.state
@@ -68,6 +69,7 @@ export async function startVitestModuleRunner(options: ContextModuleRunnerOption
   )
 
   const moduleRunner: VitestModuleRunner = new VitestModuleRunner({
+    spyModule: options.spyModule,
     evaluatedModules: options.evaluatedModules,
     evaluator,
     mocker: options.mocker,
@@ -161,8 +163,8 @@ export async function startVitestModuleRunner(options: ContextModuleRunnerOption
     vm,
   })
 
-  await moduleRunner.import('/@vite/env')
-  await moduleRunner.mocker.initializeSpyModule()
+  // await moduleRunner.import('/@vite/env')
+  // await moduleRunner.mocker.initializeSpyModule()
 
   return moduleRunner
 }

--- a/packages/vitest/src/runtime/runVmTests.ts
+++ b/packages/vitest/src/runtime/runVmTests.ts
@@ -36,6 +36,9 @@ export async function run(
   })
 
   const viteEnvironment = workerState.environment.viteEnvironment || workerState.environment.name
+  VitestIndex.expect.setState({
+    environment: workerState.environment.name,
+  })
   if (viteEnvironment === 'client') {
     const _require = createRequire(import.meta.url)
     // always mock "required" `css` files, because we cannot process them

--- a/packages/vitest/src/runtime/runners/index.ts
+++ b/packages/vitest/src/runtime/runners/index.ts
@@ -1,26 +1,21 @@
 import type { VitestRunner, VitestRunnerConstructor } from '@vitest/runner'
 import type { SerializedConfig } from '../config'
 import type { VitestModuleRunner } from '../moduleRunner/moduleRunner'
-import { join, resolve } from 'node:path'
 import { takeCoverageInsideWorker } from '../../integrations/coverage'
-import { distDir } from '../../paths'
 import { rpc } from '../rpc'
 import { loadDiffConfig, loadSnapshotSerializers } from '../setup-common'
 import { getWorkerState } from '../utils'
-
-const runnersFile = resolve(distDir, 'runners.js')
+import { NodeBenchmarkRunner } from './benchmark'
+import { VitestTestRunner } from './test'
 
 async function getTestRunnerConstructor(
   config: SerializedConfig,
   moduleRunner: VitestModuleRunner,
 ): Promise<VitestRunnerConstructor> {
   if (!config.runner) {
-    const { VitestTestRunner, NodeBenchmarkRunner } = await moduleRunner.import(
-      join('/@fs/', runnersFile),
-    )
     return (
       config.mode === 'test' ? VitestTestRunner : NodeBenchmarkRunner
-    ) as VitestRunnerConstructor
+    ) as any as VitestRunnerConstructor
   }
   const mod = await moduleRunner.import(config.runner)
   if (!mod.default && typeof mod.default !== 'function') {

--- a/packages/vitest/src/runtime/setup-common.ts
+++ b/packages/vitest/src/runtime/setup-common.ts
@@ -9,7 +9,7 @@ import { getWorkerState } from './utils'
 
 let globalSetup = false
 export async function setupCommonEnv(config: SerializedConfig): Promise<void> {
-  setupDefines(config.defines)
+  setupDefines(config)
   setupEnv(config.env)
 
   if (globalSetup) {
@@ -24,9 +24,14 @@ export async function setupCommonEnv(config: SerializedConfig): Promise<void> {
   }
 }
 
-function setupDefines(defines: Record<string, any>) {
-  for (const key in defines) {
-    (globalThis as any)[key] = defines[key]
+function setupDefines(config: SerializedConfig) {
+  if (config.serializedDefines) {
+    // eslint-disable-next-line no-new-func
+    new Function(config.serializedDefines)()
+  }
+
+  for (const key in config.defines) {
+    (globalThis as any)[key] = config.defines[key]
   }
 }
 

--- a/packages/vitest/src/runtime/setup-common.ts
+++ b/packages/vitest/src/runtime/setup-common.ts
@@ -25,11 +25,6 @@ export async function setupCommonEnv(config: SerializedConfig): Promise<void> {
 }
 
 function setupDefines(config: SerializedConfig) {
-  if (config.serializedDefines) {
-    // eslint-disable-next-line no-new-func
-    new Function(config.serializedDefines)()
-  }
-
   for (const key in config.defines) {
     (globalThis as any)[key] = config.defines[key]
   }

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -1,8 +1,10 @@
 import type { WorkerGlobalState } from '../../types/worker'
 import type { VitestModuleRunner } from '../moduleRunner/moduleRunner'
 import type { ContextModuleRunnerOptions } from '../moduleRunner/startModuleRunner'
+import * as spyModule from '@vitest/spy'
 import { EvaluatedModules } from 'vite/module-runner'
 import { startVitestModuleRunner } from '../moduleRunner/startModuleRunner'
+import { run } from '../runBaseTests'
 import { provideWorkerState } from '../utils'
 
 let _moduleRunner: VitestModuleRunner
@@ -10,12 +12,12 @@ let _moduleRunner: VitestModuleRunner
 const evaluatedModules = new EvaluatedModules()
 const moduleExecutionInfo = new Map()
 
-async function startModuleRunner(options: ContextModuleRunnerOptions) {
+function startModuleRunner(options: ContextModuleRunnerOptions) {
   if (_moduleRunner) {
     return _moduleRunner
   }
 
-  _moduleRunner = await startVitestModuleRunner(options)
+  _moduleRunner = startVitestModuleRunner(options)
   return _moduleRunner
 }
 
@@ -45,10 +47,11 @@ export async function runBaseTests(method: 'run' | 'collect', state: WorkerGloba
     })
   })
 
-  const [executor, { run }] = await Promise.all([
-    startModuleRunner({ state, evaluatedModules: state.evaluatedModules }),
-    import('../runBaseTests'),
-  ])
+  const executor = startModuleRunner({
+    state,
+    evaluatedModules: state.evaluatedModules,
+    spyModule,
+  })
   const fileSpecs = ctx.files.map(f =>
     typeof f === 'string'
       ? { filepath: f, testLocations: undefined }

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -59,10 +59,15 @@ export async function runBaseTests(method: 'run' | 'collect', state: WorkerGloba
       : f,
   )
   if (ctx.config.serializedDefines) {
-    runInThisContext(`(() =>{\n${ctx.config.serializedDefines}})()`, {
-      lineOffset: 1,
-      filename: 'virtual:load-defines.js',
-    })
+    try {
+      runInThisContext(`(() =>{\n${ctx.config.serializedDefines}})()`, {
+        lineOffset: 1,
+        filename: 'virtual:load-defines.js',
+      })
+    }
+    catch (error: any) {
+      throw new Error(`Failed to load custom "defines": ${error.message}`)
+    }
   }
 
   await run(

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -59,7 +59,10 @@ export async function runBaseTests(method: 'run' | 'collect', state: WorkerGloba
       : f,
   )
   if (ctx.config.serializedDefines) {
-    runInThisContext(ctx.config.serializedDefines)
+    runInThisContext(`(() =>{\n${ctx.config.serializedDefines}})()`, {
+      lineOffset: 1,
+      filename: 'virtual:load-defines.js',
+    })
   }
 
   await run(

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -1,6 +1,7 @@
 import type { WorkerGlobalState } from '../../types/worker'
 import type { VitestModuleRunner } from '../moduleRunner/moduleRunner'
 import type { ContextModuleRunnerOptions } from '../moduleRunner/startModuleRunner'
+import { runInThisContext } from 'node:vm'
 import * as spyModule from '@vitest/spy'
 import { EvaluatedModules } from 'vite/module-runner'
 import { startVitestModuleRunner } from '../moduleRunner/startModuleRunner'
@@ -57,6 +58,9 @@ export async function runBaseTests(method: 'run' | 'collect', state: WorkerGloba
       ? { filepath: f, testLocations: undefined }
       : f,
   )
+  if (ctx.config.serializedDefines) {
+    runInThisContext(ctx.config.serializedDefines)
+  }
 
   await run(
     method,

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -75,7 +75,7 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
     viteClientModule: stubs['/@vite/client'],
   })
 
-  const moduleRunner = await startVitestModuleRunner({
+  const moduleRunner = startVitestModuleRunner({
     context,
     evaluatedModules: state.evaluatedModules,
     state,
@@ -92,6 +92,8 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
     writable: false,
   })
   context.__vitest_mocker__ = moduleRunner.mocker
+
+  await moduleRunner.mocker.initializeSpyModule()
 
   const { run } = (await moduleRunner.import(
     entryFile,

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'node:vm'
 import type { WorkerGlobalState } from '../../types/worker'
 import { pathToFileURL } from 'node:url'
-import { isContext } from 'node:vm'
+import { isContext, runInContext } from 'node:vm'
 import { resolve } from 'pathe'
 import { distDir } from '../../paths'
 import { createCustomConsole } from '../console'
@@ -93,6 +93,9 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
   })
   context.__vitest_mocker__ = moduleRunner.mocker
 
+  if (ctx.config.serializedDefines) {
+    runInContext(ctx.config.serializedDefines, context)
+  }
   await moduleRunner.mocker.initializeSpyModule()
 
   const { run } = (await moduleRunner.import(

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -94,7 +94,9 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
   context.__vitest_mocker__ = moduleRunner.mocker
 
   if (ctx.config.serializedDefines) {
-    runInContext(ctx.config.serializedDefines, context)
+    runInContext(ctx.config.serializedDefines, context, {
+      filename: 'virtual:load-defines.js',
+    })
   }
   await moduleRunner.mocker.initializeSpyModule()
 

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -94,9 +94,14 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
   context.__vitest_mocker__ = moduleRunner.mocker
 
   if (ctx.config.serializedDefines) {
-    runInContext(ctx.config.serializedDefines, context, {
-      filename: 'virtual:load-defines.js',
-    })
+    try {
+      runInContext(ctx.config.serializedDefines, context, {
+        filename: 'virtual:load-defines.js',
+      })
+    }
+    catch (error: any) {
+      throw new Error(`Failed to load custom "defines": ${error.message}`)
+    }
   }
   await moduleRunner.mocker.initializeSpyModule()
 

--- a/packages/vitest/src/utils/config-helpers.ts
+++ b/packages/vitest/src/utils/config-helpers.ts
@@ -54,6 +54,10 @@ export function createDefinesScript(define: Record<string, any> | undefined): st
   if (!define) {
     return ''
   }
+  const serializedDefine = serializeDefine(define)
+  if (serializedDefine === '{}') {
+    return ''
+  }
   return `
 const defines = ${serializeDefine(define)}
 Object.keys(defines).forEach((key) => {
@@ -79,6 +83,9 @@ Object.keys(defines).forEach((key) => {
 function serializeDefine(define: Record<string, any>): string {
   const userDefine: Record<string, any> = {}
   for (const key in define) {
+    if (key === 'process.env.NODE_ENV' && define[key] === 'process.env.NODE_ENV') {
+      continue
+    }
     // import.meta.env.* is handled in `importAnalysis` plugin
     if (!key.startsWith('import.meta.env.')) {
       userDefine[key] = define[key]

--- a/packages/vitest/src/utils/config-helpers.ts
+++ b/packages/vitest/src/utils/config-helpers.ts
@@ -49,3 +49,60 @@ export function wrapSerializableConfig(config: SerializedConfig) {
     defines,
   } as SerializedConfig
 }
+
+export function createDefinesScript(define: Record<string, any> | undefined): string {
+  if (!define) {
+    return ''
+  }
+  return `
+const defines = ${serializeDefine(define)}
+Object.keys(defines).forEach((key) => {
+  const segments = key.split('.')
+  let target = globalThis
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    if (i === segments.length - 1) {
+      target[segment] = defines[key]
+    } else {
+      target = target[segment] || (target[segment] = {})
+    }
+  }
+})
+  `
+}
+
+/**
+ * Like `JSON.stringify` but keeps raw string values as a literal
+ * in the generated code. For example: `"window"` would refer to
+ * the global `window` object directly.
+ */
+function serializeDefine(define: Record<string, any>): string {
+  const userDefine: Record<string, any> = {}
+  for (const key in define) {
+    // import.meta.env.* is handled in `importAnalysis` plugin
+    if (!key.startsWith('import.meta.env.')) {
+      userDefine[key] = define[key]
+    }
+  }
+  let res = `{`
+  const keys = Object.keys(userDefine).sort()
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    const val = userDefine[key]
+    res += `${JSON.stringify(key)}: ${handleDefineValue(val)}`
+    if (i !== keys.length - 1) {
+      res += `, `
+    }
+  }
+  return `${res}}`
+}
+
+function handleDefineValue(value: any): string {
+  if (typeof value === 'undefined') {
+    return 'undefined'
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  return JSON.stringify(value)
+}

--- a/packages/vitest/src/utils/config-helpers.ts
+++ b/packages/vitest/src/utils/config-helpers.ts
@@ -83,6 +83,7 @@ Object.keys(defines).forEach((key) => {
 function serializeDefine(define: Record<string, any>): string {
   const userDefine: Record<string, any> = {}
   for (const key in define) {
+    // vitest sets this to avoid vite:client-inject plugin
     if (key === 'process.env.NODE_ENV' && define[key] === 'process.env.NODE_ENV') {
       continue
     }

--- a/packages/web-worker/src/runner.ts
+++ b/packages/web-worker/src/runner.ts
@@ -6,7 +6,7 @@ import {
   VitestModuleEvaluator,
 } from 'vitest/internal/module-runner'
 
-export function startWebWorkerModuleRunner(context: Record<string, unknown>): Promise<VitestModuleRunner> {
+export function startWebWorkerModuleRunner(context: Record<string, unknown>): VitestModuleRunner {
   const state = getWorkerState()
   const mocker = (globalThis as any).__vitest_mocker__
 

--- a/packages/web-worker/src/shared-worker.ts
+++ b/packages/web-worker/src/shared-worker.ts
@@ -117,37 +117,34 @@ export function createSharedWorkerConstructor(): typeof SharedWorker {
 
       this._vw_name = fileId
 
-      startWebWorkerModuleRunner(context)
-        .then((runner) => {
-          return runner.mocker.resolveId(fileId).then(({ url, id: resolvedId }) => {
-            this._vw_name = name ?? url
-            debug('initialize shared worker %s', this._vw_name)
+      const runner = startWebWorkerModuleRunner(context)
+      runner.mocker.resolveId(fileId).then(({ url, id: resolvedId }) => {
+        this._vw_name = name ?? url
+        debug('initialize shared worker %s', this._vw_name)
 
-            return runner.import(url).then(() => {
-              runner._invalidateSubTreeById([
-                resolvedId,
-                runner.mocker.getMockPath(resolvedId),
-              ])
-              this._vw_workerTarget.dispatchEvent(
-                new MessageEvent('connect', {
-                  ports: [this._vw_workerPort],
-                }),
-              )
-              debug('shared worker %s successfully initialized', this._vw_name)
-            })
-          })
+        return runner.import(url).then(() => {
+          runner._invalidateSubTreeById([
+            resolvedId,
+            runner.mocker.getMockPath(resolvedId),
+          ])
+          this._vw_workerTarget.dispatchEvent(
+            new MessageEvent('connect', {
+              ports: [this._vw_workerPort],
+            }),
+          )
+          debug('shared worker %s successfully initialized', this._vw_name)
         })
-        .catch((e) => {
-          debug('shared worker %s failed to initialize: %o', this._vw_name, e)
-          const EventConstructor = globalThis.ErrorEvent || globalThis.Event
-          const error = new EventConstructor('error', {
-            error: e,
-            message: e.message,
-          })
-          this.dispatchEvent(error)
-          this.onerror?.(error)
-          console.error(e)
+      }).catch((e) => {
+        debug('shared worker %s failed to initialize: %o', this._vw_name, e)
+        const EventConstructor = globalThis.ErrorEvent || globalThis.Event
+        const error = new EventConstructor('error', {
+          error: e,
+          message: e.message,
         })
+        this.dispatchEvent(error)
+        this.onerror?.(error)
+        console.error(e)
+      })
     }
   }
 }

--- a/test/coverage-test/utils.ts
+++ b/test/coverage-test/utils.ts
@@ -38,9 +38,6 @@ export async function runVitest(config: TestUserConfig, options = { throwOnError
     ...config,
     browser: config.browser,
   }, [], 'test', {
-    define: {
-      'test-haha': 'not-exists',
-    },
     test: {
       env: {
         COVERAGE_TEST: 'true',

--- a/test/coverage-test/utils.ts
+++ b/test/coverage-test/utils.ts
@@ -38,6 +38,9 @@ export async function runVitest(config: TestUserConfig, options = { throwOnError
     ...config,
     browser: config.browser,
   }, [], 'test', {
+    define: {
+      'test-haha': 'not-exists',
+    },
     test: {
       env: {
         COVERAGE_TEST: 'true',


### PR DESCRIPTION
### Description

This PR reduced the amount of dynamic imports during the setup. This improves the performance slightly (~10ms per test on my PC)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
