### PR TITLE
fix: deprecate `toBe*` spy assertions in favor of `toHaveBeen*` (and `toThrowError`)

### DIFF
--- a/docs/api/describe.md
+++ b/docs/api/describe.md
@@ -62,7 +62,7 @@ function numberToCurrency(value: number | string) {
 describe('numberToCurrency', () => {
   describe('given an invalid number', () => {
     test('composed of non-numbers to throw error', () => {
-      expect(() => numberToCurrency('abc')).toThrowError()
+      expect(() => numberToCurrency('abc')).toThrow()
     })
   })
 

--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1041,7 +1041,7 @@ test('spy function', () => {
 })
 ```
 
-## toHaveBeenCalledBefore <Version>3.0.0</Version> {#tohavebeencalledbefore}
+## toHaveBeenCalledBefore
 
 - **Type**: `(mock: MockInstance, failIfNoFirstInvocation?: boolean) => Awaitable<void>`
 
@@ -1060,7 +1060,7 @@ test('calls mock1 before mock2', () => {
 })
 ```
 
-## toHaveBeenCalledAfter <Version>3.0.0</Version> {#tohavebeencalledafter}
+## toHaveBeenCalledAfter
 
 - **Type**: `(mock: MockInstance, failIfNoFirstInvocation?: boolean) => Awaitable<void>`
 
@@ -1079,7 +1079,7 @@ test('calls mock1 after mock2', () => {
 })
 ```
 
-## toHaveBeenCalledExactlyOnceWith <Version>3.0.0</Version> {#tohavebeencalledexactlyoncewith}
+## toHaveBeenCalledExactlyOnceWit
 
 - **Type**: `(...args: any[]) => Awaitable<void>`
 
@@ -1368,7 +1368,7 @@ test('spy function returns bananas on second call', async () => {
 })
 ```
 
-## called
+## called <Version>4.1.0</Version> {#called}
 
 - **Type:** `Assertion` (property, not a method)
 
@@ -1391,7 +1391,7 @@ test('spy was called', () => {
 })
 ```
 
-## callCount
+## callCount <Version>4.1.0</Version> {#callcount}
 
 - **Type:** `(count: number) => void`
 
@@ -1411,7 +1411,7 @@ test('spy call count', () => {
 })
 ```
 
-## calledWith
+## calledWith <Version>4.1.0</Version> {#calledwith}
 
 - **Type:** `(...args: any[]) => void`
 
@@ -1431,7 +1431,7 @@ test('spy called with arguments', () => {
 })
 ```
 
-## calledOnce
+## calledOnce <Version>4.1.0</Version> {#calledonce}
 
 - **Type:** `Assertion` (property, not a method)
 
@@ -1453,7 +1453,7 @@ test('spy called once', () => {
 })
 ```
 
-## calledOnceWith
+## calledOnceWith <Version>4.1.0</Version> {#calledoncewith}
 
 - **Type:** `(...args: any[]) => void`
 
@@ -1471,7 +1471,7 @@ test('spy called once with arguments', () => {
 })
 ```
 
-## calledTwice
+## calledTwice <Version>4.1.0</Version> {#calledtwice}
 
 - **Type:** `Assertion` (property, not a method)
 
@@ -1494,7 +1494,7 @@ test('spy called twice', () => {
 })
 ```
 
-## calledThrice
+## calledThrice <Version>4.1.0</Version> {#calledthrice}
 
 - **Type:** `Assertion` (property, not a method)
 
@@ -1518,7 +1518,7 @@ test('spy called thrice', () => {
 })
 ```
 
-## lastCalledWith
+## lastCalledWith <Version>4.1.0</Version> {#lastcalledwith}
 
 - **Type:** `(...args: any[]) => void`
 
@@ -1537,7 +1537,7 @@ test('spy last called with', () => {
 })
 ```
 
-## nthCalledWith
+## nthCalledWith <Version>4.1.0</Version> {#nthcalledwith}
 
 - **Type:** `(n: number, ...args: any[]) => void`
 
@@ -1557,7 +1557,7 @@ test('spy nth called with', () => {
 })
 ```
 
-## returned
+## returned <Version>4.1.0</Version> {#returned}
 
 - **Type:** `Assertion` (property, not a method)
 
@@ -1579,7 +1579,7 @@ test('spy returned', () => {
 })
 ```
 
-## returnedWith
+## returnedWith <Version>4.1.0</Version> {#returnedwith}
 
 - **Type:** `(value: any) => void`
 
@@ -1601,7 +1601,7 @@ test('spy returned with value', () => {
 })
 ```
 
-## returnedTimes
+## returnedTimes <Version>4.1.0</Version> {#returnedtimes}
 
 - **Type:** `(count: number) => void`
 
@@ -1621,7 +1621,7 @@ test('spy returned times', () => {
 })
 ```
 
-## lastReturnedWith
+## lastReturnedWith <Version>4.1.0</Version> {#lastreturnedwith}
 
 - **Type:** `(value: any) => void`
 
@@ -1642,7 +1642,7 @@ test('spy last returned with', () => {
 })
 ```
 
-## nthReturnedWith
+## nthReturnedWith <Version>4.1.0</Version> {#nthreturnedwith}
 
 - **Type:** `(n: number, value: any) => void`
 
@@ -1665,7 +1665,7 @@ test('spy nth returned with', () => {
 })
 ```
 
-## calledBefore
+## calledBefore <Version>4.1.0</Version> {#calledbefore}
 
 - **Type:** `(mock: MockInstance, failIfNoFirstInvocation?: boolean) => void`
 
@@ -1685,7 +1685,7 @@ test('spy called before another', () => {
 })
 ```
 
-## calledAfter
+## calledAfter <Version>4.1.0</Version> {#calledafter}
 
 - **Type:** `(mock: MockInstance, failIfNoFirstInvocation?: boolean) => void`
 

--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1518,7 +1518,7 @@ test('spy called thrice', () => {
 })
 ```
 
-## lastCalledWith <Version>4.1.0</Version> {#lastcalledwith}
+## lastCalledWith
 
 - **Type:** `(...args: any[]) => void`
 
@@ -1537,7 +1537,7 @@ test('spy last called with', () => {
 })
 ```
 
-## nthCalledWith <Version>4.1.0</Version> {#nthcalledwith}
+## nthCalledWith
 
 - **Type:** `(n: number, ...args: any[]) => void`
 
@@ -1621,7 +1621,7 @@ test('spy returned times', () => {
 })
 ```
 
-## lastReturnedWith <Version>4.1.0</Version> {#lastreturnedwith}
+## lastReturnedWith
 
 - **Type:** `(value: any) => void`
 
@@ -1642,7 +1642,7 @@ test('spy last returned with', () => {
 })
 ```
 
-## nthReturnedWith <Version>4.1.0</Version> {#nthreturnedwith}
+## nthReturnedWith
 
 - **Type:** `(n: number, value: any) => void`
 

--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -560,7 +560,7 @@ expect(new Error('hi', { cause: 'x' })).toEqual(new Error('hi'))
 expect(new Error('hi')).toEqual(new Error('hi', { cause: 'x' }))
 ```
 
-To test if something was thrown, use [`toThrowError`](#tothrowerror) assertion.
+To test if something was thrown, use [`toThrow`](#tothrow) assertion.
 :::
 
 ## toStrictEqual
@@ -777,13 +777,13 @@ test('the number of elements must match exactly', () => {
 })
 ```
 
-## toThrowError
+## toThrow
 
 - **Type:** `(expected?: any) => Awaitable<void>`
 
-- **Alias:** `toThrow`
+- **Alias:** `toThrowError` <Deprecated />
 
-`toThrowError` asserts if a function throws an error when it is called.
+`toThrow` asserts if a function throws an error when it is called.
 
 You can provide an optional argument to test that a specific error is thrown:
 
@@ -798,7 +798,7 @@ This does not apply for async calls as [rejects](#rejects) correctly unwraps the
 ```ts
 test('expect rejects toThrow', async ({ expect }) => {
   const promise = Promise.reject(new Error('Test'))
-  await expect(promise).rejects.toThrowError()
+  await expect(promise).rejects.toThrow()
 })
 ```
 :::
@@ -818,18 +818,18 @@ function getFruitStock(type: string) {
 
 test('throws on pineapples', () => {
   // Test that the error message says "stock" somewhere: these are equivalent
-  expect(() => getFruitStock('pineapples')).toThrowError(/stock/)
-  expect(() => getFruitStock('pineapples')).toThrowError('stock')
+  expect(() => getFruitStock('pineapples')).toThrow(/stock/)
+  expect(() => getFruitStock('pineapples')).toThrow('stock')
 
   // Test the exact error message
-  expect(() => getFruitStock('pineapples')).toThrowError(
+  expect(() => getFruitStock('pineapples')).toThrow(
     /^Pineapples are not in stock$/,
   )
 
-  expect(() => getFruitStock('pineapples')).toThrowError(
+  expect(() => getFruitStock('pineapples')).toThrow(
     new Error('Pineapples are not in stock'),
   )
-  expect(() => getFruitStock('pineapples')).toThrowError(expect.objectContaining({
+  expect(() => getFruitStock('pineapples')).toThrow(expect.objectContaining({
     message: 'Pineapples are not in stock',
   }))
 })
@@ -844,7 +844,7 @@ function getAsyncFruitStock() {
 }
 
 test('throws on pineapples', async () => {
-  await expect(() => getAsyncFruitStock()).rejects.toThrowError('empty')
+  await expect(() => getAsyncFruitStock()).rejects.toThrow('empty')
 })
 ```
 :::
@@ -854,8 +854,8 @@ You can also test non-Error values that are thrown:
 
 ```ts
 test('throws non-Error values', () => {
-  expect(() => { throw 42 }).toThrowError(42)
-  expect(() => { throw { message: 'error' } }).toThrowError({ message: 'error' })
+  expect(() => { throw 42 }).toThrow(42)
+  expect(() => { throw { message: 'error' } }).toThrow({ message: 'error' })
 })
 ```
 :::
@@ -956,13 +956,13 @@ Note that since file system operation is async, you need to use `await` with `to
 
 - **Type:** `(hint?: string) => void`
 
-The same as [`toMatchSnapshot`](#tomatchsnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
+The same as [`toMatchSnapshot`](#tomatchsnapshot), but expects the same value as [`toThrow`](#tothrow).
 
 ## toThrowErrorMatchingInlineSnapshot
 
 - **Type:** `(snapshot?: string, hint?: string) => void`
 
-The same as [`toMatchInlineSnapshot`](#tomatchinlinesnapshot), but expects the same value as [`toThrowError`](#tothrowerror).
+The same as [`toMatchInlineSnapshot`](#tomatchinlinesnapshot), but expects the same value as [`toThrow`](#tothrow).
 
 ## toHaveBeenCalled
 

--- a/docs/blog/vitest-4.md
+++ b/docs/blog/vitest-4.md
@@ -260,7 +260,7 @@ expect(animal.bark()).toBeUndefined()
 
 Vitest 4 introduces a new asymmetric matcher called `expect.schemaMatching`. It accepts a [Standard Schema v1](https://standardschema.dev/) object and validates values against it, passing the assertion when the value conforms to the schema.
 
-As a reminder, asymmetric matchers can be used in all `expect` matchers that check equality, including `toEqual`, `toStrictEqual`, `toMatchObject`, `toContainEqual`, `toThrowError`, `toHaveBeenCalledWith`, `toHaveReturnedWith` and `toHaveBeenResolvedWith`.
+As a reminder, asymmetric matchers can be used in all `expect` matchers that check equality, including `toEqual`, `toStrictEqual`, `toMatchObject`, `toContainEqual`, `toThrow`, `toHaveBeenCalledWith`, `toHaveReturnedWith` and `toHaveBeenResolvedWith`.
 
 ```ts
 import { expect, test } from 'vitest'

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -633,7 +633,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     }
   })
   def(
-    ['toHaveBeenNthCalledWith', 'nthCalledWith'],
+    'toHaveBeenNthCalledWith',
     function (times: number, ...args: any[]) {
       const spy = getSpy(this)
       const spyName = spy.getMockName()
@@ -657,7 +657,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     },
   )
   def(
-    ['toHaveBeenLastCalledWith', 'lastCalledWith'],
+    'toHaveBeenLastCalledWith',
     function (...args: any[]) {
       const spy = getSpy(this)
       const spyName = spy.getMockName()
@@ -984,7 +984,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         action: 'resolve',
       },
       {
-        name: ['toHaveLastReturnedWith', 'lastReturnedWith'],
+        name: 'toHaveLastReturnedWith',
         condition: (spy, value) => {
           const result = spy.mock.results.at(-1)
           return Boolean(
@@ -1027,7 +1027,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         action: 'resolve',
       },
       {
-        name: ['toHaveNthReturnedWith', 'nthReturnedWith'],
+        name: 'toHaveNthReturnedWith',
         condition: (spy, index, value) => {
           const result = spy.mock.results[index - 1]
           return (

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -440,6 +440,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *
    * @example
    * expect(mockFunc).toBeCalledTimes(2);
+   * @deprecated Use `toHaveBeenCalledTimes` instead
    */
   toBeCalledTimes: (times: number) => void
 
@@ -461,6 +462,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *
    * @example
    * expect(mockFunc).toBeCalled();
+   * @deprecated Use `toHaveBeenCalled` instead
    */
   toBeCalled: () => void
 
@@ -481,6 +483,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *
    * @example
    * expect(mockFunc).toBeCalledWith('arg1', 42);
+   * @deprecated Use `toHaveBeenCalledWith` instead
    */
   toBeCalledWith: <E extends any[]>(...args: E) => void
 
@@ -495,16 +498,6 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
   toHaveBeenNthCalledWith: <E extends any[]>(n: number, ...args: E) => void
 
   /**
-   * Ensure that a mock function is called with specific arguments on an Nth call.
-   *
-   * Alias for `expect.toHaveBeenNthCalledWith`.
-   *
-   * @example
-   * expect(mockFunc).nthCalledWith(2, 'secondArg');
-   */
-  nthCalledWith: <E extends any[]>(nthCall: number, ...args: E) => void
-
-  /**
    * If you have a mock function, you can use `.toHaveBeenLastCalledWith`
    * to test what arguments it was last called with.
    *
@@ -514,17 +507,6 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(mockFunc).toHaveBeenLastCalledWith('lastArg');
    */
   toHaveBeenLastCalledWith: <E extends any[]>(...args: E) => void
-
-  /**
-   * If you have a mock function, you can use `.lastCalledWith`
-   * to test what arguments it was last called with.
-   *
-   * Alias for `expect.toHaveBeenLastCalledWith`.
-   *
-   * @example
-   * expect(mockFunc).lastCalledWith('lastArg');
-   */
-  lastCalledWith: <E extends any[]>(...args: E) => void
 
   /**
    * Used to test that a function throws when it is called.
@@ -547,6 +529,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(() => functionWithError()).toThrowError('Error message');
    * expect(() => parseJSON('invalid')).toThrowError(SyntaxError);
    * expect(() => { throw 42 }).toThrowError(42);
+   * @deprecated Use `toThrow` instead
    */
   toThrowError: (expected?: any) => void
 
@@ -557,6 +540,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *
    * @example
    * expect(mockFunc).toReturn();
+   * @deprecated Use `toHaveReturned` instead
    */
   toReturn: () => void
 
@@ -578,6 +562,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *
    * @example
    * expect(mockFunc).toReturnTimes(3);
+   * @deprecated Use `toHaveReturnedTimes` instead
    */
   toReturnTimes: (times: number) => void
 
@@ -599,6 +584,7 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    *
    * @example
    * expect(mockFunc).toReturnWith('returnValue');
+   * @deprecated Use `toHaveReturnedWith` instead
    */
   toReturnWith: <E>(value: E) => void
 
@@ -625,18 +611,6 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
   toHaveLastReturnedWith: <E>(value: E) => void
 
   /**
-   * Use to test the specific value that a mock function last returned.
-   * If the last call to the mock function threw an error, then this matcher will fail
-   * no matter what value you provided as the expected return value.
-   *
-   * Alias for `expect.toHaveLastReturnedWith`.
-   *
-   * @example
-   * expect(mockFunc).lastReturnedWith('lastValue');
-   */
-  lastReturnedWith: <E>(value: E) => void
-
-  /**
    * Use to test the specific value that a mock function returned for the nth call.
    * If the nth call to the mock function threw an error, then this matcher will fail
    * no matter what value you provided as the expected return value.
@@ -647,18 +621,6 @@ export interface JestAssertion<T = any> extends jest.Matchers<void, T>, CustomMa
    * expect(mockFunc).toHaveNthReturnedWith(2, 'nthValue');
    */
   toHaveNthReturnedWith: <E>(nthCall: number, value: E) => void
-
-  /**
-   * Use to test the specific value that a mock function returned for the nth call.
-   * If the nth call to the mock function threw an error, then this matcher will fail
-   * no matter what value you provided as the expected return value.
-   *
-   * Alias for `expect.toHaveNthReturnedWith`.
-   *
-   * @example
-   * expect(mockFunc).nthReturnedWith(2, 'nthValue');
-   */
-  nthReturnedWith: <E>(nthCall: number, value: E) => void
 }
 
 type VitestAssertion<A, T> = {

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -486,7 +486,7 @@ export interface InlineConfig {
   coverage?: CoverageOptions
 
   /**
-   * run test names with the specified pattern
+   * Run test names with the specified pattern
    */
   testNamePattern?: string | RegExp
 

--- a/test/browser/fixtures/expect-dom/toBeChecked.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeChecked.test.ts
@@ -69,7 +69,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('input-checked')).not.toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when input checkbox is not checked but expected to be', () => {
@@ -79,7 +79,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('input-empty')).toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" is checked but expected not to be', () => {
@@ -89,7 +89,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-checked')).not.toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" is not checked but expected to be', () => {
@@ -99,7 +99,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-unchecked')).toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when radio input is checked but expected not to be', () => {
@@ -109,7 +109,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('input-radio-checked')).not.toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when input radio is not checked but expected to be', () => {
@@ -119,7 +119,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('input-radio-unchecked')).toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="radio" is checked but expected not to be', () => {
@@ -129,7 +129,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-radio-checked')).not.toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="radio" is not checked but expected to be', () => {
@@ -139,7 +139,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-unchecked')).toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="switch" is checked but expected not to be', () => {
@@ -149,7 +149,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-switch-checked')).not.toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="switch" is not checked but expected to be', () => {
@@ -159,7 +159,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-switch-unchecked')).toBeChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" has an invalid aria-checked attribute', () => {
@@ -169,7 +169,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-invalid')).toBeChecked(),
-    ).toThrowError(
+    ).toThrow(
       /only inputs with .* a valid aria-checked attribute can be used/,
     )
   })
@@ -181,7 +181,7 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-radio-invalid')).toBeChecked(),
-    ).toThrowError(
+    ).toThrow(
       /only inputs with .* a valid aria-checked attribute can be used/,
     )
   })
@@ -193,14 +193,14 @@ describe('.toBeChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-switch-invalid')).toBeChecked(),
-    ).toThrowError(
+    ).toThrow(
       /only inputs with .* a valid aria-checked attribute can be used/,
     )
   })
 
   test('throws when the element is not an input', () => {
     const {queryByTestId} = render(`<select data-testid="select"></select>`)
-    expect(() => expect(queryByTestId('select')).toBeChecked()).toThrowError(
+    expect(() => expect(queryByTestId('select')).toBeChecked()).toThrow(
       /only inputs with type="checkbox" or type="radio" or elements with.* role="checkbox".* role="menuitemcheckbox".* role="option".* role="radio".* role="switch".* role="menuitemradio".* role="treeitem" .* can be used/,
     )
   })

--- a/test/browser/fixtures/expect-dom/toBeDisabled.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeDisabled.test.ts
@@ -43,7 +43,7 @@ test('.toBeDisabled', () => {
   expect(queryByTestId('button-element')).toBeDisabled()
   expect(() =>
     expect(queryByTestId('button-element')).not.toBeDisabled(),
-  ).toThrowError()
+  ).toThrow()
   expect(queryByTestId('textarea-element')).toBeDisabled()
   expect(queryByTestId('input-element')).toBeDisabled()
 
@@ -65,10 +65,10 @@ test('.toBeDisabled', () => {
 
   expect(queryByTestId('a-element')).not.toBeDisabled()
   expect(queryByTestId('deep-a-element')).not.toBeDisabled()
-  expect(() => expect(queryByTestId('a-element')).toBeDisabled()).toThrowError()
+  expect(() => expect(queryByTestId('a-element')).toBeDisabled()).toThrow()
   expect(() =>
     expect(queryByTestId('deep-a-element')).toBeDisabled(),
-  ).toThrowError()
+  ).toThrow()
 })
 
 test('.toBeDisabled fieldset>legend', () => {
@@ -131,12 +131,12 @@ test('.toBeDisabled custom element', () => {
   expect(queryByTestId('disabled-custom-element')).toBeDisabled()
   expect(() => {
     expect(queryByTestId('disabled-custom-element')).not.toBeDisabled()
-  }).toThrowError('element is disabled')
+  }).toThrow('element is disabled')
 
   expect(queryByTestId('enabled-custom-element')).not.toBeDisabled()
   expect(() => {
     expect(queryByTestId('enabled-custom-element')).toBeDisabled()
-  }).toThrowError('element is not disabled')
+  }).toThrow('element is not disabled')
 })
 
 test('.toBeEnabled', () => {
@@ -173,47 +173,47 @@ test('.toBeEnabled', () => {
 
   expect(() => {
     expect(queryByTestId('button-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
   expect(queryByTestId('button-element')).not.toBeEnabled()
   expect(() => {
     expect(queryByTestId('textarea-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
   expect(() => {
     expect(queryByTestId('input-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
 
   expect(() => {
     // fieldset elements can't be considered disabled, only their children
     expect(queryByTestId('fieldset-element')).toBeDisabled()
-  }).toThrowError()
+  }).toThrow()
   expect(() => {
     expect(queryByTestId('fieldset-child-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
 
   expect(queryByTestId('div-element')).toBeEnabled()
   expect(queryByTestId('div-child-element')).toBeEnabled()
 
   expect(() => {
     expect(queryByTestId('nested-form-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
   expect(() => {
     expect(queryByTestId('deep-select-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
   expect(() => {
     expect(queryByTestId('deep-optgroup-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
   expect(() => {
     expect(queryByTestId('deep-option-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
 
   expect(queryByTestId('a-element')).toBeEnabled()
   expect(() =>
     expect(queryByTestId('a-element')).not.toBeEnabled(),
-  ).toThrowError()
+  ).toThrow()
   expect(queryByTestId('deep-a-element')).toBeEnabled()
   expect(() =>
     expect(queryByTestId('deep-a-element')).not.toBeEnabled(),
-  ).toThrowError()
+  ).toThrow()
 })
 
 test('.toBeEnabled fieldset>legend', () => {
@@ -259,18 +259,18 @@ test('.toBeEnabled fieldset>legend', () => {
 
   expect(() => {
     expect(queryByTestId('inherited-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
   expect(queryByTestId('inside-legend-element')).toBeEnabled()
   expect(queryByTestId('nested-inside-legend-element')).toBeEnabled()
 
   expect(queryByTestId('first-legend-element')).toBeEnabled()
   expect(() => {
     expect(queryByTestId('second-legend-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
 
   expect(() => {
     expect(queryByTestId('outer-fieldset-element')).toBeEnabled()
-  }).toThrowError()
+  }).toThrow()
 })
 
 test('.toBeEnabled custom element', () => {
@@ -282,10 +282,10 @@ test('.toBeEnabled custom element', () => {
   expect(queryByTestId('disabled-custom-element')).not.toBeEnabled()
   expect(() => {
     expect(queryByTestId('disabled-custom-element')).toBeEnabled()
-  }).toThrowError('element is not enabled')
+  }).toThrow('element is not enabled')
 
   expect(queryByTestId('enabled-custom-element')).toBeEnabled()
   expect(() => {
     expect(queryByTestId('enabled-custom-element')).not.toBeEnabled()
-  }).toThrowError('element is enabled')
+  }).toThrow('element is enabled')
 })

--- a/test/browser/fixtures/expect-dom/toBeEmptyDOMElement.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeEmptyDOMElement.test.ts
@@ -37,27 +37,27 @@ test('.toBeEmptyDOMElement', () => {
   expect(withText).not.toBeEmptyDOMElement()
 
   // negative test cases wrapped in throwError assertions for coverage.
-  expect(() => expect(empty).not.toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(empty).not.toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(svgEmpty).not.toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(svgEmpty).not.toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(notEmpty).toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(notEmpty).toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(withComment).not.toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(withComment).not.toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(withMultipleComments).not.toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(withMultipleComments).not.toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(withElement).toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(withElement).toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(withElementAndComment).toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(withElementAndComment).toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(withWhitespace).toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(withWhitespace).toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(withText).toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(withText).toBeEmptyDOMElement()).toThrow()
 
-  expect(() => expect(fakeElement).toBeEmptyDOMElement()).toThrowError()
+  expect(() => expect(fakeElement).toBeEmptyDOMElement()).toThrow()
 
   expect(() => {
     expect(nonExistantElement).toBeEmptyDOMElement()
-  }).toThrowError()
+  }).toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toBeInTheDocument.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeInTheDocument.test.ts
@@ -43,23 +43,23 @@ test('.toBeInTheDocument', () => {
   const expectNotToBe = /expect.*not\.toBeInTheDocument/
   const userInputNode = /an HTMLElement or an SVGElement/
   const notFound = /element could not be found in the document/
-  expect(() => expect(htmlElement).not.toBeInTheDocument()).toThrowError(
+  expect(() => expect(htmlElement).not.toBeInTheDocument()).toThrow(
     expectNotToBe,
   )
-  expect(() => expect(svgElement).not.toBeInTheDocument()).toThrowError(
+  expect(() => expect(svgElement).not.toBeInTheDocument()).toThrow(
     expectNotToBe,
   )
-  expect(() => expect(detachedElement).toBeInTheDocument()).toThrowError(
+  expect(() => expect(detachedElement).toBeInTheDocument()).toThrow(
     expectToBe,
   )
-  expect(() => expect(fakeElement).toBeInTheDocument()).toThrowError(
+  expect(() => expect(fakeElement).toBeInTheDocument()).toThrow(
     userInputNode,
   )
-  expect(() => expect(nullElement).toBeInTheDocument()).toThrowError(
+  expect(() => expect(nullElement).toBeInTheDocument()).toThrow(
     notFound,
   )
-  expect(() => expect(undefinedElement).toBeInTheDocument()).toThrowError(
+  expect(() => expect(undefinedElement).toBeInTheDocument()).toThrow(
     notFound,
   )
-  expect(() => expect(undefinedElement).not.toBeInTheDocument()).not.toThrowError()
+  expect(() => expect(undefinedElement).not.toBeInTheDocument()).not.toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toBeInvalid.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeInvalid.test.ts
@@ -37,17 +37,17 @@ describe('.toBeInvalid', () => {
     // negative test cases wrapped in throwError assertions for coverage.
     expect(() =>
       expect(queryByTestId('no-aria-invalid')).toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid')).not.toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-value')).not.toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-false')).toBeInvalid(),
-    ).toThrowError()
-    expect(() => expect(invalidInputNode).not.toBeInvalid()).toThrowError()
+    ).toThrow()
+    expect(() => expect(invalidInputNode).not.toBeInvalid()).toThrow()
   })
 
   test('handles <form/>', () => {
@@ -61,8 +61,8 @@ describe('.toBeInvalid', () => {
     expect(invalidFormNode).toBeInvalid()
 
     // negative test cases wrapped in throwError assertions for coverage.
-    expect(() => expect(queryByTestId('valid')).toBeInvalid()).toThrowError()
-    expect(() => expect(invalidFormNode).not.toBeInvalid()).toThrowError()
+    expect(() => expect(queryByTestId('valid')).toBeInvalid()).toThrow()
+    expect(() => expect(invalidFormNode).not.toBeInvalid()).toThrow()
   })
 
   test('handles any element', () => {
@@ -82,19 +82,19 @@ describe('.toBeInvalid', () => {
     expect(queryByTestId('aria-invalid-false')).not.toBeInvalid()
 
     // negative test cases wrapped in throwError assertions for coverage.
-    expect(() => expect(queryByTestId('valid')).toBeInvalid()).toThrowError()
+    expect(() => expect(queryByTestId('valid')).toBeInvalid()).toThrow()
     expect(() =>
       expect(queryByTestId('no-aria-invalid')).toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid')).not.toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-value')).not.toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-false')).toBeInvalid(),
-    ).toThrowError()
+    ).toThrow()
   })
 })
 
@@ -118,17 +118,17 @@ describe('.toBeValid', () => {
     // negative test cases wrapped in throwError assertions for coverage.
     expect(() =>
       expect(queryByTestId('no-aria-invalid')).not.toBeValid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid')).toBeValid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-value')).toBeValid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-false')).not.toBeValid(),
-    ).toThrowError()
-    expect(() => expect(invalidInputNode).toBeValid()).toThrowError()
+    ).toThrow()
+    expect(() => expect(invalidInputNode).toBeValid()).toThrow()
   })
 
   test('handles <form/>', () => {
@@ -142,8 +142,8 @@ describe('.toBeValid', () => {
     expect(invalidFormNode).not.toBeValid()
 
     // negative test cases wrapped in throwError assertions for coverage.
-    expect(() => expect(queryByTestId('valid')).not.toBeValid()).toThrowError()
-    expect(() => expect(invalidFormNode).toBeValid()).toThrowError()
+    expect(() => expect(queryByTestId('valid')).not.toBeValid()).toThrow()
+    expect(() => expect(invalidFormNode).toBeValid()).toThrow()
   })
 
   test('handles any element', () => {
@@ -163,18 +163,18 @@ describe('.toBeValid', () => {
     expect(queryByTestId('aria-invalid-false')).toBeValid()
 
     // negative test cases wrapped in throwError assertions for coverage.
-    expect(() => expect(queryByTestId('valid')).not.toBeValid()).toThrowError()
+    expect(() => expect(queryByTestId('valid')).not.toBeValid()).toThrow()
     expect(() =>
       expect(queryByTestId('no-aria-invalid')).not.toBeValid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid')).toBeValid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-value')).toBeValid(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('aria-invalid-false')).not.toBeValid(),
-    ).toThrowError()
+    ).toThrow()
   })
 })

--- a/test/browser/fixtures/expect-dom/toBePartiallyChecked.test.ts
+++ b/test/browser/fixtures/expect-dom/toBePartiallyChecked.test.ts
@@ -50,7 +50,7 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('checkbox-mixed')).not.toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when input checkbox is indeterminate but expected not to be', () => {
@@ -62,7 +62,7 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('input-mixed')).not.toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when input checkbox is not checked but expected to be', () => {
@@ -72,7 +72,7 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('checkbox-empty')).toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" is partially checked but expected not to be', () => {
@@ -82,7 +82,7 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-mixed')).not.toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" is checked but expected to be partially checked', () => {
@@ -92,7 +92,7 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-checked')).toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" is not checked but expected to be', () => {
@@ -102,7 +102,7 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox')).toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when element with role="checkbox" has an invalid aria-checked attribute', () => {
@@ -112,14 +112,14 @@ describe('.toBePartiallyChecked', () => {
 
     expect(() =>
       expect(queryByTestId('aria-checkbox-invalid')).toBePartiallyChecked(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws when the element is not a checkbox', () => {
     const {queryByTestId} = render(`<select data-testid="select"></select>`)
     expect(() =>
       expect(queryByTestId('select')).toBePartiallyChecked(),
-    ).toThrowError(
+    ).toThrow(
       'only inputs with type="checkbox" or elements with role="checkbox" and a valid aria-checked attribute can be used with .toBePartiallyChecked(). Use .toHaveValue() instead',
     )
   })

--- a/test/browser/fixtures/expect-dom/toBeRequired.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeRequired.test.ts
@@ -31,32 +31,32 @@ test('.toBeRequired', () => {
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() =>
     expect(queryByTestId('required-input')).not.toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('aria-required-input')).not.toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('conflicted-input')).not.toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('not-required-input')).toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('basic-input')).toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('unsupported-type')).toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('select')).not.toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('textarea')).not.toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('supported-role')).toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('supported-role-aria')).not.toBeRequired(),
-  ).toThrowError()
+  ).toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toBeVisible.test.ts
+++ b/test/browser/fixtures/expect-dom/toBeVisible.test.ts
@@ -30,16 +30,16 @@ describe('.toBeVisible', () => {
 
     expect(() =>
       expect(container.querySelector('header')).not.toBeVisible(),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(container.querySelector('p')).toBeVisible(),
-    ).toThrowError()
+    ).toThrow()
   })
 
   it('detached element is not visible', () => {
     const subject = document.createElement('div')
     expect(subject).not.toBeVisible()
-    expect(() => expect(subject).toBeVisible()).toThrowError()
+    expect(() => expect(subject).toBeVisible()).toThrow()
   })
 
   describe('with a <details /> element', () => {

--- a/test/browser/fixtures/expect-dom/toContainElement.test.ts
+++ b/test/browser/fixtures/expect-dom/toContainElement.test.ts
@@ -33,37 +33,37 @@ test('.toContainElement positive test cases', () => {
 test('.toContainElement negative test cases', () => {
   expect(() =>
     expect(nonExistantElement).not.toContainElement(child),
-  ).toThrowError()
-  expect(() => expect(parent).toContainElement(grandparent)).toThrowError()
+  ).toThrow()
+  expect(() => expect(parent).toContainElement(grandparent)).toThrow()
   expect(() =>
     expect(nonExistantElement).toContainElement(grandparent),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(grandparent).toContainElement(nonExistantElement),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(nonExistantElement).toContainElement(nonExistantElement),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     // @ts-expect-error testing invalid assertion
     expect(nonExistantElement).toContainElement(fakeElement),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(fakeElement).toContainElement(nonExistantElement),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(fakeElement).not.toContainElement(nonExistantElement),
-  ).toThrowError()
-  expect(() => expect(fakeElement).toContainElement(grandparent)).toThrowError()
+  ).toThrow()
+  expect(() => expect(fakeElement).toContainElement(grandparent)).toThrow()
     // @ts-expect-error testing invalid assertion
-  expect(() => expect(grandparent).toContainElement(fakeElement)).toThrowError()
+  expect(() => expect(grandparent).toContainElement(fakeElement)).toThrow()
     // @ts-expect-error testing invalid assertion
-  expect(() => expect(fakeElement).toContainElement(fakeElement)).toThrowError()
-  expect(() => expect(grandparent).not.toContainElement(child)).toThrowError()
+  expect(() => expect(fakeElement).toContainElement(fakeElement)).toThrow()
+  expect(() => expect(grandparent).not.toContainElement(child)).toThrow()
   expect(() =>
     expect(grandparent).not.toContainElement(svgElement),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(grandparent).not.toContainElement(undefined),
-  ).toThrowError()
+  ).toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toContainHTML.test.ts
+++ b/test/browser/fixtures/expect-dom/toContainHTML.test.ts
@@ -39,60 +39,60 @@ describe('.toContainHTML', () => {
     // negative test cases wrapped in throwError assertions for coverage.
     expect(() =>
       expect(nonExistantElement).not.toContainHTML(stringChildElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       // @ts-expect-error testing invalid input
       expect(nonExistantElement).not.toContainHTML(nonExistantElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       // @ts-expect-error testing invalid input
       expect(stringChildElement).not.toContainHTML(fakeElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(svgElement).toContainHTML(stringChildElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(grandparent).not.toContainHTML(stringChildElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(parent).not.toContainHTML(stringChildElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(child).not.toContainHTML(stringChildElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(child).not.toContainHTML(stringChildElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(child).not.toContainHTML(stringChildElementSelfClosing),
-    ).toThrowError()
-    expect(() => expect(child).toContainHTML(nonExistantString)).toThrowError()
-    expect(() => expect(parent).toContainHTML(nonExistantString)).toThrowError()
+    ).toThrow()
+    expect(() => expect(child).toContainHTML(nonExistantString)).toThrow()
+    expect(() => expect(parent).toContainHTML(nonExistantString)).toThrow()
     expect(() =>
       expect(grandparent).toContainHTML(nonExistantString),
-    ).toThrowError()
+    ).toThrow()
       // @ts-expect-error testing invalid input
-    expect(() => expect(child).toContainHTML(nonExistantElement)).toThrowError()
+    expect(() => expect(child).toContainHTML(nonExistantElement)).toThrow()
     expect(() =>
       // @ts-expect-error testing invalid input
       expect(parent).toContainHTML(nonExistantElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       // @ts-expect-error testing invalid input
       expect(grandparent).toContainHTML(nonExistantElement),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(nonExistantElement).not.toContainHTML(incorrectStringHtml),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(grandparent).not.toContainHTML(incorrectStringHtml),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(child).not.toContainHTML(incorrectStringHtml),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(parent).not.toContainHTML(incorrectStringHtml),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('throws with an expected text', async () => {

--- a/test/browser/fixtures/expect-dom/toHaveAttribute.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveAttribute.test.ts
@@ -20,29 +20,29 @@ test('.toHaveAttribute', () => {
 
   expect(() =>
     expect(queryByTestId('ok-button')).not.toHaveAttribute('disabled'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('ok-button')).not.toHaveAttribute('type'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('ok-button')).toHaveAttribute('class'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('ok-button')).not.toHaveAttribute('type', 'submit'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('ok-button')).toHaveAttribute('type', 'button'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('svg-element')).not.toHaveAttribute('width'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('svg-element')).not.toHaveAttribute('width', '12'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     // @ts-expect-error invalid signature
     expect({thisIsNot: 'an html element'}).not.toHaveAttribute(),
-  ).toThrowError()
+  ).toThrow()
 
   // Asymmetric matchers
   expect(queryByTestId('ok-button')).toHaveAttribute(
@@ -60,5 +60,5 @@ test('.toHaveAttribute', () => {
       'type',
       expect.not.stringContaining('sub'),
     ),
-  ).toThrowError()
+  ).toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toHaveClass.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveClass.test.ts
@@ -44,52 +44,52 @@ test('.toHaveClass', () => {
 
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn-danger'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('extra'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('xtra'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('btn', 'extra xtra'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn btn-danger'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn', 'btn-danger'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('btn-link'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('cancel-button')).toHaveClass('btn-danger'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('svg-spinner')).not.toHaveClass('spinner'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('svg-spinner')).toHaveClass('wise'),
-  ).toThrowError()
+  ).toThrow()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass(),
-  ).toThrowError(/At least one expected class must be provided/)
+  ).toThrow(/At least one expected class must be provided/)
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass(''),
-  ).toThrowError(/At least one expected class must be provided/)
-  expect(() => expect(queryByTestId('no-classes')).toHaveClass()).toThrowError(
+  ).toThrow(/At least one expected class must be provided/)
+  expect(() => expect(queryByTestId('no-classes')).toHaveClass()).toThrow(
     /At least one expected class must be provided/,
   )
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass(),
-  ).toThrowError(/(none)/)
+  ).toThrow(/(none)/)
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('  '),
-  ).toThrowError(/(none)/)
+  ).toThrow(/(none)/)
 })
 
 test('.toHaveClass with regular expressions', () => {
@@ -111,11 +111,11 @@ test('.toHaveClass with regular expressions', () => {
 
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass(/danger/),
-  ).toThrowError()
+  ).toThrow()
 
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass(/dangerous/),
-  ).toThrowError()
+  ).toThrow()
 })
 
 test('.toHaveClass with exact mode option', () => {
@@ -197,13 +197,13 @@ test('.toHaveClass with exact mode option', () => {
     expect(queryByTestId('only-one-class')).not.toHaveClass('alone', {
       exact: true,
     }),
-  ).toThrowError(/Expected the element not to have EXACTLY defined classes/)
+  ).toThrow(/Expected the element not to have EXACTLY defined classes/)
 
   expect(() =>
     expect(queryByTestId('only-one-class')).toHaveClass('alone', 'foo', {
       exact: true,
     }),
-  ).toThrowError(/Expected the element to have EXACTLY defined classes/)
+  ).toThrow(/Expected the element to have EXACTLY defined classes/)
 })
 
 test('.toHaveClass combining {exact:true} and regular expressions throws an error', () => {
@@ -214,7 +214,7 @@ test('.toHaveClass combining {exact:true} and regular expressions throws an erro
     expect(queryByTestId('delete-button')).not.toHaveClass(/btn/, {
       exact: true,
     }),
-  ).toThrowError()
+  ).toThrow()
 
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass(
@@ -224,10 +224,10 @@ test('.toHaveClass combining {exact:true} and regular expressions throws an erro
       /\bbtn/,
       {exact: true},
     ),
-  ).toThrowError()
+  ).toThrow()
 
   expect(() =>
     // @ts-expect-error regexp is not supported with exact
     expect(queryByTestId('delete-button')).toHaveClass(/danger/, {exact: true}),
-  ).toThrowError()
+  ).toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toHaveFocus.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveFocus.test.ts
@@ -18,6 +18,6 @@ test('.toHaveFocus', () => {
   expect(focused).toHaveFocus()
   expect(notFocused).not.toHaveFocus()
 
-  expect(() => expect(focused).not.toHaveFocus()).toThrowError()
-  expect(() => expect(notFocused).toHaveFocus()).toThrowError()
+  expect(() => expect(focused).not.toHaveFocus()).toThrow()
+  expect(() => expect(notFocused).toHaveFocus()).toThrow()
 })

--- a/test/browser/fixtures/expect-dom/toHaveFormValues.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveFormValues.test.ts
@@ -187,7 +187,7 @@ describe('.toHaveFormValues', () => {
       const form = container.querySelector('form')
       expect(() => {
         expect(form).toHaveFormValues({})
-      }).toThrowError(/must be of the same type/)
+      }).toThrow(/must be of the same type/)
     })
 
     it('detects multiple elements with the same type and name', () => {
@@ -225,10 +225,10 @@ describe('.toHaveFormValues', () => {
       const form = container.querySelector('form')
       expect(() => {
         expect(container).toHaveFormValues(expectedValues)
-      }).toThrowError(/a form or a fieldset/)
+      }).toThrow(/a form or a fieldset/)
       expect(() => {
         expect(form).toHaveFormValues(expectedValues)
-      }).not.toThrowError()
+      }).not.toThrow()
     })
 
     it('matches change in selected value of select', () => {
@@ -254,10 +254,10 @@ describe('.toHaveFormValues', () => {
     it('work as expected', () => {
       expect(() => {
         expect(renderForm()).not.toHaveFormValues(defaultValues)
-      }).toThrowError(/Expected the element not to have form values/)
+      }).toThrow(/Expected the element not to have form values/)
       expect(() => {
         expect(renderForm()).toHaveFormValues({something: 'missing'})
-      }).toThrowError(/Expected the element to have form values/)
+      }).toThrow(/Expected the element to have form values/)
     })
   })
 })

--- a/test/browser/fixtures/expect-dom/toHaveStyle.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveStyle.test.ts
@@ -26,7 +26,7 @@ describe('.toHaveStyle', () => {
     // border: fakefake doesn't exist
     expect(() => {
       expect(container.querySelector('.label')).toHaveStyle('border: fakefake')
-    }).toThrowError()
+    }).toThrow()
 
     expect(container.querySelector('.label')).toHaveStyle(`
           height: 100%;
@@ -86,36 +86,36 @@ describe('.toHaveStyle', () => {
     //   expect(container.querySelector('.label')).not.toHaveStyle(
     //     'font-weight bold',
     //   ),
-    // ).toThrowError()
+    // ).toThrow()
 
     expect(() =>
       expect(container.querySelector('.label')).toHaveStyle(
         'font-weight: bold',
       ),
-    ).toThrowError()
+    ).toThrow()
 
     expect(() =>
       expect(container.querySelector('.label')).not.toHaveStyle('color: white'),
-    ).toThrowError()
+    ).toThrow()
 
     expect(() =>
       expect(container.querySelector('.label')).toHaveStyle(
         'transition: all 0.7s ease, width 1.0s cubic-bezier(3, 4, 5, 6);',
       ),
-    ).toThrowError()
+    ).toThrow()
 
     // Custom property names are case sensitive
     expect(() =>
       expect(container.querySelector('.label')).toHaveStyle('--VAR-NAME: 0px;'),
-    ).toThrowError()
+    ).toThrow()
 
     expect(() =>
       expect(container.querySelector('.label')).toHaveStyle('color white'),
-    ).toThrowError()
+    ).toThrow()
 
     expect(() =>
       expect(container.querySelector('.label')).toHaveStyle('--color: black'),
-    ).toThrowError()
+    ).toThrow()
     document.body.removeChild(style)
     document.body.removeChild(container)
   })
@@ -250,7 +250,7 @@ describe('.toHaveStyle', () => {
       `)
       expect(() => {
         expect(queryByTestId('color-example')).toHaveStyle({ fontSize: '12px' })
-      }).toThrowError()
+      }).toThrow()
     })
 
     test('supports dash-cased property names', () => {

--- a/test/browser/fixtures/expect-dom/toHaveTextContent.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveTextContent.test.ts
@@ -30,14 +30,14 @@ describe('.toHaveTextContent', () => {
 
     expect(() =>
       expect(queryByTestId('count-value2')).toHaveTextContent('2'),
-    ).toThrowError()
+    ).toThrow()
 
     expect(() =>
       expect(queryByTestId('count-value')).toHaveTextContent('3'),
-    ).toThrowError()
+    ).toThrow()
     expect(() =>
       expect(queryByTestId('count-value')).not.toHaveTextContent('2'),
-    ).toThrowError()
+    ).toThrow()
   })
 
   test('normalizes whitespace by default', () => {
@@ -104,6 +104,6 @@ describe('.toHaveTextContent', () => {
 
     expect(() =>
       expect(container.querySelector('span')).toHaveTextContent(''),
-    ).toThrowError(/toBeEmptyDOMElement\(\)/)
+    ).toThrow(/toBeEmptyDOMElement\(\)/)
   })
 })

--- a/test/browser/fixtures/locators/query.test.ts
+++ b/test/browser/fixtures/locators/query.test.ts
@@ -30,7 +30,7 @@ describe('locator.and', () => {
     <button title="Testing framework">Vitest</button>
     `
     const locator = page.getByRole('button').and(page.getByTitle('Testing framework'))
-    expect(() => locator.element()).toThrowError(
+    expect(() => locator.element()).toThrow(
       `strict mode violation: getByRole('button').and(getByTitle('Testing framework')) resolved to 2 elements`
     )
   })
@@ -62,7 +62,7 @@ describe('locator.or', () => {
     <a href="https://vitest.dev" title="Testing framework">Vitest</a>
     `
     const locator = page.getByRole('button').or(page.getByTitle('Testing framework'))
-    expect(() => locator.element()).toThrowError(
+    expect(() => locator.element()).toThrow(
       `strict mode violation: getByRole('button').or(getByTitle('Testing framework')) resolved to 2 elements`
     )
   })
@@ -93,7 +93,7 @@ describe('locator.filter', () => {
     expect(locator1.element()).toBe(document.querySelector('button'))
 
     const locator2 = page.getByRole('button').filter({ hasNotText: 'Vitest' })
-    expect(() => locator2.element()).toThrowError(
+    expect(() => locator2.element()).toThrow(
       `Cannot find element with locator: getByRole('button').filter({ hasNotText: 'Vitest' })`
     )
   })
@@ -106,7 +106,7 @@ describe('locator.filter', () => {
     expect(locator1.element()).toBe(document.querySelector('article'))
 
     const locator2 = page.getByRole('article').filter({ hasNotText: 'Vitest' })
-    expect(() => locator2.element()).toThrowError(
+    expect(() => locator2.element()).toThrow(
       `Cannot find element with locator: getByRole('article').filter({ hasNotText: 'Vitest' })`
     )
   })
@@ -123,13 +123,13 @@ describe('locator.filter', () => {
     expect(locator2.element()).toBe(document.querySelector('article'))
 
     const locator3 = page.getByRole('article').filter({ has: page.getByRole('alert') })
-    expect(() => locator3.element()).toThrowError(
+    expect(() => locator3.element()).toThrow(
       `Cannot find element with locator: getByRole('article').filter({ has: getByRole('alert') })`
     )
 
     // locators reversed
     const locator4 = page.getByRole('button').filter({ has: page.getByRole('article') })
-    expect(() => locator4.element()).toThrowError(
+    expect(() => locator4.element()).toThrow(
       `Cannot find element with locator: getByRole('button').filter({ has: getByRole('article') })`
     )
 
@@ -138,7 +138,7 @@ describe('locator.filter', () => {
     <article><div><button>Vitest</button></div></article>
     `
 
-    expect(() => locator1.element()).toThrowError(
+    expect(() => locator1.element()).toThrow(
       `strict mode violation: getByRole('article').filter({ has: getByRole('button') }) resolved to 2 elements`
     )
   })
@@ -152,7 +152,7 @@ describe('locator.filter', () => {
     expect(locator1.element()).toBe(document.querySelector('article'))
 
     const locator2 = page.getByRole('article').filter({ hasNot: page.getByRole('button') })
-    expect(() => locator2.element()).toThrowError(
+    expect(() => locator2.element()).toThrow(
       `Cannot find element with locator: getByRole('article').filter({ hasNot: getByRole('button') })`
     )
   })

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -27,7 +27,7 @@ test('non US keys', async () => {
   } else if (server.provider === 'webdriverio') {
     await expect(() =>
       userEvent.type(page.getByPlaceholder("type-emoji"), '😊😍')
-    ).rejects.toThrowError()
+    ).rejects.toThrow()
   } else {
     await userEvent.type(page.getByPlaceholder("type-emoji"), '😊😍')
     await expect.element(page.getByPlaceholder("type-emoji")).toHaveValue('😊😍')
@@ -43,7 +43,7 @@ test('non US keys', async () => {
     } else {
       await expect(() =>
         userEvent.fill(page.getByPlaceholder("fill-emoji"), '😊😍')
-      ).rejects.toThrowError()
+      ).rejects.toThrow()
     }
   } else {
     await userEvent.fill(page.getByPlaceholder("fill-emoji"), '😊😍')

--- a/test/cli/fixtures/network-imports/basic.test.ts
+++ b/test/cli/fixtures/network-imports/basic.test.ts
@@ -12,7 +12,7 @@ test('network imports', () => {
 
 test('doesn\'t work for http outside localhost', async () => {
   // @ts-expect-error network imports
-  await expect(() => import('http://100.0.0.0/')).rejects.toThrowError(
+  await expect(() => import('http://100.0.0.0/')).rejects.toThrow(
     'import of \'http://100.0.0.0/\' by undefined is not supported: http can only be used to load local resources (use https instead).',
   )
 })

--- a/test/cli/test/configureVitest.test.ts
+++ b/test/cli/test/configureVitest.test.ts
@@ -194,7 +194,7 @@ test('adding a plugin with existing name throws and error', async () => {
       },
     ],
   }),
-  ).rejects.toThrowError('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
+  ).rejects.toThrow('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
 
   await expect(() => throws({
     projects: [
@@ -219,7 +219,7 @@ test('adding a plugin with existing name throws and error', async () => {
       },
     ],
   }),
-  ).rejects.toThrowError('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
+  ).rejects.toThrow('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
 
   await expect(() => throws({
     projects: [
@@ -246,7 +246,7 @@ test('adding a plugin with existing name throws and error', async () => {
       },
     ],
   }),
-  ).rejects.toThrowError('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
+  ).rejects.toThrow('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
 })
 
 async function throws(cliOptions: TestUserConfig) {

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -146,7 +146,7 @@ describe.each([
     ])
     await expect(async () => {
       await config(rawConfig.options)
-    }).rejects.toThrowError(`Inspector host cannot be a URL. Use "host:port" instead of "${url}"`)
+    }).rejects.toThrow(`Inspector host cannot be a URL. Use "host:port" instead of "${url}"`)
   })
 })
 

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -234,7 +234,7 @@ test('maxConcurrency is parsed correctly', () => {
 test('cache is parsed correctly', () => {
   expect(getCLIOptions('--cache')).toEqual({ cache: {} })
   expect(getCLIOptions('--no-cache')).toEqual({ cache: false })
-  expect(() => getCLIOptions('--cache.dir=./cache')).toThrowError('--cache.dir is deprecated')
+  expect(() => getCLIOptions('--cache.dir=./cache')).toThrow('--cache.dir is deprecated')
 })
 
 test('shuffle is parsed correctly', () => {
@@ -446,7 +446,7 @@ test('public parseCLI works correctly', () => {
 
   expect(() => {
     parseCLI('node --test --coverage --browser --typecheck')
-  }).toThrowError(`Expected "vitest" as the first argument, received "node"`)
+  }).toThrow(`Expected "vitest" as the first argument, received "node"`)
 
   expect(parseCLI('vitest --project=space_1 --project=space_2')).toEqual({
     filter: [],

--- a/test/core/test/environments/happy-dom.spec.ts
+++ b/test/core/test/environments/happy-dom.spec.ts
@@ -37,5 +37,5 @@ test('can pass down a simple form data', async () => {
       body: formData,
     })
     await req.formData()
-  })()).resolves.not.toThrowError()
+  })()).resolves.not.toThrow()
 })

--- a/test/core/test/environments/jsdom.spec.ts
+++ b/test/core/test/environments/jsdom.spec.ts
@@ -24,21 +24,21 @@ test('fetch, Request, Response, and BroadcastChannel are available', () => {
 })
 
 test('Fetch API accepts other APIs', async () => {
-  expect.soft(() => new Request('http://localhost', { signal: new AbortController().signal })).not.toThrowError()
-  expect.soft(() => new Request('http://localhost', { method: 'POST', body: new FormData() })).not.toThrowError()
-  expect.soft(() => new Request('http://localhost', { method: 'POST', body: new Blob() })).not.toThrowError()
-  expect.soft(() => new Request(new URL('https://localhost'))).not.toThrowError()
+  expect.soft(() => new Request('http://localhost', { signal: new AbortController().signal })).not.toThrow()
+  expect.soft(() => new Request('http://localhost', { method: 'POST', body: new FormData() })).not.toThrow()
+  expect.soft(() => new Request('http://localhost', { method: 'POST', body: new Blob() })).not.toThrow()
+  expect.soft(() => new Request(new URL('https://localhost'))).not.toThrow()
 
   const request = new Request('http://localhost')
   expect.soft(request.headers).toBeInstanceOf(Headers)
 
   expect.soft(
     () => new Request('http://localhost', { method: 'POST', body: new URLSearchParams([['key', 'value']]) }),
-  ).not.toThrowError()
+  ).not.toThrow()
 
   const searchParams = new URLSearchParams()
   searchParams.set('key', 'value')
-  expect.soft(() => new Request('http://localhost', { method: 'POST', body: searchParams })).not.toThrowError()
+  expect.soft(() => new Request('http://localhost', { method: 'POST', body: searchParams })).not.toThrow()
 
   const clone = request.clone()
   expect.soft(clone).toBeInstanceOf(Request)
@@ -65,7 +65,7 @@ describe('FormData', () => {
         body: formData,
       })
       await req.formData()
-    })()).resolves.not.toThrowError()
+    })()).resolves.not.toThrow()
   })
 
   test('can pass down form data from a FORM element', async () => {
@@ -89,7 +89,7 @@ describe('FormData', () => {
         body: formData,
       })
       await req.formData()
-    })()).resolves.not.toThrowError()
+    })()).resolves.not.toThrow()
   })
 
   test('can pass down form data from a FORM element with a submitter', async () => {
@@ -120,7 +120,7 @@ describe('FormData', () => {
         body: formData,
       })
       await req.formData()
-    })()).resolves.not.toThrowError()
+    })()).resolves.not.toThrow()
   })
 
   // https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData#exceptions
@@ -131,7 +131,7 @@ describe('FormData', () => {
     submitter.type = 'button'
     form.append(submitter)
 
-    expect(() => new FormData(form, submitter)).toThrowError(
+    expect(() => new FormData(form, submitter)).toThrow(
       new TypeError('The specified element is not a submit button'),
     )
   })

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -8,10 +8,10 @@ test('simple usage', async () => {
 
   await expect(async () => {
     await expect.poll(() => Promise.resolve(1)).resolves.toBe(1)
-  }).rejects.toThrowError('expect.poll() is not supported in combination with .resolves')
+  }).rejects.toThrow('expect.poll() is not supported in combination with .resolves')
   await expect(async () => {
-    await expect.poll(() => Promise.reject(new Error('empty'))).rejects.toThrowError('empty')
-  }).rejects.toThrowError('expect.poll() is not supported in combination with .rejects')
+    await expect.poll(() => Promise.reject(new Error('empty'))).rejects.toThrow('empty')
+  }).rejects.toThrow('expect.poll() is not supported in combination with .rejects')
 
   const unsupported = [
     'matchSnapshot',
@@ -29,14 +29,14 @@ test('simple usage', async () => {
   for (const key of unsupported) {
     await expect(async () => {
       await expect.poll(() => Promise.resolve(1))[key as 'matchSnapshot']()
-    }).rejects.toThrowError(`expect.poll() is not supported in combination with .${key}(). Use vi.waitFor() if your assertion condition is unstable.`)
+    }).rejects.toThrow(`expect.poll() is not supported in combination with .${key}(). Use vi.waitFor() if your assertion condition is unstable.`)
   }
 })
 
 test('timeout', async () => {
   await expect(async () => {
     await expect.poll(() => false, { timeout: 100, interval: 10 }).toBe(true)
-  }).rejects.toThrowError(expect.objectContaining({
+  }).rejects.toThrow(expect.objectContaining({
     message: 'expected false to be true // Object.is equality',
     stack: expect.stringContaining('expect-poll.test.ts:38:68'),
     cause: expect.objectContaining({
@@ -50,7 +50,7 @@ test('interval', async () => {
   await expect(async () => {
     // using big values because CI can be slow
     await expect.poll(fn, { interval: 100, timeout: 500 }).toBe(false)
-  }).rejects.toThrowError()
+  }).rejects.toThrow()
   // CI can be unstable, but there should be always at least 5 calls
   expect(fn.mock.calls.length >= 4).toBe(true)
 })
@@ -60,7 +60,7 @@ test('fake timers don\'t break it', async () => {
   vi.useFakeTimers()
   await expect(async () => {
     await expect.poll(() => false, { timeout: 100 }).toBe(true)
-  }).rejects.toThrowError('expected false to be true // Object.is equality')
+  }).rejects.toThrow('expected false to be true // Object.is equality')
   vi.useRealTimers()
   const diff = Date.now() - now
   expect(diff >= 100).toBe(true)
@@ -90,7 +90,7 @@ test('toBeDefined', async () => {
 
   await expect(() =>
     expect.poll(() => 1, { timeout: 100, interval: 10 }).not.toBeDefined(),
-  ).rejects.toThrowError(expect.objectContaining({
+  ).rejects.toThrow(expect.objectContaining({
     message: 'expected 1 to be undefined',
     cause: expect.objectContaining({
       message: 'Matcher did not succeed in time.',
@@ -99,7 +99,7 @@ test('toBeDefined', async () => {
 
   await expect(() =>
     expect.poll(() => undefined, { timeout: 100, interval: 10 }).toBeDefined(),
-  ).rejects.toThrowError(expect.objectContaining({
+  ).rejects.toThrow(expect.objectContaining({
     message: 'expected undefined to be defined',
     cause: expect.objectContaining({
       message: 'Matcher did not succeed in time.',
@@ -113,7 +113,7 @@ test('should set _isLastPollAttempt flag on last call', async () => {
   })
   await expect(async () => {
     await expect.poll(fn, { interval: 100, timeout: 500 }).toBe(false)
-  }).rejects.toThrowError()
+  }).rejects.toThrow()
   fn.mock.results.forEach((result, index) => {
     const isLastCall = index === fn.mock.results.length - 1
     expect(result.value).toBe(isLastCall ? true : undefined)
@@ -139,7 +139,7 @@ test('should handle failure on last attempt', async () => {
   })
   await expect(async () => {
     await expect.poll(fn, { interval: 10, timeout: 100 }).toBe(1)
-  }).rejects.toThrowError(expect.objectContaining({
+  }).rejects.toThrow(expect.objectContaining({
     // makes sure cause message reflects the last attempt value
     message: 'expected 3 to be 1 // Object.is equality',
     cause: expect.objectContaining({

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -302,6 +302,7 @@ describe('recursive custom equality tester', () => {
 
     expect(mockFn).toHaveReturnedWith([person1, person2])
     expect(mockFn).toHaveLastReturnedWith([person1, person2])
+    expect(mockFn).to.have.lastReturnedWith([person1, person2])
     expect(mockFn).toHaveNthReturnedWith(1, [person1, person2])
   })
 })

--- a/test/core/test/fixtures/timers.suite.ts
+++ b/test/core/test/fixtures/timers.suite.ts
@@ -1494,7 +1494,7 @@ describe('FakeTimers', () => {
 
       expect(Date.now()).toBe(timeStrMs)
 
-      expect(() => timers.useFakeTimers()).not.toThrowError()
+      expect(() => timers.useFakeTimers()).not.toThrow()
 
       expect(Date.now()).toBe(timeStrMs)
 

--- a/test/core/test/imports.test.ts
+++ b/test/core/test/imports.test.ts
@@ -88,9 +88,9 @@ test('dynamic import has null prototype', async () => {
 test('dynamic import throws an error', async () => {
   const path = './some-unknown-path'
   const imported = import(path)
-  await expect(imported).rejects.toThrowError(`Cannot find module '/test/some-unknown-path' imported from ${resolve(import.meta.filename)}`)
+  await expect(imported).rejects.toThrow(`Cannot find module '/test/some-unknown-path' imported from ${resolve(import.meta.filename)}`)
   // @ts-expect-error path does not exist
-  await expect(() => import('./some-unknown-path')).rejects.toThrowError(`Cannot find module '/test/some-unknown-path' imported from ${resolve(import.meta.filename)}`)
+  await expect(() => import('./some-unknown-path')).rejects.toThrow(`Cannot find module '/test/some-unknown-path' imported from ${resolve(import.meta.filename)}`)
 })
 
 test('can import @vite/client', async () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -115,7 +115,7 @@ describe('jest-expect', () => {
     }).toThrow('')
     expect(() => {
       throw new Error('error')
-    }).not.toThrowError('')
+    }).not.toThrow('')
     expect([1, 2, 3]).toHaveLength(3)
     expect('abc').toHaveLength(3)
     expect('').not.toHaveLength(5)
@@ -300,11 +300,11 @@ describe('jest-expect', () => {
       one: expect.toBeDividedBy(1),
       two: expect.not.toBeDividedBy(5),
     })
-    expect(() => expect(2).toBeDividedBy(5)).toThrowError()
+    expect(() => expect(2).toBeDividedBy(5)).toThrow()
 
-    expect(() => expect(null).toBeTestedSync()).toThrowError('toBeTestedSync')
-    await expect(async () => await expect(null).toBeTestedAsync()).rejects.toThrowError('toBeTestedAsync')
-    await expect(async () => await expect(null).toBeTestedPromise()).rejects.toThrowError('toBeTestedPromise')
+    expect(() => expect(null).toBeTestedSync()).toThrow('toBeTestedSync')
+    await expect(async () => await expect(null).toBeTestedAsync()).rejects.toThrow('toBeTestedAsync')
+    await expect(async () => await expect(null).toBeTestedPromise()).rejects.toThrow('toBeTestedPromise')
 
     expect(expect).toBeJestCompatible()
   })
@@ -367,7 +367,7 @@ describe('jest-expect', () => {
 
     expect(() => {
       expect(complex).toHaveProperty('some-unknown-property')
-    }).toThrowError()
+    }).toThrow()
 
     expect(() => {
       expect(complex).toHaveProperty('a-b', false)
@@ -492,7 +492,7 @@ describe('jest-expect', () => {
       // underlying `toEqual` doesn't require constructor/prototype equality
       expect(() => {
         throw new Error1('hi')
-      }).toThrowError(new Error2('hi'))
+      }).toThrow(new Error2('hi'))
       expect(new Error1('hi')).toEqual(new Error2('hi'))
       expect(new Error1('hi')).not.toStrictEqual(new Error2('hi'))
     })
@@ -1105,7 +1105,7 @@ describe('async expect', () => {
       await expect((async () => new Error('msg'))()).resolves.toThrow()
     }
 
-    await expect(assertion).rejects.toThrowError('expected promise to throw an error, but it didn\'t')
+    await expect(assertion).rejects.toThrow('expected promise to throw an error, but it didn\'t')
   })
 
   it('resolves throws jest', async () => {
@@ -1113,7 +1113,7 @@ describe('async expect', () => {
       await expect((async () => new Error('msg'))()).resolves.toThrow(Error)
     }
 
-    await expect(assertion).rejects.toThrowError('expected promise to throw an error, but it didn\'t')
+    await expect(assertion).rejects.toThrow('expected promise to throw an error, but it didn\'t')
   })
 
   it('throws an error on .resolves when the argument is not a promise', () => {
@@ -1940,7 +1940,7 @@ it('error equality', () => {
     snapshotError(() =>
       expect(() => {
         throw e1
-      }).toThrowError(e2),
+      }).toThrow(e2),
     )
   }
 
@@ -1976,7 +1976,7 @@ it('error equality', () => {
 
     expect(() => {
       throw e1
-    }).toThrowError(e2)
+    }).toThrow(e2)
   }
 
   {

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -602,7 +602,7 @@ describe('jest mock compat layer', () => {
 
     Spy.mockImplementation(() => {})
 
-    expect(() => new Spy()).toThrowError(TypeError)
+    expect(() => new Spy()).toThrow(TypeError)
 
     Spy.mockImplementation(function () {
       expectTypeOf(this.test).toEqualTypeOf<() => void>()
@@ -703,7 +703,7 @@ describe('jest mock compat layer', () => {
     // foo.bar setter is inherited from Bar, so we can set it
     expect(() => {
       foo.bar = 'baz'
-    }).not.toThrowError()
+    }).not.toThrow()
     expect(foo.bar).toEqual('foo')
   })
 
@@ -731,7 +731,7 @@ describe('jest mock compat layer', () => {
     expect(() => {
       // @ts-expect-error bar is readonly
       foo.bar = 'baz'
-    }).toThrowError()
+    }).toThrow()
     expect(foo.bar).toEqual('foo')
   })
 

--- a/test/core/test/mocking/factory.test.ts
+++ b/test/core/test/mocking/factory.test.ts
@@ -59,15 +59,15 @@ vi.mock('../../src/mocks/default.ts', () => null)
 
 describe('mocking with factory', () => {
   test('missing exports on mock', () => {
-    expect(() => example.default).toThrowError('[vitest] No "default" export is defined on the "../../src/mocks/example" mock')
-    expect(() => example.boolean).toThrowError('[vitest] No "boolean" export is defined on the "../../src/mocks/example" mock')
-    expect(() => example.object).toThrowError('[vitest] No "object" export is defined on the "../../src/mocks/example" mock')
-    expect(() => example.array).toThrowError('[vitest] No "array" export is defined on the "../../src/mocks/example" mock')
-    expect(() => example.someClasses).toThrowError('[vitest] No "someClasses" export is defined on the "../../src/mocks/example" mock')
+    expect(() => example.default).toThrow('[vitest] No "default" export is defined on the "../../src/mocks/example" mock')
+    expect(() => example.boolean).toThrow('[vitest] No "boolean" export is defined on the "../../src/mocks/example" mock')
+    expect(() => example.object).toThrow('[vitest] No "object" export is defined on the "../../src/mocks/example" mock')
+    expect(() => example.array).toThrow('[vitest] No "array" export is defined on the "../../src/mocks/example" mock')
+    expect(() => example.someClasses).toThrow('[vitest] No "someClasses" export is defined on the "../../src/mocks/example" mock')
   })
 
   it('non-object return on factory gives error', async () => {
-    await expect(() => import('../../src/mocks/default.js').then(m => m.default)).rejects.toThrowError('[vitest] vi.mock("../../src/mocks/default.ts", factory?: () => unknown) is not returning an object. Did you mean to return an object with a "default" key?')
+    await expect(() => import('../../src/mocks/default.js').then(m => m.default)).rejects.toThrow('[vitest] vi.mock("../../src/mocks/default.ts", factory?: () => unknown) is not returning an object. Did you mean to return an object with a "default" key?')
   })
 
   test('defined exports on mock', async () => {

--- a/test/core/test/mocking/retry-dynamic-import.test.ts
+++ b/test/core/test/mocking/retry-dynamic-import.test.ts
@@ -13,6 +13,6 @@ describe('retry-dynamic-import', () => {
     vi.doMock('../../src/mocks/dynamic-module', () => {
       throw new Error('foobar')
     })
-    await expect(retryDynamicImport()).rejects.toThrowError(new Error('import dynamic module failed.'))
+    await expect(retryDynamicImport()).rejects.toThrow(new Error('import dynamic module failed.'))
   })
 })

--- a/test/core/test/mocking/vi-fn.test.ts
+++ b/test/core/test/mocking/vi-fn.test.ts
@@ -13,11 +13,11 @@ test('vi.fn() calls implementation if it was passed down', () => {
 
 test('vi.fn().mock cannot be overriden', () => {
   const mock = vi.fn()
-  expect(() => mock.mock = {} as any).toThrowError()
+  expect(() => mock.mock = {} as any).toThrow()
   expect(() => {
     // @ts-expect-error mock is not optional
     delete mock.mock
-  }).toThrowError()
+  }).toThrow()
 })
 
 describe('vi.fn() copies static properties', () => {
@@ -425,7 +425,7 @@ describe('vi.fn() implementations', () => {
       throw new Error('hello world')
     })
 
-    expect(() => mock()).toThrowError('hello world')
+    expect(() => mock()).toThrow('hello world')
     expect(mock.mock.results).toEqual([
       { type: 'throw', value: new Error('hello world') },
     ])
@@ -436,7 +436,7 @@ describe('vi.fn() implementations', () => {
       throw new Error('hello world')
     })
 
-    expect(() => mock()).toThrowError('hello world')
+    expect(() => mock()).toThrow('hello world')
     expect(mock.mock.results).toEqual([
       { type: 'throw', value: new Error('hello world') },
     ])
@@ -675,7 +675,7 @@ describe('vi.fn() implementations', () => {
     const log = vi.spyOn(console, 'warn')
     onTestFinished(() => log.mockRestore())
     const Mock = vi.fn(() => {})
-    expect(() => new Mock()).toThrowError()
+    expect(() => new Mock()).toThrow()
     expect(log).toHaveBeenCalledWith(
       `[vitest] The vi.fn() mock did not use 'function' or 'class' in its implementation, see https://vitest.dev/api/vi#vi-spyon for examples.`,
     )
@@ -684,7 +684,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() throws an error if new is not called on a class', () => {
     const Mock = vi.fn(class _Mock {})
     // @ts-expect-error value is not callable
-    expect(() => Mock()).toThrowError(
+    expect(() => Mock()).toThrow(
       `Class constructor _Mock cannot be invoked without 'new'`,
     )
   })
@@ -720,7 +720,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() with mockReturnValue throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockReturnValue(42)
-    expect(() => new Mock()).toThrowError(
+    expect(() => new Mock()).toThrow(
       'Cannot use `mockReturnValue` when called with `new`. Use `mockImplementation` with a `class` keyword instead.',
     )
   })
@@ -728,7 +728,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() with mockReturnValueOnce throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockReturnValueOnce(42)
-    expect(() => new Mock()).toThrowError(
+    expect(() => new Mock()).toThrow(
       'Cannot use `mockReturnValueOnce` when called with `new`. Use `mockImplementation` with a `class` keyword instead.',
     )
   })
@@ -736,7 +736,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() with mockResolvedValue throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockResolvedValue(42)
-    expect(() => new Mock()).toThrowError(
+    expect(() => new Mock()).toThrow(
       'Cannot use `mockResolvedValue` when called with `new`. Use `mockImplementation` with a `class` keyword instead.',
     )
   })
@@ -744,7 +744,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() with mockResolvedValueOnce throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockResolvedValueOnce(42)
-    expect(() => new Mock()).toThrowError(
+    expect(() => new Mock()).toThrow(
       'Cannot use `mockResolvedValueOnce` when called with `new`. Use `mockImplementation` with a `class` keyword instead.',
     )
   })
@@ -752,7 +752,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() with mockRejectedValue throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockRejectedValue(new Error('test'))
-    expect(() => new Mock()).toThrowError(
+    expect(() => new Mock()).toThrow(
       'Cannot use `mockRejectedValue` when called with `new`. Use `mockImplementation` with a `class` keyword instead.',
     )
   })
@@ -760,7 +760,7 @@ describe('vi.fn() implementations', () => {
   test('vi.fn() with mockRejectedValueOnce throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockRejectedValueOnce(new Error('test'))
-    expect(() => new Mock()).toThrowError(
+    expect(() => new Mock()).toThrow(
       'Cannot use `mockRejectedValueOnce` when called with `new`. Use `mockImplementation` with a `class` keyword instead.',
     )
   })

--- a/test/core/test/mocking/vi-spyOn.test.ts
+++ b/test/core/test/mocking/vi-spyOn.test.ts
@@ -446,7 +446,7 @@ describe('vi.spyOn() settings', () => {
     // foo.bar setter is inherited from Bar, so we can set it
     expect(() => {
       foo.bar = 'baz'
-    }).not.toThrowError()
+    }).not.toThrow()
     expect(foo.bar).toEqual('foo')
   })
 
@@ -474,7 +474,7 @@ describe('vi.spyOn() settings', () => {
     expect(() => {
       // @ts-expect-error bar cannot be overriden
       foo.bar = 'baz'
-    }).toThrowError()
+    }).toThrow()
     expect(foo.bar).toEqual('foo')
   })
 
@@ -542,20 +542,20 @@ describe('vi.spyOn() settings', () => {
 
 describe('vi.spyOn() restoration', () => {
   test('vi.spyOn() cannot spy on undefined or null', () => {
-    expect(() => vi.spyOn(undefined as any, 'test')).toThrowError('The vi.spyOn() function could not find an object to spy upon. The first argument must be defined.')
-    expect(() => vi.spyOn(null as any, 'test')).toThrowError('The vi.spyOn() function could not find an object to spy upon. The first argument must be defined.')
+    expect(() => vi.spyOn(undefined as any, 'test')).toThrow('The vi.spyOn() function could not find an object to spy upon. The first argument must be defined.')
+    expect(() => vi.spyOn(null as any, 'test')).toThrow('The vi.spyOn() function could not find an object to spy upon. The first argument must be defined.')
   })
 
   test('vi.spyOn() cannot spy on a primitive value', () => {
-    expect(() => vi.spyOn('string' as any, 'toString')).toThrowError('Vitest cannot spy on a primitive value.')
-    expect(() => vi.spyOn(0 as any, 'toString')).toThrowError('Vitest cannot spy on a primitive value.')
-    expect(() => vi.spyOn(true as any, 'toString')).toThrowError('Vitest cannot spy on a primitive value.')
-    expect(() => vi.spyOn(1n as any, 'toString')).toThrowError('Vitest cannot spy on a primitive value.')
-    expect(() => vi.spyOn(Symbol.toStringTag as any, 'toString')).toThrowError('Vitest cannot spy on a primitive value.')
+    expect(() => vi.spyOn('string' as any, 'toString')).toThrow('Vitest cannot spy on a primitive value.')
+    expect(() => vi.spyOn(0 as any, 'toString')).toThrow('Vitest cannot spy on a primitive value.')
+    expect(() => vi.spyOn(true as any, 'toString')).toThrow('Vitest cannot spy on a primitive value.')
+    expect(() => vi.spyOn(1n as any, 'toString')).toThrow('Vitest cannot spy on a primitive value.')
+    expect(() => vi.spyOn(Symbol.toStringTag as any, 'toString')).toThrow('Vitest cannot spy on a primitive value.')
   })
 
   test('vi.spyOn() cannot spy on non-existing property', () => {
-    expect(() => vi.spyOn({} as any, 'never')).toThrowError('The property "never" is not defined on the object.')
+    expect(() => vi.spyOn({} as any, 'never')).toThrow('The property "never" is not defined on the object.')
   })
 
   test('vi.spyOn() restores the original method when .mockRestore() is called', () => {
@@ -708,7 +708,7 @@ describe('vi.spyOn() on Vite SSR', () => {
     expect(() => {
       // @ts-expect-error types recognize it's not a function
       vi.spyOn(module, 'primitive')
-    }).toThrowError('vi.spyOn() can only spy on a function. Received number.')
+    }).toThrow('vi.spyOn() can only spy on a function. Received number.')
   })
 
   test('vi.spyOn() assigns the method on a getter', () => {

--- a/test/core/test/strict.test.js
+++ b/test/core/test/strict.test.js
@@ -5,13 +5,13 @@ describe('vitest runs code in strict mode', () => {
     const o = { id: 1 }
     Object.defineProperty(o, 'id', { writable: false, configurable: false })
 
-    expect(() => o.id = 42).toThrowError(TypeError)
+    expect(() => o.id = 42).toThrow(TypeError)
   })
 
   test('cannot defined non existing variable', () => {
     expect(() => {
       someGlobalVariableICameUpWith = 22
-    }).toThrowError()
+    }).toThrow()
   })
 
   test('cannot redefine getter', () => {
@@ -22,12 +22,12 @@ describe('vitest runs code in strict mode', () => {
     }
     expect(() => {
       obj2.x = 5
-    }).toThrowError(TypeError)
+    }).toThrow(TypeError)
   })
 
   test('cannot declare properties on primitives', () => {
-    expect(() => false.true = '').toThrowError(TypeError)
-    expect(() => (14).sailing = 'home').toThrowError(TypeError)
-    expect(() => 'with'.you = 'far away').toThrowError(TypeError)
+    expect(() => false.true = '').toThrow(TypeError)
+    expect(() => (14).sailing = 'home').toThrow(TypeError)
+    expect(() => 'with'.you = 'far away').toThrow(TypeError)
   })
 })

--- a/test/core/test/stubs.test.ts
+++ b/test/core/test/stubs.test.ts
@@ -50,7 +50,7 @@ describe('stubbing globals', () => {
     expect(globalThis.__defined__).toBe('false')
     vi.unstubAllGlobals()
     expect('__defined__' in globalThis).toBe(false)
-    expect(() => __defined__).toThrowError(ReferenceError)
+    expect(() => __defined__).toThrow(ReferenceError)
     expect(globalThis.__defined__).toBeUndefined()
   })
 

--- a/test/core/test/web-worker-node.test.ts
+++ b/test/core/test/web-worker-node.test.ts
@@ -245,9 +245,9 @@ it('throws syntax error if no arguments are provided', () => {
   const worker = new MyWorker()
 
   // @ts-expect-error requires at least one argument
-  expect(() => worker.postMessage()).toThrowError(SyntaxError)
-  expect(() => worker.postMessage(undefined)).not.toThrowError()
-  expect(() => worker.postMessage(null)).not.toThrowError()
+  expect(() => worker.postMessage()).toThrow(SyntaxError)
+  expect(() => worker.postMessage(undefined)).not.toThrow()
+  expect(() => worker.postMessage(null)).not.toThrow()
 })
 
 function sendEventMessage(worker: SharedWorker, msg: any) {

--- a/test/coverage-test/fixtures/workspaces/project/shared/test/utils.test.ts
+++ b/test/coverage-test/fixtures/workspaces/project/shared/test/utils.test.ts
@@ -3,5 +3,5 @@ import { raise } from '../src/utils'
 
 test('raise throws error', () => {
   const message = 'Value cannot be undefined'
-  expect(() => raise(message)).toThrowError(message)
+  expect(() => raise(message)).toThrow(message)
 })

--- a/test/coverage-test/test/run-dynamic-coverage.test.ts
+++ b/test/coverage-test/test/run-dynamic-coverage.test.ts
@@ -15,7 +15,7 @@ test('enableCoverage() collects coverage after being called', async () => {
     },
   })
 
-  await expect(readCoverageMap(), 'coverage map should not be on the disk').rejects.toThrowError(/no such file/)
+  await expect(readCoverageMap(), 'coverage map should not be on the disk').rejects.toThrow(/no such file/)
 
   await ctx!.enableCoverage()
   expect(ctx!.coverageProvider).toBeTruthy()
@@ -29,7 +29,7 @@ test('enableCoverage() collects coverage after being called', async () => {
 test('enableCoverage() invalidates circular modules', async () => {
   await cleanupCoverageJson()
 
-  await expect(readCoverageMap(), 'coverage map should not be on the disk').rejects.toThrowError(/no such file/)
+  await expect(readCoverageMap(), 'coverage map should not be on the disk').rejects.toThrow(/no such file/)
 
   // Simulating user actions in the VSCode Vitest extension:
   // 1. User clicks "Run Test with Coverage" to generate coverage files normally
@@ -82,6 +82,6 @@ test('disableCoverage() stops collecting coverage going forward', async () => {
 
   await ctx!.rerunFiles()
 
-  await expect(readCoverageMap(), 'coverage map should not be on the disk').rejects.toThrowError(/no such file/)
+  await expect(readCoverageMap(), 'coverage map should not be on the disk').rejects.toThrow(/no such file/)
   expect(ctx!.coverageProvider).toBeNull()
 })

--- a/test/ui/fixtures-browser/visual-regression.test.ts
+++ b/test/ui/fixtures-browser/visual-regression.test.ts
@@ -10,7 +10,7 @@ test('visual regression test', async ({ expect, onTestFinished }) => {
     }
   })
 
-  await expect(expect(document.body).toMatchScreenshot(screenshotName)).rejects.toThrowError(
+  await expect(expect(document.body).toMatchScreenshot(screenshotName)).rejects.toThrow(
     'No existing reference screenshot found',
   )
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

These existed primarily for a better compatibility story with Jest, even though they were already deprecated there back then. Let's cleanup and remove them in the next major completely, but they need to be deprecated first.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
