### PR TITLE
feat(api): expose `runTestFiles` as alternative to `runTestSpecifications`

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -302,6 +302,21 @@ function rerunTestSpecifications(
 
 This method emits `reporter.onWatcherRerun` and `onTestsRerun` events, then it runs tests with [`runTestSpecifications`](#runtestspecifications). If there were no errors in the main process, it will emit `reporter.onWatcherStart` event.
 
+## runTestFiles <Version>4.1.0</Version> {#runtestfiles}
+
+```ts
+function runTestFiles(
+  filepaths: string[],
+  allTestsRun = false
+): Promise<TestRunResult>
+```
+
+This automatically creates specifications to run based on filepaths filters.
+
+This is different from [`start`](#start) because it does not create a coverage provider, trigger `onInit` and `onWatcherStart` events, or throw an error if there are no files to run (in this case, the function will return empty arrays without triggering a test run).
+
+This function accepts the same filters as [`start`](#start) and the CLI.
+
 ## updateSnapshot
 
 ```ts

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -668,7 +668,7 @@ export class Vitest {
 
       this.filenamePattern = filters && filters?.length > 0 ? filters : undefined
       startSpan.setAttribute('vitest.start.filters', this.filenamePattern || [])
-      const files = await this._traces.$(
+      const specifications = await this._traces.$(
         'vitest.config.resolve_include_glob',
         async () => {
           const specifications = await this.specifications.getRelevantTestSpecifications(filters)
@@ -687,7 +687,7 @@ export class Vitest {
       )
 
       // if run with --changed, don't exit if no tests are found
-      if (!files.length) {
+      if (!specifications.length) {
         await this._traces.$('vitest.test_run', async () => {
           await this._testRun.start([])
           const coverage = await this.coverageProvider?.generateCoverage?.({ allTestsRun: true })
@@ -707,11 +707,11 @@ export class Vitest {
         unhandledErrors: [],
       }
 
-      if (files.length) {
+      if (specifications.length) {
         // populate once, update cache on watch
-        await this.cache.stats.populateStats(this.config.root, files)
+        await this.cache.stats.populateStats(this.config.root, specifications)
 
-        testModules = await this.runFiles(files, true)
+        testModules = await this.runFiles(specifications, true)
       }
 
       if (this.config.watch) {
@@ -785,6 +785,19 @@ export class Vitest {
    */
   public runTestSpecifications(specifications: TestSpecification[], allTestsRun = false): Promise<TestRunResult> {
     specifications.forEach(spec => this.specifications.ensureSpecificationCached(spec))
+    return this.runFiles(specifications, allTestsRun)
+  }
+
+  /**
+   * Runs tests for the given file paths. This does not trigger `onWatcher*` events.
+   * @param filepaths A list of file paths to run tests for.
+   * @param allTestsRun Indicates whether all tests were run. This only matters for coverage.
+   */
+  public async runTestFiles(filepaths: string[], allTestsRun = false): Promise<TestRunResult> {
+    const specifications = await this.specifications.getRelevantTestSpecifications(filepaths)
+    if (!specifications.length) {
+      return { testModules: [], unhandledErrors: [] }
+    }
     return this.runFiles(specifications, allTestsRun)
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

It could be cumbersome to create new specifications when you don't use custom options like `testIds`. This PR adds an alternative to

```ts
vitest.runTestSpecifications([
  vitest.getRootProject().createSpecification('/path/to/file.spec.ts')
])
```

Replaced with

```ts
vitest.runTestFiles(['/path/to/file.spec.ts'])
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
