### PR TITLE
docs(config): Fix a typo in the config docs

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -156,7 +156,7 @@ Color used by CLI and UI can be changed by providing an object with `color` prop
 
 - **Type:** `{ sourcemap?, deps?, ... }`
 
-Moudle runner options.
+Module runner options.
 
 #### server.sourcemap
 


### PR DESCRIPTION
### Description

Fixes a small typo in the configuration documentation hosted here:
https://vitest.dev/config/

The `server` option is described this way:
> Moudle runner options.

This PR corrects it to `module` and that's it.

Resolves issue number: N/A

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] _Run the tests with `pnpm test:ci`_ - n/a, functionality not modified

### Documentation
- [x] _If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command_. - n/a, functionality not modified

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
