### PR TITLE
fix!: move `update` flag to CLI options

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -593,14 +593,6 @@ jsdom environment exposes `jsdom` global variable equal to the current [JSDOM](h
 
 These options are passed down to `setup` method of current [`environment`](#environment). By default, you can configure only JSDOM options, if you are using it as your test environment.
 
-### update<NonProjectOption />
-
-- **Type:** `boolean`
-- **Default:** `false`
-- **CLI:** `-u`, `--update`, `--update=false`
-
-Update snapshot files. This will update all changed snapshots and delete obsolete ones.
-
 ### watch<NonProjectOption />
 
 - **Type:** `boolean`

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -360,13 +360,6 @@ export interface InlineConfig {
   projects?: TestProjectConfiguration[]
 
   /**
-   * Update snapshot
-   *
-   * @default false
-   */
-  update?: boolean
-
-  /**
    * Watch mode
    *
    * @default !process.env.CI
@@ -896,6 +889,13 @@ export interface UserConfig extends InlineConfig {
    * Use happy-dom
    */
   dom?: boolean
+
+  /**
+   * Update snapshot
+   *
+   * @default false
+   */
+  update?: boolean
 
   /**
    * Run tests that cover a list of source files


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

There is really no need to have it in the config, it's a CLI only flag. If you set it to `true`, your snapshots are always updated which defeats the purpose

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
