### PR TITLE
docs: add warning about local expect when relying on test state

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1926,7 +1926,7 @@ Whether to randomize tests.
 If you want tests to run in parallel, you can enable it with this option, or CLI argument [`--sequence.concurrent`](/guide/cli).
 
 ::: warning
-When you run tests with `sequence.concurrent` and `expect.requireAssertions` set as `true`, you should use [local expect](/guide/test-context.html#expect) instead of global one. Otherwise, your tests will fail in [some situations (#8469)](https://github.com/vitest-dev/vitest/issues/8469).
+When you run tests with `sequence.concurrent` and `expect.requireAssertions` set to `true`, you should use [local expect](/guide/test-context.html#expect) instead of the global one. Otherwise, this may cause false negatives in [some situations (#8469)](https://github.com/vitest-dev/vitest/issues/8469).
 :::
 
 #### sequence.seed<NonProjectOption />
@@ -2415,7 +2415,7 @@ You can change the value of this by calling `vi.setConfig({ expect: { requireAss
 :::
 
 ::: warning
-When you run tests with `sequence.concurrent` and `expect.requireAssertions` set as `true`, you should use [local expect](/guide/test-context.html#expect) instead of global one. Otherwise, your tests will fail in [some situations (#8469)](https://github.com/vitest-dev/vitest/issues/8469).
+When you run tests with `sequence.concurrent` and `expect.requireAssertions` set to `true`, you should use [local expect](/guide/test-context.html#expect) instead of the global one. Otherwise, this may cause false negatives in [some situations (#8469)](https://github.com/vitest-dev/vitest/issues/8469).
 :::
 
 #### expect.poll


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #8469

I added warning block for developers to use local expect when `requireAssertions` and `sequence.concurrent` are true while tests are complicatedly nested.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
