### PR TITLE
docs: mention file-based attachments are not included in blob report and update CI example

### DIFF
--- a/docs/config/attachmentsdir.md
+++ b/docs/config/attachmentsdir.md
@@ -9,5 +9,3 @@ outline: deep
 - **Default:** `'.vitest-attachments'`
 
 Directory path for storing attachments created by [`context.annotate`](/guide/test-context#annotate) relative to the project root.
-
-When using [`--reporter=blob`](/guide/reporters#blob-reporter) with [`--merge-reports`](/guide/cli#merge-reports) across CI jobs, make sure this directory is uploaded and restored together with blob reports.

--- a/docs/config/attachmentsdir.md
+++ b/docs/config/attachmentsdir.md
@@ -9,3 +9,5 @@ outline: deep
 - **Default:** `'.vitest-attachments'`
 
 Directory path for storing attachments created by [`context.annotate`](/guide/test-context#annotate) relative to the project root.
+
+When using [`--reporter=blob`](/guide/reporters#blob-reporter) with [`--merge-reports`](/guide/cli#merge-reports) across CI jobs, make sure this directory is uploaded and restored together with blob reports.

--- a/docs/guide/improving-performance.md
+++ b/docs/guide/improving-performance.md
@@ -159,6 +159,15 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+      - name: Upload attachments to GitHub Actions Artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-attachments-${{ matrix.shardIndex }}
+          path: .vitest-attachments/**
+          include-hidden-files: true
+          retention-days: 1
+
   merge-reports:
     if: ${{ !cancelled() }}
     needs: [tests]
@@ -183,9 +192,18 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
+      - name: Download attachments from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .vitest-attachments
+          pattern: blob-attachments-*
+          merge-multiple: true
+
       - name: Merge reports
         run: npx vitest --merge-reports
 ```
+
+If your tests create file-based attachments (for example via `context.annotate` or custom artifacts), upload and restore [`attachmentsDir`](/config/attachmentsdir) in the merge job as shown above.
 
 :::
 

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -592,7 +592,8 @@ All blob reports can be merged into any report by using `--merge-reports` comman
 npx vitest --merge-reports=reports --reporter=json --reporter=default
 ```
 
-If your tests create file-based attachments, also preserve and restore [`attachmentsDir`](/config/attachmentsdir) alongside blob reports in CI.
+Blob reporter output doesn't include file-based [attachments](/api/advanced/artifacts.html#testattachment).
+Make sure to merge [`attachmentsDir`](/config/attachmentsdir) separately alongside blob reports on CI when using this feature.
 
 ::: tip
 Both `--reporter=blob` and `--merge-reports` do not work in watch mode.

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -592,6 +592,8 @@ All blob reports can be merged into any report by using `--merge-reports` comman
 npx vitest --merge-reports=reports --reporter=json --reporter=default
 ```
 
+If your tests create file-based attachments, also preserve and restore [`attachmentsDir`](/config/attachmentsdir) alongside blob reports in CI.
+
 ::: tip
 Both `--reporter=blob` and `--merge-reports` do not work in watch mode.
 :::


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently following fails since blob report doesn't include file attachments, but html reporter expects them to exist.

```sh
$ vitest --run --reporter=blob
$ rm .vitest-attachments
$ vitest --run --merge-report --reporter=html
```

I'm not sure if blob reporter should be self-contained with attachments, but for CI workflow, this can be easily adjusted with extra upload/download-artifact steps, so this PR just updates docs.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
