### PR TITLE
fix: handle module-sync condition in vmThreads/vmForks require (fix #9650)

### DIFF
--- a/test/cli/test/vm-threads.test.ts
+++ b/test/cli/test/vm-threads.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { createFile, resolvePath, runVitest } from '../../test-utils'
+import { createFile, resolvePath, runInlineTests, runVitest } from '../../test-utils'
 
 test('importing files in restricted fs works correctly', async () => {
   createFile(
@@ -10,6 +10,62 @@ test('importing files in restricted fs works correctly', async () => {
 
   const { stderr, exitCode } = await runVitest({
     root: './fixtures/vm-threads',
+  })
+
+  expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
+})
+
+// The module-sync condition was added in Node 22.12/20.19 when require(esm)
+// was unflagged. The fix uses the _resolveFilename conditions option which
+// is only available on Node 22.12+. Node 20 is unfixable and reaches EOL
+// April 2026.
+const nodeMajor = Number(process.versions.node.split('.')[0])
+test.skipIf(nodeMajor < 22)('can require package with module-sync exports condition', async () => {
+  const { stderr, exitCode } = await runInlineTests({
+    // .mjs module-sync entry
+    'node_modules/module-sync-mjs/package.json': JSON.stringify({
+      name: 'module-sync-mjs',
+      exports: {
+        '.': {
+          'module-sync': './index.mjs',
+          'require': './index.cjs',
+        },
+      },
+    }),
+    'node_modules/module-sync-mjs/index.mjs': 'export const value = "esm";',
+    'node_modules/module-sync-mjs/index.cjs': 'module.exports = { value: "cjs" };',
+    // .js module-sync entry with "type": "module"
+    'node_modules/module-sync-js/package.json': JSON.stringify({
+      name: 'module-sync-js',
+      type: 'module',
+      exports: {
+        '.': {
+          'module-sync': './index.js',
+          'require': './index.cjs',
+        },
+      },
+    }),
+    'node_modules/module-sync-js/index.js': 'export const value = "esm";',
+    'node_modules/module-sync-js/index.cjs': 'module.exports = { value: "cjs" };',
+    'basic.test.js': `
+      import { createRequire } from 'node:module'
+      import { expect, test } from 'vitest'
+
+      const require = createRequire(import.meta.url)
+
+      test('require loads cjs entry for module-sync package (.mjs)', () => {
+        const mod = require('module-sync-mjs')
+        expect(mod.value).toBe('cjs')
+      })
+
+      test('require loads cjs entry for module-sync package (.js with type: module)', () => {
+        const mod = require('module-sync-js')
+        expect(mod.value).toBe('cjs')
+      })
+    `,
+  }, {
+    pool: 'vmThreads',
   })
 
   expect(stderr).toBe('')

--- a/test/core/test/parse-cjs-conditions.test.ts
+++ b/test/core/test/parse-cjs-conditions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { parseCjsConditions } from '../../../packages/vitest/src/runtime/vm/commonjs-executor'
+
+describe('parseCjsConditions', () => {
+  it('returns default conditions with no arguments', () => {
+    const result = parseCjsConditions([], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons']))
+  })
+
+  it('parses --conditions=value from execArgv', () => {
+    const result = parseCjsConditions(['--conditions=custom'], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('parses --conditions value (space-separated) from execArgv', () => {
+    const result = parseCjsConditions(['--conditions', 'custom'], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('parses -C=value from execArgv', () => {
+    const result = parseCjsConditions(['-C=custom'], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('parses -C value (space-separated) from execArgv', () => {
+    const result = parseCjsConditions(['-C', 'custom'], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('parses conditions from NODE_OPTIONS', () => {
+    const result = parseCjsConditions([], '--conditions=custom')
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('parses space-separated conditions from NODE_OPTIONS', () => {
+    const result = parseCjsConditions([], '--conditions custom')
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('handles multiple conditions from both sources', () => {
+    const result = parseCjsConditions(
+      ['--conditions=from-cli', '-C', 'another'],
+      '--conditions=from-env',
+    )
+    expect(result).toEqual(new Set([
+      'node',
+      'require',
+      'node-addons',
+      'from-cli',
+      'another',
+      'from-env',
+    ]))
+  })
+
+  it('filters out module-sync', () => {
+    const result = parseCjsConditions(['--conditions=module-sync'], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons']))
+  })
+
+  it('filters out module-sync but keeps other conditions', () => {
+    const result = parseCjsConditions(
+      ['--conditions=module-sync', '--conditions=custom'],
+      undefined,
+    )
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons', 'custom']))
+  })
+
+  it('ignores unrelated execArgv entries', () => {
+    const result = parseCjsConditions(
+      ['--experimental-vm-modules', '-e', 'console.log("hi")'],
+      undefined,
+    )
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons']))
+  })
+
+  it('ignores trailing --conditions with no value', () => {
+    const result = parseCjsConditions(['--conditions'], undefined)
+    expect(result).toEqual(new Set(['node', 'require', 'node-addons']))
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #9650

The `module-sync` exports condition can resolve to ESM files (`.mjs` or `.js` with `"type": "module"`) that the CJS `vm.Script` executor in vmThreads/vmForks cannot handle, causing `SyntaxError: Unexpected token 'export'`.

### Fix

Pass explicit CJS conditions (`node`, `require`, `node-addons`) to `require.resolve` in `CommonjsExecutor.createRequire`, excluding `module-sync`. This works on Node 22.12+ where `_resolveFilename` supports a `conditions` option. On older Node versions the option is silently ignored.

User-specified `--conditions`/`-C` flags (from both `process.execArgv` and `NODE_OPTIONS`) are respected and included in the conditions set, except for `module-sync` which is always filtered out. There is currently no public Node.js API to retrieve the resolved conditions (https://github.com/nodejs/node/issues/55824), so they are parsed from the CLI args directly.

The conditions must be a `Set` (not an array) because Node's internal resolver calls `conditions.has()`.

The hardcoded default conditions match Node's own [`initializeCjsConditions`](https://github.com/nodejs/node/blob/a57893b7993daa111849b161e62a926848e40da3/lib/internal/modules/helpers.js#L78), minus `module-sync`.

### Why the fix only works on Node 22.12+

The `module-sync` condition was added in Node 22.12 and backported to 20.19 when `require(esm)` was unflagged. The bug exists on both versions, but the fix only works on 22.12+:

- **The `conditions` option was added in Node 22.12** -- `_resolveFilename` only supports the `conditions` option starting from 22.12. On Node 20, the option is silently ignored and there is no clean way to exclude `module-sync` from userland.
- **`--no-experimental-require-module` is not viable** -- This removes `module-sync` but also disables `require(esm)` entirely, breaking other packages.
- **Node 20 reaches EOL April 2026.**

## Test plan

- Added integration test with two mock packages using `module-sync` exports condition:
  - `module-sync-mjs`: points to `.mjs` file
  - `module-sync-js`: points to `.js` file with `"type": "module"`
  - Both verify that `require()` resolves to the CJS fallback entry
  - Test is skipped on Node < 22 (fix requires the `conditions` option added in 22.12)
- Added unit tests for `parseCjsConditions` covering all flag forms (`--conditions=`, `--conditions `, `-C=`, `-C `), NODE_OPTIONS parsing, module-sync filtering, and edge cases