### PR TITLE
Fix broken link in onStackTrace documentation

### DIFF
--- a/docs/config/onstacktrace.md
+++ b/docs/config/onstacktrace.md
@@ -7,7 +7,7 @@ outline: deep
 
 - **Type**: `(error: Error, frame: ParsedStack) => boolean | void`
 
-Apply a filtering function to each frame of each stack trace when handling errors. This does not apply to stack traces printed by [`printConsoleTrace`](#printConsoleTrace). The first argument, `error`, is a `TestError`.
+Apply a filtering function to each frame of each stack trace when handling errors. This does not apply to stack traces printed by [`printConsoleTrace`](/config/printconsoletrace#printconsoletrace). The first argument, `error`, is a `TestError`.
 
 Can be useful for filtering out stack trace frames from third-party libraries.
 


### PR DESCRIPTION
Ran into this broken link. 

fyi: another thing I noticed is that links in search have `.html` suffixes:

<img width="739" height="404" alt="Screenshot 2025-12-12 at 09 52 06" src="https://github.com/user-attachments/assets/fb1ab3dc-234a-428c-8f1e-8b800234beae" />

and those buttons don't render correctly in dark mode