### PR TITLE
fix(forks): increase worker start timeout

### DIFF
--- a/packages/vitest/src/node/pools/pool.ts
+++ b/packages/vitest/src/node/pools/pool.ts
@@ -8,7 +8,7 @@ import { TypecheckPoolWorker } from './workers/typecheckWorker'
 import { VmForksPoolWorker } from './workers/vmForksWorker'
 import { VmThreadsPoolWorker } from './workers/vmThreadsWorker'
 
-const WORKER_START_TIMEOUT = 5_000
+const WORKER_START_TIMEOUT = 90_000
 
 interface Options {
   distPath: string

--- a/packages/vitest/src/node/pools/poolRunner.ts
+++ b/packages/vitest/src/node/pools/poolRunner.ts
@@ -17,8 +17,8 @@ enum RunnerState {
   STOPPED = 'stopped',
 }
 
-const START_TIMEOUT = 10_000
-const STOP_TIMEOUT = 10_000
+const START_TIMEOUT = 60_000
+const STOP_TIMEOUT = 60_000
 
 /** @experimental */
 export class PoolRunner {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes https://github.com/vitest-dev/vitest/issues/8968.

Increase worker start timeout from 5s to 90s and worker startup ping from 10s to 60s. We didn't have these timeout in v3.

Currently there's also 10s timeout used inside methods that are called within the 5s timer, so 5s is definitely not enough.

https://github.com/vitest-dev/vitest/blob/a415d0375afa4c3726174d8f87db340ca20a428c/packages/vitest/src/node/pools/poolRunner.ts#L105

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
