### PR TITLE
docs: name of `unhandledRejection` event

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -295,24 +295,14 @@ If you need to test that error was not caught, you can create a test that looks 
 
 ```ts
 test('my function throws uncaught error', async ({ onTestFinished }) => {
+  const unhandledRejectionListener = vi.fn()
+  process.on('unhandledRejection', unhandledRejectionListener)
   onTestFinished(() => {
-    // if the event was never called during the test,
-    // make sure it's removed before the next test starts
-    process.removeAllListeners('unhandledRejection')
+    process.off('unhandledRejection', unhandledRejectionListener)
   })
 
-  return new Promise((resolve, reject) => {
-    process.once('unhandledRejection', (error) => {
-      try {
-        expect(error.message).toBe('my error')
-        resolve()
-      }
-      catch (error) {
-        reject(error)
-      }
-    })
+  callMyFunctionThatRejectsError()
 
-    callMyFunctionThatRejectsError()
-  })
+  await expect.poll(unhandledRejectionListener).toHaveBeenCalled()
 })
 ```


### PR DESCRIPTION
### Description

The documentation seems to be swapping the case-sensitive naming of the _unhandled rejection_ event. At first, I'll here do a quick overview of where I think this confusion comes from:

In the HTML spec, the handler for the `onunhandledrejection` event is defined as [`unhandledrejection`](https://html.spec.whatwg.org/multipage/webappapis.html#handler-window-onunhandledrejection), which is case-sensitive.

But since the tests of vitest do not (yet) fully support running in the browser, we have to stick to what NodeJS is giving us, where the event has a different capitalization. There it's defined as [`unhandledRejection`](https://nodejs.org/api/process.html#event-unhandledrejection).

I've still not yet mentioned other runtimes, where it's again different. Just see [deno](https://deno.com/blog/v1.24#unhandledrejection-event) or [bun](https://bun.com/blog/bun-v1.1.8#new-support-for-process-on-uncaughtexception-and-process-on-unhandledrejection), each creating something on their own (whereas it seems that deno's implementation seems best compatible with what's found in the HTML spec).

Regardless of the other runtimes, in my opinion, the documentation should (if not stated otherwise) follow what is possible in node - whereas the other options might be good to mention as well, but I've left it out as I don't have any experience with those.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [X] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
