### PR TITLE
Use `meta.url` as the argument to `createRequire()` when loading a module

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -273,7 +273,7 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
       'code.file.path': filename,
     })
 
-    const require = this.createRequire(filename)
+    const require = this.createRequire(meta.url)
 
     const argumentsList = [
       ssrModuleExportsKey,
@@ -355,7 +355,7 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
   private createRequire(filename: string) {
     // \x00 is a rollup convention for virtual files,
     // it is not allowed in actual file names
-    if (filename[0] === '\x00' || !isAbsolute(filename)) {
+    if ((filename[0] === '\x00' || !isAbsolute(filename))) {
       return () => ({})
     }
     return this.vm


### PR DESCRIPTION
### Description

When creating a `require()` function using `createRequire()`, pass in the URL rather than the filename. Passing in the filename can cause bugs on Windows, and error messages along the lines of `TypeError: The argument 'path' The argument must be a file URL object, a file URL string, or an absolute path string.. `

This matches the implementation in `vite-node`: https://github.com/antfu-collective/vite-node/blob/63e2a8111cb674335823746a5df87eae666eee76/src/client.ts#L550

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
