### PR TITLE
fix: correctly inherit test options on extended tests

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -245,7 +245,7 @@ function parseArguments<T extends (...args: any[]) => any>(
   optionsOrFn: T | object | undefined,
   timeoutOrTest: T | number | undefined,
 ) {
-  if (typeof timeoutOrTest === 'object') {
+  if (timeoutOrTest != null && typeof timeoutOrTest === 'object') {
     throw new TypeError(`Siganture "test(name, fn, { ... })" was deprecated in Vitest 3 and removed in Vitest 4. Please, provide options as a second argument instead.`)
   }
 
@@ -790,9 +790,7 @@ export function createTaskCollector(
           scopedFixtures,
         )
       }
-      const { handler, options } = parseArguments(optionsOrFn, optionsOrTest)
-      const timeout = options.timeout ?? collector.options?.timeout ?? runner?.config.testTimeout
-      originalWrapper.call(context, formatName(name), handler, timeout)
+      originalWrapper.call(context, formatName(name), optionsOrFn, optionsOrTest)
     }, _context)
   }
 

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -2,6 +2,13 @@ import { assert, expect, it, suite, test } from 'vitest'
 import { two } from '../src/submodule'
 import { timeout } from '../src/timeout'
 
+const ext = test.extend({
+  todo: 1,
+})
+ext('basic', ({ todo, expect }) => {
+  expect(todo).toBe(1)
+})
+
 const testPath = expect.getState().testPath
 if (!testPath || !testPath.includes('basic.test.ts')) {
   throw new Error(`testPath is not correct: ${testPath}`)

--- a/test/core/test/basic.test.ts
+++ b/test/core/test/basic.test.ts
@@ -2,13 +2,6 @@ import { assert, expect, it, suite, test } from 'vitest'
 import { two } from '../src/submodule'
 import { timeout } from '../src/timeout'
 
-const ext = test.extend({
-  todo: 1,
-})
-ext('basic', ({ todo, expect }) => {
-  expect(todo).toBe(1)
-})
-
 const testPath = expect.getState().testPath
 if (!testPath || !testPath.includes('basic.test.ts')) {
   throw new Error(`testPath is not correct: ${testPath}`)

--- a/test/core/test/retry.test.ts
+++ b/test/core/test/retry.test.ts
@@ -64,3 +64,15 @@ describe.each([
     expect(flag3).toBe(false)
   })
 })
+
+describe('extended tests keep the options', () => {
+  const test$ = it.extend({
+    extended: true,
+  })
+
+  test$('inherits all options', { retry: 2, repeats: 1, timeout: 3456 }, ({ task }) => {
+    expect(task.retry).toBe(2)
+    expect(task.repeats).toBe(1)
+    expect(task.timeout).toBe(3456)
+  })
+})

--- a/test/core/test/retry.test.ts
+++ b/test/core/test/retry.test.ts
@@ -70,9 +70,10 @@ describe('extended tests keep the options', () => {
     extended: true,
   })
 
-  test$('inherits all options', { retry: 2, repeats: 1, timeout: 3456 }, ({ task }) => {
+  test$('inherits all options', { retry: 2, repeats: 1, timeout: 3456 }, ({ task, extended }) => {
     expect(task.retry).toBe(2)
     expect(task.repeats).toBe(1)
     expect(task.timeout).toBe(3456)
+    expect(extended).toBe(true)
   })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
