### PR TITLE
refactor(browser): restructure screenshot matcher and add documentation

### DIFF
--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -78,7 +78,7 @@ export default async function toMatchScreenshot(
     }
 
     if (result.diff) {
-      attachments.push({ name: 'diff', path: result.diff })
+      attachments.push({ name: 'diff', ...result.diff })
     }
 
     if (attachments.length > 0) {
@@ -107,7 +107,7 @@ export default async function toMatchScreenshot(
               ? `\nActual screenshot:\n  ${this.utils.RECEIVED_COLOR(result.actual.path)}`
               : null,
             result.diff
-              ? this.utils.DIM_COLOR(`\nDiff image:\n  ${result.diff}`)
+              ? this.utils.DIM_COLOR(`\nDiff image:\n  ${result.diff.path}`)
               : null,
             '',
           ]

--- a/packages/browser/src/node/commands/screenshotMatcher/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/index.ts
@@ -1,22 +1,82 @@
+import type { SnapshotUpdateState } from 'vitest'
+import type { ScreenshotMatcherOptions } from 'vitest/browser'
 import type { BrowserCommand, BrowserCommandContext } from 'vitest/node'
-import type { ScreenshotMatcherOptions } from '../../../../context'
 import type { ScreenshotMatcherArguments, ScreenshotMatcherOutput } from '../../../shared/screenshotMatcher/types'
 import type { AnyCodec } from './codecs'
 import type { AnyComparator } from './comparators'
 import type { TypedArray } from './types'
+import type { ResolvedOptions } from './utils'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname } from 'pathe'
 import { asyncTimeout, resolveOptions, takeDecodedScreenshot } from './utils'
 
-export const screenshotMatcher: BrowserCommand<
-  ScreenshotMatcherArguments
-> = async (context, name, testName, options): ScreenshotMatcherOutput => {
+/** Decoded image data with dimensions metadata. */
+type DecodedImage = Awaited<ReturnType<AnyCodec['decode']>>
+
+/** Bundle of an image with its filesystem path. */
+interface ScreenshotData {
+  image: DecodedImage
+  path: string
+}
+
+/**
+ * Discriminated union representing all possible outcomes of a screenshot comparison.
+ *
+ * Each variant is self-contained with the data needed for side effects and output building.
+ *
+ * - `unstable-screenshot`: page never stabilized within timeout
+ * - `missing-reference`: no baseline exists to compare against
+ * - `update-reference`: snapshot update was requested (run with `--update`)
+ * - `matched-immediately`: screenshot matched reference on first capture (no retries)
+ * - `matched-after-comparison`: screenshot matched after another comparison
+ * - `mismatch`: screenshot differs from reference
+ */
+type MatchOutcome
+  = | {
+    type: 'unstable-screenshot'
+    reference: ScreenshotData | null
+  }
+  | {
+    type: 'missing-reference'
+    location: 'reference' | 'diffs'
+    reference: ScreenshotData
+  }
+  | {
+    type: 'update-reference'
+    reference: ScreenshotData
+  }
+  | { type: 'matched-immediately' }
+  | { type: 'matched-after-comparison' }
+  | {
+    type: 'mismatch'
+    reference: ScreenshotData
+    actual: ScreenshotData
+    diff: ScreenshotData | null
+    message: string | null
+  }
+
+/**
+ * Browser command that compares a screenshot against a stored reference.
+ *
+ * The comparison workflow is organized as follows:
+ *
+ * 1. Load existing reference (if any)
+ * 2. Capture a stable screenshot (retrying until the page stops changing)
+ * 3. Determine the outcome based on capture results and update settings
+ * 4. Write any necessary files (new references, diffs)
+ * 5. Return result for the test runner
+ */
+export const screenshotMatcher: BrowserCommand<ScreenshotMatcherArguments> = async (
+  context,
+  name,
+  testName,
+  options,
+): ScreenshotMatcherOutput => {
   if (!context.testPath) {
-    throw new Error(`Cannot compare screenshots without a test path`)
+    throw new Error('Cannot compare screenshots without a test path')
   }
 
   const { element } = options
-
   const {
     codec,
     comparator,
@@ -25,10 +85,9 @@ export const screenshotMatcher: BrowserCommand<
   } = resolveOptions({ context, name, testName, options })
 
   const referenceFile = await readFile(paths.reference).catch(() => null)
-  const reference = referenceFile && await codec.decode(await readFile(paths.reference), {})
+  const reference = referenceFile && await codec.decode(referenceFile, {})
 
-  const abortController = new AbortController()
-  const stableScreenshot = getStableScreenshots({
+  const screenshotResult = await waitForStableScreenshot({
     codec,
     comparator,
     comparatorOptions,
@@ -37,139 +96,284 @@ export const screenshotMatcher: BrowserCommand<
     name: `${Date.now()}-${basename(paths.reference)}`,
     reference,
     screenshotOptions,
-    signal: abortController.signal,
+  }, timeout)
+
+  const outcome = await determineOutcome({
+    reference,
+    screenshot: screenshotResult && screenshotResult.actual,
+    retries: screenshotResult?.retries ?? 0,
+    updateSnapshot: context.project.serializedConfig.snapshotOptions.updateSnapshot,
+    paths,
+    comparator,
+    comparatorOptions,
   })
 
-  const value = await (
+  await performSideEffects(outcome, codec)
+
+  return buildOutput(outcome, timeout)
+}
+
+/**
+ * Core comparison logic that produces a {@linkcode MatchOutcome}.
+ *
+ * All branching logic lives here. This is the single source of truth for "what happened".
+ *
+ * The outcome carries all data needed by {@linkcode performSideEffects} and {@linkcode buildOutput}.
+ */
+async function determineOutcome(
+  {
+    comparator,
+    comparatorOptions,
+    paths,
+    reference,
+    retries,
+    screenshot,
+    updateSnapshot,
+  }: Pick<ResolvedOptions, 'comparator' | 'paths'> & {
+    comparatorOptions: ResolvedOptions['resolvedOptions']['comparatorOptions']
+    reference: DecodedImage | null
+    retries: number
+    screenshot: DecodedImage | null
+    updateSnapshot: SnapshotUpdateState
+  },
+): Promise<MatchOutcome> {
+  if (screenshot === null) {
+    return {
+      type: 'unstable-screenshot',
+      reference: reference && {
+        image: reference,
+        path: paths.reference,
+      },
+    }
+  }
+
+  // no reference to compare against - create one based on update settings
+  if (reference === null || updateSnapshot === 'all') {
+    if (updateSnapshot === 'all') {
+      return {
+        type: 'update-reference',
+        reference: {
+          image: screenshot,
+          path: paths.reference,
+        },
+      }
+    }
+
+    const location = updateSnapshot === 'none'
+      ? 'diffs'
+      : 'reference'
+
+    return {
+      type: 'missing-reference',
+      location,
+      reference: {
+        image: screenshot,
+        path: location === 'reference'
+          ? paths.reference
+          : paths.diffs.reference,
+      },
+    }
+  }
+
+  // first capture matched reference (used as baseline) - no further comparison needed
+  if (retries === 0) {
+    return { type: 'matched-immediately' }
+  }
+
+  const comparisonResult = await comparator(
+    reference,
+    screenshot,
+    { createDiff: true, ...comparatorOptions },
+  )
+
+  if (comparisonResult.pass) {
+    return { type: 'matched-after-comparison' }
+  }
+
+  return {
+    type: 'mismatch',
+    reference: {
+      image: reference,
+      path: paths.reference,
+    },
+    actual: {
+      image: screenshot,
+      path: paths.diffs.actual,
+    },
+    diff: comparisonResult.diff && {
+      image: {
+        data: comparisonResult.diff,
+        // `comparator` only returns pixel data; diff dimensions always match reference
+        metadata: reference.metadata,
+      },
+      path: paths.diffs.diff,
+    },
+    message: comparisonResult.message,
+  }
+}
+
+/**
+ * Writes files to disk based on the outcome.
+ *
+ * Only `missing-reference`, `update-reference`, and `mismatch` write files. Successful matches produce no side effects.
+ */
+async function performSideEffects(
+  outcome: MatchOutcome,
+  codec: AnyCodec,
+): Promise<void> {
+  switch (outcome.type) {
+    case 'missing-reference':
+    case 'update-reference': {
+      await writeScreenshot(
+        outcome.reference.path,
+        await codec.encode(outcome.reference.image, {}),
+      )
+
+      break
+    }
+
+    case 'mismatch': {
+      await writeScreenshot(
+        outcome.actual.path,
+        await codec.encode(outcome.actual.image, {}),
+      )
+
+      if (outcome.diff) {
+        await writeScreenshot(
+          outcome.diff.path,
+          await codec.encode(outcome.diff.image, {}),
+        )
+      }
+
+      break
+    }
+  }
+}
+
+/**
+ * Transforms a {@linkcode MatchOutcome} into the output format expected by the test runner.
+ *
+ * Maps each outcome to a pass/fail result with metadata and error messages.
+ */
+function buildOutput(
+  outcome: MatchOutcome,
+  timeout: number,
+): Awaited<ScreenshotMatcherOutput> {
+  switch (outcome.type) {
+    case 'unstable-screenshot':
+      return {
+        pass: false,
+        reference: outcome.reference && {
+          path: outcome.reference.path,
+          width: outcome.reference.image.metadata.width,
+          height: outcome.reference.image.metadata.height,
+        },
+        actual: null,
+        diff: null,
+        message: `Could not capture a stable screenshot within ${timeout}ms.`,
+      }
+
+    case 'missing-reference': {
+      return {
+        pass: false,
+        reference: {
+          path: outcome.reference.path,
+          width: outcome.reference.image.metadata.width,
+          height: outcome.reference.image.metadata.height,
+        },
+        actual: null,
+        diff: null,
+        message: outcome.location === 'reference'
+          ? 'No existing reference screenshot found; a new one was created. Review it before running tests again.'
+          : 'No existing reference screenshot found.',
+      }
+    }
+
+    case 'update-reference':
+    case 'matched-immediately':
+    case 'matched-after-comparison':
+      return { pass: true }
+
+    case 'mismatch':
+      return {
+        pass: false,
+        reference: {
+          path: outcome.reference.path,
+          width: outcome.reference.image.metadata.width,
+          height: outcome.reference.image.metadata.height,
+        },
+        actual: {
+          path: outcome.actual.path,
+          width: outcome.actual.image.metadata.width,
+          height: outcome.actual.image.metadata.height,
+        },
+        diff: outcome.diff && {
+          path: outcome.diff.path,
+          width: outcome.diff.image.metadata.width,
+          height: outcome.diff.image.metadata.height,
+        },
+        message: `Screenshot does not match the stored reference.${
+          outcome.message ? `\n${outcome.message}` : ''
+        }`,
+      }
+
+    default: {
+      // exhaustiveness check - TypeScript will error if a case is unhandled
+      outcome satisfies never
+
+      return {
+        pass: false,
+        actual: null,
+        reference: null,
+        diff: null,
+        message: `Outcome (${(outcome as MatchOutcome).type}) not handled. This is a bug in Vitest. Please, open an issue with reproduction.`,
+      }
+    }
+  }
+}
+
+/** Configuration for stable screenshot capture. */
+interface StableScreenshotOptions {
+  codec: AnyCodec
+  comparator: AnyComparator
+  comparatorOptions: ScreenshotMatcherOptions['comparatorOptions']
+  context: BrowserCommandContext
+  element: string
+  name: string
+  reference: ReturnType<AnyCodec['decode']> | null
+  screenshotOptions: ScreenshotMatcherArguments[2]['screenshotOptions']
+}
+
+/**
+ * Captures a stable screenshot with timeout handling.
+ *
+ * Wraps {@linkcode getStableScreenshot} with an abort controller that triggers when the timeout expires. Returns `null` if the page never stabilizes.
+ */
+async function waitForStableScreenshot(options: StableScreenshotOptions, timeout: number,
+): Promise<{ actual: DecodedImage; retries: number } | null> {
+  const abortController = new AbortController()
+
+  const stableScreenshot = getStableScreenshot(
+    options,
+    abortController.signal,
+  )
+
+  const result = await (
     timeout === 0
       ? stableScreenshot
       : Promise.race([
           stableScreenshot,
-          asyncTimeout(timeout).finally(() => { abortController.abort() }),
+          asyncTimeout(timeout).finally(() => abortController.abort()),
         ])
   )
 
-  // case #01
-  //  - impossible to get a stable screenshot to compare against
-  //  - fail
-  if (value === null || value.actual === null) {
-    return {
-      pass: false,
-      reference: referenceFile && { path: paths.reference, width: reference!.metadata.width, height: reference!.metadata.height },
-      actual: null,
-      diff: null,
-      message: `Could not capture a stable screenshot within ${timeout}ms.`,
-    }
-  }
-
-  const { updateSnapshot } = context.project.serializedConfig.snapshotOptions
-
-  // if there's no reference or if we want to update snapshots, we have to finish the comparison early
-  if (reference === null || updateSnapshot === 'all') {
-    const shouldCreateReference = updateSnapshot !== 'none'
-    const referencePath = shouldCreateReference ? paths.reference : paths.diffs.reference
-
-    await writeScreenshot(
-      referencePath,
-      await codec.encode(value.actual, {}),
-    )
-
-    // case #02
-    //  - got a stable screenshot, but there is no reference and we don't want to update screenshots
-    //  - fail
-    if (updateSnapshot !== 'all') {
-      return {
-        pass: false,
-        // we use `actual`'s metadata because that's the screenshot we saved
-        reference: { path: referencePath, width: value.actual.metadata.width, height: value.actual.metadata.height },
-        actual: null,
-        diff: null,
-        message: `No existing reference screenshot found${
-          shouldCreateReference
-            ? '; a new one was created. Review it before running tests again.'
-            : '.'
-        }`,
-      }
-    }
-
-    // case #03
-    //  - got a stable screenshot, there is no reference, but we want to update screenshots
-    //  - pass
-    return {
-      pass: true,
-    }
-  }
-
-  // case #04
-  //  - got a stable screenshot with no retries and there's a reference
-  //  - pass
-  if (referenceFile && value.retries === 0) {
-    return {
-      pass: true,
-    }
-  }
-
-  const finalResult = await comparator(reference, value.actual, { createDiff: true, ...comparatorOptions })
-
-  if (finalResult.pass === false && finalResult.diff !== null) {
-    const diff = await codec.encode(
-      {
-        data: finalResult.diff,
-        metadata: {
-          height: reference.metadata.height,
-          width: reference.metadata.width,
-        },
-      },
-      {},
-    )
-
-    await writeScreenshot(paths.diffs.diff, diff)
-  }
-
-  // case #05
-  //  - reference matches stable screenshot
-  //  - pass
-  if (finalResult.pass === true) {
-    return {
-      pass: true,
-    }
-  }
-
-  const actual = await codec.encode(value.actual, {})
-
-  await writeScreenshot(paths.diffs.actual, actual)
-
-  // case #06
-  //  - fallback, reference does NOT match stable screenshot
-  //  - fail
-  return {
-    pass: false,
-    reference: { path: paths.reference, width: reference.metadata.width, height: reference.metadata.height },
-    actual: { path: paths.diffs.actual, width: value.actual.metadata.width, height: value.actual.metadata.height },
-    diff: finalResult.diff && paths.diffs.diff,
-    message: `Screenshot does not match the stored reference.${
-      finalResult.message === null
-        ? ''
-        : `\n${finalResult.message}`
-    }`,
-  }
-}
-
-async function writeScreenshot(path: string, image: TypedArray) {
-  try {
-    await mkdir(dirname(path), { recursive: true })
-    await writeFile(path, image)
-  }
-  catch {
-    throw new Error('Couldn\'t write file to fs')
-  }
+  return result
 }
 
 /**
  * Takes screenshots repeatedly until the page reaches a visually stable state.
  *
- * This function compares consecutive screenshots and continues taking new ones
- * until two consecutive screenshots match according to the provided comparator.
+ * This function compares consecutive screenshots and continues taking new ones until two consecutive screenshots match according to the provided comparator.
  *
  * The process works as follows:
  *
@@ -179,10 +383,9 @@ async function writeScreenshot(path: string, image: TypedArray) {
  * 4. If they don't match, it continues with the newer screenshot as the baseline
  * 5. Repeats until stability is achieved or the operation is aborted
  *
- * @returns `Promise` resolving to an object containing the retry count and
- * final screenshot
+ * @returns `Promise` resolving to an object containing the retry count and final screenshot
  */
-async function getStableScreenshots({
+async function getStableScreenshot({
   codec,
   context,
   comparator,
@@ -191,18 +394,10 @@ async function getStableScreenshots({
   name,
   reference,
   screenshotOptions,
-  signal,
-}: {
-  codec: AnyCodec
-  comparator: AnyComparator
-  comparatorOptions: ScreenshotMatcherOptions['comparatorOptions']
-  context: BrowserCommandContext
-  element: string
-  name: string
-  reference: ReturnType<AnyCodec['decode']> | null
-  screenshotOptions: ScreenshotMatcherArguments[2]['screenshotOptions']
-  signal: AbortSignal
-}) {
+}: StableScreenshotOptions, signal: AbortSignal): Promise<{
+  retries: number
+  actual: DecodedImage
+}> {
   const screenshotArgument = {
     codec,
     context,
@@ -225,7 +420,7 @@ async function getStableScreenshots({
       takeDecodedScreenshot(screenshotArgument),
     ])
 
-    const comparatorResult = (await comparator(
+    const isStable = (await comparator(
       image1,
       image2,
       { ...comparatorOptions, createDiff: false },
@@ -233,7 +428,7 @@ async function getStableScreenshots({
 
     decodedBaseline = image2
 
-    if (comparatorResult) {
+    if (isStable) {
       break
     }
 
@@ -242,6 +437,17 @@ async function getStableScreenshots({
 
   return {
     retries,
-    actual: await decodedBaseline,
+    actual: await decodedBaseline!,
+  }
+}
+
+/** Writes encoded images to disk, creating parent directories as needed. */
+async function writeScreenshot(path: string, image: TypedArray) {
+  try {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, image)
+  }
+  catch (cause) {
+    throw new Error('Couldn\'t write file to fs', { cause })
   }
 }

--- a/packages/browser/src/node/commands/screenshotMatcher/utils.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/utils.ts
@@ -66,6 +66,20 @@ type SupportedCodecs = Parameters<typeof getCodec>[0]
 
 const supportedExtensions = ['png'] satisfies SupportedCodecs[]
 
+export interface ResolvedOptions {
+  codec: ReturnType<typeof getCodec>
+  comparator: ReturnType<typeof getComparator>
+  resolvedOptions: GlobalOptions
+  paths: {
+    reference: string
+    diffs: {
+      reference: string
+      actual: string
+      diff: string
+    }
+  }
+}
+
 export function resolveOptions(
   {
     context,
@@ -78,19 +92,7 @@ export function resolveOptions(
     testName: string
     options: ScreenshotMatcherOptions
   },
-): {
-  codec: ReturnType<typeof getCodec>
-  comparator: ReturnType<typeof getComparator>
-  resolvedOptions: GlobalOptions
-  paths: {
-    reference: string
-    diffs: {
-      reference: string
-      actual: string
-      diff: string
-    }
-  }
-} {
+): ResolvedOptions {
   if (context.testPath === undefined) {
     throw new Error('`resolveOptions` has to be used in a test file')
   }

--- a/packages/browser/src/shared/screenshotMatcher/types.ts
+++ b/packages/browser/src/shared/screenshotMatcher/types.ts
@@ -19,7 +19,7 @@ export type ScreenshotMatcherOutput = Promise<
     pass: false
     reference: ScreenshotData | null
     actual: ScreenshotData | null
-    diff: string | null
+    diff: ScreenshotData | null
     message: string
   }
   | {

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -828,11 +828,11 @@ export interface TestAnnotationArtifact extends TestArtifactBase {
   annotation: TestAnnotation
 }
 
-type VisualRegressionArtifactAttachment = TestAttachment & ({
-  name: 'reference' | 'actual'
+interface VisualRegressionArtifactAttachment extends TestAttachment {
+  name: 'reference' | 'actual' | 'diff'
   width: number
   height: number
-} | { name: 'diff' })
+}
 
 /**
  * @experimental

--- a/packages/ui/client/components/artifacts/visual-regression/VisualRegression.spec.ts
+++ b/packages/ui/client/components/artifacts/visual-regression/VisualRegression.spec.ts
@@ -8,6 +8,8 @@ import VisualRegression from './VisualRegression.vue'
 const diff = {
   name: 'diff',
   path: '/__diff.png',
+  width: 500,
+  height: 200,
 } as const
 
 const reference = {


### PR DESCRIPTION
### Description

Refactors the screenshot matcher to use a discriminated union (`MatchOutcome`) for representing comparison results, separating the branching logic from side effects and output creation.

The previous implementation had 6 exit points with interleaved file writes and return statements, making it hard to follow and modify to fix bugs or add new behaviors.

This PR:

- Introduces `MatchOutcome` type with explicit variants for each scenario
- Reorganizes the logic into three phases: determine outcome, write files, build output
- Adds documentation explaining a bit more of the process and the logic behind it
- Changes `diff` in artifact output to an object instead of just the path string, consistent with `reference` and `actual`. The type is marked as `@experimental` so shouldn't be considered a breaking change

Also fixes a double file read when loading reference (`readFile` was called twice).

This refactor should make fixing #9158 a lot easier (and less _hopes and prayers_).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
