### PR TITLE
feat(ui): add project filtering support

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -63,6 +63,7 @@ export const client = (function createVitestClient() {
 
 export const config = shallowRef<SerializedConfig>({} as any)
 export const status = ref<WebSocketStatus>('CONNECTING')
+export const availableProjects = shallowRef<string[]>([])
 
 export const current = computed(() => {
   const currentFileId = activeFileId.value
@@ -174,6 +175,7 @@ watch(
           return file
         })
       }
+      availableProjects.value = projects.map(p => p.name)
       explorerTree.loadFiles(files, projects)
       client.state.collectFiles(files)
       explorerTree.startRun()

--- a/packages/ui/client/composables/explorer/expand.ts
+++ b/packages/ui/client/composables/explorer/expand.ts
@@ -84,20 +84,28 @@ export function runExpandNode(
  *
  * @param search The search applied.
  * @param filter The filter applied.
+ * @param projectName The filter for the project name.
  */
 export function runExpandAll(
   search: string,
   filter: Filter,
+  projectName?: string,
 ) {
   expandAllNodes(explorerTree.root.tasks, false)
   const entries = [...filterAll(
     search,
     filter,
+    projectName,
   )]
   treeFilter.value.expandAll = false
   openedTreeItems.value = []
   uiEntries.value = entries
-  filteredFiles.value = entries.filter(isFileNode).map(f => findById(f.id)!)
+  if (projectName) {
+    filteredFiles.value = entries.filter(f => isFileNode(f) && f.projectName === projectName).map(f => findById(f.id)!)
+  }
+  else {
+    filteredFiles.value = entries.filter(isFileNode).map(f => findById(f.id)!)
+  }
 }
 
 export function expandNodesOnEndRun(

--- a/packages/ui/client/composables/explorer/state.ts
+++ b/packages/ui/client/composables/explorer/state.ts
@@ -1,5 +1,6 @@
 import type { File } from '@vitest/runner'
 import type { FileTreeNode, Filter, FilteredTests, TreeFilterState, UITaskTreeNode } from './types'
+import { availableProjects } from '~/composables/client'
 import { explorerTree } from './index'
 
 export const uiFiles = shallowRef<FileTreeNode[]>([])
@@ -9,6 +10,7 @@ export const openedTreeItems = useLocalStorage<string[]>(
   [],
   { shallow: true },
 )
+export const ALL_PROJECTS = '__vitest_ui_all_projects__'
 export const openedTreeItemsSet = computed(() => new Set(openedTreeItems.value))
 export const treeFilter = useLocalStorage<TreeFilterState>(
   'vitest-ui_task-tree-filter',
@@ -19,8 +21,15 @@ export const treeFilter = useLocalStorage<TreeFilterState>(
     skipped: false,
     onlyTests: false,
     search: '',
+    project: ALL_PROJECTS,
   },
 )
+export const currentProject = shallowRef(treeFilter.value?.project || ALL_PROJECTS)
+export const enableProjects = computed(() => availableProjects.value.length > 1)
+export const disableClearProjects = computed(() => currentProject.value === ALL_PROJECTS)
+export const currentProjectName = computed(() => {
+  return !enableProjects.value || currentProject.value === ALL_PROJECTS ? undefined : currentProject.value
+})
 export const search = ref<string>(treeFilter.value.search)
 const htmlEntities: Record<string, string> = {
   '&': '&amp;',

--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -11,6 +11,7 @@ import { annotateTest, collectTestsTotalData, preparePendingTasks, runCollect, r
 import { runExpandAll, runExpandNode } from '~/composables/explorer/expand'
 import { runFilter } from '~/composables/explorer/filter'
 import {
+  currentProjectName,
   filter,
   search,
 } from '~/composables/explorer/state'
@@ -70,6 +71,7 @@ export class ExplorerTree {
         skipped: filter.skipped,
         onlyTests: filter.onlyTests,
       },
+      currentProjectName.value,
     )
   }
 
@@ -152,7 +154,7 @@ export class ExplorerTree {
       success: filter.success,
       skipped: filter.skipped,
       onlyTests: filter.onlyTests,
-    })
+    }, currentProjectName.value)
   }
 
   collapseNode(id: string) {
@@ -185,7 +187,7 @@ export class ExplorerTree {
         success: filter.success,
         skipped: filter.skipped,
         onlyTests: filter.onlyTests,
-      })
+      }, currentProjectName.value)
     })
   }
 
@@ -196,7 +198,7 @@ export class ExplorerTree {
         success: filter.success,
         skipped: filter.skipped,
         onlyTests: filter.onlyTests,
-      })
+      }, currentProjectName.value)
     })
   }
 }

--- a/packages/ui/client/composables/explorer/types.ts
+++ b/packages/ui/client/composables/explorer/types.ts
@@ -73,6 +73,7 @@ export interface Filter {
 
 export interface TreeFilterState extends Filter {
   search: string
+  project: string
   expandAll?: boolean
 }
 


### PR DESCRIPTION
### Description

Adding support to filter tests by project and allow sort tests by project (rn sorted by filename + project name).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
