### PR TITLE
Fix: Expose `BaseReporter` as a part of the public API

### DIFF
--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -1,11 +1,12 @@
 import type { Reporter, TestRunEndReason } from '../types/reporter'
-import type { BaseOptions, BaseReporter } from './base'
+import type { BaseOptions } from './base'
 import type { BlobOptions } from './blob'
 import type { DefaultReporterOptions } from './default'
 import type { GithubActionsReporterOptions } from './github-actions'
 import type { HTMLOptions } from './html'
 import type { JsonOptions } from './json'
 import type { JUnitOptions } from './junit'
+import { BaseReporter } from './base'
 import { BlobReporter } from './blob'
 import { DefaultReporter } from './default'
 import { DotReporter } from './dot'
@@ -19,6 +20,7 @@ import { TreeReporter } from './tree'
 import { VerboseReporter } from './verbose'
 
 export {
+  BaseReporter,
   DefaultReporter,
   DotReporter,
   GithubActionsReporter,
@@ -30,7 +32,7 @@ export {
   TreeReporter,
   VerboseReporter,
 }
-export type { BaseReporter, Reporter, TestRunEndReason }
+export type { Reporter, TestRunEndReason }
 
 export type { BenchmarkBuiltinReporters } from './benchmark'
 export {

--- a/packages/vitest/src/public/reporters.ts
+++ b/packages/vitest/src/public/reporters.ts
@@ -1,4 +1,5 @@
 export {
+  BaseReporter,
   BenchmarkReporter,
   BenchmarkReportsMap,
   DefaultReporter,
@@ -14,7 +15,6 @@ export {
   VerboseReporter,
 } from '../node/reporters'
 export type {
-  BaseReporter,
   BenchmarkBuiltinReporters,
   BuiltinReporterOptions,
   BuiltinReporters,

--- a/test/core/test/exports.test.ts
+++ b/test/core/test/exports.test.ts
@@ -305,6 +305,7 @@ it('exports snapshot', async ({ skip, task }) => {
             "viteVersion": "string",
           },
           "./reporters": {
+            "BaseReporter": "function",
             "BenchmarkReporter": "function",
             "BenchmarkReportsMap": "object",
             "DefaultReporter": "function",

--- a/test/reporters/src/custom-reporter.ts
+++ b/test/reporters/src/custom-reporter.ts
@@ -1,10 +1,11 @@
 import type { Reporter, Vitest } from 'vitest/node'
+import { BaseReporter } from 'vitest/reporters'
 
-export default class TestReporter implements Reporter {
-  ctx!: Vitest
+export default class TestReporter extends BaseReporter implements Reporter {
   options?: unknown
 
   constructor(options?: unknown) {
+    super()
     this.options = options
   }
 


### PR DESCRIPTION
### Description

This PR exposes the `BaseReporter` abstract class, which is useful for creating custom reporters.

Fixes #8523. Closes #8524.

#### Why this matters

* Extending `BaseReporter` is [already documented](https://vitest.dev/api/advanced/reporters.html) as the recommended way to create a custom reporter (see the `custom-reporter.js` example).
* Consistent UI: `BaseReporter` provides the means to display the user-friendly summary report that’s already displayed by the `default` and `dot` reporters.

#### Notes

* If there is a desire to add a more elaborate test suite for the newly exposed reporter, I’ll be happy to add one.
* The test suite seems to be failing for reasons unrelated to this PR.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
