### PR TITLE
fix(typecheck): handle re-runs outside `tsc`

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -222,7 +222,11 @@ export function createPool(ctx: Vitest): ProcessPool {
     runTests: (files, invalidates) => executeTests('run', files, invalidates),
     collectTests: (files, invalidates) => executeTests('collect', files, invalidates),
     async close() {
-      await Promise.all([pool.close(), browserPool?.close?.()])
+      await Promise.all([
+        pool.close(),
+        browserPool?.close?.(),
+        ...ctx.projects.map(project => project.typechecker?.stop()),
+      ])
     },
   }
 }

--- a/packages/vitest/src/node/pools/workers/typecheckWorker.ts
+++ b/packages/vitest/src/node/pools/workers/typecheckWorker.ts
@@ -93,7 +93,6 @@ async function onMessage(message: WorkerRequest, project: TestProject): Promise<
 
     case 'stop': {
       await runPromise
-      await project.typechecker?.stop()
       return { type: 'stopped', __vitest_worker_response__ }
     }
   }
@@ -221,8 +220,9 @@ function createRunner(vitest: Vitest) {
 
     const files = specs.map(spec => spec.filepath)
     const promise = createDefer<void>()
+
     // check that watcher actually triggered rerun
-    const _p = new Promise<boolean>((resolve) => {
+    const triggered = await new Promise<boolean>((resolve) => {
       const _i = setInterval(() => {
         if (!project.typechecker || rerunTriggered.has(project)) {
           resolve(true)
@@ -234,15 +234,23 @@ function createRunner(vitest: Vitest) {
         clearInterval(_i)
       }, 500).unref()
     })
-    const triggered = await _p
+
+    // Re-run but wasn't triggered by tsc
+    if (promisesMap.has(project) && !triggered) {
+      return promisesMap.get(project)
+    }
+
     if (project.typechecker && !triggered) {
       const testFiles = project.typechecker.getTestFiles()
+
       for (const file of testFiles) {
         await vitest._testRun.enqueued(project, file)
       }
+
       await vitest._testRun.collected(project, testFiles)
       await onParseEnd(project, project.typechecker.getResult())
     }
+
     promises.push(promise)
     promisesMap.set(project, promise)
     promises.push(startTypechecker(project, files))


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Fixes https://github.com/vitest-dev/vitest/issues/8841

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
