### PR TITLE
fix: Remove loupe dependencies from `optimizeDeps.include` for browser mode

### DIFF
--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -282,8 +282,6 @@ export default (parentServer: ParentBrowserProject, base = '/'): Plugin[] => {
           'vitest > expect-type',
           'vitest > @vitest/snapshot > magic-string',
           'vitest > @vitest/expect > chai',
-          'vitest > @vitest/expect > chai > loupe',
-          'vitest > @vitest/utils > loupe',
           '@vitest/browser > @testing-library/user-event',
           '@vitest/browser > @testing-library/dom',
         ]


### PR DESCRIPTION
### Description

`loupe` is no longer a dependency of `chai` or `@vitest/utils`, so trying to use browser mode leads to errors like:
```
11:41:36 PM [vite] (client) Re-optimizing dependencies because vite config has changed
Failed to resolve dependency: vitest > @vitest/expect > chai > loupe, present in client 'optimizeDeps.include'
Failed to resolve dependency: vitest > @vitest/utils > loupe, present in client 'optimizeDeps.include'
11:41:36 PM [vite] (client) ✨ optimized dependencies changed. reloading

[vitest] Vite unexpectedly reloaded a test. This may cause tests to fail, lead to flaky behaviour or duplicated test runs.
For a stable experience, please add mentioned dependencies to your config's `optimizeDeps.include` field manually.
```

This makes the test run fail at first but then pass after modifying a test.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
