### PR TITLE
docs: clarify server.deps.fallbackCJS heuristic

### DIFF
--- a/docs/config/server.md
+++ b/docs/config/server.md
@@ -68,6 +68,6 @@ If a `RegExp` is provided, it is matched against the full file path.
 - **Type:** `boolean`
 - **Default:** `false`
 
-When a dependency is a valid ESM package, try to guess the cjs version based on the path. This might be helpful, if a dependency has the wrong ESM file.
+When enabled, Vitest will try to guess a CommonJS build for an ESM entry by checking a few common CJS/UMD file name and folder patterns (like `.mjs`, `.umd.js`, `.cjs.js`, `umd/`, `cjs/`, `lib/`).
 
-This might potentially cause some misalignment if a package has different logic in ESM and CJS mode.
+This is a best-effort heuristic to work around confusing or incorrect ESM/CJS packaging and may not work for all dependencies.


### PR DESCRIPTION
### Description

Clarify the documentation for `server.deps.fallbackCJS` and align it with the actual `guessCJSversion` behavior.

- Explain that it tries to guess a CommonJS build for an ESM entry by checking a few common CJS/UMD file name and folder patterns.
- Remove the confusing wording about “valid” vs “invalid” ESM from the docs.

Resolves #6352

This PR only updates the current config docs (`server` page).  
If you’d also like the v3 docs to be updated, I’m happy to open a follow-up PR against the appropriate branch.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Docs-only change, so I didn't run the full `test:ci` suite.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
