### PR TITLE
fix: correctly remove undefined values in options

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -308,10 +308,11 @@ export async function VitestPlugin(
     ModuleRunnerTransform(),
   ].filter(notNullish)
 }
+
 function removeUndefinedValues<T extends Record<string, any>>(
   obj: T,
 ): T {
-  for (const key in Object.keys(obj)) {
+  for (const key in obj) {
     if (obj[key] === undefined) {
       delete obj[key]
     }


### PR DESCRIPTION
### Description

This `removeUndefinedValues` utility function was added by #2281. However, there's a bug in the implementation: It performs an `in` loop over the array returned by `Object.keys`, which means that it iterates over the array indices `1, 2, 3...` instead of the actual object keys. That makes it effectively a no-op.

Since no one has noticed this in 3 years, simply removing the function would be one option. It's not clear to me why the `TypeError` described in #2153 occurred. However, this PR goes with the other option: Implementing the intended behavior by removing the `Object.keys` so that `in` iterates over the object's keys.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it. (**Author note:** Unfortunately, there's no existing test coverage for this part of the codebase.)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
