### PR TITLE
docs: fix broken /config link in browser context types

### DIFF
--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -514,7 +514,7 @@ export interface LocatorSelectors {
    */
   getByTitle: (text: string | RegExp, options?: LocatorOptions) => Locator
   /**
-   * Creates a locator capable of finding an element that matches the specified test id attribute. You can configure the attribute name with [`browser.locators.testIdAttribute`](/config/#browser-locators-testidattribute).
+   * Creates a locator capable of finding an element that matches the specified test id attribute. You can configure the attribute name with [`browser.locators.testIdAttribute`](https://vitest.dev/config/#browser-locators-testidattribute).
    * @see {@link https://vitest.dev/api/browser/locators#getbytestid}
    */
   getByTestId: (text: string | RegExp) => Locator


### PR DESCRIPTION
## Summary

Fix broken docs link(s) pointing to `/config/#...`.

Fixes https://github.com/vitest-dev/vitest/issues/9593
