### PR TITLE
fix(coverage): istanbul untested files source maps are off

### DIFF
--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -88,28 +88,30 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider<ResolvedCover
       sourceMap as any,
     )
 
-    const transformMap = new GenMapping(sourceMap)
+    if (!id.includes('vitest-uncovered-coverage=true')) {
+      const transformMap = new GenMapping(sourceMap)
 
-    eachMapping(new TraceMap(sourceMap as any), (mapping) => {
-      addMapping(transformMap, {
-        generated: { line: mapping.generatedLine, column: mapping.generatedColumn },
-        original: { line: mapping.generatedLine, column: mapping.generatedColumn },
-        content: sourceCode,
-        name: mapping.name || '',
-        source: mapping.source || '',
+      eachMapping(new TraceMap(sourceMap as any), (mapping) => {
+        addMapping(transformMap, {
+          generated: { line: mapping.generatedLine, column: mapping.generatedColumn },
+          original: { line: mapping.generatedLine, column: mapping.generatedColumn },
+          content: sourceCode,
+          name: mapping.name || '',
+          source: mapping.source || '',
+        })
       })
-    })
 
-    const encodedMap = toEncodedMap(transformMap)
-    delete encodedMap.file
-    delete encodedMap.ignoreList
-    delete encodedMap.sourceRoot
+      const encodedMap = toEncodedMap(transformMap)
+      delete encodedMap.file
+      delete encodedMap.ignoreList
+      delete encodedMap.sourceRoot
 
-    this.instrumenter.instrumentSync(
-      sourceCode,
-      id,
-      encodedMap as any,
-    )
+      this.instrumenter.instrumentSync(
+        sourceCode,
+        id,
+        encodedMap as any,
+      )
+    }
 
     const map = this.instrumenter.lastSourceMap() as any
     this.transformedModuleIds.add(id)
@@ -225,7 +227,7 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider<ResolvedCover
       }
 
       // Make sure file is not served from cache so that instrumenter loads up requested file coverage
-      await transform(`${filename}?cache=${cacheKey}`)
+      await transform(`${filename}?cache=${cacheKey}&vitest-uncovered-coverage=true`)
       const lastCoverage = this.instrumenter.lastFileCoverage()
       coverageMap.addFileCoverage(lastCoverage)
 

--- a/test/coverage-test/setup.ts
+++ b/test/coverage-test/setup.ts
@@ -3,14 +3,14 @@ import { expect } from 'vitest'
 import { formatSummary } from './utils'
 
 expect.addSnapshotSerializer({
-  test: val => val.constructor.name === 'CoverageMap',
+  test: val => val.constructor?.name === 'CoverageMap',
   serialize: (val: CoverageMap, config, indentation, depth, refs, printer) => {
     return printer(formatSummary(val.getCoverageSummary()), config, indentation, depth, refs)
   },
 })
 
 expect.addSnapshotSerializer({
-  test: val => val.constructor.name === 'FileCoverage',
+  test: val => val.constructor?.name === 'FileCoverage',
   serialize: (val: FileCoverage, config, indentation, depth, refs, printer) => {
     return printer(formatSummary(val.toSummary()), config, indentation, depth, refs)
   },

--- a/test/coverage-test/test/results-snapshot.test.ts
+++ b/test/coverage-test/test/results-snapshot.test.ts
@@ -39,4 +39,34 @@ test('coverage results matches snapshot', async () => {
       },
     }
   `)
+
+  const lineCoverages = coverageMap.files().reduce((all, file) => ({
+    [file]: coverageMap.fileCoverageFor(file).getLineCoverage(),
+    ...all,
+  }), {})
+
+  expect(lineCoverages).toMatchInlineSnapshot(`
+    {
+      "<process-cwd>/fixtures/src/even.ts": {
+        "2": 1,
+        "6": 0,
+      },
+      "<process-cwd>/fixtures/src/math.ts": {
+        "10": 0,
+        "14": 0,
+        "2": 1,
+        "6": 0,
+      },
+      "<process-cwd>/fixtures/src/untested-file.ts": {
+        "14": 0,
+        "21": 0,
+        "33": 0,
+        "35": 0,
+        "39": 0,
+        "41": 0,
+        "46": 0,
+        "9": 0,
+      },
+    }
+  `)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixing https://github.com/vitest-dev/vitest/pull/9040 broke source maps for untested files. There's now a test case that verifies this doesn't happen in future. 🙃 

<img width="800" src="https://github.com/user-attachments/assets/246c7878-88cd-435c-8376-a4efeca7ebef" />

_Before on left, after on right_


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
