### PR TITLE
docs: fix API config typo

### DIFF
--- a/docs/config/api.md
+++ b/docs/config/api.md
@@ -16,7 +16,7 @@ Listen to port and serve API for [the UI](/guide/ui) or [browser server](/guide/
 - **Type:** `boolean`
 - **Default:** `true` if not exposed to the network, `false` otherwise
 
-Vitest server can save test files or snapshot files via the API. This allows anyone who can connect to the API the ability to run any arbitary code on your machine.
+Vitest server can save test files or snapshot files via the API. This allows anyone who can connect to the API the ability to run any arbitrary code on your machine.
 
 ::: danger SECURITY ADVICE
 Vitest does not expose the API to the internet by default and only listens on `localhost`. However if `host` is manually exposed to the network, anyone who connects to it can run arbitrary code on your machine, unless `api.allowWrite` and `api.allowExec` are set to `false`.


### PR DESCRIPTION
### Description

- Fixes a typo in `docs/config/api.md` by changing `arbitary` to `arbitrary` in the `api.allowWrite` security note.
- No related issue; this is a minor documentation typo fix.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

### Guideline alignment
- https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md

### Validation
- `git diff --check`
- No tests added; documentation-only change.
