### PR TITLE
docs: add Vite and Node.js prerequisites to Vitest 4 migration guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -7,6 +7,13 @@ outline: deep
 
 ## Migrating to Vitest 4.0 {#vitest-4}
 
+::: warning Prerequisites
+Vitest 4.0 requires **Vite >= 6.0.0** and **Node.js >= 20.0.0**. Before proceeding
+with any other migration steps, ensure your environment meets these requirements.
+Running Vitest 4.0 on older versions of Vite or Node.js is not supported and may
+result in unexpected errors.
+:::
+
 ### V8 Code Coverage Major Changes
 
 Vitest's V8 code coverage provider is now using more accurate coverage result remapping logic.


### PR DESCRIPTION
### Description

The Vitest 4.0 migration guide doesn't mention upfront that Vite >= 6.0.0 and Node.js >= 20.0.0 are required. Users can work through the entire migration only to hit compatibility errors at build time.

This PR adds a warning callout at the top of the Vitest 4 migration section so the environment requirements are visible before anyone starts.

Resolves #9646

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.