### PR TITLE
fix(experimental): export `setupEnvironment` for custom pools

### DIFF
--- a/docs/guide/advanced/pool.md
+++ b/docs/guide/advanced/pool.md
@@ -120,7 +120,7 @@ Your `CustomPoolRunner` will be controlling how your custom test runner worker l
 In your worker file, you can import helper utilities from `vitest/worker`:
 
 ```ts [my-worker.ts]
-import { init, runBaseTests } from 'vitest/worker'
+import { init, runBaseTests, setupEnvironment } from 'vitest/worker'
 
 init({
   post: (response) => {
@@ -141,7 +141,8 @@ init({
   deserialize: (value) => {
     // Optional, provide custom deserializer for `on` callbacks
   },
-  runTests: state => runBaseTests('run', state),
-  collectTests: state => runBaseTests('collect', state),
+  runTests: (state, traces) => runBaseTests('run', state, traces),
+  collectTests: (state, traces) => runBaseTests('collect', state, traces),
+  setup: setupEnvironment,
 })
 ```

--- a/packages/vitest/src/public/worker.ts
+++ b/packages/vitest/src/public/worker.ts
@@ -1,2 +1,2 @@
-export { runBaseTests } from '../runtime/workers/base'
+export { runBaseTests, setupEnvironment } from '../runtime/workers/base'
 export { init } from '../runtime/workers/init'

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -30,6 +30,7 @@ function startModuleRunner(options: ContextModuleRunnerOptions) {
 let _currentEnvironment!: Environment
 let _environmentTime: number
 
+/** @experimental */
 export async function setupEnvironment(context: WorkerSetupContext): Promise<() => Promise<void>> {
   const startTime = performance.now()
   const {

--- a/test/core/test/exports.test.ts
+++ b/test/core/test/exports.test.ts
@@ -340,6 +340,7 @@ it('exports snapshot', async ({ skip, task }) => {
           "./worker": {
             "init": "function",
             "runBaseTests": "function",
+            "setupEnvironment": "function",
           },
         }
       `)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Example usage at https://github.com/AriPerkkio/vitest-pool-example/pull/1

Added into ecosystem at https://github.com/vitest-dev/vitest-ecosystem-ci/pull/45

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
