### PR TITLE
fix: change default generics type parameter of `CustomMatchers`

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1773,7 +1773,7 @@ This function is compatible with Jest's `expect.extend`, so any library that use
 If you are using TypeScript, since Vitest 0.31.0 you can extend default `Assertion` interface in an ambient declaration file (e.g: `vitest.d.ts`) with the code below:
 
 ```ts
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toBeFoo: () => R
 }
 

--- a/docs/blog/vitest-3-2.md
+++ b/docs/blog/vitest-3-2.md
@@ -242,7 +242,7 @@ For example, to have a type-safe `toBeFoo` matcher, you can write something like
 ```ts twoslash
 import { expect } from 'vitest'
 
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toBeFoo: (arg: string) => R
 }
 

--- a/docs/guide/extending-matchers.md
+++ b/docs/guide/extending-matchers.md
@@ -29,7 +29,7 @@ If you are using TypeScript, you can extend default `Assertion` interface in an 
 ```ts [<Version>3.2.0</Version>]
 import 'vitest'
 
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toBeFoo: () => R
 }
 
@@ -40,7 +40,7 @@ declare module 'vitest' {
 ```ts [<Version>3.0.0</Version>]
 import 'vitest'
 
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toBeFoo: () => R
 }
 

--- a/test/cli/fixtures/expect-soft/expects/soft.test.ts
+++ b/test/cli/fixtures/expect-soft/expects/soft.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toBeAsync: (expected: unknown) => Promise<R>;
   toBeDividedBy(divisor: number): R
 }

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -8,7 +8,7 @@ import { assert, beforeAll, describe, expect, it, vi } from 'vitest'
 class TestError extends Error {}
 
 // For expect.extend
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toBeDividedBy: (divisor: number) => R
   toBeTestedAsync: () => Promise<R>
   toBeTestedSync: () => R

--- a/test/typescript/test-d/expect-extend.test-d.ts
+++ b/test/typescript/test-d/expect-extend.test-d.ts
@@ -1,6 +1,6 @@
 import { expect, expectTypeOf, test } from 'vitest'
 
-interface CustomMatchers<R = unknown> {
+interface CustomMatchers<R = any> {
   toMatchSchema: (schema: { a: string }) => R
   toEqualMultiple: (a: string, b: number) => R
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #7731

I just changed default generics type parameter, from `unknown` to `any`, as described in the issue.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
