### PR TITLE
fix(pool): init `VITEST_POOL_ID` + `VITEST_WORKER_ID` before environment setup

### DIFF
--- a/packages/vitest/src/node/pools/pool.ts
+++ b/packages/vitest/src/node/pools/pool.ts
@@ -113,7 +113,7 @@ export class Pool {
           WORKER_START_TIMEOUT,
         )
 
-        await runner.start().finally(() => clearTimeout(id))
+        await runner.start({ workerId: task.context.workerId }).finally(() => clearTimeout(id))
       }
 
       const span = runner.startTracesSpan(`vitest.worker.${method}`)

--- a/packages/vitest/src/node/pools/poolRunner.ts
+++ b/packages/vitest/src/node/pools/poolRunner.ts
@@ -138,7 +138,7 @@ export class PoolRunner {
       : undefined
   }
 
-  async start(): Promise<void> {
+  async start(options: { workerId: number }): Promise<void> {
     // Wait for any ongoing operation to complete
     if (this._operationLock) {
       await this._operationLock
@@ -182,6 +182,7 @@ export class PoolRunner {
       this.postMessage({
         type: 'start',
         poolId: this.poolId!,
+        workerId: options.workerId,
         __vitest_worker_request__: true,
         options: {
           reportMemory: this.worker.reportMemory ?? false,

--- a/packages/vitest/src/node/pools/types.ts
+++ b/packages/vitest/src/node/pools/types.ts
@@ -71,6 +71,7 @@ export type WorkerRequest
     | {
       type: 'start'
       poolId: number
+      workerId: WorkerExecuteContext['workerId'] // Initial worker ID, may change when non-isolated worker runs multiple test files
       options: { reportMemory: boolean }
       context: {
         environment: WorkerTestEnvironment

--- a/packages/vitest/src/runtime/workers/init.ts
+++ b/packages/vitest/src/runtime/workers/init.ts
@@ -42,6 +42,7 @@ export function init(worker: Options): void {
     switch (message.type) {
       case 'start': {
         process.env.VITEST_POOL_ID = String(message.poolId)
+        process.env.VITEST_WORKER_ID = String(message.workerId)
         reportMemory = message.options.reportMemory
 
         const tracesStart = performance.now()

--- a/test/core/test/environments/custom-env.test.ts
+++ b/test/core/test/environments/custom-env.test.ts
@@ -10,4 +10,8 @@ test('custom env is defined', () => {
   expect((global as any).POOL_ID_DURING_ENV_SETUP).toBeDefined()
   expect(process.env.VITEST_POOL_ID).toBeDefined()
   expect((global as any).POOL_ID_DURING_ENV_SETUP).toBe(process.env.VITEST_POOL_ID)
+
+  expect((global as any).WORKER_ID_DURING_ENV_SETUP).toBeDefined()
+  expect(process.env.VITEST_WORKER_ID).toBeDefined()
+  expect((global as any).WORKER_ID_DURING_ENV_SETUP).toBe(process.env.VITEST_WORKER_ID)
 })

--- a/test/core/vitest-environment-custom/index.ts
+++ b/test/core/vitest-environment-custom/index.ts
@@ -13,6 +13,7 @@ export default <Environment>{
       testEnvironment: 'custom',
       option: custom.option,
       POOL_ID_DURING_ENV_SETUP: process.env.VITEST_POOL_ID,
+      WORKER_ID_DURING_ENV_SETUP: process.env.VITEST_WORKER_ID,
       setTimeout,
       clearTimeout,
       AbortController,
@@ -33,6 +34,7 @@ export default <Environment>{
     global.testEnvironment = 'custom'
     global.option = custom.option
     global.POOL_ID_DURING_ENV_SETUP = process.env.VITEST_POOL_ID
+    global.WORKER_ID_DURING_ENV_SETUP = process.env.VITEST_WORKER_ID
 
     return {
       teardown() {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Fixes https://github.com/vitest-dev/vitest/issues/9058

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
