### PR TITLE
docs: fix duplicated word in browser assertions docs

### DIFF
--- a/docs/api/browser/assertions.md
+++ b/docs/api/browser/assertions.md
@@ -370,7 +370,7 @@ await expect.element(getByTestId('parent')).toContainHTML('</span>')
 ::: warning
 Chances are you probably do not need to use this matcher. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised.
 
-It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that that html code was used as intended.
+It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that html code was used as intended.
 
 It should not be used to check DOM structure that you control. Please, use [`toContainElement`](#tocontainelement) instead.
 :::


### PR DESCRIPTION
### Description

Resolves #issue-number: N/A (trivial docs typo fix)

- Fix duplicated wording in `docs/api/browser/assertions.md`:
  - `validate that that html code` -> `validate that html code`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed. (N/A: trivial docs wording fix)
- [x] Ideally, include a test that fails without this PR but passes with it. (N/A: docs-only wording change)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations. (Not available here)

### Tests
- [x] Run the tests with `pnpm test:ci`. (Not applicable for this docs-only change; PR CI checks are green)

### Documentation
- [x] If you introduce new functionality, document it. (No new functionality introduced)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
