### PR TITLE
docs: Add warning regarding 'types' condition in ssr.resolve.conditions

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -96,6 +96,12 @@ Since Vitest defaults to the `node` environment (which uses `viteEnvironment: 's
 You can learn more about Vite environments and Vitest environments in [`environment`](/config/environment).
 :::
 
+::: warning Avoid adding `types` condition
+The `types` condition in `exports` and `imports` is usually reserved for Typescript, for libraries to declare where the declaration files are located (`.d.ts` files).
+
+If you add `types` to `ssr.resolve.conditions`, Vitest will try to import the `types` export from packages (`.d.ts`) instead of the `.js` files and Node.js will fail with error `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`
+:::
+
 ## Segfaults and Native Code Errors
 
 Running [native NodeJS modules](https://nodejs.org/api/addons.html) in `pool: 'threads'` can run into cryptic errors coming from the native code.


### PR DESCRIPTION

### Description

Add warning about using 'types' condition in exports and imports.

I recently faced a bug related to this.

Reproduction: https://github.com/danilofuchs/vitest-subpath-imports-ts

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
