### PR TITLE
refactor(vitest): get current test name from task property

### DIFF
--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -10,7 +10,6 @@ import {
   setState,
 } from '@vitest/expect'
 import { getCurrentTest } from '@vitest/runner'
-import { getTestName } from '@vitest/runner/utils'
 import { getWorkerState } from '../../runtime/utils'
 import { createExpectPoll } from './poll'
 import './setup'
@@ -51,7 +50,7 @@ export function createExpect(test?: Test | TaskPopulated): ExpectStatic {
         return getWorkerState().filepath
       },
       currentTestName: test
-        ? getTestName(test as Test)
+        ? test.fullTestName ?? ''
         : globalState.currentTestName,
     },
     expect,


### PR DESCRIPTION
### Description

With `fullTestName` being available on tasks, it's wasteful to compute the value again.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
