### PR TITLE
perf(vm): optimize memory management and module loading performance

### DIFF
--- a/packages/vitest/src/runtime/vm/file-map.ts
+++ b/packages/vitest/src/runtime/vm/file-map.ts
@@ -2,37 +2,160 @@ import fs from 'node:fs'
 
 const { promises, readFileSync } = fs
 
+// Memory management thresholds for LRU cache
+const EVICTION_TRIGGER_RATIO = 0.9 // Start eviction at 90% of memory limit
+const EVICTION_TARGET_RATIO = 0.8 // Evict down to 80% to provide buffer
+
 export class FileMap {
-  private fsCache = new Map<string, string>()
-  private fsBufferCache = new Map<string, Buffer<ArrayBuffer>>()
+  private fsCache = new Map<string, CacheEntry<string>>()
+  private fsBufferCache = new Map<string, CacheEntry<Buffer<ArrayBuffer>>>()
+  private totalMemory = 0
+  private readonly maxMemory: number
+  private readonly evictionThreshold: number
+
+  constructor(options: { maxMemory?: number } = {}) {
+    this.maxMemory = options.maxMemory ?? 50 * 1024 * 1024 // 50MB default
+    this.evictionThreshold = this.maxMemory * EVICTION_TRIGGER_RATIO
+  }
+
+  private evictLRU(): void {
+    // Evict down to target ratio to provide buffer for future allocations
+    const targetMemory = this.maxMemory * EVICTION_TARGET_RATIO
+
+    if (this.totalMemory <= targetMemory) {
+      return
+    }
+
+    // Collect all entries with metadata for efficient sorting
+    const allEntries: Array<{
+      path: string
+      lastAccess: number
+      size: number
+      type: 'string' | 'buffer'
+    }> = []
+
+    for (const [path, entry] of this.fsCache.entries()) {
+      allEntries.push({
+        path,
+        lastAccess: entry.lastAccess,
+        size: entry.size,
+        type: 'string',
+      })
+    }
+
+    for (const [path, entry] of this.fsBufferCache.entries()) {
+      allEntries.push({
+        path,
+        lastAccess: entry.lastAccess,
+        size: entry.size,
+        type: 'buffer',
+      })
+    }
+
+    // Sort once by access time (oldest first)
+    allEntries.sort((a, b) => a.lastAccess - b.lastAccess)
+
+    // Evict oldest entries until we reach target memory
+    for (const entry of allEntries) {
+      if (this.totalMemory <= targetMemory) {
+        break
+      }
+
+      // Remove the entry from appropriate cache
+      if (entry.type === 'string') {
+        this.fsCache.delete(entry.path)
+      }
+      else {
+        this.fsBufferCache.delete(entry.path)
+      }
+
+      this.totalMemory -= entry.size
+    }
+  }
 
   public async readFileAsync(path: string): Promise<string> {
     const cached = this.fsCache.get(path)
     if (cached != null) {
-      return cached
+      cached.lastAccess = Date.now()
+      return cached.data
     }
+
     const source = await promises.readFile(path, 'utf-8')
-    this.fsCache.set(path, source)
+    // length * 1.2 is a fast approximation of Buffer.byteLength() (~28x faster)
+    const size = source.length * 1.2
+    const entry: CacheEntry<string> = {
+      data: source,
+      lastAccess: Date.now(),
+      size,
+    }
+
+    this.fsCache.set(path, entry)
+    this.totalMemory += size
+
+    // Only check for eviction when we exceed the threshold
+    if (this.totalMemory > this.evictionThreshold) {
+      this.evictLRU()
+    }
+
     return source
   }
 
   public readFile(path: string): string {
     const cached = this.fsCache.get(path)
     if (cached != null) {
-      return cached
+      cached.lastAccess = Date.now()
+      return cached.data
     }
+
     const source = readFileSync(path, 'utf-8')
-    this.fsCache.set(path, source)
+    // Fast approximation of Buffer.byteLength() for performance (~28x faster)
+    // Most source files are ASCII-heavy, so 1.2x provides reasonable overestimate
+    const size = source.length * 1.2 // Replaces Buffer.byteLength(source, 'utf-8')
+    const entry: CacheEntry<string> = {
+      data: source,
+      lastAccess: Date.now(),
+      size,
+    }
+
+    this.fsCache.set(path, entry)
+    this.totalMemory += size
+
+    // Only check for eviction when we exceed the threshold
+    if (this.totalMemory > this.evictionThreshold) {
+      this.evictLRU()
+    }
+
     return source
   }
 
   public readBuffer(path: string): Buffer<ArrayBuffer> {
     const cached = this.fsBufferCache.get(path)
     if (cached != null) {
-      return cached
+      cached.lastAccess = Date.now()
+      return cached.data
     }
+
     const buffer = readFileSync(path)
-    this.fsBufferCache.set(path, buffer)
+    const entry: CacheEntry<Buffer<ArrayBuffer>> = {
+      data: buffer,
+      lastAccess: Date.now(),
+      size: buffer.length,
+    }
+
+    this.fsBufferCache.set(path, entry)
+    this.totalMemory += buffer.length
+
+    // Only check for eviction when we exceed the threshold
+    if (this.totalMemory > this.evictionThreshold) {
+      this.evictLRU()
+    }
+
     return buffer
   }
+}
+
+interface CacheEntry<T> {
+  data: T
+  lastAccess: number
+  size: number
 }


### PR DESCRIPTION
### Description

This PR is an effort to improve VM performance around module loading.

The biggest change is adding an upper bound to the size of the `FileMap` cache to prevent OOM errors, using LRU to evict files if the cache approaches the limit. That upper bound is set to 50MB, which is an arbitrary number. This could be made configurable, though in practice I'd expect 50MB to be small enough to prevent OOM while large enough to provide adequate caching in the vast majority of cases. (The upper bound is also somewhat fuzzy because calculating the exact size of files in the cache would be expensive, so I opted to use `length * 1.2` as an approximation.)

As an optimization, this PR adds logic to prevent duplicate module loading in the ESM executor. It also applies several micro-optimizations, such as using `Map` instead of `Object` for cache lookups.

The benchmarks show no improvement on net, but this should be a win in terms of avoiding OOM errors, and the duplicate module loading check should produce gains in some scenarios.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`. (**Author's note:** These tests don't seem to work on my Mac.)

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
