### PR TITLE
fix(browser-webdriverio): fall back to WebDriver Classic #9244

### DIFF
--- a/packages/browser-webdriverio/src/webdriverio.ts
+++ b/packages/browser-webdriverio/src/webdriverio.ts
@@ -117,14 +117,19 @@ export class WebdriverBrowserProvider implements BrowserProvider {
     if (this.topLevelContext == null || !this.browser) {
       throw new Error(`The browser has no open pages.`)
     }
-    await this.browser.send({
-      method: 'browsingContext.setViewport',
-      params: {
-        context: this.topLevelContext,
-        devicePixelRatio: 1,
-        viewport: options,
-      },
-    })
+    if (this.browser.isBidi) {
+      await this.browser.send({
+        method: 'browsingContext.setViewport',
+        params: {
+          context: this.topLevelContext,
+          devicePixelRatio: 1,
+          viewport: options,
+        },
+      })
+    }
+    else {
+      await this.browser.setWindowSize(options.width, options.height)
+    }
   }
 
   getCommandsContext(): {


### PR DESCRIPTION
### Description

  Check `browser.isBidi` before using BiDi commands in `setViewport`. When BiDi is unavailable (e.g., Safari or when `wdio:enforceWebDriverClassic` is set), fall back to `setWindowSize` instead of failing.

Resolves #9244

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
