### PR TITLE
docs: add Locator as a possible element type in `toContainElement()` matcher (fix #8910)

### DIFF
--- a/docs/guide/browser/assertion-api.md
+++ b/docs/guide/browser/assertion-api.md
@@ -324,7 +324,7 @@ await expect.element(page.getByText('Vitest')).toBeInViewport({ ratio: 1 })
 ## toContainElement
 
 ```ts
-function toContainElement(element: HTMLElement | SVGElement | null): Promise<void>
+function toContainElement(element: HTMLElement | SVGElement | Locator | null): Promise<void>
 ```
 
 This allows you to assert whether an element contains another element as a descendant or not.

--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -1,7 +1,7 @@
 // Disable automatic exports.
 
 import { ARIARole } from './aria-role.ts'
-import { ScreenshotComparatorRegistry, ScreenshotMatcherOptions } from './context.js'
+import { Locator, ScreenshotComparatorRegistry, ScreenshotMatcherOptions } from './context.js'
 
 export interface TestingLibraryMatchers<E, R> {
   /**
@@ -207,7 +207,7 @@ export interface TestingLibraryMatchers<E, R> {
    * await expect.element(ancestor).not.toContainElement(nonExistentElement)
    * @see https://vitest.dev/guide/browser/assertion-api#tocontainelement
    */
-  toContainElement(element: HTMLElement | SVGElement | null): R
+  toContainElement(element: HTMLElement | SVGElement | Locator | null): R
   /**
    * @description
    * Assert whether a string representing a HTML element is contained in another element.


### PR DESCRIPTION
### Description

As mentioned in #8910, actual implementation of `toContainElement()` matcher of accepts `Locator` for `element`, but TypeScript doesn't allow this, as well as it's not stated in the docs

Resolves #8910

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
