### PR TITLE
docs: fix stale pool mentions in common errors page

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -45,9 +45,9 @@ export default defineConfig({
 
 ## Failed to Terminate Worker
 
-This error can happen when NodeJS's `fetch` is used with default [`pool: 'threads'`](/config/#threads). This issue is tracked on issue [Timeout abort can leave process(es) running in the background #3077](https://github.com/vitest-dev/vitest/issues/3077).
+This error can happen when NodeJS's `fetch` is used with [`pool: 'threads'`](/config/pool#threads) (for example, if you explicitly set it). This issue is tracked on issue [Timeout abort can leave process(es) running in the background #3077](https://github.com/vitest-dev/vitest/issues/3077).
 
-As a workaround, you can switch to [`pool: 'forks'`](/config/#forks) or [`pool: 'vmForks'`](/config/#vmforks).
+As a workaround, you can switch to [`pool: 'forks'`](/config/pool#forks) (the default) or [`pool: 'vmForks'`](/config/pool#vmforks).
 
 ::: code-group
 ```ts [vitest.config.js]

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -45,24 +45,9 @@ export default defineConfig({
 
 ## Failed to Terminate Worker
 
-This error can happen when NodeJS's `fetch` is used with [`pool: 'threads'`](/config/pool#threads) (for example, if you explicitly set it). This issue is tracked on issue [Timeout abort can leave process(es) running in the background #3077](https://github.com/vitest-dev/vitest/issues/3077).
+This error can happen when NodeJS's `fetch` is used with [`pool: 'threads'`](/config/pool#threads). See [#3077](https://github.com/vitest-dev/vitest/issues/3077) for details.
 
-As a workaround, you can switch to [`pool: 'forks'`](/config/pool#forks) (the default) or [`pool: 'vmForks'`](/config/pool#vmforks).
-
-::: code-group
-```ts [vitest.config.js]
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    pool: 'forks',
-  },
-})
-```
-```bash [CLI]
-vitest --pool=forks
-```
-:::
+The default [`pool: 'forks'`](/config/pool#forks) does not have this issue. If you've explicitly set `pool: 'threads'`, switching back to `'forks'` or using [`'vmForks'`](/config/pool#vmforks) will resolve it.
 
 ## Custom package conditions are not resolved
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I noticed https://vitest.dev/guide/common-errors.html#failed-to-terminate-worker section hasn't been updated after forks became default.This brushes up a bit.

Also `/config/#threads` is an invalid link. It's replaced with `/config/pool#threads`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
