### PR TITLE
fix: filter ECONNRESET erros by default

### DIFF
--- a/test/cli/test/econnreset-errors.test.ts
+++ b/test/cli/test/econnreset-errors.test.ts
@@ -1,0 +1,118 @@
+import http from 'node:http'
+import { runInlineTests } from '#test-utils'
+import { describe, expect, test } from 'vitest'
+
+describe('ECONNRESET errors are filtered by default', () => {
+  test('ECONNRESET error code is ignored', async () => {
+    const { stderr, exitCode } = await runInlineTests({
+      'econnreset.test.js': `
+        import { test } from "vitest"
+
+        test("Some test", () => {
+          const error = new Error("socket hang up")
+          error.code = 'ECONNRESET'
+          Promise.reject(error)
+        })
+      `,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toMatch('ECONNRESET')
+    expect(stderr).not.toMatch('socket hang up')
+    expect(stderr).not.toMatch('Unhandled')
+  })
+
+  test('socket hang up message is ignored', async () => {
+    const { stderr, exitCode } = await runInlineTests({
+      'socket-hangup.test.js': `
+        import { test } from "vitest"
+
+        test("Some test", () => {
+          const error = new Error("socket hang up")
+          Promise.reject(error)
+        })
+      `,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toMatch('socket hang up')
+    expect(stderr).not.toMatch('Unhandled')
+  })
+
+  test('other unhandled errors are still reported', async () => {
+    const { stderr, exitCode } = await runInlineTests({
+      'other-error.test.js': `
+        import { test } from "vitest"
+
+        test("Some test", () => {
+          Promise.reject(new Error("intentional error"))
+        })
+      `,
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toMatch('Unhandled')
+    expect(stderr).toMatch('intentional error')
+  })
+
+  test('ECONNRESET errors can still be caught by onUnhandledError', async () => {
+    const { stderr, exitCode } = await runInlineTests({
+      'econnreset-custom.test.js': `
+        import { test } from "vitest"
+
+        test("Some test", () => {
+          const error = new Error("socket hang up")
+          error.code = 'ECONNRESET'
+          Promise.reject(error)
+        })
+      `,
+    }, {
+      onUnhandledError(err) {
+        if ('code' in err && err.code === 'ECONNRESET') {
+          return false
+        }
+      },
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toMatch('ECONNRESET')
+  })
+
+  test('real HTTP connection error scenario', async () => {
+    const server = http.createServer((req, _res) => {
+      req.socket.destroy()
+    })
+
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, () => {
+        resolve((server.address() as any).port)
+      })
+    })
+
+    const { stderr, exitCode } = await runInlineTests({
+      'http-error.test.js': `
+        import { test } from "vitest"
+        import http from "node:http"
+
+        test("HTTP connection test", async () => {
+          const req = http.get('http://localhost:${port}', () => {
+          })
+
+          req.on('error', (err) => {
+            Promise.reject(err)
+          })
+
+          await new Promise(resolve => setTimeout(resolve, 100))
+        })
+      `,
+    })
+
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve())
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toMatch('ECONNRESET')
+    expect(stderr).not.toMatch('socket hang up')
+  })
+})


### PR DESCRIPTION
### Description

This PR fixes an issue where ECONNRESET "socket hang up" errors were being reported as unhandled errors during test execution, particularly affecting Angular projects that migrated from Jest to Vitest.

**Problem:**
When running tests in Angular projects (and other frameworks that make HTTP requests), ECONNRESET errors frequently appear in the console output. These errors occur when HTTP connections are closed during test teardown before responses complete, which is normal behavior when the test environment shuts down. However, Vitest was catching these as unhandled errors and reporting them, cluttering the console and potentially causing confusion.

**Example error:**
```
Error: socket hang up
    at _destroy (node:_http_client:959:15)
    at onSocketNT (node:_http_client:982:5)
    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
  code: 'ECONNRESET'
}
```

**Solution:**
This PR adds automatic filtering for ECONNRESET errors and "socket hang up" messages in the `StateManager.catchError()` method, similar to how `VITEST_PENDING` errors are handled. The implementation:

1. Filters ECONNRESET errors by default - Errors with `code === 'ECONNRESET'` are automatically ignored
2. Filters "socket hang up" messages - Errors containing "socket hang up" in the message are also filtered (case-insensitive)
3. Maintains backward compatibility - Users can still override this behavior using the `onUnhandledError` callback
4. Scalable design - Uses centralized constants (`IGNORED_NETWORK_ERROR_CODES`, `IGNORED_NETWORK_ERROR_MESSAGES`) and a helper function (`isIgnoredNetworkError`) for easy extension

**Implementation details:**
- Added `isIgnoredNetworkError()` helper function to check if an error should be ignored
- Uses a `Set` for O(1) error code lookups
- Case-insensitive message pattern matching
- Well-documented with JSDoc comments

**Benefits:**
- Cleaner console output for Angular/Vitest users
- No false positives from benign network errors
- Easy to extend for other network errors if needed
- No breaking changes - fully backward compatible

Resolves #9489


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Added comprehensive test suite (`test/cli/test/econnreset-errors.test.ts`) with 5 test cases:
- ECONNRESET error code is ignored
- Socket hang up message is ignored  
- Other unhandled errors are still reported (ensures no regression)
- ECONNRESET errors can still be caught by `onUnhandledError` callback
- Real HTTP connection error scenario

All tests pass and existing unhandled error tests continue to work correctly.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

Code is well-documented with JSDoc comments explaining why these errors are filtered. No user-facing documentation changes needed as this is an internal fix that improves error handling behavior.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

PR title: `fix: filter ECONNRESET errors by default`
