### PR TITLE
chore: type error on `birpc@3.0.0` types

### DIFF
--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -87,7 +87,7 @@ export function createClient(url: string, options: VitestClientOptions = {}): Vi
     },
   }
 
-  const birpcHandlers: BirpcOptions<WebSocketHandlers> = {
+  const birpcHandlers = {
     post: msg => ctx.ws.send(msg),
     on: fn => (onMessage = fn),
     serialize: e =>
@@ -103,7 +103,7 @@ export function createClient(url: string, options: VitestClientOptions = {}): Vi
       }),
     deserialize: parse,
     timeout: -1,
-  }
+  } satisfies BirpcOptions<WebSocketHandlers>
 
   ctx.rpc = createBirpc<WebSocketHandlers, WebSocketEvents>(
     functions,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

After https://github.com/vitest-dev/vitest/pull/9195 `main` CI started to fail on typecheck.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
