### PR TITLE
docs: fix configureVitest hook typo

### DIFF
--- a/docs/api/advanced/plugin.md
+++ b/docs/api/advanced/plugin.md
@@ -11,7 +11,7 @@ This is an advanced API. If you just want to [run tests](/guide/), you probably 
 This guide assumes you know how to work with [Vite plugins](https://vite.dev/guide/api-plugin.html).
 :::
 
-Vitest supports a `configureVitest` [plugin](https://vite.dev/guide/api-plugin.html) hook hook since version 3.1.
+Vitest supports a `configureVitest` [plugin](https://vite.dev/guide/api-plugin.html) hook since version 3.1.
 
 ::: code-group
 ```ts [only vitest]


### PR DESCRIPTION
### Description

- Fixes a duplicate word in the advanced plugin guide by changing `hook hook` to `hook`.

No related issue. This is a minor documentation typo fix.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
