### PR TITLE
fix(ui): allow relative paths for coverage URL in UI builds

### DIFF
--- a/packages/ui/client/composables/navigation.ts
+++ b/packages/ui/client/composables/navigation.ts
@@ -51,10 +51,10 @@ export const coverageUrl = computed(() => {
     const idx = coverage.value!.reportsDirectory.lastIndexOf('/')
     const htmlReporterSubdir = coverage.value!.htmlReporter?.subdir
     return htmlReporterSubdir
-      ? `/${coverage.value!.reportsDirectory.slice(idx + 1)}/${
+      ? `${coverage.value!.reportsDirectory.slice(idx + 1)}/${
         htmlReporterSubdir
       }/index.html`
-      : `/${coverage.value!.reportsDirectory.slice(idx + 1)}/index.html`
+      : `${coverage.value!.reportsDirectory.slice(idx + 1)}/index.html`
   }
 
   return undefined


### PR DESCRIPTION

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This fix removes the leading forward slash (`/`) on the computed `coverageUrl` value for the Vitest UI coverage html report preview. 

Before this fix, if the built html coverage report files are deployed to a **subdirectory** (e.g. `www.vitest.dev/some/sub/directory/`), the `coverageURL` will not point to the correct location of the coverage report. This fix allows for the files to be referenced relatively to where the main Vitest UI html files are deployed, regardless of whether they are deployed at the root or in a sub route of a server.

### Example

`pnpm vitest` is run with the following config:

```ts
/// <reference types="vitest" />
/// <reference types="@vitest/browser/providers/playwright" />

import { defineConfig } from 'vite';

export default defineConfig({
  test: {
    outputFile: {
      html: './vitest/report/index.html',
    },
    reporters: ['html'],
    coverage: {
      enabled: true,
      reportsDirectory: './vitest/report/coverage',
      reportOnFailure: true,
      reporter: [['html', { subdir: 'ui' }]],
      include: ['src/**/*.ts', 'src/**/*.vue'],
    },
  },
});

```

#### Output
```shell
 HTML  Report is generated
       You can run npx vite preview --outDir vitest/report to see the test results.
```

#### Before Fix

When running `npx vite preview --outDir vitest/report` and navigating to `localhost:8080`, the Coverage tab inside Vitest UI renders fine:

<img width="495" height="101" alt="image" src="https://github.com/user-attachments/assets/f4528541-b60b-4229-9e27-b1116b4e3ed2" />
<img width="849" height="251" alt="image" src="https://github.com/user-attachments/assets/918815c2-1e8c-4223-b43f-3db823289be0" />

But if you run these files on a server at a **subdirectory**, the path to the coverage files doesn't resolve correctly. You can mimic this by running `npx vite preview --outDir vitest` instead of `vitest/report` and navigating to `localhost:8080/report/index.html`:

<img width="476" height="74" alt="image" src="https://github.com/user-attachments/assets/935ac786-de4f-4459-80be-81f15cd76967" />

The path to the coverage html file should be `http://localhost:8080/report/coverage/ui/index.html`. But because of the leading slash on `/coverage/ui/index.html`, it is mistakenly resolved to the root of the domain: `http://localhost:8080/coverage/ui/index.html`. And the coverage content is missing in the UI:

<img width="1206" height="721" alt="Screenshot 2025-09-08 at 15 13 57" src="https://github.com/user-attachments/assets/54024cd9-fd3a-46d3-a57e-b9cfce444bb0" />

#### After Fix

Without the leading `/`, the path is able to resolve relatively to the Vitest UI html file, and use the correct path:

<img width="508" height="87" alt="image" src="https://github.com/user-attachments/assets/45cdb6ec-b8d3-4701-a678-4b9ff4172250" />

<img width="867" height="372" alt="Screenshot 2025-09-08 at 15 14 08" src="https://github.com/user-attachments/assets/787fa88d-eb6a-4826-a28e-f51b107bafdb" />



<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
  - **_I'm hoping that this PR being a small 2 line change will allow this to be merged without a related issue._**
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - **_I'm not sure if a test should be included for this small change... One that would involve building the files and spinning up a server during the test? If necessary, I can add it after request from the maintainers._**
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
