### PR TITLE
docs: update old `VITE_NODE_DEPS_MODULE_DIRECTORIES` references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ And re-run `pnpm install` to link the package.
 Add a `.npmrc` file with following line next to the `package.json`:
 
 ```sh
-VITE_NODE_DEPS_MODULE_DIRECTORIES=/node_modules/,/packages/
+VITEST_MODULE_DIRECTORIES=/node_modules/,/packages/
 ```
 
 ## Pull Request Guidelines

--- a/test/config/test/exec-args.test.ts
+++ b/test/config/test/exec-args.test.ts
@@ -40,7 +40,7 @@ test('should not pass execArgv to workers when not specified in the config', asy
     nodeOptions: {
       cwd: `${process.cwd()}/fixtures/no-exec-args-fixtures`,
       env: {
-        VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
+        VITEST_MODULE_DIRECTORIES: '/node_modules/,/packages/',
         NO_COLOR: '1',
       },
     },
@@ -63,7 +63,7 @@ test('should let allowed args pass to workers', async () => {
     nodeOptions: {
       cwd: `${process.cwd()}/fixtures/allowed-exec-args-fixtures`,
       env: {
-        VITE_NODE_DEPS_MODULE_DIRECTORIES: '/node_modules/,/packages/',
+        VITEST_MODULE_DIRECTORIES: '/node_modules/,/packages/',
         NO_COLOR: '1',
       },
     },


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Ran into issues on new dev environment after following contribution guide as it's still referencing old module directories env var. Also replaced references from tests so that migration guide is the only place that mentions the old value.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
