### PR TITLE
fix: typo in browser.provider error

### DIFF
--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -468,7 +468,7 @@ export class TestProject {
     }
     const provider = this.config.browser.provider || childProject.config.browser.provider
     if (provider == null) {
-      throw new Error(`Proider was not specified in the "browser.provider" setting. Please, pass down playwright(), webdriverio() or preview() from "@vitest/browser-playwright", "@vitest/browser-webdriverio" or "@vitest/browser-preview" package respectively.`)
+      throw new Error(`Provider was not specified in the "browser.provider" setting. Please, pass down playwright(), webdriverio() or preview() from "@vitest/browser-playwright", "@vitest/browser-webdriverio" or "@vitest/browser-preview" package respectively.`)
     }
     if (typeof provider.serverFactory !== 'function') {
       throw new TypeError(`The browser provider options do not return a "serverFactory" function. Are you using the latest "@vitest/browser-${provider.name}" package?`)


### PR DESCRIPTION
### Description

Fix a typo in the word "Proider" -> "Provider".

Resolves #9393
