### PR TITLE
docs: fix server.debug property names

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -167,17 +167,17 @@ Inject inline source map to modules.
 
 #### server.debug
 
-- **Type:** `{ dumpModules?, loadDumppedModules? }`
+- **Type:** `{ dump?, load? }`
 
 Module runner debugger options.
 
-#### server.debug.dumpModules
+#### server.debug.dump
 
 - **Type:** `boolean | string`
 
 Dump the transformed module to filesystem. Passing a string will dump to the specified path.
 
-#### server.debug.loadDumppedModules
+#### server.debug.load
 
 - **Type:** `boolean`
 
@@ -214,7 +214,7 @@ If `true`, every dependency will be inlined. All dependencies, specified in [`ss
 - **Type** `boolean`
 - **Default:** `false`
 
-When a dependency is a valid ESM package, try to guess the cjs version based on the path. This might be helpful, if a dependency has the wrong ESM file.
+When a dependency is a valid ESM package, try to guess the CJS version based on the path. This might be helpful, if a dependency has the wrong ESM file.
 
 This might potentially cause some misalignment if a package has different logic in ESM and CJS mode.
 


### PR DESCRIPTION
### Description

The documentation contains wrong property names for the [`server.debug`](https://vitest.dev/config/#server-debug) object.

- `dumpModules` => `dump`
- `loadDumppedModules` => `load`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
