### PR TITLE
docs: add vite+ alpha announcement banner

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -135,6 +135,12 @@ export default ({ mode }: { mode: string }) => {
       }, */
       },
 
+      banner: {
+        id: 'viteplus-alpha',
+        text: 'Announcing Vite+ Alpha: Open source. Unified. Next-gen.',
+        url: 'https://voidzero.dev/posts/announcing-vite-plus-alpha?utm_source=vitest&utm_content=top_banner',
+      },
+
       carbonAds: {
         code: 'CW7DVKJE',
         placement: 'vitestdev',


### PR DESCRIPTION
Merge after Vite+ Alpha post is published: https://voidzero.dev/posts/announcing-vite-plus-alpha
