### PR TITLE
Improve Developer Experience

### DIFF
--- a/docs/.vitepress/components.d.ts
+++ b/docs/.vitepress/components.d.ts
@@ -17,6 +17,8 @@ declare module 'vue' {
     HomePage: typeof import('./components/HomePage.vue')['default']
     ListItem: typeof import('./components/ListItem.vue')['default']
     NonProjectOption: typeof import('./components/NonProjectOption.vue')['default']
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
     Version: typeof import('./components/Version.vue')['default']
   }
 }

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1846,6 +1846,50 @@ Path to custom tsconfig, relative to the project root.
 
 Minimum time in milliseconds it takes to spawn the typechecker.
 
+### ui
+
+- **Type:** `boolean | UIConfig`
+- **Default:** `false`
+- **CLI:** `--ui`
+
+Enable Vitest UI. When set to `true`, it's equivalent to `{ enabled: true }`.
+
+```ts
+export default defineConfig({
+  test: {
+    ui: true,
+    // or with configuration
+    ui: {
+      enabled: true,
+      screenshotsInReport: true,
+    },
+  },
+})
+```
+
+#### ui.enabled
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Enable Vitest UI.
+
+#### ui.screenshotsInReport
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Display screenshots in the test reports within Vitest UI. Screenshots must be captured using `page.screenshot()` in browser tests or by enabling [`browser.screenshotTestEnd`](/guide/browser/config#browser-screenshottestend).
+
+The screenshots are loaded from the [`browser.screenshotDirectory`](/guide/browser/config#browser-screenshotdirectory) and displayed in a carousel in the UI. Duplicate screenshot paths are automatically deduplicated.
+
+:::tip
+This works with:
+- Manual screenshots via `page.screenshot()`
+- Auto-captured screenshots via `browser.screenshotTestEnd`
+- Failure screenshots via `browser.screenshotFailures`
+:::
+
 ### slowTestThreshold<NonProjectOption />
 
 - **Type**: `number`

--- a/docs/guide/browser/config.md
+++ b/docs/guide/browser/config.md
@@ -87,6 +87,8 @@ List of available `browser` options:
 - [`browser.testerHtmlPath`](#browser-testerhtmlpath)
 - [`browser.screenshotDirectory`](#browser-screenshotdirectory)
 - [`browser.screenshotFailures`](#browser-screenshotfailures)
+- [`browser.screenshotTestEnd`](#browser-screenshottestend)
+- [`browser.cleanupScreenshots`](#browser-cleanupscreenshots)
 - [`browser.provider`](#browser-provider)
 
 Under the hood, Vitest transforms these instances into separate [test projects](/advanced/api/test-project) sharing a single Vite server for better caching performance.
@@ -246,6 +248,41 @@ Path to the screenshots directory relative to the `root`.
 - **Default:** `!browser.ui`
 
 Should Vitest take screenshots if the test fails.
+
+## browser.screenshotTestEnd
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Automatically capture screenshots at the end of every test. Screenshots are saved to the [`browser.screenshotDirectory`](#browser-screenshotdirectory) with an `-auto` suffix to distinguish them from manual screenshots.
+
+When combined with [`ui.screenshotsInReport`](/config/#ui-screenshotsinreport), these screenshots will appear in the Vitest UI test reports.
+
+:::tip
+This feature is useful for visual debugging and creating visual test reports. The screenshots are stored in `task.meta.screenshotPaths` and can be accessed by reporters.
+:::
+
+:::warning
+This option requires a browser provider that supports screenshots (Playwright or WebDriverIO). It is automatically disabled when using the `preview` provider.
+:::
+
+## browser.cleanupScreenshots
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Clean up old screenshots before running tests. This only deletes screenshots from the current browser instance to avoid conflicts when running multiple browser configurations.
+
+The cleanup applies to:
+- Manual screenshots (with numbered suffixes like `-1.png`, `-2.png`)
+- Auto-captured screenshots (with `-auto` suffix)
+- Failure screenshots (if using default paths)
+
+Screenshots are identified by the instance name suffix (e.g., `-chromium.png`, `-firefox.png`). If no instance name is configured, all screenshots in the directory will be cleaned up.
+
+:::tip
+Enable this option to prevent screenshot directories from accumulating files across test runs, especially useful in CI environments.
+:::
 
 ## browser.orchestratorScripts
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -39,6 +39,54 @@ export default defineConfig({
 
 You can check your coverage report in Vitest UI: see [Vitest UI Coverage](/guide/coverage#vitest-ui) for more details.
 
+## Screenshots in Reports
+
+Vitest UI can display screenshots captured during browser tests. To enable this feature:
+
+1. Enable screenshot capture in your tests using one of these methods:
+   - **Manual**: Call `page.screenshot()` in your tests
+   - **Automatic**: Enable [`browser.screenshotTestEnd`](/guide/browser/config#browser-screenshottestend)
+   - **On Failure**: Enable [`browser.screenshotFailures`](/guide/browser/config#browser-screenshotfailures)
+
+2. Enable screenshot display in the UI:
+
+```ts [vitest.config.ts]
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      screenshotTestEnd: true, // Auto-capture at end of every test
+    },
+    ui: {
+      enabled: true,
+      screenshotsInReport: true, // Display in UI
+    },
+  },
+})
+```
+
+Screenshots will appear in a carousel viewer in the test report, making it easy to visually verify test behavior. The UI automatically deduplicates screenshot paths, so if a test fails and captures both a failure screenshot and an end-of-test screenshot of the same view, it will only appear once.
+
+### Cleaning Up Screenshots
+
+To prevent screenshot directories from accumulating files across test runs, enable cleanup in your browser configuration:
+
+```ts [vitest.config.ts]
+export default defineConfig({
+  test: {
+    browser: {
+      cleanupScreenshots: true, // Clean before running tests
+    },
+    ui: {
+      enabled: true,
+      screenshotsInReport: true,
+    },
+  },
+})
+```
+
+The cleanup is instance-specific, so screenshots from other browser configurations (e.g., different viewports or browsers) won't be deleted.
+
 ::: warning
 If you still want to see how your tests are running in real time in the terminal, don't forget to add `default` reporter to `reporters` option: `['default', 'html']`.
 :::

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -301,7 +301,7 @@ export const page: BrowserPage = {
         }
       : options
 
-    return ensureAwaited(error => triggerCommand(
+    const screenshot = await ensureAwaited(error => triggerCommand(
       '__vitest_screenshot',
       [
         name,
@@ -314,6 +314,14 @@ export const page: BrowserPage = {
       ],
       error,
     ))
+
+    // Store screenshot path in array for UI display
+    if (screenshot && typeof screenshot === 'string') {
+      currentTest.meta.screenshotPaths ??= []
+      currentTest.meta.screenshotPaths.push(screenshot)
+    }
+
+    return screenshot
   },
   getByRole() {
     throw new Error(`Method "getByRole" is not supported by the "${provider}" provider.`)

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -291,8 +291,13 @@ export const page: BrowserPage = {
     screenshotIds[repeatCount] ??= {}
     screenshotIds[repeatCount][taskName] = number + 1
 
+    // Append instance name only when screenshotTestEnd is enabled (for multi-instance automatic screenshots)
+    const config = getBrowserState().config
+    const shouldAppendInstance = config.browser?.screenshotTestEnd && config.name
+    const baseName = `${taskName.replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-')}-${number}`
+    const instanceSuffix = shouldAppendInstance ? `-${config.name}` : ''
     const name
-      = options.path || `${taskName.replace(/[^a-z0-9]/gi, '-')}-${number}.png`
+      = options.path || `${baseName}${instanceSuffix}.png`
 
     const normalizedOptions = 'mask' in options
       ? {

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -74,6 +74,11 @@ export function createBrowserRunner(
       await super.onBeforeTryTask?.(...args)
       const trace = this.config.browser.trace
       const test = args[0]
+
+      // Clear screenshot paths array to prevent memory leak in long test runs
+      if (test.meta.screenshotPaths) {
+        test.meta.screenshotPaths = []
+      }
       if (trace === 'off') {
         return
       }

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -199,6 +199,14 @@ export function createBrowserRunner(
           if (!('filepath' in suite)) {
             return
           }
+
+          // Cleanup old screenshots if enabled
+          if (this.config.browser.cleanupScreenshots) {
+            await rpc().cleanupScreenshots(suite.filepath, this.config.name).catch((err) => {
+              console.warn('[vitest] Failed to cleanup screenshots:', err)
+            })
+          }
+
           const map = await rpc().getBrowserFileSourceMap(suite.filepath)
           this.sourceMapCache.set(suite.filepath, map)
           const snapshotEnvironment = this.config.snapshotOptions.snapshotEnvironment

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -108,7 +108,8 @@ export default (parentServer: ParentBrowserProject, base = '/'): Plugin[] => {
             }
 
             const task = parentServer.vitest.state.idMap.get(id)
-            const file = task?.meta.failScreenshotPath
+            // Check for both failScreenshotPath and screenshotPath
+            const file = task?.meta.failScreenshotPath || task?.meta.screenshotPath
             if (!file) {
               res.statusCode = 404
               res.end()

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -11,7 +11,7 @@ import { AutomockedModule, AutospiedModule, ManualMockedModule, RedirectedModule
 import { ServerMockResolver } from '@vitest/mocker/node'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
-import { dirname, join } from 'pathe'
+import { dirname, join, resolve, sep } from 'pathe'
 import { createDebugger, isFileServingAllowed, isValidApiRequest } from 'vitest/node'
 import { WebSocketServer } from 'ws'
 
@@ -372,6 +372,15 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
 
               if (shouldDelete) {
                 const filePath = join(screenshotDir, file)
+
+                // Security: Validate that the resolved path is still within screenshotDir
+                // This prevents path traversal attacks if the file variable could be malicious
+                const normalizedFilePath = resolve(filePath)
+                const normalizedScreenshotDir = resolve(screenshotDir)
+                if (!normalizedFilePath.startsWith(normalizedScreenshotDir + sep)) {
+                  continue // Skip files outside the screenshot directory
+                }
+
                 checkFileAccess(filePath)
                 rmSync(filePath, { force: true })
               }

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -57,6 +57,9 @@ export interface WebSocketBrowserHandlers {
   // cdp
   sendCdpEvent: (sessionId: string, event: string, payload?: Record<string, unknown>) => unknown
   trackCdpEvent: (sessionId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) => void
+
+  // screenshot cleanup
+  cleanupScreenshots: (testPath: string, instanceName: string | undefined) => Promise<void>
 }
 
 export type Awaitable<T> = T | PromiseLike<T>

--- a/packages/ui/client/components/ScreenshotCarousel.vue
+++ b/packages/ui/client/components/ScreenshotCarousel.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = defineProps<{
+  screenshotUrls: string[]
+  alt?: string
+}>()
+
+const showFullscreen = ref(false)
+const currentIndex = ref(0)
+
+// Extract filename from URL
+function getFilenameFromUrl(url: string): string {
+  try {
+    const urlObj = new URL(url, window.location.origin)
+    const path = urlObj.searchParams.get('path') || ''
+    return path.split('/').pop()?.split('\\').pop() || 'screenshot.png'
+  }
+  catch {
+    return 'screenshot.png'
+  }
+}
+
+// Extract short label from filename (e.g., "1", "2", "auto") for display in carousel thumbnails
+// Pattern: test-name-NUMBER-instance or test-name-auto-instance
+// The instance name is the last segment (or doesn't exist)
+// The label is the second-to-last segment (or last if no instance)
+function getShortLabel(filename: string): string {
+  // Remove .png extension
+  const nameWithoutExt = filename.replace(/\.png$/, '')
+
+  const parts = nameWithoutExt.split('-')
+
+  // Check if "auto" exists
+  const autoIndex = parts.lastIndexOf('auto')
+  if (autoIndex !== -1) {
+    return 'auto'
+  }
+
+  // Look for last number in the parts (should be before instance name)
+  // Start from the end and find the first number
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (/^\d+$/.test(parts[i])) {
+      return parts[i]
+    }
+  }
+
+  // Fallback to full filename
+  return filename
+}
+
+const filenames = computed(() => props.screenshotUrls.map(getFilenameFromUrl))
+const shortLabels = computed(() => filenames.value.map(getShortLabel))
+
+function openFullscreen(index: number) {
+  currentIndex.value = index
+  showFullscreen.value = true
+}
+
+function closeFullscreen() {
+  showFullscreen.value = false
+}
+
+function nextImage() {
+  if (currentIndex.value < props.screenshotUrls.length - 1) {
+    currentIndex.value++
+  }
+}
+
+function prevImage() {
+  if (currentIndex.value > 0) {
+    currentIndex.value--
+  }
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    closeFullscreen()
+  }
+  else if (event.key === 'ArrowRight') {
+    nextImage()
+  }
+  else if (event.key === 'ArrowLeft') {
+    prevImage()
+  }
+}
+</script>
+
+<template>
+  <div class="screenshot-carousel">
+    <!-- Thumbnails Grid -->
+    <div class="screenshot-grid">
+      <div
+        v-for="(url, index) in screenshotUrls"
+        :key="url"
+        class="screenshot-item"
+      >
+        <img
+          :src="url"
+          :alt="alt || `Test screenshot ${index + 1}`"
+          class="screenshot-thumbnail"
+          @click="openFullscreen(index)"
+        >
+        <div class="screenshot-filename">
+          {{ shortLabels[index] }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Fullscreen overlay -->
+    <div
+      v-if="showFullscreen"
+      class="screenshot-overlay"
+      tabindex="0"
+      @click="closeFullscreen"
+      @keydown="handleKeydown"
+    >
+      <!-- Navigation buttons -->
+      <button
+        v-if="currentIndex > 0"
+        class="screenshot-nav screenshot-nav-prev"
+        @click.stop="prevImage"
+      >
+        ‹
+      </button>
+
+      <img
+        :src="screenshotUrls[currentIndex]"
+        :alt="alt || `Test screenshot ${currentIndex + 1}`"
+        class="screenshot-fullscreen"
+        @click.stop
+      >
+
+      <button
+        v-if="currentIndex < screenshotUrls.length - 1"
+        class="screenshot-nav screenshot-nav-next"
+        @click.stop="nextImage"
+      >
+        ›
+      </button>
+
+      <!-- Counter with filename -->
+      <div class="screenshot-counter">
+        <div class="screenshot-counter-text">
+          {{ currentIndex + 1 }} / {{ screenshotUrls.length }}
+        </div>
+        <div class="screenshot-counter-filename">
+          {{ filenames[currentIndex] }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.screenshot-carousel {
+  margin: 0.5rem 0;
+}
+
+.screenshot-grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.screenshot-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.screenshot-thumbnail {
+  max-height: 200px;
+  max-width: 300px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+}
+
+.screenshot-thumbnail:hover {
+  opacity: 0.8;
+}
+
+.screenshot-filename {
+  font-size: 0.75rem;
+  color: rgba(128, 128, 128, 0.8);
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.screenshot-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  cursor: pointer;
+}
+
+.screenshot-overlay:focus {
+  outline: none;
+}
+
+.screenshot-fullscreen {
+  max-width: 90vw;
+  max-height: 90vh;
+  cursor: default;
+  border-radius: 4px;
+}
+
+.screenshot-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  font-size: 2.5rem;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+  padding-bottom: 0.15rem;
+}
+
+.screenshot-nav:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.screenshot-nav-prev {
+  left: 2rem;
+}
+
+.screenshot-nav-next {
+  right: 2rem;
+}
+
+.screenshot-counter {
+  position: absolute;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.screenshot-counter-text {
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+}
+
+.screenshot-counter-filename {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  max-width: 50vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/packages/ui/client/components/StatusBanner.vue
+++ b/packages/ui/client/components/StatusBanner.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import type { RunnerTask, RunnerTestFile } from 'vitest'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  task?: RunnerTask
+  file?: RunnerTestFile
+  message?: string
+  clickable?: boolean
+}>()
+
+const emit = defineEmits<{
+  click: []
+}>()
+
+const state = computed(() => {
+  const item = props.task || props.file
+  if (!item) {
+    return 'pass'
+  }
+
+  // Check if skipped
+  if (item.result?.state === 'skip' || item.mode === 'skip' || item.mode === 'todo') {
+    return 'skip'
+  }
+
+  // Check if running
+  if (item.result?.state === 'run') {
+    return 'run'
+  }
+
+  // Check if failed
+  if (item.result?.state === 'fail') {
+    return 'fail'
+  }
+
+  // Default to pass
+  return 'pass'
+})
+
+const statusClass = computed(() => {
+  switch (state.value) {
+    case 'fail': return 'status-banner-fail'
+    case 'run': return 'status-banner-run'
+    case 'skip': return 'status-banner-skip'
+    default: return 'status-banner-pass'
+  }
+})
+
+const defaultMessage = computed(() => {
+  if (props.message) {
+    return props.message
+  }
+
+  const isFile = !!props.file
+
+  switch (state.value) {
+    case 'fail':
+      return isFile ? 'Tests failed in this file' : 'Test failed'
+    case 'run':
+      return isFile ? 'Tests are running...' : 'Test is running...'
+    case 'skip':
+      return isFile ? 'All tests were skipped in this file' : 'Test was skipped'
+    default:
+      return isFile ? 'All tests passed in this file' : 'Test passed'
+  }
+})
+</script>
+
+<template>
+  <div
+    p="x4 y2"
+    m-2
+    rounded
+    text="sm"
+    :class="[statusClass, clickable ? 'status-banner-clickable' : '']"
+    @click="clickable ? emit('click') : undefined"
+  >
+    {{ defaultMessage }}
+  </div>
+</template>
+
+<style scoped>
+.status-banner-pass {
+  background: var(--status-pass-bg);
+  color: var(--status-pass-text);
+}
+
+.status-banner-fail {
+  background: var(--status-fail-bg);
+  color: var(--status-fail-text);
+}
+
+.status-banner-skip {
+  background: var(--status-skip-bg);
+  color: var(--status-skip-text);
+}
+
+.status-banner-run {
+  background: var(--status-run-bg);
+  color: var(--status-run-text);
+}
+
+.status-banner-clickable {
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.status-banner-clickable:hover {
+  opacity: 0.8;
+}
+</style>

--- a/packages/ui/client/components/StatusIcon.vue
+++ b/packages/ui/client/components/StatusIcon.vue
@@ -38,7 +38,8 @@ defineProps<{
   <div
     v-else-if="mode === 'skip' || state === 'skip'"
     v-tooltip.right="'Skipped'"
-    text-gray-500
+    text-purple-500
+    op-50
     flex-shrink-0
     i-carbon:redo
     rotate-90

--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -132,18 +132,18 @@ useResizeObserver(() => testExplorerRef.value, ([{ contentRect }]) => {
       <DetailsPanel>
         <template v-if="initialized" #summary>
           <div grid="~ items-center gap-x-1 cols-[auto_min-content_auto] rows-[min-content_min-content]">
-            <span text-red5>
+            <span :style="{ color: 'var(--status-fail-text)' }">
               FAIL ({{ testsTotal.failed }})
             </span>
             <span>/</span>
-            <span text-yellow5>
+            <span :style="{ color: 'var(--status-run-text)' }">
               RUNNING ({{ testsTotal.running }})
             </span>
-            <span text-green5>
+            <span :style="{ color: 'var(--status-pass-text)' }">
               PASS ({{ testsTotal.success }})
             </span>
             <span>/</span>
-            <span class="text-purple5:50">
+            <span :style="{ color: 'var(--status-skip-text)' }">
               SKIP ({{ filter.onlyTests ? testsTotal.skipped : '--' }})
             </span>
           </div>

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -4,9 +4,10 @@ import { computed } from 'vue'
 import { browserState, config } from '~/composables/client'
 import { isDark } from '~/composables/dark'
 import { mapLeveledTaskStacks } from '~/composables/error'
-import { openScreenshot, useScreenshot } from '~/composables/screenshot'
-import IconButton from '../IconButton.vue'
+import { activeFileId, selectedTest } from '~/composables/params'
+import { getScreenshotUrls, hasScreenshot, useScreenshot } from '~/composables/screenshot'
 import Modal from '../Modal.vue'
+import ScreenshotCarousel from '../ScreenshotCarousel.vue'
 import StatusBanner from '../StatusBanner.vue'
 import ScreenshotError from './ScreenshotError.vue'
 import ViewReportError from './ViewReportError.vue'
@@ -28,10 +29,21 @@ function collectFailed(task: RunnerTask, level: number): LeveledTask[] {
     return [{ ...task, level }]
   }
   else {
-    return [
-      { ...task, level },
-      ...task.tasks.flatMap(t => collectFailed(t, level + 1)),
-    ]
+    // For suites/describes, only collect child test failures, not the suite itself
+    return task.tasks.flatMap(t => collectFailed(t, level))
+  }
+}
+
+function collectPassed(task: RunnerTask, level: number): LeveledTask[] {
+  if (task.result?.state !== 'pass') {
+    return []
+  }
+
+  if (task.type === 'test') {
+    return [{ ...task, level }]
+  }
+  else {
+    return task.tasks.flatMap(t => collectPassed(t, level + 1))
   }
 }
 
@@ -61,22 +73,56 @@ const failed = computed(() => {
     : failedFlatMap
 })
 
+const passed = computed(() => {
+  const file = props.file
+  return file.tasks?.flatMap(t => collectPassed(t, 0)) ?? []
+})
+
 const {
   currentTask,
   showScreenshot,
   showScreenshotModal,
   currentScreenshotUrl,
 } = useScreenshot()
+
+function navigateToTest(task: RunnerTask) {
+  activeFileId.value = task.file.id
+  selectedTest.value = task.id
+}
+
+function getFullTestName(task: RunnerTask): string {
+  const names: string[] = []
+  let current: RunnerTask | undefined = task
+
+  while (current) {
+    if (current.type !== 'file') {
+      names.unshift(current.name)
+    }
+    current = current.suite
+  }
+
+  return names.join(' > ')
+}
 </script>
 
 <template>
   <div h-full class="scrolls">
     <template v-if="failed.length">
-      <div v-for="task of failed" :id="task.id" :key="task.id">
+      <div v-for="task of failed" :id="task.id" :key="task.id" class="test-card">
+        <h3 class="test-name" @click="navigateToTest(task)">
+          {{ getFullTestName(task) }}
+        </h3>
         <StatusBanner :task="task" />
+        <!-- Display screenshot when screenshotsInReport is enabled -->
+        <div v-if="config.ui.screenshotsInReport && hasScreenshot(task)" p="x3 y2" m-2>
+          <ScreenshotCarousel
+            :screenshot-urls="getScreenshotUrls(task)"
+            :alt="`Screenshot for ${task.name}`"
+          />
+        </div>
+        <!-- Only show error container if there are actual errors -->
         <div
-          bg="red-500/10"
-          text="red-500 sm"
+          v-if="task.result?.htmlError || task.result?.errors?.length"
           p="x3 y2"
           m-2
           rounded
@@ -127,6 +173,21 @@ const {
     </template>
     <template v-else>
       <StatusBanner :file="file" />
+      <!-- Display screenshots for passed tests when screenshotsInReport is enabled -->
+      <template v-if="config.ui.screenshotsInReport && passed.length">
+        <div v-for="task of passed" :id="task.id" :key="task.id" class="test-card">
+          <h3 class="test-name" @click="navigateToTest(task)">
+            {{ getFullTestName(task) }}
+          </h3>
+          <StatusBanner :task="task" />
+          <div v-if="hasScreenshot(task)" p="x3 y2" m-2>
+            <ScreenshotCarousel
+              :screenshot-urls="getScreenshotUrls(task)"
+              :alt="`Screenshot for ${task.name}`"
+            />
+          </div>
+        </div>
+      </template>
     </template>
     <template v-if="browserState">
       <Modal v-model="showScreenshot" direction="right">
@@ -146,6 +207,30 @@ const {
 </template>
 
 <style scoped>
+.test-card {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.1);
+}
+
+.test-card:last-child {
+  border-bottom: none;
+}
+
+.test-name {
+  margin: 0.5rem 0.5rem 0 0.5rem;
+  padding: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+  color: var(--color-text);
+}
+
+.test-name:hover {
+  opacity: 0.7;
+}
+
 .task-error {
   --cm-ttc-c-thumb: #ccc;
 }

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -7,6 +7,7 @@ import { mapLeveledTaskStacks } from '~/composables/error'
 import { openScreenshot, useScreenshot } from '~/composables/screenshot'
 import IconButton from '../IconButton.vue'
 import Modal from '../Modal.vue'
+import StatusBanner from '../StatusBanner.vue'
 import ScreenshotError from './ScreenshotError.vue'
 import ViewReportError from './ViewReportError.vue'
 
@@ -72,6 +73,7 @@ const {
   <div h-full class="scrolls">
     <template v-if="failed.length">
       <div v-for="task of failed" :id="task.id" :key="task.id">
+        <StatusBanner :task="task" />
         <div
           bg="red-500/10"
           text="red-500 sm"
@@ -124,9 +126,7 @@ const {
       </div>
     </template>
     <template v-else>
-      <div bg="green-500/10" text="green-500 sm" p="x4 y2" m-2 rounded>
-        All tests passed in this file
-      </div>
+      <StatusBanner :file="file" />
     </template>
     <template v-if="browserState">
       <Modal v-model="showScreenshot" direction="right">

--- a/packages/ui/client/components/views/ViewTestReport.vue
+++ b/packages/ui/client/components/views/ViewTestReport.vue
@@ -8,10 +8,11 @@ import { browserState, config } from '~/composables/client'
 import { showAnnotationSource } from '~/composables/codemirror'
 import { isDark } from '~/composables/dark'
 import { mapLeveledTaskStacks } from '~/composables/error'
-import { openScreenshot, useScreenshot } from '~/composables/screenshot'
+import { getScreenshotUrls, hasScreenshot, openScreenshot, useScreenshot } from '~/composables/screenshot'
 import AnnotationAttachmentImage from '../AnnotationAttachmentImage.vue'
 import IconButton from '../IconButton.vue'
 import Modal from '../Modal.vue'
+import ScreenshotCarousel from '../ScreenshotCarousel.vue'
 import StatusBanner from '../StatusBanner.vue'
 import ScreenshotError from './ScreenshotError.vue'
 import ViewReportError from './ViewReportError.vue'
@@ -47,6 +48,7 @@ const kWellKnownMeta = new Set([
   'benchmark',
   'typecheck',
   'failScreenshotPath',
+  'screenshotPaths',
 ])
 const meta = computed(() => {
   return Object.entries(props.test.meta).filter(([name]) => {
@@ -59,6 +61,13 @@ const meta = computed(() => {
   <div h-full class="scrolls">
     <div v-if="failed">
       <StatusBanner :task="test" />
+      <!-- Display screenshot when screenshotsInReport is enabled -->
+      <div v-if="config.ui.screenshotsInReport && hasScreenshot(test)" p="x3 y2" m-2>
+        <ScreenshotCarousel
+          :screenshot-urls="getScreenshotUrls(test)"
+          :alt="`Screenshot for ${test.name}`"
+        />
+      </div>
       <div
         bg="red-500/10"
         text="red-500 sm"
@@ -105,6 +114,13 @@ const meta = computed(() => {
     </div>
     <template v-else>
       <StatusBanner :task="test" />
+      <!-- Display screenshot for passed test when screenshotsInReport is enabled -->
+      <div v-if="config.ui.screenshotsInReport && hasScreenshot(test)" p="x3 y2" m-2>
+        <ScreenshotCarousel
+          :screenshot-urls="getScreenshotUrls(test)"
+          :alt="`Screenshot for ${test.name}`"
+        />
+      </div>
     </template>
     <template v-if="test.annotations.length">
       <h1 m-2>

--- a/packages/ui/client/components/views/ViewTestReport.vue
+++ b/packages/ui/client/components/views/ViewTestReport.vue
@@ -12,6 +12,7 @@ import { openScreenshot, useScreenshot } from '~/composables/screenshot'
 import AnnotationAttachmentImage from '../AnnotationAttachmentImage.vue'
 import IconButton from '../IconButton.vue'
 import Modal from '../Modal.vue'
+import StatusBanner from '../StatusBanner.vue'
 import ScreenshotError from './ScreenshotError.vue'
 import ViewReportError from './ViewReportError.vue'
 
@@ -57,6 +58,7 @@ const meta = computed(() => {
 <template>
   <div h-full class="scrolls">
     <div v-if="failed">
+      <StatusBanner :task="test" />
       <div
         bg="red-500/10"
         text="red-500 sm"
@@ -102,9 +104,7 @@ const meta = computed(() => {
       </div>
     </div>
     <template v-else>
-      <div bg="green-500/10" text="green-500 sm" p="x4 y2" m-2 rounded>
-        All tests passed in this file
-      </div>
+      <StatusBanner :task="test" />
     </template>
     <template v-if="test.annotations.length">
       <h1 m-2>

--- a/packages/ui/client/composables/screenshot.ts
+++ b/packages/ui/client/composables/screenshot.ts
@@ -1,8 +1,55 @@
 import type { RunnerTask } from 'vitest'
 import { computed, ref } from 'vue'
 
+export function hasScreenshot(task: RunnerTask): boolean {
+  const hasArray = task.meta?.screenshotPaths && Array.isArray(task.meta.screenshotPaths) && task.meta.screenshotPaths.length > 0
+  const hasSingle = !!task.meta?.failScreenshotPath
+  return hasArray || hasSingle
+}
+
+export function getScreenshotUrls(task: RunnerTask): string[] {
+  const pathSet = new Set<string>()
+
+  // Add screenshots from array (manual + auto)
+  if (task.meta?.screenshotPaths && Array.isArray(task.meta.screenshotPaths)) {
+    task.meta.screenshotPaths.forEach((path) => {
+      if (path) {
+        pathSet.add(path)
+      }
+    })
+  }
+
+  // Add failure screenshot if present (deduplicate with Set)
+  if (task.meta?.failScreenshotPath) {
+    pathSet.add(task.meta.failScreenshotPath)
+  }
+
+  // Sort paths: auto screenshots first, then manual screenshots by number
+  const sortedPaths = Array.from(pathSet).sort((a, b) => {
+    const aIsAuto = a.includes('-auto-') || a.includes('-auto.')
+    const bIsAuto = b.includes('-auto-') || b.includes('-auto.')
+
+    // Auto screenshots come first
+    if (aIsAuto && !bIsAuto) {
+      return -1
+    }
+    if (!aIsAuto && bIsAuto) {
+      return 1
+    }
+
+    // Both auto or both manual: sort alphabetically (which sorts numbers correctly)
+    return a.localeCompare(b)
+  })
+
+  // Convert unique paths to URLs
+  return sortedPaths.map(path =>
+    `/__vitest_attachment__?path=${encodeURIComponent(path)}&contentType=image/png&token=${(window as any).VITEST_API_TOKEN}`,
+  )
+}
+
 export function openScreenshot(task: RunnerTask) {
   const filePath = task.meta?.failScreenshotPath
+    || (task.meta?.screenshotPaths && task.meta.screenshotPaths[0])
   if (filePath) {
     fetch(`/__open-in-editor?file=${encodeURIComponent(filePath)}`)
   }
@@ -13,11 +60,18 @@ export function useScreenshot() {
   const timestamp = ref(Date.now())
   const currentTask = ref<RunnerTask | undefined>()
   const currentScreenshotUrl = computed(() => {
-    const id = currentTask.value?.id
-    // force refresh
+    const task = currentTask.value
+    if (!task) {
+      return undefined
+    }
+    const screenshotPath = task.meta?.failScreenshotPath
+      || (task.meta?.screenshotPaths && task.meta.screenshotPaths[0])
+    if (!screenshotPath) {
+      return undefined
+    }
+    // force refresh with timestamp
     const t = timestamp.value
-    // browser plugin using /, change this if base can be modified
-    return id ? `/__screenshot-error?id=${encodeURIComponent(id)}&t=${t}` : undefined
+    return `/__vitest_attachment__?path=${encodeURIComponent(screenshotPath)}&contentType=image/png&token=${(window as any).VITEST_API_TOKEN}&t=${t}`
   })
 
   function showScreenshotModal(task: RunnerTask) {

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -10,6 +10,16 @@ body {
   --color-text-dark: #ddd;
   --color-text: var(--color-text-light);
   --background-color: #e4e4e4;
+
+  /* Test status colors */
+  --status-pass-bg: rgba(34, 197, 94, 0.1);
+  --status-pass-text: rgb(34, 197, 94);
+  --status-fail-bg: rgba(239, 68, 68, 0.1);
+  --status-fail-text: rgb(239, 68, 68);
+  --status-skip-bg: rgba(168, 85, 247, 0.1);
+  --status-skip-text: rgba(168, 85, 247, 0.5);
+  --status-run-bg: rgba(234, 179, 8, 0.1);
+  --status-run-text: rgb(234, 179, 8);
 }
 
 html.dark {

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -761,6 +761,22 @@ export function resolveConfig(
   else {
     resolved.browser.screenshotFailures ??= !isPreview && !resolved.browser.ui
   }
+
+  // Set default for screenshotTestEnd
+  if (isPreview && resolved.browser.screenshotTestEnd === true) {
+    console.warn(c.yellow(
+      [
+        `Browser provider "preview" doesn't support screenshots, `,
+        `so "browser.screenshotTestEnd" option is forcefully disabled. `,
+        `Set "browser.screenshotTestEnd" to false or remove it from the config to suppress this warning.`,
+      ].join(''),
+    ))
+    resolved.browser.screenshotTestEnd = false
+  }
+  else {
+    resolved.browser.screenshotTestEnd ??= false
+  }
+
   if (resolved.browser.provider && resolved.browser.provider.options == null) {
     resolved.browser.provider.options = {}
   }

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -777,6 +777,9 @@ export function resolveConfig(
     resolved.browser.screenshotTestEnd ??= false
   }
 
+  // Set default for cleanupScreenshots
+  resolved.browser.cleanupScreenshots ??= false
+
   if (resolved.browser.provider && resolved.browser.provider.options == null) {
     resolved.browser.provider.options = {}
   }

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -60,7 +60,8 @@ export function resolveApiServerConfig<Options extends ApiConfig & Omit<UserConf
 ): ApiConfig | undefined {
   let api: ApiConfig | undefined
 
-  if (options.ui && !options.api) {
+  const uiEnabled = options.ui === true || (typeof options.ui === 'object' && options.ui.enabled === true)
+  if (uiEnabled && !options.api) {
     api = { port: defaultPort }
   }
   else if (options.api === true) {
@@ -537,6 +538,29 @@ export function resolveConfig(
   const api = resolveApiServerConfig(options, defaultPort)
   resolved.api = { ...api, token: __VITEST_GENERATE_UI_TOKEN__ ? crypto.randomUUID() : '0' }
 
+  // normalize ui config
+  if (typeof options.ui === 'boolean') {
+    resolved.ui = {
+      enabled: options.ui,
+      screenshotsInReport: false,
+      cleanupScreenshots: false,
+    }
+  }
+  else if (typeof options.ui === 'object') {
+    resolved.ui = {
+      enabled: options.ui.enabled ?? false,
+      screenshotsInReport: options.ui.screenshotsInReport ?? false,
+      cleanupScreenshots: options.ui.cleanupScreenshots ?? false,
+    }
+  }
+  else {
+    resolved.ui = {
+      enabled: false,
+      screenshotsInReport: false,
+      cleanupScreenshots: false,
+    }
+  }
+
   if (options.related) {
     resolved.related = toArray(options.related).map(file =>
       resolve(resolved.root, file),
@@ -754,7 +778,7 @@ export function resolveConfig(
       resolved.includeTaskLocation ??= true
     }
   }
-  else if (resolved.ui) {
+  else if (resolved.ui.enabled) {
     resolved.includeTaskLocation ??= true
   }
 

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -108,6 +108,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
         ui: browser.ui,
         viewport: browser.viewport,
         screenshotFailures: browser.screenshotFailures,
+        screenshotTestEnd: browser.screenshotTestEnd,
         locators: {
           testIdAttribute: browser.locators.testIdAttribute,
         },

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -109,6 +109,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
         viewport: browser.viewport,
         screenshotFailures: browser.screenshotFailures,
         screenshotTestEnd: browser.screenshotTestEnd,
+        cleanupScreenshots: browser.cleanupScreenshots,
         locators: {
           testIdAttribute: browser.locators.testIdAttribute,
         },

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -120,6 +120,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
         trace: browser.trace.mode,
       }
     })(config.browser),
+    ui: config.ui,
     standalone: config.standalone,
     printConsoleTrace:
       config.printConsoleTrace ?? globalConfig.printConsoleTrace,

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -205,7 +205,7 @@ export class Logger {
       this.log(PAD + c.gray(`Running tests with seed "${this.ctx.config.sequence.seed}"`))
     }
 
-    if (this.ctx.config.ui) {
+    if (this.ctx.config.ui === true || (typeof this.ctx.config.ui === 'object' && this.ctx.config.ui.enabled === true)) {
       const host = this.ctx.config.api?.host || 'localhost'
       const port = this.ctx.vite.config.server.port
       const base = this.ctx.config.uiBase

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -240,6 +240,13 @@ export interface BrowserConfigOptions {
   screenshotFailures?: boolean
 
   /**
+   * Automatically capture screenshots at the end of each test
+   * Requires browser mode to be enabled
+   * @default false
+   */
+  screenshotTestEnd?: boolean
+
+  /**
    * Path to the index.html file that will be used to run tests.
    */
   testerHtmlPath?: string

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -247,6 +247,14 @@ export interface BrowserConfigOptions {
   screenshotTestEnd?: boolean
 
   /**
+   * Clean up old screenshots before running tests
+   * Only deletes screenshots from the current browser instance to avoid conflicts
+   * Applies to both default __screenshots__ directory and custom screenshotDirectory
+   * @default false
+   */
+  cleanupScreenshots?: boolean
+
+  /**
    * Path to the index.html file that will be used to run tests.
    */
   testerHtmlPath?: string

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -46,6 +46,33 @@ export type ApiConfig = Pick<
   'port' | 'strictPort' | 'host' | 'middlewareMode'
 >
 
+export interface UIConfig {
+  /**
+   * Enable Vitest UI
+   *
+   * @default false
+   */
+  enabled?: boolean
+
+  /**
+   * Display screenshots in the test report
+   * Screenshots must be captured using page.screenshot() in browser tests
+   * and will be loaded from the __screenshots__ directory
+   *
+   * @default false
+   */
+  screenshotsInReport?: boolean
+
+  /**
+   * Clean up old screenshots before running tests
+   * Only deletes screenshots from the current browser instance to avoid conflicts
+   * Applies to both default __screenshots__ directory and custom screenshotDirectory
+   *
+   * @default false
+   */
+  cleanupScreenshots?: boolean
+}
+
 export interface EnvironmentOptions {
   /**
    * jsdom options.
@@ -515,10 +542,11 @@ export interface InlineConfig {
 
   /**
    * Enable Vitest UI
+   * Can be a boolean to enable/disable, or an object with UI configuration options
    *
    * @default false
    */
-  ui?: boolean
+  ui?: boolean | UIConfig
 
   /**
    * options for test in a browser environment
@@ -1014,6 +1042,7 @@ export interface ResolvedConfig
   defines: Record<string, any>
 
   api: ApiConfig & { token: string }
+  ui: boolean | UIConfig
   cliExclude?: string[]
 
   project: string[]

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -112,6 +112,7 @@ export interface SerializedConfig {
   }
   ui: {
     enabled: boolean
+    screenshotsInReport: boolean
   }
   standalone: boolean
   logHeapUsage: boolean | undefined

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -110,6 +110,9 @@ export interface SerializedConfig {
     trace: BrowserTraceViewMode
     trackUnhandledErrors: boolean
   }
+  ui: {
+    enabled: boolean
+  }
   standalone: boolean
   logHeapUsage: boolean | undefined
   coverage: SerializedCoverageConfig

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -103,6 +103,7 @@ export interface SerializedConfig {
       testIdAttribute: string
     }
     screenshotFailures: boolean
+    screenshotTestEnd: boolean
     providerOptions: {
       // for playwright
       actionTimeout?: number

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -104,6 +104,7 @@ export interface SerializedConfig {
     }
     screenshotFailures: boolean
     screenshotTestEnd: boolean
+    cleanupScreenshots: boolean
     providerOptions: {
       // for playwright
       actionTimeout?: number

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -109,6 +109,7 @@ declare module '@vitest/runner' {
     typecheck?: boolean
     benchmark?: boolean
     failScreenshotPath?: string
+    screenshotPaths?: string[]
   }
 
   interface File {

--- a/test/browser/test/screenshot-array.test.ts
+++ b/test/browser/test/screenshot-array.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest'
+import { page } from 'vitest/browser'
+
+describe('screenshot array storage', () => {
+  test('screenshotPaths array is cleared on retry', { retry: 1 }, async ({ task }) => {
+    // This test verifies that the screenshotPaths array is cleared before each
+    // retry attempt to prevent memory leaks in long test runs with retries
+
+    // Use Vitest's built-in retryCount property to track attempts
+    const retryCount = task.result?.retryCount || 0
+
+    if (retryCount === 0) {
+      // First attempt: verify array starts empty
+      expect(task.meta.screenshotPaths).toBeUndefined()
+
+      // Take a screenshot
+      const screenshot = await page.screenshot()
+      expect(screenshot).toBeTruthy()
+      expect(task.meta.screenshotPaths!.length).toBe(1)
+
+      // Force retry by throwing error
+      throw new Error('Intentional error to trigger retry')
+    }
+    else {
+      // Second attempt: THIS is where we verify the array was cleared
+      // The onBeforeTryTask hook should have cleared the array
+      const initialLength = task.meta.screenshotPaths?.length || 0
+      expect(initialLength).toBe(0) // Array should be cleared!
+
+      // Take a new screenshot in the retry
+      const screenshot = await page.screenshot()
+      expect(screenshot).toBeTruthy()
+
+      // Should only have 1 screenshot from THIS attempt, not 2 total
+      expect(task.meta.screenshotPaths!.length).toBe(1)
+    }
+  })
+
+  test('manual screenshots should appear in screenshotPaths array', async ({ task }) => {
+    // Verify array starts fresh
+    const initialLength = task.meta.screenshotPaths?.length || 0
+
+    // Take multiple manual screenshots
+    const screenshot1 = await page.screenshot()
+    const screenshot2 = await page.screenshot()
+
+    // Verify screenshots were taken and are different
+    expect(screenshot1).toBeTruthy()
+    expect(screenshot2).toBeTruthy()
+    expect(screenshot1).not.toBe(screenshot2)
+
+    // Verify they're stored in the array
+    expect(task.meta.screenshotPaths).toBeDefined()
+    expect(Array.isArray(task.meta.screenshotPaths)).toBe(true)
+    expect(task.meta.screenshotPaths!.length).toBe(initialLength + 2)
+    expect(task.meta.screenshotPaths).toContain(screenshot1)
+    expect(task.meta.screenshotPaths).toContain(screenshot2)
+  })
+
+  test('deduplication removes duplicate screenshot paths', async ({ task }) => {
+    // Take a screenshot
+    const screenshot = await page.screenshot()
+    expect(screenshot).toBeTruthy()
+
+    // Manually add the same screenshot path again to simulate a duplicate
+    // (This can happen when both screenshotFailures and screenshotTestEnd are enabled)
+    task.meta.screenshotPaths!.push(screenshot as string)
+
+    // Now the array should have duplicates
+    expect(task.meta.screenshotPaths!.length).toBe(2)
+    expect(task.meta.screenshotPaths![0]).toBe(task.meta.screenshotPaths![1])
+
+    // Use Set to deduplicate (same logic as UI layer)
+    const uniquePaths = [...new Set(task.meta.screenshotPaths)]
+
+    // After deduplication, should only have 1 unique path
+    expect(uniquePaths.length).toBe(1)
+    expect(uniquePaths[0]).toBe(screenshot)
+  })
+
+  test('multiple manual screenshots maintain correct order', async ({ task }) => {
+    // Take 3 screenshots in sequence
+    const screenshot1 = await page.screenshot()
+    const screenshot2 = await page.screenshot()
+    const screenshot3 = await page.screenshot()
+
+    // Verify all are different
+    expect(screenshot1).not.toBe(screenshot2)
+    expect(screenshot2).not.toBe(screenshot3)
+    expect(screenshot1).not.toBe(screenshot3)
+
+    // Verify they're in the array in order
+    expect(task.meta.screenshotPaths!.length).toBe(3)
+    expect(task.meta.screenshotPaths![0]).toBe(screenshot1)
+    expect(task.meta.screenshotPaths![1]).toBe(screenshot2)
+    expect(task.meta.screenshotPaths![2]).toBe(screenshot3)
+  })
+
+  test('screenshotPaths array is initialized when taking first screenshot', async ({ task }) => {
+    // Before taking any screenshot, array might not exist or be undefined
+    // Take a screenshot
+    await page.screenshot()
+
+    // Now array should be initialized and have one entry
+    expect(task.meta.screenshotPaths).toBeDefined()
+    expect(Array.isArray(task.meta.screenshotPaths)).toBe(true)
+    expect(task.meta.screenshotPaths!.length).toBeGreaterThan(0)
+  })
+})

--- a/test/browser/test/screenshot-cleanup.test.ts
+++ b/test/browser/test/screenshot-cleanup.test.ts
@@ -1,0 +1,192 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'pathe'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+describe('screenshot cleanup', { timeout: 30000 }, () => {
+  const testDir = join(import.meta.dirname, '__test-screenshots__')
+  const screenshotsDir = join(testDir, '__screenshots__', 'test.spec.ts')
+
+  beforeEach(() => {
+    // Create test directory structure
+    mkdirSync(screenshotsDir, { recursive: true })
+  })
+
+  test('cleanup removes instance-specific screenshots only', async () => {
+    // Simulate a scenario where we have screenshots from multiple instances
+    const mobileScreenshot1 = join(screenshotsDir, 'test-name-1-mobile.png')
+    const mobileScreenshot2 = join(screenshotsDir, 'test-name-2-mobile.png')
+    const mobileAuto = join(screenshotsDir, 'test-name-auto-mobile.png')
+    const desktopScreenshot1 = join(screenshotsDir, 'test-name-1-desktop.png')
+    const desktopAuto = join(screenshotsDir, 'test-name-auto-desktop.png')
+
+    // Create fake screenshot files
+    writeFileSync(mobileScreenshot1, 'mobile1')
+    writeFileSync(mobileScreenshot2, 'mobile2')
+    writeFileSync(mobileAuto, 'mobile-auto')
+    writeFileSync(desktopScreenshot1, 'desktop1')
+    writeFileSync(desktopAuto, 'desktop-auto')
+
+    // All files should exist
+    expect(existsSync(mobileScreenshot1)).toBe(true)
+    expect(existsSync(mobileScreenshot2)).toBe(true)
+    expect(existsSync(mobileAuto)).toBe(true)
+    expect(existsSync(desktopScreenshot1)).toBe(true)
+    expect(existsSync(desktopAuto)).toBe(true)
+
+    // Import the cleanup logic (this would be called via RPC in real usage)
+    // For now, we're testing the cleanup pattern logic
+    const instanceName = 'mobile'
+    const patterns = [`-${instanceName}.png`, `-auto-${instanceName}.png`]
+
+    // Simulate cleanup: remove files matching patterns
+    const { readdirSync, rmSync } = await import('node:fs')
+    const files = readdirSync(screenshotsDir)
+    for (const file of files) {
+      const shouldDelete = patterns.some(pattern => file.includes(pattern))
+      if (shouldDelete) {
+        rmSync(join(screenshotsDir, file), { force: true })
+      }
+    }
+
+    // Mobile screenshots should be deleted
+    expect(existsSync(mobileScreenshot1)).toBe(false)
+    expect(existsSync(mobileScreenshot2)).toBe(false)
+    expect(existsSync(mobileAuto)).toBe(false)
+
+    // Desktop screenshots should still exist
+    expect(existsSync(desktopScreenshot1)).toBe(true)
+    expect(existsSync(desktopAuto)).toBe(true)
+  })
+
+  test('cleanup with no instance name removes all screenshots', async () => {
+    const screenshot1 = join(screenshotsDir, 'test-name-1.png')
+    const screenshot2 = join(screenshotsDir, 'test-name-2.png')
+    const autoScreenshot = join(screenshotsDir, 'test-name-auto.png')
+
+    writeFileSync(screenshot1, 'test1')
+    writeFileSync(screenshot2, 'test2')
+    writeFileSync(autoScreenshot, 'auto')
+
+    expect(existsSync(screenshot1)).toBe(true)
+    expect(existsSync(screenshot2)).toBe(true)
+    expect(existsSync(autoScreenshot)).toBe(true)
+
+    // Cleanup with no instance name should remove all
+    const instanceName = undefined
+    const patterns = instanceName ? [`-${instanceName}.png`, `-auto-${instanceName}.png`] : ['.png']
+
+    const { readdirSync, rmSync } = await import('node:fs')
+    const files = readdirSync(screenshotsDir)
+    for (const file of files) {
+      const shouldDelete = patterns.some(pattern =>
+        pattern === '.png' ? file.endsWith(pattern) : file.includes(pattern),
+      )
+      if (shouldDelete) {
+        rmSync(join(screenshotsDir, file), { force: true })
+      }
+    }
+
+    // All should be deleted
+    expect(existsSync(screenshot1)).toBe(false)
+    expect(existsSync(screenshot2)).toBe(false)
+    expect(existsSync(autoScreenshot)).toBe(false)
+  })
+
+  test('cleanup handles non-existent directory gracefully', async () => {
+    const nonExistentDir = join(testDir, '__screenshots__', 'non-existent.spec.ts')
+
+    // Should not throw
+    expect(() => {
+      if (!existsSync(nonExistentDir)) {
+        // No error
+      }
+    }).not.toThrow()
+  })
+
+  test('cleanup removes manual numbered screenshots correctly', async () => {
+    // Create manual screenshots with numbering
+    const manual1 = join(screenshotsDir, 'test-name-1-mobile.png')
+    const manual2 = join(screenshotsDir, 'test-name-2-mobile.png')
+    const manual3 = join(screenshotsDir, 'test-name-3-mobile.png')
+    const desktopManual1 = join(screenshotsDir, 'test-name-1-desktop.png')
+
+    writeFileSync(manual1, 'manual1')
+    writeFileSync(manual2, 'manual2')
+    writeFileSync(manual3, 'manual3')
+    writeFileSync(desktopManual1, 'desktop1')
+
+    expect(existsSync(manual1)).toBe(true)
+    expect(existsSync(manual2)).toBe(true)
+    expect(existsSync(manual3)).toBe(true)
+    expect(existsSync(desktopManual1)).toBe(true)
+
+    // Cleanup mobile instance
+    const instanceName = 'mobile'
+    const { readdirSync, rmSync } = await import('node:fs')
+    const files = readdirSync(screenshotsDir)
+
+    for (const file of files) {
+      if (!file.endsWith('.png')) {
+        continue
+      }
+
+      const shouldDelete = file.endsWith(`-${instanceName}.png`) || file.endsWith(`-auto-${instanceName}.png`)
+
+      if (shouldDelete) {
+        rmSync(join(screenshotsDir, file), { force: true })
+      }
+    }
+
+    // All mobile screenshots should be deleted
+    expect(existsSync(manual1)).toBe(false)
+    expect(existsSync(manual2)).toBe(false)
+    expect(existsSync(manual3)).toBe(false)
+
+    // Desktop screenshot should remain
+    expect(existsSync(desktopManual1)).toBe(true)
+  })
+
+  test('cleanup prevents path traversal attacks', async () => {
+    // This test verifies that the cleanup logic validates paths to prevent
+    // deletion of files outside the screenshot directory
+    const screenshot = join(screenshotsDir, 'test-name.png')
+    const outsideFile = join(testDir, 'outside.png')
+
+    writeFileSync(screenshot, 'inside')
+    writeFileSync(outsideFile, 'outside')
+
+    expect(existsSync(screenshot)).toBe(true)
+    expect(existsSync(outsideFile)).toBe(true)
+
+    // Simulate the cleanup logic with path validation
+    const { readdirSync, rmSync } = await import('node:fs')
+    const { resolve, sep } = await import('pathe')
+    const files = readdirSync(screenshotsDir)
+
+    for (const file of files) {
+      if (!file.endsWith('.png')) {
+        continue
+      }
+
+      // This is the security check that prevents path traversal
+      const filePath = join(screenshotsDir, file)
+      const normalizedFilePath = resolve(filePath)
+      const normalizedScreenshotDir = resolve(screenshotsDir)
+
+      // Skip files outside the screenshot directory
+      if (!normalizedFilePath.startsWith(normalizedScreenshotDir + sep)) {
+        continue
+      }
+
+      rmSync(filePath, { force: true })
+    }
+
+    // File inside screenshot directory should be deleted
+    expect(existsSync(screenshot)).toBe(false)
+
+    // File outside should NOT be deleted (security check prevents it)
+    // Note: readdirSync won't return files outside the directory anyway,
+    // but this test documents the security validation that's in place
+    expect(existsSync(outsideFile)).toBe(true)
+  })
+})

--- a/test/browser/test/screenshot-naming.test.ts
+++ b/test/browser/test/screenshot-naming.test.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs'
+import { describe, expect, test } from 'vitest'
+import { page } from 'vitest/browser'
+
+describe('screenshot naming', () => {
+  test('manual screenshots get sequential numbers', async () => {
+    // Take multiple manual screenshots
+    const screenshot1 = await page.screenshot()
+    const screenshot2 = await page.screenshot()
+    const screenshot3 = await page.screenshot()
+
+    // All should be different paths
+    expect(screenshot1).toBeTruthy()
+    expect(screenshot2).toBeTruthy()
+    expect(screenshot3).toBeTruthy()
+    expect(screenshot1).not.toBe(screenshot2)
+    expect(screenshot2).not.toBe(screenshot3)
+
+    // Should contain sequential numbers
+    expect(screenshot1).toContain('-1')
+    expect(screenshot2).toContain('-2')
+    expect(screenshot3).toContain('-3')
+
+    // Verify files exist
+    expect(existsSync(screenshot1!)).toBe(true)
+    expect(existsSync(screenshot2!)).toBe(true)
+    expect(existsSync(screenshot3!)).toBe(true)
+  })
+
+  test('auto-capture uses separate naming with -auto suffix', async () => {
+    // This test will trigger auto-capture at the end when ui.screenshotsInReport is enabled
+    // The auto-captured screenshot should have '-auto' in the name
+    // Manual screenshots should not affect the auto-capture
+
+    const screenshot1 = await page.screenshot()
+    const screenshot2 = await page.screenshot()
+
+    // Manual screenshots should be numbered sequentially
+    expect(screenshot1).toContain('-1')
+    expect(screenshot2).toContain('-2')
+
+    // The auto-capture (triggered at end of test) should use '-auto' suffix
+    // We can't directly verify this in the test itself, but the naming logic
+    // ensures it won't clash with manual screenshots
+  })
+})

--- a/test/config/test/browser-screenshot-config.test.ts
+++ b/test/config/test/browser-screenshot-config.test.ts
@@ -1,0 +1,133 @@
+import { playwright } from '@vitest/browser-playwright'
+import { preview } from '@vitest/browser-preview'
+import { expect, onTestFinished, test } from 'vitest'
+import { createVitest } from 'vitest/node'
+
+async function vitest(cliOptions: any, configValue: any) {
+  const vitest = await createVitest('test', { ...cliOptions, watch: false }, { test: configValue as any })
+  onTestFinished(() => vitest.close())
+  return vitest
+}
+
+test('browser.screenshotTestEnd defaults to false', async () => {
+  const { config } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: preview(),
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  expect(config.browser.screenshotTestEnd).toBe(false)
+})
+
+test('browser.screenshotTestEnd: true works with playwright', async () => {
+  const { config } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      screenshotTestEnd: true,
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  expect(config.browser.screenshotTestEnd).toBe(true)
+})
+
+test('browser.screenshotTestEnd is disabled for preview provider', async () => {
+  const { config } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: preview(),
+      screenshotTestEnd: true,
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  // Should be forcefully disabled for preview provider
+  expect(config.browser.screenshotTestEnd).toBe(false)
+})
+
+test('browser.cleanupScreenshots defaults to false', async () => {
+  const { config } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: preview(),
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  expect(config.browser.cleanupScreenshots).toBe(false)
+})
+
+test('browser.cleanupScreenshots: true works', async () => {
+  const { config } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: preview(),
+      cleanupScreenshots: true,
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  expect(config.browser.cleanupScreenshots).toBe(true)
+})
+
+test('browser.cleanupScreenshots is serialized to runtime config', async () => {
+  const { config, projects } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: preview(),
+      cleanupScreenshots: true,
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  // Verify it's in the resolved config
+  expect(config.browser.cleanupScreenshots).toBe(true)
+
+  // Verify it would be serialized (this tests the integration from config -> serialization)
+  const project = projects[0]
+  expect(project.config.browser.cleanupScreenshots).toBe(true)
+})
+
+test('browser.screenshotTestEnd works with browser.cleanupScreenshots', async () => {
+  const { config } = await vitest({}, {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      screenshotTestEnd: true,
+      cleanupScreenshots: true,
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+    ui: {
+      enabled: true,
+      screenshotsInReport: true,
+    },
+  })
+
+  expect(config.browser.screenshotTestEnd).toBe(true)
+  expect(config.browser.cleanupScreenshots).toBe(true)
+  expect(config.ui.screenshotsInReport).toBe(true)
+})

--- a/test/config/test/ui-config.test.ts
+++ b/test/config/test/ui-config.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'vitest'
+import { createVitest } from 'vitest/node'
+
+test('ui: true resolves to enabled config', async () => {
+  const vitest = await createVitest('test', {
+    ui: true,
+  })
+
+  expect(vitest.config.ui).toEqual({
+    enabled: true,
+    screenshotsInReport: false,
+    cleanupScreenshots: false,
+  })
+
+  await vitest.close()
+})
+
+test('ui: false resolves to disabled config', async () => {
+  const vitest = await createVitest('test', {
+    ui: false,
+  })
+
+  expect(vitest.config.ui).toEqual({
+    enabled: false,
+    screenshotsInReport: false,
+    cleanupScreenshots: false,
+  })
+
+  await vitest.close()
+})
+
+test('ui: { enabled: true } works', async () => {
+  const vitest = await createVitest('test', {
+    ui: { enabled: true },
+  })
+
+  expect(vitest.config.ui).toEqual({
+    enabled: true,
+    screenshotsInReport: false,
+    cleanupScreenshots: false,
+  })
+
+  await vitest.close()
+})
+
+test('ui: { screenshotsInReport: true } does not implicitly enable UI', async () => {
+  const vitest = await createVitest('test', {
+    ui: { screenshotsInReport: true },
+  })
+
+  expect(vitest.config.ui).toEqual({
+    enabled: false,
+    screenshotsInReport: true,
+    cleanupScreenshots: false,
+  })
+
+  await vitest.close()
+})
+
+test('ui: { enabled: true, screenshotsInReport: true } enables both', async () => {
+  const vitest = await createVitest('test', {
+    ui: {
+      enabled: true,
+      screenshotsInReport: true,
+    },
+  })
+
+  expect(vitest.config.ui).toEqual({
+    enabled: true,
+    screenshotsInReport: true,
+    cleanupScreenshots: false,
+  })
+
+  await vitest.close()
+})
+
+test('ui: { cleanupScreenshots: true } works', async () => {
+  const vitest = await createVitest('test', {
+    ui: { cleanupScreenshots: true },
+  })
+
+  expect(vitest.config.ui).toEqual({
+    enabled: false,
+    screenshotsInReport: false,
+    cleanupScreenshots: true,
+  })
+
+  await vitest.close()
+})
+
+test('ui: undefined defaults to disabled config', async () => {
+  const vitest = await createVitest('test', {})
+
+  expect(vitest.config.ui).toEqual({
+    enabled: false,
+    screenshotsInReport: false,
+    cleanupScreenshots: false,
+  })
+
+  await vitest.close()
+})

--- a/test/ui/test/screenshot-composable.spec.ts
+++ b/test/ui/test/screenshot-composable.spec.ts
@@ -1,0 +1,188 @@
+import type { RunnerTask } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { getScreenshotUrls, hasScreenshot } from '../../../packages/ui/client/composables/screenshot'
+
+// Mock window.VITEST_API_TOKEN for Node.js test environment
+beforeEach(() => {
+  vi.stubGlobal('window', { VITEST_API_TOKEN: 'test-token' })
+})
+
+describe('screenshot composable', () => {
+  describe('getScreenshotUrls', () => {
+    test('deduplicates when same screenshot is in both failScreenshotPath and screenshotPaths', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [
+            '/path/to/test-auto-mobile.png',
+          ],
+          failScreenshotPath: '/path/to/test-auto-mobile.png', // Same path!
+        },
+      } as unknown as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      // Should deduplicate to 1 URL, not 2
+      expect(urls.length).toBe(1)
+      expect(urls[0]).toContain('test-auto-mobile.png')
+
+      // Extract path from URL to verify it's correct
+      const urlPath = decodeURIComponent(urls[0].match(/path=([^&]+)/)?.[1] || '')
+      expect(urlPath).toBe('/path/to/test-auto-mobile.png')
+    })
+
+    test('handles manual screenshots correctly', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [
+            '/path/to/test-1-mobile.png',
+            '/path/to/test-2-mobile.png',
+          ],
+        },
+      } as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      expect(urls.length).toBe(2)
+      expect(urls[0]).toContain('test-1-mobile.png')
+      expect(urls[1]).toContain('test-2-mobile.png')
+    })
+
+    test('sorts auto screenshots before manual screenshots', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [
+            '/path/to/test-1-mobile.png',
+            '/path/to/test-2-mobile.png',
+            '/path/to/test-auto-mobile.png', // Auto screenshot should come first
+          ],
+        },
+      } as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      expect(urls.length).toBe(3)
+
+      // First URL should be the auto screenshot
+      expect(urls[0]).toContain('test-auto-mobile.png')
+
+      // Then manual screenshots in order
+      expect(urls[1]).toContain('test-1-mobile.png')
+      expect(urls[2]).toContain('test-2-mobile.png')
+    })
+
+    test('handles mixed manual, auto, and failure screenshots with deduplication', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [
+            '/path/to/test-1-mobile.png',
+            '/path/to/test-auto-mobile.png', // Also in failScreenshotPath
+            '/path/to/test-2-mobile.png',
+          ],
+          failScreenshotPath: '/path/to/test-auto-mobile.png', // Duplicate
+        },
+      } as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      // Should deduplicate the auto screenshot, resulting in 3 unique URLs
+      expect(urls.length).toBe(3)
+
+      // Auto screenshot should be first
+      expect(urls[0]).toContain('test-auto-mobile.png')
+
+      // Manual screenshots should follow in order
+      expect(urls[1]).toContain('test-1-mobile.png')
+      expect(urls[2]).toContain('test-2-mobile.png')
+    })
+
+    test('returns empty array when no screenshots exist', () => {
+      const task = {
+        meta: {},
+      } as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      expect(urls.length).toBe(0)
+    })
+
+    test('filters out null or undefined screenshot paths', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [
+            '/path/to/test-1.png',
+            null as any,
+            '/path/to/test-2.png',
+            undefined as any,
+          ],
+        },
+      } as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      // Should only include the 2 valid paths
+      expect(urls.length).toBe(2)
+      expect(urls[0]).toContain('test-1.png')
+      expect(urls[1]).toContain('test-2.png')
+    })
+
+    test('URL encoding handles special characters in paths', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [
+            '/path/to/test with spaces.png',
+            '/path/to/test-with-特殊字符.png',
+          ],
+        },
+      } as RunnerTask
+
+      const urls = getScreenshotUrls(task)
+
+      expect(urls.length).toBe(2)
+
+      // Verify paths are properly encoded in the URL query parameter
+      // The path parameter value is URL-encoded, but the query string structure is not double-encoded
+      expect(urls[0]).toContain('path=%2Fpath%2Fto%2Ftest%20with%20spaces.png')
+      expect(urls[1]).toContain('%E7%89%B9%E6%AE%8A%E5%AD%97%E7%AC%A6')
+    })
+  })
+
+  describe('hasScreenshot', () => {
+    test('returns true when screenshotPaths array has items', () => {
+      const task = {
+        meta: {
+          screenshotPaths: ['/path/to/test.png'],
+        },
+      } as RunnerTask
+
+      expect(hasScreenshot(task)).toBe(true)
+    })
+
+    test('returns true when failScreenshotPath exists', () => {
+      const task = {
+        meta: {
+          failScreenshotPath: '/path/to/failure.png',
+        },
+      } as RunnerTask
+
+      expect(hasScreenshot(task)).toBe(true)
+    })
+
+    test('returns false when no screenshots exist', () => {
+      const task = {
+        meta: {},
+      } as RunnerTask
+
+      expect(hasScreenshot(task)).toBe(false)
+    })
+
+    test('returns false when screenshotPaths is empty array', () => {
+      const task = {
+        meta: {
+          screenshotPaths: [],
+        },
+      } as unknown as RunnerTask
+
+      expect(hasScreenshot(task)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
### Description

This Pull Request introduces several changes, all backwards compatible and tested.

~~Resolves #issue-number~~ - No issue created as these were DX problems I encountered whilst integrating Vitest and Vitest Browser Mode into my stack.

Each commit is scoped and should provide an easy way to see each change made and all the relevant file changes in one commit per ~thing.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

---

Changelist:

### UI Configuration

- `vitest.config.ts` now supports a `ui` object (and remains backwards compatible with the standard `ui: true`
```typescript
...
ui: {
 enabled: !process.env.CI,
}
...
```

### Screenshots in Reports

- Screenshots created through the the existing `browser.screenshotFailures` and the new  `browser.screenshotTestEnd` will now be displayed nicely, using the new `ScreenshotCarousel.vue` component, in `ViewReport.vue` and `ViewTestReport.vue`.
- Why do this? I found myself running browsers in headless mode and then further confused that to see the "state" of the app manually I would need to open one of the chromium browsers and possibly be able to see things. Whilst writing tests as well as doing spot-checks or just even getting used to Vitest Browser Mode and building trust with the tooling I wanted to be able to **see** things.

```typescript
...
ui: {
 enabled: true,
 screenshotsInReport: true,
}
...
```

<img width="1743" height="514" alt="image" src="https://github.com/user-attachments/assets/cef6e65c-642e-495f-aaf7-196f8bc60f66" />

###  Automatic Screenshots

- Given the rationale above (spot-checks, building trust in the tooling, or a general desire to **see** things no matter the reason), I realised quickly after integrating Vitest Browser Mode that the only way to generate screenshots to see how things look at the end of the test was a manual `await page.screenshot();` or `browser.screenshotFailures` (which only covered failures). Further experiments with `test-setup.ts` and `afterAll` hooks etc. and annotations were a failure. Annotations failed because the `ui` library would build the URLs in an invalid way by adding content-type headers which without it wouldn't display in-line. I immediately set out to have auto-screenshotting alongside the above feature `ui.screenshotsInReport`.

```typescript
...
browser: {
 enabled: true,
 provider: playwright(),
 screenshotTestEnd: true,
 instances: [
   {
     browser: "chromium",
     name: "user-portal-desktop",
     viewport: { width: 1920, height: 1080 },
   },
   {
     browser: "chromium",
     name: "user-portal-mobile",
     viewport: { width: 390, height: 659 },
   },
 ],
 headless: true,
},
...
```

### Screenshot Cleanup

- Later on in the day it occurred to me that manual screenshots (`await page.screenshot();`) that are removed from the test would potentially linger. I naturally considered a bash script to cleanup lingering images but I had a _whilst I'm here_ sort-of moment and decided to add `browser.cleanupScreenshots`. 
- This feature will, at test-start, have each browser instance be responsible for itself and cleanup any matching screenshots in the default `__screenshots__/<test>/` directory.
- I realised that manual screenshots that specify another path are not the responsibility of a cleanup mechanic because they're a user's responsibility and if a user is setting a specific directory they are likely also cleaning it up themselves.
- I'm aware already that the automatic screenshots and even the manual ones will get replaced on the next test run so this feature is really just about cleaning up orphaned screenshots, though I acknowledge it opens the door to a potential `vitest cleanup` style command too.

```typescript
...
browser: {
 enabled: true,
 cleanupScreenshots: true,
},
...
```

### Inconsistent Status Banner

- In my first day of using Vitest UI I realised that only tests that are passing get a banner saying they're all green, but then I realised that running and skipped tests get the same hardcoded banner which was really misleading... as a result I created `StatusBanner.vue`.
- This new component centralises the status text logic as well as allows a simple one liner to add the status banner to all states (failed / passed / running / skipped)

<img width="1716" height="977" alt="image" src="https://github.com/user-attachments/assets/9a0b8ea2-d729-4f75-ace4-0a822f89f731" />

### Centralising Status Colours

- I noticed that the `skipped` icon (curved downwards arrow) was not using the precedented `skipped purple` and that in the several places that did use these colours they were all hardcoded... as a result I added the colours to `main.css`
- By centralising the colours it means they can be changed in one place (I didn't get all the places that use it) much easier... such as changing that purple to a more traditional `grey` for skipped
- I'm aware the purple icon looks... not great... but also using colours to symbolise statuses and then not being consistent is worse.. at least now that colour can be changed in fewer spots!

<img width="69" height="119" alt="image" src="https://github.com/user-attachments/assets/079e6031-5be4-4f90-b922-b3c73b2558eb" />

### Improved File Report Layout

- The layout for a file's report (not the individual test report but the file's report) in `ViewReport.vue` was a strange mess and not well organised. I've improved the layout as follows:

```
[Test Path] (clickable link that'll take you to the test itself)
[StatusBanner]
[Screenshots] (if `ui.screenshotsInReport` is enabled)
[HTML Error / Error]
```

- If the testing gods grace you with multiple failed tests in one test file it is now much more readable. 
- I did originally make the HTML errors collapsible (and even `ui.htmlErrorsCollapsedByDefault`) but I decided to remove that in the end as I was already making a lot of changes in one PR.

<img width="2430" height="941" alt="image" src="https://github.com/user-attachments/assets/fbaa5db4-b2e2-4234-a7a1-06ad462c4003" />

---

Final note: I do apologise for the large PR (31 file changes) but it actually look me 8 hours to re-commit everything in an easy way (1 ~thing per commit) so you could easily view things so to make each one a branch and PR them in wouldn't have been feasible. 

- I'm available in Slack and Discord for more immediate discussions.
- Willing and able to remove things on request or change things with quick turnaround. Trying to make this PR as easy to merge in as possible so I don't have to live off of a fork for the foreseeable future.
