### PR TITLE
fix(expect): fix objectContaining with proxy

### DIFF
--- a/packages/expect/src/jest-asymmetric-matchers.ts
+++ b/packages/expect/src/jest-asymmetric-matchers.ts
@@ -167,8 +167,8 @@ export class ObjectContaining extends AsymmetricMatcher<
         result = false
         break
       }
-      const value = Object.getOwnPropertyDescriptor(this.sample, property)?.value ?? this.sample[property]
-      const otherValue = Object.getOwnPropertyDescriptor(other, property)?.value ?? other[property]
+      const value = this.sample[property]
+      const otherValue = other[property]
       if (!equals(
         value,
         otherValue,


### PR DESCRIPTION
### Description

Fixes https://github.com/vitest-dev/vitest/issues/9488

There was regression in v4 from https://github.com/vitest-dev/vitest/pull/8241. 

For the proxy of the form `thing = new Proxy(originalObject, { ...trap... })`, equality should be based on `thing[key]` (triggering proxy trap) instead of `Object.getOwnPropertyDescriptor` (picking up `originalObject` value). This still enumerate equality comparison keys based on `Object.keys + getOwnPropertySymbols` which is the main part of https://github.com/vitest-dev/vitest/pull/8241.

It might look slightly inconsistent, but I verified this is what happens with `toEqual` too as seen in the tests (also this is the Jest behavior).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
