### PR TITLE
fix: fix `URL.name` on jsdom

### DIFF
--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -232,7 +232,7 @@ export default <Environment>{
 }
 
 function createCompatRequest(utils: CompatUtils) {
-  return class Request extends NodeRequest_ {
+  const CompatRequest = class Request extends NodeRequest_ {
     constructor(...args: [input: RequestInfo, init?: RequestInit]) {
       const [input, init] = args
       if (init?.body != null) {
@@ -254,10 +254,12 @@ function createCompatRequest(utils: CompatUtils) {
       return instance instanceof NodeRequest_
     }
   }
+  Object.defineProperty(CompatRequest, 'name', { value: 'Request' })
+  return CompatRequest
 }
 
 function createJSDOMCompatURL(utils: CompatUtils): typeof URL {
-  return class URL extends NodeURL {
+  const CompatURL = class URL extends NodeURL {
     static createObjectURL(blob: any): string {
       if (blob instanceof utils.window.Blob) {
         const compatBlob = utils.makeCompatBlob(blob)
@@ -270,6 +272,10 @@ function createJSDOMCompatURL(utils: CompatUtils): typeof URL {
       return instance instanceof NodeURL
     }
   } as typeof URL
+  // bundlers may rename the class expression to avoid conflicts (e.g. URL$1)
+  // https://github.com/vitest-dev/vitest/issues/9761
+  Object.defineProperty(CompatURL, 'name', { value: 'URL' })
+  return CompatURL
 }
 
 interface CompatUtils {

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -232,7 +232,7 @@ export default <Environment>{
 }
 
 function createCompatRequest(utils: CompatUtils) {
-  const CompatRequest = class Request extends NodeRequest_ {
+  class Request extends NodeRequest_ {
     constructor(...args: [input: RequestInfo, init?: RequestInit]) {
       const [input, init] = args
       if (init?.body != null) {
@@ -254,12 +254,11 @@ function createCompatRequest(utils: CompatUtils) {
       return instance instanceof NodeRequest_
     }
   }
-  Object.defineProperty(CompatRequest, 'name', { value: 'Request' })
-  return CompatRequest
+  return Request
 }
 
 function createJSDOMCompatURL(utils: CompatUtils): typeof URL {
-  const CompatURL = class URL extends NodeURL {
+  class URL extends NodeURL {
     static createObjectURL(blob: any): string {
       if (blob instanceof utils.window.Blob) {
         const compatBlob = utils.makeCompatBlob(blob)
@@ -271,11 +270,8 @@ function createJSDOMCompatURL(utils: CompatUtils): typeof URL {
     static [Symbol.hasInstance](instance: unknown): boolean {
       return instance instanceof NodeURL
     }
-  } as typeof URL
-  // bundlers may rename the class expression to avoid conflicts (e.g. URL$1)
-  // https://github.com/vitest-dev/vitest/issues/9761
-  Object.defineProperty(CompatURL, 'name', { value: 'URL' })
-  return CompatURL
+  }
+  return URL
 }
 
 interface CompatUtils {

--- a/test/core/test/environments/jsdom.spec.ts
+++ b/test/core/test/environments/jsdom.spec.ts
@@ -319,6 +319,11 @@ test('URL.createObjectUrl works properly', () => {
   }).not.toThrow()
 })
 
+test('compat classes preserve their .name property', () => {
+  expect(URL.name).toBe('URL')
+  expect(Request.name).toBe('Request')
+})
+
 test('jsdom global is exposed', () => {
   // @ts-expect-error -- jsdom is not exposed in our types because we use a single tsconfig for all
   const dom = jsdom


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9761

It looks like `return class ...` pattern is an edge for bundler to get class name right. Even Rolldown's [`keepNames`](https://rolldown.rs/reference/OutputOptions.keepNames#keepnames) gets wrong

- [Rolldown repl](https://repl.rolldown.rs/#eNqNUs1q4zAQfpVBLDiB4LJXX/e69LCwN18UaZxoo4yMNNqmhBx76yO0L9cn6Uhq2rSUUmOwNT/ffN98OqpJDUflyOKh51T+SQ1v55Uy5bifQ2Q4wt8/v0EnuA4Wy+8Jphj20JGchxx9B/KMNNLVFTw93gNvXQIbMFHHcBPibqQpk2EXCExEzQVlsYTjSAAROUeJe51SHYQHRrJv02oVQGLNzsAWvQ+l99zYyQBvOyHVWACcRmqHFjCBUvDY+7BZXEzvSe9xCUIZDzMaRgudJDpYZwZtOGtfAz9+dmdpD3dNWpGUauhL1pL/Pm0pFt4F8oKuADWaYgiqgWPG00rF4L0NN9RL6eQ2F/59kvngpMXJEf6q6Vcfz21VqGyjlEqhzr5+XxsW1QpHc+YBGmS/R9Z9Da3KLnmLMDmPCRL6ttX1bY3KWln8lxe12QLrdQGTljCXiyH7BAiZK/aL5TvE+VrkpwGK9NXZ3OVISvYwa7PTG+z/pSDi2wbexZr2CjYqi7MYhGQcplHJjIJUgATpv5R5uRiJ1ekZ22cK4g==)
- [Rollup repl](https://rollupjs.org/repl/?version=4.59.0&shareable=eyJleGFtcGxlIjpudWxsLCJtb2R1bGVzIjpbeyJjb2RlIjoiaW1wb3J0IHsgVVJMIGFzIE5vZGVVUkwgfSBmcm9tICdub2RlOnVybCcgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgXG5mdW5jdGlvbiBjcmVhdGVVUkwoKSB7XG4gIGNvbnN0IFVSTCA9IGNsYXNzIFVSTCBleHRlbmRzIE5vZGVVUkwge1xuICAgIHN0YXRpYyBoZWxsbygpIHsgcmV0dXJuICd3b3JsZCcgfSAgICAgXG4gIH1cbiAgcmV0dXJuIFVSTFxufSAgICAgICAgIFxuXG5jb25zb2xlLmxvZyhjcmVhdGVVUkwoKS5uYW1lKSAvLyBleHBlY3RlZCAnVVJMJyBidXQgYWN0dWFsICdVUkwkMSciLCJpc0VudHJ5Ijp0cnVlLCJuYW1lIjoibWFpbi5qcyJ9XSwib3B0aW9ucyI6e319)

I tweaked it so that the bundler kicks in class name preservation properly. I will report to Rolldown whether this is intended later.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
