### PR TITLE
fix: allow bun native modules to load

### DIFF
--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -69,7 +69,7 @@ export function createMethodsRPC(project: TestProject, options: MethodsOptions =
         return {
           file,
           // TODO: use isBuiltin defined in the environment
-          url: !resolved.id.startsWith('node:') && isBuiltin(resolved.id)
+          url: !resolved.id.startsWith('bun:') && !resolved.id.startsWith('node:') && isBuiltin(resolved.id)
             ? `node:${resolved.id}`
             : resolved.id,
           id: resolved.id,

--- a/packages/vitest/src/runtime/moduleRunner/startModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startModuleRunner.ts
@@ -174,7 +174,7 @@ export function toBuiltin(id: string): string {
     id = id.slice(browserExternalLength)
   }
 
-  if (!id.startsWith('node:')) {
+  if (!id.startsWith('bun:') && !id.startsWith('node:')) {
     id = `node:${id}`
   }
   return id


### PR DESCRIPTION
### Description

Allow native modules for Bun to load within Vitest context. 

Allow to fix the errors like following for native bun modules.

> ResolveMessage: No such built-in module: node:bun:ffi

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

There is no new functionality in this PR. 

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
