### PR TITLE
feat(browser): add page.route intercept support

### DIFF
--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -668,11 +668,68 @@ export const userEvent: UserEvent
  */
 export const commands: BrowserCommands
 
+export type BrowserRouteMatch = string | RegExp
+
+export interface BrowserRouteRequest {
+  url(): string
+  method(): string
+  headers(): Record<string, string>
+  postData(): string | null
+  resourceType(): string | undefined
+}
+
+export interface BrowserRouteFulfillOptions {
+  status?: number
+  headers?: Record<string, string>
+  body?: string
+  /**
+   * Convenience option that sets the `content-type` header.
+   */
+  contentType?: string
+}
+
+export interface BrowserRouteAbortOptions {
+  errorCode?: string
+}
+
+export interface BrowserRouteContinueOverrides {
+  url?: string
+  method?: string
+  headers?: Record<string, string>
+  postData?: string
+}
+
+export interface BrowserRoute {
+  request(): BrowserRouteRequest
+  fulfill(options: BrowserRouteFulfillOptions): Promise<void> | void
+  abort(error?: string | BrowserRouteAbortOptions): void
+  continue(overrides?: BrowserRouteContinueOverrides): void
+}
+
+export type BrowserRouteHandler = (
+  route: BrowserRoute,
+  request: BrowserRouteRequest
+) => unknown | Promise<unknown>
+
 export interface BrowserPage extends LocatorSelectors {
   /**
    * Change the size of iframe's viewport.
    */
   viewport(width: number, height: number): Promise<void>
+  /**
+   * Intercept network requests that match the provided pattern.
+   * Only available for the `playwright` and `webdriverio` providers.
+   */
+  route(match: BrowserRouteMatch, handler: BrowserRouteHandler): Promise<void>
+  /**
+   * Remove previously registered route handlers.
+   * If `handler` is omitted, every handler for the pattern is removed.
+   */
+  unroute(match: BrowserRouteMatch, handler?: BrowserRouteHandler): Promise<void>
+  /**
+   * Remove every route handler registered in the current session.
+   */
+  unrouteAll(): Promise<void>
   /**
    * Make a screenshot of the test iframe or a specific element.
    * @returns Path to the screenshot file or path and base64.

--- a/packages/browser/src/node/commands/index.ts
+++ b/packages/browser/src/node/commands/index.ts
@@ -4,6 +4,11 @@ import {
   removeFile,
   writeFile,
 } from './fs'
+import {
+  register as registerRoute,
+  reset as resetRoutes,
+  unregister as unregisterRoute,
+} from './route'
 import { screenshot } from './screenshot'
 import { screenshotMatcher } from './screenshotMatcher'
 
@@ -15,4 +20,7 @@ export default {
   __vitest_fileInfo: _fileInfo as typeof _fileInfo,
   __vitest_screenshot: screenshot as typeof screenshot,
   __vitest_screenshotMatcher: screenshotMatcher as typeof screenshotMatcher,
+  __vitest_route_register: registerRoute as typeof registerRoute,
+  __vitest_route_unregister: unregisterRoute as typeof unregisterRoute,
+  __vitest_route_reset: resetRoutes as typeof resetRoutes,
 }

--- a/packages/browser/src/node/commands/route.ts
+++ b/packages/browser/src/node/commands/route.ts
@@ -1,0 +1,40 @@
+import type { BrowserCommand } from 'vitest/node'
+
+export type SerializedRouteMatcher
+  = | { type: 'string'; value: string }
+    | { type: 'regexp'; value: string; flags: string }
+
+export interface RouteRegisterPayload {
+  id: string
+  matcher: SerializedRouteMatcher
+}
+
+interface RouteCapableProvider {
+  registerRoute?: (sessionId: string, payload: RouteRegisterPayload) => Promise<void>
+  unregisterRoute?: (sessionId: string, id: string) => Promise<void>
+  resetRoutes?: (sessionId: string) => Promise<void>
+}
+
+export const register: BrowserCommand<[RouteRegisterPayload]> = async (context, payload) => {
+  const provider = context.provider as RouteCapableProvider
+  if (!provider.registerRoute) {
+    throw new Error('The current browser provider does not support route interception.')
+  }
+  await provider.registerRoute(context.sessionId, payload)
+}
+
+export const unregister: BrowserCommand<[string]> = async (context, id) => {
+  const provider = context.provider as RouteCapableProvider
+  if (!provider.unregisterRoute) {
+    throw new Error('The current browser provider does not support route interception.')
+  }
+  await provider.unregisterRoute(context.sessionId, id)
+}
+
+export const reset: BrowserCommand<[]> = async (context) => {
+  const provider = context.provider as RouteCapableProvider
+  if (!provider.resetRoutes) {
+    throw new Error('The current browser provider does not support route interception.')
+  }
+  await provider.resetRoutes(context.sessionId)
+}

--- a/test/browser/test/route.test.ts
+++ b/test/browser/test/route.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+
+afterEach(async () => {
+  await page.unrouteAll()
+})
+
+it('fulfills intercepted requests', async () => {
+  await page.route(/\/api\/route-fulfill$/, (route) => {
+    route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'stubbed' }),
+    })
+  })
+
+  const response = await fetch('/api/route-fulfill')
+  expect(response.status).toBe(201)
+  const data = await response.json()
+  expect(data).toEqual({ message: 'stubbed' })
+})
+
+it('aborts intercepted requests', async () => {
+  await page.route(/\/api\/route-abort$/, (route) => {
+    route.abort()
+  })
+
+  await expect(fetch('/api/route-abort')).rejects.toBeInstanceOf(Error)
+})


### PR DESCRIPTION
### Description

Adds first-class network interception support to Vitest browser mode. page.route, page.unroute, and page.unrouteAll are now available to tests, piping through new RPC commands and provider hooks. The Playwright backend reuses its native routing while WebdriverIO integrates with browser.mock (BiDi) so both providers can fulfill, continue, or abort requests. Tests cover fulfill/abort flows and cleanup guarantees.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
