### PR TITLE
feat: conditional judgment for deleting the "html" reporter

### DIFF
--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -2,7 +2,6 @@ import type { Plugin } from 'vite'
 import type { Vitest } from 'vitest/node'
 import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { toArray } from '@vitest/utils/helpers'
 import { basename, resolve } from 'pathe'
 import sirv from 'sirv'
 import c from 'tinyrainbow'
@@ -131,14 +130,6 @@ function resolveCoverageFolder(ctx: Vitest) {
   const options = ctx.config
   const htmlReporter
     = options.api?.port && options.coverage?.enabled
-      ? toArray(options.coverage.reporter).find((reporter) => {
-          if (typeof reporter === 'string') {
-            return reporter === 'html'
-          }
-
-          return reporter[0] === 'html'
-        })
-      : undefined
 
   if (!htmlReporter) {
     return undefined


### PR DESCRIPTION
### Description

This PR removes the hard dependency on the built-in `html` coverage reporter when resolving the coverage HTML folder exposed by the Vitest API server.

Previously, the coverage UI was only enabled when the `html` reporter was explicitly configured. This assumption prevents custom or third-party coverage reporters from exposing valid HTML coverage output through the Vitest server, even when they generate static HTML reports.

With this change, Vitest determines whether to expose the coverage folder based on coverage configuration and resolved output paths, rather than relying on the reporter name. This makes the behavior more flexible and allows custom HTML-based coverage reporters to integrate with the Vitest UI without needing to masquerade as the built-in `html` reporter.

<img width="824" height="613" alt="截屏2025-12-17 19 27 51" src="https://github.com/user-attachments/assets/cf95b9a0-ff56-43c2-bd1f-f7eb0016f3af" />


---

### Additional Context

This change is backward compatible with the existing `html` reporter behavior and does not alter the default coverage directory structure. It only relaxes the reporter-type constraint to improve extensibility for custom coverage reporters.

---

### Tests

* [x] Run the tests with `pnpm test:ci`.

---

### Checklist

* [ ] This PR references a related issue discussing the behavior change.
* [ ] Tests are added or updated to cover the new behavior.
* [x] No unnecessary changes to `pnpm-lock.yaml`.
* [x] Allow edits by maintainers is enabled.