### PR TITLE
feat(ui): support lcov coverage reporter

### DIFF
--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -87,16 +87,16 @@ function expandTests() {
         />
         <VueTooltip
           v-if="coverageConfigured && !coverageEnabled"
-          title="Coverage enabled but missing html reporter"
+          title="Coverage enabled but missing html or lcov reporter"
           class="w-1.4em h-1.4em op100 rounded flex color-red5 dark:color-#f43f5e cursor-help"
         >
           <div class="i-carbon:folder-off ma" />
           <template #popper>
             <div class="op100 gap-1 p-y-1" grid="~ items-center cols-[1.5em_1fr]">
               <div class="i-carbon:information-square w-1.5em h-1.5em" />
-              <div>Coverage enabled but missing html reporter.</div>
+              <div>Coverage enabled but missing html or lcov reporter.</div>
               <div style="grid-column: 2">
-                Add html reporter to your configuration to see coverage here.
+                Add html or lcov reporter to your configuration to see coverage here.
               </div>
             </div>
           </template>

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -46,13 +46,23 @@ export function serializeConfig(project: TestProject): SerializedConfig {
         'html',
         { subdir?: string },
       ] | undefined
-      const subdir = htmlReporter && htmlReporter[1]?.subdir
+      const htmlSubdir = htmlReporter && htmlReporter[1]?.subdir
+
+      const lcovReporter = coverage.reporter.find(([reporterName]) => reporterName === 'lcov') as [
+        'lcov',
+        { subdir?: string },
+      ] | undefined
+      const lcovSubdir = lcovReporter && lcovReporter[1]?.subdir
+
       return {
         reportsDirectory: coverage.reportsDirectory,
         provider: coverage.provider,
         enabled: coverage.enabled,
         htmlReporter: htmlReporter
-          ? { subdir }
+          ? { subdir: htmlSubdir }
+          : undefined,
+        lcovReporter: lcovReporter
+          ? { subdir: lcovSubdir }
           : undefined,
         customProviderModule: 'customProviderModule' in coverage
           ? coverage.customProviderModule

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -129,6 +129,9 @@ export interface SerializedCoverageConfig {
   htmlReporter: {
     subdir: string | undefined
   } | undefined
+  lcovReporter: {
+    subdir: string | undefined
+  } | undefined
   enabled: boolean
   customProviderModule: string | undefined
 }

--- a/test/ui/.gitignore
+++ b/test/ui/.gitignore
@@ -1,2 +1,3 @@
 html
+html-lcov
 test-results

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -291,6 +291,38 @@ test.describe('ui', () => {
   })
 })
 
+test.describe('ui with lcov coverage', () => {
+  let vitest: Vitest | undefined
+
+  test.beforeAll(async () => {
+    // silence Vitest logs
+    const stdout = new Writable({ write: (_, __, callback) => callback() })
+    const stderr = new Writable({ write: (_, __, callback) => callback() })
+    vitest = await startVitest('test', [], {
+      watch: true,
+      ui: true,
+      open: false,
+      api: { port },
+      coverage: { enabled: true, reporter: ['lcov'] },
+      reporters: [],
+    }, {}, {
+      stdout,
+      stderr,
+    })
+    expect(vitest).toBeDefined()
+  })
+
+  test.afterAll(async () => {
+    await vitest?.close()
+  })
+
+  test('coverage with lcov reporter', async ({ page }) => {
+    await page.goto(pageUrl)
+    await page.getByLabel('Show coverage').click()
+    await page.frameLocator('#vitest-ui-coverage').getByRole('heading', { name: 'All files' }).click()
+  })
+})
+
 test.describe('standalone', () => {
   let vitest: Vitest | undefined
 


### PR DESCRIPTION
### Description

 Previously, the UI coverage viewer only supported the `html` reporter. This PR adds support for the `lcov` reporter,
 which generates coverage reports in `lcov-report/index.html`.

 Note: When both reporters are configured, `html` takes priority for backward compatibility.

Resolves #6381

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
