### PR TITLE
test: test oxc decorators and coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ui:build": "vite build packages/ui",
     "ui:dev": "npm -C packages/ui run dev:client",
     "ui:test": "npm -C packages/ui run test:run",
+    "override-rolldown": "yq -i '.overrides.vite = \"npm:vite@beta\"' pnpm-workspace.yaml",
     "test:browser:webdriverio": "pnpm -C test/browser run test:webdriverio",
     "test:browser:playwright": "pnpm -C test/browser run test:playwright"
   },

--- a/test/coverage-test/fixtures/configs/vitest.config.decorators.ts
+++ b/test/coverage-test/fixtures/configs/vitest.config.decorators.ts
@@ -7,7 +7,7 @@ import base from "./vitest.config";
 export default mergeConfig(
   base,
   defineConfig({
-    plugins: [DecoratorsPlugin()],
+    plugins: process.env.TEST_OXC_DECORATOR ? [] : [DecoratorsPlugin()],
     test: {},
   })
 );

--- a/test/coverage-test/test/decorators.test.ts
+++ b/test/coverage-test/test/decorators.test.ts
@@ -25,6 +25,7 @@ test('decorators generated metadata is ignored', async ({ onTestFinished }) => {
   expect.soft(lineCoverage['12']).toBe(0)
 
   if (rolldownVersion) {
+    // Test OXC decorator support
     vi.stubEnv('TEST_OXC_DECORATOR', 'true')
     onTestFinished(() => {
       vi.unstubAllEnvs()
@@ -41,7 +42,7 @@ test('decorators generated metadata is ignored', async ({ onTestFinished }) => {
     const lineCoverage = fileCoverage.getLineCoverage()
     const branchCoverage = fileCoverage.getBranchCoverageByLine()
 
-    expect.soft(lineCoverage['4']).toBeUndefined()
+    expect.soft(lineCoverage['4']).toBe(1) // this is different from SWC. This is fine since the whole line is covered.
     expect.soft(branchCoverage['4']).toBeUndefined()
 
     // Covered branch should be marked correctly

--- a/test/coverage-test/test/decorators.test.ts
+++ b/test/coverage-test/test/decorators.test.ts
@@ -1,8 +1,9 @@
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
+import { rolldownVersion } from 'vitest/node'
 import { DecoratorsTester } from '../fixtures/src/decorators'
 import { coverageTest, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
 
-test('decorators generated metadata is ignored', async () => {
+test('decorators generated metadata is ignored', async ({ onTestFinished }) => {
   await runVitest({
     include: [normalizeURL(import.meta.url)],
     config: 'fixtures/configs/vitest.config.decorators.ts',
@@ -14,14 +15,41 @@ test('decorators generated metadata is ignored', async () => {
   const lineCoverage = fileCoverage.getLineCoverage()
   const branchCoverage = fileCoverage.getBranchCoverageByLine()
 
-  expect(lineCoverage['4']).toBeUndefined()
-  expect(branchCoverage['4']).toBeUndefined()
+  expect.soft(lineCoverage['4']).toBeUndefined()
+  expect.soft(branchCoverage['4']).toBeUndefined()
 
   // Covered branch should be marked correctly
-  expect(lineCoverage['7']).toBe(1)
+  expect.soft(lineCoverage['7']).toBe(1)
 
   // Uncovered branch should be marked correctly
-  expect(lineCoverage['12']).toBe(0)
+  expect.soft(lineCoverage['12']).toBe(0)
+
+  if (rolldownVersion) {
+    vi.stubEnv('TEST_OXC_DECORATOR', 'true')
+    onTestFinished(() => {
+      vi.unstubAllEnvs()
+    })
+
+    await runVitest({
+      include: [normalizeURL(import.meta.url)],
+      config: 'fixtures/configs/vitest.config.decorators.ts',
+      coverage: { reporter: ['json', 'html'] },
+    })
+
+    const coverageMap = await readCoverageMap()
+    const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/decorators.ts')
+    const lineCoverage = fileCoverage.getLineCoverage()
+    const branchCoverage = fileCoverage.getBranchCoverageByLine()
+
+    expect.soft(lineCoverage['4']).toBeUndefined()
+    expect.soft(branchCoverage['4']).toBeUndefined()
+
+    // Covered branch should be marked correctly
+    expect.soft(lineCoverage['7']).toBe(1)
+
+    // Uncovered branch should be marked correctly
+    expect.soft(lineCoverage['12']).toBe(0)
+  }
 })
 
 coverageTest('cover decorators', () => {

--- a/test/coverage-test/test/decorators.test.ts
+++ b/test/coverage-test/test/decorators.test.ts
@@ -3,7 +3,7 @@ import { rolldownVersion } from 'vitest/node'
 import { DecoratorsTester } from '../fixtures/src/decorators'
 import { coverageTest, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
 
-test('decorators generated metadata is ignored', async ({ onTestFinished }) => {
+test('decorators generated metadata is ignored', async () => {
   await runVitest({
     include: [normalizeURL(import.meta.url)],
     config: 'fixtures/configs/vitest.config.decorators.ts',
@@ -23,34 +23,37 @@ test('decorators generated metadata is ignored', async ({ onTestFinished }) => {
 
   // Uncovered branch should be marked correctly
   expect.soft(lineCoverage['12']).toBe(0)
+})
 
-  if (rolldownVersion) {
-    // Test OXC decorator support
-    vi.stubEnv('TEST_OXC_DECORATOR', 'true')
-    onTestFinished(() => {
-      vi.unstubAllEnvs()
-    })
-
-    await runVitest({
-      include: [normalizeURL(import.meta.url)],
-      config: 'fixtures/configs/vitest.config.decorators.ts',
-      coverage: { reporter: ['json', 'html'] },
-    })
-
-    const coverageMap = await readCoverageMap()
-    const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/decorators.ts')
-    const lineCoverage = fileCoverage.getLineCoverage()
-    const branchCoverage = fileCoverage.getBranchCoverageByLine()
-
-    expect.soft(lineCoverage['4']).toBe(1) // this is different from SWC. This is fine since the whole line is covered.
-    expect.soft(branchCoverage['4']).toBeUndefined()
-
-    // Covered branch should be marked correctly
-    expect.soft(lineCoverage['7']).toBe(1)
-
-    // Uncovered branch should be marked correctly
-    expect.soft(lineCoverage['12']).toBe(0)
+test('decorators generated metadata is covered with OXC decorators', async ({ onTestFinished }) => {
+  if (!rolldownVersion) {
+    return
   }
+
+  vi.stubEnv('TEST_OXC_DECORATOR', 'true')
+  onTestFinished(() => {
+    vi.unstubAllEnvs()
+  })
+
+  await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    config: 'fixtures/configs/vitest.config.decorators.ts',
+    coverage: { reporter: ['json', 'html'] },
+  })
+
+  const coverageMap = await readCoverageMap()
+  const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/decorators.ts')
+  const lineCoverage = fileCoverage.getLineCoverage()
+  const branchCoverage = fileCoverage.getBranchCoverageByLine()
+
+  expect.soft(lineCoverage['4']).toBe(1) // this is different from SWC case above
+  expect.soft(branchCoverage['4']).toBeUndefined()
+
+  // Covered branch should be marked correctly
+  expect.soft(lineCoverage['7']).toBe(1)
+
+  // Uncovered branch should be marked correctly
+  expect.soft(lineCoverage['12']).toBe(0)
 })
 
 coverageTest('cover decorators', () => {


### PR DESCRIPTION
### Description

There's a coverage test using `swc.vite` for decorator. On Vite 8 with oxc, the same decorator feature is expected to available. So this PR tests that path. cc @Dunqing 

It's currently failing since Vitest coverage processing targets only `__ts_decorate` generated by swc as coverage exclusion. I'm not sure which side is supposed to what, so here this PR adds test cases to demonstrate current behavior.

Transform examples
- [swc](https://play.swc.rs/?version=1.15.13&code=H4sIAAAAAAAAA4WPQU7DQAxF9znF36UsRtkjRaoENwAOMJ35kBGJHY1dVIR6d5JAKxALFt68%2F%2Fwtdx1oYxEPuVg8jAzCk4eFEG7dIUpwC0mnieIIAabwITr8fWYamF6RlSato0gaj5ko3nQd9sua6GY0PM1aHWmMZrhn0hpdqz3SnBUfDTDRB827%2FYNOvAqYY41LwnqLNfChyMvN5gPlGbtrfoHAcvlO31iZsf7wTUV1%2FmFv9Nz87UHf92iPkr4q2l%2B9Txf8f%2FM6508dnvsfWwEAAA%3D%3D&config=H4sIAAAAAAAAA21Quw6DMAzc%2BQqUmblD5658hBUMSgVJZBuJCPHvdYJ4tGqGKHe%2BO9tZq7o2HGay2EJk86yFZmwy%2B2arcNWnAgEaUBQbZI%2BLmKbwWolAjHQqC8fJCyxZLSkiW3Lxcmi9QxsIJNC9YT7bGSsEnvtA03fyiAPY9Dr8P%2FZ7dIsCHQj861AuM4VuHvG2o866b%2Fgwl8h51yelexh5%2FxjH7eHMydX2ASZfbshFAQAA)
- [oxc](https://playground.oxc.rs/?options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Afalse%2C%22transform%22%3Atrue%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22node20%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=%2F%2F+eslint-disable-next-line+ts%2Fban-ts-comment+--+so+that+typecheck+doesn%27t+include+it%0A%2F%2F+%40ts-nocheck%0Aexport+class+DecoratorsTester+%7B%0A++method%28%40SomeDecorator+parameter%3A+Something%29+%7B%0A++++if+%28parameter%29+%7B%0A++++++%2F%2F+Covered+line%0A++++++noop%28parameter%29%0A++++%7D%0A%0A++++if+%28parameter+%3D%3D%3D+%27uncovered%27%29+%7B%0A++++++%2F%2F+Uncovered+line%0A++++++noop%28parameter%29%0A++++%7D%0A++%7D%0A%7D)
  - [sourcemap](https://evanw.github.io/source-map-visualization/#ODUxAGltcG9ydCBfZGVjb3JhdGVNZXRhZGF0YSBmcm9tICJAb3hjLXByb2plY3QvcnVudGltZS9oZWxwZXJzL2RlY29yYXRlTWV0YWRhdGEiOwppbXBvcnQgX2RlY29yYXRlUGFyYW0gZnJvbSAiQG94Yy1wcm9qZWN0L3J1bnRpbWUvaGVscGVycy9kZWNvcmF0ZVBhcmFtIjsKaW1wb3J0IF9kZWNvcmF0ZSBmcm9tICJAb3hjLXByb2plY3QvcnVudGltZS9oZWxwZXJzL2RlY29yYXRlIjsKdmFyIF9yZWY7Ci8vIGVzbGludC1kaXNhYmxlLW5leHQtbGluZSB0cy9iYW4tdHMtY29tbWVudCAtLSBzbyB0aGF0IHR5cGVjaGVjayBkb2Vzbid0IGluY2x1ZGUgaXQKLy8gQHRzLW5vY2hlY2sKZXhwb3J0IGNsYXNzIERlY29yYXRvcnNUZXN0ZXIgewoJbWV0aG9kKHBhcmFtZXRlcikgewoJCWlmIChwYXJhbWV0ZXIpIHsKCQkJLy8gQ292ZXJlZCBsaW5lCgkJCW5vb3AocGFyYW1ldGVyKTsKCQl9CgkJaWYgKHBhcmFtZXRlciA9PT0gInVuY292ZXJlZCIpIHsKCQkJLy8gVW5jb3ZlcmVkIGxpbmUKCQkJbm9vcChwYXJhbWV0ZXIpOwoJCX0KCX0KfQpfZGVjb3JhdGUoWwoJX2RlY29yYXRlUGFyYW0oMCwgU29tZURlY29yYXRvciksCglfZGVjb3JhdGVNZXRhZGF0YSgiZGVzaWduOnR5cGUiLCBGdW5jdGlvbiksCglfZGVjb3JhdGVNZXRhZGF0YSgiZGVzaWduOnBhcmFtdHlwZXMiLCBbdHlwZW9mIChfcmVmID0gdHlwZW9mIFNvbWV0aGluZyAhPT0gInVuZGVmaW5lZCIgJiYgU29tZXRoaW5nKSA9PT0gImZ1bmN0aW9uIiA/IF9yZWYgOiBPYmplY3RdKSwKCV9kZWNvcmF0ZU1ldGFkYXRhKCJkZXNpZ246cmV0dXJudHlwZSIsIHZvaWQgMCkKXSwgRGVjb3JhdG9yc1Rlc3Rlci5wcm90b3R5cGUsICJtZXRob2QiLCBudWxsKTsKNTc5AHsidmVyc2lvbiI6MywibmFtZXMiOltdLCJzb3VyY2VzIjpbInRlc3QudHN4Il0sInNvdXJjZXNDb250ZW50IjpbIi8vIGVzbGludC1kaXNhYmxlLW5leHQtbGluZSB0cy9iYW4tdHMtY29tbWVudCAtLSBzbyB0aGF0IHR5cGVjaGVjayBkb2Vzbid0IGluY2x1ZGUgaXRcbi8vIEB0cy1ub2NoZWNrXG5leHBvcnQgY2xhc3MgRGVjb3JhdG9yc1Rlc3RlciB7XG4gIG1ldGhvZChAU29tZURlY29yYXRvciBwYXJhbWV0ZXI6IFNvbWV0aGluZykge1xuICAgIGlmIChwYXJhbWV0ZXIpIHtcbiAgICAgIC8vIENvdmVyZWQgbGluZVxuICAgICAgbm9vcChwYXJhbWV0ZXIpXG4gICAgfVxuXG4gICAgaWYgKHBhcmFtZXRlciA9PT0gJ3VuY292ZXJlZCcpIHtcbiAgICAgIC8vIFVuY292ZXJlZCBsaW5lXG4gICAgICBub29wKHBhcmFtZXRlcilcbiAgICB9XG4gIH1cbn0iXSwibWFwcGluZ3MiOiI7Ozs7OztBQUVBLE9BQU8sTUFBTSxpQkFBaUI7Q0FDNUIsT0FBTyxBQUFlLFdBQXNCO0FBQzFDLE1BQUksV0FBVzs7QUFFYixRQUFLLFVBQVU7O0FBR2pCLE1BQUksY0FBYyxhQUFhOztBQUU3QixRQUFLLFVBQVU7Ozs7O21CQVJYLGNBQWEifQ==)

---

EDIT: The behavior difference turns out to be inessential, so the test is simply adjusted for oxc decorator case.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
