### PR TITLE
docs: fix browser api typo

### DIFF
--- a/docs/config/browser/api.md
+++ b/docs/config/browser/api.md
@@ -16,7 +16,7 @@ Configure options for Vite server that serves code in the browser. Does not affe
 - **Type:** `boolean`
 - **Default:** `true` if not exposed to the network, `false` otherwise
 
-Vitest saves [annotation attachments](/guide/test-annotations), [artifacts](/api/advanced/artifacts) and [snapshots](/guide/snapshot) by receiving a WebSocket connection from the browser. This allows anyone who can connect to the API write any arbitary code on your machine within the root of your project (configured by [`fs.allow`](https://vite.dev/config/server-options#server-fs-allow)).
+Vitest saves [annotation attachments](/guide/test-annotations), [artifacts](/api/advanced/artifacts) and [snapshots](/guide/snapshot) by receiving a WebSocket connection from the browser. This allows anyone who can connect to the API write any arbitrary code on your machine within the root of your project (configured by [`fs.allow`](https://vite.dev/config/server-options#server-fs-allow)).
 
 If browser server is not exposed to the internet (the host is `localhost`), this should not be a problem, so the default value in that case is `true`. If you override the host, Vitest will set `allowWrite` to `false` by default to prevent potentially harmful writes.
 


### PR DESCRIPTION
### Description

Fixes a typo in the browser API docs ("arbitary" -> "arbitrary").

Resolves N/A

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
  - Not run (docs-only change).

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.
  - Not applicable (docs typo).

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.


