### PR TITLE
fix(benchmark): avoid duplicate output for top-level bench tasks

### DIFF
--- a/test/cli/fixtures/benchmarking/top-level/no-describe.bench.ts
+++ b/test/cli/fixtures/benchmarking/top-level/no-describe.bench.ts
@@ -1,0 +1,5 @@
+import { bench } from 'vitest'
+
+bench('sum', () => {
+  1 + 1
+}, { iterations: 1, time: 0 })

--- a/test/cli/fixtures/benchmarking/top-level/with-describe.bench.ts
+++ b/test/cli/fixtures/benchmarking/top-level/with-describe.bench.ts
@@ -1,0 +1,7 @@
+import { bench, describe } from 'vitest'
+
+describe('group', () => {
+  bench('sum', () => {
+    1 + 1
+  }, { iterations: 1, time: 0 })
+})

--- a/test/cli/test/benchmarking.test.ts
+++ b/test/cli/test/benchmarking.test.ts
@@ -42,6 +42,15 @@ it('non-tty', async () => {
   }
 })
 
+it('top-level bench output is not duplicated', async () => {
+  const root = pathe.join(import.meta.dirname, '../fixtures/benchmarking/top-level')
+  const result = await runVitest({ root }, [], { mode: 'benchmark' })
+
+  expect(result.stderr).toBe('')
+  expect(result.stdout.match(/✓ no-describe\.bench\.ts/g)).toHaveLength(1)
+  expect(result.stdout.match(/✓ with-describe\.bench\.ts > group/g)).toHaveLength(1)
+})
+
 it.for([true, false])('includeSamples %s', async (includeSamples) => {
   const result = await runVitest(
     {


### PR DESCRIPTION
## Summary
- prevent benchmark tables from being printed multiple times for the same task id in one run
- keep existing suite/module behavior while deduplicating repeated module print events
- add a regression fixture and CLI test for top-level benchmark output

## Repro
Fixes #9718.

## Validation
- `pnpm --filter test-cli test test/benchmarking.test.ts`
