### PR TITLE
perf(pool): resolve all environments first

### DIFF
--- a/packages/vitest/src/utils/test-helpers.ts
+++ b/packages/vitest/src/utils/test-helpers.ts
@@ -1,28 +1,22 @@
-import type { TestProject } from '../node/project'
 import type { TestSpecification } from '../node/spec'
 import type { EnvironmentOptions, VitestEnvironment } from '../node/types/config'
 import type { ContextTestEnvironment } from '../types/worker'
 import { promises as fs } from 'node:fs'
-import { groupBy } from './base'
 
-export const envsOrder: string[] = ['node', 'jsdom', 'happy-dom', 'edge-runtime']
-
-export interface FileByEnv {
-  file: string
-  env: VitestEnvironment
-  envOptions: EnvironmentOptions | null
-}
-
-export async function groupFilesByEnv(
-  files: Array<TestSpecification>,
-): Promise<Record<string, {
-  file: { filepath: string; testLocations: number[] | undefined }
-  project: TestProject
-  environment: ContextTestEnvironment
-}[]>> {
-  const filesWithEnv = await Promise.all(
-    files.map(async ({ moduleId: filepath, project, testLines }) => {
-      const code = await fs.readFile(filepath, 'utf-8')
+export async function getSpecificationsEnvironments(
+  specifications: Array<TestSpecification>,
+): Promise<WeakMap<TestSpecification, ContextTestEnvironment>> {
+  const environments = new WeakMap<TestSpecification, ContextTestEnvironment>()
+  const cache = new Map<string, string>()
+  await Promise.all(
+    specifications.map(async (spec) => {
+      const { moduleId: filepath, project } = spec
+      // reuse if projects have the same test files
+      let code = cache.get(filepath)
+      if (!code) {
+        code = await fs.readFile(filepath, 'utf-8')
+        cache.set(filepath, code)
+      }
 
       // 1. Check for control comments in the file
       let env = code.match(/@(?:vitest|jest)-environment\s+([\w-]+)\b/)?.[1]
@@ -43,16 +37,8 @@ export async function groupFilesByEnv(
           ? ({ [envKey]: envOptions } as EnvironmentOptions)
           : null,
       }
-      return {
-        file: {
-          filepath,
-          testLocations: testLines,
-        },
-        project,
-        environment,
-      }
+      environments.set(spec, environment)
     }),
   )
-
-  return groupBy(filesWithEnv, ({ environment }) => environment.name)
+  return environments
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

There is no big noticeable change locally, to be honest. But the old architecture is just wrong

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
