### PR TITLE
fix(runner): don't bundle runner with utils

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -1,7 +1,7 @@
 import type { GlobalChannelIncomingEvent, IframeChannelIncomingEvent, IframeChannelOutgoingEvent, IframeViewportDoneEvent, IframeViewportFailEvent } from '@vitest/browser/client'
 import type { BrowserTesterOptions, SerializedConfig } from 'vitest'
 import { channel, client, globalChannel } from '@vitest/browser/client'
-import { generateHash } from '@vitest/runner/utils'
+import { generateFileHash } from '@vitest/runner/utils'
 import { relative } from 'pathe'
 import { getUiAPI } from './ui'
 import { getBrowserState, getConfig } from './utils'
@@ -291,9 +291,8 @@ async function sendEventToIframe(event: IframeChannelOutgoingEvent) {
 
 function generateFileId(file: string) {
   const config = getConfig()
-  const project = config.name || ''
   const path = relative(config.root, file)
-  return generateHash(`${path}${project}`)
+  return generateFileHash(path, config.name)
 }
 
 async function setIframeViewport(

--- a/packages/browser/src/client/ui.ts
+++ b/packages/browser/src/client/ui.ts
@@ -1,5 +1,6 @@
 import type { BrowserUI } from 'vitest'
 
+/* @__NO_SIDE_EFFECTS__ */
 export function getUiAPI(): BrowserUI | undefined {
   // @ts-expect-error not typed global
   return window.__vitest_ui_api__

--- a/packages/runner/src/collect.ts
+++ b/packages/runner/src/collect.ts
@@ -2,7 +2,7 @@ import type { FileSpecification, VitestRunner } from './types/runner'
 import type { File, SuiteHooks } from './types/tasks'
 import { toArray } from '@vitest/utils'
 import { processError } from '@vitest/utils/error'
-import { collectorContext } from './context'
+import { collectorContext, setFileContext } from './context'
 import { getHooks, setHooks } from './map'
 import { runSetupFiles } from './setup'
 import {
@@ -32,6 +32,7 @@ export async function collectTests(
     const testLocations = typeof spec === 'string' ? undefined : spec.testLocations
 
     const file = createFileTask(filepath, config.root, config.name, runner.pool)
+    setFileContext(file, Object.create(null))
     file.shuffle = config.sequence.shuffle
 
     runner.onCollectStart?.(file)

--- a/packages/runner/src/utils/collect.ts
+++ b/packages/runner/src/utils/collect.ts
@@ -3,7 +3,6 @@ import type { File, Suite, TaskBase } from '../types/tasks'
 import { processError } from '@vitest/utils/error'
 import { parseSingleStack } from '@vitest/utils/source-map'
 import { relative } from 'pathe'
-import { setFileContext } from '../context'
 
 /**
  * If any tasks been marked as `only`, mark all other tasks as `skip`.
@@ -155,6 +154,7 @@ function checkAllowOnly(task: TaskBase, allowOnly?: boolean) {
   }
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 export function generateHash(str: string): string {
   let hash = 0
   if (str.length === 0) {
@@ -197,7 +197,6 @@ export function createFileTask(
     pool,
   }
   file.file = file
-  setFileContext(file, Object.create(null))
   return file
 }
 
@@ -206,11 +205,12 @@ export function createFileTask(
  * @param file File relative to the root of the project to keep ID the same between different machines
  * @param projectName The name of the test project
  */
+/* @__NO_SIDE_EFFECTS__ */
 export function generateFileHash(
   file: string,
   projectName: string | undefined,
 ): string {
-  return generateHash(`${file}${projectName || ''}`)
+  return /* @__PURE__ */ generateHash(`${file}${projectName || ''}`)
 }
 
 export function findTestFileStackTrace(testFilePath: string, error: string): ParsedStack | undefined {


### PR DESCRIPTION
### Description

Importing `collect` in `utils` blows up the bundle when anything is imported from it (in the browser orchestrator, for example)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
