### PR TITLE
fix(pool): prevent writing to closed worker

### DIFF
--- a/packages/vitest/src/node/pools/pool.ts
+++ b/packages/vitest/src/node/pools/pool.ts
@@ -78,7 +78,7 @@ export class Pool {
 
       // active tasks receive cancel signal and shut down gracefully
       async function cancelTask() {
-        await runner.waitForTerminated
+        await runner.waitForTerminated()
         resolver.reject(new Error('Cancelled'))
       }
 

--- a/packages/vitest/src/node/pools/poolRunner.ts
+++ b/packages/vitest/src/node/pools/poolRunner.ts
@@ -45,7 +45,7 @@ export class PoolRunner {
     return this._state === RunnerState.STOPPED
   }
 
-  public get waitForTerminated(): Promise<void> {
+  public waitForTerminated(): Promise<void> {
     return this._terminatePromise
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #9014

When user's test case doesn't do proper clean up, it can trigger rpc calls after test finished. In the reproduction there's `rpc.fetch()` that resolves on main thread after worker has stopped. This leads to `EPIPE` as IPC is closed already.

This is reproducible by having Vite plugin that takes long time on specific file transform, and that file is imported without awaiting it in test case.

Minimal repro for `test/core` - this will raise `Error: [vitest-worker]: Closing rpc while "fetch" was pending` errors on worker side so not adding the test case for now:

```ts
import { defineConfig } from 'vitest/config'

export default defineConfig({
  plugins: [
    {
      name: 'slow-down-transform',
      enforce: 'pre',
      async resolveId(id) {
        if (id.includes('vitest-test:slow-transform')) {
          return '\0vitest-test-slow-transform'
        }
      },
      async load(id) {
        if (id.includes('vitest-test-slow-transform')) {
          await new Promise(res => setTimeout(res, 1000))
          return `export default "Hello world"`
        }
      },
    },
  ],
});
```

```ts
import { test } from 'vitest'

test('should not cause EPIPE when imports resolve after test finishes', async () => {
  for (const _ of Array.from({ length: 50 }).fill(0)) {
    const cache = Math.round(Math.random() * 1000)

    setTimeout(
      () =>
        import(`vitest-test:slow-transform` + `?cache=${cache}`),
      2,
    ).unref()
  }
})
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
