### PR TITLE
refactor: remove duplicate values from `coverage.exclude`

### DIFF
--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -58,6 +58,27 @@ List of files excluded from coverage as glob patterns.
 
 See [Including and excluding files from coverage report](/guide/coverage.html#including-and-excluding-files-from-coverage-report) for examples.
 
+The internal implementation will by default write some configuration files into it, as listed below:
+```ts
+[
+  'vitest.config.ts',
+  'vitest.config.mts',
+  'vitest.config.cts',
+  'vitest.config.js',
+  'vitest.config.mjs',
+  'vitest.config.cjs',
+  'vite.config.ts',
+  'vite.config.mts',
+  'vite.config.cts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.cjs',
+  '**\/virtual:*',
+  '**\/__x00__*',
+  '**/node_modules/**'
+]
+```
+
 ## coverage.clean
 
 - **Type:** `boolean`

--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -58,27 +58,6 @@ List of files excluded from coverage as glob patterns.
 
 See [Including and excluding files from coverage report](/guide/coverage.html#including-and-excluding-files-from-coverage-report) for examples.
 
-The internal implementation will by default write some configuration files into it, as listed below:
-```ts
-[
-  'vitest.config.ts',
-  'vitest.config.mts',
-  'vitest.config.cts',
-  'vitest.config.js',
-  'vitest.config.mjs',
-  'vitest.config.cjs',
-  'vite.config.ts',
-  'vite.config.mts',
-  'vite.config.cts',
-  'vite.config.js',
-  'vite.config.mjs',
-  'vite.config.cjs',
-  '**\/virtual:*',
-  '**\/__x00__*',
-  '**/node_modules/**'
-]
-```
-
 ## coverage.clean
 
 - **Type:** `boolean`

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -26,6 +26,7 @@ import { isCI, stdProvider } from '../../utils/env'
 import { getWorkersCountByPercentage } from '../../utils/workers'
 import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
+import { basename } from 'node:path'
 
 function resolvePath(path: string, root: string) {
   return normalize(
@@ -394,7 +395,7 @@ export function resolveConfig(
 
   // Add hard-coded default coverage exclusions. These cannot be overidden by user config.
   // Override original exclude array for cases where user re-uses same object in test.exclude.
-  resolved.coverage.exclude = [
+  resolved.coverage.exclude = [...new Set([
     ...resolved.coverage.exclude,
 
     // Exclude setup files
@@ -410,7 +411,7 @@ export function resolveConfig(
     ...resolved.include,
 
     // Configs
-    resolved.config && slash(resolved.config),
+    resolved.config && basename(slash(resolved.config)),
     ...configFiles,
 
     // Vite internal
@@ -418,7 +419,7 @@ export function resolveConfig(
     '**\/__x00__*',
 
     '**/node_modules/**',
-  ].filter(pattern => typeof pattern === 'string')
+  ])].filter(pattern => typeof pattern === 'string')
 
   resolved.forceRerunTriggers = [
     ...resolved.forceRerunTriggers,

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -394,7 +394,7 @@ export function resolveConfig(
 
   // Add hard-coded default coverage exclusions. These cannot be overidden by user config.
   // Override original exclude array for cases where user re-uses same object in test.exclude.
-  resolved.coverage.exclude = [
+  resolved.coverage.exclude = [...new Set([
     ...resolved.coverage.exclude,
 
     // Exclude setup files
@@ -418,7 +418,7 @@ export function resolveConfig(
     '**\/__x00__*',
 
     '**/node_modules/**',
-  ].filter(pattern => typeof pattern === 'string')
+  ])].filter(pattern => typeof pattern === 'string')
 
   resolved.forceRerunTriggers = [
     ...resolved.forceRerunTriggers,

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -394,7 +394,7 @@ export function resolveConfig(
 
   // Add hard-coded default coverage exclusions. These cannot be overidden by user config.
   // Override original exclude array for cases where user re-uses same object in test.exclude.
-  resolved.coverage.exclude = [...new Set([
+  resolved.coverage.exclude = [
     ...resolved.coverage.exclude,
 
     // Exclude setup files
@@ -418,7 +418,7 @@ export function resolveConfig(
     '**\/__x00__*',
 
     '**/node_modules/**',
-  ])].filter(pattern => typeof pattern === 'string')
+  ].filter(pattern => typeof pattern === 'string')
 
   resolved.forceRerunTriggers = [
     ...resolved.forceRerunTriggers,

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -9,6 +9,7 @@ import type {
 } from '../types/config'
 import type { BaseCoverageOptions, CoverageReporterWithOptions } from '../types/coverage'
 import crypto from 'node:crypto'
+import { basename } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { slash, toArray } from '@vitest/utils/helpers'
 import { resolveModule } from 'local-pkg'
@@ -26,7 +27,6 @@ import { isCI, stdProvider } from '../../utils/env'
 import { getWorkersCountByPercentage } from '../../utils/workers'
 import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
-import { basename } from 'node:path'
 
 function resolvePath(path: string, root: string) {
   return normalize(


### PR DESCRIPTION
### Description
When `vitest --coverage` is executed, `resolveConfig` will be executed twice.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
