### PR TITLE
fix(coverage): prevent ENOENT race condition when writing coverage files

### DIFF
--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -240,7 +240,11 @@ export class BaseCoverageProvider<Options extends ResolvedCoverageOptions<'istan
       })
     }
 
+    const dirExistedBefore = existsSync(this.coverageFilesDirectory)
+    console.log(`[vitest:coverage] clean() mkdir: path=${this.coverageFilesDirectory}, existedBefore=${dirExistedBefore}`)
     await fs.mkdir(this.coverageFilesDirectory, { recursive: true })
+    const dirExistsAfter = existsSync(this.coverageFilesDirectory)
+    console.log(`[vitest:coverage] clean() mkdir complete: existsAfter=${dirExistsAfter}`)
 
     this.coverageFiles = new Map()
     this.pendingPromises = []
@@ -268,11 +272,9 @@ export class BaseCoverageProvider<Options extends ResolvedCoverageOptions<'istan
     // If there's a result from previous run, overwrite it
     entry[environment][testFilenames] = filename
 
-    // Ensure directory exists before writing. This prevents ENOENT errors
-    // when onAfterSuiteRun fires before clean() finishes creating the directory.
-    // This can happen in environments with slower I/O (e.g., Docker with volume mounts).
-    const promise = fs.mkdir(this.coverageFilesDirectory, { recursive: true })
-      .then(() => fs.writeFile(filename, JSON.stringify(coverage), 'utf-8'))
+    const dirExists = existsSync(this.coverageFilesDirectory)
+    console.log(`[vitest:coverage] onAfterSuiteRun() writeFile: path=${filename}, dirExists=${dirExists}`)
+    const promise = fs.writeFile(filename, JSON.stringify(coverage), 'utf-8')
     this.pendingPromises.push(promise)
   }
 


### PR DESCRIPTION
Ensure the coverage temp directory exists before writing coverage data in onAfterSuiteRun. This prevents ENOENT errors when the directory hasn't been created yet or filesystem has eventual consistency issues.

This race condition manifests in environments with slower I/O, such as Docker containers with volume mounts.

### Description

I was trying to verify that Jules AI agent (jules.google.com) is able to run tests in [my repository](https://github.com/vadimpiven/node_reqwest/blob/eec9b97bcff4e3c750db8b529b1faeef96ea376f/packages/node/package.json#L86) in docker-compose ([setup](https://github.com/vadimpiven/node_reqwest/blob/eec9b97bcff4e3c750db8b529b1faeef96ea376f/AGENTS.md)), and the following error was constantly reproducing on the first try to run tests:

```bash
> node-reqwest@0.0.0 test:vitest /workspace/packages/node
> pnpm exec vitest run --coverage


 RUN  v4.0.16 /workspace/packages/node
      Coverage enabled with istanbul

 ✓ tests/vitest/mitmproxy.test.ts (2 tests | 1 skipped) 3ms
 ✓ tests/vitest/index.test.ts (1 test) 1ms

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: ENOENT: no such file or directory, open '/workspace/packages/node/coverage-vitest/.tmp/coverage-0.json'
 ❯ open node:internal/fs/promises:641:25
 ❯ Object.writeFile node:internal/fs/promises:1215:14

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { errno: -2, code: 'ENOENT', syscall: 'open', path: '/workspace/packages/node/coverage-vitest/.tmp/coverage-0.json' }



 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
/workspace/packages/node:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  node-reqwest@0.0.0 test: `pnpm run test:ts && pnpm run test:rust`
Exit status 1
 ELIFECYCLE  Test failed. See above for more details.
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
