### PR TITLE
feat: support vite 8 beta, fix type issues in the config with different vite versions

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -138,7 +138,8 @@
     "@vitest/browser-webdriverio": "workspace:*",
     "@vitest/ui": "workspace:*",
     "happy-dom": "*",
-    "jsdom": "*"
+    "jsdom": "*",
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
   },
   "peerDependenciesMeta": {
     "@edge-runtime/vm": {
@@ -167,6 +168,9 @@
     },
     "jsdom": {
       "optional": true
+    },
+    "vite": {
+      "optional": false
     }
   },
   "dependencies": {
@@ -188,7 +192,7 @@
     "tinyexec": "^1.0.2",
     "tinyglobby": "catalog:",
     "tinyrainbow": "catalog:",
-    "vite": "^6.0.0 || ^7.0.0",
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
     "why-is-node-running": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Specifies "vite" in both `peerDependencies` and `dependencies` to avoid breaking change. This makes it so TypeScript shares the same types even if `defineConfig` is imported from `vitest/config`. This also makes it so we always reuse the same version of Vite that was installed. If no Vite is installed, package manager installs it (unless you are using yarn 1 which will install the latest version 🤷 - don't use it! it's not been maintained for 8 years!).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
