### PR TITLE
docs: minor improvements for "expect" documentation

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -188,7 +188,7 @@ Try not to use `toBe` with floating-point numbers. Since JavaScript rounds them,
 
 - **Type:** `(value: number, numDigits?: number) => Awaitable<void>`
 
-Use `toBeCloseTo` to compare floating-point numbers. The optional `numDigits` argument limits the number of digits to check _after_ the decimal point. For example:
+Use `toBeCloseTo` to compare floating-point numbers. The optional `numDigits` argument limits the number of digits to check _after_ the decimal point. The default for `numDigits` is 2. For example:
 
 ```ts
 import { expect, test } from 'vitest'
@@ -343,7 +343,7 @@ function apples() {
 }
 
 function bananas() {
-  return null
+  return undefined
 }
 
 test('we don\'t have apples', () => {
@@ -428,6 +428,17 @@ test('stock is type of string', () => {
   expect(actual).toBeTypeOf('string')
 })
 ```
+
+:::warning
+`toBeTypeOf` uses the native `typeof` operator under the hood with all its quirks, most notably that the value `null` has type `object`.
+
+```ts
+test('toBeTypeOf cannot check for null or array', () => {
+  expect(null).toBeTypeOf('object')
+  expect([]).toBeTypeOf('object')
+})
+```
+:::
 
 ## toBeInstanceOf
 
@@ -587,7 +598,13 @@ import { getAllFruits } from './stocks.js'
 
 test('the fruit list contains orange', () => {
   expect(getAllFruits()).toContain('orange')
+})
 
+test('pineapple contains apple', () => {
+  expect('pineapple').toContain('apple')
+})
+
+test('the element contains a class and is contained', () => {
   const element = document.querySelector('#el')
   // element has a class
   expect(element.classList).toContain('flex')
@@ -683,6 +700,9 @@ test('John Doe Invoice', () => {
 
   // Wrap your key in an array to avoid the key from being parsed as a deep reference
   expect(invoice).toHaveProperty(['P.O'], '12345')
+
+  // Deep equality of object property
+  expect(invoice).toHaveProperty('items[0]', { type: 'apples', quantity: 10 })
 })
 ```
 
@@ -1207,6 +1227,8 @@ test('spy function returns bananas on a last call', () => {
 
 You can call this assertion to check if a function has successfully returned a value with certain parameters on a certain call. Requires a spy function to be passed to `expect`.
 
+The count starts at 1. So, to check the second entry, you would write `.toHaveNthReturnedWith(2, ...)`.
+
 ```ts
 import { expect, test, vi } from 'vitest'
 
@@ -1315,6 +1337,8 @@ test('spy function resolves bananas on a last call', async () => {
 You can call this assertion to check if a function has successfully resolved a certain value on a specific invocation. Requires a spy function to be passed to `expect`.
 
 If the function returned a promise, but it was not resolved yet, this will fail.
+
+The count starts at 1. So, to check the second entry, you would write `.toHaveNthResolvedWith(2, ...)`.
 
 ```ts
 import { expect, test, vi } from 'vitest'

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -405,7 +405,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
   /**
    * Using exact equality with floating point numbers is a bad idea.
    * Rounding means that intuitive things fail.
-   * The default for `precision` is 2.
+   * The default for `numDigits` is 2.
    *
    * @example
    * expect(price).toBeCloseTo(9.99, 2);


### PR DESCRIPTION
### Description

A few minor improvements for the `expect.md` documentation page.

- `toBeCloseTo`: Mention default value of 2 for `numDigits` argument.
- `toBeNullable`: Change one `null` to `undefined` in example.
- `toBeTypeOf`: Add warning and example for `null` being an "object".
- `toContain`: Add example for substring matching. Separate example into multiple `test`s for readability.
- `toHaveProperty`: Add example for object deep equality.
- `toHaveNthReturnedWith` and `toHaveNthResolvedWith`: Add the same "Count starts at 1" sentence like in "toHaveBeenNthCalledWith".

Fixed one documentation typo in `packages/expect/src/types.ts` (argument name mismatch).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
