### PR TITLE
fix: rename groupId with groupOrder typo in error message (fix #8855)

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -392,7 +392,7 @@ function groupSpecs(specs: TestSpecification[], environments: Awaited<ReturnType
 
     const order = spec.project.config.sequence.groupOrder
 
-    // Files that have disabled parallelism and default groupId are set into their own group
+    // Files that have disabled parallelism and default groupOrder are set into their own group
     if (order === 0 && spec.project.config.fileParallelism === false) {
       return sequential.specs.push([spec])
     }
@@ -401,11 +401,11 @@ function groupSpecs(specs: TestSpecification[], environments: Awaited<ReturnType
     const isolate = spec.project.config.isolate
     groups[order] ||= { specs: [], maxWorkers }
 
-    // Multiple projects with different maxWorkers but same groupId
+    // Multiple projects with different maxWorkers but same groupOrder
     if (groups[order].maxWorkers !== maxWorkers) {
       const last = groups[order].specs.at(-1)?.at(-1)?.project.name
 
-      throw new Error(`Projects "${last}" and "${spec.project.name}" have different 'maxWorkers' but same 'sequence.groupId'.\nProvide unique 'sequence.groupId' for them.`)
+      throw new Error(`Projects "${last}" and "${spec.project.name}" have different 'maxWorkers' but same 'sequence.groupOrder'.\nProvide unique 'sequence.groupOrder' for them.`)
     }
 
     // Non-isolated single worker can receive all files at once


### PR DESCRIPTION
### Description

This PR solves the invalid error message described in issue #8855

All I did was rename **groupId** with **groupOrder**.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [X] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
