### PR TITLE
fix: recursively autospy module object

### DIFF
--- a/packages/mocker/src/automocker.ts
+++ b/packages/mocker/src/automocker.ts
@@ -134,9 +134,28 @@ export function mockObject(
         continue
       }
 
+      if (options.type === 'autospy' && type === 'Module') {
+        // Replace with clean object to recursively autospy exported module objects:
+        //   export * as ns from "./ns"
+        // or
+        //   import * as ns from "./ns"
+        //   export { ns }
+        const exports = Object.create(null)
+        Object.defineProperty(exports, Symbol.toStringTag, {
+          value: 'Module',
+          configurable: true,
+          writable: true,
+        })
+        try {
+          newContainer[property] = exports
+        }
+        catch {
+          continue
+        }
+      }
       // Sometimes this assignment fails for some unknown reason. If it does,
       // just move along.
-      if (!define(newContainer, property, isFunction || options.type === 'autospy' ? value : {})) {
+      else if (!define(newContainer, property, isFunction || options.type === 'autospy' ? value : {})) {
         continue
       }
 

--- a/test/core/src/mocks/autospying-namespace/index.ts
+++ b/test/core/src/mocks/autospying-namespace/index.ts
@@ -1,0 +1,1 @@
+export * as NamespaceTarget from './namespaceTarget.js'

--- a/test/core/src/mocks/autospying-namespace/namespaceTarget.ts
+++ b/test/core/src/mocks/autospying-namespace/namespaceTarget.ts
@@ -1,0 +1,1 @@
+export const computeSquare = (n: number) => n * n

--- a/test/core/test/mocking/autospying.test.ts
+++ b/test/core/test/mocking/autospying.test.ts
@@ -1,10 +1,12 @@
 import axios from 'axios'
 import { expect, test, vi } from 'vitest'
 import { getAuthToken } from '../../src/env'
+import * as NamespaceModule from '../../src/mocks/autospying-namespace/index.js'
 
 vi.mock(import('../../src/env'), { spy: true })
 
 vi.mock('axios', { spy: true })
+vi.mock('../../src/mocks/autospying-namespace/index.js', { spy: true })
 
 test('getAuthToken is spied', async () => {
   import.meta.env.AUTH_TOKEN = '123'
@@ -22,4 +24,10 @@ test('package in __mocks__ has lower priority', async () => {
   // isAxiosError is not defined in __mocks__
   expect(axios.isAxiosError(new Error('test'))).toBe(false)
   expect(axios.isAxiosError).toHaveBeenCalled()
+})
+
+test('spies on namespace re-exports', async () => {
+  expect(vi.isMockFunction(NamespaceModule.NamespaceTarget.computeSquare)).toBe(true)
+  expect(NamespaceModule.NamespaceTarget.computeSquare(5)).toBe(25)
+  expect(NamespaceModule.NamespaceTarget.computeSquare).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9558

This could be debatable whether autospy should preserve identity of re-exported module object, but in my opinion, this is a reasonable and convenient behavior.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
