### PR TITLE
docs: improve common-errors.md formatting and fix typos

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -8,9 +8,9 @@ title: Common Errors | Guide
 
 If you receive an error that module cannot be found, it might mean several different things:
 
-- 1. You misspelled the path. Make sure the path is correct.
+1. You misspelled the path. Make sure the path is correct.
 
-- 2. It's possible that you rely on `baseUrl` in your `tsconfig.json`. Vite doesn't take into account `tsconfig.json` by default, so you might need to install [`vite-tsconfig-paths`](https://www.npmjs.com/package/vite-tsconfig-paths) yourself, if you rely on this behaviour.
+2. It's possible that you rely on `baseUrl` in your `tsconfig.json`. Vite doesn't take into account `tsconfig.json` by default, so you might need to install [`vite-tsconfig-paths`](https://www.npmjs.com/package/vite-tsconfig-paths) yourself, if you rely on this behavior.
 
 ```ts
 import { defineConfig } from 'vitest/config'
@@ -28,7 +28,7 @@ Or rewrite your path to not be relative to root:
 + import helpers from '../src/helpers'
 ```
 
-- 3. Make sure you don't have relative [aliases](/config/#alias). Vite treats them as relative to the file where the import is instead of the root.
+3. Make sure you don't have relative [aliases](/config/#alias). Vite treats them as relative to the file where the import is instead of the root.
 
 ```ts
 import { defineConfig } from 'vitest/config'
@@ -47,7 +47,7 @@ export default defineConfig({
 
 This error can happen when NodeJS's `fetch` is used with default [`pool: 'threads'`](/config/#threads). This issue is tracked on issue [Timeout abort can leave process(es) running in the background #3077](https://github.com/vitest-dev/vitest/issues/3077).
 
-As work-around you can switch to [`pool: 'forks'`](/config/#forks) or [`pool: 'vmForks'`](/config/#vmforks).
+As a workaround, you can switch to [`pool: 'forks'`](/config/#forks) or [`pool: 'vmForks'`](/config/#vmforks).
 
 ::: code-group
 ```ts [vitest.config.js]
@@ -120,7 +120,7 @@ Running [native NodeJS modules](https://nodejs.org/api/addons.html) in `pool: 't
 - `Abort trap: 6`
 - `internal error: entered unreachable code`
 
-In these cases the native module is likely not built to be multi-thread safe. As work-around, you can switch to `pool: 'forks'` which runs the test cases in multiple `node:child_process` instead of multiple `node:worker_threads`.
+In these cases the native module is likely not built to be multi-thread safe. As a workaround, you can switch to `pool: 'forks'` which runs the test cases in multiple `node:child_process` instead of multiple `node:worker_threads`.
 
 ::: code-group
 ```ts [vitest.config.js]


### PR DESCRIPTION
## Summary

This PR improves the formatting and fixes minor issues in the common-errors.md documentation.

## Changes

- Fixed inconsistent list formatting (changed `- 1.`, `- 2.`, `- 3.` to proper numbered list `1.`, `2.`, `3.`)
- Fixed spelling: `behaviour` → `behavior` (for American English consistency)
- Fixed grammar: `As work-around` → `As a workaround` (2 occurrences)

## Why

These small fixes improve readability and maintain consistency with the rest of the documentation.