### PR TITLE
feat: Introduce a new DOM matcher: `toHaveTagName`

### DIFF
--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -379,6 +379,23 @@ export interface TestingLibraryMatchers<E, R> {
   toHaveStyle(css: string | Partial<CSSStyleDeclaration>): R
   /**
    * @description
+   * Assert whether the given element has a specific tag name.
+   * @example
+  * <button
+  *   type="submit"
+  *   data-testid="submit-button"
+  * >
+  *   Submit
+  * </button>
+   *
+   * const submit = page.getByTestId('submit-button')
+   * await expect.element(submit).toHaveTagName('button')
+   * await expect.element(submit).not.toHaveTagName('a')
+   * @see https://vitest.dev/api/browser/assertions#tohavetagname
+   */
+  toHaveTagName(expectedTagName: Lowercase<string>): R
+  /**
+   * @description
    * Check whether the given element has a text content or not.
    *
    * When a string argument is passed through, it will perform a partial case-sensitive match to the element

--- a/packages/browser/src/client/tester/expect/index.ts
+++ b/packages/browser/src/client/tester/expect/index.ts
@@ -21,6 +21,7 @@ import toHaveFormValues from './toHaveFormValues'
 import toHaveRole from './toHaveRole'
 import toHaveSelection from './toHaveSelection'
 import toHaveStyle from './toHaveStyle'
+import toHaveTagName from './toHaveTagName'
 import toHaveTextContent from './toHaveTextContent'
 import toHaveValue from './toHaveValue'
 import toMatchScreenshot from './toMatchScreenshot'
@@ -45,6 +46,7 @@ export const matchers: MatchersObject = {
   toHaveFocus,
   toHaveFormValues,
   toHaveStyle,
+  toHaveTagName,
   toHaveTextContent,
   toHaveValue,
   toHaveDisplayValue,

--- a/packages/browser/src/client/tester/expect/toHaveTagName.ts
+++ b/packages/browser/src/client/tester/expect/toHaveTagName.ts
@@ -1,0 +1,35 @@
+import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { Locator } from '../locators'
+import { getElementFromUserInput, getMessage, getTag } from './utils'
+
+export default function toHaveTagName(
+  this: MatcherState,
+  actual: Element | Locator,
+  expectedTagName: Lowercase<string>,
+): ExpectationResult {
+  const htmlElement = getElementFromUserInput(actual, toHaveTagName, this)
+  const receivedTagName = getTag(htmlElement).toLowerCase()
+
+  if (typeof expectedTagName === 'string') {
+    expectedTagName = expectedTagName.toLowerCase() as Lowercase<string>
+  }
+
+  return {
+    pass: this.equals(receivedTagName, expectedTagName, this.customTesters),
+    message: () => {
+      const to = this.isNot ? 'not to' : 'to'
+      return getMessage(
+        this,
+        this.utils.matcherHint(
+          `${this.isNot ? '.not' : ''}.toHaveTagName`,
+          'element',
+          '',
+        ),
+        `Expected element ${to} have tag name`,
+        expectedTagName,
+        'Received',
+        receivedTagName,
+      )
+    },
+  }
+}

--- a/test/browser/fixtures/expect-dom/toHaveTagName.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveTagName.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from './utils'
+
+describe('.toHaveTagName', () => {
+  test('works with HTML and SVG elements', () => {
+    const { queryByTestId } = render(`
+      <button data-testid="button">Submit</button>
+      <svg data-testid="icon"></svg>
+    `)
+
+    const button = queryByTestId('button')
+    const icon = queryByTestId('icon')
+
+    expect(button).toHaveTagName('button')
+    expect(button).not.toHaveTagName('a')
+    expect(icon).toHaveTagName('svg')
+    expect(icon).not.toHaveTagName('div')
+  })
+
+  test('supports locators and `expect.element`', async () => {
+    render(`
+      <button data-testid="button">Submit</button>
+    `)
+
+    const button = page.getByTestId('button')
+
+    expect(button).toHaveTagName('button')
+    expect(button).not.toHaveTagName('a')
+    await expect.element(button).toHaveTagName('button')
+    await expect.element(button).not.toHaveTagName('a')
+  })
+
+  test('supports asymmetric matchers', () => {
+    const { queryByTestId } = render(`
+      <button data-testid="button">Submit</button>
+    `)
+
+    const button = queryByTestId('button')
+
+    expect(button).toHaveTagName(expect.stringContaining('on'))
+    expect(button).not.toHaveTagName(expect.stringContaining('a'))
+  })
+
+  test('throws on failed expectations and invalid targets', () => {
+    const { queryByTestId } = render(`
+      <button data-testid="button">Submit</button>
+    `)
+
+    const button = queryByTestId('button')
+
+    expect(() => {
+      expect(button).toHaveTagName('a')
+    }).toThrow(/expected element to have tag name/i)
+
+    expect(() => {
+      expect(button).not.toHaveTagName('button')
+    }).toThrow(/expected element not to have tag name/i)
+
+    expect(() => {
+      expect('not-an-element').toHaveTagName('p')
+    }).toThrow(/an HTMLElement or an SVGElement/i)
+
+    // @ts-expect-error tag names should be lowercased
+    expect(button).toHaveTagName('BUTTON')
+  })
+})


### PR DESCRIPTION
### Description

This PR implements a new DOM matcher for browser testing: `toHaveTagName`.

`toHaveTagName` is a simple but useful matcher for testing polymorphic components and is much more expressive than checking the `tagName` property directly.

Please compare the following:

```ts
const button = getByTestId('submit-button');

expect(button).toBeVisible();
expect(button).toHaveTagName('button');
expect(button).toHaveTextContent('Sign Up');
```

```ts
expect(button).toBeVisible();
expect(button.element().tagName).toBe('BUTTON'); // 👎
expect(button).toHaveTextContent('Sign Up');
```

### Checklist

- [ ] It’s really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don’t make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by GitHub organizations.

### Tests

- [x] Run the tests with `pnpm test:ci`.

### Documentation

- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
