### PR TITLE
perf(browser): specify target browsers in build config

### DIFF
--- a/packages/browser/src/client/vite.config.ts
+++ b/packages/browser/src/client/vite.config.ts
@@ -4,14 +4,18 @@ import { resolve } from 'pathe'
 import { globSync } from 'tinyglobby'
 import * as vite from 'vite'
 
+const browserTargets = ['chrome87', 'firefox78', 'safari15.4', 'edge88']
+
 export default vite.defineConfig({
   server: {
     watch: { ignored: ['**/**'] },
   },
   esbuild: {
+    target: browserTargets,
     legalComments: 'inline',
   },
   build: {
+    target: browserTargets,
     minify: false,
     outDir: '../../dist/client',
     emptyOutDir: false,


### PR DESCRIPTION
### Description

This PR adds the list of [supported browsers](https://vitest.dev/guide/browser/#browser-compatibility) as parameters in the build config for `@vitest/browser`. This should result in a slightly smaller, more optimized build.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
