### PR TITLE
feat: add hooks with type-safe extra context to TestAPI

### DIFF
--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -455,4 +455,26 @@ test('types are correct', ({
   // ...
 })
 ```
+
 :::
+
+When using `test.extend`, the extended `test` object provides type-safe `beforeEach` and `afterEach` hooks that are aware of the new context:
+
+```ts
+const test = baseTest.extend<{
+  todos: number[]
+}>({
+  todos: async ({}, use) => {
+    await use([])
+  },
+})
+
+// Unlike global hooks, these hooks are aware of the extended context
+test.beforeEach(({ todos }) => {
+  todos.push(1)
+})
+
+test.afterEach(({ todos }) => {
+  console.log(todos)
+})
+```

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -33,6 +33,7 @@ import {
   withTimeout,
 } from './context'
 import { mergeContextFixtures, mergeScopedFixtures, withFixtures } from './fixture'
+import { afterAll, afterEach, beforeAll, beforeEach } from './hooks'
 import { getHooks, setFn, setHooks, setTestFixture } from './map'
 import { getCurrentTest } from './test-state'
 import { findTestFileStackTrace } from './utils'
@@ -793,6 +794,11 @@ export function createTaskCollector(
       originalWrapper.call(context, formatName(name), optionsOrFn, optionsOrTest)
     }, _context)
   }
+
+  taskFn.beforeEach = beforeEach
+  taskFn.afterEach = afterEach
+  taskFn.beforeAll = beforeAll
+  taskFn.afterAll = afterAll
 
   const _test = createChainable(
     ['concurrent', 'sequential', 'skip', 'only', 'todo', 'fails'],

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -1,5 +1,6 @@
 import type { Awaitable, TestError } from '@vitest/utils'
 import type { FixtureItem } from '../fixture'
+import type { afterAll, afterEach, beforeAll, beforeEach } from '../hooks'
 import type { ChainableFunction } from '../utils/chain'
 
 export type RunMode = 'run' | 'skip' | 'only' | 'todo' | 'queued'
@@ -482,8 +483,15 @@ interface ExtendedAPI<ExtraContext> {
   runIf: (condition: any) => ChainableTestAPI<ExtraContext>
 }
 
+interface Hooks<ExtraContext> {
+  beforeAll: typeof beforeAll
+  afterAll: typeof afterAll
+  beforeEach: typeof beforeEach<ExtraContext>
+  afterEach: typeof afterEach<ExtraContext>
+}
+
 export type TestAPI<ExtraContext = object> = ChainableTestAPI<ExtraContext>
-  & ExtendedAPI<ExtraContext> & {
+  & ExtendedAPI<ExtraContext> & Hooks<ExtraContext> & {
     extend: <T extends Record<string, any> = object>(
       fixtures: Fixtures<T, ExtraContext>
     ) => TestAPI<{

--- a/test/core/test/test-extend.test.ts
+++ b/test/core/test/test-extend.test.ts
@@ -497,3 +497,33 @@ describe('suite with timeout', () => {
     expect(task.timeout).toBe(1_000)
   })
 }, 100)
+
+describe('type-safe fixture hooks', () => {
+  const counterTest = test.extend<{
+    counter: { value: number }
+    fileCounter: { value: number }
+  }>({
+    counter: async ({}, use) => { await use({ value: 0 }) },
+    fileCounter: [async ({}, use) => { await use({ value: 0 }) }, { scope: 'file' }],
+  })
+
+  counterTest.beforeEach(({ counter }) => {
+    // shouldn't have typescript error because of 'counter' here
+    counter.value += 1
+  })
+
+  counterTest.afterEach(({ fileCounter }) => {
+    // shouldn't have typescript error because of 'fileCounter' here
+    fileCounter.value += 2
+  })
+
+  // beforeAll and afterAll hooks are not tested here, because they don't provide an extra context
+
+  counterTest('beforeEach fixture hook can adapt type-safe context', ({ counter }) => {
+    expect(counter.value).toBe(1)
+  })
+
+  counterTest('afterEach fixture hook can adapt type-safe context', ({ fileCounter }) => {
+    expect(fileCounter.value).toBe(2)
+  })
+})


### PR DESCRIPTION
### Description

This PR adds hooks to the `TestAPI` (`test`), that provide type-safe `ExtraContext`.

Details can be viewed here: #8617.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it. -> **Not sure how I could achieve this here, as it would be a type error.**
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Tests fail on my branch, but the same tests also fail on the `main` branch. So it doesn't seem to be related to this PR changes.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
