### PR TITLE
docs: fix test tags typo

### DIFF
--- a/docs/guide/test-tags.md
+++ b/docs/guide/test-tags.md
@@ -204,7 +204,7 @@ vitest --tags-filter=frontend
 vitest --tags-filter="frontend and backend"
 ```
 
-If you are running Vitest UI, you can start a filter with a `tag:` prefix to filter out tests by tags using the same tags expression sytax:
+If you are running Vitest UI, you can start a filter with a `tag:` prefix to filter out tests by tags using the same tags expression syntax:
 
 <img alt="The tags filter in Vitest UI" img-light src="/ui/light-ui-tags.png">
 <img alt="The tags filter in Vitest UI" img-dark src="/ui/dark-ui-tags.png">


### PR DESCRIPTION
### Description

- Fixes a typo in the test tags guide by changing `sytax` to `syntax`.

No related issue. This is a minor documentation typo fix.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
