### PR TITLE
fix(fsModuleCache): don't store importers in cache

### DIFF
--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -33,7 +33,7 @@ export class FileSystemModuleCache {
   private rootCache: string
   private metadataFilePath: string
 
-  private version = '1.0.0-beta.3'
+  private version = '1.0.0-beta.4'
   private fsCacheRoots = new WeakMap<ResolvedConfig, string>()
   private fsEnvironmentHashMap = new WeakMap<DevEnvironment, string>()
   private fsCacheKeyGenerators = new Set<CacheKeyIdGenerator>()
@@ -108,7 +108,6 @@ export class FileSystemModuleCache {
       url: meta.url,
       file: meta.file,
       code,
-      importers: meta.importers,
       importedUrls: meta.importedUrls,
       mappings: meta.mappings,
     }
@@ -117,7 +116,6 @@ export class FileSystemModuleCache {
   async saveCachedModule<T extends FetchResult>(
     cachedFilePath: string,
     fetchResult: T,
-    importers: string[] = [],
     importedUrls: string[] = [],
     mappings: boolean = false,
   ): Promise<void> {
@@ -126,7 +124,6 @@ export class FileSystemModuleCache {
         file: fetchResult.file,
         id: fetchResult.id,
         url: fetchResult.url,
-        importers,
         importedUrls,
         mappings,
       } satisfies Omit<CachedInlineModuleMeta, 'code'>
@@ -367,7 +364,6 @@ export interface CachedInlineModuleMeta {
   id: string
   file: string | null
   code: string
-  importers: string[]
   mappings: boolean
   importedUrls: string[]
 }

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -125,19 +125,18 @@ class ModuleFetcher {
       })
     }
 
-    const cachedModule = await this.getCachedModule(cachePath, environment, moduleGraphModule)
+    const cachedModule = await this.getCachedModule(cachePath, environment, moduleGraphModule, importer)
     if (cachedModule) {
       this.recordResult(trace, cachedModule)
       return cachedModule
     }
 
     const result = await this.fetchAndProcess(environment, url, importer, moduleGraphModule, options)
-    const importers = this.getSerializedDependencies(moduleGraphModule)
     const importedUrls = this.getSerializedImports(moduleGraphModule)
     const map = moduleGraphModule.transformResult?.map
     const mappings = map && !('version' in map) && map.mappings === ''
 
-    return this.cacheResult(result, cachePath, importers, importedUrls, !!mappings)
+    return this.cacheResult(result, cachePath, importedUrls, !!mappings)
   }
 
   // we need this for UI to be able to show a module graph
@@ -147,17 +146,6 @@ class ModuleFetcher {
       imports.push(importer.url)
     })
     return imports
-  }
-
-  // we need this for the watcher to be able to find the related test file
-  private getSerializedDependencies(node: EnvironmentModuleNode): string[] {
-    const dependencies: string[] = []
-    node.importers.forEach((importer) => {
-      if (importer.id) {
-        dependencies.push(importer.id)
-      }
-    })
-    return dependencies
   }
 
   private recordResult(trace: Span, result: FetchResult | FetchCachedFileSystemResult): void {
@@ -235,6 +223,7 @@ class ModuleFetcher {
     cachePath: string,
     environment: DevEnvironment,
     moduleGraphModule: EnvironmentModuleNode,
+    importer: string | undefined,
   ): Promise<FetchResult | FetchCachedFileSystemResult | undefined> {
     if (moduleGraphModule.transformResult?.__vitestTmp) {
       return {
@@ -270,12 +259,12 @@ class ModuleFetcher {
     }
 
     // we populate the module graph to make the watch mode work because it relies on importers
-    cachedModule.importers.forEach((importer) => {
+    if (importer) {
       const environmentNode = environment.moduleGraph.getModuleById(importer)
       if (environmentNode) {
         moduleGraphModule.importers.add(environmentNode)
       }
-    })
+    }
 
     await Promise.all(cachedModule.importedUrls.map(async (url) => {
       const moduleNode = await environment.moduleGraph.ensureEntryFromUrl(url).catch(() => null)
@@ -317,7 +306,6 @@ class ModuleFetcher {
   private async cacheResult(
     result: FetchResult,
     cachePath: string,
-    importers: string[] = [],
     importedUrls: string[] = [],
     mappings = false,
   ): Promise<FetchResult | FetchCachedFileSystemResult> {
@@ -331,7 +319,7 @@ class ModuleFetcher {
     }
 
     const savePromise = this.fsCache
-      .saveCachedModule(cachePath, result, importers, importedUrls, mappings)
+      .saveCachedModule(cachePath, result, importedUrls, mappings)
       .then(() => result)
       .finally(() => {
         saveCachePromises.delete(cachePath)


### PR DESCRIPTION
The file can be imported by multiple different files at different times and by different projects. We already have the `importer` that we can use to populate `node.importers`.

The bug found when testing https://github.com/vitest-dev/vitest/actions/runs/20852420928/job/59910449565?pr=9367