### PR TITLE
fix(reporters): prevent yellow dots in dot reporter when all tests pass

### DIFF
--- a/packages/vitest/src/node/reporters/dot.ts
+++ b/packages/vitest/src/node/reporters/dot.ts
@@ -45,6 +45,7 @@ export class DotReporter extends BaseReporter {
 
   onWatcherRerun(files: string[], trigger?: string): void {
     this.tests.clear()
+    this.finishedTests.clear()
     this.renderer?.start()
     super.onWatcherRerun(files, trigger)
   }
@@ -111,7 +112,7 @@ export class DotReporter extends BaseReporter {
       return
     }
 
-    const finishedTests = Array.from(this.tests).filter(entry => entry[1] !== 'pending')
+    const finishedTests = Array.from(this.tests).filter(([id]) => this.finishedTests.has(id))
 
     if (finishedTests.length < columns) {
       return
@@ -178,14 +179,18 @@ function formatTests(states: TestCaseState[]): string {
       continue
     }
 
-    output += currentIcon.color(currentIcon.char.repeat(count))
+    if (count > 0) {
+      output += currentIcon.color(currentIcon.char.repeat(count))
+    }
 
     // Start tracking new group
     count = 1
     currentIcon = icon
   }
 
-  output += currentIcon.color(currentIcon.char.repeat(count))
+  if (count > 0) {
+    output += currentIcon.color(currentIcon.char.repeat(count))
+  }
 
   return output
 }


### PR DESCRIPTION
Fixes #9681

The dot reporter had two bugs:

1. In `onTestModuleEnd`, it filtered finished tests by checking `state !== 'pending'`. This incorrectly included tests in 'run' state (which haven't finished yet). The fix checks against the `finishedTests` Set instead.

2. In `onWatcherRerun`, the `finishedTests` Set wasn't cleared, causing issues with test tracking across watch reloads. Added `this.finishedTests.clear()` to fix this.

3. In `formatTests`, empty groups with count=0 were still being formatted, causing empty yellow ANSI escape sequences. Added checks to skip formatting when count is 0.

The result: all dots now correctly display green when tests pass, with no spurious yellow dots remaining.