### PR TITLE
fix: re-export CDP Session directly from playwright

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -111,7 +111,6 @@
     "pathe": "catalog:",
     "periscopic": "^4.0.2",
     "playwright": "^1.53.0",
-    "playwright-core": "^1.53.0",
     "safaridriver": "^1.0.0",
     "vitest": "workspace:*",
     "webdriverio": "^9.15.0"

--- a/packages/browser/providers/playwright.d.ts
+++ b/packages/browser/providers/playwright.d.ts
@@ -5,10 +5,9 @@ import type {
   FrameLocator,
   LaunchOptions,
   Page,
-  CDPSession,
+  CDPSession as PWCDPSession,
   ConnectOptions
 } from 'playwright'
-import { Protocol } from 'playwright-core/types/protocol'
 import '../matchers.js'
 import type {} from "vitest/node"
 
@@ -60,22 +59,5 @@ declare module '@vitest/browser/context' {
 
   export interface ScreenshotOptions extends PWScreenshotOptions {}
 
-  export interface CDPSession {
-    send<T extends keyof Protocol.CommandParameters>(
-      method: T,
-      params?: Protocol.CommandParameters[T]
-    ): Promise<Protocol.CommandReturnValues[T]>
-    on<T extends keyof Protocol.Events>(
-      event: T,
-      listener: (payload: Protocol.Events[T]) => void
-    ): this;
-    once<T extends keyof Protocol.Events>(
-      event: T,
-      listener: (payload: Protocol.Events[T]) => void
-    ): this;
-    off<T extends keyof Protocol.Events>(
-      event: T,
-      listener: (payload: Protocol.Events[T]) => void
-    ): this;
-  }
+  export interface CDPSession extends PWCDPSession {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,9 +511,6 @@ importers:
       playwright:
         specifier: ^1.53.0
         version: 1.53.0
-      playwright-core:
-        specifier: ^1.53.0
-        version: 1.53.0
       safaridriver:
         specifier: ^1.0.0
         version: 1.0.0


### PR DESCRIPTION
### Description

Fix removal of the `playwright-core/types/protocol` export.

Should fix #8671 for v3

Unfortunately, the `playwright.d.ts` file is not type checked owing to `skipLibCheck` being `true`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
