### PR TITLE
perf: replace startsWith with strict equality

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -166,7 +166,7 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
         }
 
         // Do not use pathToFileURL to avoid encoding filename parts
-        const url = `file://${filename.startsWith('/') ? '' : '/'}${filename}`
+        const url = `file://${filename[0] === '/' ? '' : '/'}${filename}`
 
         const sources = await this.getSources(
           url,

--- a/packages/runner/src/fixture.ts
+++ b/packages/runner/src/fixture.ts
@@ -366,7 +366,7 @@ function getUsedProps(fn: Function) {
     }
   }
 
-  if (!(first.startsWith('{') && first.endsWith('}'))) {
+  if (!(first[0] === '{' && first.endsWith('}'))) {
     throw new Error(
       `The first argument inside a fixture must use object destructuring pattern, e.g. ({ test } => {}). Instead, received "${first}".`,
     )

--- a/packages/snapshot/src/port/utils.ts
+++ b/packages/snapshot/src/port/utils.ts
@@ -72,7 +72,7 @@ export function addExtraLineBreaks(string: string): string {
 // Instead of trim, which can remove additional newlines or spaces
 // at beginning or end of the content from a custom serializer.
 export function removeExtraLineBreaks(string: string): string {
-  return string.length > 2 && string.startsWith('\n') && string.endsWith('\n')
+  return string.length > 2 && string[0] === '\n' && string.endsWith('\n')
     ? string.slice(1, -1)
     : string
 }

--- a/packages/vite-node/src/cli.ts
+++ b/packages/vite-node/src/cli.ts
@@ -192,13 +192,13 @@ function parseServerOptions(
       inline:
         inlineOptions !== true
           ? inlineOptions.map((dep) => {
-              return dep.startsWith('/') && dep.endsWith('/')
+              return dep[0] === '/' && dep.endsWith('/')
                 ? new RegExp(dep)
                 : dep
             })
           : true,
       external: toArray(serverOptions.deps?.external).map((dep) => {
-        return dep.startsWith('/') && dep.endsWith('/') ? new RegExp(dep) : dep
+        return dep[0] === '/' && dep.endsWith('/') ? new RegExp(dep) : dep
       }),
       moduleDirectories: serverOptions.deps?.moduleDirectories
         ? toArray(serverOptions.deps?.moduleDirectories)

--- a/packages/vite-node/src/server.ts
+++ b/packages/vite-node/src/server.ts
@@ -129,7 +129,7 @@ export class ViteNodeServer {
 
     options.deps.moduleDirectories = options.deps.moduleDirectories.map(
       (dir) => {
-        if (!dir.startsWith('/')) {
+        if (dir[0] !== '/') {
           dir = `/${dir}`
         }
         if (!dir.endsWith('/')) {

--- a/packages/vite-node/src/source-map.ts
+++ b/packages/vite-node/src/source-map.ts
@@ -41,7 +41,7 @@ export function withInlineSourcemap(
       if (isAbsolute(source)) {
         const actualPath
           = !source.startsWith(withTrailingSlash(options.root))
-            && source.startsWith('/')
+            && source[0] === '/'
             ? resolve(options.root, source.slice(1))
             : source
         return relative(dirname(options.filepath), actualPath)
@@ -63,7 +63,7 @@ export function withInlineSourcemap(
   // so that debuggers can be set to break on first line
   // Since Vite 6, import statements at the top of the file are preserved correctly,
   // so we don't need to add this mapping anymore.
-  if (!options.noFirstLineMapping && map.mappings.startsWith(';')) {
+  if (!options.noFirstLineMapping && map.mappings[0] === ';') {
     map.mappings = `AAAA,CAAA${map.mappings}`
   }
 

--- a/packages/vite-node/src/utils.ts
+++ b/packages/vite-node/src/utils.ts
@@ -137,7 +137,7 @@ export function toFilePath(
       return { absolute: id.slice(4), exists: true }
     }
     // check if /src/module.js -> <root>/src/module.js
-    if (!id.startsWith(withTrailingSlash(root)) && id.startsWith('/')) {
+    if (!id.startsWith(withTrailingSlash(root)) && id[0] === '/') {
       const resolved = resolve(root, id.slice(1))
       if (existsSync(cleanUrl(resolved))) {
         return { absolute: resolved, exists: true }
@@ -159,7 +159,7 @@ export function toFilePath(
   // disambiguate the `<UNIT>:/` on windows: see nodejs/node#31710
   return {
     path:
-      isWindows && absolute.startsWith('/')
+      isWindows && absolute[0] === '/'
         ? slash(fileURLToPath(pathToFileURL(absolute.slice(1)).href))
         : absolute,
     exists,

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -205,7 +205,7 @@ function removeQuotes<T>(str: T): T {
     }
     return str
   }
-  if (str.startsWith('"') && str.endsWith('"')) {
+  if (str[0] === '"' && str.endsWith('"')) {
     return str.slice(1, -1) as unknown as T
   }
   if (str.startsWith(`'`) && str.endsWith(`'`)) {

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -364,7 +364,7 @@ export function resolveConfig(
 
   resolved.deps.moduleDirectories = resolved.deps.moduleDirectories.map(
     (dir) => {
-      if (!dir.startsWith('/')) {
+      if (dir[0] !== '/') {
         dir = `/${dir}`
       }
       if (!dir.endsWith('/')) {

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -169,7 +169,7 @@ function inlineSourceMap(result: TransformResult) {
 
   // If the first line is not present on source maps, add simple 1:1 mapping ([0,0,0,0], [1,0,0,0])
   // so that debuggers can be set to break on first line
-  if (sourceMap.mappings.startsWith(';')) {
+  if (sourceMap.mappings[0] === ';') {
     sourceMap.mappings = `AAAA,CAAA${sourceMap.mappings}`
   }
 

--- a/packages/vitest/src/node/printError.ts
+++ b/packages/vitest/src/node/printError.ts
@@ -327,7 +327,7 @@ function handleImportOutsideModuleError(stack: string, logger: ErrorLogger) {
 
   const path = normalize(stack.split('\n')[0].trim())
   let name = path.split('/node_modules/').pop() || ''
-  if (name?.startsWith('@')) {
+  if (name[0] === '@') {
     name = name.split('/').slice(0, 2).join('/')
   }
   else {

--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -305,7 +305,7 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
   private createRequire(filename: string) {
     // \x00 is a rollup convention for virtual files,
     // it is not allowed in actual file names
-    if (filename.startsWith('\x00') || !isAbsolute(filename)) {
+    if (filename[0] === '\x00' || !isAbsolute(filename)) {
       return () => ({})
     }
     return this.vm

--- a/packages/vitest/src/typecheck/parse.ts
+++ b/packages/vitest/src/typecheck/parse.ts
@@ -67,7 +67,7 @@ export async function getRawErrsMapFromTsCompile(tscErrorStdout: string): Promis
         if (!next) {
           return prev
         }
-        else if (!next.startsWith(' ')) {
+        else if (next[0] !== ' ') {
           prev.push(next)
         }
         else {

--- a/packages/vitest/src/utils/base.ts
+++ b/packages/vitest/src/utils/base.ts
@@ -24,7 +24,7 @@ export function escapeRegExp(s: string): string {
 }
 
 export function wildcardPatternToRegExp(pattern: string): RegExp {
-  const negated = pattern.startsWith('!')
+  const negated = pattern[0] === '!'
 
   if (negated) {
     pattern = pattern.slice(1)


### PR DESCRIPTION
### Description
When determining the value of the first letter of a string, using strict equality is more efficient than startsWith. refer to [link](https://perf.link/#eyJpZCI6InpyZjd5OHg5Mm13IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnLicpKSIsInJ1bnMiOls2MDAwMCw1NTAwMCw1NzAwMCw3MjAwMCwyNzAwMCw5MzAwMCw5NjAwMCw4MTAwMCwxMTEwMDAsMzAwMCwyODAwMCwxMzAwMDAsMTUwMDAsMjEwMDAsMTU0MDAwLDEwMDAsNTYwMDAsODkwMDAsMzkwMDAsMzMwMDAsMTIwMDAsMzAwMCwyNDAwMCw0MDAwMCwxMjAwMCwxMjAwMCwzNjAwMCwxNTYwMDAsMTA3MDAwLDIwMDAwLDE3MjAwMCwzMzAwMCwyNTAwMCw3MDAwLDEzMDAwLDEyNTAwMCwxNTYwMDAsMTMwMDAsNTgwMDAsMTY5MDAwLDEyMDAwLDIwMDAsMTkwMDAsNDYwMDAsMzAwMCw3NTAwMCwzNDAwMCwxOTAwMCw4NTAwMCwxMzkwMDAsMTY3MDAwLDM4MDAwLDQzMDAwLDQ1MDAwLDM3MDAwLDMzMDAwLDg4MDAwLDE4MDAwLDM3MDAwLDI5MDAwLDQwMDAwLDM0MDAwLDYwMDAwLDQ1MDAwLDEyMzAwMCwyMDAwMCwxMDAwMCw3NjAwMCwxNDAwMCw1NDAwMCw0MzAwMCw3NzAwMCw1MDAwLDU2MDAwLDIwMDAsNDkwMDAsNDMwMDAsNDUwMDAsNDcwMDAsNzQwMDAsMzEwMDAsMjkwMDAsMzkwMDAsMzQwMDAsNDgwMDAsNTIwMDAsMTIwMDAsMjIwMDAsMjAwMCwyMDAwLDIwMDAwLDE1MDAwLDU0MDAwLDQ1MDAwLDkwMDAsMjAwMDAsMTQwMDAsNzAwMCw1NDAwMCw0MTAwMF0sIm9wcyI6NDg1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAyMDAiLCJjb2RlIjoiZGF0YS5maW5kKHggPT4geFswXSA9PT0gJy4nKSIsInJ1bnMiOls4NTAwMCw3NzAwMCw4NzAwMCw5MjAwMCwyOTAwMCwxMTMwMDAsMTE5MDAwLDExMDAwMCwxMzUwMDAsMTAwMCwzMjAwMCwxNTUwMDAsMjMwMDAsMzMwMDAsMTEzMDAwLDE2NTAwMCw3NDAwMCwxMTQwMDAsMjMwMDAsNDIwMDAsMTAwMDAsMTM4MDAwLDQyMDAwLDU2MDAwLDE3MDAwLDE4MDAwMCw0NjAwMCwxNzcwMDAsMTM1MDAwLDIxMDAwLDE2NzAwMCwzNDAwMCwxOTAwMCw4MDAwLDQwMDAsMTU0MDAwLDE3ODAwMCwxOTYwMDAsODQwMDAsMTg3MDAwLDE2MDAwLDExMDAwLDI0MDAwLDQ3MDAwLDE4NDAwMCw5MzAwMCw0NzAwMCwxOTYwMDAsOTAwMDAsMTY2MDAwLDE4MTAwMCw1MDAwMCwzOTAwMCw1NDAwMCw1NjAwMCwzODAwMCwxMTIwMDAsMjQwMDAsNTEwMDAsNDQwMDAsMzMwMDAsNDUwMDAsNzUwMDAsMjUwMDAsMTQyMDAwLDExMDAwLDE4MzAwMCw5NjAwMCwxMDAwLDUxMDAwLDU3MDAwLDk5MDAwLDE5NjAwMCw3MTAwMCwyMDAwLDY5MDAwLDY2MDAwLDYxMDAwLDY1MDAwLDEwMzAwMCwzNTAwMCwyMTAwMCw1MjAwMCw1OTAwMCwyMzAwMCw0NTAwMCwxMzgwMDAsMzMwMDAsMjAwMCwyMDAwLDI4MDAwLDExMDAwLDU4MDAwLDYyMDAwLDYwMDAsMzAwMDAsMTMwMDAsMjAwMCw3MTAwMCw2NDAwMF0sIm9wcyI6NzIwNDB9XSwidXBkYXRlZCI6IjIwMjUtMDgtMDdUMTQ6MTI6NTUuNDEwWiJ9)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
