### PR TITLE
fix: very minor typo in "Chrome DevTools Protocol"

### DIFF
--- a/docs/api/browser/commands.md
+++ b/docs/api/browser/commands.md
@@ -38,7 +38,7 @@ it('handles files', async () => {
 
 ## CDP Session
 
-Vitest exposes access to raw Chrome Devtools Protocol via the `cdp` method exported from `vitest/browser`. It is mostly useful to library authors to build tools on top of it.
+Vitest exposes access to raw Chrome DevTools Protocol via the `cdp` method exported from `vitest/browser`. It is mostly useful to library authors to build tools on top of it.
 
 ```ts
 import { cdp } from 'vitest/browser'


### PR DESCRIPTION

### Description

This is such a minor thing, but I noticed in the docs that `Chrome DevTools Protocol` was incorrectly capitalised 

It should always be "Chrome DevTools Protocol" 
(for reference - https://chromedevtools.github.io/devtools-protocol/ has it like that)

(I realise this is a very small change ... I'm not creating this PR just to get a commit into vitest. It is just a small typo that i caught when reviewing the vitest browser mode docs this week.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
