### PR TITLE
chore: keep length static

### DIFF
--- a/docs/api/mock.md
+++ b/docs/api/mock.md
@@ -21,9 +21,17 @@ getApplesSpy.mock.calls.length === 1
 You should use mock assertions (e.g., [`toHaveBeenCalled`](/api/expect#tohavebeencalled)) on [`expect`](/api/expect) to assert mock results. This API reference describes available properties and methods to manipulate mock behavior.
 
 ::: warning IMPORTANT
-Vitest spies inherit implementation's `length` property. This means that `length` can be different from the original implementation:
+Vitest spies inherit implementation's [`length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) property when initialized, but it doesn't override it if the implementation was changed later:
 
-```ts
+::: code-group
+```ts [vi.fn]
+const fn = vi.fn((arg1) => {})
+fn.length // == 1
+
+fn.mockImplementation(() => {})
+fn.length // == 1
+```
+```ts [vi.spyOn]
 const example = {
   fn(arg1, arg2) {
     // ...
@@ -34,7 +42,7 @@ const fn = vi.spyOn(example, 'fn')
 fn.length // == 2
 
 fn.mockImplementation(() => {})
-fn.length // == 0
+fn.length // == 2
 ```
 :::
 

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -48,6 +48,13 @@ export function createMockInstance(options: MockInstanceOption = {}): Mock {
     state,
     ...options,
   })
+  const mockLength = (mockImplementation || originalImplementation)?.length ?? 0
+  Object.defineProperty(mock, 'length', {
+    writable: true,
+    enumerable: false,
+    value: mockLength,
+    configurable: true,
+  })
   // inherit the default name so it appears in snapshots and logs
   // this is used by `vi.spyOn()` for better debugging.
   // when `vi.fn()` is called, we just use the default string
@@ -494,25 +501,6 @@ function createMock(
   if (original) {
     copyOriginalStaticProperties(namedObject[name], original)
   }
-  let overrideLength: number | undefined
-  Object.defineProperty(namedObject[name], 'length', {
-    configurable: true,
-    get: () => {
-      if (overrideLength != null) {
-        return overrideLength
-      }
-
-      const implementation = config.onceMockImplementations[0]
-        || config.mockImplementation
-        || prototypeConfig?.onceMockImplementations[0]
-        || prototypeConfig?.mockImplementation
-        || original
-      return implementation?.length ?? 0
-    },
-    set: (length: number) => {
-      overrideLength = length
-    },
-  })
   return namedObject[name]
 }
 

--- a/test/core/test/mocking/vi-fn.test.ts
+++ b/test/core/test/mocking/vi-fn.test.ts
@@ -20,21 +20,45 @@ test('vi.fn().mock cannot be overriden', () => {
   }).toThrowError()
 })
 
-test('vi.fn() has correct length', () => {
-  const fn0 = vi.fn(() => {})
-  expect(fn0.length).toBe(0)
+describe('fn.length is consistent', () => {
+  test('vi.fn() has correct length', () => {
+    const fn0 = vi.fn(() => {})
+    expect(fn0.length).toBe(0)
 
-  const fnArgs = vi.fn((..._args) => {})
-  expect(fnArgs.length).toBe(0)
+    const fnArgs = vi.fn((..._args) => {})
+    expect(fnArgs.length).toBe(0)
 
-  const fn1 = vi.fn((_arg1) => {})
-  expect(fn1.length).toBe(1)
+    const fn1 = vi.fn((_arg1) => {})
+    expect(fn1.length).toBe(1)
 
-  const fn2 = vi.fn((_arg1, _arg2) => {})
-  expect(fn2.length).toBe(2)
+    const fn2 = vi.fn((_arg1, _arg2) => {})
+    expect(fn2.length).toBe(2)
 
-  const fn3 = vi.fn((_arg1, _arg2, _arg3) => {})
-  expect(fn3.length).toBe(3)
+    const fn3 = vi.fn((_arg1, _arg2, _arg3) => {})
+    expect(fn3.length).toBe(3)
+  })
+
+  test('vi.fn() always returns length of the initial implementation', () => {
+    const fn = vi.fn<(...args: any[]) => void>((_arg) => {})
+
+    expect(fn.length).toBe(1)
+
+    fn.mockImplementationOnce(() => {})
+
+    expect(fn.length).toBe(1)
+    fn(1)
+    expect(fn.length).toBe(1)
+
+    fn.mockImplementation((_arg1, _arg2) => {})
+
+    expect(fn.length).toBe(1)
+    fn(1)
+    expect(fn.length).toBe(1)
+
+    fn.withImplementation((_arg1, _arg2, _arg3) => {}, () => {
+      expect(fn.length).toBe(1)
+    })
+  })
 })
 
 test('vi.fn() has overridable length', () => {


### PR DESCRIPTION
### Description

Follow up to https://github.com/vitest-dev/vitest/pull/8778

Dynamic nature of it would be a big breaking change to how V3 worked and it works incorrectly (correctly) with `mock.mockReturnValue` (and similar) - the length is 0 in that case, but the user probably wanted it to be the same as the original implementation


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
