### PR TITLE
fix: override fake timers when `useFakeTimers` is called multiple times

### DIFF
--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -145,6 +145,7 @@ export class FakeTimers {
   }
 
   useFakeTimers(): void {
+    const fakeDate = this._fakingDate || Date.now()
     if (this._fakingDate) {
       resetDate()
       this._fakingDate = null
@@ -167,7 +168,7 @@ export class FakeTimers {
     }
 
     this._clock = this._fakeTimers.install({
-      now: this._fakingDate || Date.now(),
+      now: fakeDate,
       ...this._userConfig,
       toFake: this._userConfig?.toFake || toFake,
       ignoreMissingTimers: true,

--- a/test/core/test/fixtures/timers.suite.ts
+++ b/test/core/test/fixtures/timers.suite.ts
@@ -278,7 +278,7 @@ describe('FakeTimers', () => {
         },
         global,
       })
-      expect(() => timers.runAllTimers()).toThrow(/Timers are not mocked/)
+      expect(() => timers.runAllTimers()).toThrow(/A function to advance timers was called but the timers APIs are not mocked/)
     })
 
     it('does nothing when no timers have been scheduled', () => {
@@ -422,7 +422,7 @@ describe('FakeTimers', () => {
         },
         global,
       })
-      await expect(timers.runAllTimersAsync()).rejects.toThrow(/Timers are not mocked/)
+      await expect(timers.runAllTimersAsync()).rejects.toThrow(/A function to advance timers was called but the timers APIs are not mocked/)
     })
 
     it('only runs a setTimeout callback once (ever)', async () => {
@@ -1494,7 +1494,9 @@ describe('FakeTimers', () => {
 
       expect(Date.now()).toBe(timeStrMs)
 
-      expect(() => timers.useFakeTimers()).toThrowError(/date was mocked/)
+      expect(() => timers.useFakeTimers()).not.toThrowError()
+
+      expect(Date.now()).toBe(timeStrMs)
 
       // Some test
 


### PR DESCRIPTION
Fixes #8464

This PR
- overrides fake timers when `useFakeTimers` is called multiple times (previously only the first call would be respected)
- improves the error message when fake timer methods were called without `useFakeTimers`