### PR TITLE
fix(browser): locator which does not locate any element is not visible

### DIFF
--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -21,7 +21,7 @@ function element<T extends HTMLElement | SVGElement | null | Locator>(elementOrL
     const isNot = chai.util.flag(this, 'negate') as boolean
     const name = chai.util.flag(this, '_name') as string
     // special case for `toBeInTheDocument` matcher
-    if (isNot && name === 'toBeInTheDocument') {
+    if (isNot && (name === 'toBeInTheDocument' || name === 'toBeVisible')) {
       return elementOrLocator.query()
     }
     if (name === 'toHaveLength') {

--- a/packages/browser/src/client/tester/expect/toBeVisible.ts
+++ b/packages/browser/src/client/tester/expect/toBeVisible.ts
@@ -21,15 +21,18 @@ import { getElementFromUserInput, queryElementFromUserInput } from './utils'
 
 export default function toBeVisible(
   this: MatcherState,
-  actual: Element | Locator,
+  actual: Element | Locator | null,
 ): ExpectationResult {
   // When using expect(locator).not.toBeVisible(), we want the test to succeed, so we query instead of getting
   // the element, to avoid an exception if the element can't be found
-  const htmlElement = this.isNot ? queryElementFromUserInput(actual, toBeVisible, this) : getElementFromUserInput(actual, toBeVisible, this)
+  let htmlElement: null | HTMLElement | SVGElement = null
+  if (actual !== null || !this.isNot) {
+    htmlElement = this.isNot ? queryElementFromUserInput(actual, toBeVisible, this) : getElementFromUserInput(actual, toBeVisible, this)
+  }
   const isInDocument
     = htmlElement != null && htmlElement.ownerDocument === htmlElement.getRootNode({ composed: true })
   beginAriaCaches()
-  const isVisible = isInDocument && isElementVisible(htmlElement)
+  const isVisible = htmlElement != null && isInDocument && isElementVisible(htmlElement)
   endAriaCaches()
   return {
     pass: isVisible,

--- a/test/browser/fixtures/expect-dom/toBeVisible.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeVisible.test.ts
@@ -43,10 +43,15 @@ describe('.toBeVisible', () => {
     expect(() => expect(subject).toBeVisible()).toThrowError()
   })
 
-  it('locator which does not locate any element is not visible', () => {
+  it('locator which does not locate any element is not visible', async () => {
     const locator = page.getByTestId('not-existing');
     expect(locator).not.toBeVisible()
     expect(() => expect(locator).toBeVisible()).toThrowError()
+  })
+
+  it('locator which does not locate any element is not visible when using expect.element', async () => {
+    const locator = page.getByTestId('not-existing');
+    await expect.element(locator).not.toBeVisible()
   })
 
   describe('with a <details /> element', () => {


### PR DESCRIPTION
### Description

When using an assertion such as `expect(page.getByTestId('not-existing')).not.toBeVisible()`, the assertion used to fail because the assertion tried to get the element of the locator, which threw an exception. After this fix, the assertion will pass, because an element that does not exist (and which is thus not in the document) is de facto not visible. It allows the developer to use `not.toBeVisible()` without having to care if the element is hidden in the DOM or removed from the DOM.

See https://github.com/vitest-dev/vitest/discussions/8946#discussioncomment-14882890

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`. **but so many tests are failing that can't possibly come from the tiny fix I introduced**

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
