### PR TITLE
fix(pool): avoid `--require` argument when running in deno

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -272,8 +272,8 @@ function resolveOptions(ctx: Vitest) {
       ...execArgv,
       ...conditions,
       '--experimental-import-meta-resolve',
-      '--require',
-      suppressWarningsPath,
+      // https://github.com/vitest-dev/vitest/issues/8896
+      ...((globalThis as any).Deno ? [] : ['--require', suppressWarningsPath]),
     ],
     env: {
       TEST: 'true',


### PR DESCRIPTION
### Description

This is a hotfix for Deno runtime not supporting `--require` argument and broken in latest vitest v4 (but i guess is safe fix as deno does not emit such warns anyway)

Resolves #8896
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
