### PR TITLE
fix(types): `bench.reporters` no longer gives type errors when passing file name string paths

### DIFF
--- a/packages/vitest/src/node/types/benchmark.ts
+++ b/packages/vitest/src/node/types/benchmark.ts
@@ -25,12 +25,12 @@ export interface BenchmarkUserOptions {
   includeSource?: string[]
 
   /**
-   * Custom reporter for output. Can contain one or more built-in report names, reporter instances,
-   * and/or paths to custom reporters
+   * Custom reporters to use for output. Can contain one or more built-in reporter names, reporter instances,
+   * and/or paths to custom reporter files to import.
    *
    * @default ['default']
    */
-  reporters?: Arrayable<BenchmarkBuiltinReporters | Reporter>
+  reporters?: Arrayable<BenchmarkBuiltinReporters | Reporter | (string & {})>
 
   /**
    * @deprecated Use `benchmark.outputJson` instead


### PR DESCRIPTION
### Description

Fixes a oneline typing error inside `vitest/node` that caused TypeScript to produce type errors complain about `bench.reporters` not accepting arbitrary strings for reporter file paths. Vitest processes them just fine, but the type was overly restrictive and led to type errors that contradicted existing docs. 

Fixes #9692 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - Should I add a type test that creates a config with a string benchmark file?
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
N/A - this is fixing a type bug
### Documentation
N/A - this is fixing a bug
### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
