### PR TITLE
fix(expect): preserve `currentTestName` in extended matchers

### DIFF
--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -35,6 +35,7 @@ function getMatcherState(
     subsetEquality,
   }
   let task: Test | undefined = util.flag(assertion, 'vitest-test')
+  const currentTestName = task?.fullTestName ?? ''
 
   if (task?.type !== 'test') {
     task = undefined
@@ -43,6 +44,7 @@ function getMatcherState(
   const matcherState: MatcherState = {
     ...getState(expect),
     task,
+    currentTestName,
     customTesters: getCustomEqualityTesters(),
     isNot,
     utils: jestUtils,


### PR DESCRIPTION
### Description

This was stacked on top of _far too many_ branches, but we finally got here 🙌🏼

Fixes #8853

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
