### PR TITLE
docs(reporters): correct gitHub-actions reporter documentation

### DIFF
--- a/docs/config/reporters.md
+++ b/docs/config/reporters.md
@@ -14,7 +14,7 @@ interface UserConfig {
 type ConfigReporter = string | Reporter | [string, object?]
 ```
 
-- **Default:** [`'default'`](/guide/reporters#default-reporter)
+- **Default:** [`'default'`](/guide/reporters#default-reporter) (or [[`'default'`](/guide/reporters#default-reporter), [`'github-actions'`](/guide/reporters#github-actions-reporter)] when `process.env.GITHUB_ACTIONS === 'true'`)
 - **CLI:**
   - `--reporter=tap` for a single reporter
   - `--reporter=verbose --reporter=github-actions` for multiple reporters

--- a/docs/config/reporters.md
+++ b/docs/config/reporters.md
@@ -14,7 +14,7 @@ interface UserConfig {
 type ConfigReporter = string | Reporter | [string, object?]
 ```
 
-- **Default:** [`'default'`](/guide/reporters#default-reporter) (or [[`'default'`](/guide/reporters#default-reporter), [`'github-actions'`](/guide/reporters#github-actions-reporter)] when `process.env.GITHUB_ACTIONS === 'true'`)
+- **Default:** [`'default'`](/guide/reporters#default-reporter) (or <code>[['default'](/guide/reporters#default-reporter), ['github-actions'](/guide/reporters#github-actions-reporter)]</code> when `process.env.GITHUB_ACTIONS === 'true'`)
 - **CLI:**
   - `--reporter=tap` for a single reporter
   - `--reporter=verbose --reporter=github-actions` for multiple reporters

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -532,7 +532,7 @@ export default defineConfig({
 ### GitHub Actions Reporter {#github-actions-reporter}
 
 Output [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)
-to provide annotations for test failures. This reporter is automatically enabled with a [`default`](#default-reporter) reporter when `process.env.GITHUB_ACTIONS === 'true'`.
+to provide annotations for test failures. This reporter is automatically enabled when the `reporters` setting is unset and `process.env.GITHUB_ACTIONS === 'true'`.
 
 <img alt="GitHub Actions" img-dark src="https://github.com/vitest-dev/vitest/assets/4232207/336cddc2-df6b-4b8a-8e72-4d00010e37f5">
 <img alt="GitHub Actions" img-light src="https://github.com/vitest-dev/vitest/assets/4232207/ce8447c1-0eab-4fe1-abef-d0d322290dca">

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -537,7 +537,7 @@ to provide annotations for test failures. This reporter is automatically enabled
 <img alt="GitHub Actions" img-dark src="https://github.com/vitest-dev/vitest/assets/4232207/336cddc2-df6b-4b8a-8e72-4d00010e37f5">
 <img alt="GitHub Actions" img-light src="https://github.com/vitest-dev/vitest/assets/4232207/ce8447c1-0eab-4fe1-abef-d0d322290dca">
 
-If you configure non-default reporters, you need to explicitly add `github-actions`.
+If you configure reporters, you need to explicitly add `github-actions`.
 
 ```ts
 export default defineConfig({

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -532,7 +532,7 @@ export default defineConfig({
 ### GitHub Actions Reporter {#github-actions-reporter}
 
 Output [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)
-to provide annotations for test failures. This reporter is automatically enabled when the `reporters` setting is unset and `process.env.GITHUB_ACTIONS === 'true'`.
+to provide annotations for test failures. This reporter is automatically enabled when the `reporters` option is not configured and `process.env.GITHUB_ACTIONS === 'true'` (on GitHub Actions environment).
 
 <img alt="GitHub Actions" img-dark src="https://github.com/vitest-dev/vitest/assets/4232207/336cddc2-df6b-4b8a-8e72-4d00010e37f5">
 <img alt="GitHub Actions" img-light src="https://github.com/vitest-dev/vitest/assets/4232207/ce8447c1-0eab-4fe1-abef-d0d322290dca">
@@ -542,7 +542,7 @@ If you configure reporters, you need to explicitly add `github-actions`.
 ```ts
 export default defineConfig({
   test: {
-    reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot'],
+    reporters: process.env.GITHUB_ACTIONS === 'true' ? ['dot', 'github-actions'] : ['dot'],
   },
 })
 ```
@@ -552,7 +552,7 @@ You can customize the file paths that are printed in [GitHub's annotation comman
 ```ts
 export default defineConfig({
   test: {
-    reporters: process.env.GITHUB_ACTIONS
+    reporters: process.env.GITHUB_ACTIONS === 'true'
       ? [
           'default',
           ['github-actions', { onWritePath(path) {

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -397,10 +397,10 @@ export interface InlineConfig {
   root?: string
 
   /**
-   * Custom reporter for output. Can contain one or more built-in report names, reporter instances,
+   * Custom reporter for output. Can contain one or more built-in reporter names, reporter instances,
    * and/or paths to custom reporters.
    *
-   * @default []
+   * @default ['default'] (or ['default', 'github-actions'] when `process.env.GITHUB_ACTIONS === 'true'`)
    */
   reporters?:
     | Arrayable<ReporterName | InlineReporter>


### PR DESCRIPTION
### Description

Based on my experience testing this a bit, it seems like this reporter is only included by default when no reporters are set at all, _not when the reporter called "default" is set_. This documentation states otherwise. 

To test, I did `GITHUB_ACTIONS=true pnpm test` in a project with a failing test. When the config has `reporters: ['default']`, the GHA stuff doesn't get logged. When the config is totally empty or the env var check is manually added, the GHA stuff does get logged.

It's possible that this is a bug and the intention is to match the documentation's behavior? 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [X] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

(Documentation only change)

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
