### PR TITLE
fix(happy-dom): support fetch globals

### DIFF
--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -63,8 +63,18 @@ export default <Environment>{
 
     const { keys, originals } = populateGlobal(global, win, {
       bindFunctions: true,
-      // jsdom doesn't support Request and Response, but happy-dom does
-      additionalKeys: ['Request', 'Response', 'MessagePort', 'fetch'],
+      // jsdom doesn't support fetch API, but happy-dom does
+      additionalKeys: [
+        'Request',
+        'Response',
+        'MessagePort',
+        'fetch',
+        'Headers',
+        'AbortController',
+        'AbortSignal',
+        'URL',
+        'URLSearchParams',
+      ],
     })
 
     return {

--- a/test/core/test/happy-dom.test.ts
+++ b/test/core/test/happy-dom.test.ts
@@ -120,6 +120,20 @@ it('globals are the same', () => {
   expect(Blob).toBe(globalThis.Blob)
 })
 
+it('fetch globals work', () => {
+  const file = new File([window.Buffer.from('<foo />')], 'a.xml')
+  expect(() => URL.createObjectURL(file)).not.toThrow()
+
+  expect(new File([], 'test.txt')).toBeInstanceOf(Blob)
+
+  const response = new Response('', {
+    headers: new Headers({
+      'Content-Type': 'application/json',
+    }),
+  })
+  expect(response.headers.get('content-type')).toBe('application/json')
+})
+
 it.skipIf(import.meta.env.VITEST_VM_POOL)('default view references global object', () => {
   expect(document.defaultView).toBe(window)
   expect(document.defaultView).toBe(globalThis)


### PR DESCRIPTION
### Description

Fixes #8777
Fixes #8788

We removed fetch related globals from the KEYS to support jsdom, but happy-dom does define them properly, so they need to stay in the happy-dom environment.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
