### PR TITLE
refactor: remove chai-subset

### DIFF
--- a/packages/browser/src/client/tsconfig.json
+++ b/packages/browser/src/client/tsconfig.json
@@ -12,8 +12,7 @@
   "include": [
     "./**/*.ts",
     "../types.ts",
-    "../../matchers.d.ts",
-    "../../../vitest/src/integrations/chai/chai-subset.d.ts"
+    "../../matchers.d.ts"
   ],
   "exclude": [
     "./vite.config.ts"

--- a/packages/vitest/LICENSE.md
+++ b/packages/vitest/LICENSE.md
@@ -280,35 +280,6 @@ Repository: egoist/cac
 
 ---------------------------------------
 
-## chai-subset
-License: MIT
-By: Andrii Shumada, Robert Herhold
-Repository: https://github.com/debitoor/chai-subset.git
-
-> The MIT License (MIT)
->
-> Copyright (c) 2014 
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
----------------------------------------
-
 ## find-up
 License: MIT
 By: Sindre Sorhus

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -195,7 +195,6 @@
     "acorn-walk": "catalog:",
     "birpc": "catalog:",
     "cac": "catalog:",
-    "chai-subset": "^1.6.0",
     "find-up": "^6.3.0",
     "flatted": "catalog:",
     "happy-dom": "^18.0.1",

--- a/packages/vitest/src/integrations/chai/chai-subset.d.ts
+++ b/packages/vitest/src/integrations/chai/chai-subset.d.ts
@@ -1,5 +1,0 @@
-declare module 'chai-subset' {
-  const chaiSubset: Chai.ChaiPlugin
-
-  export = chaiSubset
-}

--- a/packages/vitest/src/integrations/chai/setup.ts
+++ b/packages/vitest/src/integrations/chai/setup.ts
@@ -4,11 +4,9 @@ import {
   JestChaiExpect,
   JestExtend,
 } from '@vitest/expect'
-import Subset from 'chai-subset'
 import { SnapshotPlugin } from '../snapshot/chai'
 
 chai.use(JestExtend)
 chai.use(JestChaiExpect)
-chai.use(Subset)
 chai.use(SnapshotPlugin)
 chai.use(JestAsymmetricMatchers)

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -4,24 +4,6 @@ import type { SnapshotState } from '@vitest/snapshot'
 import type { BenchmarkResult } from '../runtime/types/benchmark'
 import type { UserConsoleLog } from './general'
 
-declare global {
-  // eslint-disable-next-line ts/no-namespace
-  namespace Chai {
-    interface ContainSubset {
-      (expected: any): Assertion
-    }
-
-    interface Assertion {
-      containSubset: ContainSubset
-    }
-
-    interface Assert {
-      // eslint-disable-next-line ts/method-signature-style
-      containSubset(val: any, exp: any, msg?: string): void
-    }
-  }
-}
-
 interface SnapshotMatcher<T> {
   <U extends { [P in keyof T]: any }>(
     snapshot: Partial<U>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1021,9 +1021,6 @@ importers:
       cac:
         specifier: 'catalog:'
         version: 6.7.14(patch_hash=a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588)
-      chai-subset:
-        specifier: ^1.6.0
-        version: 1.6.0
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
@@ -4817,11 +4814,6 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
-
-  chai-subset@1.6.0:
-    resolution: {integrity: sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==}
-    engines: {node: '>=4'}
-    deprecated: 'functionality of this lib is built-in to chai now. see more details here: https://github.com/debitoor/chai-subset/pull/85'
 
   chai@6.0.1:
     resolution: {integrity: sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==}
@@ -12833,8 +12825,6 @@ snapshots:
   caniuse-lite@1.0.30001741: {}
 
   ccount@2.0.1: {}
-
-  chai-subset@1.6.0: {}
 
   chai@6.0.1: {}
 


### PR DESCRIPTION
### Description

`chai-subset` has been [deprecated](https://www.npmjs.com/package/chai-subset) as the functionality has been built into chai itself since [chai v5.2.0](https://github.com/chaijs/chai/releases/tag/v5.2.0). Vitest is currently on chai v6.

I tested manually and can confirm `expect.containSubset` already exists in `chai` and `@types/chai`.



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
