### PR TITLE
perf: use ES2022 language features

### DIFF
--- a/packages/browser/src/client/tester/expect/utils.ts
+++ b/packages/browser/src/client/tester/expect/utils.ts
@@ -128,7 +128,7 @@ export function toSentence(
   array: string[],
   { wordConnector = ', ', lastWordConnector = ' and ' }: ToSentenceOptions = {},
 ): string {
-  return [array.slice(0, -1).join(wordConnector), array[array.length - 1]].join(
+  return [array.slice(0, -1).join(wordConnector), array.at(-1)].join(
     array.length > 1 ? lastWordConnector : '',
   )
 }

--- a/packages/browser/src/node/serverOrchestrator.ts
+++ b/packages/browser/src/node/serverOrchestrator.ts
@@ -13,7 +13,7 @@ export async function resolveOrchestrator(
   // it's possible to open the page without a context
   if (!sessionId) {
     const contexts = [...globalServer.children].flatMap(p => [...p.state.orchestrators.keys()])
-    sessionId = contexts[contexts.length - 1] ?? 'none'
+    sessionId = contexts.at(-1) ?? 'none'
   }
 
   // it's ok to not have a session here, especially in the preview provider

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -467,7 +467,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const actual = this._obj as any
       const [propertyName, expected] = args
       const getValue = () => {
-        const hasOwn = Object.prototype.hasOwnProperty.call(
+        const hasOwn = Object.hasOwn(
           actual,
           propertyName,
         )
@@ -660,7 +660,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     function (...args: any[]) {
       const spy = getSpy(this)
       const spyName = spy.getMockName()
-      const lastCall = spy.mock.calls[spy.mock.calls.length - 1]
+      const lastCall = spy.mock.calls.at(-1)
 
       this.assert(
         lastCall && equalsArgumentArray(lastCall, args),
@@ -965,11 +965,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         name: 'toHaveLastResolvedWith',
         condition: (spy, value) => {
           const result
-            = spy.mock.settledResults[spy.mock.settledResults.length - 1]
-          return (
+            = spy.mock.settledResults.at(-1)
+          return Boolean(
             result
             && result.type === 'fulfilled'
-            && jestEquals(result.value, value)
+            && jestEquals(result.value, value),
           )
         },
         action: 'resolve',
@@ -977,11 +977,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       {
         name: ['toHaveLastReturnedWith', 'lastReturnedWith'],
         condition: (spy, value) => {
-          const result = spy.mock.results[spy.mock.results.length - 1]
-          return (
+          const result = spy.mock.results.at(-1)
+          return Boolean(
             result
             && result.type === 'return'
-            && jestEquals(result.value, value)
+            && jestEquals(result.value, value),
           )
         },
         action: 'return',
@@ -992,7 +992,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const spy = getSpy(this)
       const results
         = action === 'return' ? spy.mock.results : spy.mock.settledResults
-      const result = results[results.length - 1]
+      const result = results.at(-1)
       const spyName = spy.getMockName()
       this.assert(
         condition(spy, value),

--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -294,7 +294,7 @@ function hasDefinedKey(obj: any, key: string) {
 }
 
 function hasKey(obj: any, key: string) {
-  return Object.prototype.hasOwnProperty.call(obj, key)
+  return Object.hasOwn(obj, key)
 }
 
 export function isA(typeName: string, value: unknown): boolean {
@@ -342,7 +342,7 @@ export function hasProperty(obj: object | null, property: string): boolean {
     return false
   }
 
-  if (Object.prototype.hasOwnProperty.call(obj, property)) {
+  if (Object.hasOwn(obj, property)) {
     return true
   }
 
@@ -571,7 +571,7 @@ function hasPropertyInObject(object: object, key: string | symbol): boolean {
   }
 
   return (
-    Object.prototype.hasOwnProperty.call(object, key)
+    Object.hasOwn(object, key)
     || hasPropertyInObject(Object.getPrototypeOf(object), key)
   )
 }

--- a/packages/expect/src/state.ts
+++ b/packages/expect/src/state.ts
@@ -6,7 +6,7 @@ import {
   MATCHERS_OBJECT,
 } from './constants'
 
-if (!Object.prototype.hasOwnProperty.call(globalThis, MATCHERS_OBJECT)) {
+if (!Object.hasOwn(globalThis, MATCHERS_OBJECT)) {
   const globalState = new WeakMap<ExpectStatic, MatcherState>()
   const matchers = Object.create(null)
   const customEqualityTesters: Array<Tester> = []

--- a/packages/mocker/src/node/resolver.ts
+++ b/packages/mocker/src/node/resolver.ts
@@ -176,7 +176,7 @@ function getDepsCacheDir(config: ViteConfig): string {
 }
 
 function withTrailingSlash(path: string): string {
-  if (path[path.length - 1] !== '/') {
+  if (path.at(-1) !== '/') {
     return `${path}/`
   }
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -449,7 +449,7 @@ export const DEFAULT_OPTIONS: Options = {
 
 function validateOptions(options: OptionsReceived) {
   for (const key of Object.keys(options)) {
-    if (!Object.prototype.hasOwnProperty.call(DEFAULT_OPTIONS, key)) {
+    if (!Object.hasOwn(DEFAULT_OPTIONS, key)) {
       throw new Error(`pretty-format: Unknown option "${key}".`)
     }
   }

--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -395,7 +395,7 @@ function splitByComma(s: string) {
     if (s[i] === '{' || s[i] === '[') {
       stack.push(s[i] === '{' ? '}' : ']')
     }
-    else if (s[i] === stack[stack.length - 1]) {
+    else if (s[i] === stack.at(-1)) {
       stack.pop()
     }
     else if (!stack.length && s[i] === ',') {

--- a/packages/snapshot/src/port/inlineSnapshot.ts
+++ b/packages/snapshot/src/port/inlineSnapshot.ts
@@ -198,7 +198,7 @@ export function stripSnapshotIndentation(inlineSnapshot: string): string {
     return inlineSnapshot
   }
 
-  if (lines[0].trim() !== '' || lines[lines.length - 1].trim() !== '') {
+  if (lines[0].trim() !== '' || lines.at(-1)?.trim() !== '') {
     // If not blank first and last lines, abort.
     return inlineSnapshot
   }

--- a/packages/ui/client/utils/task.ts
+++ b/packages/ui/client/utils/task.ts
@@ -1,7 +1,7 @@
 import type { RunnerTask, RunnerTestSuite } from 'vitest'
 
 export function isSuite(task: RunnerTask): task is RunnerTestSuite {
-  return Object.hasOwnProperty.call(task, 'tasks')
+  return Object.hasOwn(task, 'tasks')
 }
 
 export function isTaskDone(task: RunnerTask) {

--- a/packages/utils/src/diff/cleanupSemantic.ts
+++ b/packages/utils/src/diff/cleanupSemantic.ts
@@ -501,7 +501,7 @@ function diff_cleanupMerge(diffs: Array<Diff>) {
         break
     }
   }
-  if (diffs[diffs.length - 1][1] === '') {
+  if (diffs.at(-1)?.[1] === '') {
     diffs.pop()
   } // Remove the dummy entry at the end.
 

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -86,7 +86,7 @@ export function unwrapId(id: string): string {
 }
 
 export function withTrailingSlash(path: string): string {
-  if (path[path.length - 1] !== '/') {
+  if (path.at(-1) !== '/') {
     return `${path}/`
   }
   return path

--- a/packages/vite-node/src/client.ts
+++ b/packages/vite-node/src/client.ts
@@ -254,7 +254,7 @@ export class ViteNodeRunner {
 
   /** @internal */
   async cachedRequest(id: string, fsPath: string, callstack: string[]) {
-    const importee = callstack[callstack.length - 1]
+    const importee = callstack.at(-1)
 
     const mod = this.moduleCache.get(fsPath)
     const { imports, importers } = mod

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -242,7 +242,7 @@ function traverseBetweenDirs(
 }
 
 export function withTrailingSlash(path: string): string {
-  if (path[path.length - 1] !== '/') {
+  if (path.at(-1) !== '/') {
     return `${path}/`
   }
 

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -370,7 +370,7 @@ async function resolveTestProjectConfigs(
             projectsConfigFiles.push(configFile)
           }
           else {
-            const directory = file[file.length - 1] === '/' ? file : `${file}/`
+            const directory = file.at(-1) === '/' ? file : `${file}/`
             nonConfigProjectDirectories.push(directory)
           }
         }


### PR DESCRIPTION
This PR updates code in packages that target Node.js 18+ to take advantage of two ES2022 features that have been supported since Node.js 16:

* [Array.prototype.at()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at)
* [Object.hasOwn()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`. (**Author's note:** On my Mac, several tests fail on both `main` and this PR branch.)

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
