### PR TITLE
chore: simplified array.from map

### DIFF
--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -214,7 +214,7 @@ function traverseReceivedFiles(collect: boolean) {
       continue
     }
     createOrUpdateFileNode(file, collect)
-    createOrUpdateEntry(Array.from(entries).map(id => idMap.get(id)).filter(Boolean) as Task[])
+    createOrUpdateEntry(Array.from(entries, id => idMap.get(id)).filter(Boolean) as Task[])
   }
 }
 
@@ -303,7 +303,7 @@ function collectData(
 ) {
   const idMap = client.state.idMap
   const filesMap = new Map(explorerTree.root.tasks.filter(f => idMap.has(f.id)).map(f => [f.id, f]))
-  const useFiles = Array.from(filesMap.values()).map(file => [file.id, findById(file.id)] as const)
+  const useFiles = Array.from(filesMap.values(), file => [file.id, findById(file.id)] as const)
   const data = {
     files: filesMap.size,
     time: time > 1000 ? `${(time / 1000).toFixed(2)}s` : `${Math.round(time)}ms`,


### PR DESCRIPTION
### Description

I made a minor adjustment. The `Array.from` method already accepts a second argument, which can replace the map call in the chain, simplifying the code.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
