### PR TITLE
fix: replace wildcard exports `"./*"` with specific files in vitest package

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -39,7 +39,7 @@
         "default": "./index.cjs"
       }
     },
-    "./*": "./*",
+    "./package.json": "./package.json",
     "./globals": {
       "types": "./globals.d.ts"
     },

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -41,6 +41,7 @@
     },
     "./package.json": "./package.json",
     "./optional-types.js": "./optional-types.js",
+    "./src/*": "./src/*",
     "./globals": {
       "types": "./globals.d.ts"
     },

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -40,7 +40,7 @@
       }
     },
     "./package.json": "./package.json",
-    "./optional-types.js": "./optional-types.js",
+    "./optional-types.js": "./optional-types.d.ts",
     "./src/*": "./src/*",
     "./globals": {
       "types": "./globals.d.ts"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -40,6 +40,7 @@
       }
     },
     "./package.json": "./package.json",
+    "./optional-types.js": "./optional-types.js",
     "./globals": {
       "types": "./globals.d.ts"
     },

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -40,7 +40,9 @@
       }
     },
     "./package.json": "./package.json",
-    "./optional-types.js": "./optional-types.d.ts",
+    "./optional-types.js": {
+      "types": "./optional-types.d.ts"
+    },
     "./src/*": "./src/*",
     "./globals": {
       "types": "./globals.d.ts"

--- a/test/core/test/exports.test.ts
+++ b/test/core/test/exports.test.ts
@@ -276,6 +276,7 @@ it('exports snapshot', async ({ skip, task }) => {
             "version": "string",
             "viteVersion": "string",
           },
+          "./optional-types.js": {},
           "./reporters": {
             "BenchmarkReporter": "function",
             "BenchmarkReportsMap": "object",


### PR DESCRIPTION
### Description

The top level `./*` includes all the build output `vitest/dist/...`. Limiting this should prevent IDE import completion to pick up cryptic names directly from those files.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
