### PR TITLE
fix: increase stacktrace limit for `--detect-async-leaks`

### DIFF
--- a/packages/vitest/src/runtime/detect-async-leaks.ts
+++ b/packages/vitest/src/runtime/detect-async-leaks.ts
@@ -28,14 +28,19 @@ export function detectAsyncLeaks(testFile: string, projectName: string): () => P
       }
 
       let stack = ''
+      const limit = Error.stackTraceLimit
 
       // VitestModuleEvaluator's async wrapper of node:vm causes out-of-bound stack traces, simply skip it.
       // Crash fixed in https://github.com/vitejs/vite/pull/21585
       try {
+        Error.stackTraceLimit = 100
         stack = new Error('VITEST_DETECT_ASYNC_LEAKS').stack || ''
       }
       catch {
         return
+      }
+      finally {
+        Error.stackTraceLimit = limit
       }
 
       if (!stack.includes(testFile)) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Bug fix for unreleased https://github.com/vitest-dev/vitest/pull/9528.

While testing noticed that floating `fetch()` calls are not detected. The default stacktrace limit was not catching those. Jest seems to use `100` so let's do same.

Also a single `fetch` call seems to trigger multiple `PROMISE` async resource hooks. We'll need to normalize these into one, based on type+position.

With these changes we can detect case below. Notice that there's no `await` so `try-catch` is ignored - Vitest is pointing out actual bugs:

<img width="687" height="369" alt="image" src="https://github.com/user-attachments/assets/6fa9e005-104b-4127-8b62-7f97de6dc050" />


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
