### PR TITLE
fix: don't merge errors with different diffs for reporting

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -617,6 +617,7 @@ export abstract class BaseReporter implements Reporter {
     const failedTests = tests.filter(i => i.result?.state === 'fail')
     const failedTotal = countTestErrors(failedSuites) + countTestErrors(failedTests)
 
+    // TODO: error divider should take into account merged errors for counting
     let current = 1
     const errorDivider = () => this.error(`${c.red(c.dim(divider(`[${current++}/${failedTotal}]`, undefined, 1)))}\n`)
 

--- a/test/reporters/fixtures/merge-errors/basic.test.ts
+++ b/test/reporters/fixtures/merge-errors/basic.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+
+// not merged
+test.for([1, 2])("test-a %$", (n) => {
+  expect(n).toBe(0);
+});
+
+// merged
+test.for([1, 2])("test-b %$", (n) => {
+  expect(1).toBe(0);
+});
+
+// not merged
+test.each([
+  {
+    actual: ["a".repeat(50)],
+    expected: ["b".repeat(50)],
+  },
+  {
+    actual: ["c".repeat(50)],
+    expected: ["d".repeat(50)],
+  },
+])("test-c %$", async ({ actual, expected }) => {
+  expect(actual).toEqual(expect.arrayContaining(expected));
+});

--- a/test/reporters/tests/__snapshots__/default.test.ts.snap
+++ b/test/reporters/tests/__snapshots__/default.test.ts.snap
@@ -1,0 +1,110 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`default reporter > merge identical errors 1`] = `
+"
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  basic.test.ts > test-a 1
+AssertionError: expected 1 to be +0 // Object.is equality
+
+- Expected
++ Received
+
+- 0
++ 1
+
+ ❯ basic.test.ts:5:13
+      3| // not merged
+      4| test.for([1, 2])("test-a %$", (n) => {
+      5|   expect(n).toBe(0);
+       |             ^
+      6| });
+      7| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/6]⎯
+
+ FAIL  basic.test.ts > test-a 2
+AssertionError: expected 2 to be +0 // Object.is equality
+
+- Expected
++ Received
+
+- 0
++ 2
+
+ ❯ basic.test.ts:5:13
+      3| // not merged
+      4| test.for([1, 2])("test-a %$", (n) => {
+      5|   expect(n).toBe(0);
+       |             ^
+      6| });
+      7| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/6]⎯
+
+ FAIL  basic.test.ts > test-b 1
+ FAIL  basic.test.ts > test-b 2
+AssertionError: expected 1 to be +0 // Object.is equality
+
+- Expected
++ Received
+
+- 0
++ 1
+
+ ❯ basic.test.ts:10:13
+      8| // merged
+      9| test.for([1, 2])("test-b %$", (n) => {
+     10|   expect(1).toBe(0);
+       |             ^
+     11| });
+     12| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/6]⎯
+
+ FAIL  basic.test.ts > test-c 1
+AssertionError: expected [ Array(1) ] to deeply equal ArrayContaining{…}
+
+- Expected
++ Received
+
+- ArrayContaining [
+-   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
++ [
++   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  ]
+
+ ❯ basic.test.ts:24:18
+     22|   },
+     23| ])("test-c %$", async ({ actual, expected }) => {
+     24|   expect(actual).toEqual(expect.arrayContaining(expected));
+       |                  ^
+     25| });
+     26| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/6]⎯
+
+ FAIL  basic.test.ts > test-c 2
+AssertionError: expected [ Array(1) ] to deeply equal ArrayContaining{…}
+
+- Expected
++ Received
+
+- ArrayContaining [
+-   "dddddddddddddddddddddddddddddddddddddddddddddddddd",
++ [
++   "cccccccccccccccccccccccccccccccccccccccccccccccccc",
+  ]
+
+ ❯ basic.test.ts:24:18
+     22|   },
+     23| ])("test-c %$", async ({ actual, expected }) => {
+     24|   expect(actual).toEqual(expect.arrayContaining(expected));
+       |                  ^
+     25| });
+     26| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/6]⎯
+
+"
+`;

--- a/test/reporters/tests/default.test.ts
+++ b/test/reporters/tests/default.test.ts
@@ -290,4 +290,13 @@ describe('default reporter', async () => {
 
     expect(stderr).toMatch('FAIL   > { name: fails, meta: Failing test added this } (Custom getFullName here')
   })
+
+  test('merge identical errors', async () => {
+    const { stderr } = await runVitest({
+      root: 'fixtures/merge-errors',
+      reporters: [['default', { isTTY: true, summary: false }]],
+      config: false,
+    })
+    expect(stderr).toMatchSnapshot()
+  })
 }, 120000)


### PR DESCRIPTION
### Description

Resolves https://github.com/vitest-dev/vitest/issues/8858

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
