### PR TITLE
fix(reporters): report correct test run duration at the end

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -2,6 +2,7 @@ import type { File, Task, TestAnnotation } from '@vitest/runner'
 import type { SerializedError } from '@vitest/utils'
 import type { TestError, UserConsoleLog } from '../../types/general'
 import type { Vitest } from '../core'
+import type { TestSpecification } from '../spec'
 import type { Reporter, TestRunEndReason } from '../types/reporter'
 import type { TestCase, TestCollection, TestModule, TestModuleState, TestResult, TestSuite, TestSuiteState } from './reported-tasks'
 import { performance } from 'node:perf_hooks'
@@ -57,7 +58,6 @@ export abstract class BaseReporter implements Reporter {
     this.ctx = ctx
 
     this.ctx.logger.printBanner()
-    this.start = performance.now()
   }
 
   log(...messages: any): void {
@@ -70,6 +70,11 @@ export abstract class BaseReporter implements Reporter {
 
   relative(path: string): string {
     return relative(this.ctx.config.root, path)
+  }
+
+  onTestRunStart(_specifications: ReadonlyArray<TestSpecification>): void {
+    this.start = performance.now()
+    this._timeStart = formatTimeString(new Date())
   }
 
   onTestRunEnd(
@@ -419,9 +424,6 @@ export abstract class BaseReporter implements Reporter {
     for (const testModule of this.failedUnwatchedFiles) {
       this.printTestModule(testModule)
     }
-
-    this._timeStart = formatTimeString(new Date())
-    this.start = performance.now()
   }
 
   onUserConsoleLog(log: UserConsoleLog, taskState?: TestResult['state']): void {

--- a/packages/vitest/src/node/reporters/default.ts
+++ b/packages/vitest/src/node/reporters/default.ts
@@ -42,6 +42,7 @@ export class DefaultReporter extends BaseReporter {
       }
     }
 
+    super.onTestRunStart(specifications)
     this.summary?.onTestRunStart(specifications)
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Related: #8955

This doesn't fix UI, only the terminal

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
