### PR TITLE
test: allow running browser mode tests with docker playwright + add docs examples

### DIFF
--- a/docs/config/browser/playwright.md
+++ b/docs/config/browser/playwright.md
@@ -105,17 +105,22 @@ export default defineConfig({
     browser: {
       provider: playwright({
         connectOptions: {
+          // match with playwright server port in docker
           wsEndpoint: 'ws://127.0.0.1:6677/',
         },
       }),
-      instances: [{ browser: 'webkit' }],
+      instances: [
+        { browser: 'chromium' },
+        { browser: 'firefox' },
+        { browser: 'webkit' },
+      ],
     },
   },
 })
 ```
 
 ::: tip
-Using `network_mode: host` lets the containerized browser reach Vitest's dev server on localhost without needing to expose it on `0.0.0.0`. Make sure the Playwright version in the Docker image matches the version installed locally.
+Using `network_mode: host` lets the containerized browser reach Vitest's dev server on localhost without needing to expose it on `0.0.0.0`. Alternatively you can use [`connectOptions.exposeNetwork`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect-option-expose-network).
 :::
 
 ## contextOptions

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -1,0 +1,11 @@
+# browser test
+
+## Using docker playwright
+
+```sh
+# Start playwright server
+pnpm compose up -d
+
+# Run tests with BROWSER_WS_ENDPOINT
+BROWSER_WS_ENDPOINT=ws://127.0.0.1:6677/ pnpm test:playwright
+```

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -6,7 +6,7 @@ Some test suites don't support running it remotely (`fixtures/inspect` and `fixt
 
 ```sh
 # Start playwright browser server
-pnpm compose up -d
+pnpm docker up -d
 
 # Run tests with BROWSER_WS_ENDPOINT
 BROWSER_WS_ENDPOINT=ws://127.0.0.1:6677/ pnpm test:playwright

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -1,9 +1,11 @@
-# browser test
+# Browser Tests
 
 ## Using docker playwright
 
+Some test suites don't support running it remotely (`fixtures/inspect` and `fixtures/insecure-context`).
+
 ```sh
-# Start playwright server
+# Start playwright browser server
 pnpm compose up -d
 
 # Run tests with BROWSER_WS_ENDPOINT

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.58.1-noble
+    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 127.0.0.1"
+    init: true
+    network_mode: host
+    user: pwuser

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -1,7 +1,8 @@
 services:
   playwright:
     image: mcr.microsoft.com/playwright:v1.58.1-noble
-    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 127.0.0.1"
+    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 0.0.0.0"
     init: true
-    network_mode: host
     user: pwuser
+    ports:
+      - "6677:6677"

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -1,8 +1,9 @@
 services:
   playwright:
     image: mcr.microsoft.com/playwright:v1.58.1-noble
-    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 0.0.0.0"
+    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 127.0.0.1"
     init: true
+    # use this network_mode to allow browsers inside containers to access dev servers on host.
+    # alternatively `connectOptions.exposeNetwork: '<loopback>'` can be also used.
+    network_mode: host
     user: pwuser
-    ports:
-      - '6677:6677'

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -5,4 +5,4 @@ services:
     init: true
     user: pwuser
     ports:
-      - "6677:6677"
+      - '6677:6677'

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -3,7 +3,5 @@ services:
     image: mcr.microsoft.com/playwright:v1.58.1-noble
     command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 127.0.0.1"
     init: true
-    # use this network_mode to allow browsers inside containers to access dev servers on host.
-    # alternatively `connectOptions.exposeNetwork: '<loopback>'` can be also used.
     network_mode: host
     user: pwuser

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -1,7 +1,9 @@
 services:
   playwright:
     image: mcr.microsoft.com/playwright:v1.58.1-noble
-    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 127.0.0.1"
+    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 0.0.0.0"
     init: true
-    network_mode: host
+    ipc: host
     user: pwuser
+    ports:
+      - '6677:6677'

--- a/test/browser/fixtures/trace-view/vitest.config.ts
+++ b/test/browser/fixtures/trace-view/vitest.config.ts
@@ -1,13 +1,13 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
-import { playwright } from '@vitest/browser-playwright'
+import { providers } from '../../settings'
 
 export default defineConfig({
   cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
   test: {
     browser: {
       enabled: true,
-      provider: playwright(),
+      provider: providers.playwright(),
       instances: [
         { browser: 'chromium' },
         { browser: 'firefox' },

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -26,7 +26,8 @@
     "test:browser:preview": "PROVIDER=preview vitest",
     "test:browser:playwright": "PROVIDER=playwright vitest",
     "test:browser:webdriverio": "PROVIDER=webdriverio vitest",
-    "test:browser:playwright:html": "PROVIDER=playwright vitest --reporter=html"
+    "test:browser:playwright:html": "PROVIDER=playwright vitest --reporter=html",
+    "compose": "docker compose"
   },
   "devDependencies": {
     "@types/react": "^19.2.10",

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -27,7 +27,7 @@
     "test:browser:playwright": "PROVIDER=playwright vitest",
     "test:browser:webdriverio": "PROVIDER=webdriverio vitest",
     "test:browser:playwright:html": "PROVIDER=playwright vitest --reporter=html",
-    "compose": "docker compose"
+    "docker": "docker compose"
   },
   "devDependencies": {
     "@types/react": "^19.2.10",

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -23,12 +23,6 @@ export const provider
       })
     : providers[providerName]()
 
-export const browser = process.env.BROWSER || (provider.name !== 'playwright' ? 'chromium' : 'chrome')
-
-const devInstances: BrowserInstanceOption[] = [
-  { browser: browser as any },
-]
-
 const playwrightInstances: BrowserInstanceOption[] = [
   { browser: 'chromium' },
   { browser: 'firefox' },
@@ -42,8 +36,8 @@ const webdriverioInstances: BrowserInstanceOption[] = [
   { browser: 'firefox' },
 ]
 
-export const instances = process.env.BROWSER
-  ? devInstances
+export const instances: BrowserInstanceOption[] = process.env.BROWSER
+  ? [{ browser: process.env.BROWSER as any }]
   : provider.name === 'playwright'
     ? playwrightInstances
     : webdriverioInstances

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -34,7 +34,12 @@ const webdriverioInstances: BrowserInstanceOption[] = [
 ]
 
 export const instances: BrowserInstanceOption[] = process.env.BROWSER
-  ? [{ browser: process.env.BROWSER as any }]
+  ? [
+      {
+        browser: process.env.BROWSER as any,
+        headless: process.env.BROWSER === 'safari' ? false : undefined,
+      },
+    ]
   : provider.name === 'playwright'
     ? playwrightInstances
     : webdriverioInstances

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -11,7 +11,6 @@ export const providers = {
         ...options,
         connectOptions: {
           wsEndpoint: process.env.BROWSER_WS_ENDPOINT,
-          exposeNetwork: '<loopback>',
         },
       }
     : options),

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -11,6 +11,7 @@ export const providers = {
         ...options,
         connectOptions: {
           wsEndpoint: process.env.BROWSER_WS_ENDPOINT,
+          exposeNetwork: '<loopback>',
         },
       }
     : options),

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -10,11 +10,20 @@ export const providers = {
   webdriverio,
 }
 
-export const provider = providers[providerName]()
+// Run browser test suites with playwright browsers in docker container
+// $ docker compose up -d
+// $ BROWSER_WS_ENDPOINT=ws://127.0.0.1:6677/ pnpm test:playwright
+export const provider
+  = providerName === 'playwright' && process.env.BROWSER_WS_ENDPOINT
+    ? playwright({
+        connectOptions: { wsEndpoint: process.env.BROWSER_WS_ENDPOINT },
+      })
+    : providers[providerName]()
+
 export const browser = process.env.BROWSER || (provider.name !== 'playwright' ? 'chromium' : 'chrome')
 
 const devInstances: BrowserInstanceOption[] = [
-  { browser },
+  { browser: browser as any },
 ]
 
 const playwrightInstances: BrowserInstanceOption[] = [

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -4,24 +4,25 @@ import { preview } from '@vitest/browser-preview'
 import { webdriverio } from '@vitest/browser-webdriverio'
 
 const providerName = (process.env.PROVIDER || 'playwright') as 'playwright' | 'webdriverio' | 'preview'
-export const providers = {
-  playwright,
-  preview,
-  webdriverio,
-}
 
 // Run browser test suites with playwright browsers in docker container
 // $ docker compose up -d
 // $ BROWSER_WS_ENDPOINT=ws://127.0.0.1:6677/ pnpm test:playwright
-export const provider
-  = providerName === 'playwright' && process.env.BROWSER_WS_ENDPOINT
-    ? playwright({
+export const providers = {
+  playwright: (options?: Parameters<typeof playwright>[0]) => playwright(process.env.BROWSER_WS_ENDPOINT
+    ? {
+        ...options,
         connectOptions: {
           wsEndpoint: process.env.BROWSER_WS_ENDPOINT,
           exposeNetwork: '<loopback>',
         },
-      })
-    : providers[providerName]()
+      }
+    : options),
+  preview,
+  webdriverio,
+}
+
+export const provider = providers[providerName]()
 
 const playwrightInstances: BrowserInstanceOption[] = [
   { browser: 'chromium' },

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -16,7 +16,10 @@ export const providers = {
 export const provider
   = providerName === 'playwright' && process.env.BROWSER_WS_ENDPOINT
     ? playwright({
-        connectOptions: { wsEndpoint: process.env.BROWSER_WS_ENDPOINT },
+        connectOptions: {
+          wsEndpoint: process.env.BROWSER_WS_ENDPOINT,
+          exposeNetwork: '<loopback>',
+        },
       })
     : providers[providerName]()
 

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -5,9 +5,6 @@ import { webdriverio } from '@vitest/browser-webdriverio'
 
 const providerName = (process.env.PROVIDER || 'playwright') as 'playwright' | 'webdriverio' | 'preview'
 
-// Run browser test suites with playwright browsers in docker container
-// $ docker compose up -d
-// $ BROWSER_WS_ENDPOINT=ws://127.0.0.1:6677/ pnpm test:playwright
 export const providers = {
   playwright: (options?: Parameters<typeof playwright>[0]) => playwright(process.env.BROWSER_WS_ENDPOINT
     ? {

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -21,6 +21,7 @@ export async function runInlineBrowserTests(
         enabled: true,
         provider,
         instances,
+        headless: true,
         ...config?.browser,
       } as TestUserConfig['browser'],
     },
@@ -38,7 +39,7 @@ export async function runBrowserTests(
     watch: false,
     reporters: 'none',
     ...config,
-    browser: config?.browser,
+    browser: { headless: true, ...config?.browser },
     $viteConfig: viteOverrides,
   }, include, runnerOptions)
 }

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -2,9 +2,9 @@ import type { UserConfig as ViteUserConfig } from 'vite'
 import type { TestUserConfig } from 'vitest/node'
 import type { RunVitestConfig, TestFsStructure, VitestRunnerCLIOptions } from '../../test-utils'
 import { runInlineTests, runVitest } from '../../test-utils'
-import { browser, instances, provider } from '../settings'
+import { instances, provider } from '../settings'
 
-export { browser, instances, provider } from '../settings'
+export { instances, provider } from '../settings'
 
 export async function runInlineBrowserTests(
   structure: TestFsStructure,
@@ -21,7 +21,6 @@ export async function runInlineBrowserTests(
         enabled: true,
         provider,
         instances,
-        headless: browser !== 'safari',
         ...config?.browser,
       } as TestUserConfig['browser'],
     },
@@ -39,10 +38,7 @@ export async function runBrowserTests(
     watch: false,
     reporters: 'none',
     ...config,
-    browser: {
-      headless: browser !== 'safari',
-      ...config?.browser,
-    } as TestUserConfig['browser'],
+    browser: config?.browser,
     $viteConfig: viteOverrides,
   }, include, runnerOptions)
 }

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -1,21 +1,11 @@
-import type { BrowserCommand, BrowserInstanceOption } from 'vitest/node'
+import type { BrowserCommand } from 'vitest/node'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as util from 'node:util'
-import { playwright } from '@vitest/browser-playwright'
-import { preview } from '@vitest/browser-preview'
-import { webdriverio } from '@vitest/browser-webdriverio'
 import { defineConfig } from 'vitest/config'
+import { instances, provider } from './settings'
 
 const dir = dirname(fileURLToPath(import.meta.url))
-
-const providerName = process.env.PROVIDER || 'playwright'
-const browser = process.env.BROWSER as 'firefox' || (providerName === 'playwright' ? 'chromium' : 'chrome')
-const provider = {
-  playwright,
-  preview,
-  webdriverio,
-}[providerName]
 
 const myCustomCommand: BrowserCommand<[arg1: string, arg2: string]> = ({ testPath }, arg1, arg2) => {
   return { testPath, arg1, arg2 }
@@ -24,21 +14,6 @@ const myCustomCommand: BrowserCommand<[arg1: string, arg2: string]> = ({ testPat
 const stripVTControlCharacters: BrowserCommand<[text: string]> = (_, text) => {
   return util.stripVTControlCharacters(text)
 }
-
-const devInstances: BrowserInstanceOption[] = [
-  { browser },
-]
-
-const playwrightInstances: BrowserInstanceOption[] = [
-  { browser: 'chromium' },
-  { browser: 'firefox' },
-  { browser: 'webkit' },
-]
-
-const webdriverioInstances: BrowserInstanceOption[] = [
-  { browser: 'chrome' },
-  { browser: 'firefox' },
-]
 
 export default defineConfig({
   server: {
@@ -66,12 +41,8 @@ export default defineConfig({
     browser: {
       enabled: true,
       headless: false,
-      instances: process.env.BROWSER
-        ? devInstances
-        : providerName === 'playwright'
-          ? playwrightInstances
-          : webdriverioInstances,
-      provider: provider(),
+      instances,
+      provider,
       // isolate: false,
       testerHtmlPath: './custom-tester.html',
       orchestratorScripts: [


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Related 
- https://github.com/vitest-dev/vitest/discussions/9306
- https://github.com/vitest-dev/vitest/issues/9169

I investigated playwright docker and browser mode. I adjusted `test/browser` test suites to so I can test it with playwright docker (mostly to test webkit on my archlinux machine). The documentation is also added to mention this use case.

There are two cases `test/browser/fixtures/inspect` and `test/browser/fixtures/insecure-context` not working. I found `inspect` can actually work with remote playwright. I'll create a separate PR to fix things around `connectOptions` and `launchOptions`. 

I'm not sure it's worth running `wsEndpoint` test cases as another CI matrix. It looks technically doable, but I'll figure that out and discuss separately later.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
