### PR TITLE
docs: use `msw/browser` in component testing examples

### DIFF
--- a/docs/guide/browser/component-testing.md
+++ b/docs/guide/browser/component-testing.md
@@ -295,7 +295,9 @@ test('UserProfile handles loading, success, and error states', async () => {
 })
 ```
 
-> See more details on [using MSW in the browser](https://mswjs.io/docs/integrations/browser).
+::: tip
+See more details on [using MSW in the browser](https://mswjs.io/docs/integrations/browser).
+:::
 
 ### Testing Component Communication
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I've noticed the docs using `msw/node` in component tests, which will throw. Replaces the recommendation to `msw/browser`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
