### PR TITLE
fix: cancelling should stop current test immediately

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -349,7 +349,7 @@ This makes this method very slow, unless you disable isolation before collecting
 function cancelCurrentRun(reason: CancelReason): Promise<void>
 ```
 
-This method will gracefully cancel all ongoing tests. It will wait for started tests to finish running and will not run tests that were scheduled to run but haven't started yet.
+This method will gracefully cancel all ongoing tests. It will stop the on-going tests and will not run tests that were scheduled to run but haven't started yet.
 
 ## setGlobalTestNamePattern
 

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -825,7 +825,7 @@ function markPendingTasksAsSkipped(suite: Suite, runner: VitestRunner, note?: st
     if (!t.result || t.result.state === 'run') {
       t.mode = 'skip'
       t.result = { ...t.result, state: 'skip', note }
-      updateTask('test-finished', t, runner)
+      updateTask('test-cancel', t, runner)
     }
 
     if (t.type === 'suite') {

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -792,6 +792,12 @@ function failTask(result: TaskResult, err: unknown, diffOptions: DiffOptions | u
     return
   }
 
+  if (err instanceof TestRunAbortError) {
+    result.state = 'skip'
+    result.note = err.message
+    return
+  }
+
   result.state = 'fail'
   const errors = Array.isArray(err) ? err : [err]
   for (const e of errors) {
@@ -810,6 +816,20 @@ function markTasksAsSkipped(suite: Suite, runner: VitestRunner) {
     updateTask('test-finished', t, runner)
     if (t.type === 'suite') {
       markTasksAsSkipped(t, runner)
+    }
+  })
+}
+
+function markPendingTasksAsSkipped(suite: Suite, runner: VitestRunner, note?: string) {
+  suite.tasks.forEach((t) => {
+    if (!t.result || t.result.state === 'run') {
+      t.mode = 'skip'
+      t.result = { ...t.result, state: 'skip', note }
+      updateTask('test-finished', t, runner)
+    }
+
+    if (t.type === 'suite') {
+      markPendingTasksAsSkipped(t, runner, note)
     }
   })
 }
@@ -1028,8 +1048,10 @@ export async function startTests(specs: string[] | FileSpecification[], runner: 
   runner.cancel = (reason) => {
     // We intentionally create only one error since there is only one test run that can be cancelled
     const error = new TestRunAbortError('The test run was aborted by the user.', reason)
-    getRunningTests().forEach(test =>
-      abortContextSignal(test.context, error),
+    getRunningTests().forEach((test) => {
+      abortContextSignal(test.context, error)
+      markPendingTasksAsSkipped(test.file, runner, error.message)
+    },
     )
     return cancel?.(reason)
   }

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -32,6 +32,7 @@ import {
   collectTask,
   createTestContext,
   runWithSuite,
+  withCancel,
   withTimeout,
 } from './context'
 import { configureProps, TestFixtures, withFixtures } from './fixture'
@@ -412,7 +413,7 @@ function createSuiteCollector(
       setFn(
         task,
         withTimeout(
-          withAwaitAsyncAssertions(withFixtures(handler, { context }), task),
+          withCancel(withAwaitAsyncAssertions(withFixtures(handler, { context }), task), task.context.signal),
           timeout,
           false,
           stackTraceError,

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -259,6 +259,7 @@ export type TaskUpdateEvent
     | 'test-prepare'
     | 'test-finished'
     | 'test-retried'
+    | 'test-cancel'
     | 'suite-prepare'
     | 'suite-finished'
     | 'before-hook-start'

--- a/packages/vitest/src/node/test-run.ts
+++ b/packages/vitest/src/node/test-run.ts
@@ -232,6 +232,11 @@ export class TestRun {
       return
     }
 
+    if (event === 'test-cancel' && entity.type === 'test') {
+      // This is used to just update state of the task
+      return
+    }
+
     if (event === 'test-prepare' && entity.type === 'test') {
       return await this.vitest.report('onTestCaseReady', entity)
     }

--- a/test/cli/fixtures/cancel-run/blocked-test-cases.test.ts
+++ b/test/cli/fixtures/cancel-run/blocked-test-cases.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, test } from 'vitest'
+
+afterEach(async (context) => {
+  (context.task.meta as any).afterEachDone = true
+})
+
+describe('these should pass', () => {
+  test('one', async () => {})
+  test('two', async () => {})
+})
+
+test('this test starts and gets cancelled, its after each should be called', async ({ annotate }) => {
+  await annotate('Running long test, do the cancelling now!')
+
+  await new Promise(resolve => setTimeout(resolve, 100_000))
+})
+
+describe('these should not start but should be skipped', () => {
+  test('third, no after each expected', async () => {})
+
+  describe("nested", () => {
+    test('fourth, no after each expected', async () => {})
+  });
+})
+
+test('fifth, no after each expected', async () => {})

--- a/test/cli/fixtures/cancel-run/blocked-thread.test.ts
+++ b/test/cli/fixtures/cancel-run/blocked-thread.test.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'node:child_process'
+import { test } from 'vitest'
+
+test('block whole test runner thread/process', { timeout: 30_000 }, async () => {
+  // Note that this can also block the RPC before onTestCaseReady is emitted to main thread
+  execSync("sleep 40")
+})

--- a/test/cli/fixtures/cancel-run/slow-timeouting.test.ts
+++ b/test/cli/fixtures/cancel-run/slow-timeouting.test.ts
@@ -1,6 +1,0 @@
-import { test } from 'vitest'
-
-test('slow timeouting test', { timeout: 30_000 }, async () => {
-  console.log("Running slow timeouting test")
-  await new Promise(resolve => setTimeout(resolve, 40_000))
-})

--- a/test/cli/test/cancel-run.test.ts
+++ b/test/cli/test/cancel-run.test.ts
@@ -1,10 +1,13 @@
+import type { TestModule } from 'vitest/node'
 import { Readable, Writable } from 'node:stream'
 import { stripVTControlCharacters } from 'node:util'
 import { createDefer } from '@vitest/utils/helpers'
 import { expect, onTestFinished, test, vi } from 'vitest'
 import { createVitest, registerConsoleShortcuts } from 'vitest/node'
 
-test('can force cancel a run', async () => {
+const CTRL_C = '\x03'
+
+test('can force cancel a run via CLI', { timeout: 5_000 }, async () => {
   const onExit = vi.fn<never>()
   const exit = process.exit
   onTestFinished(() => {
@@ -12,10 +15,11 @@ test('can force cancel a run', async () => {
   })
   process.exit = onExit
 
-  const onTestCaseReady = createDefer<void>()
+  const onTestModuleStart = createDefer<void>()
   const vitest = await createVitest('test', {
     root: 'fixtures/cancel-run',
-    reporters: [{ onTestCaseReady: () => onTestCaseReady.resolve() }],
+    include: ['blocked-thread.test.ts'],
+    reporters: [{ onTestModuleStart: () => onTestModuleStart.resolve() }],
   })
   onTestFinished(() => vitest.close())
 
@@ -27,17 +31,99 @@ test('can force cancel a run', async () => {
   const onLog = vi.spyOn(vitest.logger, 'log').mockImplementation(() => {})
   const promise = vitest.start()
 
-  await onTestCaseReady
+  await onTestModuleStart
 
   // First CTRL+c should log warning about graceful exit
-  stdin.emit('data', '\x03')
+  stdin.emit('data', CTRL_C)
+
+  // Let the test case start running
+  await new Promise(resolve => setTimeout(resolve, 100))
 
   const logs = onLog.mock.calls.map(log => stripVTControlCharacters(log[0] || '').trim())
   expect(logs).toContain('Cancelling test run. Press CTRL+c again to exit forcefully.')
 
   // Second CTRL+c should stop run
-  stdin.emit('data', '\x03')
+  stdin.emit('data', CTRL_C)
   await promise
 
   expect(onExit).toHaveBeenCalled()
+})
+
+test('cancelling test run stops test execution immediately', async () => {
+  const onTestRunEnd = createDefer<readonly TestModule[]>()
+  const onTestCaseReady = createDefer<void>()
+
+  const vitest = await createVitest('test', {
+    root: 'fixtures/cancel-run',
+    include: ['blocked-test-cases.test.ts'],
+    reporters: [{
+      onTestCaseAnnotate: (_, annotation) => {
+        if (annotation.message === 'Running long test, do the cancelling now!') {
+          onTestCaseReady.resolve()
+        }
+      },
+      onTestRunEnd(testModules) {
+        onTestRunEnd.resolve(testModules)
+      },
+    }],
+  })
+  onTestFinished(() => vitest.close())
+
+  const promise = vitest.start()
+
+  await onTestCaseReady
+  await vitest.cancelCurrentRun('keyboard-input')
+
+  const testModules = await onTestRunEnd
+  await Promise.all([vitest.close(), promise])
+
+  expect(testModules).toHaveLength(1)
+
+  const tests = Array.from(testModules[0].children.allTests().map(test => ({
+    name: test.name,
+    status: test.result().state,
+    note: (test.result() as any).note,
+    afterEachRun: (test.meta() as any).afterEachDone === true,
+  })))
+
+  expect(tests).toMatchInlineSnapshot(`
+    [
+      {
+        "afterEachRun": true,
+        "name": "one",
+        "note": undefined,
+        "status": "passed",
+      },
+      {
+        "afterEachRun": true,
+        "name": "two",
+        "note": undefined,
+        "status": "passed",
+      },
+      {
+        "afterEachRun": true,
+        "name": "this test starts and gets cancelled, its after each should be called",
+        "note": "The test run was aborted by the user.",
+        "status": "skipped",
+      },
+      {
+        "afterEachRun": false,
+        "name": "third, no after each expected",
+        "note": "The test run was aborted by the user.",
+        "status": "skipped",
+      },
+      {
+        "afterEachRun": false,
+        "name": "fourth, no after each expected",
+        "note": "The test run was aborted by the user.",
+        "status": "skipped",
+      },
+      {
+        "afterEachRun": false,
+        "name": "fifth, no after each expected",
+        "note": "The test run was aborted by the user.",
+        "status": "skipped",
+      },
+    ]
+  `)
 })

--- a/test/cli/test/cancel-run.test.ts
+++ b/test/cli/test/cancel-run.test.ts
@@ -7,7 +7,7 @@ import { createVitest, registerConsoleShortcuts } from 'vitest/node'
 
 const CTRL_C = '\x03'
 
-test('can force cancel a run via CLI', { timeout: 5_000 }, async () => {
+test('can force cancel a run via CLI', async () => {
   const onExit = vi.fn<never>()
   const exit = process.exit
   onTestFinished(() => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Speeds up test cancellation by doing similar test function rejection as timeout errors do.

For Node API users this is essential, as they cannot do forceful test cancellation without shutting down whole process.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
