### PR TITLE
fix: support `import.meta.resolve` on Vite 7

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -6,7 +6,7 @@ import type { ExternalModulesExecutor } from '../external-executor'
 import type { ModuleExecutionInfo } from './moduleDebug'
 import type { VitestModuleEvaluator } from './moduleEvaluator'
 import type { VitestTransportOptions } from './moduleTransport'
-import { ModuleRunner } from 'vite/module-runner'
+import { createNodeImportMeta, ModuleRunner } from 'vite/module-runner'
 import { VitestMocker } from './moduleMocker'
 import { VitestTransport } from './moduleTransport'
 
@@ -15,7 +15,8 @@ export class VitestModuleRunner extends ModuleRunner {
   public mocker: VitestMocker
   public moduleExecutionInfo: ModuleExecutionInfo
 
-  constructor(private options: VitestModuleRunnerOptions) {
+  constructor(private vitestOptions: VitestModuleRunnerOptions) {
+    const options = vitestOptions;
     const transport = new VitestTransport(options.transport)
     const evaluatedModules = options.evaluatedModules
     super(
@@ -24,6 +25,7 @@ export class VitestModuleRunner extends ModuleRunner {
         hmr: false,
         evaluatedModules,
         sourcemapInterceptor: 'prepareStackTrace',
+        createImportMeta: createNodeImportMeta,
       },
       options.evaluator,
     )
@@ -56,7 +58,7 @@ export class VitestModuleRunner extends ModuleRunner {
   }
 
   public async import(rawId: string): Promise<any> {
-    const resolved = await this.options.transport.resolveId(rawId)
+    const resolved = await this.vitestOptions.transport.resolveId(rawId)
     if (!resolved) {
       return super.import(rawId)
     }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/6953

Since Vite 7.1, module runner implements `import.meta.resolve` via custom node loader https://github.com/vitejs/vite/pull/20260.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
