### PR TITLE
fix: support iterables in toBeOneOf matcher (fix #8902)

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -379,19 +379,23 @@ test('getApplesCount has some unusual side effects...', () => {
 
 ## toBeOneOf
 
-- **Type:** `(sample: Array<any>) => any`
+- **Type:** `(sample: Array<any> | Iterable<any>) => any`
 
-`toBeOneOf` asserts if a value matches any of the values in the provided array.
+`toBeOneOf` asserts if a value matches any of the values in the provided array or iterable (Set, Map, etc.).
 
 ```ts
 import { expect, test } from 'vitest'
 
 test('fruit is one of the allowed values', () => {
-  expect(fruit).toBeOneOf(['apple', 'banana', 'orange'])
+  expect('apple').toBeOneOf(['apple', 'banana', 'orange'])
+
+  // Also works with Sets and other iterables
+  const allowedFruits = new Set(['apple', 'banana', 'orange'])
+  expect('apple').toBeOneOf(allowedFruits)
 })
 ```
 
-The asymmetric matcher is particularly useful when testing optional properties that could be either `null` or `undefined`:
+The asymmetric matcher is particularly useful when testing optional properties:
 
 ```ts
 test('optional properties can be null or undefined', () => {
@@ -408,10 +412,6 @@ test('optional properties can be null or undefined', () => {
   })
 })
 ```
-
-:::tip
-You can use `expect.not` with this matcher to ensure a value does NOT match any of the provided options.
-:::
 
 ## toBeTypeOf
 

--- a/packages/expect/src/custom-matchers.ts
+++ b/packages/expect/src/custom-matchers.ts
@@ -27,18 +27,26 @@ ${printReceived(actual)}`,
     }
   },
 
-  toBeOneOf(actual: unknown, expected: Array<unknown>) {
+  toBeOneOf(actual: unknown, expected: Array<unknown> | Iterable<unknown>) {
     const { equals, customTesters } = this
     const { printReceived, printExpected, matcherHint } = this.utils
 
-    if (!Array.isArray(expected)) {
+    const isArray = Array.isArray(expected)
+    const isString = typeof expected === 'string'
+    const isIterable = !isString
+      && expected != null
+      && typeof (expected as any)[Symbol.iterator] === 'function'
+
+    if (!isArray && !isIterable) {
       throw new TypeError(
-        `You must provide an array to ${matcherHint('.toBeOneOf')}, not '${typeof expected}'.`,
+        `You must provide an array or iterable to ${matcherHint('.toBeOneOf')}, not '${typeof expected}'.`,
       )
     }
 
-    const pass = expected.length === 0
-      || expected.some(item =>
+    const expectedArray = isArray ? expected : Array.from(expected as Iterable<unknown>)
+
+    const pass = expectedArray.length === 0
+      || expectedArray.some(item =>
         equals(item, actual, customTesters),
       )
 
@@ -47,20 +55,20 @@ ${printReceived(actual)}`,
       message: () =>
         pass
           ? `\
-${matcherHint('.not.toBeOneOf', 'received', '')}
-
-Expected value to not be one of:
-${printExpected(expected)}
-Received:
-${printReceived(actual)}`
+  ${matcherHint('.not.toBeOneOf', 'received', '')}
+  
+  Expected value to not be one of:
+  ${printExpected(expectedArray)}
+  Received:
+  ${printReceived(actual)}`
           : `\
-${matcherHint('.toBeOneOf', 'received', '')}
-
-Expected value to be one of:
-${printExpected(expected)}
-
-Received:
-${printReceived(actual)}`,
+  ${matcherHint('.toBeOneOf', 'received', '')}
+  
+  Expected value to be one of:
+  ${printExpected(expectedArray)}
+  
+  Received:
+  ${printReceived(actual)}`,
     }
   },
 }

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -129,14 +129,16 @@ interface CustomMatcher {
   toSatisfy: (matcher: (value: any) => boolean, message?: string) => any
 
   /**
-   * Matches if the received value is one of the values in the expected array.
+   * Matches if the received value is one of the values in the expected array or iterable.
    *
    * @example
    * expect(1).toBeOneOf([1, 2, 3])
    * expect('foo').toBeOneOf([expect.any(String)])
+   * expect('bar').toBeOneOf(new Set(['foo', 'bar', 'baz']))
+   * expect('id1').toBeOneOf(myMap.keys())
    * expect({ a: 1 }).toEqual({ a: expect.toBeOneOf(['1', '2', '3']) })
    */
-  toBeOneOf: <T>(sample: Array<T>) => any
+  toBeOneOf: <T>(sample: Array<T> | Iterable<T>) => any
 }
 
 export interface AsymmetricMatchersContaining extends CustomMatcher {

--- a/test/core/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/core/test/__snapshots__/jest-expect.test.ts.snap
@@ -711,17 +711,17 @@ exports[`toBeOneOf() > error message 1`] = `
   "actual": "undefined",
   "diff": undefined,
   "expected": "undefined",
-  "message": "expect(received).toBeOneOf()
-
-Expected value to be one of:
-Array [
+  "message": "  expect(received).toBeOneOf()
+  
+  Expected value to be one of:
+  Array [
   0,
   1,
   2,
 ]
-
-Received:
-3",
+  
+  Received:
+  3",
 }
 `;
 
@@ -730,15 +730,15 @@ exports[`toBeOneOf() > error message 2`] = `
   "actual": "undefined",
   "diff": undefined,
   "expected": "undefined",
-  "message": "expect(received).toBeOneOf()
-
-Expected value to be one of:
-Array [
+  "message": "  expect(received).toBeOneOf()
+  
+  Expected value to be one of:
+  Array [
   Any<String>,
 ]
-
-Received:
-3",
+  
+  Received:
+  3",
 }
 `;
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -676,6 +676,83 @@ describe('toBeOneOf()', () => {
     snapshotError(() => expect({ a: 0 }).toEqual(expect.toBeOneOf([expect.objectContaining({ b: 0 }), null, undefined])))
     snapshotError(() => expect({ name: 'mango' }).toEqual({ name: expect.toBeOneOf(['apple', 'banana', 'orange']) }))
   })
+
+  describe('with iterables', () => {
+    it('pass with Set', () => {
+      expect(0).toBeOneOf(new Set([0, 1, 2]))
+      expect('apple').toBeOneOf(new Set(['apple', 'banana', 'orange']))
+      expect(true).toBeOneOf(new Set([true, false]))
+      expect(null).toBeOneOf(new Set([null, undefined]))
+    })
+
+    it('pass with Set and null/undefined values', () => {
+      expect(3).not.toBeOneOf(new Set([0, 1, 2]))
+      expect('mango').not.toBeOneOf(new Set(['apple', 'banana', 'orange']))
+      expect(false).not.toBeOneOf(new Set([null, undefined]))
+    })
+
+    it('pass with Map keys', () => {
+      const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']])
+      expect(2).toBeOneOf(map.keys())
+      expect(4).not.toBeOneOf(map.keys())
+    })
+
+    it('pass with Map values', () => {
+      const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']])
+      expect('b').toBeOneOf(map.values())
+      expect('d').not.toBeOneOf(map.values())
+    })
+
+    it('pass with generator', () => {
+      function* generator() {
+        yield 1
+        yield 2
+        yield 3
+      }
+      expect(2).toBeOneOf(generator())
+      expect(5).not.toBeOneOf(generator())
+    })
+
+    it('pass with TypedArray', () => {
+      expect(2).toBeOneOf(new Uint8Array([1, 2, 3]))
+      expect(5).not.toBeOneOf(new Uint8Array([1, 2, 3]))
+    })
+
+    it('pass with custom iterable', () => {
+      const customIterable = {
+        * [Symbol.iterator]() {
+          yield 'a'
+          yield 'b'
+          yield 'c'
+        },
+      }
+      expect('b').toBeOneOf(customIterable)
+      expect('d').not.toBeOneOf(customIterable)
+    })
+
+    it.fails('fail with Set and missing negotiation', () => {
+      expect(3).toBeOneOf(new Set([0, 1, 2]))
+      expect('mango').toBeOneOf(new Set(['apple', 'banana', 'orange']))
+    })
+  })
+
+  it('reject invalid types', () => {
+    expect(() => expect('test').toBeOneOf('invalid' as any))
+      .toThrow('You must provide an array or iterable to')
+    expect(() => expect('test').toBeOneOf(123 as any))
+      .toThrow('You must provide an array or iterable to')
+    expect(() => expect('test').toBeOneOf({ a: 1 } as any))
+      .toThrow('You must provide an array or iterable to')
+    expect(() => expect('test').toBeOneOf(null as any))
+      .toThrow('You must provide an array or iterable to')
+    expect(() => expect('test').toBeOneOf(undefined as any))
+      .toThrow('You must provide an array or iterable to')
+  })
+
+  it('reject strings (even though they are technically iterable)', () => {
+    expect(() => expect('a').toBeOneOf('abc' as any))
+      .toThrow('You must provide an array or iterable to')
+  })
 })
 
 describe('toSatisfy()', () => {


### PR DESCRIPTION
### Description

Adds support for iterables (Set, Map, generators, etc.) to the `toBeOneOf` matcher, expanding beyond just arrays as requested.

Currently, `toBeOneOf` only accepts arrays. However, Sets and other iterables are common in JavaScript and forcing users to convert them to arrays (`[...mySet]`) is unnecessary.

Resolves  #8902.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
