### PR TITLE
chore: compare `attachment.body` for `null` & `undefined`

### DIFF
--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -168,8 +168,8 @@ export function createTestContext(
       type: type || 'notice',
     }
     if (attachment) {
-      if (!attachment.body && !attachment.path) {
-        throw new TypeError(`Test attachment requires body or path to be set. Both are missing.`)
+      if ((attachment.body === null || attachment.body === undefined) && !attachment.path) {
+        throw new TypeError(`Test attachment requires "body" or "path" to be set. Both are missing.`)
       }
       if (attachment.body && attachment.path) {
         throw new TypeError(`Test attachment requires only one of "body" or "path" to be set. Both are specified.`)

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -168,7 +168,7 @@ export function createTestContext(
       type: type || 'notice',
     }
     if (attachment) {
-      if ((attachment.body === null || attachment.body === undefined) && !attachment.path) {
+      if (attachment.body == null && !attachment.path) {
         throw new TypeError(`Test attachment requires "body" or "path" to be set. Both are missing.`)
       }
       if (attachment.body && attachment.path) {


### PR DESCRIPTION
I think it resolves https://github.com/vitest-dev/vitest/issues/8630