### PR TITLE
fix(mocker): fix mock transform with class

### DIFF
--- a/packages/mocker/src/node/esmWalker.ts
+++ b/packages/mocker/src/node/esmWalker.ts
@@ -157,6 +157,17 @@ export function esmWalker(
           identifiers.push([node, parentStack.slice(0)])
         }
       }
+      else if (node.type === 'ClassDeclaration' && node.id) {
+        // A class declaration name could shadow an import, so add its name to the parent scope
+        const parentScope = findParentScope(parentStack)
+        if (parentScope) {
+          setScope(parentScope, node.id.name)
+        }
+      }
+      else if (node.type === 'ClassExpression' && node.id) {
+        // A class expression name could shadow an import, so add its name to the scope
+        setScope(node, node.id.name)
+      }
       else if (isFunctionNode(node)) {
         // If it is a function declaration, it could be shadowing an import
         // Add its name to the scope so it won't get replaced

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -1117,6 +1117,52 @@ const Baz = class extends Foo {}
     `)
   })
 
+  test('classDeclaration shadowing import', () => {
+    const input = `\
+import { Bar } from "./repro.js"
+{
+  class Bar {
+    test() {}
+  }
+  const Zoo = class Zoo extends Bar {}
+}
+`
+    expect(hoistSimpleCodeWithoutMocks(input)).toMatchInlineSnapshot(`
+      "vi.mock('faker');
+      const __vi_import_0__ = await import("./repro.js");
+      import {vi} from "vitest";
+
+      {
+        class Bar {
+          test() {}
+        }
+        const Zoo = class Zoo extends Bar {}
+      }"
+    `)
+  })
+
+  test('classExpression name shadowing import', () => {
+    const input = `\
+import { Foo } from "./foo.js"
+const Bar = class Foo {
+  static create() {
+    return new Foo()
+  }
+}
+`
+    expect(hoistSimpleCodeWithoutMocks(input)).toMatchInlineSnapshot(`
+      "vi.mock('faker');
+      const __vi_import_0__ = await import("./foo.js");
+      import {vi} from "vitest";
+
+      const Bar = class Foo {
+        static create() {
+          return new Foo()
+        }
+      }"
+    `)
+  })
+
   test('import assertion attribute', () => {
     expect(
       hoistSimpleCodeWithoutMocks(`


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The bug is found when investigating Vite 8 https://github.com/vitest-dev/vitest/pull/9415. 

https://github.com/vitest-dev/vitest/blob/f8879a82f95e7640d379e1e4b3ef30dec4ff8f3a/test/core/test/mocking/automocking-class-inheritence.test.ts#L45-L51

The transform scope issue didn't manifest with esbuild ts transform since esbuild was deconflicting by itself by `Bar -> Bar2`. Now this manifested with Oxc since inner `Bar` were kept as is. 

The test case added here is raw js, so it fails without the fix.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
