### PR TITLE
fix(mocker): support mocking builtins without `node:` prefix

### DIFF
--- a/test/core/test/mocked-node-module.test.ts
+++ b/test/core/test/mocked-node-module.test.ts
@@ -1,0 +1,18 @@
+/* eslint-disable unicorn/prefer-node-protocol */
+
+import fs from 'fs/promises'
+import { expect, test, vi } from 'vitest'
+
+vi.mock(import('fs/promises'), async (importOriginal) => {
+  const { default: original } = await importOriginal()
+  return {
+    default: {
+      ...original,
+      readFile: vi.fn(),
+    },
+  }
+})
+
+test('fs is defined when node: prefix is not used', () => {
+  expect(vi.isMockFunction(fs.readFile)).toBe(true)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #8802

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
