### PR TITLE
fix: ensure snapshot client is singleton across all test contexts

### DIFF
--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -9,17 +9,19 @@ import {
 } from '@vitest/snapshot'
 import { createAssertionMessage, recordAsyncExpect } from '../../../../expect/src/utils'
 
-let _client: SnapshotClient
+const __SNAPSHOT_CLIENT__ = Symbol('__SNAPSHOT_CLIENT__')
 
 export function getSnapshotClient(): SnapshotClient {
-  if (!_client) {
-    _client = new SnapshotClient({
+  let client = Reflect.get(globalThis, __SNAPSHOT_CLIENT__) as SnapshotClient
+  if (!client) {
+    client = new SnapshotClient({
       isEqual: (received, expected) => {
         return equals(received, expected, [iterableEquality, subsetEquality])
       },
     })
+    Reflect.set(globalThis, __SNAPSHOT_CLIENT__, client)
   }
-  return _client
+  return client
 }
 
 function getError(expected: () => void | Error, promise: string | undefined) {


### PR DESCRIPTION
Save `SnapshotClient` instance to `globalThis` to ensure it works correctly even if multiple versions of `vitest` exist within node_modules.

🤖 Generated with [Claude Code](https://claude.ai/code)

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
If multiple versions of `vitest` exist within node_modules, test will fails with `Did you call 'SnapshotClient.setup()'` message.

<img width="2034" height="634" alt="image" src="https://github.com/user-attachments/assets/4f272eb3-685f-4461-9cd3-391cadd31bb1" />

<!-- You can also add additional context here -->
I used grep and found multiple instances of vitest code in node_modules.

```bash
grep -R "function getSnapshotClient" .                                                       node(v22.19.0) 
./node_modules/.pnpm/vitest@3.2.4_@types+node@24.5.2_happy-dom@18.0.1_jiti@2.6.0_postcss@8.5.6_typescript@5._71a7ed56a32d02315aceec2c8a4208ac/node_modules/vitest/dist/chunks/vi.bdSIJ99Y.js:function getSnapshotClient() {
./node_modules/.pnpm/vitest@3.2.4_@types+node@24.5.2_happy-dom@18.0.1_jiti@2.6.0_postcss@8.5.6_typescript@5.9.2_yaml@2.8.1/node_modules/vitest/dist/chunks/vi.bdSIJ99Y.js:function getSnapshotClient() {
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
