### PR TITLE
feat: allow `vitest list` to statically collect tests instead of running files to collect them

### DIFF
--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -339,7 +339,13 @@ async function collect(mode: VitestRunMode, cliFilters: string[], options: CliOp
       run: true,
     }, undefined, undefined, cliFilters)
     if (!options.filesOnly) {
-      const { testModules: tests, unhandledErrors: errors } = await ctx.collect(cliFilters.map(normalize))
+      const { testModules: tests, unhandledErrors: errors } = await ctx.collect(
+        cliFilters.map(normalize),
+        {
+          staticParse: options.staticParse,
+          staticParseConcurrency: options.staticParseConcurrency,
+        },
+      )
 
       if (errors.length) {
         console.error('\nThere were unhandled errors during test collection')

--- a/packages/vitest/src/node/cli/cli-api.ts
+++ b/packages/vitest/src/node/cli/cli-api.ts
@@ -28,9 +28,19 @@ export interface CliOptions extends UserConfig {
    * Output collected test files only
    */
   filesOnly?: boolean
+  /**
+   * Parse files statically instead of running them to collect tests
+   * @experimental
+   */
+  staticParse?: boolean
+  /**
+   * How many tests to process at the same time
+   * @experimental
+   */
+  staticParseConcurrency?: number
 
   /**
-   * Override vite config's configLoader from cli.
+   * Override vite config's configLoader from CLI.
    * Use `bundle` to bundle the config with esbuild or `runner` (experimental) to process it on the fly (default: `bundle`).
    * This is only available with **vite version 6.1.0** and above.
    * @experimental

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -912,6 +912,8 @@ export const cliOptionsConfig: VitestCLIOptions = {
   json: null,
   provide: null,
   filesOnly: null,
+  staticParse: null,
+  staticParseConcurrency: null,
   projects: null,
   watchTriggerPatterns: null,
   tags: null,
@@ -939,6 +941,13 @@ export const collectCliOptionsConfig: VitestCLIOptions = {
   },
   filesOnly: {
     description: 'Print only test files with out the test cases',
+  },
+  staticParse: {
+    description: 'Parse files statically instead of running them to collect tests (default: false)',
+  },
+  staticParseConcurrency: {
+    description: 'How many tests to process at the same time (default: os.availableParallelism())',
+    argument: '<limit>',
   },
   changed: {
     description: 'Print only tests that are affected by the changed files (default: `false`)',

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -655,7 +655,7 @@ export class Vitest {
     await this._testRun.updated(packs, events).catch(noop)
   }
 
-  async collect(filters?: string[]): Promise<TestRunResult> {
+  async collect(filters?: string[], options?: { staticParse?: boolean; staticParseConcurrency?: number }): Promise<TestRunResult> {
     return this._traces.$('vitest.collect', async (collectSpan) => {
       const filenamePattern = filters && filters?.length > 0 ? filters : []
       collectSpan.setAttribute('vitest.collect.filters', filenamePattern)
@@ -681,6 +681,13 @@ export class Vitest {
       // if run with --changed, don't exit if no tests are found
       if (!files.length) {
         return { testModules: [], unhandledErrors: [] }
+      }
+
+      if (options?.staticParse) {
+        const testModules = await this.experimental_parseSpecifications(files, {
+          concurrency: options.staticParseConcurrency,
+        })
+        return { testModules, unhandledErrors: [] }
       }
 
       return this.collectTests(files)

--- a/test/cli/test/__snapshots__/list.test.ts.snap
+++ b/test/cli/test/__snapshots__/list.test.ts.snap
@@ -59,6 +59,16 @@ math.test.ts > failing test
 "
 `;
 
+exports[`correctly outputs all tests with args: "--static-parse" 1`] = `
+"basic.test.ts > basic suite > inner suite > some test
+basic.test.ts > basic suite > inner suite > another test
+basic.test.ts > basic suite > basic test
+basic.test.ts > outside test
+math.test.ts > 1 plus 1
+math.test.ts > failing test
+"
+`;
+
 exports[`correctly outputs all tests with args: "--typecheck" 1`] = `
 "type.test-d.ts > 1 plus 1
 basic.test.ts > basic suite > inner suite > some test

--- a/test/cli/test/list.test.ts
+++ b/test/cli/test/list.test.ts
@@ -9,6 +9,7 @@ test.each([
   ['--browser.enabled'],
   ['--typecheck'],
   ['--typecheck.only'],
+  ['--static-parse'],
 ])('correctly outputs all tests with args: "%s"', async (...args) => {
   const { stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)
   expect(stdout).toMatchSnapshot()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is to allow the extension to just run `vitest list --static-parse` command 
