### PR TITLE
feat(reporters): add `agent` reporter to reduce ai agent token usage

### DIFF
--- a/docs/config/reporters.md
+++ b/docs/config/reporters.md
@@ -42,6 +42,7 @@ Note that the [coverage](/guide/coverage) feature uses a different [`coverage.re
 - [`tap-flat`](/guide/reporters#tap-flat-reporter)
 - [`hanging-process`](/guide/reporters#hanging-process-reporter)
 - [`github-actions`](/guide/reporters#github-actions-reporter)
+- [`agent`](/guide/reporters#agent-reporter)
 - [`blob`](/guide/reporters#blob-reporter)
 
 ## Example

--- a/docs/guide/browser/visual-regression-testing.md
+++ b/docs/guide/browser/visual-regression-testing.md
@@ -606,7 +606,6 @@ screenshots should use the service.
 
 The cleanest approach is using [Test Projects](/guide/projects):
 
-
 ```ts [vitest.config.ts]
 import { env } from 'node:process'
 import { defineConfig } from 'vitest/config'
@@ -662,7 +661,6 @@ export default defineConfig({
   },
 })
 ```
-
 
 Follow the [official guide to create a Playwright Workspace](https://learn.microsoft.com/en-us/azure/app-testing/playwright-workspaces/quickstart-run-end-to-end-tests?tabs=playwrightcli&pivots=playwright-test-runner#create-a-workspace).
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -102,7 +102,7 @@ Hide logs for skipped tests
 - **CLI:** `--reporter <name>`
 - **Config:** [reporters](/config/reporters)
 
-Specify reporters (default, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
+Specify reporters (default, agent, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
 
 ### outputFile
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -237,4 +237,3 @@ Merges every blob report located in the specified folder (`.vitest-reports` by d
 ```sh
 vitest --merge-reports --reporter=junit
 ```
-

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -98,6 +98,10 @@ This example will write separate JSON and XML reports as well as printing a verb
 
 By default (i.e. if no reporter is specified), Vitest will display summary of running tests and their status at the bottom. Once a suite passes, its status will be reported on top of the summary.
 
+::: tip
+When Vitest detects it is running inside an AI coding agent, the [`agent`](#agent-reporter) reporter is used instead to reduce output and minimize token usage. You can override this by explicitly configuring the [`reporters`](/config/reporters) option.
+:::
+
 You can disable the summary by configuring the reporter:
 
 :::code-group
@@ -636,6 +640,26 @@ export default defineConfig({
   },
 })
 ```
+
+### Agent Reporter
+
+Outputs a minimal report optimized for AI coding assistants and LLM-based workflows. Only failed tests and their error messages are displayed. Console logs from passing tests and the summary section are suppressed to reduce token usage.
+
+This reporter is automatically enabled when no `reporters` option is configured and Vitest detects it is running inside an AI coding agent. If you configure custom reporters, you can explicitly add `agent`:
+
+:::code-group
+```bash [CLI]
+npx vitest --reporter=agent
+```
+
+```ts [vitest.config.ts]
+export default defineConfig({
+  test: {
+    reporters: ['agent']
+  },
+})
+```
+:::
 
 ### Blob Reporter
 

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -23,7 +23,7 @@ import {
   defaultPort,
 } from '../../constants'
 import { benchmarkConfigDefaults, configDefaults } from '../../defaults'
-import { isCI, stdProvider } from '../../utils/env'
+import { isAgent, isCI, stdProvider } from '../../utils/env'
 import { getWorkersCountByPercentage } from '../../utils/workers'
 import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
@@ -729,7 +729,7 @@ export function resolveConfig(
   }
 
   if (!resolved.reporters.length) {
-    resolved.reporters.push(['default', {}])
+    resolved.reporters.push([isAgent ? 'agent' : 'default', {}])
 
     // also enable github-actions reporter as a default
     if (process.env.GITHUB_ACTIONS === 'true') {

--- a/packages/vitest/src/node/reporters/agent.ts
+++ b/packages/vitest/src/node/reporters/agent.ts
@@ -1,0 +1,31 @@
+import type { TestSpecification } from '../test-specification'
+import type { DefaultReporterOptions } from './default'
+import type { TestCase, TestModule, TestModuleState } from './reported-tasks'
+import { DefaultReporter } from './default'
+
+export class AgentReporter extends DefaultReporter {
+  renderSucceed = false
+
+  constructor(options: DefaultReporterOptions = {}) {
+    super({ silent: 'passed-only', ...options, summary: false })
+  }
+
+  onTestRunStart(specifications: ReadonlyArray<TestSpecification>): void {
+    super.onTestRunStart(specifications)
+    this.renderSucceed = false
+  }
+
+  protected printTestModule(testModule: TestModule): void {
+    if (testModule.state() !== 'failed') {
+      return
+    }
+    super.printTestModule(testModule)
+  }
+
+  protected printTestCase(moduleState: TestModuleState, test: TestCase): void {
+    const testResult = test.result()
+    if (testResult.state === 'failed') {
+      super.printTestCase(moduleState, test)
+    }
+  }
+}

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -37,6 +37,7 @@ const BADGE_PADDING = '       '
 
 export interface BaseOptions {
   isTTY?: boolean
+  silent?: boolean | 'passed-only'
 }
 
 export abstract class BaseReporter implements Reporter {
@@ -49,16 +50,19 @@ export abstract class BaseReporter implements Reporter {
   renderSucceed = false
 
   protected verbose = false
+  protected silent?: boolean | 'passed-only'
 
   private _filesInWatchMode = new Map<string, number>()
   private _timeStart = formatTimeString(new Date())
 
   constructor(options: BaseOptions = {}) {
     this.isTTY = options.isTTY ?? isTTY
+    this.silent = options.silent
   }
 
   onInit(ctx: Vitest): void {
     this.ctx = ctx
+    this.silent ??= this.ctx.config.silent
 
     this.ctx.logger.printBanner()
   }
@@ -117,8 +121,8 @@ export abstract class BaseReporter implements Reporter {
     this.printTestModule(testModule)
   }
 
-  private logFailedTask(task: Task) {
-    if (this.ctx.config.silent === 'passed-only') {
+  protected logFailedTask(task: Task): void {
+    if (this.silent === 'passed-only') {
       for (const log of task.logs || []) {
         this.onUserConsoleLog(log, 'failed')
       }
@@ -504,11 +508,11 @@ export abstract class BaseReporter implements Reporter {
   }
 
   shouldLog(log: UserConsoleLog, taskState?: TestResult['state']): boolean {
-    if (this.ctx.config.silent === true) {
+    if (this.silent === true) {
       return false
     }
 
-    if (this.ctx.config.silent === 'passed-only' && taskState !== 'failed') {
+    if (this.silent === 'passed-only' && taskState !== 'failed') {
       return false
     }
 

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -6,6 +6,7 @@ import type { GithubActionsReporterOptions } from './github-actions'
 import type { HTMLOptions } from './html'
 import type { JsonOptions } from './json'
 import type { JUnitOptions } from './junit'
+import { AgentReporter } from './agent'
 import { BlobReporter } from './blob'
 import { DefaultReporter } from './default'
 import { DotReporter } from './dot'
@@ -19,6 +20,7 @@ import { TreeReporter } from './tree'
 import { VerboseReporter } from './verbose'
 
 export {
+  AgentReporter,
   DefaultReporter,
   DotReporter,
   GithubActionsReporter,
@@ -46,6 +48,7 @@ export type {
 
 export const ReportersMap = {
   'default': DefaultReporter as typeof DefaultReporter,
+  'agent': AgentReporter as typeof AgentReporter,
   'blob': BlobReporter as typeof BlobReporter,
   'verbose': VerboseReporter as typeof VerboseReporter,
   'dot': DotReporter as typeof DotReporter,
@@ -62,6 +65,7 @@ export type BuiltinReporters = keyof typeof ReportersMap
 
 export interface BuiltinReporterOptions {
   'default': DefaultReporterOptions
+  'agent': DefaultReporterOptions
   'verbose': DefaultReporterOptions
   'dot': BaseOptions
   'tree': BaseOptions

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -43,6 +43,7 @@ export { VmThreadsPoolWorker } from '../node/pools/workers/vmThreadsWorker'
 export type { SerializedTestProject, TestProject } from '../node/project'
 
 export {
+  AgentReporter,
   BenchmarkReporter,
   BenchmarkReportsMap,
   DefaultReporter,

--- a/packages/vitest/src/public/reporters.ts
+++ b/packages/vitest/src/public/reporters.ts
@@ -1,4 +1,5 @@
 export {
+  AgentReporter,
   BenchmarkReporter,
   BenchmarkReportsMap,
   DefaultReporter,

--- a/packages/vitest/src/utils/env.ts
+++ b/packages/vitest/src/utils/env.ts
@@ -12,4 +12,4 @@ export const isDeno: boolean
 export const isWindows: boolean = (isNode || isDeno) && process.platform === 'win32'
 export const isBrowser: boolean = typeof window !== 'undefined'
 export const isTTY: boolean = ((isNode || isDeno) && process.stdout?.isTTY && !isCI)
-export { isCI, provider as stdProvider } from 'std-env'
+export { isAgent, isCI, provider as stdProvider } from 'std-env'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ catalogs:
       specifier: ^3.0.2
       version: 3.0.2
     std-env:
-      specifier: ^3.10.0
-      version: 3.10.0
+      specifier: ^4.0.0-rc.1
+      version: 4.0.0-rc.1
     strip-literal:
       specifier: ^3.1.0
       version: 3.1.0
@@ -701,7 +701,7 @@ importers:
         version: 2.1.1
       std-env:
         specifier: 'catalog:'
-        version: 3.10.0
+        version: 4.0.0-rc.1
       tinyrainbow:
         specifier: 'catalog:'
         version: 3.0.3
@@ -1046,7 +1046,7 @@ importers:
         version: 4.0.3
       std-env:
         specifier: 'catalog:'
-        version: 3.10.0
+        version: 4.0.0-rc.1
       tinybench:
         specifier: ^2.9.0
         version: 2.9.0
@@ -9191,6 +9191,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.0.0-rc.1:
+    resolution: {integrity: sha512-2gE+MEGsqvDEjl7LqbrCEB3Lo6+Pmt8ULCIsutKTesFBzSuNIkiWPSy65sa7WrlLebc9LcfnS5eyj69mutUp1A==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -18295,6 +18298,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.0.0-rc.1: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,7 +78,7 @@ catalog:
   pathe: ^2.0.3
   playwright: ^1.58.2
   sirv: ^3.0.2
-  std-env: ^3.10.0
+  std-env: ^4.0.0-rc.1
   strip-literal: ^3.1.0
   tinyexec: ^1.0.2
   tinyglobby: ^0.2.15

--- a/test/cli/test/config/browser-configs.test.ts
+++ b/test/cli/test/config/browser-configs.test.ts
@@ -649,7 +649,7 @@ function getCliConfig(options: TestUserConfig, cli: string[], fs: TestFsStructur
     {
       nodeOptions: {
         env: {
-          CI: 'false',
+          CI: '',
           GITHUB_ACTIONS: undefined,
         },
       },

--- a/test/cli/test/reporters/agent.test.ts
+++ b/test/cli/test/reporters/agent.test.ts
@@ -1,0 +1,92 @@
+import { runVitest, StableTestFileOrderSorter } from '#test-utils'
+import { describe, expect, test } from 'vitest'
+import { DefaultReporter } from 'vitest/node'
+import { trimReporterOutput } from './utils'
+
+describe('agent reporter', async () => {
+  test('hides passed module headers, shows only failed tests, and prints end summary', async () => {
+    const { stdout } = await runVitest({
+      include: ['b1.test.ts', 'b2.test.ts'],
+      root: 'fixtures/reporters/default',
+      reporters: [['agent', {}]],
+      fileParallelism: false,
+      sequence: {
+        sequencer: StableTestFileOrderSorter,
+      },
+    })
+
+    const output = trimReporterOutput(stdout)
+    expect(output).toMatchInlineSnapshot(`
+      "❯ b1.test.ts (13 tests | 1 failed) [...]ms
+           × b failed test [...]ms
+       ❯ b2.test.ts (13 tests | 1 failed) [...]ms
+           × b failed test [...]ms"
+    `)
+
+    const summary = stdout.replace(/\d+ms/g, '[...]ms').split('\n').filter(line => /Test Files|^\s*Tests\b/.test(line)).map(line => line.trim()).join('\n')
+    expect(summary).toMatchInlineSnapshot(`
+      "Test Files  2 failed (2)
+      Tests  2 failed | 24 passed (26)"
+    `)
+  })
+
+  test('hides all output for passed-only modules', async () => {
+    const { stdout } = await runVitest({
+      include: ['b1.test.ts', 'b2.test.ts'],
+      root: 'fixtures/reporters/default',
+      reporters: [['agent', {}]],
+      fileParallelism: false,
+      testNamePattern: 'passed',
+      sequence: {
+        sequencer: StableTestFileOrderSorter,
+      },
+    })
+
+    const output = trimReporterOutput(stdout)
+    expect(output).toMatchInlineSnapshot(`""`)
+  })
+
+  test('shows console logs only from failed file, suite, and tests', async () => {
+    const { stdout } = await runVitest({
+      config: false,
+      include: ['./fixtures/reporters/console-some-failing.test.ts'],
+      reporters: [['agent', { isTTY: true }]],
+    })
+
+    const logs = stdout.split('\n').filter(line => line.includes('Log from')).join('\n')
+    expect(logs).toMatchInlineSnapshot(`
+      "Log from failed test
+      Log from failed test
+      Log from failed suite
+      Log from failed file"
+    `)
+  })
+
+  test('does not change silent behavior for other reporters', async () => {
+    const { stdout } = await runVitest({
+      config: false,
+      include: ['./fixtures/reporters/console-some-failing.test.ts'],
+      reporters: [new LogReporter(), ['agent', { isTTY: true }]],
+    })
+
+    const logs = stdout.split('\n').filter(line => line.includes('Log from')).join('\n')
+    expect(logs).toMatchInlineSnapshot(`
+      "Log from failed file
+      Log from passed test
+      Log from failed test
+      Log from failed suite
+      Log from passed test
+      Log from failed test
+      Log from passed suite
+      Log from passed test
+      Log from failed test
+      Log from failed test
+      Log from failed suite
+      Log from failed file"
+    `)
+  })
+}, 120000)
+
+class LogReporter extends DefaultReporter {
+  isTTY = true
+}

--- a/test/core/test/exports.test.ts
+++ b/test/core/test/exports.test.ts
@@ -86,6 +86,7 @@ it('exports snapshot', async ({ skip, task }) => {
         "takeCoverageInsideWorker": "function",
       },
       "./node": {
+        "AgentReporter": "function",
         "BaseCoverageProvider": "function",
         "BaseSequencer": "function",
         "BenchmarkReporter": "function",
@@ -140,6 +141,7 @@ it('exports snapshot', async ({ skip, task }) => {
         "viteVersion": "string",
       },
       "./reporters": {
+        "AgentReporter": "function",
         "BenchmarkReporter": "function",
         "BenchmarkReportsMap": "object",
         "DefaultReporter": "function",

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -172,6 +172,7 @@ export async function runVitest(
       ...cliOptions,
       env: {
         NO_COLOR: 'true',
+        AI_AGENT: '',
         ...rest.env,
         ...cliOptions?.env,
       },
@@ -281,7 +282,13 @@ async function runCli(command: 'vitest', _options?: CliOptions | string, ...args
     args.push('--maxWorkers=1')
   }
 
-  const subprocess = x(command, args, options as Options).process!
+  const subprocess = x(command, args, {
+    ...options as Options,
+    nodeOptions: {
+      ...(options as Options)?.nodeOptions,
+      env: { ...process.env, AI_AGENT: '', ...(options as Options)?.nodeOptions?.env },
+    },
+  }).process!
   const cli = new Cli({
     stdin: subprocess.stdin!,
     stdout: subprocess.stdout!,


### PR DESCRIPTION
### Description

Test run output tends to be "token inefficient". When running Vitest it prints every passed test and their logs. This PR is aimed at reducing token usage during test runs when Vitest is run by a coding agent by omitting passed tests completely from the streamed output. Instead, it only prints failing tests and the final test run summary. This should make running Vitest much more token efficient. 

* `AI_AGENT=1 pnpm vitest` → only prints failing tests and the final summary
* `pnpm vitest` → no output change

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
