### PR TITLE
fix(docs): remove `--browser.provider` from docs

### DIFF
--- a/docs/config/browser/provider.md
+++ b/docs/config/browser/provider.md
@@ -6,8 +6,6 @@ outline: deep
 # browser.provider {#browser-provider}
 
 - **Type:** `BrowserProviderOption`
-- **Default:** `'preview'`
-- **CLI:** `--browser.provider=playwright`
 
 The return value of the provider factory. You can import the factory from `@vitest/browser-<provider-name>` or make your own provider:
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -332,13 +332,6 @@ Specify which IP addresses the server should listen on. Set this to `0.0.0.0` or
 
 Set to true to exit if port is already in use, instead of automatically trying the next available port
 
-### browser.provider
-
-- **CLI:** `--browser.provider <name>`
-- **Config:** [browser.provider](/config/browser/provider)
-
-Provider used to run browser tests. Some browsers are only available for specific providers. Can be "webdriverio", "playwright", "preview", or the path to a custom provider. Visit [`browser.provider`](/config/browser/provider) for more information
-
 ### browser.isolate
 
 - **CLI:** `--browser.isolate`

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -348,19 +348,6 @@ export const cliOptionsConfig: VitestCLIOptions = {
         argument: '[port]',
         subcommands: apiConfig(defaultBrowserPort),
       },
-      provider: {
-        description:
-          'Provider used to run browser tests. Some browsers are only available for specific providers. Can be "webdriverio", "playwright", "preview", or the path to a custom provider. Visit [`browser.provider`](https://vitest.dev/config/browser/provider) for more information',
-        argument: '<name>',
-        subcommands: null, // don't support custom objects
-        transform(value) {
-          const supported = ['playwright', 'webdriverio', 'preview']
-          if (typeof value !== 'string' || !supported.includes(value)) {
-            throw new Error(`Unsupported browser provider: ${value}. Supported providers are: ${supported.join(', ')}`)
-          }
-          return { name: value, _cli: true }
-        },
-      },
       isolate: {
         description:
           'Run every browser test file in isolation. To disable isolation, use `--browser.isolate=false` (default: `true`)',
@@ -397,6 +384,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
       testerHtmlPath: null,
       instances: null,
       expect: null,
+      provider: null,
     },
   },
   pool: {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #8970

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
