### PR TITLE
Fix typo in BrowserServerFactory options parameter

### DIFF
--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -38,7 +38,7 @@ export interface BrowserServerOptions {
 }
 
 export interface BrowserServerFactory {
-  (otpions: BrowserServerOptions): Promise<ParentProjectBrowser>
+  (options: BrowserServerOptions): Promise<ParentProjectBrowser>
 }
 
 export interface BrowserProvider {


### PR DESCRIPTION
Just noticed this small typo in vscode autocomplete. Trying to figure out building a [Custom Provider](https://vitest.dev/config/browser/provider.html#custom-provider-advanced).