### PR TITLE
fix(runner): properly encode Uint8Array body in annotations

### DIFF
--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -289,14 +289,15 @@ export function setFileContext(file: File, context: Record<string, unknown>): vo
 
 const table: string[] = []
 for (let i = 65; i < 91; i++) {
-  table.push(String.fromCharCode(i))
+  table.push(String.fromCharCode(i)) // A-Z
 }
 for (let i = 97; i < 123; i++) {
-  table.push(String.fromCharCode(i))
+  table.push(String.fromCharCode(i)) // a-z
 }
 for (let i = 0; i < 10; i++) {
-  table.push(i.toString(10))
+  table.push(i.toString(10)) // 0-9
 }
+table.push('+', '/')
 
 function encodeUint8Array(bytes: Uint8Array): string {
   let base64 = ''

--- a/test/cli/test/annotations.test.ts
+++ b/test/cli/test/annotations.test.ts
@@ -19,6 +19,9 @@ test('simple', async ({ annotate }) => {
   await annotate('3', { path: './test-3.js' })
   await annotate('4', 'warning', { path: './test-4.js' })
   await externalAnnotate(annotate)
+  await annotate('with base64 body', { body: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/' })
+  await annotate('with Uint8Array body', { body: new Uint8Array(Array.from({ length: 256 }).map((_, i) => i)) })
+  await annotate('with contentType', { body: '', contentType: 'text/plain' })
 })
 
 describe('suite', () => {
@@ -61,7 +64,7 @@ describe('API', () => {
           {
             onTestCaseAnnotate(testCase, annotation) {
               const path = annotation.attachment?.path?.replace(testCase.project.config.root, '<root>').replace(/\w+\.js$/, '<hash>.js')
-              events.push(`[annotate] ${testCase.name} ${annotation.message} ${annotation.type} ${path}`)
+              events.push(`[annotate] ${testCase.name} ${annotation.message} ${annotation.type} path=${path} contentType=${annotation.attachment?.contentType} body=${annotation.attachment?.body}`)
             },
             onTestCaseReady(testCase) {
               events.push(`[ready] ${testCase.name}`)
@@ -97,15 +100,18 @@ describe('API', () => {
     expect(events).toMatchInlineSnapshot(`
       [
         "[ready] simple",
-        "[annotate] simple 1 notice undefined",
-        "[annotate] simple 2 warning undefined",
-        "[annotate] simple 3 notice <root>/.vitest-attachments/3-<hash>.js",
-        "[annotate] simple 4 warning <root>/.vitest-attachments/4-<hash>.js",
-        "[annotate] simple external notice undefined",
+        "[annotate] simple 1 notice path=undefined contentType=undefined body=undefined",
+        "[annotate] simple 2 warning path=undefined contentType=undefined body=undefined",
+        "[annotate] simple 3 notice path=<root>/.vitest-attachments/3-<hash>.js contentType=text/javascript body=undefined",
+        "[annotate] simple 4 warning path=<root>/.vitest-attachments/4-<hash>.js contentType=text/javascript body=undefined",
+        "[annotate] simple external notice path=undefined contentType=undefined body=undefined",
+        "[annotate] simple with base64 body notice path=undefined contentType=undefined body=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+        "[annotate] simple with Uint8Array body notice path=undefined contentType=undefined body=AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==",
+        "[annotate] simple with contentType notice path=undefined contentType=text/plain body=",
         "[result] simple",
         "[ready] second",
-        "[annotate] second 5 notice undefined",
-        "[annotate] second 6 notice https://absolute-path.com",
+        "[annotate] second 5 notice path=undefined contentType=undefined body=undefined",
+        "[annotate] second 6 notice path=https://absolute-path.com contentType=undefined body=undefined",
         "[result] second",
       ]
     `)
@@ -117,7 +123,7 @@ describe('API', () => {
             "location": {
               "column": 11,
               "file": "<root>/basic.test.ts",
-              "line": 15,
+              "line": 18,
             },
             "message": "5",
             "type": "notice",
@@ -129,7 +135,7 @@ describe('API', () => {
             "location": {
               "column": 11,
               "file": "<root>/basic.test.ts",
-              "line": 16,
+              "line": 19,
             },
             "message": "6",
             "type": "notice",
@@ -189,6 +195,43 @@ describe('API', () => {
             "message": "external",
             "type": "notice",
           },
+          {
+            "attachment": {
+              "body": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
+            },
+            "location": {
+              "column": 9,
+              "file": "<root>/basic.test.ts",
+              "line": 11,
+            },
+            "message": "with base64 body",
+            "type": "notice",
+          },
+          {
+            "attachment": {
+              "body": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==",
+            },
+            "location": {
+              "column": 9,
+              "file": "<root>/basic.test.ts",
+              "line": 12,
+            },
+            "message": "with Uint8Array body",
+            "type": "notice",
+          },
+          {
+            "attachment": {
+              "body": "",
+              "contentType": "text/plain",
+            },
+            "location": {
+              "column": 9,
+              "file": "<root>/basic.test.ts",
+              "line": 13,
+            },
+            "message": "with contentType",
+            "type": "notice",
+          },
         ],
       }
     `)
@@ -234,6 +277,9 @@ describe('reporters', () => {
               # notice: 3
               # warning: 4
               # notice: external
+              # notice: with base64 body
+              # notice: with Uint8Array body
+              # notice: with contentType
           ok 2 - suite # time=<time> {
               1..1
               ok 1 - second # time=<time>
@@ -264,6 +310,9 @@ describe('reporters', () => {
           # notice: 3
           # warning: 4
           # notice: external
+          # notice: with base64 body
+          # notice: with Uint8Array body
+          # notice: with contentType
       ok 2 - basic.test.ts > suite > second # time=<time>
           # notice: 5
           # notice: 6
@@ -301,6 +350,12 @@ describe('reporters', () => {
                       <property name="warning" value="4">
                       </property>
                       <property name="notice" value="external">
+                      </property>
+                      <property name="notice" value="with base64 body">
+                      </property>
+                      <property name="notice" value="with Uint8Array body">
+                      </property>
+                      <property name="notice" value="with contentType">
                       </property>
                   </properties>
               </testcase>
@@ -346,9 +401,15 @@ describe('reporters', () => {
 
       ::notice file=<root>/basic.test.ts,line=10,column=9::external
 
-      ::notice file=<root>/basic.test.ts,line=15,column=11::5
+      ::notice file=<root>/basic.test.ts,line=11,column=9::with base64 body
 
-      ::notice file=<root>/basic.test.ts,line=16,column=11::6
+      ::notice file=<root>/basic.test.ts,line=12,column=9::with Uint8Array body
+
+      ::notice file=<root>/basic.test.ts,line=13,column=9::with contentType
+
+      ::notice file=<root>/basic.test.ts,line=18,column=11::5
+
+      ::notice file=<root>/basic.test.ts,line=19,column=11::6
       "
     `)
   })
@@ -383,12 +444,18 @@ describe('reporters', () => {
            ↳ 4
          ❯ basic.test.ts:10:9 notice
            ↳ external
+         ❯ basic.test.ts:11:9 notice
+           ↳ with base64 body
+         ❯ basic.test.ts:12:9 notice
+           ↳ with Uint8Array body
+         ❯ basic.test.ts:13:9 notice
+           ↳ with contentType
 
        ✓ basic.test.ts > suite > second <time>
 
-         ❯ basic.test.ts:15:11 notice
+         ❯ basic.test.ts:18:11 notice
            ↳ 5
-         ❯ basic.test.ts:16:11 notice
+         ❯ basic.test.ts:19:11 notice
            ↳ 6
 
       "


### PR DESCRIPTION
### Description

This PR fixes an issue with the incorrect encoding of the Uint8Array body in test annotations. The root cause is that [the table for base64 encoding](https://github.com/vitest-dev/vitest/blob/97aed7454f09d352a9e71b3cd67c3584238cf455/packages/runner/src/context.ts#L290) is missing characters at indices 62 and 63. This bug causes "undefined" to appear in the base64-encoded body. I've figured this out while trying to view image annotations in an HTML report. They were not loading.
Reproducible in Vitest v4.0.7 (and I believe since the introduction of annotations in v3.2.0).

I didn't find a reported issue on GitHub.

BTW, I have a small question. Is there a reason to use `for` loops to populate the `table` instead of a simple `const table = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'`? :thinking: 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
