### PR TITLE
fix(runtime): surface reporter hook errors from onUserConsoleLog (fix #9736)

### DIFF
--- a/packages/vitest/src/runtime/console.ts
+++ b/packages/vitest/src/runtime/console.ts
@@ -114,13 +114,15 @@ export function createCustomConsole(defaultState?: WorkerGlobalState): Console {
   ) {
     const timer = timers.get(taskId)!
     const time = type === 'stderr' ? timer.stderrTime : timer.stdoutTime
-    state().rpc.onUserConsoleLog({
+    void state().rpc.onUserConsoleLog({
       type,
       content: content || '<empty line>',
       taskId,
       time: time || RealDate.now(),
       size,
       origin,
+    }).catch((error) => {
+      state().rpc.onUnhandledError(error, 'Unhandled Reporter Error')
     })
   }
 

--- a/packages/vitest/src/runtime/rpc.ts
+++ b/packages/vitest/src/runtime/rpc.ts
@@ -82,7 +82,6 @@ export function createRuntimeRpc(
       },
       {
         eventNames: [
-          'onUserConsoleLog',
           'onCollected',
           'onCancel',
         ],

--- a/test/cli/test/reporters/console.test.ts
+++ b/test/cli/test/reporters/console.test.ts
@@ -92,3 +92,24 @@ test.for(['forks', 'threads'])('interleave (pool = %s)', async (pool) => {
     },
   ])
 })
+
+test('surfaces reporter errors thrown from onUserConsoleLog', async () => {
+  const { ctx, exitCode } = await runVitest({
+    root: './fixtures/reporters',
+    reporters: [
+      {
+        onUserConsoleLog() {
+          throw new Error('Reporter onUserConsoleLog failed')
+        },
+      } satisfies Reporter,
+    ],
+  }, [resolve('./fixtures/reporters/console.test.ts')])
+
+  expect(exitCode).toBe(1)
+  expect(
+    ctx!.state.getUnhandledErrors().some(error =>
+      (error as any).type === 'Unhandled Reporter Error'
+      && String(error).includes('Reporter onUserConsoleLog failed'),
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
## Summary
- stop treating `onUserConsoleLog` as fire-and-forget RPC so reporter exceptions can propagate
- forward rejected console-log RPC calls to `onUnhandledError` with `Unhandled Reporter Error`
- add a CLI regression test that verifies `onUserConsoleLog` reporter exceptions fail the run

## Before
Reporter exceptions thrown from `onUserConsoleLog` during normal test runs were silently ignored, so runs could still exit successfully.

## After
Reporter exceptions from `onUserConsoleLog` are captured as unhandled reporter errors and the run exits non-zero.

## Validation
- `pnpm --filter test-cli exec vitest test/reporters/console.test.ts`