### PR TITLE
fix: remove the `.name` from statically collected test

### DIFF
--- a/packages/vitest/src/node/ast-collect.ts
+++ b/packages/vitest/src/node/ast-collect.ts
@@ -161,6 +161,10 @@ function astParseFile(filepath: string, code: string) {
       }
       else {
         message = code.slice(messageNode.start, messageNode.end)
+
+        if (message.endsWith('.name')) {
+          message = message.slice(0, -5)
+        }
       }
 
       if (message.startsWith('0,')) {

--- a/test/cli/test/static-collect.test.ts
+++ b/test/cli/test/static-collect.test.ts
@@ -775,6 +775,28 @@ test('collects tests when test functions are globals', async () => {
   `)
 })
 
+test('remove .name from the function identifiers', async () => {
+  const testModule = await collectTests(`
+    import { test } from 'vitest'
+
+    test(Service.name, () => {
+      // ...
+    })
+`)
+  expect(testModule).toMatchInlineSnapshot(`
+    {
+      "Service": {
+        "errors": [],
+        "fullName": "Service",
+        "id": "-1732721377_0",
+        "location": "4:4",
+        "mode": "run",
+        "state": "pending",
+      },
+    }
+  `)
+})
+
 test('collects tests with tags as a string', async () => {
   const testModule = await collectTests(`
     import { test } from 'vitest'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vscode/issues/660

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
