### PR TITLE
fix: respect project `resolve.conditions` for externals

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1353,9 +1353,6 @@ importers:
       '@vitest/browser-webdriverio':
         specifier: workspace:*
         version: link:../../packages/browser-webdriverio
-      '@vitest/test-dep-conditions':
-        specifier: file:./deps/test-dep-conditions
-        version: file:test/config/deps/test-dep-conditions
       '@vitest/test-dep-optimizer-external':
         specifier: file:./deps/optimizer/external
         version: file:test/config/deps/optimizer/external
@@ -1371,6 +1368,9 @@ importers:
       ssr-no-external-dep:
         specifier: file:./deps/vite-ssr-resolve/ssr-no-external-dep
         version: file:test/config/deps/vite-ssr-resolve/ssr-no-external-dep
+      test-dep-conditions:
+        specifier: file:./deps/test-dep-conditions
+        version: file:test/config/deps/test-dep-conditions
       tinyexec:
         specifier: ^1.0.2
         version: 1.0.2
@@ -5144,12 +5144,6 @@ packages:
 
   '@vitest/test-dep-cjs@file:test/core/deps/dep-cjs':
     resolution: {directory: test/core/deps/dep-cjs, type: directory}
-
-  '@vitest/test-dep-conditions-indirect@file:test/config/deps/test-dep-conditions-indirect':
-    resolution: {directory: test/config/deps/test-dep-conditions-indirect, type: directory}
-
-  '@vitest/test-dep-conditions@file:test/config/deps/test-dep-conditions':
-    resolution: {directory: test/config/deps/test-dep-conditions, type: directory}
 
   '@vitest/test-dep-nested-cjs@file:test/core/deps/dep-nested-cjs':
     resolution: {directory: test/core/deps/dep-nested-cjs, type: directory}
@@ -9377,6 +9371,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  test-dep-conditions-indirect@file:test/config/deps/test-dep-conditions-indirect:
+    resolution: {directory: test/config/deps/test-dep-conditions-indirect, type: directory}
+
+  test-dep-conditions@file:test/config/deps/test-dep-conditions:
+    resolution: {directory: test/config/deps/test-dep-conditions, type: directory}
+
   text-decoder@1.1.1:
     resolution: {integrity: sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==}
 
@@ -13496,12 +13496,6 @@ snapshots:
       - supports-color
 
   '@vitest/test-dep-cjs@file:test/core/deps/dep-cjs': {}
-
-  '@vitest/test-dep-conditions-indirect@file:test/config/deps/test-dep-conditions-indirect': {}
-
-  '@vitest/test-dep-conditions@file:test/config/deps/test-dep-conditions':
-    dependencies:
-      '@vitest/test-dep-conditions-indirect': file:test/config/deps/test-dep-conditions-indirect
 
   '@vitest/test-dep-nested-cjs@file:test/core/deps/dep-nested-cjs': {}
 
@@ -18518,6 +18512,12 @@ snapshots:
       acorn: 8.11.3(patch_hash=62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4)
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  test-dep-conditions-indirect@file:test/config/deps/test-dep-conditions-indirect: {}
+
+  test-dep-conditions@file:test/config/deps/test-dep-conditions:
+    dependencies:
+      test-dep-conditions-indirect: file:test/config/deps/test-dep-conditions-indirect
 
   text-decoder@1.1.1:
     dependencies:

--- a/test/config/deps/test-dep-conditions-indirect/package.json
+++ b/test/config/deps/test-dep-conditions-indirect/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/test-dep-conditions-indirect",
+  "name": "test-dep-conditions-indirect",
   "type": "module",
   "private": true,
   "exports": {

--- a/test/config/deps/test-dep-conditions/indirect.js
+++ b/test/config/deps/test-dep-conditions/indirect.js
@@ -1,8 +1,8 @@
-import conditionCustom from '@vitest/test-dep-conditions-indirect/custom'
-import conditionDevelopment from '@vitest/test-dep-conditions-indirect/development'
-import conditionModule from '@vitest/test-dep-conditions-indirect/module'
-import conditionNode from '@vitest/test-dep-conditions-indirect/node'
-import conditionProductioin from '@vitest/test-dep-conditions-indirect/production'
+import conditionCustom from 'test-dep-conditions-indirect/custom'
+import conditionDevelopment from 'test-dep-conditions-indirect/development'
+import conditionModule from 'test-dep-conditions-indirect/module'
+import conditionNode from 'test-dep-conditions-indirect/node'
+import conditionProductioin from 'test-dep-conditions-indirect/production'
 
 export default {
   conditionCustom,

--- a/test/config/deps/test-dep-conditions/package.json
+++ b/test/config/deps/test-dep-conditions/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitest/test-dep-conditions",
+  "name": "test-dep-conditions",
   "type": "module",
   "private": true,
   "exports": {
@@ -27,6 +27,6 @@
     "./indirect": "./indirect.js"
   },
   "dependencies": {
-    "@vitest/test-dep-conditions-indirect": "file:../test-dep-conditions-indirect"
+    "test-dep-conditions-indirect": "file:../test-dep-conditions-indirect"
   }
 }

--- a/test/config/fixtures/conditions-projects/project-a/basic.test.js
+++ b/test/config/fixtures/conditions-projects/project-a/basic.test.js
@@ -1,0 +1,37 @@
+import { test, expect } from "vitest";
+import conditionCustom from "@vitest/test-dep-conditions/custom";
+import conditionModule from "@vitest/test-dep-conditions/module";
+import conditionNode from "@vitest/test-dep-conditions/node";
+import conditionDevelopment from "@vitest/test-dep-conditions/development";
+import conditionProduction from "@vitest/test-dep-conditions/production";
+import inline from "@vitest/test-dep-conditions/inline";
+import indirect from "@vitest/test-dep-conditions/indirect";
+
+import { viteVersion } from "vitest/node";
+const viteMajor = Number(viteVersion.split(".")[0]);
+
+test("conditions", () => {
+  expect({
+    inline,
+    conditionCustom,
+    conditionModule,
+    conditionNode,
+    conditionDevelopment,
+    conditionProduction,
+    indirect,
+  }).toEqual({
+    inline: false,
+    conditionCustom: true,
+    conditionDevelopment: true,
+    conditionModule: viteMajor <= 5,
+    conditionNode: true,
+    conditionProduction: false,
+    indirect: {
+      conditionCustom: true,
+      conditionDevelopment: true,
+      conditionModule: viteMajor <= 5 && inline,
+      conditionNode: true,
+      conditionProductioin: false,
+    },
+  });
+});

--- a/test/config/fixtures/conditions-projects/project-a/basic.test.js
+++ b/test/config/fixtures/conditions-projects/project-a/basic.test.js
@@ -1,11 +1,11 @@
 import { test, expect } from "vitest";
-import conditionCustom from "@vitest/test-dep-conditions/custom";
-import conditionModule from "@vitest/test-dep-conditions/module";
-import conditionNode from "@vitest/test-dep-conditions/node";
-import conditionDevelopment from "@vitest/test-dep-conditions/development";
-import conditionProduction from "@vitest/test-dep-conditions/production";
-import inline from "@vitest/test-dep-conditions/inline";
-import indirect from "@vitest/test-dep-conditions/indirect";
+import conditionCustom from "test-dep-conditions/custom";
+import conditionModule from "test-dep-conditions/module";
+import conditionNode from "test-dep-conditions/node";
+import conditionDevelopment from "test-dep-conditions/development";
+import conditionProduction from "test-dep-conditions/production";
+import inline from "test-dep-conditions/inline";
+import indirect from "test-dep-conditions/indirect";
 
 import { viteVersion } from "vitest/node";
 const viteMajor = Number(viteVersion.split(".")[0]);

--- a/test/config/fixtures/conditions-projects/project-a/vitest.config.ts
+++ b/test/config/fixtures/conditions-projects/project-a/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  define: {
+    "import.meta.__IS_INLINE__": "true",
+  },
+  ssr: {
+    resolve: {
+      conditions: ["custom"],
+    },
+  },
+});

--- a/test/config/fixtures/conditions-projects/project-a/vitest.config.ts
+++ b/test/config/fixtures/conditions-projects/project-a/vitest.config.ts
@@ -1,3 +1,4 @@
+import { defaultServerConditions } from "vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -6,7 +7,7 @@ export default defineConfig({
   },
   ssr: {
     resolve: {
-      conditions: ["custom"],
+      conditions: ["custom", ...defaultServerConditions.filter((c) => c !== "module")],
     },
   },
 });

--- a/test/config/fixtures/conditions-projects/project-b/basic.test.js
+++ b/test/config/fixtures/conditions-projects/project-b/basic.test.js
@@ -1,11 +1,11 @@
 import { test, expect } from "vitest";
-import conditionCustom from "@vitest/test-dep-conditions/custom";
-import conditionModule from "@vitest/test-dep-conditions/module";
-import conditionNode from "@vitest/test-dep-conditions/node";
-import conditionDevelopment from "@vitest/test-dep-conditions/development";
-import conditionProduction from "@vitest/test-dep-conditions/production";
-import inline from "@vitest/test-dep-conditions/inline";
-import indirect from "@vitest/test-dep-conditions/indirect";
+import conditionCustom from "test-dep-conditions/custom";
+import conditionModule from "test-dep-conditions/module";
+import conditionNode from "test-dep-conditions/node";
+import conditionDevelopment from "test-dep-conditions/development";
+import conditionProduction from "test-dep-conditions/production";
+import inline from "test-dep-conditions/inline";
+import indirect from "test-dep-conditions/indirect";
 
 import { viteVersion } from "vitest/node";
 const viteMajor = Number(viteVersion.split(".")[0]);

--- a/test/config/fixtures/conditions-projects/project-b/basic.test.js
+++ b/test/config/fixtures/conditions-projects/project-b/basic.test.js
@@ -1,0 +1,37 @@
+import { test, expect } from "vitest";
+import conditionCustom from "@vitest/test-dep-conditions/custom";
+import conditionModule from "@vitest/test-dep-conditions/module";
+import conditionNode from "@vitest/test-dep-conditions/node";
+import conditionDevelopment from "@vitest/test-dep-conditions/development";
+import conditionProduction from "@vitest/test-dep-conditions/production";
+import inline from "@vitest/test-dep-conditions/inline";
+import indirect from "@vitest/test-dep-conditions/indirect";
+
+import { viteVersion } from "vitest/node";
+const viteMajor = Number(viteVersion.split(".")[0]);
+
+test("conditions", () => {
+  expect({
+    inline,
+    conditionCustom,
+    conditionModule,
+    conditionNode,
+    conditionDevelopment,
+    conditionProduction,
+    indirect,
+  }).toEqual({
+    inline: false,
+    conditionCustom: false,
+    conditionDevelopment: true,
+    conditionModule: viteMajor <= 5,
+    conditionNode: true,
+    conditionProduction: false,
+    indirect: {
+      conditionCustom: false,
+      conditionDevelopment: true,
+      conditionModule: viteMajor <= 5 && inline,
+      conditionNode: true,
+      conditionProductioin: false,
+    },
+  });
+});

--- a/test/config/fixtures/conditions-projects/project-b/vitest.config.ts
+++ b/test/config/fixtures/conditions-projects/project-b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  define: {
+    "import.meta.__IS_INLINE__": "true",
+  },
+});

--- a/test/config/fixtures/conditions-projects/vite.config.ts
+++ b/test/config/fixtures/conditions-projects/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: ["project-a", "project-b"],
+  },
+});

--- a/test/config/fixtures/conditions/basic.test.js
+++ b/test/config/fixtures/conditions/basic.test.js
@@ -1,11 +1,11 @@
 import { test, expect } from 'vitest';
-import conditionCustom from '@vitest/test-dep-conditions/custom';
-import conditionModule from '@vitest/test-dep-conditions/module';
-import conditionNode from '@vitest/test-dep-conditions/node';
-import conditionDevelopment from '@vitest/test-dep-conditions/development';
-import conditionProduction from '@vitest/test-dep-conditions/production';
-import inline from '@vitest/test-dep-conditions/inline';
-import indirect from '@vitest/test-dep-conditions/indirect';
+import conditionCustom from 'test-dep-conditions/custom';
+import conditionModule from 'test-dep-conditions/module';
+import conditionNode from 'test-dep-conditions/node';
+import conditionDevelopment from 'test-dep-conditions/development';
+import conditionProduction from 'test-dep-conditions/production';
+import inline from 'test-dep-conditions/inline';
+import indirect from 'test-dep-conditions/indirect';
 
 import { viteVersion } from 'vitest/node'
 const viteMajor = Number(viteVersion.split('.')[0])

--- a/test/config/package.json
+++ b/test/config/package.json
@@ -11,12 +11,12 @@
     "@vitest/browser-playwright": "workspace:*",
     "@vitest/browser-preview": "workspace:*",
     "@vitest/browser-webdriverio": "workspace:*",
-    "@vitest/test-dep-conditions": "file:./deps/test-dep-conditions",
     "@vitest/test-dep-optimizer-external": "file:./deps/optimizer/external",
     "@vitest/test-dep-optimizer-optimized": "file:./deps/optimizer/optimized",
     "inline-dep": "file:./deps/vite-ssr-resolve/inline-dep",
     "other-dep": "file:./deps/vite-ssr-resolve/other-dep",
     "ssr-no-external-dep": "file:./deps/vite-ssr-resolve/ssr-no-external-dep",
+    "test-dep-conditions": "file:./deps/test-dep-conditions",
     "tinyexec": "^1.0.2",
     "vite": "latest",
     "vitest": "workspace:*"

--- a/test/config/test/conditions-cli.test.ts
+++ b/test/config/test/conditions-cli.test.ts
@@ -82,7 +82,7 @@ test('conditions (inline direct)', async () => {
     root: 'fixtures/conditions',
     server: {
       deps: {
-        inline: ['@vitest/test-dep-conditions'],
+        inline: ['test-dep-conditions'],
       },
     },
   })
@@ -95,7 +95,7 @@ test('conditions (inline indirect)', async () => {
     root: 'fixtures/conditions',
     server: {
       deps: {
-        inline: ['@vitest/test-dep-conditions', '@vitest/test-dep-conditions-indirect'],
+        inline: ['test-dep-conditions', 'test-dep-conditions-indirect'],
       },
     },
   })
@@ -107,45 +107,12 @@ test('project resolve.conditions', async () => {
   const { stderr, errorProjectTree } = await runVitest({
     root: 'fixtures/conditions-projects',
   })
-  expect(stderr).toMatchInlineSnapshot(`
-    "
-    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
-
-     FAIL  |project-a| basic.test.js > conditions
-    AssertionError: expected { inline: false, …(6) } to deeply equal { inline: false, …(6) }
-
-    - Expected
-    + Received
-
-    @@ -1,7 +1,7 @@
-      {
-    -   "conditionCustom": true,
-    +   "conditionCustom": false,
-        "conditionDevelopment": true,
-        "conditionModule": false,
-        "conditionNode": true,
-        "conditionProduction": false,
-        "indirect": {
-
-     ❯ basic.test.js:22:6
-         20|     conditionProduction,
-         21|     indirect,
-         22|   }).toEqual({
-           |      ^
-         23|     inline: false,
-         24|     conditionCustom: true,
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
-
-    "
-  `)
+  expect(stderr).toBe('')
   expect(errorProjectTree()).toMatchInlineSnapshot(`
     {
       "project-a": {
         "basic.test.js": {
-          "conditions": [
-            "expected { inline: false, …(6) } to deeply equal { inline: false, …(6) }",
-          ],
+          "conditions": "passed",
         },
       },
       "project-b": {

--- a/test/config/test/conditions-cli.test.ts
+++ b/test/config/test/conditions-cli.test.ts
@@ -102,3 +102,64 @@ test('conditions (inline indirect)', async () => {
 
   expect(stderr).toBe('')
 })
+
+test('project resolve.conditions', async () => {
+  const { stderr, errorProjectTree } = await runVitest({
+    root: 'fixtures/conditions-projects',
+  })
+  expect(stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  |project-a| basic.test.js > conditions
+    AssertionError: expected { inline: false, …(6) } to deeply equal { inline: false, …(6) }
+
+    - Expected
+    + Received
+
+    @@ -1,13 +1,13 @@
+      {
+    -   "conditionCustom": true,
+    +   "conditionCustom": false,
+        "conditionDevelopment": true,
+        "conditionModule": false,
+        "conditionNode": true,
+        "conditionProduction": false,
+        "indirect": {
+    -     "conditionCustom": true,
+    +     "conditionCustom": false,
+          "conditionDevelopment": true,
+          "conditionModule": false,
+          "conditionNode": true,
+          "conditionProductioin": false,
+        },
+
+     ❯ basic.test.js:22:6
+         20|     conditionProduction,
+         21|     indirect,
+         22|   }).toEqual({
+           |      ^
+         23|     inline: false,
+         24|     conditionCustom: true,
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+    "
+  `)
+  expect(errorProjectTree()).toMatchInlineSnapshot(`
+    {
+      "project-a": {
+        "basic.test.js": {
+          "conditions": [
+            "expected { inline: false, …(6) } to deeply equal { inline: false, …(6) }",
+          ],
+        },
+      },
+      "project-b": {
+        "basic.test.js": {
+          "conditions": "passed",
+        },
+      },
+    }
+  `)
+})

--- a/test/config/test/conditions-cli.test.ts
+++ b/test/config/test/conditions-cli.test.ts
@@ -117,7 +117,7 @@ test('project resolve.conditions', async () => {
     - Expected
     + Received
 
-    @@ -1,13 +1,13 @@
+    @@ -1,7 +1,7 @@
       {
     -   "conditionCustom": true,
     +   "conditionCustom": false,
@@ -126,13 +126,6 @@ test('project resolve.conditions', async () => {
         "conditionNode": true,
         "conditionProduction": false,
         "indirect": {
-    -     "conditionCustom": true,
-    +     "conditionCustom": false,
-          "conditionDevelopment": true,
-          "conditionModule": false,
-          "conditionNode": true,
-          "conditionProductioin": false,
-        },
 
      ❯ basic.test.js:22:6
          20|     conditionProduction,

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -243,6 +243,9 @@ export async function runVitest(
     errorTree() {
       return buildErrorTree(ctx?.state.getTestModules() || [])
     },
+    errorProjectTree() {
+      return buildErrorProjectTree(ctx?.state.getTestModules() || [])
+    },
     testTree() {
       return buildTestTree(ctx?.state.getTestModules() || [])
     },
@@ -639,6 +642,20 @@ export function buildTestProjectTree(testModules: TestModule[], onTestCase?: (re
     projectTree[projectName] = {
       ...projectTree[projectName],
       ...buildTestTree([testModule], onTestCase),
+    }
+  }
+
+  return projectTree
+}
+
+export function buildErrorProjectTree(testModules: TestModule[]) {
+  const projectTree: Record<string, Record<string, any>> = {}
+
+  for (const testModule of testModules) {
+    const projectName = testModule.project.name
+    projectTree[projectName] = {
+      ...projectTree[projectName],
+      ...buildErrorTree([testModule]),
     }
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/5301

Thanks to the pool rewrite, it's now possible to configure `resolve.conditions → execArgv --conditions` per project.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
