### PR TITLE
chore: warn agents not to use `pnpm test` with double hyphens `--`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,17 @@ Vitest is a next-generation testing framework powered by Vite. This is a monorep
 - **Core directory test**: `CI=true pnpm test <test-file>` (for `test/core`)
 - **Browser tests**: `CI=true pnpm test:browser:playwright` or `CI=true pnpm test:browser:webdriverio`
 
+**IMPORTANT: Do NOT use `--` when passing test filters to pnpm.**
+Using `--` causes pnpm to drop the filter, resulting in a full test run instead of a filtered one.
+
+```bash
+# WRONG - runs ALL tests (filter is ignored):
+pnpm test -- basic.test.ts -t 'expect'
+
+# CORRECT - runs only matching tests:
+pnpm test basic.test.ts -t 'expect'
+```
+
 When writing tests, AVOID using `toContain` for validation. Prefer using `toMatchInlineSnapshot` to include the test error and its stack. If snapshot is failing, update the snapshot instead of reverting it to `toContain`.
 
 If you need to typecheck tests, run `pnpm typecheck` from the root of the workspace.


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I've seen agents accidentally doing heavy full test run by doing `pnpm test -- <some filter>`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
