### PR TITLE
fix(browser): make sure userEvent actions support `ensureAwaited`

### DIFF
--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -51,10 +51,10 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     setup() {
       return createUserEvent()
     },
-    async cleanup() {
+    cleanup() {
       // avoid cleanup rpc call if there is nothing to cleanup
       if (!keyboard.unreleased.length) {
-        return
+        return Promise.resolve()
       }
       return ensureAwaited(async (error) => {
         await triggerCommand('__vitest_cleanup', [keyboard], error)
@@ -100,7 +100,7 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     },
 
     // testing-library user-event
-    async type(element, text, options) {
+    type(element, text, options) {
       return ensureAwaited(async (error) => {
         const selector = await convertToSelector(element, options)
         const { unreleased } = await triggerCommand<{ unreleased: string[] }>(
@@ -118,7 +118,7 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
     tab(options = {}) {
       return ensureAwaited(error => triggerCommand('__vitest_tab', [options], error))
     },
-    async keyboard(text) {
+    keyboard(text) {
       return ensureAwaited(async (error) => {
         const { unreleased } = await triggerCommand<{ unreleased: string[] }>(
           '__vitest_keyboard',
@@ -128,14 +128,14 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
         keyboard.unreleased = unreleased
       })
     },
-    async copy() {
-      await userEvent.keyboard(`{${modifier}>}{c}{/${modifier}}`)
+    copy() {
+      return userEvent.keyboard(`{${modifier}>}{c}{/${modifier}}`)
     },
-    async cut() {
-      await userEvent.keyboard(`{${modifier}>}{x}{/${modifier}}`)
+    cut() {
+      return userEvent.keyboard(`{${modifier}>}{x}{/${modifier}}`)
     },
-    async paste() {
-      await userEvent.keyboard(`{${modifier}>}{v}{/${modifier}}`)
+    paste() {
+      return userEvent.keyboard(`{${modifier}>}{v}{/${modifier}}`)
     },
   }
   return userEvent

--- a/packages/browser/src/client/tester/locators/index.ts
+++ b/packages/browser/src/client/tester/locators/index.ts
@@ -135,7 +135,7 @@ export abstract class Locator {
     return this.triggerCommand<void>('__vitest_fill', this.selector, text, options)
   }
 
-  public async upload(files: string | string[] | File | File[], options?: UserEventUploadOptions): Promise<void> {
+  public upload(files: string | string[] | File | File[], options?: UserEventUploadOptions): Promise<void> {
     return ensureAwaited(async (error) => {
       const filesPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
         if (typeof file === 'string') {

--- a/test/browser/fixtures/failing/failing.test.ts
+++ b/test/browser/fixtures/failing/failing.test.ts
@@ -1,4 +1,4 @@
-import { page } from 'vitest/browser'
+import { page, userEvent } from 'vitest/browser'
 import { index } from '@vitest/bundled-lib'
 import { expect, it } from 'vitest'
 import { throwError } from './src/error'
@@ -19,6 +19,20 @@ it('several locator methods are not awaited', () => {
   page.getByRole('button').dblClick()
   page.getByRole('button').click()
   page.getByRole('button').tripleClick()
+  userEvent.type(page.getByRole('textbox'), '123')
+  userEvent.keyboard('123')
+  userEvent.copy()
+  userEvent.cut()
+  userEvent.paste()
+  userEvent.tab()
+  userEvent.dragAndDrop(page.getByRole('button'), page.getByRole('button'))
+  userEvent.fill(page.getByRole('textbox'), '123')
+  userEvent.upload(page.getByRole('textbox'), './file.js')
+  userEvent.unhover(page.getByRole('button'))
+  userEvent.hover(page.getByRole('button'))
+  userEvent.clear(page.getByRole('button'))
+  userEvent.selectOptions(page.getByRole('button'), '123')
+  userEvent.wheel(page.getByRole('button'), { direction: 'down' })
 })
 
 it('correctly prints error from a bundled file', () => {

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -208,7 +208,7 @@ error with a stack
 })
 
 test(`stack trace points to correct file in every browser when failed`, async () => {
-  expect.assertions(15)
+  expect.assertions(29)
   const { stderr } = await runBrowserTests({
     root: './fixtures/failing',
     reporters: [
@@ -252,12 +252,26 @@ test(`stack trace points to correct file in every browser when failed`, async ()
   expect(stderr).toMatch(/failing.test.ts:19:(27|36)/)
   expect(stderr).toMatch(/failing.test.ts:20:(27|33)/)
   expect(stderr).toMatch(/failing.test.ts:21:(27|39)/)
+  expect(stderr).toMatch(/failing.test.ts:22:(12|17)/)
+  expect(stderr).toMatch(/failing.test.ts:23:(12|21)/)
+  expect(stderr).toMatch(/failing.test.ts:24:(12|17)/)
+  expect(stderr).toMatch(/failing.test.ts:25:(12|16)/)
+  expect(stderr).toMatch(/failing.test.ts:26:(12|18)/)
+  expect(stderr).toMatch(/failing.test.ts:27:(12|16)/)
+  expect(stderr).toMatch(/failing.test.ts:28:(12|24)/)
+  expect(stderr).toMatch(/failing.test.ts:29:(12|17)/)
+  expect(stderr).toMatch(/failing.test.ts:30:(12|19)/)
+  expect(stderr).toMatch(/failing.test.ts:31:(12|20)/)
+  expect(stderr).toMatch(/failing.test.ts:32:(12|18)/)
+  expect(stderr).toMatch(/failing.test.ts:33:(12|18)/)
+  expect(stderr).toMatch(/failing.test.ts:34:(12|26)/)
+  expect(stderr).toMatch(/failing.test.ts:35:(12|18)/)
 
   expect(stderr).toMatch(/bundled-lib\/src\/b.js:2:(9|19)/)
   expect(stderr).toMatch(/bundled-lib\/src\/index.js:5:(16|18)/)
 
   // index() is called from a bundled file
-  expect(stderr).toMatch(/failing.test.ts:25:(2|8)/)
+  expect(stderr).toMatch(/failing.test.ts:39:(2|8)/)
 })
 
 test('user-event', async () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The function that returns `ensureAwaited` has to be sync, otherwise `then` is called automatically by JavaScript

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
