### PR TITLE
docs: update `TestSuite` meta example

### DIFF
--- a/docs/advanced/api/test-suite.md
+++ b/docs/advanced/api/test-suite.md
@@ -197,14 +197,16 @@ Note that errors are serialized into simple objects: `instanceof Error` will alw
 function meta(): TaskMeta
 ```
 
-Custom [metadata](/advanced/metadata) that was attached to the suite during its execution or collection. The meta can be attached by assigning a property to the `task.meta` object during a test run:
+Custom [metadata](/advanced/metadata) that was attached to the suite during its execution or collection. The meta can be attached by assigning a property to the `suite.meta` object during a test run:
 
-```ts {5,10}
+```ts {7,12}
 import { test } from 'vitest'
+import { getCurrentSuite } from 'vitest/suite'
 
-describe('the validation works correctly', (task) => {
+describe('the validation works correctly', () => {
   // assign "decorated" during collection
-  task.meta.decorated = false
+  const { suite } = getCurrentSuite()
+  suite!.meta.decorated = true
 
   test('some test', ({ task }) => {
     // assign "decorated" during test run, it will be available


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Updates an invalid example on how to set suite meta during test collection.

Resolves #8631 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
