### PR TITLE
fix: make `mockObject` change backwards compatible

### DIFF
--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -114,7 +114,7 @@ export class ModuleMocker implements TestModuleMocker {
       const url = new URL(`/@id/${resolvedId}`, this.getBaseUrl())
       const query = url.search ? `${url.search}&t=${now()}` : `?t=${now()}`
       const moduleObject = await import(/* @vite-ignore */ `${url.pathname}${query}&mock=${mock.type}${url.hash}`)
-      return this.mockObject(moduleObject, undefined, mock.type) as T
+      return this.mockObject(moduleObject, mock.type) as T
     }
 
     return import(/* @vite-ignore */ mock.redirect)
@@ -122,9 +122,27 @@ export class ModuleMocker implements TestModuleMocker {
 
   public mockObject(
     object: Record<string | symbol, any>,
+    moduleType?: 'automock' | 'autospy',
+  ): Record<string | symbol, any>
+  public mockObject(
+    object: Record<string | symbol, any>,
     mockExports: Record<string | symbol, any> | undefined,
-    moduleType: 'automock' | 'autospy' = 'automock',
+    moduleType?: 'automock' | 'autospy',
+  ): Record<string | symbol, any>
+  public mockObject(
+    object: Record<string | symbol, any>,
+    mockExportsOrModuleType?: Record<string | symbol, any> | 'automock' | 'autospy',
+    moduleType?: 'automock' | 'autospy',
   ): Record<string | symbol, any> {
+    let mockExports: Record<string | symbol, any> | undefined
+    if (mockExportsOrModuleType === 'automock' || mockExportsOrModuleType === 'autospy') {
+      moduleType = mockExportsOrModuleType
+      mockExports = undefined
+    }
+    else {
+      mockExports = mockExportsOrModuleType
+    }
+    moduleType ??= 'automock'
     const result = mockObject(
       {
         globalConstructors: {

--- a/packages/mocker/src/node/automock.ts
+++ b/packages/mocker/src/node/automock.ts
@@ -191,7 +191,7 @@ const __vitest_current_es_module__ = {
   __esModule: true,
   ${allSpecifiers.map(({ name }) => `["${name}"]: ${name},`).join('\n  ')}
 }
-const __vitest_mocked_module__ = globalThis[${globalThisAccessor}].mockObject(__vitest_current_es_module__, undefined, "${mockType}")
+const __vitest_mocked_module__ = globalThis[${globalThisAccessor}].mockObject(__vitest_current_es_module__, "${mockType}")
 `
   const assigning = allSpecifiers
     .map(({ name }, index) => {

--- a/packages/mocker/src/types.ts
+++ b/packages/mocker/src/types.ts
@@ -46,8 +46,12 @@ export interface TestModuleMocker {
   importMock(rawId: string, importer: string): Promise<any>
   mockObject(
     object: Record<string | symbol, any>,
-    mockExports?: Record<string | symbol, any>,
-    behavior?: 'automock' | 'autospy',
+    moduleType?: 'automock' | 'autospy',
+  ): Record<string | symbol, any>
+  mockObject(
+    object: Record<string | symbol, any>,
+    mockExports: Record<string | symbol, any> | undefined,
+    moduleType?: 'automock' | 'autospy',
   ): Record<string | symbol, any>
   getMockContext(): ModuleMockContext
   reset(): void

--- a/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
+++ b/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
@@ -198,9 +198,27 @@ export class BareModuleMocker implements TestModuleMocker {
 
   public mockObject(
     object: Record<string | symbol, any>,
-    mockExports: Record<string | symbol, any> = {},
-    behavior: 'automock' | 'autospy' = 'automock',
+    moduleType?: 'automock' | 'autospy',
+  ): Record<string | symbol, any>
+  public mockObject(
+    object: Record<string | symbol, any>,
+    mockExports: Record<string | symbol, any> | undefined,
+    moduleType?: 'automock' | 'autospy',
+  ): Record<string | symbol, any>
+  public mockObject(
+    object: Record<string | symbol, any>,
+    mockExportsOrModuleType?: Record<string | symbol, any> | 'automock' | 'autospy',
+    moduleType?: 'automock' | 'autospy',
   ): Record<string | symbol, any> {
+    let mockExports: Record<string | symbol, any> | undefined
+    if (mockExportsOrModuleType === 'automock' || mockExportsOrModuleType === 'autospy') {
+      moduleType = mockExportsOrModuleType
+      mockExports = undefined
+    }
+    else {
+      mockExports = mockExportsOrModuleType
+    }
+    moduleType ??= 'automock'
     const createMockInstance = this.spyModule?.createMockInstance
     if (!createMockInstance) {
       throw this.createError(
@@ -211,7 +229,7 @@ export class BareModuleMocker implements TestModuleMocker {
       {
         globalConstructors: this.primitives,
         createMockInstance,
-        type: behavior,
+        type: moduleType,
       },
       object,
       mockExports,

--- a/test/core/test/browserAutomocker.test.ts
+++ b/test/core/test/browserAutomocker.test.ts
@@ -17,7 +17,7 @@ export function test() {}
       __esModule: true,
       ["test"]: test,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["test"]
     export {
       __vitest_mocked_0__ as test,
@@ -37,7 +37,7 @@ export class Test {}
       __esModule: true,
       ["Test"]: Test,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["Test"]
     export {
       __vitest_mocked_0__ as Test,
@@ -57,7 +57,7 @@ export default class Test {}
       __esModule: true,
       ["__vitest_default"]: __vitest_default,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_default"]
     export {
       __vitest_mocked_0__ as default,
@@ -75,7 +75,7 @@ export default function test() {}
       __esModule: true,
       ["__vitest_default"]: __vitest_default,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_default"]
     export {
       __vitest_mocked_0__ as default,
@@ -93,7 +93,7 @@ export default someVariable
       __esModule: true,
       ["__vitest_default"]: __vitest_default,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_default"]
     export {
       __vitest_mocked_0__ as default,
@@ -111,7 +111,7 @@ export default 'test'
       __esModule: true,
       ["__vitest_default"]: __vitest_default,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_default"]
     export {
       __vitest_mocked_0__ as default,
@@ -129,7 +129,7 @@ export default null
       __esModule: true,
       ["__vitest_default"]: __vitest_default,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_default"]
     export {
       __vitest_mocked_0__ as default,
@@ -149,7 +149,7 @@ export default test
       __esModule: true,
       ["__vitest_default"]: __vitest_default,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_default"]
     export {
       __vitest_mocked_0__ as default,
@@ -175,7 +175,7 @@ export const test3 = function test4() {}
       ["test2"]: test2,
       ["test3"]: test3,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["test"]
     const __vitest_mocked_1__ = __vitest_mocked_module__["test2"]
     const __vitest_mocked_2__ = __vitest_mocked_module__["test3"]
@@ -203,7 +203,7 @@ export const [...rest2] = []
       ["rest"]: rest,
       ["rest2"]: rest2,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["test"]
     const __vitest_mocked_1__ = __vitest_mocked_module__["rest"]
     const __vitest_mocked_2__ = __vitest_mocked_module__["rest2"]
@@ -230,7 +230,7 @@ export const test = 2, test2 = 3, test4 = () => {}, test5 = function() {};
       ["test4"]: test4,
       ["test5"]: test5,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["test"]
     const __vitest_mocked_1__ = __vitest_mocked_module__["test2"]
     const __vitest_mocked_2__ = __vitest_mocked_module__["test4"]
@@ -263,7 +263,7 @@ export const { ...rest2 } = {}
       ["alias"]: alias,
       ["rest2"]: rest2,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["test"]
     const __vitest_mocked_1__ = __vitest_mocked_module__["rest"]
     const __vitest_mocked_2__ = __vitest_mocked_module__["alias"]
@@ -293,7 +293,7 @@ it('correctly parses export specifiers', () => {
       ["test"]: test,
       ["test"]: test,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["test"]
     const __vitest_mocked_1__ = __vitest_mocked_module__["test"]
     const __vitest_mocked_2__ = __vitest_mocked_module__["test"]
@@ -324,7 +324,7 @@ export { testing as name4 } from './another-module'
       ["__vitest_imported_2__"]: __vitest_imported_2__,
       ["__vitest_imported_3__"]: __vitest_imported_3__,
     }
-    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, undefined, "automock")
+    const __vitest_mocked_module__ = globalThis["__vitest_mocker__"].mockObject(__vitest_current_es_module__, "automock")
     const __vitest_mocked_0__ = __vitest_mocked_module__["__vitest_imported_0__"]
     const __vitest_mocked_1__ = __vitest_mocked_module__["__vitest_imported_1__"]
     const __vitest_mocked_2__ = __vitest_mocked_module__["__vitest_imported_2__"]


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
