### PR TITLE
ci: check for stale cli-generated.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Generate CLI docs
+        run: pnpm -C docs run cli-table
+
       # check uncommited LICENSE.md, auto-imports.d.ts, etc...
       - name: Check stale build artifacts
         run: git diff --exit-code


### PR DESCRIPTION
### Description

Add `pnpm -C docs run cli-table` to the lint job before the stale artifact check. This regenerates `cli-generated.md` during CI so the `git diff --exit-code` check can catch when it's out of sync with the CLI config.

The lint job already checks for stale build artifacts, but `cli-generated.md` was never regenerated because the docs build isn't part of the main `pnpm run build`. This allowed stale CLI docs to slip through PRs.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.