### PR TITLE
feat: Expose `startModuleRunner()` from `vitest/worker`

### DIFF
--- a/packages/vitest/src/node/pools/types.ts
+++ b/packages/vitest/src/node/pools/types.ts
@@ -24,8 +24,9 @@ export interface PoolWorker {
   readonly reportMemory?: boolean
   readonly cacheFs?: boolean
 
-  on: (event: string, callback: (arg: any) => void) => void
-  off: (event: string, callback: (arg: any) => void) => void
+  on: ((event: 'error', callback: (maybeError: unknown) => void) => void) & ((event: 'exit', callback: () => void) => void) & ((event: 'message', callback: (response: WorkerResponse) => void) => void)
+
+  off: ((event: 'exit', callback: () => void) => void)
   send: (message: WorkerRequest) => void
   deserialize: (data: unknown) => unknown
 

--- a/packages/vitest/src/public/worker.ts
+++ b/packages/vitest/src/public/worker.ts
@@ -1,2 +1,2 @@
-export { runBaseTests, setupEnvironment } from '../runtime/workers/base'
+export { runBaseTests, setupEnvironment, startModuleRunner } from '../runtime/workers/base'
 export { init } from '../runtime/workers/init'

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -18,7 +18,7 @@ let _moduleRunner: VitestModuleRunner
 const evaluatedModules = new VitestEvaluatedModules()
 const moduleExecutionInfo = new Map()
 
-function startModuleRunner(options: ContextModuleRunnerOptions) {
+export function startModuleRunner(options: ContextModuleRunnerOptions): VitestModuleRunner {
   if (_moduleRunner) {
     return _moduleRunner
   }


### PR DESCRIPTION
### Description

Internally, `runBaseTests()` calls `startModuleRunner()`, which constructs a singleton `VitestModuleRunner`. We (Cloudflare) would like access to this singleton so we can transform and import code with Vite ourselves from within a custom pool (e.g. for user worker's default exports and Durable Objects). Vitest exposes a `startVitestModuleRunner()` function that we can use to get a new instance of the module runner, but we need the _exact_ instance Vitest is using to run tests so that e.g. `instanceof` checks on DurableObjects during a test run work as expected.

I appreciate this is a weird niche use case! Happy to clarify more.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
