### PR TITLE
fix(pool): runner's error listener causing `MaxListenersExceededWarning`

### DIFF
--- a/packages/vitest/src/node/pools/pool.ts
+++ b/packages/vitest/src/node/pools/pool.ts
@@ -76,12 +76,6 @@ export class Pool {
       const activeTask = { task, resolver, method, cancelTask }
       this.activeTasks.push(activeTask)
 
-      runner.on('error', (error) => {
-        resolver.reject(
-          new Error(`[vitest-pool]: Worker ${task.worker} emitted error.`, { cause: error }),
-        )
-      })
-
       async function cancelTask() {
         await runner.stop()
         resolver.reject(new Error('Cancelled'))
@@ -104,6 +98,12 @@ export class Pool {
       runner.on('message', onFinished)
 
       if (!runner.isStarted) {
+        runner.on('error', (error) => {
+          resolver.reject(
+            new Error(`[vitest-pool]: Worker ${task.worker} emitted error.`, { cause: error }),
+          )
+        })
+
         const id = setTimeout(
           () => resolver.reject(new Error(`[vitest-pool]: Timeout starting ${task.worker} runner.`)),
           WORKER_START_TIMEOUT,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Fixes case where runner's error listener is attached multiple times. This happens when isolation is disabled.
- Stacktrace at https://github.com/vitest-dev/vitest/issues/8808#issuecomment-3448353214

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
