### PR TITLE
fix: inherit `fsModuleCachePath` by default

### DIFF
--- a/docs/api/advanced/plugin.md
+++ b/docs/api/advanced/plugin.md
@@ -170,4 +170,4 @@ export function plugin(options: PluginOptions) {
 }
 ```
 
-If the `false` is returned, the module will not be cached on the file system.
+If `false` is returned, the module will not be cached on the file system.

--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -614,4 +614,4 @@ This method will [collect tests](#parsespecification) from an array of specifica
 function experimental_clearCache(): Promise<void>
 ```
 
-Deletes all Vitest caches, including [`experimental.fsModuleCache`](/config/experimental#fsmodulecache).
+Deletes all Vitest caches, including [`experimental.fsModuleCache`](/config/experimental#experimental-fsmodulecache).

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -102,6 +102,10 @@ export function WorkspaceVitestPlugin(
           vitestConfig.experimental ??= {}
           vitestConfig.experimental.fsModuleCache = project.vitest.config.experimental.fsModuleCache
         }
+        if (testConfig.experimental?.fsModuleCachePath == null && project.vitest.config.experimental?.fsModuleCachePath !== null) {
+          vitestConfig.experimental ??= {}
+          vitestConfig.experimental.fsModuleCachePath = project.vitest.config.experimental.fsModuleCachePath
+        }
 
         return {
           base: '/',

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -1,5 +1,6 @@
 import type { UserConfig as ViteUserConfig } from 'vite'
 import type { TestUserConfig } from 'vitest/node'
+import { resolve } from 'pathe'
 import { describe, expect, it, onTestFinished } from 'vitest'
 import { createVitest, parseCLI } from 'vitest/node'
 
@@ -94,6 +95,7 @@ it('experimental fsModuleCache is inherited in a project', async () => {
   const v = await vitest({}, {
     experimental: {
       fsModuleCache: true,
+      fsModuleCachePath: './node_modules/custom-cache-path',
     },
     projects: [
       {
@@ -105,12 +107,16 @@ it('experimental fsModuleCache is inherited in a project', async () => {
   })
   expect(v.config.experimental.fsModuleCache).toBe(true)
   expect(v.projects[0].config.experimental.fsModuleCache).toBe(true)
+
+  expect(v.config.experimental.fsModuleCachePath).toBe(resolve('./node_modules/custom-cache-path'))
+  expect(v.projects[0].config.experimental.fsModuleCachePath).toBe(resolve('./node_modules/custom-cache-path'))
 })
 
 it('project overrides experimental fsModuleCache', async () => {
   const v = await vitest({}, {
     experimental: {
       fsModuleCache: true,
+      fsModuleCachePath: './node_modules/custom-cache-path',
     },
     projects: [
       {
@@ -118,6 +124,7 @@ it('project overrides experimental fsModuleCache', async () => {
           name: 'project',
           experimental: {
             fsModuleCache: false,
+            fsModuleCachePath: './node_modules/project-cache-path',
           },
         },
       },
@@ -125,4 +132,7 @@ it('project overrides experimental fsModuleCache', async () => {
   })
   expect(v.config.experimental.fsModuleCache).toBe(true)
   expect(v.projects[0].config.experimental.fsModuleCache).toBe(false)
+
+  expect(v.config.experimental.fsModuleCachePath).toBe(resolve('./node_modules/custom-cache-path'))
+  expect(v.projects[0].config.experimental.fsModuleCachePath).toBe(resolve('./node_modules/project-cache-path'))
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Related #9026

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
