### PR TITLE
docs: add warning for clearMocks option in async tests

### DIFF
--- a/docs/config/clearmocks.md
+++ b/docs/config/clearmocks.md
@@ -23,5 +23,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will clear the mock history for all mocks, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async [concurrent tests](/api/test#test-concurrent). If enabled, the completion of one test will clear the mock history for all mocks, including those currently being used by other tests in progress.
 :::

--- a/docs/config/clearmocks.md
+++ b/docs/config/clearmocks.md
@@ -21,3 +21,7 @@ export default defineConfig({
   },
 })
 ```
+
+::: warning
+Do not use this option with async concurrent tests. If enabled, the completion of one test will clear the mock history for all mocks, including those currently being used by other tests in progress.
+:::

--- a/docs/config/clearmocks.md
+++ b/docs/config/clearmocks.md
@@ -23,5 +23,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Do not use this option with async concurrent tests. If enabled, the completion of one test will clear the mock history for all mocks, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will clear the mock history for all mocks, including those currently being used by other tests in progress.
 :::

--- a/docs/config/mockreset.md
+++ b/docs/config/mockreset.md
@@ -23,5 +23,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will clear the mock history and implementation for all mocks, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async [concurrent tests](/api/test#test-concurrent). If enabled, the completion of one test will clear the mock history and implementation for all mocks, including those currently being used by other tests in progress.
 :::

--- a/docs/config/mockreset.md
+++ b/docs/config/mockreset.md
@@ -21,3 +21,7 @@ export default defineConfig({
   },
 })
 ```
+
+::: warning
+Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will clear the mock history and implementation for all mocks, including those currently being used by other tests in progress.
+:::

--- a/docs/config/restoremocks.md
+++ b/docs/config/restoremocks.md
@@ -23,5 +23,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore the implementation for all spies, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async [concurrent tests](/api/test#test-concurrent). If enabled, the completion of one test will restore the implementation for all spies, including those currently being used by other tests in progress.
 :::

--- a/docs/config/restoremocks.md
+++ b/docs/config/restoremocks.md
@@ -21,3 +21,7 @@ export default defineConfig({
   },
 })
 ```
+
+::: warning
+Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore the implementation for all spies, including those currently being used by other tests in progress.
+:::

--- a/docs/config/unstubenvs.md
+++ b/docs/config/unstubenvs.md
@@ -21,5 +21,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore all the values changed with `vi.stubEnv`, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async [concurrent tests](/api/test#test-concurrent). If enabled, the completion of one test will restore all the values changed with [`vi.stubEnv`](/api/vi#vi-stubenv), including those currently being used by other tests in progress.
 :::

--- a/docs/config/unstubenvs.md
+++ b/docs/config/unstubenvs.md
@@ -19,3 +19,7 @@ export default defineConfig({
   },
 })
 ```
+
+::: warning
+Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore the values changed with `vi.stubEnv`, including those currently being used by other tests in progress.
+:::

--- a/docs/config/unstubenvs.md
+++ b/docs/config/unstubenvs.md
@@ -21,5 +21,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore the values changed with `vi.stubEnv`, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore all the values changed with `vi.stubEnv`, including those currently being used by other tests in progress.
 :::

--- a/docs/config/unstubglobals.md
+++ b/docs/config/unstubglobals.md
@@ -19,3 +19,7 @@ export default defineConfig({
   },
 })
 ```
+
+::: warning
+Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore all global values that were changed with `vi.stubGlobal`, including those currently being used by other tests in progress.
+:::

--- a/docs/config/unstubglobals.md
+++ b/docs/config/unstubglobals.md
@@ -21,5 +21,5 @@ export default defineConfig({
 ```
 
 ::: warning
-Be aware that this option may cause problems with async concurrent tests. If enabled, the completion of one test will restore all global values that were changed with `vi.stubGlobal`, including those currently being used by other tests in progress.
+Be aware that this option may cause problems with async [concurrent tests](/api/test#test-concurrent). If enabled, the completion of one test will restore all global values that were changed with [`vi.stubGlobal`](/api/vi#vi-stubglobal), including those currently being used by other tests in progress.
 :::


### PR DESCRIPTION
### Description

IIUC enabling this option causes problem with async concurrent tests.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
