### PR TITLE
feat(cache): add opt-out on a plugin level, fix internal root cache

### DIFF
--- a/docs/config/experimental.md
+++ b/docs/config/experimental.md
@@ -62,6 +62,34 @@ export default defineConfig({
 
 If you are a plugin author, consider defining a [cache key generator](/api/advanced/plugin#definecachekeygenerator) in your plugin if it can be registered with different options that affect the transform result.
 
+On the other hand, if your plugin should not affect the cache key, you can opt-out by setting `api.vitest.experimental.ignoreFsModuleCache` to `true`:
+
+```js [vitest.config.js]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'vitest-cache',
+      api: {
+        vitest: {
+          experimental: {
+            ignoreFsModuleCache: true,
+          },
+        },
+      },
+    },
+  ],
+  test: {
+    experimental: {
+      fsModuleCache: true,
+    },
+  },
+})
+```
+
+Note that you can still define the cache key generator even the plugin opt-out of module caching.
+
 ## experimental.fsModuleCachePath <Version type="experimental">4.0.11</Version> {#experimental-fsmodulecachepath}
 
 - **Type:** `string`

--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -1,6 +1,5 @@
 import type { DevEnvironment, FetchResult } from 'vite'
 import type { Vitest } from '../core'
-import type { VitestResolver } from '../resolver'
 import type { ResolvedConfig } from '../types/config'
 import fs, { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { readFile, rename, rm, stat, unlink, writeFile } from 'node:fs/promises'
@@ -34,7 +33,7 @@ export class FileSystemModuleCache {
   private rootCache: string
   private metadataFilePath: string
 
-  private version = '1.0.0-beta.2'
+  private version = '1.0.0-beta.3'
   private fsCacheRoots = new WeakMap<ResolvedConfig, string>()
   private fsEnvironmentHashMap = new WeakMap<DevEnvironment, string>()
   private fsCacheKeyGenerators = new Set<CacheKeyIdGenerator>()
@@ -92,7 +91,7 @@ export class FileSystemModuleCache {
     | undefined
   > {
     if (!existsSync(cachedFilePath)) {
-      debugFs?.(`${c.red('[empty]')} ${cachedFilePath} doesn't exist, transforming by vite instead`)
+      debugFs?.(`${c.red('[empty]')} ${cachedFilePath} doesn't exist, transforming by vite first`)
       return
     }
 
@@ -173,7 +172,6 @@ export class FileSystemModuleCache {
   generateCachePath(
     vitestConfig: ResolvedConfig,
     environment: DevEnvironment,
-    resolver: VitestResolver,
     id: string,
     fileContent: string,
   ): string | null {
@@ -181,7 +179,7 @@ export class FileSystemModuleCache {
     // TODO: figure out a way to still support it
     if (fileContent.includes('import.meta.glob(')) {
       this.saveMemoryCache(environment, id, null)
-      debugMemory?.(`${c.yellow('[write]')} ${id} was bailed out`)
+      debugMemory?.(`${c.yellow('[write]')} ${id} was bailed out because it has "import.meta.glob"`)
       return null
     }
 
@@ -215,7 +213,9 @@ export class FileSystemModuleCache {
           resolve: config.resolve,
           // plugins can have different options, so this is not the best key,
           // but we canot access the options because there is no standard API for it
-          plugins: config.plugins.map(p => p.name),
+          plugins: config.plugins
+            .filter(p => p.api?.vitest?.experimental?.ignoreFsModuleCache !== true)
+            .map(p => p.name),
           // in case local plugins change
           // configFileDependencies also includes configFile
           configFileDependencies: config.configFileDependencies.map(file => tryReadFileSync(file)),
@@ -245,6 +245,7 @@ export class FileSystemModuleCache {
     let cacheRoot = this.fsCacheRoots.get(vitestConfig)
     if (cacheRoot == null) {
       cacheRoot = vitestConfig.experimental.fsModuleCachePath || this.rootCache
+      this.fsCacheRoots.set(vitestConfig, cacheRoot)
       if (!existsSync(cacheRoot)) {
         mkdirSync(cacheRoot, { recursive: true })
       }

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -181,7 +181,6 @@ class ModuleFetcher {
     return this.fsCache.generateCachePath(
       this.config,
       environment,
-      this.resolver,
       moduleGraphModule.id!,
       fileContent,
     )


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Noticed the need for this when working on the vscode extension - we have to add a plugin, but we want to reuse the cache if possible.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
