### PR TITLE
docs: incorrect example of `use`

### DIFF
--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -382,11 +382,11 @@ import { test as baseTest } from 'vitest'
 
 export const test = baseTest.extend({
   perFile: [
-    ({}, { use }) => use([]),
+    ({}, use) => use([]),
     { scope: 'file' },
   ],
   perWorker: [
-    ({}, { use }) => use([]),
+    ({}, use) => use([]),
     { scope: 'worker' },
   ],
 })
@@ -397,7 +397,7 @@ The value is initialised the first time any test has accessed it, unless the fix
 ```ts
 const test = baseTest.extend({
   perFile: [
-    ({}, { use }) => use([]),
+    ({}, use) => use([]),
     {
       scope: 'file',
       // always run this hook before any test


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
