### PR TITLE
docs: update globals config file path

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -458,9 +458,9 @@ export default defineConfig({
 })
 ```
 
-To get TypeScript working with the global APIs, add `vitest/globals` to the `types` field in your `tsconfig.json`
+To get TypeScript working with the global APIs, add `vitest/globals` to the `types` field in your `tsconfig.json` or `tsconfig.app.json`
 
-```json [tsconfig.json]
+```json [tsconfig.json/tsconfig.app.json]
 {
   "compilerOptions": {
     "types": ["vitest/globals"]
@@ -470,7 +470,7 @@ To get TypeScript working with the global APIs, add `vitest/globals` to the `typ
 
 If you have redefined your [`typeRoots`](https://www.typescriptlang.org/tsconfig/#typeRoots) to include more types in your compilation, you will have to add back the `node_modules` to make `vitest/globals` discoverable.
 
-```json [tsconfig.json]
+```json [tsconfig.json/tsconfig.app.json]
 {
   "compilerOptions": {
     "typeRoots": ["./types", "./node_modules/@types", "./node_modules"],


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Description: Updated documentation to include 'tsconfig.app.json' for TypeScript configuration.

Current behavior: The [globals config guide](https://vitest.dev/config/#globals) only indicates in the tsconfig.json file, but it works in tsconfig.app.json instead of tsconfig.json on projects created by create vite. There are some [discussions](https://github.com/vitest-dev/vitest/discussions/1573) about this issue, check the [demo](https://stackblitz.com/~/github.com/13RTK/vitest-react-globals-demo) on stackblitz

After update: If the project is based on create vite, users will try to attach to tsconfig.app.json to solve this config problem

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
