### PR TITLE
feat: introduce separate packages for browser mode providers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,7 +89,7 @@ export default antfu(
   },
   {
     // these files define vitest as peer dependency
-    files: [`packages/{coverage-*,ui,browser,web-worker}/${GLOB_SRC}`],
+    files: [`packages/{coverage-*,ui,browser,web-worker,browser-*}/${GLOB_SRC}`],
     rules: {
       'no-restricted-imports': [
         'error',

--- a/packages/browser-playwright/package.json
+++ b/packages/browser-playwright/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@vitest/browser-playwright",
+  "type": "module",
+  "version": "4.0.0-beta.13",
+  "description": "Browser running for Vitest using playwright",
+  "license": "MIT",
+  "funding": "https://opencollective.com/vitest",
+  "homepage": "https://vitest.dev/guide/browser/playwright",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vitest-dev/vitest.git",
+    "directory": "packages/browser-playwright"
+  },
+  "bugs": {
+    "url": "https://github.com/vitest-dev/vitest/issues"
+  },
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "premove dist && pnpm rollup -c",
+    "dev": "rollup -c --watch --watch.include 'src/**'"
+  },
+  "peerDependencies": {
+    "playwright": "*",
+    "vitest": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": false
+    }
+  },
+  "dependencies": {
+    "@vitest/browser": "workspace:*",
+    "@vitest/mocker": "workspace:*",
+    "tinyrainbow": "catalog:"
+  },
+  "devDependencies": {
+    "playwright": "^1.55.0",
+    "playwright-core": "^1.55.0",
+    "vitest": "workspace:*"
+  }
+}

--- a/packages/browser-playwright/rollup.config.js
+++ b/packages/browser-playwright/rollup.config.js
@@ -1,0 +1,62 @@
+import { createRequire } from 'node:module'
+import commonjs from '@rollup/plugin-commonjs'
+import json from '@rollup/plugin-json'
+import resolve from '@rollup/plugin-node-resolve'
+import { defineConfig } from 'rollup'
+import oxc from 'unplugin-oxc/rollup'
+import { createDtsUtils } from '../../scripts/build-utils.js'
+
+const require = createRequire(import.meta.url)
+const pkg = require('./package.json')
+
+const external = [
+  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.peerDependencies || {}),
+  /^@?vitest(\/|$)/,
+  '@vitest/browser/utils',
+  'worker_threads',
+  'node:worker_threads',
+  'vite',
+  'playwright-core/types/protocol',
+]
+
+const dtsUtils = createDtsUtils()
+
+const plugins = [
+  resolve({
+    preferBuiltins: true,
+  }),
+  json(),
+  commonjs(),
+  oxc({
+    transform: { target: 'node18' },
+  }),
+]
+
+export default () =>
+  defineConfig([
+    {
+      input: './src/index.ts',
+      output: {
+        dir: 'dist',
+        format: 'esm',
+      },
+      external,
+      context: 'null',
+      plugins: [
+        ...dtsUtils.isolatedDecl(),
+        ...plugins,
+      ],
+    },
+    {
+      input: dtsUtils.dtsInput('src/index.ts'),
+      output: {
+        dir: 'dist',
+        entryFileNames: '[name].d.ts',
+        format: 'esm',
+      },
+      watch: false,
+      external,
+      plugins: dtsUtils.dts(),
+    },
+  ])

--- a/packages/browser-playwright/src/index.ts
+++ b/packages/browser-playwright/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  playwright,
+  PlaywrightBrowserProvider,
+  type PlaywrightProviderOptions,
+} from './provider'

--- a/packages/browser-playwright/src/provider.ts
+++ b/packages/browser-playwright/src/provider.ts
@@ -25,6 +25,7 @@ import type {
   CDPSession,
   TestProject,
 } from 'vitest/node'
+import { createBrowserServer } from '@vitest/browser'
 import { createManualModuleSource } from '@vitest/mocker/node'
 import c from 'tinyrainbow'
 import { createDebugger, isCSSRequest } from 'vitest/node'
@@ -75,9 +76,7 @@ export function playwright(options: PlaywrightProviderOptions = {}): BrowserProv
     providerFactory(project) {
       return new PlaywrightBrowserProvider(project, options)
     },
-    // --browser.provider=playwright
-    // @ts-expect-error hidden way to bypass importing playwright
-    _cli: true,
+    serverFactory: createBrowserServer,
   }
 }
 

--- a/packages/browser-playwright/tsconfig.json
+++ b/packages/browser-playwright/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "vite/client"],
+    "isolatedDeclarations": true
+  },
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/vite.config.ts",
+    "src/client/**/*.ts"
+  ]
+}

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -732,6 +732,28 @@ export interface BrowserPage extends LocatorSelectors {
 
 export interface BrowserLocators {
   createElementLocators(element: Element): LocatorSelectors
+  // TODO: enhance docs
+  /**
+   * Extends `page.*` and `locator.*` interfaces.
+   * @see {@link}
+   *
+   * @example
+   * ```ts
+   * import { locators } from '@vitest/browser/context'
+   *
+   * declare module '@vitest/browser/context' {
+   *   interface LocatorSelectors {
+   *     getByCSS(css: string): Locator
+   *   }
+   * }
+   *
+   * locators.extend({
+   *   getByCSS(css: string) {
+   *     return `css=${css}`
+   *   }
+   * })
+   * ```
+   */
   extend(methods: {
     [K in keyof LocatorSelectors]?: (this: BrowserPage | Locator, ...args: Parameters<LocatorSelectors[K]>) => ReturnType<LocatorSelectors[K]> | string
   }): void

--- a/packages/browser/src/node/providers/preview.ts
+++ b/packages/browser/src/node/providers/preview.ts
@@ -4,7 +4,7 @@ export function preview(): BrowserProviderOption {
   return {
     name: 'preview',
     options: {},
-    factory(project) {
+    providerFactory(project) {
       return new PreviewBrowserProvider(project)
     },
     // --browser.provider=preview

--- a/packages/browser/src/node/providers/webdriverio.ts
+++ b/packages/browser/src/node/providers/webdriverio.ts
@@ -27,7 +27,7 @@ export function webdriverio(options: WebdriverProviderOptions = {}): BrowserProv
     name: 'webdriverio',
     supportedBrowser: webdriverBrowsers,
     options,
-    factory(project) {
+    providerFactory(project) {
       return new WebdriverBrowserProvider(project, options)
     },
     // --browser.provider=webdriverio

--- a/packages/browser/src/node/utils.ts
+++ b/packages/browser/src/node/utils.ts
@@ -20,14 +20,14 @@ export async function getBrowserProvider(
     options.provider == null
     // the provider is provided via `--browser.provider=playwright`
     // or the config was serialized, but we can infer the factory by the name
-    || ('_cli' in options.provider && typeof options.provider.factory !== 'function')
+    || ('_cli' in options.provider && typeof options.provider.providerFactory !== 'function')
   ) {
     const providers = await import('./providers/index')
     const name = (options.provider?.name || 'preview') as 'preview' | 'webdriverio' | 'playwright'
     if (!(name in providers)) {
       throw new Error(`Unknown browser provider "${name}". Available providers: ${Object.keys(providers).join(', ')}.`)
     }
-    return (providers[name] as (options?: object) => BrowserProviderOption)(options.provider?.options).factory(project)
+    return (providers[name] as (options?: object) => BrowserProviderOption)(options.provider?.options).providerFactory(project)
   }
   const supportedBrowsers = options.provider.supportedBrowser || []
   if (supportedBrowsers.length && !supportedBrowsers.includes(browser)) {
@@ -37,10 +37,10 @@ export async function getBrowserProvider(
       }". Supported browsers: ${supportedBrowsers.join(', ')}.`,
     )
   }
-  if (typeof options.provider.factory !== 'function') {
-    throw new TypeError(`The "${name}" browser provider does not provide a "factory" function. Received ${typeof options.provider.factory}.`)
+  if (typeof options.provider.providerFactory !== 'function') {
+    throw new TypeError(`The "${name}" browser provider does not provide a "factory" function. Received ${typeof options.provider.providerFactory}.`)
   }
-  return options.provider.factory(project)
+  return options.provider.providerFactory(project)
 }
 
 export function slash(path: string): string {

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -2,7 +2,7 @@ import type { MockedModule } from '@vitest/mocker'
 import type { CancelReason } from '@vitest/runner'
 import type { Awaitable, ParsedStack, TestError } from '@vitest/utils'
 import type { StackTraceParserOptions } from '@vitest/utils/source-map'
-import type { ViteDevServer } from 'vite'
+import type { Plugin, ViteDevServer } from 'vite'
 import type { BrowserTraceViewMode } from '../../runtime/config'
 import type { BrowserTesterOptions } from '../../types/browser'
 import type { TestProject } from '../project'
@@ -25,7 +25,13 @@ export interface BrowserProviderOption<Options extends object = object> {
   name: string
   supportedBrowser?: ReadonlyArray<string>
   options: Options
-  factory: (project: TestProject) => BrowserProvider
+  providerFactory: (project: TestProject) => BrowserProvider
+  serverFactory: (
+    project: TestProject,
+    configFile: string | undefined,
+    prePlugins: Plugin[],
+    postPlugins: Plugin[],
+  ) => Promise<ParentProjectBrowser>
 }
 
 export interface BrowserProvider {
@@ -285,6 +291,7 @@ export interface BrowserServerState {
 
 export interface ParentProjectBrowser {
   spawn: (project: TestProject) => ProjectBrowser
+  vite: ViteDevServer
 }
 
 export interface ProjectBrowser {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,28 @@ importers:
         specifier: ^9.19.2
         version: 9.19.2
 
+  packages/browser-playwright:
+    dependencies:
+      '@vitest/browser':
+        specifier: workspace:*
+        version: link:../browser
+      '@vitest/mocker':
+        specifier: workspace:*
+        version: link:../mocker
+      tinyrainbow:
+        specifier: 'catalog:'
+        version: 3.0.3
+    devDependencies:
+      playwright:
+        specifier: ^1.55.0
+        version: 1.55.0
+      playwright-core:
+        specifier: ^1.55.0
+        version: 1.55.0
+      vitest:
+        specifier: workspace:*
+        version: link:../vitest
+
   packages/coverage-istanbul:
     dependencies:
       '@istanbuljs/schema':


### PR DESCRIPTION
### Description

instead of having all providers inside `@vitest/browser`, there are now 3 different packages:

- `@vitest/browser-playwright`
- `@vitest/browser-webdriveiro`
- `@vitest/browser-preview`

The context is now imported from `vitest/browser`. The types for it are augmented by your provider.
