### PR TITLE
fix: workaround `noExternal` merging bug on Vite 6

### DIFF
--- a/packages/vitest/src/node/plugins/runnerTransform.ts
+++ b/packages/vitest/src/node/plugins/runnerTransform.ts
@@ -146,6 +146,7 @@ export function ModuleRunnerTransform(): VitePlugin {
           environment.resolve.noExternal = true
 
           // Workaround `noExternal` merging bug on Vite 6
+          // https://github.com/vitejs/vite/pull/20502
           if (name === 'ssr') {
             delete config.ssr?.noExternal
           }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vitest/issues/8899

I think what's happening is that `config.ssr.noExternal: ["something"]` and `config.environments.ssr.resolve.noExternal: true` are getting merged to `noExternal: ["something", true]` right after Vitest's config hook. This PR workarounds it by clearing it out so they become `noExternal: true`.

Either we workaround on Vitest or backport https://github.com/vitejs/vite/pull/20502/ to Vite 6, which might be equally simple though.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
