### PR TITLE
chore: bump node version to lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,9 @@ jobs:
         node_version: [20, 22, 24]
         include:
           - os: macos-latest
-            node_version: 22
+            node_version: 24
           - os: windows-latest
-            node_version: 22
+            node_version: 24
       fail-fast: false
 
     steps:
@@ -168,7 +168,7 @@ jobs:
 
   test-rolldown:
     needs: changed
-    # macos-latest is the fastes one
+    # macos-latest is the fastest one
     name: 'Rolldown&Test: node-22, macos-latest'
     if: needs.changed.outputs.should_skip != 'true'
     runs-on: macos-latest

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "pnpm ci:docs"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF docs/ package.json pnpm-lock.yaml"
 
 [build.environment]
-NODE_VERSION = "22"
+NODE_VERSION = "24"
 # don't need playwright for docs build
 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 # https://github.com/nodejs/corepack/issues/612#issuecomment-2631462297


### PR DESCRIPTION
actually node v24 is now lts. I've tried to change something. will it be ok ? 