### PR TITLE
docs: Improve `onStackTrace` docs to include limitations and tips

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1931,11 +1931,9 @@ Apply a filtering function to each frame of each stack trace when handling error
 
 Can be useful for filtering out stack trace frames from third-party libraries.
 
-
 ::: tip
 The stack trace's total size is also typically limited by V8's [`Error.stackTraceLimit`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stackTraceLimit) number. You could set this to a high value in your test setup function to prevent stacks from being truncated.
 :::
-
 
 ```ts
 import type { ParsedStack, TestError } from 'vitest'


### PR DESCRIPTION
### Description

As discussed here: https://github.com/vitest-dev/vitest/discussions/8149
I've updated the docs to include a callout to the V8 stack trace limit feature, and to mention that the stack trace filtering doesn't apply to regular console logs that might get printed by `printConsoleTrace`
I've tried to fix the latter by calling the appropriate filtering functions, but it looks like `printConsoleTrace` is implemented in workers, which only have access to the serialized config, which of course lacks the `onStackTrace` filtering function.

In the discussion we also talked about removing the `.slice` from this code path since it might limit the stack frames to the first 6, but after a second look I think it's doing the opposite, basically removing the first 6 stack frames that are vite internals in a transparent way, which I think probably helps make the stack frames more readable

PS If you know how could/should I add the filter function to the serialized config in workers, so it could apply to `printConsoleTrace` I'd be happy to have a go at it, but couldn't find examples of similar things in the config, and this seems like it could be a performance critical problem.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
