### PR TITLE
feat: stabilize experimental features

### DIFF
--- a/docs/api/advanced/reporters.md
+++ b/docs/api/advanced/reporters.md
@@ -15,7 +15,7 @@ Vitest has its own test run lifecycle. These are represented by reporter's metho
       - [`onHookStart(beforeAll)`](#onhookstart)
       - [`onHookEnd(beforeAll)`](#onhookend)
         - [`onTestCaseReady`](#ontestcaseready)
-          - [`onTestAnnotate`](#ontestannotate) <Version>3.2.0</Version>
+          - [`onTestCaseAnnotate`](#ontestcaseannotate) <Version>3.2.0</Version>
           - [`onTestCaseArtifactRecord`](#ontestcaseartifactrecord) <Version type="experimental">4.0.11</Version>
           - [`onHookStart(beforeEach)`](#onhookstart)
           - [`onHookEnd(beforeEach)`](#onhookend)
@@ -313,16 +313,16 @@ This method is called when the test has finished running or was just skipped. No
 
 At this point, [`testCase.result()`](/api/advanced/test-case#result) will have non-pending state.
 
-## onTestAnnotate <Version>3.2.0</Version> {#ontestannotate}
+## onTestCaseAnnotate <Version>3.2.0</Version> {#ontestcaseannotate}
 
 ```ts
-function onTestAnnotate(
+function onTestCaseAnnotate(
   testCase: TestCase,
   annotation: TestAnnotation,
 ): Awaitable<void>
 ```
 
-The `onTestAnnotate` hook is associated with the [`context.annotate`](/guide/test-context#annotate) method. When `annotate` is invoked, Vitest serialises it and sends the same attachment to the main thread where reporter can interact with it.
+The `onTestCaseAnnotate` hook is associated with the [`context.annotate`](/guide/test-context#annotate) method. When `annotate` is invoked, Vitest serialises it and sends the same attachment to the main thread where reporter can interact with it.
 
 If the path is specified, Vitest stores it in a separate directory (configured by [`attachmentsDir`](/config/#attachmentsdir)) and modifies the `path` property to reference it.
 

--- a/docs/api/advanced/test-module.md
+++ b/docs/api/advanced/test-module.md
@@ -121,9 +121,13 @@ interface ImportDuration {
 }
 ```
 
-## viteEnvironment <Version type="experimental">4.0.15</Version> <Experimental /> {#viteenvironment}
+## viteEnvironment <Version>4.1.0</Version> {#viteenvironment}
 
 This is a Vite's [`DevEnvironment`](https://vite.dev/guide/api-environment) that transforms all files inside of the test module.
+
+::: details History
+- `v4.0.15`: added as experimental
+:::
 
 ## toTestSpecification <Version>4.1.0</Version> {#totestspecification}
 

--- a/docs/api/advanced/test-specification.md
+++ b/docs/api/advanced/test-specification.md
@@ -40,7 +40,7 @@ The ID of the module in Vite's module graph. Usually, it's an absolute file path
 
 Instance of [`TestModule`](/api/advanced/test-module) associated with the specification. If test wasn't queued yet, this will be `undefined`.
 
-## pool <Badge type="warning">experimental</Badge> {#pool}
+## pool {#pool}
 
 The [`pool`](/config/#pool) in which the test module will run.
 

--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -478,9 +478,7 @@ function onCancel(fn: (reason: CancelReason) => Awaitable<void>): () => void
 
 Register a handler that will be called when the test run is cancelled with [`vitest.cancelCurrentRun`](#cancelcurrentrun).
 
-::: warning EXPERIMENTAL
-Since 4.0.10, `onCancel` returns a teardown function that will remove the listener.
-:::
+Since 4.0.10, `onCancel` experimentally returns a teardown function that will remove the listener. Since 4.1.0 this behaviour is considered stable.
 
 ## onClose
 

--- a/docs/api/browser/context.md
+++ b/docs/api/browser/context.md
@@ -222,7 +222,6 @@ export const utils: {
   /**
    * Configures default options of `prettyDOM` and `debug` functions.
    * This will also affect `vitest-browser-{framework}` package.
-   * @experimental
    */
   configurePrettyDOM(options: StringifyOptions): void
   /**

--- a/docs/guide/advanced/tests.md
+++ b/docs/guide/advanced/tests.md
@@ -27,10 +27,6 @@ for (const testModule of testModules) {
 }
 ```
 
-::: tip
-[`TestModule`](/api/advanced/test-module), [`TestSuite`](/api/advanced/test-suite) and [`TestCase`](/api/advanced/test-case) APIs are not experimental and follow SemVer since Vitest 2.1.
-:::
-
 ## `createVitest`
 
 Creates a [Vitest](/api/advanced/vitest) instances without running tests.

--- a/docs/guide/environment.md
+++ b/docs/guide/environment.md
@@ -49,7 +49,7 @@ import type { Environment } from 'vitest/runtime'
 export default <Environment>{
   name: 'custom',
   viteEnvironment: 'ssr',
-  // optional - only if you support "experimental-vm" pool
+  // optional - only if you support "vmForks" or "vmThreads" pools
   async setupVM() {
     const vm = await import('node:vm')
     const context = vm.createContext()

--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -98,7 +98,7 @@ It will compare with the content of `./test/basic.output.html`. And can be writt
 
 ## Visual Snapshots
 
-For visual regression testing of UI components and pages, Vitest provides built-in support through [browser mode](/guide/browser/) with the [`toMatchScreenshot()`](/api/browser/assertions#tomatchscreenshot-experimental) assertion:
+For visual regression testing of UI components and pages, Vitest provides built-in support through [browser mode](/guide/browser/) with the [`toMatchScreenshot()`](/api/browser/assertions#tomatchscreenshot) assertion:
 
 ```ts
 import { expect, test } from 'vitest'

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -866,7 +866,6 @@ export const utils: {
   /**
    * Configures default options of `prettyDOM` and `debug` functions.
    * This will also affect `vitest-browser-{framework}` package.
-   * @experimental
    */
   configurePrettyDOM(options: StringifyOptions): void
   /**

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -492,9 +492,6 @@ function getElementError(selector: string, container: Element): Error {
   return error
 }
 
-/**
- * @experimental
- */
 function configurePrettyDOM(options: StringifyOptions) {
   defaultOptions = options
 }

--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -35,7 +35,6 @@ export interface HoistMocksOptions {
    * @default ["hoisted"]
    */
   hoistedMethodNames?: string[]
-  // @experimental, TODO
   globalThisAccessor?: string
   regexpHoistable?: RegExp
   codeFrameGenerator?: CodeFrameGenerator

--- a/packages/vitest/src/node/test-specification.ts
+++ b/packages/vitest/src/node/test-specification.ts
@@ -27,7 +27,6 @@ export class TestSpecification {
   public readonly moduleId: string
   /**
    * The current test pool. It's possible to have multiple pools in a single test project with `typecheck.enabled`.
-   * @experimental In later versions, the project will only support a single pool.
    */
   public readonly pool: Pool
   /**

--- a/packages/vitest/src/node/types/reporter.ts
+++ b/packages/vitest/src/node/types/reporter.ts
@@ -13,7 +13,6 @@ export interface Reporter {
   /**
    * Called when the project initiated the browser instance.
    * project.browser will always be defined.
-   * @experimental
    */
   onBrowserInit?: (project: TestProject) => Awaitable<void>
   /** @internal   */


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR stabilized these features added in 4.0.* as experimental:

- `configurePrettyDOM`
- `globalThisAccessor` property in mocking transforms
- `TestModule.prototype.viteEnvironment`
- `TestSpecification.prototype.pool` property - providing `pool` is still considered internal, but receiving the value from the specification is ok
- `onBrowserInit` reporter hook
- providing `Set` to `toBeOneOf`
- `onCancel` hook returns a cleanup function
