### PR TITLE
fix: show the assertion error first when `expect.poll` assertion fails

### DIFF
--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -88,12 +88,13 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
             timeoutId = setTimeout(() => {
               clearTimeout(intervalId)
               chai.util.flag(assertion, '_isLastPollAttempt', true)
-              const rejectWithCause = (cause: any) => {
+              const rejectWithCause = (error: any) => {
+                if (error.cause == null) {
+                  error.cause = new Error('Matcher did not succeed in time')
+                }
                 reject(
                   copyStackTrace(
-                    new Error('Matcher did not succeed in time.', {
-                      cause,
-                    }),
+                    error,
                     STACK_TRACE_ERROR,
                   ),
                 )


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
