### PR TITLE
perf: make build targets more modern and consistent

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -55,6 +55,9 @@
     "dummy.js",
     "providers"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "typecheck": "tsc -p ./src/client/tsconfig.json --noEmit",
     "typecheck:why": "tsc -p ./src/client/tsconfig.json --noEmit --explainFiles > explainTypes.txt",

--- a/packages/browser/src/client/tsconfig.json
+++ b/packages/browser/src/client/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
     "lib": [
-      "dom",
-      "esnext",
+      "DOM",
+      "ES2021",
       "DOM.Iterable"
     ],
     "types": ["vite/client"],

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
     "types": ["node", "vite/client"],
     "isolatedDeclarations": true

--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -36,6 +36,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch --watch.include 'src/**'"

--- a/packages/coverage-istanbul/tsconfig.json
+++ b/packages/coverage-istanbul/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "isolatedDeclarations": true

--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -40,6 +40,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch --watch.include 'src/**'"

--- a/packages/coverage-v8/tsconfig.json
+++ b/packages/coverage-v8/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "types": ["@vitest/browser/providers/playwright"],

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -28,6 +28,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/expect/rollup.config.js
+++ b/packages/expect/rollup.config.js
@@ -18,7 +18,7 @@ const dtsUtils = createDtsUtils()
 const plugins = [
   ...dtsUtils.isolatedDecl(),
   oxc({
-    transform: { target: 'node14' },
+    transform: { target: 'node18' },
   }),
 ]
 

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "isolatedDeclarations": true
   },

--- a/packages/mocker/package.json
+++ b/packages/mocker/package.json
@@ -53,6 +53,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/mocker/rollup.config.js
+++ b/packages/mocker/rollup.config.js
@@ -36,7 +36,7 @@ const plugins = [
   }),
   json(),
   oxc({
-    transform: { target: 'node14' },
+    transform: { target: 'node18' },
   }),
   commonjs(),
 ]

--- a/packages/mocker/tsconfig.json
+++ b/packages/mocker/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM"],
     "moduleResolution": "Bundler",
     "types": ["vite/client"],
     "isolatedDeclarations": true

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -29,6 +29,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/pretty-format/tsconfig.json
+++ b/packages/pretty-format/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "moduleResolution": "Bundler",
     "isolatedDeclarations": true
   },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -37,6 +37,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/runner/rollup.config.js
+++ b/packages/runner/rollup.config.js
@@ -25,7 +25,7 @@ const dtsUtils = createDtsUtils()
 const plugins = [
   ...dtsUtils.isolatedDecl(),
   oxc({
-    transform: { target: 'node14' },
+    transform: { target: 'node18' },
   }),
   json(),
 ]

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
     "moduleResolution": "Bundler",
     "isolatedDeclarations": true
   },

--- a/packages/snapshot/package.json
+++ b/packages/snapshot/package.json
@@ -37,6 +37,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/snapshot/rollup.config.js
+++ b/packages/snapshot/rollup.config.js
@@ -29,7 +29,7 @@ const plugins = [
   }),
   commonjs(),
   oxc({
-    transform: { target: 'node14' },
+    transform: { target: 'node18' },
   }),
 ]
 

--- a/packages/snapshot/tsconfig.json
+++ b/packages/snapshot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "isolatedDeclarations": true

--- a/packages/spy/package.json
+++ b/packages/spy/package.json
@@ -28,6 +28,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/spy/rollup.config.js
+++ b/packages/spy/rollup.config.js
@@ -17,7 +17,7 @@ const dtsUtils = createDtsUtils()
 const plugins = [
   ...dtsUtils.isolatedDecl(),
   oxc({
-    transform: { target: 'node14' },
+    transform: { target: 'node18' },
   }),
 ]
 

--- a/packages/spy/tsconfig.json
+++ b/packages/spy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "isolatedDeclarations": true

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && pnpm build:node && pnpm build:client",
     "build:client": "vite build",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "lib": ["dom", "esnext", "DOM.Iterable"],
     "skipLibCheck": true
   },
   "include": ["./client/**/*"],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -80,6 +80,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch"

--- a/packages/utils/rollup.config.js
+++ b/packages/utils/rollup.config.js
@@ -40,7 +40,7 @@ const plugins = [
   }),
   json(),
   oxc({
-    transform: { target: 'node14' },
+    transform: { target: 'node18' },
   }),
   commonjs(),
 ]

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
     "moduleResolution": "Bundler",
     "isolatedDeclarations": true

--- a/packages/vite-node/rollup.config.js
+++ b/packages/vite-node/rollup.config.js
@@ -43,7 +43,7 @@ const plugins = [
   commonjs(),
   oxc({
     transform: {
-      target: 'node14',
+      target: 'node18',
       define: process.env.VITE_TEST_WATCHER_DEBUG === 'false'
         ? { 'process.env.VITE_TEST_WATCHER_DEBUG': 'false' }
         : {},

--- a/packages/vite-node/tsconfig.json
+++ b/packages/vite-node/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "isolatedDeclarations": true
   },

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "isolatedDeclarations": true
   },

--- a/packages/web-worker/package.json
+++ b/packages/web-worker/package.json
@@ -32,6 +32,9 @@
     "*.d.ts",
     "dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "dev": "rollup -c --watch --watch.include 'src/**'",

--- a/packages/web-worker/tsconfig.json
+++ b/packages/web-worker/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
-    "lib": ["ESNext", "WebWorker", "DOM"],
+    "lib": ["ES2021", "WebWorker", "DOM"],
     "isolatedDeclarations": true
   },
   "exclude": ["./dist"]

--- a/packages/ws-client/tsconfig.json
+++ b/packages/ws-client/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
-    "lib": ["DOM"],
     "isolatedDeclarations": true
   },
   "exclude": ["./dist"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["esnext"],
+    "target": "ES2023",
+    "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
+  }
+}

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,22 +1,20 @@
 {
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "types": [
-      "node",
-      "vite/client"
-    ]
-  },
-  "exclude": [
-    "**/dist/**",
-    "./packages/vitest/dist/**",
-    "./packages/*/*.d.ts",
-    "./packages/*/*.d.cts",
-    "./examples/**/*.*",
-    "./bench/**",
-    "./test/benchmark/fixtures/**",
-    "./test/typescript/**",
-    "./test/browser/**",
-    "**/coverage/fixtures/**",
-    "./test/watch/fixtures/**"
-  ]
+  "references": [
+    { "path": "./packages/browser" },
+    { "path": "./packages/coverage-istanbul" },
+    { "path": "./packages/coverage-v8" },
+    { "path": "./packages/expect" },
+    { "path": "./packages/mocker" },
+    { "path": "./packages/pretty-format" },
+    { "path": "./packages/runner" },
+    { "path": "./packages/snapshot" },
+    { "path": "./packages/spy" },
+    { "path": "./packages/ui" },
+    { "path": "./packages/utils" },
+    { "path": "./packages/vite-node" },
+    { "path": "./packages/vitest" },
+    { "path": "./packages/web-worker" },
+    { "path": "./packages/ws-client" }
+  ],
+  "files": []
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}


### PR DESCRIPTION
### Description

Per https://github.com/vitest-dev/vitest/discussions/8489, this PR updates all packages that target Node.js 14 to target Node.js 18:

* Adds or updates the `engines` declaration in `package.json
* Switches the oxc transform target from `node14` `node18`
* Targets ES2022 in `tsconfig.json`

It also updates the `tsconfig.json` in browser-facing packages to target ES2021, the newest ECMAScript version that's fully supported by [compatible browsers](https://vitest.dev/guide/browser/#browser-compatibility).

This should improve performance and reduce build size. To make this pattern easier to maintain going forward, I've created separate `tsconfig.node.json` and `tsconfig.browser.json` base configs for packages to extend.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`. (**Author's note:** Several tests fail on `main` on my Mac.)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
