### PR TITLE
perf: avoid fetchModule roundtrip if the module is cached

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/startModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startModuleRunner.ts
@@ -85,12 +85,6 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
     mocker: options.mocker,
     transport: {
       async fetchModule(id, importer, options) {
-        // if module is invalidated, the worker will be recreated,
-        // so cached is always true in a single worker
-        if (options?.cached) {
-          return { cache: true }
-        }
-
         const resolvingModules = state().resolvingModules
 
         if (isWindows) {
@@ -132,6 +126,12 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
 
           if (isBuiltin(rawId) || rawId.startsWith(browserExternalId)) {
             return { externalize: toBuiltin(rawId), type: 'builtin' }
+          }
+
+          // if module is invalidated, the worker will be recreated,
+          // so cached is always true in a single worker
+          if (options?.cached) {
+            return { cache: true }
           }
 
           const otelCarrier = traces?.getContextCarrier()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This has a noticeable effect (before/after):

```ts
   Duration  25.29s (transform 47.80s, setup 14.48s, collect 110.46s, tests 60.00s, environment 20.94s, prepare 452ms)
   Duration  22.11s (transform 18.42s, setup 16.63s, collect 79.83s, tests 54.14s, environment 24.67s, prepare 481ms)
```

We can avoid the roundtrip because if the module is invalidated, then we will destroy the worker, so we can be sure the module didn't change.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
