### PR TITLE
refactor: return after `beforeAll`

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -819,7 +819,6 @@ export async function runSuite(suite: Suite, runner: VitestRunner): Promise<void
     updateTask('suite-finished', suite, runner)
   }
   else {
-    let beforeAllError: unknown
     let suiteRan = false
 
     try {
@@ -837,10 +836,9 @@ export async function runSuite(suite: Suite, runner: VitestRunner): Promise<void
             ))
           }
           catch (e) {
-            beforeAllError = e
-            failTask(suite.result!, beforeAllError, runner.config.diffOptions)
+            failTask(suite.result!, e, runner.config.diffOptions)
             markTasksAsSkipped(suite, runner)
-            throw e
+            return
           }
 
           // run suite children
@@ -895,10 +893,7 @@ export async function runSuite(suite: Suite, runner: VitestRunner): Promise<void
       if (!suiteRan) {
         markTasksAsSkipped(suite, runner)
       }
-      // don't push beforeAll error again - it was already pushed to preserve the order of beforeAll/afterAll
-      if (e !== beforeAllError) {
-        failTask(suite.result!, e, runner.config.diffOptions)
-      }
+      failTask(suite.result!, e, runner.config.diffOptions)
     }
 
     if (suite.mode === 'run' || suite.mode === 'queued') {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Doing these checks is just more confusing. We can return from suite instead of rethrowing the error, because `finally` with `afterAll` will run anyway.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
