### PR TITLE
docs: documentation for `server.deps.fallbackCJS` is confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,8 @@ See [Contributing Guide](https://github.com/vitest-dev/vitest/blob/main/CONTRIBU
 ## License
 
 [MIT](./LICENSE) License © 2021-Present VoidZero Inc. and Vitest contributors
+
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Description

### Describe the bug

In the [main documentation](https://vitest.dev/config/#server-deps-fallbackcjs): 
> When a dependency is a valid ESM package, try to guess the cjs version based on the path. Thi

## Changes Made

- docs: Added contributing section

Fixes #6352
