### PR TITLE
fix: propagate experimental CLI options to child projects

### DIFF
--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -112,6 +112,9 @@ export function WorkspaceVitestPlugin(
         if (testConfig.experimental?.nodeLoader == null && project.vitest.config.experimental?.nodeLoader != null) {
           vitestConfig.experimental.nodeLoader = project.vitest.config.experimental.nodeLoader
         }
+        if (testConfig.experimental?.importDurations == null && project.vitest.config.experimental?.importDurations != null) {
+          vitestConfig.experimental.importDurations = project.vitest.config.experimental.importDurations
+        }
 
         return {
           base: '/',

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -59,7 +59,6 @@ export async function resolveProjects(
     'inspectBrk',
     'fileParallelism',
     'tagsFilter',
-    'experimental',
   ] as const
 
   const cliOverrides = overridesOptions.reduce((acc, name) => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Related to https://github.com/vitest-dev/vitest/issues/9141#issuecomment-3798770829

Cli flag `--experimental.importDurations.print` is not propagated to child projects and this caused child projects to have `print = false`, which defaulted `limit` to `0`, meaning no import duration data was collected.

After the change, this works:

```sh
$ pnpm test --experimental.importDurations.print
...
Import Duration Breakdown (ordered by Total Time) (Top 10)
test/cli-test.test.ts                              self:   38ms total:  488ms ████████████████████
 ↳ ../../packages/vitest/src/node/cli/cac.ts       self:   34ms total:  284ms ████████████░░░░░░░░
 ↳ ..../packages/vitest/src/node/cli/cli-config.ts self:   18ms total:  246ms ██████████░░░░░░░░░░
 ↳ .../packages/vitest/src/node/reporters/index.ts self:   78ms total:  228ms █████████░░░░░░░░░░░
test/injector-mock.test.ts                         self:   24ms total:  167ms ███████░░░░░░░░░░░░░
test/module-diagnostic.test.ts                     self:   12ms total:  117ms █████░░░░░░░░░░░░░░░
 ↳ ../test-utils/index.ts                          self:    6ms total:  105ms ████░░░░░░░░░░░░░░░░
 ↳ ../../packages/vitest/dist/node.js              self:   94ms total:   94ms ████░░░░░░░░░░░░░░░░
test/browserAutomocker.test.ts                     self:    6ms total:   92ms ████░░░░░░░░░░░░░░░░
 ↳ ../../packages/mocker/dist/node.js              self:   86ms total:   86ms ████░░░░░░░░░░░░░░░░

Total imports: 829
Slowest import (total-time): 488ms
Total import time (self/total): 3.04s / 6.10s
```

#### Questions

- Not entirely sure if others `experimental` should be treated in the same way, but I didn't find any harm for currently available experimental cli flags.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
