### PR TITLE
fix(spy): fallback to object accessor if descriptor's value is `undefined`

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -263,6 +263,12 @@ export function spyOn<T extends object, K extends keyof T>(
 
   if (originalDescriptor) {
     original = originalDescriptor[accessType]
+    // weird Proxy edge case where descriptor's value is undefined,
+    // but there's still a value on the object when called
+    // https://github.com/vitest-dev/vitest/issues/9439
+    if (original == null && accessType === 'value') {
+      original = object[key] as unknown as Procedure
+    }
   }
   else if (accessType !== 'value') {
     original = () => object[key]

--- a/test/core/test/mocking/vi-spyOn.test.ts
+++ b/test/core/test/mocking/vi-spyOn.test.ts
@@ -1,61 +1,85 @@
 import type { MockContext } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
 
-test('vi.fn() has correct length', () => {
-  const fn0 = vi.spyOn({ fn: () => {} }, 'fn')
-  expect(fn0.length).toBe(0)
+describe('vi.spyOn() edge cases', () => {
+  test('vi.spyOn() has correct length', () => {
+    const fn0 = vi.spyOn({ fn: () => {} }, 'fn')
+    expect(fn0.length).toBe(0)
 
-  const fnArgs = vi.spyOn({ fn: (..._args: any[]) => {} }, 'fn')
-  expect(fnArgs.length).toBe(0)
+    const fnArgs = vi.spyOn({ fn: (..._args: any[]) => {} }, 'fn')
+    expect(fnArgs.length).toBe(0)
 
-  const fn1 = vi.spyOn({ fn: (_arg1: any) => {} }, 'fn')
-  expect(fn1.length).toBe(1)
+    const fn1 = vi.spyOn({ fn: (_arg1: any) => {} }, 'fn')
+    expect(fn1.length).toBe(1)
 
-  const fn2 = vi.spyOn({ fn: (_arg1: any, _arg2: any) => {} }, 'fn')
-  expect(fn2.length).toBe(2)
+    const fn2 = vi.spyOn({ fn: (_arg1: any, _arg2: any) => {} }, 'fn')
+    expect(fn2.length).toBe(2)
 
-  const fn3 = vi.spyOn({ fn: (_arg1: any, _arg2: any, _arg3: any) => {} }, 'fn')
-  expect(fn3.length).toBe(3)
-})
-
-describe('vi.spyOn() copies static properties', () => {
-  test('vi.spyOn() copies properties from functions', () => {
-    function a() {}
-    a.HELLO_WORLD = true
-    const obj = {
-      a,
-    }
-
-    const spy = vi.spyOn(obj, 'a')
-
-    expect(obj.a.HELLO_WORLD).toBe(true)
-    expect(spy.HELLO_WORLD).toBe(true)
+    const fn3 = vi.spyOn({ fn: (_arg1: any, _arg2: any, _arg3: any) => {} }, 'fn')
+    expect(fn3.length).toBe(3)
   })
 
-  test('vi.spyOn() copies properties from classes', () => {
-    class A {
-      static HELLO_WORLD = true
-    }
-    const obj = {
-      A,
-    }
-
-    const spy = vi.spyOn(obj, 'A')
-
-    expect(obj.A.HELLO_WORLD).toBe(true)
-    expect(spy.HELLO_WORLD).toBe(true)
+  test('can spy on a proxy with undefined descriptor\'s value', () => {
+    const obj = new Proxy<{ fn: () => number }>({} as any, {
+      get(_, prop) {
+        if (prop === 'fn') {
+          return () => 42
+        }
+      },
+      getOwnPropertyDescriptor(_, prop) {
+        if (prop === 'fn') {
+          return {
+            configurable: true,
+            enumerable: true,
+            value: undefined,
+            writable: true,
+          }
+        }
+      },
+    })
+    const spy = vi.spyOn(obj, 'fn')
+    expect(spy()).toBe(42)
   })
 
-  test('vi.spyOn() ignores node.js.promisify symbol', () => {
-    const promisifySymbol = Symbol.for('nodejs.util.promisify.custom')
-    class Example {
-      static [promisifySymbol] = () => Promise.resolve(42)
-    }
-    const obj = { Example }
+  describe('vi.spyOn() copies static properties', () => {
+    test('vi.spyOn() copies properties from functions', () => {
+      function a() {}
+      a.HELLO_WORLD = true
+      const obj = {
+        a,
+      }
 
-    const spy = vi.spyOn(obj, 'Example')
+      const spy = vi.spyOn(obj, 'a')
 
-    expect(spy[promisifySymbol]).toBe(undefined)
+      expect(obj.a.HELLO_WORLD).toBe(true)
+      expect(spy.HELLO_WORLD).toBe(true)
+    })
+
+    test('vi.spyOn() copies properties from classes', () => {
+      class A {
+        static HELLO_WORLD = true
+      }
+      const obj = {
+        A,
+      }
+
+      const spy = vi.spyOn(obj, 'A')
+
+      expect(obj.A.HELLO_WORLD).toBe(true)
+      expect(spy.HELLO_WORLD).toBe(true)
+    })
+
+    test('vi.spyOn() ignores node.js.promisify symbol', () => {
+      const promisifySymbol = Symbol.for('nodejs.util.promisify.custom')
+      class Example {
+        static [promisifySymbol] = () => Promise.resolve(42)
+      }
+      const obj = { Example }
+
+      const spy = vi.spyOn(obj, 'Example')
+
+      expect(spy[promisifySymbol]).toBe(undefined)
+    })
   })
 })
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #9439

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
