### PR TITLE
fix(module-runner): resolve `resolvedSources` correctly

### DIFF
--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -21,6 +21,7 @@ export type {
   SerializedCoverageConfig,
 } from '../runtime/config'
 
+export { VitestEvaluatedModules as EvaluatedModules } from '../runtime/moduleRunner/evaluatedModules'
 export type {
   BenchFactory,
   BenchFunction,
@@ -134,5 +135,3 @@ export type {
 export type { SerializedError } from '@vitest/utils'
 export type { SerializedTestSpecification }
 export type { DiffOptions } from '@vitest/utils/diff'
-
-export { EvaluatedModules } from 'vite/module-runner'

--- a/packages/vitest/src/runtime/moduleRunner/evaluatedModules.ts
+++ b/packages/vitest/src/runtime/moduleRunner/evaluatedModules.ts
@@ -1,0 +1,15 @@
+import { dirname, resolve } from 'pathe'
+import { EvaluatedModules } from 'vite/module-runner'
+
+// TODO: this is not needed in Vite 7.2+
+export class VitestEvaluatedModules extends EvaluatedModules {
+  getModuleSourceMapById(id: string): any { /** the return type is not exposed by Vite */
+    const map = super.getModuleSourceMapById(id)
+    if (map != null && !('_patched' in map)) {
+      ;(map as any)._patched = true
+      const dir = dirname(map.url)
+      map.resolvedSources = (map.map.sources || []).map(s => resolve(dir, s || ''))
+    }
+    return map
+  }
+}

--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -2,9 +2,9 @@ import type { ModuleRunner } from 'vite/module-runner'
 import type { ContextRPC, WorkerGlobalState } from '../types/worker'
 import type { VitestWorker } from './workers/types'
 import { createStackString, parseStacktrace } from '@vitest/utils/source-map'
-import { EvaluatedModules } from 'vite/module-runner'
 import { loadEnvironment } from '../integrations/env/loader'
 import { setupInspect } from './inspector'
+import { VitestEvaluatedModules } from './moduleRunner/evaluatedModules'
 import { createRuntimeRpc, rpcDone } from './rpc'
 import { isChildProcess } from './utils'
 import { disposeInternalListeners } from './workers/utils'
@@ -67,7 +67,7 @@ export async function execute(method: 'run' | 'collect', ctx: ContextRPC, worker
     const state = {
       ctx,
       // here we create a new one, workers can reassign this if they need to keep it non-isolated
-      evaluatedModules: new EvaluatedModules(),
+      evaluatedModules: new VitestEvaluatedModules(),
       resolvingModules,
       moduleExecutionInfo: new Map(),
       config: ctx.config,

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -3,7 +3,7 @@ import type { VitestModuleRunner } from '../moduleRunner/moduleRunner'
 import type { ContextModuleRunnerOptions } from '../moduleRunner/startModuleRunner'
 import { runInThisContext } from 'node:vm'
 import * as spyModule from '@vitest/spy'
-import { EvaluatedModules } from 'vite/module-runner'
+import { VitestEvaluatedModules } from '../moduleRunner/evaluatedModules'
 import { createNodeImportMeta } from '../moduleRunner/moduleRunner'
 import { startVitestModuleRunner } from '../moduleRunner/startModuleRunner'
 import { run } from '../runBaseTests'
@@ -11,7 +11,7 @@ import { provideWorkerState } from '../utils'
 
 let _moduleRunner: VitestModuleRunner
 
-const evaluatedModules = new EvaluatedModules()
+const evaluatedModules = new VitestEvaluatedModules()
 const moduleExecutionInfo = new Map()
 
 function startModuleRunner(options: ContextModuleRunnerOptions) {

--- a/test/cli/test/__snapshots__/stacktraces.test.ts.snap
+++ b/test/cli/test/__snapshots__/stacktraces.test.ts.snap
@@ -119,23 +119,29 @@ Error: __TEST_STACK_TS__
 
  FAIL  error-in-package.test.js > transpiled
 Error: __TEST_STACK_TRANSPILED__
- ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled.js:22:9
-      7|   throw new Error("__TEST_STACK_TRANSPILED__");
-      8| }
-     10| 
- ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled.js:12:3
+ ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled.ts:22:9
+ ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled.ts:12:3
  ❯ error-in-package.test.js:16:22
+     14| 
+     15| test('transpiled', () => {
+     16|   testStackTranspiled()
+       |                      ^
+     17| })
+     18| 
 
 ⎯⎯[3/4]⎯
 
  FAIL  error-in-package.test.js > transpiled inline
 Error: __TEST_STACK_TRANSPILED_INLINE__
- ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.js:22:9
-      7|   throw new Error("__TEST_STACK_TRANSPILED_INLINE__");
-      8| }
-     10| 
- ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.js:12:3
+ ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.ts:22:9
+ ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.ts:12:3
  ❯ error-in-package.test.js:20:28
+     18| 
+     19| test('transpiled inline', () => {
+     20|   testStackTranspiledInline()
+       |                            ^
+     21| })
+     22| 
 
 ⎯⎯[4/4]⎯
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is a bug in Vite. It's fixed in Vite 7.2, but we also support Vite 6+, so we need to have the workaround for now.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
