### PR TITLE
docs: Update CLI flag name

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -7,7 +7,7 @@ title: Debugging | Guide
 :::tip
 When debugging tests you might want to use following options:
 
-- [`--test-timeout=0`](/guide/cli#testtimeout) to prevent tests from timing out when stopping at breakpoints
+- [`--testTimeout=0`](/guide/cli#testtimeout) to prevent tests from timing out when stopping at breakpoints
 - [`--no-file-parallelism`](/guide/cli#fileparallelism) to prevent test files from running parallel
 
 :::


### PR DESCRIPTION
### Description

I noticed that `--test-timeout` flag has been renamed to `--testTimeout`. This PR updates debugging.md with the new name.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
