### PR TITLE
feat!: remove deprecated order from test() API

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -315,6 +315,12 @@ Vitest 4.0 removes some deprecated APIs, including:
 - `deps.external`, `deps.inline`, `deps.fallbackCJS` config options. Use `server.deps.external`, `server.deps.inline`, or `server.deps.fallbackCJS` instead.
 - `browser.testerScripts` config option. Use [`browser.testerHtmlPath`](/guide/browser/config#browser-testerhtmlpath) instead.
 - `minWorkers` config option. Only `maxWorkers` has any effect on how tests are running, so we are removing this public option.
+- Vitest no longer supports providing test options as a third argument to `test` and `describe`. Use the second argument instead:
+
+```ts
+test('example', () => { /* ... */ }, { retry: 2 }) // [!code --]
+test('example', { retry: 2 }, () => { /* ... */ }) // [!code ++]
+```
 
 This release also removes all deprecated types. This finally fixes an issue where Vitest accidentally pulled in `@types/node` (see [#5481](https://github.com/vitest-dev/vitest/issues/5481) and [#6141](https://github.com/vitest-dev/vitest/issues/6141)).
 

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -3,7 +3,6 @@ import type { DiffOptions } from '@vitest/utils/diff'
 import type { FileSpecification, VitestRunner } from './types/runner'
 import type {
   File,
-  HookListener,
   SequenceHooks,
   Suite,
   SuiteHooks,
@@ -130,7 +129,7 @@ export async function callSuiteHook<T extends keyof SuiteHooks>(
   currentTask: Task,
   name: T,
   runner: VitestRunner,
-  args: SuiteHooks[T][0] extends HookListener<infer A, any> ? A : never,
+  args: SuiteHooks[T][0] extends (...args: infer A) => Awaitable<any> ? A : never,
 ): Promise<unknown[]> {
   const sequence = runner.config.sequence.hooks
 
@@ -154,7 +153,7 @@ export async function callSuiteHook<T extends keyof SuiteHooks>(
     return getBeforeHookCleanupCallback(
       hook,
       await hook(...args),
-      name === 'beforeEach' ? args[0] : undefined,
+      name === 'beforeEach' ? args[0] as TestContext : undefined,
     )
   }
 

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -252,21 +252,8 @@ function parseArguments<T extends (...args: any[]) => any>(
   let options: TestOptions = {}
   let fn: T | undefined
 
-  // it('', () => {}, { retry: 2 })
-  if (typeof timeoutOrTest === 'object') {
-    // it('', { retry: 2 }, { retry: 3 })
-    if (typeof optionsOrFn === 'object') {
-      throw new TypeError(
-        'Cannot use two objects as arguments. Please provide options and a function callback in that order.',
-      )
-    }
-    console.warn(
-      'Using an object as a third argument is deprecated. Vitest 4 will throw an error if the third argument is not a timeout number. Please use the second argument for options. See more at https://vitest.dev/guide/migration',
-    )
-    options = timeoutOrTest
-  }
   // it('', () => {}, 1000)
-  else if (typeof timeoutOrTest === 'number') {
+  if (typeof timeoutOrTest === 'number') {
     options = { timeout: timeoutOrTest }
   }
   // it('', { retry: 2 }, () => {})

--- a/packages/runner/src/types.ts
+++ b/packages/runner/src/types.ts
@@ -16,8 +16,6 @@ export type {
   FixtureFn,
   FixtureOptions,
   Fixtures,
-  HookCleanupCallback,
-  HookListener,
   ImportDuration,
   InferFixturesTypes,
   OnTestFailedHandler,

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -345,18 +345,10 @@ type ExtractEachCallbackArgs<T extends ReadonlyArray<any>> = {
                     : 'fallback']
 
 interface EachFunctionReturn<T extends any[]> {
-  /**
-   * @deprecated Use options as the second argument instead
-   */
   (
     name: string | Function,
     fn: (...args: T) => Awaitable<void>,
-    options: TestCollectorOptions
-  ): void
-  (
-    name: string | Function,
-    fn: (...args: T) => Awaitable<void>,
-    options?: number | TestCollectorOptions
+    options?: number
   ): void
   (
     name: string | Function,
@@ -411,18 +403,10 @@ interface SuiteForFunction {
 }
 
 interface TestCollectorCallable<C = object> {
-  /**
-   * @deprecated Use options as the second argument instead
-   */
-  <ExtraContext extends C>(
-    name: string | Function,
-    fn: TestFunction<ExtraContext>,
-    options: TestCollectorOptions
-  ): void
   <ExtraContext extends C>(
     name: string | Function,
     fn?: TestFunction<ExtraContext>,
-    options?: number | TestCollectorOptions
+    options?: number
   ): void
   <ExtraContext extends C>(
     name: string | Function,
@@ -560,18 +544,10 @@ export type Fixtures<T extends Record<string, any>, ExtraContext = object> = {
 export type InferFixturesTypes<T> = T extends TestAPI<infer C> ? C : T
 
 interface SuiteCollectorCallable<ExtraContext = object> {
-  /**
-   * @deprecated Use options as the second argument instead
-   */
-  <OverrideExtraContext extends ExtraContext = ExtraContext>(
-    name: string | Function,
-    fn: SuiteFactory<OverrideExtraContext>,
-    options: TestOptions
-  ): SuiteCollector<OverrideExtraContext>
   <OverrideExtraContext extends ExtraContext = ExtraContext>(
     name: string | Function,
     fn?: SuiteFactory<OverrideExtraContext>,
-    options?: number | TestOptions
+    options?: number
   ): SuiteCollector<OverrideExtraContext>
   <OverrideExtraContext extends ExtraContext = ExtraContext>(
     name: string | Function,
@@ -593,18 +569,6 @@ export type SuiteAPI<ExtraContext = object> = ChainableSuiteAPI<ExtraContext> & 
   skipIf: (condition: any) => ChainableSuiteAPI<ExtraContext>
   runIf: (condition: any) => ChainableSuiteAPI<ExtraContext>
 }
-
-/**
- * @deprecated
- */
-export type HookListener<T extends any[], Return = void> = (
-  ...args: T
-) => Awaitable<Return>
-
-/**
- * @deprecated
- */
-export type HookCleanupCallback = unknown
 
 export interface BeforeAllListener {
   (suite: Readonly<Suite | File>): Awaitable<unknown>

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -83,8 +83,6 @@ export {
   test,
 } from '@vitest/runner'
 export type {
-  HookCleanupCallback,
-  HookListener,
   ImportDuration,
   OnTestFailedHandler,
   OnTestFinishedHandler,

--- a/test/core/test/task-collector.test.ts
+++ b/test/core/test/task-collector.test.ts
@@ -6,9 +6,9 @@ test('collector keeps the order of arguments', () => {
   const fn = vi.fn()
   const collector = createTaskCollector(fn)
   const cb = vi.fn()
-  const options = {}
+  const options = { timeout: 100 }
 
-  collector('a', cb, options)
+  collector('a', cb, options.timeout)
 
   expect(fn).toHaveBeenNthCalledWith(1, 'a', cb, options)
 
@@ -16,7 +16,7 @@ test('collector keeps the order of arguments', () => {
 
   expect(fn).toHaveBeenNthCalledWith(2, 'a', options, cb)
 
-  collector.each([1])('a', cb, options)
+  collector.each([1])('a', cb, options.timeout)
 
   expect(fn).toHaveBeenNthCalledWith(3, 'a', expect.any(Function), options)
 

--- a/test/core/test/task-collector.test.ts
+++ b/test/core/test/task-collector.test.ts
@@ -10,7 +10,7 @@ test('collector keeps the order of arguments', () => {
 
   collector('a', cb, options.timeout)
 
-  expect(fn).toHaveBeenNthCalledWith(1, 'a', cb, options)
+  expect(fn).toHaveBeenNthCalledWith(1, 'a', cb, options.timeout)
 
   collector('a', options, cb)
 
@@ -18,7 +18,7 @@ test('collector keeps the order of arguments', () => {
 
   collector.each([1])('a', cb, options.timeout)
 
-  expect(fn).toHaveBeenNthCalledWith(3, 'a', expect.any(Function), options)
+  expect(fn).toHaveBeenNthCalledWith(3, 'a', expect.any(Function), options.timeout)
 
   collector.each([1])('a', options, cb)
 

--- a/test/core/test/test-options.test.ts
+++ b/test/core/test/test-options.test.ts
@@ -8,17 +8,14 @@ describe('all test variations are allowed', () => {
   test.skip('skipped explicitly', fail)
   test.skip('skipped explicitly', fail, 1000)
   test('skipped explicitly via options', { skip: true }, fail)
-  test('skipped explicitly via options as the last argument', fail, { skip: true })
 
   test.todo('todo explicitly', fail)
   test.todo('todo explicitly', fail, 1000)
   test('todo explicitly via options', { todo: true }, fail)
-  test('todo explicitly via options as the last argument', fail, { todo: true })
 
   test.fails('fails by default', fail)
   test.fails('fails by default', fail, 1000)
   test('fails explicitly via options', { fails: true }, fail)
-  test('fails explicitly via options as the last argument', fail, { fails: true })
 })
 
 describe('only is allowed explicitly', () => {
@@ -29,9 +26,4 @@ describe('only is allowed explicitly', () => {
 describe('only is allowed via options', () => {
   test('not only by default', fail)
   test('only via options', { only: true }, () => {})
-})
-
-describe('only is allowed via option as the last argument', () => {
-  test('not only by default', fail)
-  test('only via options as the last argument', () => {}, { only: true })
 })

--- a/test/core/test/timeout.spec.ts
+++ b/test/core/test/timeout.spec.ts
@@ -1,11 +1,9 @@
 import { describe, expect, test } from 'vitest'
 
-describe('suite timeout', () => {
+describe('suite timeout', { timeout: 100 }, () => {
   test('timeout is inherited', async ({ task }) => {
     expect(task.timeout).toBe(100)
   })
-}, {
-  timeout: 100,
 })
 
 describe('suite timeout simple input', () => {


### PR DESCRIPTION
### Description

This order was deprecated and printed a warning in Vitest 3:

```ts
test('hello', () => {}, { timeout: 100 }) 
```

Now it throws an error instead. It was also removed from the types. Please, use this syntax instead:

```ts
test('hello', { timeout: 100 }, () => {}) 
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
