### PR TITLE
fix: trim trailing white spaces in code block

### DIFF
--- a/packages/vitest/src/node/printError.ts
+++ b/packages/vitest/src/node/printError.ts
@@ -469,10 +469,8 @@ export function generateCodeFrame(
           return ''
         }
 
-        res.push(
-          (lineNo(j + 1)
-            + truncateString(lines[j].replace(/\t/g, ' '), columns - 5 - indent)).trimEnd(),
-        )
+        const truncatedLine = truncateString(lines[j].replace(/\t/g, ' '), columns - 5 - indent)
+        res.push(lineNo(j + 1) + (truncatedLine ? ' ' + truncatedLine : truncatedLine))
 
         if (j === i) {
           // push underline
@@ -481,12 +479,12 @@ export function generateCodeFrame(
             1,
             end > count ? lineLength - pad : end - start,
           )
-          res.push(lineNo() + ' '.repeat(pad) + c.red('^'.repeat(length)))
+          res.push(lineNo() + ' '.repeat(pad + 1) + c.red('^'.repeat(length)))
         }
         else if (j > i) {
           if (end > count) {
             const length = Math.max(1, Math.min(end - count, lineLength))
-            res.push(lineNo() + c.red('^'.repeat(length)))
+            res.push(lineNo() + ' ' + c.red('^'.repeat(length)))
           }
           count += lineLength + 1
         }
@@ -503,5 +501,5 @@ export function generateCodeFrame(
 }
 
 function lineNo(no: number | string = '') {
-  return c.gray(`${String(no).padStart(3, ' ')}| `)
+  return c.gray(`${String(no).padStart(3, ' ')}|`)
 }

--- a/packages/vitest/src/node/printError.ts
+++ b/packages/vitest/src/node/printError.ts
@@ -470,8 +470,8 @@ export function generateCodeFrame(
         }
 
         res.push(
-          lineNo(j + 1)
-          + truncateString(lines[j].replace(/\t/g, ' '), columns - 5 - indent),
+          (lineNo(j + 1)
+            + truncateString(lines[j].replace(/\t/g, ' '), columns - 5 - indent)).trimEnd(),
         )
 
         if (j === i) {

--- a/packages/vitest/src/node/printError.ts
+++ b/packages/vitest/src/node/printError.ts
@@ -469,7 +469,7 @@ export function generateCodeFrame(
           return ''
         }
 
-        const truncatedLine = truncateString(lines[j].replace(/\t/g, ' '), columns - 5 - indent)
+        const truncatedLine = truncateString(lines[j].replace(/\t/g, ' '), columns - 5 - indent).trimEnd()
         res.push(lineNo(j + 1) + (truncatedLine ? ' ' + truncatedLine : truncatedLine))
 
         if (j === i) {

--- a/test/browser/specs/__snapshots__/expect-element-no-awaited.test.ts.snap
+++ b/test/browser/specs/__snapshots__/expect-element-no-awaited.test.ts.snap
@@ -15,7 +15,7 @@ await expect.element(locator).toBeInTheDocument()
      18|         expect.element(element).toBeInTheDocument();
        |                                 ^
      19|       })
-     20|       
+     20|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 

--- a/test/browser/specs/__snapshots__/expect-element-no-awaited.test.ts.snap
+++ b/test/browser/specs/__snapshots__/expect-element-no-awaited.test.ts.snap
@@ -11,7 +11,7 @@ await expect.element(locator).toBeInTheDocument()
 
  ❯ expect-element.test.js:18:33
      16|         const element = page.getByText("Hello Vitest!");
-     17| 
+     17|
      18|         expect.element(element).toBeInTheDocument();
        |                                 ^
      19|       })

--- a/test/cli/test/__snapshots__/list.test.ts.snap
+++ b/test/cli/test/__snapshots__/list.test.ts.snap
@@ -3,18 +3,18 @@
 exports[`basic output shows error 1`] = `
 "Error: describe error
  ❯ describe-error.test.ts:4:9
-      2| 
+      2|
       3| describe('describe error', () => {
       4|   throw new Error('describe error')
        |         ^
-      5| 
+      5|
       6|   it('wont run', () => {
 
 Error: top level error
  ❯ top-level-error.test.ts:1:7
       1| throw new Error('top level error')
        |       ^
-      2| 
+      2|
 
 "
 `;
@@ -78,18 +78,18 @@ exports[`correctly outputs all tests with args: "--typecheck.only" 1`] = `
 exports[`json output shows error 1`] = `
 "Error: describe error
  ❯ describe-error.test.ts:4:9
-      2| 
+      2|
       3| describe('describe error', () => {
       4|   throw new Error('describe error')
        |         ^
-      5| 
+      5|
       6|   it('wont run', () => {
 
 Error: top level error
  ❯ top-level-error.test.ts:1:7
       1| throw new Error('top level error')
        |       ^
-      2| 
+      2|
 
 "
 `;
@@ -97,18 +97,18 @@ Error: top level error
 exports[`json with a file output shows error 1`] = `
 "Error: describe error
  ❯ describe-error.test.ts:4:9
-      2| 
+      2|
       3| describe('describe error', () => {
       4|   throw new Error('describe error')
        |         ^
-      5| 
+      5|
       6|   it('wont run', () => {
 
 Error: top level error
  ❯ top-level-error.test.ts:1:7
       1| throw new Error('top level error')
        |       ^
-      2| 
+      2|
 
 "
 `;

--- a/test/cli/test/__snapshots__/stacktraces.test.ts.snap
+++ b/test/cli/test/__snapshots__/stacktraces.test.ts.snap
@@ -7,12 +7,12 @@ exports[`stacktrace filtering > filters stacktraces 1`] = `
  FAIL  error-with-stack.test.js > error in deps
 Error: Something truly horrible has happened!
  ❯ d error-with-stack.test.js:20:9
-     18| 
+     18|
      19| function d() {
      20|   throw new Error('Something truly horrible has happened!')
        |         ^
      21| }
-     22| 
+     22|
  ❯ c error-with-stack.test.js:16:3
  ❯ a error-with-stack.test.js:8:3
  ❯ error-with-stack.test.js:4:3
@@ -31,12 +31,12 @@ Error: __TEST_STACK__
  ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/index.js:10:9
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/index.js:4:3
  ❯ error-in-package.test.js:8:12
-      6| 
+      6|
       7| test('js', () => {
       8|   testStack()
        |            ^
       9| })
-     10| 
+     10|
 
 ⎯⎯[1/4]⎯
 
@@ -48,7 +48,7 @@ Error: __TEST_STACK_TS__
      22|   throw new Error('__TEST_STACK_TS__')
        |         ^
      23| }
-     24| 
+     24|
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/ts.ts:12:3
  ❯ error-in-package.test.js:12:14
 
@@ -59,12 +59,12 @@ Error: __TEST_STACK_TRANSPILED__
  ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled.js:7:9
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled.js:3:3
  ❯ error-in-package.test.js:16:22
-     14| 
+     14|
      15| test('transpiled', () => {
      16|   testStackTranspiled()
        |                      ^
      17| })
-     18| 
+     18|
 
 ⎯⎯[3/4]⎯
 
@@ -73,12 +73,12 @@ Error: __TEST_STACK_TRANSPILED_INLINE__
  ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.js:7:9
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.js:3:3
  ❯ error-in-package.test.js:20:28
-     18| 
+     18|
      19| test('transpiled inline', () => {
      20|   testStackTranspiledInline()
        |                            ^
      21| })
-     22| 
+     22|
 
 ⎯⎯[4/4]⎯
 
@@ -92,12 +92,12 @@ exports[`stacktrace in dependency package > inline 1`] = `
  FAIL  error-in-package.test.js > js
 Error: __TEST_STACK__
  ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/index.js:10:9
-      8| 
+      8|
       9| function innerTestStack() {
      10|   throw new Error('__TEST_STACK__')
        |         ^
      11| }
-     12| 
+     12|
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/index.js:4:3
  ❯ error-in-package.test.js:8:12
 
@@ -111,7 +111,7 @@ Error: __TEST_STACK_TS__
      22|   throw new Error('__TEST_STACK_TS__')
        |         ^
      23| }
-     24| 
+     24|
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/ts.ts:12:3
  ❯ error-in-package.test.js:12:14
 
@@ -122,12 +122,12 @@ Error: __TEST_STACK_TRANSPILED__
  ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled.ts:22:9
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled.ts:12:3
  ❯ error-in-package.test.js:16:22
-     14| 
+     14|
      15| test('transpiled', () => {
      16|   testStackTranspiled()
        |                      ^
      17| })
-     18| 
+     18|
 
 ⎯⎯[3/4]⎯
 
@@ -136,12 +136,12 @@ Error: __TEST_STACK_TRANSPILED_INLINE__
  ❯ innerTestStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.ts:22:9
  ❯ testStack (NODE_MODULES)/@test/test-dep-error/transpiled-inline.ts:12:3
  ❯ error-in-package.test.js:20:28
-     18| 
+     18|
      19| test('transpiled inline', () => {
      20|   testStackTranspiledInline()
        |                            ^
      21| })
-     22| 
+     22|
 
 ⎯⎯[4/4]⎯
 
@@ -155,12 +155,12 @@ exports[`stacktrace in vmThreads 1`] = `
  FAIL  error-with-stack.test.js > error in deps
 Error: Something truly horrible has happened!
  ❯ d error-with-stack.test.js:20:9
-     18| 
+     18|
      19| function d() {
      20|   throw new Error('Something truly horrible has happened!')
        |         ^
      21| }
-     22| 
+     22|
  ❯ c error-with-stack.test.js:16:3
  ❯ b error-with-stack.test.js:12:3
  ❯ a error-with-stack.test.js:8:3
@@ -183,7 +183,7 @@ ReferenceError: bar is not defined
       3|   return bar()
        |   ^
       4| }
-      5| 
+      5|
  ❯ error-in-deps.test.js:5:6
 
 ⎯⎯[1/1]⎯
@@ -204,7 +204,7 @@ imba-parser error: Unexpected 'CALL_END'
 
 exports[`stacktraces should respect sourcemaps > add.test.ts 1`] = `
 " ❯ add.test.ts:12:24
-     10| 
+     10|
      11| it('add', () => {
      12|   expect(add(a.count)).toBe(100)
        |                        ^
@@ -220,13 +220,13 @@ exports[`stacktraces should respect sourcemaps > add-in-imba.test.imba 1`] = `
       8|  expect(add(1)).toBe 3
        |                 ^
       9|  expect(add(1, 2, 3)).toBe 6
-     10| 
+     10|
 "
 `;
 
 exports[`stacktraces should respect sourcemaps > add-in-js.test.js 1`] = `
 " ❯ add-in-js.test.js:6:17
-      4| 
+      4|
       5| it('add', () => {
       6|   expect(add()).toBe(100)
        |                 ^
@@ -245,63 +245,63 @@ exports[`stacktraces should respect sourcemaps > error-in-deps.test.js 1`] = `
 
 exports[`stacktraces should respect sourcemaps > error-in-package.test.js 1`] = `
 " ❯ error-in-package.test.js:8:12
-      6| 
+      6|
       7| test('js', () => {
       8|   testStack()
        |            ^
       9| })
-     10| 
+     10|
 "
 `;
 
 exports[`stacktraces should respect sourcemaps > error-with-stack.test.js 1`] = `
 " ❯ d error-with-stack.test.js:20:9
-     18| 
+     18|
      19| function d() {
      20|   throw new Error('Something truly horrible has happened!')
        |         ^
      21| }
-     22| 
+     22|
  ❯ c error-with-stack.test.js:16:3"
 `;
 
 exports[`stacktraces should respect sourcemaps > mocked-global.test.js 1`] = `
 " ❯ mocked-global.test.js:6:13
-      4| 
+      4|
       5| test('failed', () => {
       6|   expect(1).toBe(2)
        |             ^
       7| })
-      8| 
+      8|
 "
 `;
 
 exports[`stacktraces should respect sourcemaps > mocked-imported.test.js 1`] = `
 " ❯ mocked-imported.test.js:6:13
-      4| 
+      4|
       5| test('failed', () => {
       6|   expect(1).toBe(2)
        |             ^
       7| })
-      8| 
+      8|
 "
 `;
 
 exports[`stacktraces should respect sourcemaps > mocked-imported.test.ts 1`] = `
 " ❯ mocked-imported.test.ts:6:13
-      4| 
+      4|
       5| test('failed', () => {
       6|   expect(1).toBe(2)
        |             ^
       7| })
-      8| 
+      8|
 "
 `;
 
 exports[`stacktraces should respect sourcemaps > require-assertions.test.js 1`] = `
 " ❯ require-assertions.test.js:3:5
       1| import { test } from 'vitest'
-      2| 
+      2|
       3| test('assertion is not called', () => {
        |     ^
       4|   // no expect

--- a/test/cli/test/annotations.test.ts
+++ b/test/cli/test/annotations.test.ts
@@ -508,7 +508,7 @@ describe('reporters', () => {
              11|               throw new Error('thrown error')
                |                     ^
              12|             })
-             13|           
+             13|
 
          ❯ basic.test.ts:9:15 notice
            ↳ printed
@@ -549,7 +549,7 @@ describe('reporters', () => {
               6|               throw new Error('thrown error')
                |                     ^
               7|             })
-              8|           
+              8|
 
          ❯ basic.test.ts:5:15 notice
            ↳ printed
@@ -587,7 +587,7 @@ describe('reporters', () => {
               6|               throw new Error('thrown error')
                |                     ^
               7|             })
-              8|           
+              8|
 
          ❯ basic.test.ts:5:15 notice
            ↳ printed 1
@@ -602,7 +602,7 @@ describe('reporters', () => {
               6|               throw new Error('thrown error')
                |                     ^
               7|             })
-              8|           
+              8|
 
          ❯ basic.test.ts:5:15 notice
            ↳ printed 2

--- a/test/cli/test/around-each.test.ts
+++ b/test/cli/test/around-each.test.ts
@@ -148,7 +148,7 @@ test('throws error when runTest is called multiple times', async () => {
           6|         await runTest() // second call should throw
            |               ^
           7|       })
-          8| 
+          8|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 
@@ -442,7 +442,7 @@ test('aroundEach cleanup error is reported', async () => {
           8|         throw new Error('cleanup error')
            |               ^
           9|       })
-         10| 
+         10|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 
@@ -758,7 +758,7 @@ test('aroundEach setup phase timeout', async () => {
     AroundHookSetupError: The setup phase of "aroundEach" hook timed out after 100ms.
      ❯ setup-timeout.test.ts:4:7
           2|       import { aroundEach, test } from 'vitest'
-          3| 
+          3|
           4|       aroundEach(async (runTest) => {
            |       ^
           5|         console.log('>> setup start')
@@ -798,7 +798,7 @@ test('aroundEach teardown phase timeout', async () => {
     AroundHookTeardownError: The teardown phase of "aroundEach" hook timed out after 100ms.
      ❯ teardown-timeout.test.ts:4:7
           2|       import { aroundEach, test } from 'vitest'
-          3| 
+          3|
           4|       aroundEach(async (runTest) => {
            |       ^
           5|         console.log('>> setup')
@@ -879,7 +879,7 @@ test('aroundEach default timeout uses hookTimeout config', async () => {
     AroundHookSetupError: The setup phase of "aroundEach" hook timed out after 10ms.
      ❯ default-timeout.test.ts:4:7
           2|       import { aroundEach, test } from 'vitest'
-          3| 
+          3|
           4|       aroundEach(async (runTest) => {
            |       ^
           5|         // Setup takes longer than hookTimeout (10ms)
@@ -929,7 +929,7 @@ test('multiple aroundEach hooks with different timeouts', async () => {
      FAIL  multiple-timeouts.test.ts > test
     AroundHookSetupError: The setup phase of "aroundEach" hook timed out after 10ms.
      ❯ multiple-timeouts.test.ts:12:7
-         10| 
+         10|
          11|       // Inner hook with 50ms timeout - this should timeout during set…
          12|       aroundEach(async (runTest) => {
            |       ^
@@ -991,7 +991,7 @@ test('multiple aroundEach hooks where inner teardown times out', async () => {
      FAIL  multiple-teardown-timeout.test.ts > test
     AroundHookTeardownError: The teardown phase of "aroundEach" hook timed out after 10ms.
      ❯ multiple-teardown-timeout.test.ts:12:7
-         10| 
+         10|
          11|       // Inner hook with 50ms timeout - this should timeout during tea…
          12|       aroundEach(async (runTest) => {
            |       ^
@@ -1392,7 +1392,7 @@ test('aroundAll throws error when runSuite is called multiple times', async () =
           6|         await runSuite() // second call should throw
            |               ^
           7|       })
-          8| 
+          8|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 
@@ -1527,7 +1527,7 @@ test('aroundAll setup phase timeout', async () => {
     AroundHookSetupError: The setup phase of "aroundAll" hook timed out after 10ms.
      ❯ timeout.test.ts:4:7
           2|       import { test, aroundAll } from 'vitest'
-          3| 
+          3|
           4|       aroundAll(async (runSuite) => {
            |       ^
           5|         console.log('>> aroundAll setup starting')
@@ -1578,7 +1578,7 @@ test('aroundAll teardown phase timeout', async () => {
     AroundHookTeardownError: The teardown phase of "aroundAll" hook timed out after 10ms.
      ❯ teardown-timeout.test.ts:4:7
           2|       import { test, aroundAll } from 'vitest'
-          3| 
+          3|
           4|       aroundAll(async (runSuite) => {
            |       ^
           5|         console.log('>> aroundAll setup')
@@ -1871,12 +1871,12 @@ test('tests are skipped when aroundAll setup fails', async () => {
      FAIL  aroundAll-setup-error.test.ts [ aroundAll-setup-error.test.ts ]
     Error: aroundAll setup error
      ❯ aroundAll-setup-error.test.ts:5:15
-          3| 
+          3|
           4|       aroundAll(async () => {
           5|         throw new Error('aroundAll setup error')
            |               ^
           6|       })
-          7| 
+          7|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 

--- a/test/cli/test/no-module-runner.test.ts
+++ b/test/cli/test/no-module-runner.test.ts
@@ -520,7 +520,7 @@ if (import.meta.vitest) {
        FAIL  in-source.ts:12:3 > works
       Error: test throws correctly
        ❯ <anonymous> in-source.ts:13:11
-           11| 
+           11|
            12|   test('works', () => {
            13|     throw new Error('test throws correctly')
              |           ^
@@ -566,7 +566,7 @@ test('not reported')
       Error: [vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock
        ❯ add.js?mock=manual:2:65
        ❯ <anonymous> add.test.js:2:1
-            1| 
+            1|
             2| import { add } from './add.js'
              | ^
             3| vi.mock('./add.js', () => {

--- a/test/cli/test/reporters/__snapshots__/default.test.ts.snap
+++ b/test/cli/test/reporters/__snapshots__/default.test.ts.snap
@@ -19,7 +19,7 @@ AssertionError: expected 1 to be +0 // Object.is equality
       5|   expect(n).toBe(0);
        |             ^
       6| });
-      7| 
+      7|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/6]⎯
 
@@ -38,7 +38,7 @@ AssertionError: expected 2 to be +0 // Object.is equality
       5|   expect(n).toBe(0);
        |             ^
       6| });
-      7| 
+      7|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/6]⎯
 
@@ -58,7 +58,7 @@ AssertionError: expected 1 to be +0 // Object.is equality
      10|   expect(1).toBe(0);
        |             ^
      11| });
-     12| 
+     12|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/6]⎯
 
@@ -80,7 +80,7 @@ AssertionError: expected [ Array(1) ] to deeply equal ArrayContaining{…}
      24|   expect(actual).toEqual(expect.arrayContaining(expected));
        |                  ^
      25| });
-     26| 
+     26|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/6]⎯
 
@@ -102,7 +102,7 @@ AssertionError: expected [ Array(1) ] to deeply equal ArrayContaining{…}
      24|   expect(actual).toEqual(expect.arrayContaining(expected));
        |                  ^
      25| });
-     26| 
+     26|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/6]⎯
 

--- a/test/cli/test/reporters/indicator-position.test.ts
+++ b/test/cli/test/reporters/indicator-position.test.ts
@@ -25,7 +25,7 @@ test('should print correct indicator position', async () => {
     + 2
 
      ❯ indicator-position.test.js:12:17
-         10| 
+         10|
          11| test('', async () => {
          12|   expect(1 + 1).toBe(3)
            |                 ^

--- a/test/cli/test/reporters/merge-reports.test.ts
+++ b/test/cli/test/reporters/merge-reports.test.ts
@@ -60,7 +60,7 @@ test('merge reports', async () => {
          15|   expect(1).toBe(2)
            |             ^
          16| })
-         17| 
+         17|
 
      FAIL  second.test.ts > test 2-1
     AssertionError: expected 1 to be 2 // Object.is equality
@@ -77,7 +77,7 @@ test('merge reports', async () => {
           5|   expect(1).toBe(2)
            |             ^
           6| })
-          7| 
+          7|
     "
   `)
 

--- a/test/cli/test/stacktraces.test.ts
+++ b/test/cli/test/stacktraces.test.ts
@@ -127,12 +127,12 @@ it('custom helper with captureStackTrace', async () => {
     + 3
 
      ❯ basic.test.ts:5:3
-          3| 
+          3|
           4| test("sync", async () => {
           5|   assertHelper(3, 4);
            |   ^
           6| });
-          7| 
+          7|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯
 
@@ -146,12 +146,12 @@ it('custom helper with captureStackTrace', async () => {
     + 3
 
      ❯ basic.test.ts:9:3
-          7| 
+          7|
           8| test("async", async () => {
           9|   await assertHelperAsync(3, 4)
            |   ^
          10| })
-         11| 
+         11|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯
 
@@ -165,12 +165,12 @@ it('custom helper with captureStackTrace', async () => {
     + 3
 
      ❯ assertHelperBad helper.ts:23:20
-         21| 
+         21|
          22| export function assertHelperBad(expected: any, actual: any) {
          23|   expect(expected).toBe(actual);
            |                    ^
          24| }
-         25| 
+         25|
      ❯ basic.test.ts:13:3
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯

--- a/test/cli/test/test-tags.test.ts
+++ b/test/cli/test/test-tags.test.ts
@@ -158,10 +158,10 @@ test('throws an error if no tags are defined in the config, but in the test', as
      FAIL  basic.test.js [ basic.test.js ]
     Error: The Vitest config does't define any "tags", cannot apply "unknown" tag for this test. See: https://vitest.dev/guide/test-tags
      ❯ basic.test.js:2:9
-          1| 
+          1|
           2|         test('test 1', { tags: ['unknown'] }, () => {})
            |         ^
-          3|       
+          3|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 
@@ -190,10 +190,10 @@ test('throws an error if tag is not defined in the config, but in the test', asy
     Error: The tag "unknown" is not defined in the configuration. Available tags are:
     - known
      ❯ basic.test.js:2:9
-          1| 
+          1|
           2|         test('test 1', { tags: ['unknown'] }, () => {})
            |         ^
-          3|       
+          3|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 

--- a/test/config/test/__snapshots__/hook-timeout.test.ts.snap
+++ b/test/config/test/__snapshots__/hook-timeout.test.ts.snap
@@ -8,11 +8,11 @@ exports[`timeout error with stack trace 1`] = `
 Error: Hook timed out in 10ms.
 If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  ❯ basic.test.ts:4:3
-      2| 
+      2|
       3| describe('beforeAll', () => {
       4|   beforeAll(() => new Promise(() => {}), 10)
        |   ^
-      5| 
+      5|
       6|   it('ok', () => {})
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/10]⎯
@@ -21,11 +21,11 @@ If this is a long-running hook, pass a timeout value as the last argument or con
 Error: Hook timed out in 30ms.
 If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  ❯ basic.test.ts:16:3
-     14| 
+     14|
      15| describe('afterAll', () => {
      16|   afterAll(() => new Promise(() => {}), 30)
        |   ^
-     17| 
+     17|
      18|   it('ok', () => {})
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/10]⎯
@@ -34,11 +34,11 @@ If this is a long-running hook, pass a timeout value as the last argument or con
 Error: Hook timed out in 50ms.
 If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  ❯ basic.test.ts:28:3
-     26| 
+     26|
      27| describe('cleanup-beforeAll', () => {
      28|   beforeAll(() => () => new Promise(() => {}), 50)
        |   ^
-     29| 
+     29|
      30|   it('ok', () => {})
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/10]⎯
@@ -50,11 +50,11 @@ If this is a long-running hook, pass a timeout value as the last argument or con
 Error: Hook timed out in 20ms.
 If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  ❯ basic.test.ts:10:3
-      8| 
+      8|
       9| describe('beforeEach', () => {
      10|   beforeEach(() => new Promise(() => {}), 20)
        |   ^
-     11| 
+     11|
      12|   it('ok', () => {})
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/10]⎯
@@ -63,11 +63,11 @@ If this is a long-running hook, pass a timeout value as the last argument or con
 Error: Hook timed out in 40ms.
 If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  ❯ basic.test.ts:22:3
-     20| 
+     20|
      21| describe('afterEach', () => {
      22|   afterEach(() => new Promise(() => {}), 40)
        |   ^
-     23| 
+     23|
      24|   it('ok', () => {})
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/10]⎯
@@ -76,11 +76,11 @@ If this is a long-running hook, pass a timeout value as the last argument or con
 Error: Hook timed out in 60ms.
 If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  ❯ basic.test.ts:34:3
-     32| 
+     32|
      33| describe('cleanup-beforeEach', () => {
      34|   beforeEach(() => () => new Promise(() => {}), 60)
        |   ^
-     35| 
+     35|
      36|   it('ok', () => {})
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/10]⎯
@@ -128,10 +128,10 @@ Error: Test timed out in 123ms.
 If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
  ❯ basic.test.ts:52:1
      50| })
-     51| 
+     51|
      52| it("test timeout", () => new Promise(() => {}), 123)
        | ^
-     53| 
+     53|
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/10]⎯
 

--- a/test/core/test/__snapshots__/injector-mock.test.ts.snap
+++ b/test/core/test/__snapshots__/injector-mock.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited assigned vi.hoisted is called inside vi.mock 1`] = `"Cannot call vi.hoisted() inside vi.mock('./mocked'): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited assigned vi.hoisted is called inside vi.mock 2`] = `
-"      2| 
+"      2|
       3| vi.mock('./mocked', async () => {
       4|   const variable = await vi.hoisted(() => 1)
        |                          ^
@@ -14,7 +14,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited vi.hoisted is called inside vi.mock 1`] = `"Cannot call vi.hoisted() inside vi.mock('./mocked'): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited vi.hoisted is called inside vi.mock 2`] = `
-"      2| 
+"      2|
       3| vi.mock('./mocked', async () => {
       4|   await vi.hoisted(() => 1)
        |         ^
@@ -26,7 +26,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited vi.hoisted is exported as default export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export default await vi.hoisted(async () => {
        | ^
       4|   return {}
@@ -37,7 +37,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited vi.hoisted is exported as named export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export const values = await vi.hoisted(async () => {
        | ^
       4|   return {}
@@ -47,7 +47,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.hoisted is called inside vi.mock 1`] = `"Cannot call vi.hoisted() inside vi.mock('./mocked'): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.hoisted is called inside vi.mock 2`] = `
-"      2| 
+"      2|
       3| vi.mock('./mocked', () => {
       4|   const variable = vi.hoisted(() => 1)
        |                    ^
@@ -59,7 +59,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.hoisted is exported as a named export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export const values = vi.hoisted(async () => {
        | ^
       4|   return {}
@@ -70,7 +70,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.hoisted is exported as default 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export default vi.hoisted(() => {
        | ^
       4|   return {}
@@ -80,7 +80,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock inside vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock inside vi.hoisted 2`] = `
-"      2| 
+"      2|
       3| vi.hoisted(() => {
       4|   vi.mock('./mocked')
        |   ^
@@ -91,7 +91,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside assigned awaited vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside assigned awaited vi.hoisted 2`] = `
-"      2| 
+"      2|
       3| const values = await vi.hoisted(async () => {
       4|   vi.mock('./mocked')
        |   ^
@@ -102,7 +102,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside assigned vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside assigned vi.hoisted 2`] = `
-"      2| 
+"      2|
       3| const values = vi.hoisted(() => {
       4|   vi.mock('./mocked')
        |   ^
@@ -113,7 +113,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside awaited vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside awaited vi.hoisted 2`] = `
-"      2| 
+"      2|
       3| await vi.hoisted(async () => {
       4|   vi.mock('./mocked')
        |   ^
@@ -125,7 +125,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is exported as a named export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export const mocked = vi.mock('./mocked')
        | ^
       4| "
@@ -135,7 +135,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is exported as default export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export default vi.mock('./mocked')
        | ^
       4| "
@@ -145,7 +145,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.unmock is exported as a named export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export const mocked = vi.unmock('./mocked')
        | ^
       4| "
@@ -155,7 +155,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.unmock is exported as default export 2`] = `
 "      1| import { vi } from 'vitest'
-      2| 
+      2|
       3| export default vi.unmock('./mocked')
        | ^
       4| "

--- a/test/core/test/__snapshots__/injector-mock.test.ts.snap
+++ b/test/core/test/__snapshots__/injector-mock.test.ts.snap
@@ -8,7 +8,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       4|   const variable = await vi.hoisted(() => 1)
        |                          ^
       5| })
-      6| "
+      6|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited vi.hoisted is called inside vi.mock 1`] = `"Cannot call vi.hoisted() inside vi.mock('./mocked'): both methods are hoisted to the top of the file and not actually called inside each other."`;
@@ -19,7 +19,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       4|   await vi.hoisted(() => 1)
        |         ^
       5| })
-      6| "
+      6|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if awaited vi.hoisted is exported as default export 1`] = `"Cannot export hoisted variable. You can control hoisting behavior by placing the import from this file first."`;
@@ -85,7 +85,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       4|   vi.mock('./mocked')
        |   ^
       5| })
-      6| "
+      6|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside assigned awaited vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
@@ -96,7 +96,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       4|   vi.mock('./mocked')
        |   ^
       5| })
-      6| "
+      6|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside assigned vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
@@ -107,7 +107,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       4|   vi.mock('./mocked')
        |   ^
       5| })
-      6| "
+      6|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is called inside awaited vi.hoisted 1`] = `"Cannot call vi.mock('./mocked') inside vi.hoisted(): both methods are hoisted to the top of the file and not actually called inside each other."`;
@@ -118,7 +118,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       4|   vi.mock('./mocked')
        |   ^
       5| })
-      6| "
+      6|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is exported as a named export 1`] = `"Cannot export the result of "vi.mock". Remove export declaration because "vi.mock" doesn't return anything."`;
@@ -128,7 +128,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       2|
       3| export const mocked = vi.mock('./mocked')
        | ^
-      4| "
+      4|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.mock is exported as default export 1`] = `"Cannot export the result of "vi.mock". Remove export declaration because "vi.mock" doesn't return anything."`;
@@ -138,7 +138,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       2|
       3| export default vi.mock('./mocked')
        | ^
-      4| "
+      4|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.unmock is exported as a named export 1`] = `"Cannot export the result of "vi.unmock". Remove export declaration because "vi.unmock" doesn't return anything."`;
@@ -148,7 +148,7 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       2|
       3| export const mocked = vi.unmock('./mocked')
        | ^
-      4| "
+      4|"
 `;
 
 exports[`throws an error when nodes are incompatible > correctly throws an error if vi.unmock is exported as default export 1`] = `"Cannot export the result of "vi.unmock". Remove export declaration because "vi.unmock" doesn't return anything."`;
@@ -158,5 +158,5 @@ exports[`throws an error when nodes are incompatible > correctly throws an error
       2|
       3| export default vi.unmock('./mocked')
        | ^
-      4| "
+      4|"
 `;

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -16,7 +16,7 @@ exports[`should fail > typecheck files 2`] = `
 TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has no call signatures.
  ❯ fail.test-d.ts:15:19
      13|   })
-     14| 
+     14|
      15|   expectTypeOf(1).toBeVoid()
        |                   ^
      16| })"
@@ -37,7 +37,7 @@ exports[`should fail > typecheck files 4`] = `
 " FAIL  fail.test-d.ts > failing test
 TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string, Actual number"'.
  ❯ fail.test-d.ts:4:33
-      2| 
+      2|
       3| test('failing test', () => {
       4|   expectTypeOf(1).toEqualTypeOf<string>()
        |                                 ^
@@ -70,7 +70,7 @@ exports[`should fail > typecheck files 7`] = `
 " FAIL  js-fail.test-d.js > js test fails
 TypeCheckError: This expression is not callable. Type 'ExpectArray<number>' has no call signatures.
  ❯ js-fail.test-d.js:6:19
-      4| 
+      4|
       5| test('js test fails', () => {
       6|   expectTypeOf(1).toBeArray()
        |                   ^
@@ -81,7 +81,7 @@ exports[`should fail > typecheck files 8`] = `
 " FAIL  node-types.test-d.ts > buffer is not available
 TypeCheckError: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try \`npm i --save-dev @types/node\` and then add 'node' to the types field in your tsconfig.
  ❯ node-types.test-d.ts:4:3
-      2| 
+      2|
       3| test('buffer is not available', () => {
       4|   Buffer.from([])
        |   ^
@@ -92,7 +92,7 @@ exports[`should fail > typecheck files 9`] = `
 " FAIL  only.test-d.ts > failing test
 TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string, Actual number"'.
  ❯ only.test-d.ts:4:33
-      2| 
+      2|
       3| test.only('failing test', () => {
       4|   expectTypeOf(1).toEqualTypeOf<string>()
        |                                 ^


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I have my vscode with auto trimming of trailing white spaces, which causes breaking snapshots with code block generated by `expect(stderr).toMatchInlineSnapshot()`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
