### PR TITLE
chore: print a better error when browser orchestrator fails to run a test

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -35,7 +35,7 @@ export class IframeOrchestrator {
     this.cancelled = false
 
     const config = getConfig()
-    debug('create testers', options.files.join(', '))
+    debug('create testers', ...options.files.join(', '))
     const container = await getContainer(config)
 
     if (config.browser.ui) {
@@ -62,7 +62,7 @@ export class IframeOrchestrator {
       }
 
       const file = options.files[i]
-      debug('create iframe', file)
+      debug('create iframe', file.filepath)
 
       await this.runIsolatedTestInIframe(
         container,

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -157,7 +157,7 @@ let preparedData:
   | Awaited<ReturnType<typeof prepareTestEnvironment>>
   | undefined
 
-async function executeTests(method: 'run' | 'collect', files: FileSpecification[]) {
+async function executeTests(method: 'run' | 'collect', specifications: FileSpecification[]) {
   if (!preparedData) {
     throw new Error(`Data was not properly initialized. This is a bug in Vitest. Please, open a new issue with reproduction.`)
   }
@@ -166,21 +166,20 @@ async function executeTests(method: 'run' | 'collect', files: FileSpecification[
 
   const { runner, state } = preparedData
 
-  state.ctx.files = files
+  state.ctx.files = specifications
   runner.setMethod(method)
 
   const version = url.searchParams.get('browserv') || ''
-  files.forEach(({ filepath }) => {
+  specifications.forEach(({ filepath }) => {
     const currentVersion = browserHashMap.get(filepath)
     if (!currentVersion || currentVersion[1] !== version) {
       browserHashMap.set(filepath, version)
     }
   })
 
-  debug?.('prepare time', state.durations.prepare, 'ms')
-
-  for (const file of files) {
+  for (const file of specifications) {
     state.filepath = file.filepath
+    debug?.('running test file', file.filepath)
 
     if (method === 'run') {
       await startTests([file], runner)

--- a/packages/vitest/src/node/pools/browser.ts
+++ b/packages/vitest/src/node/pools/browser.ts
@@ -347,7 +347,9 @@ class BrowserPool {
             return
           }
           debug?.('[%s] error during %s test run: %s', sessionId, file, error)
-          this.reject(error)
+          this.reject(
+            new Error(`Failed to run the test ${file.filepath}.`, { cause: error }),
+          )
         })
     }).catch(err => this.reject(err))
   }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
