### PR TITLE
fix: align `VitestRunnerConfig` optional fields with `SerializedConfig`

### DIFF
--- a/packages/runner/src/types/runner.ts
+++ b/packages/runner/src/types/runner.ts
@@ -22,10 +22,10 @@ import type {
 export interface VitestRunnerConfig {
   root: string
   setupFiles: string[]
-  name?: string
+  name: string | undefined
   passWithNoTests: boolean
-  testNamePattern?: RegExp
-  allowOnly?: boolean
+  testNamePattern: RegExp | undefined
+  allowOnly: boolean
   sequence: {
     shuffle?: boolean
     concurrent?: boolean
@@ -33,17 +33,17 @@ export interface VitestRunnerConfig {
     hooks: SequenceHooks
     setupFiles: SequenceSetupFiles
   }
-  chaiConfig?: {
+  chaiConfig: {
     truncateThreshold?: number
-  }
+  } | undefined
   maxConcurrency: number
   testTimeout: number
   hookTimeout: number
   retry: SerializableRetry
-  includeTaskLocation?: boolean
+  includeTaskLocation: boolean | undefined
   diffOptions?: DiffOptions
   tags: TestTagDefinition[]
-  tagsFilter?: string[]
+  tagsFilter: string[] | undefined
   strictTags: boolean
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1315,6 +1315,15 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/vitest
 
+  test/cli/dts/exact-optional-property:
+    devDependencies:
+      '@vitest/runner':
+        specifier: workspace:*
+        version: link:../../../../packages/runner
+      vitest:
+        specifier: workspace:*
+        version: link:../../../../packages/vitest
+
   test/cli/dts/fixture-extend:
     devDependencies:
       vitest:

--- a/test/cli/dts/exact-optional-property/package.json
+++ b/test/cli/dts/exact-optional-property/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitest/test-integration-exact-optional-property",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "tsc -b"
+  },
+  "devDependencies": {
+    "@vitest/runner": "workspace:*",
+    "vitest": "workspace:*"
+  }
+}

--- a/test/cli/dts/exact-optional-property/package.json
+++ b/test/cli/dts/exact-optional-property/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/test-integration-exact-optional-property",
+  "name": "@vitest/test-integration-dts-exact-optional-property",
   "type": "module",
   "private": true,
   "scripts": {

--- a/test/cli/dts/exact-optional-property/src/reporter.ts
+++ b/test/cli/dts/exact-optional-property/src/reporter.ts
@@ -1,0 +1,8 @@
+import type { File } from '@vitest/runner'
+import { DefaultReporter } from 'vitest/reporters'
+
+export class MyReporter extends DefaultReporter {
+  override reportTestSummary(files: File[], errors: unknown[], leakCount: number): void {
+    super.reportTestSummary(files, errors, leakCount)
+  }
+}

--- a/test/cli/dts/exact-optional-property/src/runner.ts
+++ b/test/cli/dts/exact-optional-property/src/runner.ts
@@ -1,0 +1,4 @@
+import type { VitestRunner } from '@vitest/runner'
+import { VitestTestRunner } from 'vitest/runners'
+
+export class MyRunner extends VitestTestRunner implements VitestRunner {}

--- a/test/cli/dts/exact-optional-property/tsconfig.json
+++ b/test/cli/dts/exact-optional-property/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": ["../_shared/tsconfig.patch.json"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9126

The issue seems to be only the specific `VitestRunnerConfig` type and `SerializedConfig` compatibility since we duplicate subset of types manually. I aligned this with this PR and I think we can close that issue.

I also researched whether automatic conversion `x?: t ➡️ x?: t | undefined` during d.ts emit, but indeed there's no such thing.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
