### PR TITLE
docs: hint to typescript matcher extensions in image snapshots

### DIFF
--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -98,7 +98,7 @@ It will compare with the content of `./test/basic.output.html`. And can be writt
 
 ## Image Snapshots
 
-It's also possible to snapshot images using [`jest-image-snapshot`](https://github.com/americanexpress/jest-image-snapshot).
+It's also possible to snapshot images using [`jest-image-snapshot`](https://github.com/americanexpress/jest-image-snapshot). When using Typescript, you will need to [extend the `Assertion` interface](/guide/extending-matchers.html).
 
 ```bash
 npm i -D jest-image-snapshot


### PR DESCRIPTION
### Description

The [Snapshot guide](https://vitest.dev/guide/snapshot.html#image-snapshots) describes usage of the `toMatchImageSnapshot` matcher from `jest-image-snapshot`.

In Typescript, it is necessary to extend the `Assertion` type declaration, otherwise `expect().toMatchImageSnapshot` isn't typed. This PR adds a reference to the [Extending matchers](https://vitest.dev/guide/extending-matchers.html) page.

<hr> 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
