### PR TITLE
fix: parsing of stack trace for bun runtime

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -783,7 +783,7 @@ function getImporter(name: string) {
   const stackArray = stackTrace.split('\n')
   // if there is no message in a stack trace, use the item - 1
   const importerStackIndex = stackArray.findLastIndex((stack) => {
-    return stack.includes(` at Object.${name}`) || stack.includes(`${name}@`)
+    return stack.includes(` at Object.${name}`) || stack.includes(`${name}@`) || stack.includes(` at ${name} (`)
   })
   const stack = parseSingleStack(stackArray[importerStackIndex + 1])
   return stack?.file || ''


### PR DESCRIPTION
### Description

Fixes the different parsing logic for the bun runtime that is affecting the mocking.

Resolves #9031

Here is stack trace for the **NodeJS** runtime. 

```log
'Error: $$stack trace error',
'    at createSimpleStackTrace (file:///my-project/node_modules/@vitest/utils/dist/helpers.js:43:14)',
'    at getImporter (file:///my-project/node_modules/vitest/dist/chunks/vi.BZvkKVkM.js:3769:21)',
'    at Object.mock (file:///my-project/node_modules/vitest/dist/chunks/vi.BZvkKVkM.js:3655:21)',
'    at /my-project/packages/beacon-node/test/unit/api/impl/events/events.test.ts:2:26',
'    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)'
```

Here is stack trace for the **Bun** runtime for same scenario. 

```log
'Error: $$stack trace error',
'    at createSimpleStackTrace (/my-project/node_modules/@vitest/utils/dist/helpers.js:43:18)',
'    at getImporter (/my-project//node_modules/vitest/dist/chunks/vi.BZvkKVkM.js:3754:21)',
'    at mock (/my-project/node_modules/vitest/dist/chunks/vi.BZvkKVkM.js:3655:21)',
'    at <anonymous> (/my-project/packages/beacon-node/test/unit/api/impl/events/events.test.ts:2:30)',
'    at runInlinedModule (/my-project/node_modules/vitest/dist/module-evaluator.js:136:118)',
'    at directRequest (/my-project/node_modules/vitest/node_modules/vite/dist/node/module-runner.js:1112:80)',
'    at cachedRequest (/my-project/node_modules/vitest/node_modules/vite/dist/node/module-runner.js:1030:79)',
'    at processTicksAndRejections (native)'
```


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
