### PR TITLE
fix(ui): collect file/suite/test duration correctly

### DIFF
--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -48,7 +48,7 @@ export function createOrUpdateFileNode(
     fileNode.typecheck = !!file.meta && 'typecheck' in file.meta
     fileNode.state = file.result?.state
     fileNode.mode = file.mode
-    fileNode.duration = file.result?.duration
+    fileNode.duration = typeof file.result?.duration === 'number' ? Math.round(file.result.duration) : undefined
     fileNode.collectDuration = file.collectDuration
     fileNode.setupDuration = file.setupDuration
     fileNode.environmentLoad = file.environmentLoad
@@ -68,7 +68,7 @@ export function createOrUpdateFileNode(
       tasks: [],
       typecheck: !!file.meta && 'typecheck' in file.meta,
       indent: 0,
-      duration: file.result?.duration != null ? Math.round(file.result?.duration) : undefined,
+      duration: typeof file.result?.duration === 'number' ? Math.round(file.result.duration) : undefined,
       filepath: file.filepath,
       projectName: file.projectName || '',
       projectNameColor: explorerTree.colors.get(file.projectName || '') || getProjectNameColor(file.projectName),
@@ -131,8 +131,8 @@ export function createOrUpdateNode(
 ) {
   const node = explorerTree.nodes.get(parentId) as ParentTreeNode | undefined
   let taskNode: UITaskTreeNode | undefined
-  const duration = task.result?.duration != null
-    ? Math.round(task.result?.duration)
+  const duration = typeof task.result?.duration === 'number'
+    ? Math.round(task.result.duration)
     : undefined
   if (node) {
     taskNode = explorerTree.nodes.get(task.id)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
From time to time I get weird numbers running `test/core` with the UI or `test/browser`:

<img width="429" height="311" alt="image" src="https://github.com/user-attachments/assets/1b04b906-4204-467c-b9b9-497860f7b919" />


Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
