### PR TITLE
fix(config): validate sequence.groupOrder is a finite number

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -775,7 +775,7 @@ export function resolveConfig(
   if (resolved.sequence.groupOrder != null) {
     const order = Number(resolved.sequence.groupOrder)
     if (!Number.isFinite(order)) {
-      throw new Error(
+      throw new TypeError(
         `Invalid "sequence.groupOrder" value: expected a finite number, received ${JSON.stringify(resolved.sequence.groupOrder)}`,
       )
     }

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -772,7 +772,18 @@ export function resolveConfig(
       ? RandomSequencer
       : BaseSequencer
   }
-  resolved.sequence.groupOrder ??= 0
+  if (resolved.sequence.groupOrder != null) {
+    const order = Number(resolved.sequence.groupOrder)
+    if (!Number.isFinite(order)) {
+      throw new Error(
+        `Invalid "sequence.groupOrder" value: expected a finite number, received ${JSON.stringify(resolved.sequence.groupOrder)}`,
+      )
+    }
+    resolved.sequence.groupOrder = order
+  }
+  else {
+    resolved.sequence.groupOrder = 0
+  }
   resolved.sequence.hooks ??= 'stack'
   // Set seed if either files or tests are shuffled
   if (resolved.sequence.sequencer === RandomSequencer || resolved.sequence.shuffle) {

--- a/test/cli/test/group-order.test.ts
+++ b/test/cli/test/group-order.test.ts
@@ -1,6 +1,27 @@
 import { expect, test } from 'vitest'
 import { runInlineTests } from '../../test-utils'
 
+test('throws on invalid groupOrder type (array instead of number)', async () => {
+  const { stderr } = await runInlineTests({
+    'example.test.ts': `test('ok', () => {})`,
+  }, {
+    $cliOptions: { globals: true },
+    projects: [
+      {
+        test: {
+          name: 'fast',
+          include: ['./example.test.ts'],
+          sequence: {
+            // @ts-expect-error -- testing runtime validation
+            groupOrder: ['fast'],
+          },
+        },
+      },
+    ],
+  })
+  expect(stderr).toContain('Invalid "sequence.groupOrder" value')
+})
+
 test('tests run according to the group order', async () => {
   const { stdout, stderr } = await runInlineTests({
     'example.1.test.ts': `test('1', () => {})`,


### PR DESCRIPTION
## Description

When `sequence.groupOrder` receives a non-number value (e.g., an array like `['fast']`), it silently coerces to `NaN` via `groups[order]` lookup in `groupSpecs`. All projects then share the same group key, triggering a confusing error:

```
Error: Projects "fast" and "unit" have different 'maxWorkers' but same 'sequence.groupOrder'.
Provide unique 'sequence.groupOrder' for them.
```

There is no indication that the root cause is an invalid config value — the user sees an error about `maxWorkers` grouping, not about the invalid type.

## Root cause

In `resolveConfig.ts`, `sequence.groupOrder` is defaulted with `??= 0` but has no type validation. When a non-number value passes through:

1. `Number(['fast'])` → `NaN`
2. `groups[NaN]` creates a single group for all projects
3. Projects with different `maxWorkers` end up in the same group → error

## Fix

Added runtime validation in `resolveConfig.ts`:
- Checks `Number.isFinite()` after coercion
- Throws a clear error: `Invalid "sequence.groupOrder" value: expected a finite number, received ["fast"]`
- Coerces valid numeric strings (e.g., `"1"`) to numbers gracefully

## Test

Added a test case in `test/cli/test/group-order.test.ts` that passes an array instead of a number and verifies the validation error message.

Fixes #9821

---

| | |
|---|---|
| **Type** | Bug fix |
| **Scope** | `packages/vitest/src/node/config/resolveConfig.ts` |
| **Test** | `test/cli/test/group-order.test.ts` |