### PR TITLE
feat(cli): add --repeats to the cli options

### DIFF
--- a/docs/config/repeats.md
+++ b/docs/config/repeats.md
@@ -1,0 +1,12 @@
+---
+title: repeats | Config
+outline: deep
+---
+
+# Repeats
+
+- **Type:** `number`
+- **Default:** `0`
+- **CLI:** `--repeats=<number>`
+
+Repeat the test a specific number of times regardless of the result.

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -525,6 +525,13 @@ Stop test execution when given number of tests have failed (default: `0`)
 
 Retry the test specific number of times if it fails (default: `0`)
 
+### repeats
+
+- **CLI:** `--repeats <number>`
+- **Config:** [repeats](/config/repeats)
+
+Repeat the test a specific number of times regardless of the result (default: `0`)
+
 ### diff.aAnnotation
 
 - **CLI:** `--diff.aAnnotation <annotation>`

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -298,7 +298,7 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   const suite = test.suite || test.file
   const $ = runner.trace!
 
-  const repeats = test.repeats ?? 0
+  const repeats = (test.repeats || runner.config.repeats) ?? 0
   for (let repeatCount = 0; repeatCount <= repeats; repeatCount++) {
     const retry = test.retry ?? 0
     for (let retryCount = 0; retryCount <= retry; retryCount++) {

--- a/packages/runner/src/types/runner.ts
+++ b/packages/runner/src/types/runner.ts
@@ -39,6 +39,7 @@ export interface VitestRunnerConfig {
   retry: number
   includeTaskLocation?: boolean
   diffOptions?: DiffOptions
+  repeats?: number
 }
 
 /**

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -651,6 +651,10 @@ export const cliOptionsConfig: VitestCLIOptions = {
       'Threshold in milliseconds for a test or suite to be considered slow (default: `300`)',
     argument: '<threshold>',
   },
+  repeats: {
+    description: 'Number of times to repeat each test',
+    argument: '<repeats>',
+  },
   teardownTimeout: {
     description:
       'Default timeout of a teardown function in milliseconds (default: `10000`)',

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -531,6 +531,10 @@ export const cliOptionsConfig: VitestCLIOptions = {
       'Retry the test specific number of times if it fails (default: `0`)',
     argument: '<times>',
   },
+  repeats: {
+    description: 'Repeat the test a specific number of times regardless of the result (default: `0`)',
+    argument: '<number>',
+  },
   diff: {
     description:
       'DiffOptions object or a path to a module which exports DiffOptions object',
@@ -650,10 +654,6 @@ export const cliOptionsConfig: VitestCLIOptions = {
     description:
       'Threshold in milliseconds for a test or suite to be considered slow (default: `300`)',
     argument: '<threshold>',
-  },
-  repeats: {
-    description: 'Number of times to repeat each test',
-    argument: '<repeats>',
   },
   teardownTimeout: {
     description:

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -35,6 +35,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
     // TODO: non serializable function?
     diff: config.diff,
     retry: config.retry,
+    repeats: config.repeats,
     disableConsoleIntercept: config.disableConsoleIntercept,
     root: config.root,
     name: config.name,
@@ -134,6 +135,5 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       fsModuleCache: config.experimental.fsModuleCache ?? false,
       printImportBreakdown: config.experimental.printImportBreakdown,
     },
-    repeats: config.repeats,
   }
 }

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -134,6 +134,6 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       fsModuleCache: config.experimental.fsModuleCache ?? false,
       printImportBreakdown: config.experimental.printImportBreakdown,
     },
-    repeats: config.repeats
+    repeats: config.repeats,
   }
 }

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -134,5 +134,6 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       fsModuleCache: config.experimental.fsModuleCache ?? false,
       printImportBreakdown: config.experimental.printImportBreakdown,
     },
+    repeats: config.repeats
   }
 }

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -683,6 +683,13 @@ export interface InlineConfig {
   slowTestThreshold?: number
 
   /**
+ * Number of times to repeat the tests.
+ * @default 0
+ *
+ */
+  repeats?: number
+
+  /**
    * Path to a custom test runner.
    */
   runner?: string

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -683,10 +683,10 @@ export interface InlineConfig {
   slowTestThreshold?: number
 
   /**
- * Number of times to repeat the tests.
- * @default 0
- *
- */
+   * Number of times to repeat the tests.
+   * @default 0
+   *
+   */
   repeats?: number
 
   /**

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -78,6 +78,7 @@ export interface SerializedConfig {
   } | undefined
   diff: string | SerializedDiffOptions | undefined
   retry: number
+  repeats?: number
   includeTaskLocation: boolean | undefined
   inspect: boolean | string | undefined
   inspectBrk: boolean | string | undefined
@@ -121,7 +122,6 @@ export interface SerializedConfig {
     fsModuleCache: boolean
     printImportBreakdown: boolean | undefined
   }
-  repeats?: number
 }
 
 export interface SerializedCoverageConfig {

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -121,6 +121,7 @@ export interface SerializedConfig {
     fsModuleCache: boolean
     printImportBreakdown: boolean | undefined
   }
+  repeats?: number
 }
 
 export interface SerializedCoverageConfig {

--- a/test/cli/fixtures/repeats/repeats.test.ts
+++ b/test/cli/fixtures/repeats/repeats.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "vitest";
+
+test("test should pass", () => {
+    expect(2).toBe(2)
+})
+
+test("test should repeat 2 times", { repeats: 2 }, () => {
+    expect(2).toBe(2)
+})

--- a/test/cli/test/repeats.test.ts
+++ b/test/cli/test/repeats.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+import { runVitestCli } from '../../test-utils'
+
+test("tests are repeating using cli args", async () => {
+  const {
+    stdout,
+  } = await runVitestCli('run', 'test/cli/fixtures/repeats/repeats.test.ts', '--repeats', '3', '--reporter', 'verbose')
+  expect(stdout).toContain('(repeat x3)')
+  expect(stdout).toContain('(repeat x2)')
+})

--- a/test/cli/test/repeats.test.ts
+++ b/test/cli/test/repeats.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
 import { runVitestCli } from '../../test-utils'
 
-test("tests are repeating using cli args", async () => {
+test('tests are repeating using cli args', async () => {
   const {
     stdout,
-  } = await runVitestCli('run', 'test/cli/fixtures/repeats/repeats.test.ts', '--repeats', '3', '--reporter', 'verbose')
+  } = await runVitestCli('run', '--root', 'fixtures/repeats', '--repeats', '3', '--reporter', 'verbose')
   expect(stdout).toContain('(repeat x3)')
   expect(stdout).toContain('(repeat x2)')
 })


### PR DESCRIPTION
### Description
This pull request exposes the repeat option of the test options to the cli

<img width="816" height="244" alt="image" src="https://github.com/user-attachments/assets/7d612429-ea84-4cc7-978b-421ff23f2caf" />

it will prioritize the test option value over the cli value for an individual test.
so if your code was:
```ts
test("bar() to return bar", async () => {
  expect(await bar()).toBe('bar')
})


test("1 + 1 = 2", { repeats: 10 }, () => {
  expect(1 + 1).toBe(2)
})
```

it will output:
<img width="825" height="242" alt="image" src="https://github.com/user-attachments/assets/64dd90b8-a53e-4c81-a37e-937d6b0bf79e" />


Resolves #7352

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
