### PR TITLE
fix: replace crypto.randomUUID to allow insecure environments (fix #9…

### DIFF
--- a/packages/browser/src/client/public/esm-client-injector.js
+++ b/packages/browser/src/client/public/esm-client-injector.js
@@ -9,7 +9,7 @@
     }
 
     const { evaluatedModules } = __vitest_worker__
-    const moduleId = crypto.randomUUID()
+    const moduleId = `${Math.random()}`
     const viteModule = evaluatedModules.ensureModule(moduleId, moduleId)
 
     viteModule.evaluated = false

--- a/test/browser/fixtures/insecure-context/src/basic.test.ts
+++ b/test/browser/fixtures/insecure-context/src/basic.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+
+test("basic", async () => {
+  expect(window.isSecureContext).toBe(false);
+  expect(1).toBe((await import("./dynamic-import")).default);
+});

--- a/test/browser/fixtures/insecure-context/src/dynamic-import.ts
+++ b/test/browser/fixtures/insecure-context/src/dynamic-import.ts
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/browser/fixtures/insecure-context/vitest.config.ts
+++ b/test/browser/fixtures/insecure-context/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+import os from "node:os";
+import { defineConfig } from "vitest/config";
+import { instances, provider } from "../../settings";
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider,
+      instances,
+    },
+  },
+  server: {
+    host: os.hostname(), // To force an insecure-context, a host which is not 127.0.0.1 or localhost is needed
+  },
+});

--- a/test/browser/specs/insecure-context.test.ts
+++ b/test/browser/specs/insecure-context.test.ts
@@ -1,0 +1,13 @@
+import os from 'node:os'
+import { expect, test } from 'vitest'
+import { instances, runBrowserTests } from './utils'
+
+// server.host = os.hostname // doesnt work on mac, therefore the test is only run on linux
+test.runIf(os.platform() === 'linux')('server-host check dynamic import at insecure context', async () => {
+  const { stdout, stderr } = await runBrowserTests({
+    root: './fixtures/insecure-context',
+  })
+
+  expect(stderr).toBe('')
+  expect(stdout).toReportSummaryTestFiles({ passed: instances.length })
+})


### PR DESCRIPTION
fixes #9338

### Description

crypto.randomUUID is not available in the browser in case it gets executed in an insecure environment Math.random() should suffice for mocking

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
