### PR TITLE
feat: support `update: "none"` and add docs about snapshots behavior on CI

### DIFF
--- a/docs/config/update.md
+++ b/docs/config/update.md
@@ -5,11 +5,17 @@ outline: deep
 
 # update <CRoot /> {#update}
 
-- **Type:** `boolean | 'new' | 'all'`
+- **Type:** `boolean | 'new' | 'all' | 'none'`
 - **Default:** `false`
-- **CLI:** `-u`, `--update`, `--update=false`, `--update=new`
+- **CLI:** `-u`, `--update`, `--update=false`, `--update=new`, `--update=none`
 
-Update snapshot files. The behaviour depends on the value:
+Define snapshot update behavior.
 
-- `true` or `'all'`: updates all changed snapshots and delete obsolete ones
+- `true` or `'all'`: updates all changed snapshots and deletes obsolete ones
 - `new`: generates new snapshots without changing or deleting obsolete ones
+- `none`: does not write snapshots and fails on snapshot mismatches, missing snapshots, and obsolete snapshots
+
+When `update` is `false` (the default), Vitest resolves snapshot update mode by environment:
+
+- Local runs (non-CI): works same as `new`
+- CI runs (`process.env.CI` is truthy): works same as `none`

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -16,7 +16,7 @@ Path to config file
 - **CLI:** `-u, --update [type]`
 - **Config:** [update](/config/update)
 
-Update snapshot (accepts boolean, "new" or "all")
+Update snapshot (accepts boolean, "new", "all" or "none")
 
 ### watch
 

--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -79,6 +79,12 @@ Or you can use the `--update` or `-u` flag in the CLI to make Vitest update snap
 vitest -u
 ```
 
+### CI behavior
+
+By default, Vitest does not write snapshots in CI (`process.env.CI` is truthy) and any snapshot mismatches, missing snapshots, and obsolete snapshots fail the run. See [`update`](/config/update) for the details.
+
+An **obsolete snapshot** is a snapshot entry (or snapshot file) that no longer matches any collected test. This usually happens after removing or renaming tests.
+
 ## File Snapshots
 
 When calling `toMatchSnapshot()`, we store all snapshots in a formatted snap file. That means we need to escape some characters (namely the double-quote `"` and backtick `` ` ``) in the snapshot string. Meanwhile, you might lose the syntax highlighting for the snapshot content (if they are in some language).

--- a/examples/basic/test/suite.test.ts
+++ b/examples/basic/test/suite.test.ts
@@ -7,7 +7,6 @@ describe('suite name', () => {
 
   it('bar', () => {
     expect(1 + 1).eq(2)
-    expect(3).toMatchInlineSnapshot()
   })
 
   it('snapshot', () => {

--- a/examples/basic/test/suite.test.ts
+++ b/examples/basic/test/suite.test.ts
@@ -7,6 +7,7 @@ describe('suite name', () => {
 
   it('bar', () => {
     expect(1 + 1).eq(2)
+    expect(3).toMatchInlineSnapshot()
   })
 
   it('snapshot', () => {

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -84,7 +84,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   update: {
     shorthand: 'u',
-    description: 'Update snapshot (accepts boolean, "new" or "all")',
+    description: 'Update snapshot (accepts boolean, "new", "all" or "none")',
     argument: '[type]',
   },
   watch: {

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -566,7 +566,7 @@ export function resolveConfig(
     expand: resolved.expandSnapshotDiff ?? false,
     snapshotFormat: resolved.snapshotFormat || {},
     updateSnapshot:
-      UPDATE_SNAPSHOT === 'all' || UPDATE_SNAPSHOT === 'new'
+      UPDATE_SNAPSHOT === 'all' || UPDATE_SNAPSHOT === 'new' || UPDATE_SNAPSHOT === 'none'
         ? UPDATE_SNAPSHOT
         : isCI && !UPDATE_SNAPSHOT ? 'none' : UPDATE_SNAPSHOT ? 'all' : 'new',
     resolveSnapshotPath: options.resolveSnapshotPath,

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -380,7 +380,7 @@ export interface InlineConfig {
    *
    * @default false
    */
-  update?: boolean | 'all' | 'new'
+  update?: boolean | 'all' | 'new' | 'none'
 
   /**
    * Watch mode

--- a/test/cli/test/around-each.test.ts
+++ b/test/cli/test/around-each.test.ts
@@ -1463,6 +1463,9 @@ test('aroundAll throws error when runSuite is not called', async () => {
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "no-run.test.ts": {
+        "__module_errors__": [
+          "The \`runSuite()\` callback was not called in the \`aroundAll\` hook. Make sure to call \`runSuite()\` to run the suite.",
+        ],
         "test": "skipped",
       },
     }
@@ -1584,6 +1587,9 @@ test('aroundAll setup phase timeout', async () => {
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "timeout.test.ts": {
+        "__module_errors__": [
+          "The setup phase of "aroundAll" hook timed out after 10ms.",
+        ],
         "test": "skipped",
       },
     }
@@ -1635,6 +1641,9 @@ test('aroundAll teardown phase timeout', async () => {
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "teardown-timeout.test.ts": {
+        "__module_errors__": [
+          "The teardown phase of "aroundAll" hook timed out after 10ms.",
+        ],
         "test": "passed",
       },
     }
@@ -1974,6 +1983,9 @@ test('tests are skipped when aroundAll setup fails', async () => {
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "aroundAll-setup-error.test.ts": {
+        "__module_errors__": [
+          "aroundAll setup error",
+        ],
         "test should be skipped": "skipped",
       },
     }
@@ -2461,6 +2473,9 @@ test('nested aroundAll setup error is not propagated to outer runSuite catch', a
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "nested-around-all-setup-error.test.ts": {
+        "__module_errors__": [
+          "inner aroundAll setup error",
+        ],
         "repro": "skipped",
       },
     }
@@ -2524,6 +2539,9 @@ test('nested aroundAll teardown error is not propagated to outer runSuite catch'
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "nested-around-all-teardown-error.test.ts": {
+        "__module_errors__": [
+          "inner aroundAll teardown error",
+        ],
         "repro": "passed",
       },
     }
@@ -2712,6 +2730,11 @@ test('three nested aroundAll teardown errors are all reported', async () => {
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "triple-around-all-teardown-errors.test.ts": {
+        "__module_errors__": [
+          "inner aroundAll teardown error",
+          "middle aroundAll teardown error",
+          "outer aroundAll teardown error",
+        ],
         "repro": "passed",
       },
     }

--- a/test/snapshots/test/ci.test.ts
+++ b/test/snapshots/test/ci.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { runVitestCli } from '../../test-utils'
+
+test('CI behavior', async () => {
+  // cleanup snapshot
+  const root = path.join(import.meta.dirname, 'fixtures/ci')
+  fs.rmSync(path.join(root, '__snapshots__'), { recursive: true, force: true })
+
+  // snapshot fails with CI
+  let result = await runVitestCli({
+    nodeOptions: {
+      env: {
+        CI: 'true',
+      },
+    },
+  }, '--root', root)
+  expect(result.stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  basic.test.ts > basic
+    Error: Snapshot \`basic 1\` mismatched
+     ❯ basic.test.ts:4:16
+          2|
+          3| test("basic", () => {
+          4|   expect("ok").toMatchSnapshot()
+           |                ^
+          5| })
+          6|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+    "
+  `)
+
+  // snapshot created without CI
+  result = await runVitestCli(
+    {
+      nodeOptions: {
+        env: {
+          CI: '',
+        },
+      },
+    },
+    '--root',
+    root,
+  )
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.stdout).toContain('Snapshots  1 written')
+})

--- a/test/snapshots/test/ci.test.ts
+++ b/test/snapshots/test/ci.test.ts
@@ -13,6 +13,7 @@ test('CI behavior', async () => {
     nodeOptions: {
       env: {
         CI: 'true',
+        GITHUB_ACTIONS: 'true',
       },
     },
   }, '--root', root)
@@ -41,6 +42,7 @@ test('CI behavior', async () => {
       nodeOptions: {
         env: {
           CI: '',
+          GITHUB_ACTIONS: '',
         },
       },
     },

--- a/test/snapshots/test/fixtures/ci/.gitignore
+++ b/test/snapshots/test/fixtures/ci/.gitignore
@@ -1,0 +1,1 @@
+__snapshots__

--- a/test/snapshots/test/fixtures/ci/basic.test.ts
+++ b/test/snapshots/test/fixtures/ci/basic.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "vitest"
+
+test("basic", () => {
+  expect("ok").toMatchSnapshot()
+})

--- a/test/snapshots/test/obsolete.test.ts
+++ b/test/snapshots/test/obsolete.test.ts
@@ -49,6 +49,12 @@ test('obsolete snapshot fails with update:none', async () => {
   expect(result.errorTree()).toMatchInlineSnapshot(`
     Object {
       "src/test1.test.ts": Object {
+        "__module_errors__": Array [
+          "Obsolete snapshots found when no snapshot update is expected.
+    · foo 1
+    · fuu 1
+    ",
+        ],
         "bar": "passed",
         "foo": "passed",
         "fuu": "passed",

--- a/test/snapshots/test/obsolete.test.ts
+++ b/test/snapshots/test/obsolete.test.ts
@@ -1,39 +1,62 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { expect, test } from 'vitest'
-import { runVitestCli } from '../../test-utils'
+import { runVitest } from '../../test-utils'
 
-test('obsolete snapshot fails CI', async () => {
+test('obsolete snapshot fails with update:none', async () => {
   // cleanup snapshot
   const root = path.join(import.meta.dirname, 'fixtures/obsolete')
   fs.rmSync(path.join(root, 'src/__snapshots__'), { recursive: true, force: true })
 
   // initial run to write snapshot
-  let vitest = await runVitestCli('--root', root, '--update')
-  expect(vitest.stdout).toContain('Snapshots  5 written')
-  expect(vitest.stderr).toBe('')
+  let result = await runVitest({ root, update: true })
+  expect(result.stderr).toBe('')
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    Object {
+      "src/test1.test.ts": Object {
+        "bar": "passed",
+        "foo": "passed",
+        "fuu": "passed",
+      },
+      "src/test2.test.ts": Object {
+        "bar": "passed",
+        "foo": "passed",
+      },
+    }
+  `)
 
   // test fails with obsolete snapshots
-  // (use cli to test `updateSnapshot: 'none'`)
-  vitest = await runVitestCli(
-    {
-      nodeOptions: {
-        env: {
-          CI: 'true',
-          TEST_OBSOLETE: 'true',
-        },
-      },
-    },
-    '--root',
+  result = await runVitest({
     root,
-  )
-  expect(vitest.stdout).toContain('2 obsolete')
-  expect(vitest.stdout).toContain('Test Files  1 failed | 1 passed')
-  expect(vitest.stdout).toContain('Tests  5 passed')
-  expect(vitest.stderr).toContain(`
-Error: Obsolete snapshots found when no snapshot update is expected.
-· foo 1
-· fuu 1
-`)
-  expect(vitest.exitCode).toBe(1)
+    update: 'none',
+    env: {
+      TEST_OBSOLETE: 'true',
+    },
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  src/test1.test.ts [ src/test1.test.ts ]
+    Error: Obsolete snapshots found when no snapshot update is expected.
+    · foo 1
+    · fuu 1
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+    "
+  `)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    Object {
+      "src/test1.test.ts": Object {
+        "bar": "passed",
+        "foo": "passed",
+        "fuu": "passed",
+      },
+      "src/test2.test.ts": Object {
+        "bar": "passed",
+        "foo": "passed",
+      },
+    }
+  `)
 })

--- a/test/snapshots/test/test-update.test.ts
+++ b/test/snapshots/test/test-update.test.ts
@@ -67,7 +67,7 @@ test('test update', async () => {
   `)
 
   // re-run without update and files are unchanged
-  const result2 = await runVitest({ root: dstDir, update: false })
+  const result2 = await runVitest({ root: dstDir, update: 'none' })
   expect(result2.stderr).toMatchInlineSnapshot(`""`)
   expect(result2.errorTree()).toEqual(result.errorTree())
   expect(readFiles(dstDir)).toEqual(resultFiles)

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -575,6 +575,16 @@ export function buildErrorTree(testModules: TestModule[]) {
       }
       return suiteChildren
     },
+    (testModule, moduleChildren) => {
+      const errors = testModule.errors().map(error => error.message)
+      if (errors.length > 0) {
+        return {
+          ...moduleChildren,
+          __module_errors__: errors,
+        }
+      }
+      return moduleChildren
+    },
   )
 }
 
@@ -582,6 +592,7 @@ export function buildTestTree(
   testModules: TestModule[],
   onTestCase?: (result: TestCase) => unknown,
   onTestSuite?: (testSuite: TestSuite, suiteChildren: Record<string, any>) => unknown,
+  onTestModule?: (testModule: TestModule, moduleChildren: Record<string, any>) => unknown,
 ) {
   type TestTree = Record<string, any>
 
@@ -613,7 +624,8 @@ export function buildTestTree(
   for (const module of testModules) {
     // Use relative module ID for cleaner output
     const key = module.relativeModuleId
-    tree[key] = walkCollection(module.children)
+    const moduleChildren = walkCollection(module.children)
+    tree[key] = onTestModule ? onTestModule(module, moduleChildren) : moduleChildren
   }
 
   return tree


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9694

It turns out current `update: false` behavior is quite confusing. However, I don't think I would change that now, so instead, this PR added support for explicit `update: "none"` since otherwise it's almost impossible to explain the behavior in the doc.

TODO:
- [x] test `update: false` with and without `CI`

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
