### PR TITLE
docs: Update globals.md with tsconfig.app.json guidance

### DIFF
--- a/docs/config/globals.md
+++ b/docs/config/globals.md
@@ -34,6 +34,10 @@ To get TypeScript working with the global APIs, add `vitest/globals` to the `typ
 }
 ```
 
+::: tip
+If you create a project using `create vue`, the `tsconfig.app.json` file should be used to place these configurations; only then will they take effect in the project.
+:::
+
 If you have redefined your [`typeRoots`](https://www.typescriptlang.org/tsconfig/#typeRoots) to include additional types in your compilation, you will need to add back the `node_modules` to make `vitest/globals` discoverable:
 
 ```json [tsconfig.json]


### PR DESCRIPTION
When creating a project with Create Vue, I noticed that adding "types\": [\"vitest/globals\"] to tsconfig.json does not take effect. However, placing this configuration in tsconfig.app.json works as expected. This behavior is not caused by my local setup, but by how Create Vue structures and applies TypeScript configuration files. Therefore, it’s worth adding a small note to clarify this.

If this issue is caused by my own mistake, I would appreciate it if you could help clarify my confusion.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
