### PR TITLE
fix(coverage): check path boundaries in prefix matching

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -6,6 +6,7 @@ import { existsSync, promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 // @ts-expect-error -- untyped
 import { mergeProcessCovs } from '@bcoe/v8-coverage'
+import { startsWithPathPrefix } from '@vitest/utils/helpers'
 import astV8ToIstanbul from 'ast-v8-to-istanbul'
 import libCoverage from 'istanbul-lib-coverage'
 import libReport from 'istanbul-lib-report'
@@ -397,7 +398,7 @@ export class V8CoverageProvider extends BaseCoverageProvider<ResolvedCoverageOpt
         if (result.url.startsWith('/@fs')) {
           result.url = `${FILE_PROTOCOL}${removeStartsWith(result.url, '/@fs')}`
         }
-        else if (result.url.startsWith(project.config.root)) {
+        else if (startsWithPathPrefix(result.url, project.config.root)) {
           result.url = `${FILE_PROTOCOL}${result.url}`
         }
         else {
@@ -472,7 +473,7 @@ function findLongestFunctionLength(functions: Profiler.FunctionCoverage[]) {
 }
 
 function removeStartsWith(filepath: string, start: string) {
-  if (filepath.startsWith(start)) {
+  if (startsWithPathPrefix(filepath, start)) {
     return filepath.slice(start.length)
   }
 

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -95,6 +95,17 @@ export function withTrailingSlash(path: string): string {
   return path
 }
 
+/**
+ * Check if `filepath` starts with `prefix` at a path boundary (`/`),
+ * avoiding false positives like `/packages/pkg-a` matching `/packages/pkg-a-utils`.
+ * Also handles Windows paths where filenames may have a leading `/` before the root.
+ */
+export function startsWithPathPrefix(filepath: string, prefix: string): boolean {
+  // On Windows, filenames may start with "/" while roots don't
+  const path = filepath.startsWith('/') && !prefix.startsWith('/') ? filepath.slice(1) : filepath
+  return path.startsWith(prefix) && (path.length === prefix.length || path[prefix.length] === '/')
+}
+
 export function filterOutComments(s: string): string {
   const result: string[] = []
   let commentState: 'none' | 'singleline' | 'multiline' = 'none'

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -9,7 +9,7 @@ import { existsSync, promises as fs, readdirSync, writeFileSync } from 'node:fs'
 import module from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { slash } from '@vitest/utils/helpers'
+import { slash, startsWithPathPrefix } from '@vitest/utils/helpers'
 import { relative, resolve } from 'pathe'
 import pm from 'picomatch'
 import { glob } from 'tinyglobby'
@@ -688,8 +688,8 @@ export class BaseCoverageProvider<Options extends ResolvedCoverageOptions<'istan
       for (const project of projects) {
         const root = project.config.root
 
-        // On Windows root doesn't start with "/" while filenames do
-        if (!filename.startsWith(root) && !filename.startsWith(`/${root}`)) {
+        // startsWithPathPrefix handles Windows where filenames may have a leading "/"
+        if (!startsWithPathPrefix(filename, root)) {
           continue
         }
 

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -1,5 +1,5 @@
 import { objDisplay } from '@vitest/utils/display'
-import { assertTypes, deepClone, deepMerge, isNegativeNaN, objectAttr, toArray } from '@vitest/utils/helpers'
+import { assertTypes, deepClone, deepMerge, isNegativeNaN, objectAttr, startsWithPathPrefix, toArray } from '@vitest/utils/helpers'
 import { parseSingleFFOrSafariStack } from '@vitest/utils/source-map'
 import { EvaluatedModules } from 'vite/module-runner'
 import { beforeAll, describe, expect, test } from 'vitest'
@@ -306,6 +306,22 @@ describe('isNegativeNaN', () => {
   ${Number.NEGATIVE_INFINITY} | ${false}
   `('isNegativeNaN($value) -> $expected', ({ value, expected }) => {
     expect(isNegativeNaN(value)).toBe(expected)
+  })
+})
+
+describe('startsWithPathPrefix', () => {
+  test.each`
+    filepath                                    | prefix                          | expected
+    ${'/workspace/packages/pkg-a/src/index.ts'} | ${'/workspace/packages/pkg-a'}  | ${true}
+    ${'/workspace/packages/pkg-a'}              | ${'/workspace/packages/pkg-a'}  | ${true}
+    ${'/workspace/packages/pkg-a-utils/src/index.ts'} | ${'/workspace/packages/pkg-a'} | ${false}
+    ${'/workspace/packages/pkg-a-utils'}        | ${'/workspace/packages/pkg-a'}  | ${false}
+    ${'/@fs/some/path'}                         | ${'/@fs'}                       | ${true}
+    ${'/@fs-extra/path'}                        | ${'/@fs'}                       | ${false}
+    ${'/C:/workspace/pkg-a/src/index.ts'}       | ${'C:/workspace/pkg-a'}         | ${true}
+    ${'/C:/workspace/pkg-a-utils/src/index.ts'} | ${'C:/workspace/pkg-a'}         | ${false}
+  `('startsWithPathPrefix($filepath, $prefix) -> $expected', ({ filepath, prefix, expected }) => {
+    expect(startsWithPathPrefix(filepath, prefix)).toBe(expected)
   })
 })
 


### PR DESCRIPTION
### Description

When using `@vitest/coverage-v8` in browser mode with a vitest workspace, files from cross-package dependencies fail to parse if one package name is a **string prefix** of another (e.g., `pkg-a` and `pkg-a-utils`).

The coverage provider logs errors like:
```
Failed to parse file:///path/to/packages/pkg-a-utils/src/index.ts. Excluding it from coverage.
Error [RollupError]: Expected ',', got '{'
```
Note: I didn't create an issue for this, just opened this PR.

#### The issue

`@vitest/coverage-v8` performs string prefix matching against `project.config.root` without checking path boundaries. This affects `packages/coverage-v8/src/provider.ts` and `packages/vitest/src/node/coverage.ts`.

In `vitest` workspace mode, each project has its own `project.config.root` set to the package directory. When two packages share a path prefix, the `startsWith` check produces false positives.

For example, when the `pkg-a` project processes coverage data containing a file from `pkg-a-utils`:

filepath:  /workspace/packages/pkg-a-utils/src/index.ts
root:      /workspace/packages/pkg-a

filepath.startsWith(root) → TRUE → filepath.slice(root.length) → "-utils/src/index.ts" // invalid path → the fallback reads raw TypeScript → Rollup's `parseAstAsync` cannot parse it

In `createUncoveredFileTransformer`, `/workspace/packages/pkg-a-utils/src/index.ts` incorrectly matches pkg-a's root, so the file is transformed by the wrong project's Vite server.

[Reproduction repo](https://github.com/arminmeh/vitest-coverage-bug)

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
