### PR TITLE
fix(browser): move check allow out of forEach

### DIFF
--- a/packages/browser/src/node/project.ts
+++ b/packages/browser/src/node/project.ts
@@ -106,8 +106,8 @@ export class ProjectBrowser implements IProjectBrowser {
     if (this.provider.initScripts) {
       this.parent.initScripts = this.provider.initScripts
       // make sure the script can be imported
+      const allow = this.parent.vite.config.server.fs.allow
       this.provider.initScripts.forEach((script) => {
-        const allow = this.parent.vite.config.server.fs.allow
         if (!allow.includes(script)) {
           allow.push(script)
         }


### PR DESCRIPTION
### Description

I just made a small fix: moved the getting `allow` outside the loop.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
