### PR TITLE
fix: deprecate unused types in matcher context

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -47,7 +47,13 @@ export interface MatcherState {
   customTesters: Array<Tester>
   assertionCalls: number
   currentTestName?: string
+  /**
+   * @deprecated exists only in types
+   */
   dontThrow?: () => void
+  /**
+   * @deprecated exists only in types
+   */
   error?: Error
   equals: (
     a: unknown,
@@ -55,15 +61,19 @@ export interface MatcherState {
     customTesters?: Array<Tester>,
     strictCheck?: boolean,
   ) => boolean
+  /**
+   * @deprecated exists only in types
+   */
   expand?: boolean
   expectedAssertionsNumber?: number | null
   expectedAssertionsNumberErrorGen?: (() => Error) | null
   isExpectingAssertions?: boolean
   isExpectingAssertionsError?: Error | null
   isNot: boolean
-  // environment: VitestEnvironment
   promise: string
-  // snapshotState: SnapshotState
+  /**
+   * @deprecated exists only in types
+   */
   suppressedErrors: Array<Error>
   testPath?: string
   utils: ReturnType<typeof getMatcherUtils> & {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

These properties are not used at all

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
