### PR TITLE
fix(bench): avoid printing results twice when bench is not wrapped in describe

### DIFF
--- a/test/cli/fixtures/benchmarking/top-level/base.bench.ts
+++ b/test/cli/fixtures/benchmarking/top-level/base.bench.ts
@@ -1,0 +1,5 @@
+import { bench } from "vitest";
+
+bench('top-level-bench', () => {
+  1+1;
+})

--- a/test/cli/test/benchmarking.test.ts
+++ b/test/cli/test/benchmarking.test.ts
@@ -183,3 +183,12 @@ it('basic', { timeout: 60_000 }, async () => {
     ]
   `)
 })
+
+// https://github.com/vitest-dev/vitest/issues/9718
+it('top level bench should print result once', async () => {
+  const root = pathe.join(import.meta.dirname, '../fixtures/benchmarking/top-level')
+  const { stdout } = await runVitest({ root }, [], { mode: 'benchmark' })
+
+  const occurrences = stdout.split('\n').filter(l => /✓\s+base\.bench\.ts/.test(l)).length
+  expect(occurrences).toBe(1)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Ensures each benchmark (top-level or described) prints results exactly once.

Resolves #9718 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
