### PR TITLE
chore(benchmarks): update guidelines for benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,9 @@ VITEST_MODULE_DIRECTORIES=/node_modules/,/packages/
 
 ## Pull Request Guidelines
 
+Benchmark-related changes are currently not accepted.\
+Please open an issue for discussion before working on any benchmark-related PRs.
+
 - Checkout a topic branch from a base branch, e.g. `main`, and merge back against that branch.
 
 - If adding a new feature:


### PR DESCRIPTION
### Description

- Followup of https://github.com/vitest-dev/vitest/pull/9722

This PR adds a short note to the Pull Request Guidelines in `CONTRIBUTING.md` clarifying that benchmark-related changes are currently on hold while the benchmarking system is under review.

This change only updates documentation and does not modify any code or project behaviour.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
