### PR TITLE
perf(expect): optimize checking the input type

### DIFF
--- a/packages/browser/src/client/tester/expect/toHaveFormValues.ts
+++ b/packages/browser/src/client/tester/expect/toHaveFormValues.ts
@@ -66,13 +66,16 @@ export default function toHaveFormValues(
 // Returns the combined value of several elements that have the same name
 // e.g. radio buttons or groups of checkboxes
 function getMultiElementValue(elements: HTMLInputElement[]) {
-  const types = [...new Set(elements.map(element => element.type))]
-  if (types.length !== 1) {
-    throw new Error(
-      'Multiple form elements with the same name must be of the same type',
-    )
+  let type = ''
+  for (const element of elements) {
+    if (type && type !== element.type) {
+      throw new Error(
+        'Multiple form elements with the same name must be of the same type',
+      )
+    }
+    type = element.type
   }
-  switch (types[0]) {
+  switch (type) {
     case 'radio': {
       const selected = elements.find(radio => radio.checked)
       return selected ? selected.value : undefined


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixed duplicate `type` search to run in a single loop without creating intermediate collections. The current implementation uses three new collections and three loops (map → set → spread).


Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
