### PR TITLE
fix(coverage): prevent filtering out virtual files before remapping to sources

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -2,7 +2,7 @@ import type { CoverageMap } from 'istanbul-lib-coverage'
 import type { ProxifiedModule } from 'magicast'
 import type { Profiler } from 'node:inspector'
 import type { CoverageProvider, ReportContext, ResolvedCoverageOptions, TestProject, Vite, Vitest } from 'vitest/node'
-import { promises as fs } from 'node:fs'
+import { existsSync, promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 // @ts-expect-error -- untyped
 import { mergeProcessCovs } from '@bcoe/v8-coverage'
@@ -86,9 +86,15 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
       coverageMap.merge(await transformCoverage(untestedCoverage))
     }
 
-    if (this.options.excludeAfterRemap) {
-      coverageMap.filter(filename => this.isIncluded(filename))
-    }
+    coverageMap.filter((filename) => {
+      const exists = existsSync(filename)
+
+      if (this.options.excludeAfterRemap) {
+        return exists && this.isIncluded(filename)
+      }
+
+      return exists
+    })
 
     if (debug.enabled) {
       debug(`Generate coverage total time ${(performance.now() - start!).toFixed()} ms`)

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -6,7 +6,7 @@ import type { SerializedCoverageConfig } from '../runtime/config'
 import type { AfterSuiteRunMeta } from '../types/general'
 import { existsSync, promises as fs, readdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { cleanUrl, slash } from '@vitest/utils/helpers'
+import { slash } from '@vitest/utils/helpers'
 import { relative, resolve } from 'pathe'
 import pm from 'picomatch'
 import { glob } from 'tinyglobby'
@@ -161,18 +161,11 @@ export class BaseCoverageProvider<Options extends ResolvedCoverageOptions<'istan
     // By default `coverage.include` matches all files, except "coverage.exclude"
     const glob = this.options.include || '**'
 
-    let included = roots.some((root) => {
-      const options: pm.PicomatchOptions = {
-        contains: true,
-        dot: true,
-        cwd: root,
-        ignore: this.options.exclude,
-      }
-
-      return pm.isMatch(filename, glob, options)
+    const included = pm.isMatch(filename, glob, {
+      contains: true,
+      dot: true,
+      ignore: this.options.exclude,
     })
-
-    included &&= existsSync(cleanUrl(filename))
 
     this.globCache.set(filename, included)
 

--- a/test/coverage-test/fixtures/configs/vitest.config.virtual-files.ts
+++ b/test/coverage-test/fixtures/configs/vitest.config.virtual-files.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { Plugin, defineConfig, mergeConfig } from 'vitest/config'
+import { transformWithEsbuild } from 'vite'
 
 import base from './vitest.config'
 
@@ -22,6 +25,10 @@ function VirtualFilesPlugin(): Plugin {
       if (id === '\0vitest-custom-virtual-file-2') {
         return 'src/\0vitest-custom-virtual-file-2.ts'
       }
+
+      if (id.includes('vitest-custom-virtual:math')) {
+        return resolve(import.meta.dirname, "../src/vitest-custom-virtual:math")
+      }
     },
     load(id) {
       if (id === 'src/virtual:vitest-custom-virtual-file-1.ts') {
@@ -37,6 +44,13 @@ function VirtualFilesPlugin(): Plugin {
           const virtualFile = "This file should be excluded from coverage report #2"
           export default virtualFile;
         `
+      }
+
+      if(id.includes("vitest-custom-virtual:math")) {
+        const filename = resolve(import.meta.dirname, "../src/math.ts");
+        const sources = readFileSync(filename, "utf8")
+
+        return transformWithEsbuild(sources, filename)
       }
     },
   }

--- a/test/coverage-test/fixtures/src/virtual-files.ts
+++ b/test/coverage-test/fixtures/src/virtual-files.ts
@@ -1,10 +1,12 @@
 // @ts-expect-error -- untyped virtual file provided by custom plugin
 import virtualFile1 from 'virtual:vitest-custom-virtual-file-1'
 
-
 // @ts-expect-error -- untyped virtual file provided by custom plugin
 import virtualFile2 from '\0vitest-custom-virtual-file-2'
 
+// @ts-expect-error -- untyped virtual file provided by custom plugin
+import * as virtualMath from 'vitest-custom-virtual:math'
+
 export function getVirtualFileImports() {
-  return { virtualFile1, virtualFile2 }
+  return { virtualFile1, virtualFile2, virtualMath }
 }

--- a/test/coverage-test/fixtures/test/virtual-files-fixture.test.ts
+++ b/test/coverage-test/fixtures/test/virtual-files-fixture.test.ts
@@ -2,9 +2,11 @@ import { expect, test } from 'vitest'
 import { getVirtualFileImports} from '../src/virtual-files'
 
 test("verify virtual files work", () => {
-  const {virtualFile1, virtualFile2} = getVirtualFileImports()
+  const {virtualFile1, virtualFile2, virtualMath} = getVirtualFileImports()
 
   expect(virtualFile1).toBe('This file should be excluded from coverage report #1')
   expect(virtualFile2).toBe('This file should be excluded from coverage report #2')
 
+  expect(virtualMath).toHaveProperty('sum')
+  expect(virtualMath.sum(50, 65)).toBe(115)
 })

--- a/test/coverage-test/test/virtual-files.test.ts
+++ b/test/coverage-test/test/virtual-files.test.ts
@@ -26,4 +26,16 @@ test('virtual files should be excluded', async () => {
     // Vitest browser
     expect(file).not.toContain('\x00')
   }
+
+  expect(files).toContain('<process-cwd>/fixtures/src/math.ts')
+
+  const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/math.ts')
+  expect(fileCoverage).toMatchInlineSnapshot(`
+    {
+      "branches": "0/0 (100%)",
+      "functions": "1/4 (25%)",
+      "lines": "1/4 (25%)",
+      "statements": "1/4 (25%)",
+    }
+  `)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Fixes https://github.com/vitest-dev/vitest/issues/8854

This change feels a bit wrong. Angular should really use the original filenames and do transforms on plugin. There is really no reason to use virtual files. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
