### PR TITLE
fix(reporter): `dot` reporter leaves pending tests

### DIFF
--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -2,6 +2,7 @@ import type { Test } from '@vitest/runner'
 import type { SerializedError } from '@vitest/utils'
 import type { Writable } from 'node:stream'
 import type { Vitest } from '../core'
+import type { TestSpecification } from '../test-specification'
 import type { TestRunEndReason } from '../types/reporter'
 import type { TestCase, TestModule } from './reported-tasks'
 import c from 'tinyrainbow'
@@ -35,6 +36,12 @@ export class DotReporter extends BaseReporter {
 
   // Ignore default logging of base reporter
   printTestModule(): void {}
+
+  onTestRunStart(_specifications: ReadonlyArray<TestSpecification>): void {
+    super.onTestRunStart(_specifications)
+
+    this.renderer?.start()
+  }
 
   onWatcherRerun(files: string[], trigger?: string): void {
     this.tests.clear()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vitest/issues/9681

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
