### PR TITLE
docs: warn that artifacts may have empty attachments

### DIFF
--- a/docs/api/advanced/artifacts.md
+++ b/docs/api/advanced/artifacts.md
@@ -64,6 +64,12 @@ The `TestArtifactBase` interface is the base for all test artifacts.
 
 Extend this interface when creating custom test artifacts. Vitest automatically manages the `attachments` array and injects the `location` property to indicate where the artifact was created in your test code.
 
+::: danger
+When running with [`api.allowWrite`](/config/api#api-allowwrite) or [`browser.api.allowWrite`](/config/browser/api#api-allowwrite) disabled, Vitest empties the `attachments` array on every artifact before reporting it.
+
+If your custom artifact narrows the `attachments` type (e.g. to a tuple), include `| []` in the union so the type reflects what actually happens at runtime.
+:::
+
 ### `TestAttachment`
 
 ```ts
@@ -109,6 +115,7 @@ Here are a few guidelines or best practices to follow:
 - Try using a `Symbol` as the **registry key** to guarantee uniqueness
 - The `type` property should follow the pattern `'package-name:artifact-name'`, **`'internal:'` is a reserved prefix**
 - Use `attachments` to include files or data; extend [`TestAttachment`](#testattachment) for custom metadata
+- If you narrow the `attachments` type (e.g. to a tuple), include `| []` in the union since Vitest may empty the array at runtime (see [`TestArtifactBase`](#testartifactbase))
 - `location` property is automatically injected
 
 ## Custom Artifacts
@@ -127,7 +134,7 @@ interface AccessibilityArtifact extends TestArtifactBase {
   type: 'a11y:report'
   passed: boolean
   wcagLevel: 'A' | 'AA' | 'AAA'
-  attachments: [A11yReportAttachment]
+  attachments: [A11yReportAttachment] | []
 }
 
 const a11yReportKey = Symbol('report')

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -1293,6 +1293,8 @@ export interface TestArtifactLocation extends FileLocation {}
  * Base interface for all test artifacts.
  *
  * Extend this interface when creating custom test artifacts. Vitest automatically manages the `attachments` array and injects the `location` property to indicate where the artifact was created in your test code.
+ *
+ * **Important**: when running with [`api.allowWrite`](https://vitest.dev/config/api#api-allowwrite) or [`browser.api.allowWrite`](https://vitest.dev/config/browser/api#api-allowwrite) disabled, Vitest empties the `attachments` array on every artifact before reporting it.
  */
 export interface TestArtifactBase {
   /** File or data attachments associated with this artifact */


### PR DESCRIPTION
### Description

Since #9350, artifacts' attachments can get removed. Better document this behavior ~~(because _I_ got hit by it while working on #9588)~~ and fix the example, as it would introduce bugs at runtime 😛

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
