### PR TITLE
fix: log seed when shuffle.tests is enabled

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -742,7 +742,7 @@ export function resolveConfig(
   }
   resolved.sequence.groupOrder ??= 0
   resolved.sequence.hooks ??= 'stack'
-  if (resolved.sequence.sequencer === RandomSequencer) {
+  if (resolved.sequence.sequencer === RandomSequencer || resolved.sequence.shuffle) {
     resolved.sequence.seed ??= Date.now()
   }
 

--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -232,7 +232,7 @@ export class Logger {
 
     this.log(withLabel(color, mode, `v${this.ctx.version} `) + c.gray(this.ctx.config.root))
 
-    if (this.ctx.config.sequence.sequencer === RandomSequencer) {
+    if (this.ctx.config.sequence.sequencer === RandomSequencer || this.ctx.config.sequence.shuffle) {
       this.log(PAD + c.gray(`Running tests with seed "${this.ctx.config.sequence.seed}"`))
     }
 


### PR DESCRIPTION
Fixes #9557

## Summary
When only `sequence.shuffle.tests` is enabled (without `shuffle.files`), the seed was not being logged even though it was being used to shuffle tests.

## Changes
- Set `sequence.seed` when shuffle is enabled (either via `RandomSequencer` or `shuffle.tests`)
- Update logger to check if shuffle is enabled, not just if sequencer is `RandomSequencer`

## Test Plan
1. Verified all existing sequence-shuffle tests still pass
2. Manually tested with config `sequence: { shuffle: { tests: true } }` and confirmed seed is now logged:
   ```
   Running tests with seed "1770513343097"
   ```

This ensures users can reproduce test runs when using `shuffle.tests`.