### PR TITLE
fix(spy): `mockReturnValue` with class mocks

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -121,11 +121,17 @@ export function createMockInstance(options: MockInstanceOption = {}): Mock<Proce
   }
 
   mock.mockReturnValue = function mockReturnValue(value) {
-    return mock.mockImplementation(() => value)
+    // eslint-disable-next-line prefer-arrow-callback
+    return mock.mockImplementation(function () {
+      return value
+    })
   }
 
   mock.mockReturnValueOnce = function mockReturnValueOnce(value) {
-    return mock.mockImplementationOnce(() => value)
+    // eslint-disable-next-line prefer-arrow-callback
+    return mock.mockImplementationOnce(function () {
+      return value
+    })
   }
 
   mock.mockResolvedValue = function mockResolvedValue(value) {

--- a/packages/spy/src/types.ts
+++ b/packages/spy/src/types.ts
@@ -47,7 +47,7 @@ export type MockParameters<T extends Procedure | Constructable> = T extends Cons
     ? Parameters<T> : never
 
 export type MockReturnType<T extends Procedure | Constructable> = T extends Constructable
-  ? void
+  ? InstanceType<T>
   : T extends Procedure
     ? ReturnType<T> : never
 

--- a/test/core/test/mocking/vi-fn.test-d.ts
+++ b/test/core/test/mocking/vi-fn.test-d.ts
@@ -17,11 +17,11 @@ test('spy.mock when implementation is a class', () => {
   const Mock = vi.fn(Klass)
 
   expectTypeOf(Mock.mock.calls).toEqualTypeOf<[a: string, b?: number][]>()
-  expectTypeOf(Mock.mock.results).toEqualTypeOf<MockResult<void>[]>()
+  expectTypeOf(Mock.mock.results).toEqualTypeOf<MockResult<Klass>[]>()
   expectTypeOf(Mock.mock.contexts).toEqualTypeOf<Klass[]>()
   expectTypeOf(Mock.mock.instances).toEqualTypeOf<Klass[]>()
   expectTypeOf(Mock.mock.invocationCallOrder).toEqualTypeOf<number[]>()
-  expectTypeOf(Mock.mock.settledResults).toEqualTypeOf<MockSettledResult<void>[]>()
+  expectTypeOf(Mock.mock.settledResults).toEqualTypeOf<MockSettledResult<Klass>[]>()
   expectTypeOf(Mock.mock.lastCall).toEqualTypeOf<[a: string, b?: number] | undefined>()
 
   // static properties are defined

--- a/test/core/test/spy.test.ts
+++ b/test/core/test/spy.test.ts
@@ -30,4 +30,11 @@ describe('spyOn', () => {
 
     expect(hw.hello()).toEqual('hello world')
   })
+
+  test('mock return value for constructor', () => {
+    vi.spyOn(mock, 'HelloWorld').mockReturnValueOnce({ hello: () => 'hello world' })
+
+    const mockedHelloWorld = new mock.HelloWorld()
+    expect(mockedHelloWorld.hello()).toEqual('hello world')
+  })
 })


### PR DESCRIPTION
### Description

In 4.0 Vitest does not allow mock constructor with arrow functions, but `mockReturnValue` still uses `() => value`, the code:

```javascript
const module = {
	foo: class {
		hello() { return "world"; }
	},
};

vi.spyOn(module, "foo");

it("should work", () => {
	vi.mocked(module.foo).mockReturnValue({ hello: () => "WORLD" });
	expect(new module.foo().hello()).toBe("WORLD");
});
```

throws error `TypeError: () => value is not a constructor`.

This PR fix the regression.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
