### PR TITLE
test: fix vite 8 stack trace snapshot

### DIFF
--- a/test/browser/specs/errors.test.ts
+++ b/test/browser/specs/errors.test.ts
@@ -1,5 +1,6 @@
 import path from 'pathe'
 import { expect, test } from 'vitest'
+import { rolldownVersion } from 'vitest/node'
 import { buildTestProjectTree } from '../../test-utils'
 import { instances, runBrowserTests, runInlineBrowserTests } from './utils'
 
@@ -163,21 +164,40 @@ test('prints source-mapped stack for optimized dependency', async () => {
 
   for (const [name, tree] of Object.entries(projectTree)) {
     if (name === 'webkit') {
-      expect(tree).toMatchInlineSnapshot(`
-        {
-          "basic.test.ts": {
-            "fail": [
-              {
-                "message": "this is test dependency error",
-                "stacks": [
-                  "throwDepError at ../../../../node_modules/.pnpm/<normalized>/node_modules/test-dep-error/index.js:2:18",
-                  " at basic.test.ts:5:16",
-                ],
-              },
-            ],
-          },
-        }
-      `)
+      if (rolldownVersion) {
+        expect(tree).toMatchInlineSnapshot(`
+          {
+            "basic.test.ts": {
+              "fail": [
+                {
+                  "message": "this is test dependency error",
+                  "stacks": [
+                    "throwDepError at ../../../../node_modules/.pnpm/<normalized>/node_modules/test-dep-error/index.js:2:18",
+                    " at basic.test.ts:5:2",
+                  ],
+                },
+              ],
+            },
+          }
+        `)
+      }
+      else {
+        expect(tree).toMatchInlineSnapshot(`
+          {
+            "basic.test.ts": {
+              "fail": [
+                {
+                  "message": "this is test dependency error",
+                  "stacks": [
+                    "throwDepError at ../../../../node_modules/.pnpm/<normalized>/node_modules/test-dep-error/index.js:2:18",
+                    " at basic.test.ts:5:16",
+                  ],
+                },
+              ],
+            },
+          }
+        `)
+      }
     }
     else {
       expect(tree).toMatchInlineSnapshot(`


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixing yet another Vite 8 stack position difference introduced by https://github.com/vitest-dev/vitest/pull/9721

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
