### PR TITLE
fix: log deprecated `test.poolOptions` if it's set

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -147,6 +147,10 @@ export function resolveConfig(
     resolved.poolRunner = options.pool
   }
 
+  if ('poolOptions' in resolved) {
+    logger.deprecate('`test.poolOptions` was removed in Vitest 4. All previous `poolOptions` are now top-level options. Please, refer to the migration guide: https://vitest.dev/guide/migration#pool-rework')
+  }
+
   resolved.pool ??= 'forks'
 
   resolved.project = toArray(resolved.project)


### PR DESCRIPTION
### Description

We usually have a grace period when deprecated features are not removed, but Vitest 4 removes `poolOptions` without deprecating it, so some users don't realise it.
