### PR TITLE
fix: custom expect messages for expect.extend matchers

### DIFF
--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -389,3 +389,91 @@ describe('Temporal equality', () => {
     })
   })
 })
+
+describe('expect with custom message', () => {
+  describe('built-in matchers', () => {
+    test('sync matcher throws custom message on failure', () => {
+      expect(() => expect(1, 'custom message').toBe(2)).toThrow('custom message')
+    })
+
+    test('async rejects matcher throws custom message on failure', async ({ expect }) => {
+      const asyncAssertion = expect(Promise.reject(new Error('test error')), 'custom async message').rejects.toBe(2)
+      await expect(asyncAssertion).rejects.toThrow('custom async message')
+    })
+
+    test('async resolves matcher throws custom message on failure', async ({ expect }) => {
+      const asyncAssertion = expect(Promise.resolve(1), 'custom async message').resolves.toBe(2)
+      await expect(asyncAssertion).rejects.toThrow('custom async message')
+    })
+
+    test('not matcher throws custom message on failure', () => {
+      expect(() => expect(1, 'custom message').not.toBe(1)).toThrow('custom message')
+    })
+  })
+
+  describe('custom matchers with expect.extend', () => {
+    test('sync custom matcher throws custom message on failure', ({ expect }) => {
+      expect.extend({
+        toBeFoo(actual) {
+          const { isNot } = this
+          return {
+            pass: actual === 'foo',
+            message: () => `${actual} is${isNot ? ' not' : ''} foo`,
+          }
+        },
+      })
+      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrow('custom message')
+    })
+
+    test('sync custom matcher passes with custom message when assertion succeeds', ({ expect }) => {
+      expect.extend({
+        toBeFoo(actual) {
+          const { isNot } = this
+          return {
+            pass: actual === 'foo',
+            message: () => `${actual} is${isNot ? ' not' : ''} foo`,
+          }
+        },
+      })
+      expect(() => (expect('foo', 'custom message') as any).toBeFoo()).not.toThrow()
+    })
+
+    test('async custom matcher throws custom message on failure', async ({ expect }) => {
+      expect.extend({
+        async toBeFoo(actual) {
+          const resolvedValue = await actual
+          return {
+            pass: resolvedValue === 'foo',
+            message: () => `${resolvedValue} is not foo`,
+          }
+        },
+      })
+      const asyncAssertion = (expect(Promise.resolve('bar'), 'custom async message') as any).toBeFoo()
+      await expect(asyncAssertion).rejects.toThrow('custom async message')
+    })
+
+    test('async custom matcher with not throws custom message on failure', async ({ expect }) => {
+      expect.extend({
+        async toBeFoo(actual) {
+          const resolvedValue = await actual
+          return {
+            pass: resolvedValue === 'foo',
+            message: () => `${resolvedValue} is not foo`,
+          }
+        },
+      })
+      const asyncAssertion = (expect(Promise.resolve('foo'), 'custom async message') as any).not.toBeFoo()
+      await expect(asyncAssertion).rejects.toThrow('custom async message')
+    })
+  })
+
+  describe('edge cases', () => {
+    test('empty custom message falls back to default matcher message', () => {
+      expect(() => expect(1, '').toBe(2)).toThrow('expected 1 to be 2 // Object.is equality')
+    })
+
+    test('undefined custom message falls back to default matcher message', () => {
+      expect(() => expect(1, undefined as any).toBe(2)).toThrow('expected 1 to be 2 // Object.is equality')
+    })
+  })
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When passing a message parameter to expect(), the custom message was not
included in the final error for matchers defined using expect.extend().

fixes #8366 
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
