### PR TITLE
perf(utils): optimized reducer to avoid creating new objects

### DIFF
--- a/packages/vitest/src/utils/serialization.ts
+++ b/packages/vitest/src/utils/serialization.ts
@@ -3,11 +3,11 @@
 function cloneByOwnProperties(value: any) {
   // Clones the value's properties into a new Object. The simpler approach of
   // Object.assign() won't work in the case that properties are not enumerable.
-  return Object.getOwnPropertyNames(value).reduce(
-    (clone, prop) => ({
-      ...clone,
-      [prop]: value[prop],
-    }),
+  return Object.getOwnPropertyNames(value).reduce<Record<string, any>>(
+    (clone, prop) => {
+      clone[prop] = value[prop]
+      return clone
+    },
     {},
   )
 }


### PR DESCRIPTION
### Description

Rewrote reducer to avoid creating a new object on each iteration and prevent O(n²) complexity.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
