### PR TITLE
feat: support `VITEST_OPTIONS`, `VITEST_FILTERS`, `--injectReporter`

### DIFF
--- a/docs/.vitepress/scripts/cli-generator.ts
+++ b/docs/.vitepress/scripts/cli-generator.ts
@@ -42,6 +42,7 @@ const skipConfig = new Set([
   'browser.name',
   'browser.fileParallelism',
   'clearCache',
+  'injectReporter',
 ])
 
 function resolveOptions(options: CLIOptions<any>, parentName?: string) {

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -518,12 +518,26 @@ Default hook timeout in milliseconds (default: `10000`). Use `0` to disable time
 
 Stop test execution when given number of tests have failed (default: `0`)
 
-### retry
+### retry.count
 
-- **CLI:** `--retry <times>`
-- **Config:** [retry](/config/retry)
+- **CLI:** `--retry.count <times>`
+- **Config:** [retry.count](/config/retry#retry-count)
 
-Retry the test specific number of times if it fails (default: `0`)
+Number of times to retry a test if it fails (default: `0`)
+
+### retry.delay
+
+- **CLI:** `--retry.delay <ms>`
+- **Config:** [retry.delay](/config/retry#retry-delay)
+
+Delay in milliseconds between retry attempts (default: `0`)
+
+### retry.condition
+
+- **CLI:** `--retry.condition <pattern>`
+- **Config:** [retry.condition](/config/retry#retry-condition)
+
+Regex pattern to match error messages that should trigger a retry. Only errors matching this pattern will cause a retry (default: retry on all errors)
 
 ### diff.aAnnotation
 
@@ -797,6 +811,12 @@ Start Vitest without running tests. Tests will be running only on change. This o
 - **CLI:** `--clearCache`
 
 Delete all Vitest caches, including `experimental.fsModuleCache`, without running any tests. This will reduce the performance in the subsequent test run.
+
+### injectReporter
+
+- **CLI:** `--injectReporter <name>`
+
+Inject custom reporter(s) into the reporters list without overriding existing ones.
 
 ### experimental.fsModuleCache
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -140,6 +140,20 @@ Boolean options can be negated with `no-` prefix. Specifying the value as `false
 vitest --no-api
 vitest --api=false
 ```
+
+Since Vitest 4.1, CLI also accepts options via `VITEST_OPTIONS` environmental variable, similar to [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions):
+
+```
+VITEST_OPTIONS=--reporter=dot vitest
+```
+
+This can be useful if you spawn `vitest` manually in a custom script. `VITEST_OPTIONS` will be merged with other CLI options.
+
+Vitest also accepts `VITEST_FILTERS` environment variable to pass down additional filters:
+
+```
+VITEST_FILTERS=basic.test.ts vitest advanced.test.ts
+```
 :::
 
 <!--@include: ./cli-generated.md-->

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -300,12 +300,13 @@ function normalizeCliOptions(cliFilters: string[], argv: CliOptions): CliOptions
 async function start(mode: VitestRunMode, cliFilters: string[], options: CliOptions): Promise<void> {
   try {
     const { startVitest } = await import('./cli-api')
+    if (process.env.VITEST_FILTERS) {
+      cliFilters.push(...process.env.VITEST_FILTERS.split(' '))
+    }
     let normalizedOptions = normalizeCliOptions(cliFilters, options)
     if (process.env.VITEST_OPTIONS) {
-      const vitestConfig = parseCLI(process.env.VITEST_OPTIONS)
-      const vitestFilters = process.env.VITEST_FILTERS?.split(' ') || []
-      normalizedOptions = mergeConfig(normalizedOptions, normalizeCliOptions(vitestFilters, vitestConfig.options)) as CliOptions
-      cliFilters.push(...vitestFilters)
+      const vitestConfig = parseCLI(`vitest ${process.env.VITEST_OPTIONS}`).options
+      normalizedOptions = mergeConfig(normalizedOptions, normalizeCliOptions([], vitestConfig)) as CliOptions
     }
     const ctx = await startVitest(mode, cliFilters.map(normalize), normalizedOptions)
     if (!ctx.shouldKeepServer()) {

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -788,6 +788,11 @@ export const cliOptionsConfig: VitestCLIOptions = {
   clearCache: {
     description: 'Delete all Vitest caches, including `experimental.fsModuleCache`, without running any tests. This will reduce the performance in the subsequent test run.',
   },
+  injectReporter: {
+    description: 'Inject custom reporter(s) into the reporters list without overriding existing ones.',
+    argument: '<name>',
+    array: true,
+  },
 
   experimental: {
     description: 'Experimental features.',

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -645,6 +645,15 @@ export function resolveConfig(
     }
   }
 
+  if (resolved.injectReporter) {
+    resolved.injectReporter.forEach((reporter) => {
+      const path = /^\.\.?\//.test(reporter)
+        ? resolve(process.cwd(), reporter)
+        : reporter
+      resolved.reporters.push([path, {}])
+    })
+  }
+
   if (resolved.changed) {
     resolved.passWithNoTests ??= true
   }

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -997,6 +997,11 @@ export interface UserConfig extends InlineConfig {
    * @experimental
    */
   clearCache?: boolean
+
+  /**
+   * Inject custom reporter(s) into the reporters list without overriding existing ones.
+   */
+  injectReporter?: string[]
 }
 
 export type OnUnhandledErrorCallback = (error: (TestError | Error) & { type: string }) => boolean | void

--- a/test/cli/test/config-env-option.test.ts
+++ b/test/cli/test/config-env-option.test.ts
@@ -1,0 +1,73 @@
+import { resolve } from 'node:path'
+import { runVitestCli, useFS } from '#test-utils'
+import { expect, test } from 'vitest'
+
+test('passing down VITEST_FILTERS works', async () => {
+  const root = resolve(process.cwd(), `vitest-test-${crypto.randomUUID()}`)
+  useFS(root, {
+    'basic-1.test.js': `test('basic 1', () => {})`,
+    'basic-2.test.js': `test('basic 2', () => {})`,
+    'vitest.config.js': {
+      test: {
+        globals: true,
+      },
+    },
+  })
+
+  const { stdout, stderr } = await runVitestCli({
+    nodeOptions: {
+      env: {
+        VITEST_FILTERS: 'basic-1',
+      },
+    },
+  }, `--root`, root)
+
+  expect(stderr).toBe('')
+  expect(stdout).toContain('1 passed')
+  expect(stdout).toContain('basic-1')
+  expect(stdout).not.toContain('basic-2')
+})
+
+test('passing down VITEST_OPTIONS overrides argv', async () => {
+  const root = resolve(process.cwd(), `vitest-test-${crypto.randomUUID()}`)
+  useFS(root, {
+    'output.test.js': `test('basic 1', () => {})`,
+    'vitest.config.js': `
+    export default {
+      test: {
+        globals: true,
+        reporters: [
+          {
+            onInit(vitest) {
+              console.log(JSON.stringify(vitest.getRootProject().serializedConfig))
+              throw new Error('Stopping tests')
+            }
+          }
+        ]
+      },
+    }
+    `,
+  })
+
+  const { stdout } = await runVitestCli({
+    nodeOptions: {
+      env: {
+        VITEST_OPTIONS: '--logHeapUsage --allowOnly --sequence.seed 123 --testTimeout 5321 --pool forks --globals --retry 6 --passWithNoTests --bail 100',
+      },
+    },
+  }, `--root`, root, '--testTimeout', '999', '--pool', 'vmThreads')
+  const config = JSON.parse(stdout)
+  expect(config).toMatchObject({
+    logHeapUsage: true,
+    allowOnly: true,
+    sequence: {
+      seed: 123,
+    },
+    testTimeout: 5321, // not 999
+    pool: 'forks', // not vmThreads
+    globals: true,
+    retry: 6,
+    passWithNoTests: true,
+    bail: 100,
+  })
+})

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -321,6 +321,13 @@ test('clearScreen', async (ctx) => {
   `)
 })
 
+test('--injectReporter', () => {
+  expect(getCLIOptions('--injectReporter=./my-reporter.js')).toEqual({ injectReporter: ['./my-reporter.js'] })
+  expect(getCLIOptions('--injectReporter ./my-reporter.js --injectReporter ./another-reporter.js')).toEqual({
+    injectReporter: ['./my-reporter.js', './another-reporter.js'],
+  })
+})
+
 test('merge-reports', () => {
   expect(getCLIOptions('--merge-reports')).toEqual({ mergeReports: '.vitest-reports' })
   expect(getCLIOptions('--merge-reports=different-folder')).toEqual({ mergeReports: 'different-folder' })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is to support running `vitest` by the vscode extension in such a way that doesn't require passing `--` to the cli script

TODO:
- tests
- support `--inject-reporter=` to avoid overriding reporters
- show in docs how priority is resolved
- think about VITEST_MAX_WORKERS

The name is based on well-established `NODE_OPTIONS`

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
