### PR TITLE
fix(coverage): enforce order of `vitest:coverage-transform` plugin

### DIFF
--- a/packages/vitest/src/node/plugins/coverageTransform.ts
+++ b/packages/vitest/src/node/plugins/coverageTransform.ts
@@ -4,6 +4,7 @@ import type { Vitest } from '../core'
 export function CoverageTransform(ctx: Vitest): VitePlugin {
   return {
     name: 'vitest:coverage-transform',
+    enforce: 'post',
     transform(srcCode, id) {
       return ctx.coverageProvider?.onFileTransform?.(
         srcCode,

--- a/test/coverage-test/fixtures/configs/vitest.config.multi-transforms.ts
+++ b/test/coverage-test/fixtures/configs/vitest.config.multi-transforms.ts
@@ -37,7 +37,7 @@ export default defineConfig({
 /**
  * Plugin for transforming `.custom-1` and/or `.custom-2` files to Javascript
  */
-function customFilePlugin(postfix: "1" | "2"): Plugin {
+export function customFilePlugin(postfix: "1" | "2"): Plugin {
   function transform(code: MagicString) {
     code.replaceAll(
       "<function covered>",

--- a/test/coverage-test/test/transform-plugin-order.istanbul.test.ts
+++ b/test/coverage-test/test/transform-plugin-order.istanbul.test.ts
@@ -1,0 +1,29 @@
+import { expect } from 'vitest'
+import { customFilePlugin } from '../fixtures/configs/vitest.config.multi-transforms'
+import { readCoverageMap, runVitest, test } from '../utils'
+
+test('custom `viteOverrides.plugins` work with `vitest:coverage-transform` plugin (#8468)', async () => {
+  const viteOverrides = { plugins: [customFilePlugin('1')] }
+
+  await runVitest({
+    include: ['fixtures/test/custom-1-syntax.test.ts'],
+    coverage: { reporter: 'json' },
+  }, undefined, viteOverrides)
+
+  const coverageMap = await readCoverageMap()
+  expect(coverageMap.files()).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/covered.custom-1",
+    ]
+  `)
+
+  const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/covered.custom-1')
+  expect(fileCoverage).toMatchInlineSnapshot(`
+    {
+      "branches": "0/0 (100%)",
+      "functions": "1/2 (50%)",
+      "lines": "1/2 (50%)",
+      "statements": "1/2 (50%)",
+    }
+  `)
+})

--- a/test/coverage-test/utils.ts
+++ b/test/coverage-test/utils.ts
@@ -1,4 +1,5 @@
 import type { CoverageSummary, FileCoverageData } from 'istanbul-lib-coverage'
+import type { UserConfig as ViteUserConfig } from 'vite'
 import type { TestFunction } from 'vitest'
 import type { TestUserConfig } from 'vitest/node'
 import { existsSync, readFileSync } from 'node:fs'
@@ -29,7 +30,7 @@ export function coverageTest(name: string, fn: TestFunction) {
   }
 }
 
-export async function runVitest(config: TestUserConfig, options = { throwOnError: true }) {
+export async function runVitest(config: TestUserConfig, options = { throwOnError: true }, viteOverrides: ViteUserConfig = {}) {
   const provider = process.env.COVERAGE_PROVIDER as any
 
   const result = await testUtils.runVitest({
@@ -38,6 +39,7 @@ export async function runVitest(config: TestUserConfig, options = { throwOnError
     ...config,
     browser: config.browser,
   }, [], 'test', {
+    ...viteOverrides,
     test: {
       env: {
         COVERAGE_TEST: 'true',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Fixes https://github.com/vitest-dev/vitest/issues/8468

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
