### PR TITLE
chore: correct 'overriden' → 'overridden' typos in docs and tests

### DIFF
--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -199,7 +199,7 @@ describe(
       },
       ({ task }) => {
         // task.meta === { nested: { object: false } }
-        // notice array got lost because "nested" object was overriden
+        // notice array got lost because "nested" object was overridden
       }
     )
   }

--- a/docs/guide/test-context.md
+++ b/docs/guide/test-context.md
@@ -502,7 +502,7 @@ test.describe('a nested suite', () => {
 
 Consider overriding it on the top level of the module, or by using [`injected`](#default-fixture-injected) option and providing the value in the project config.
 
-Also note that in [non-isolate](/config/isolate) mode overriding a `worker` fixture will affect the fixture value in all test files running after it was overriden.
+Also note that in [non-isolate](/config/isolate) mode overriding a `worker` fixture will affect the fixture value in all test files running after it was overridden.
 :::
 
 #### Test Scope (Default)

--- a/docs/guide/test-tags.md
+++ b/docs/guide/test-tags.md
@@ -45,7 +45,7 @@ export default defineConfig({
 ```
 
 ::: warning
-If several tags have the same options and are used on the same test, they will be resolved in the order they were specified, or sorted by priority first (the lower the number, the higher the priority). Tags without a defined priority are merged first and will be overriden by higher priority ones:
+If several tags have the same options and are used on the same test, they will be resolved in the order they were specified, or sorted by priority first (the lower the number, the higher the priority). Tags without a defined priority are merged first and will be overridden by higher priority ones:
 
 ```ts
 test('flaky database test', { tags: ['flaky', 'db'] })

--- a/test/core/test/jest-mock.test.ts
+++ b/test/core/test/jest-mock.test.ts
@@ -176,7 +176,7 @@ describe('jest mock compat layer', () => {
     spy.mockRestore()
 
     // Sicne Vitest 4 this is a special case where
-    // vi.fn(impl) will always return impl, unless overriden
+    // vi.fn(impl) will always return impl, unless overridden
     expect(spy.getMockImplementation()).toBe(originalFn)
 
     expect(spy.mock.results).toEqual([])

--- a/test/core/test/mocking/vi-fn.test.ts
+++ b/test/core/test/mocking/vi-fn.test.ts
@@ -11,7 +11,7 @@ test('vi.fn() calls implementation if it was passed down', () => {
   expect(mock()).toBe(3)
 })
 
-test('vi.fn().mock cannot be overriden', () => {
+test('vi.fn().mock cannot be overridden', () => {
   const mock = vi.fn()
   expect(() => mock.mock = {} as any).toThrow()
   expect(() => {

--- a/test/core/test/mocking/vi-mockObject.test.ts
+++ b/test/core/test/mocking/vi-mockObject.test.ts
@@ -81,7 +81,7 @@ test('instance mocks are independently tracked, but prototype shares the state',
   vi.mocked(t1.method).mockReturnValue(100)
   t1.method()
   expect(t1.method).toHaveBeenCalledTimes(2)
-  // tracks methods even when t1.method implementation is overriden
+  // tracks methods even when t1.method implementation is overridden
   expect(Class.prototype.method).toHaveBeenCalledTimes(3)
 })
 

--- a/test/core/test/mocking/vi-spyOn.test.ts
+++ b/test/core/test/mocking/vi-spyOn.test.ts
@@ -120,7 +120,7 @@ describe('vi.spyOn() state', () => {
     assertStateEmpty(state)
   })
 
-  test('vi.spyOn() spies and tracks overriden sync calls', () => {
+  test('vi.spyOn() spies and tracks overridden sync calls', () => {
     const object = createObject()
     const mock = vi.spyOn(object, 'method')
     mock.mockImplementation(() => 100)
@@ -153,7 +153,7 @@ describe('vi.spyOn() state', () => {
     assertStateEmpty(state)
   })
 
-  test('vi.spyOn() spies and tracks overriden sync calls with context', () => {
+  test('vi.spyOn() spies and tracks overridden sync calls with context', () => {
     const object = createObject()
     const mock = vi.spyOn(object, 'method')
     mock.mockImplementation(() => 100)
@@ -187,7 +187,7 @@ describe('vi.spyOn() state', () => {
     assertStateEmpty(state)
   })
 
-  test('vi.spyOn() spies and tracks overriden sync prototype calls with context', () => {
+  test('vi.spyOn() spies and tracks overridden sync prototype calls with context', () => {
     const object = createObject()
     const mock = vi.spyOn(object, 'method')
     mock.mockImplementation(function (this: any) {
@@ -224,7 +224,7 @@ describe('vi.spyOn() state', () => {
     assertStateEmpty(state)
   })
 
-  test('vi.spyOn() spies and tracks overriden sync class calls with context', () => {
+  test('vi.spyOn() spies and tracks overridden sync class calls with context', () => {
     const object = createObject()
     const mock = vi.spyOn(object, 'Class')
     mock.mockImplementation(class {
@@ -262,7 +262,7 @@ describe('vi.spyOn() state', () => {
     assertStateEmpty(state)
   })
 
-  test('vi.spyOn() spies and tracks overriden async calls', async () => {
+  test('vi.spyOn() spies and tracks overridden async calls', async () => {
     const object = createObject()
     const mock = vi.spyOn(object, 'async')
     mock.mockImplementation(() => Promise.resolve(100))
@@ -450,7 +450,7 @@ describe('vi.spyOn() settings', () => {
     expect(foo.bar).toEqual('foo')
   })
 
-  test('vi.spyOn() inherits overriden methods', () => {
+  test('vi.spyOn() inherits overridden methods', () => {
     class Bar {
       _bar = 'bar'
       get bar(): string {
@@ -472,7 +472,7 @@ describe('vi.spyOn() settings', () => {
     expect(foo.bar).toEqual('foo')
     // foo.bar setter is not inherited from Bar
     expect(() => {
-      // @ts-expect-error bar cannot be overriden
+      // @ts-expect-error bar cannot be overridden
       foo.bar = 'baz'
     }).toThrow()
     expect(foo.bar).toEqual('foo')
@@ -642,7 +642,7 @@ describe('vi.spyOn() restoration', () => {
 
     object.getter = 100
 
-    expect(object.getter).toBe(42) // getter was not overriden
+    expect(object.getter).toBe(42) // getter was not overridden
     expect(spy.mock.calls).toHaveLength(1)
     spy.mockRestore()
 
@@ -660,7 +660,7 @@ describe('vi.spyOn() restoration', () => {
 
     object.getter = 100
 
-    expect(object.getter).toBe(42) // getter was not overriden
+    expect(object.getter).toBe(42) // getter was not overridden
     expect(spy.mock.calls).toHaveLength(1)
     vi.restoreAllMocks()
 


### PR DESCRIPTION
## Summary

Fix the recurring typo `overriden` → `overridden` across documentation and test files.

### Changed files

**Docs:**
- `docs/guide/test-context.md`
- `docs/guide/test-tags.md`
- `docs/api/test.md`

**Tests:**
- `test/core/test/mocking/vi-mockObject.test.ts`
- `test/core/test/mocking/vi-fn.test.ts`
- `test/core/test/mocking/vi-spyOn.test.ts`
- `test/core/test/jest-mock.test.ts`

No behavioral changes — only spelling corrections in comments, test descriptions, and documentation.