### PR TITLE
fix: revert "refactor(coverage): use `node:inspector/promises` (#8381)"

### DIFF
--- a/packages/coverage-v8/src/index.ts
+++ b/packages/coverage-v8/src/index.ts
@@ -1,7 +1,7 @@
 import type { Profiler } from 'node:inspector'
 import type { CoverageProviderModule } from 'vitest/node'
 import type { ScriptCoverageWithOffset, V8CoverageProvider } from './provider'
-import inspector from 'node:inspector/promises'
+import inspector from 'node:inspector'
 import { fileURLToPath } from 'node:url'
 import { normalize } from 'pathe'
 import { provider } from 'std-env'
@@ -19,29 +19,43 @@ const mod: CoverageProviderModule = {
     enabled = true
 
     session.connect()
-    await session.post('Profiler.enable')
-    await session.post('Profiler.startPreciseCoverage', { callCount: true, detailed: true })
+    await new Promise(resolve => session.post('Profiler.enable', resolve))
+    await new Promise(resolve =>
+      session.post(
+        'Profiler.startPreciseCoverage',
+        { callCount: true, detailed: true },
+        resolve,
+      ))
   },
 
-  async takeCoverage(options): Promise<{ result: ScriptCoverageWithOffset[] }> {
+  takeCoverage(options): Promise<{ result: ScriptCoverageWithOffset[] }> {
     if (provider === 'stackblitz') {
-      return { result: [] }
+      return Promise.resolve({ result: [] })
     }
 
-    const coverage = await session.post('Profiler.takePreciseCoverage')
-    const result: ScriptCoverageWithOffset[] = []
+    return new Promise((resolve, reject) => {
+      session.post('Profiler.takePreciseCoverage', async (error, coverage) => {
+        if (error) {
+          return reject(error)
+        }
 
-    // Reduce amount of data sent over rpc by doing some early result filtering
-    for (const entry of coverage.result) {
-      if (filterResult(entry)) {
-        result.push({
-          ...entry,
-          startOffset: options?.moduleExecutionInfo?.get(normalize(fileURLToPath(entry.url)))?.startOffset || 0,
-        })
-      }
-    }
+        try {
+          const result = coverage.result
+            .filter(filterResult)
+            .map((res) => {
+              return {
+                ...res,
+                startOffset: options?.moduleExecutionInfo?.get(normalize(fileURLToPath(res.url)))?.startOffset || 0,
+              }
+            })
 
-    return { result }
+          resolve({ result })
+        }
+        catch (e) {
+          reject(e)
+        }
+      })
+    })
   },
 
   async stopCoverage({ isolate }) {
@@ -49,8 +63,8 @@ const mod: CoverageProviderModule = {
       return
     }
 
-    await session.post('Profiler.stopPreciseCoverage')
-    await session.post('Profiler.disable')
+    await new Promise(resolve => session.post('Profiler.stopPreciseCoverage', resolve))
+    await new Promise(resolve => session.post('Profiler.disable', resolve))
     session.disconnect()
   },
 


### PR DESCRIPTION
This reverts commit 058b78194c5529a857cf39a60e534bbc722997de.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->
- Reverts https://github.com/vitest-dev/vitest/pull/8381

We want to support EOL Node 18 too.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
