### PR TITLE
test: increase wdio "inspect" timeout

### DIFF
--- a/test/browser/specs/inspect.test.ts
+++ b/test/browser/specs/inspect.test.ts
@@ -20,10 +20,9 @@ test.each(['', 'with workspace'])('--inspect-brk stops at test file %s', async (
 
   await vitest.waitForStdout(`Debugger listening on ws://${REMOTE_DEBUG_URL}`)
 
-  const url = await vi.waitFor(() =>
-    fetch(`http://${REMOTE_DEBUG_URL}/json/list`)
-      .then(response => response.json())
-      .then(json => json[0].webSocketDebuggerUrl))
+  const url = await vi.waitFor(() => fetch(`http://${REMOTE_DEBUG_URL}/json/list`)
+    .then(response => response.json())
+    .then(json => json[0].webSocketDebuggerUrl), { timeout: 30_000 })
 
   const { receive, send } = await createChannel(url)
 
@@ -47,7 +46,7 @@ test.each(['', 'with workspace'])('--inspect-brk stops at test file %s', async (
 
   await vitest.waitForStdout('Test Files  1 passed (1)')
   await waitForClose()
-})
+}, 60_000)
 
 async function createChannel(url: string) {
   const ws = new WebSocket(url)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The debugger message is printed out even before we start the browser, so it needs some time.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
