### PR TITLE
test: enhance test utils with `errorTree({ project, stackTrace })`

### DIFF
--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -26,5 +26,5 @@ Some test suites don't support running it remotely (`fixtures/inspect` and `fixt
 pnpm docker up -d
 
 # Run tests with BROWSER_WS_ENDPOINT
-BROWSER_WS_ENDPOINT=ws://127.0.0.1:6677/ pnpm run test:playwright
+BROWSER_WS_ENDPOINT=true pnpm run test:playwright
 ```

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -5,12 +5,14 @@ import { webdriverio } from '@vitest/browser-webdriverio'
 
 const providerName = (process.env.PROVIDER || 'playwright') as 'playwright' | 'webdriverio' | 'preview'
 
+const wsEndpoint = process.env.BROWSER_WS_ENDPOINT === 'true' ? 'ws://127.0.0.1:6677/' : process.env.BROWSER_WS_ENDPOINT
+
 export const providers = {
-  playwright: (options?: Parameters<typeof playwright>[0]) => playwright(process.env.BROWSER_WS_ENDPOINT
+  playwright: (options?: Parameters<typeof playwright>[0]) => playwright(wsEndpoint
     ? {
         ...options,
         connectOptions: {
-          wsEndpoint: process.env.BROWSER_WS_ENDPOINT,
+          wsEndpoint,
           exposeNetwork: '<loopback>',
         },
       }

--- a/test/browser/specs/assertion-helper.test.ts
+++ b/test/browser/specs/assertion-helper.test.ts
@@ -4,20 +4,11 @@ import { buildTestProjectTree } from '../../test-utils'
 import { instances, runBrowserTests } from './utils'
 
 test('vi.defineHelper hides internal stack traces', async () => {
-  const { results, ctx } = await runBrowserTests({
+  const { errorTree } = await runBrowserTests({
     root: './fixtures/assertion-helper',
   })
 
-  const projectTree = buildTestProjectTree(results, (testCase) => {
-    const result = testCase.result()
-    return result.errors.map((e) => {
-      const stacks = e.stacks.map(s => ({
-        ...s,
-        file: path.relative(ctx.config.root, s.file),
-      }))
-      return ({ message: e.message, stacks })
-    })
-  })
+  const projectTree = errorTree({ project: true, stackTrace: true })
   expect(Object.keys(projectTree).sort()).toEqual(instances.map(i => i.browser).sort())
 
   for (const [name, tree] of Object.entries(projectTree)) {
@@ -29,12 +20,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'async' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 8,
-                    "file": "basic.test.ts",
-                    "line": 26,
-                    "method": "",
-                  },
+                  "basic.test.ts:26:8",
                 ],
               },
             ],
@@ -42,12 +28,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'soft' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 14,
-                    "file": "basic.test.ts",
-                    "line": 30,
-                    "method": "",
-                  },
+                  "basic.test.ts:30:14",
                 ],
               },
             ],
@@ -55,12 +36,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'soft async' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 8,
-                    "file": "basic.test.ts",
-                    "line": 34,
-                    "method": "",
-                  },
+                  "basic.test.ts:34:8",
                 ],
               },
             ],
@@ -68,12 +44,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'sync' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 10,
-                    "file": "basic.test.ts",
-                    "line": 22,
-                    "method": "",
-                  },
+                  "basic.test.ts:22:10",
                 ],
               },
             ],
@@ -92,12 +63,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'async' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 20,
-                    "file": "basic.test.ts",
-                    "line": 9,
-                    "method": "",
-                  },
+                  "basic.test.ts:9:20",
                 ],
               },
             ],
@@ -105,12 +71,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'soft' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 14,
-                    "file": "basic.test.ts",
-                    "line": 30,
-                    "method": "",
-                  },
+                  "basic.test.ts:30:14",
                 ],
               },
             ],
@@ -118,12 +79,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'soft async' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 25,
-                    "file": "basic.test.ts",
-                    "line": 18,
-                    "method": "",
-                  },
+                  "basic.test.ts:18:25",
                 ],
               },
             ],
@@ -131,12 +87,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'sync' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 10,
-                    "file": "basic.test.ts",
-                    "line": 22,
-                    "method": "",
-                  },
+                  "basic.test.ts:22:10",
                 ],
               },
             ],
@@ -152,12 +103,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'async' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 2,
-                    "file": "basic.test.ts",
-                    "line": 26,
-                    "method": "",
-                  },
+                  "basic.test.ts:26:2",
                 ],
               },
             ],
@@ -165,12 +111,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'soft' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 2,
-                    "file": "basic.test.ts",
-                    "line": 30,
-                    "method": "",
-                  },
+                  "basic.test.ts:30:2",
                 ],
               },
             ],
@@ -178,12 +119,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'soft async' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 2,
-                    "file": "basic.test.ts",
-                    "line": 34,
-                    "method": "",
-                  },
+                  "basic.test.ts:34:2",
                 ],
               },
             ],
@@ -191,12 +127,7 @@ test('vi.defineHelper hides internal stack traces', async () => {
               {
                 "message": "expected 'sync' to deeply equal 'x'",
                 "stacks": [
-                  {
-                    "column": 2,
-                    "file": "basic.test.ts",
-                    "line": 22,
-                    "method": "",
-                  },
+                  "basic.test.ts:22:2",
                 ],
               },
             ],

--- a/test/browser/specs/assertion-helper.test.ts
+++ b/test/browser/specs/assertion-helper.test.ts
@@ -1,6 +1,4 @@
-import path from 'node:path'
 import { expect, test } from 'vitest'
-import { buildTestProjectTree } from '../../test-utils'
 import { instances, runBrowserTests } from './utils'
 
 test('vi.defineHelper hides internal stack traces', async () => {
@@ -17,36 +15,20 @@ test('vi.defineHelper hides internal stack traces', async () => {
         {
           "basic.test.ts": {
             "async": [
-              {
-                "message": "expected 'async' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:26:8",
-                ],
-              },
+              "expected 'async' to deeply equal 'x'
+            at basic.test.ts:26:8",
             ],
             "soft": [
-              {
-                "message": "expected 'soft' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:30:14",
-                ],
-              },
+              "expected 'soft' to deeply equal 'x'
+            at basic.test.ts:30:14",
             ],
             "soft async": [
-              {
-                "message": "expected 'soft async' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:34:8",
-                ],
-              },
+              "expected 'soft async' to deeply equal 'x'
+            at basic.test.ts:34:8",
             ],
             "sync": [
-              {
-                "message": "expected 'sync' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:22:10",
-                ],
-              },
+              "expected 'sync' to deeply equal 'x'
+            at basic.test.ts:22:10",
             ],
           },
         }
@@ -60,36 +42,20 @@ test('vi.defineHelper hides internal stack traces', async () => {
         {
           "basic.test.ts": {
             "async": [
-              {
-                "message": "expected 'async' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:9:20",
-                ],
-              },
+              "expected 'async' to deeply equal 'x'
+            at basic.test.ts:9:20",
             ],
             "soft": [
-              {
-                "message": "expected 'soft' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:30:14",
-                ],
-              },
+              "expected 'soft' to deeply equal 'x'
+            at basic.test.ts:30:14",
             ],
             "soft async": [
-              {
-                "message": "expected 'soft async' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:18:25",
-                ],
-              },
+              "expected 'soft async' to deeply equal 'x'
+            at basic.test.ts:18:25",
             ],
             "sync": [
-              {
-                "message": "expected 'sync' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:22:10",
-                ],
-              },
+              "expected 'sync' to deeply equal 'x'
+            at basic.test.ts:22:10",
             ],
           },
         }
@@ -100,36 +66,20 @@ test('vi.defineHelper hides internal stack traces', async () => {
         {
           "basic.test.ts": {
             "async": [
-              {
-                "message": "expected 'async' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:26:2",
-                ],
-              },
+              "expected 'async' to deeply equal 'x'
+            at basic.test.ts:26:2",
             ],
             "soft": [
-              {
-                "message": "expected 'soft' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:30:2",
-                ],
-              },
+              "expected 'soft' to deeply equal 'x'
+            at basic.test.ts:30:2",
             ],
             "soft async": [
-              {
-                "message": "expected 'soft async' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:34:2",
-                ],
-              },
+              "expected 'soft async' to deeply equal 'x'
+            at basic.test.ts:34:2",
             ],
             "sync": [
-              {
-                "message": "expected 'sync' to deeply equal 'x'",
-                "stacks": [
-                  "basic.test.ts:22:2",
-                ],
-              },
+              "expected 'sync' to deeply equal 'x'
+            at basic.test.ts:22:2",
             ],
           },
         }

--- a/test/config/test/conditions-cli.test.ts
+++ b/test/config/test/conditions-cli.test.ts
@@ -104,11 +104,11 @@ test('conditions (inline indirect)', async () => {
 })
 
 test('project resolve.conditions', async () => {
-  const { stderr, errorProjectTree } = await runVitest({
+  const { stderr, errorTree } = await runVitest({
     root: 'fixtures/conditions-projects',
   })
   expect(stderr).toBe('')
-  expect(errorProjectTree()).toMatchInlineSnapshot(`
+  expect(errorTree({ project: true })).toMatchInlineSnapshot(`
     {
       "project-a": {
         "basic.test.js": {

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -573,12 +573,13 @@ export class StableTestFileOrderSorter {
 export function buildErrorTree(testModules: TestModule[], options?: { stackTrace?: boolean }) {
   const root = testModules[0]!.project.config.root
 
-  function mapError(e: { message: string; stacks?: { file: string; line: number; column: number }[] }) {
+  function mapError(e: { message: string; stacks?: { file: string; line: number; column: number; method: string }[] }) {
     if (options?.stackTrace) {
-      return {
-        message: e.message,
-        stacks: (e.stacks || []).map(s => `${relative(root, s.file)}:${s.line}:${s.column}`),
-      }
+      const stacks = (e.stacks || []).map((s) => {
+        const loc = `${relative(root, s.file)}:${s.line}:${s.column}`
+        return s.method ? `    at ${s.method} (${loc})` : `    at ${loc}`
+      })
+      return [e.message, ...stacks].join('\n')
     }
     return e.message
   }

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -571,7 +571,7 @@ export class StableTestFileOrderSorter {
 }
 
 export function buildErrorTree(testModules: TestModule[], options?: { stackTrace?: boolean }) {
-  const root = testModules[0]!.project.config.root
+  const root = testModules[0]?.project.config.root
 
   function mapError(e: { message: string; stacks?: { file: string; line: number; column: number; method: string }[] }) {
     if (options?.stackTrace) {

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -241,16 +241,16 @@ export async function runVitest(
     get results() {
       return ctx?.state.getTestModules() || []
     },
-    errorTree() {
-      const tree = buildErrorTree(ctx?.state.getTestModules() || [])
+    errorTree(options?: { project?: boolean; stackTrace?: boolean }) {
+      const modules = ctx?.state.getTestModules() || []
+      const tree = options?.project
+        ? buildErrorProjectTree(modules, options)
+        : buildErrorTree(modules, options)
       const errors = ctx?.state.getUnhandledErrors()
       if (errors && errors.length > 0) {
         tree.__unhandled_errors__ = errors.map((e: any) => e.message)
       }
       return tree
-    },
-    errorProjectTree() {
-      return buildErrorProjectTree(ctx?.state.getTestModules() || [])
     },
     testTree() {
       return buildTestTree(ctx?.state.getTestModules() || [])
@@ -570,32 +570,44 @@ export class StableTestFileOrderSorter {
   }
 }
 
-export function buildErrorTree(testModules: TestModule[]) {
+export function buildErrorTree(testModules: TestModule[], options?: { stackTrace?: boolean }) {
+  const root = testModules[0]!.project.config.root
+
+  function mapError(e: { message: string; stacks?: { file: string; line: number; column: number }[] }) {
+    if (options?.stackTrace) {
+      return {
+        message: e.message,
+        stacks: (e.stacks || []).map(s => `${relative(root, s.file)}:${s.line}:${s.column}`),
+      }
+    }
+    return e.message
+  }
+
   return buildTestTree(
     testModules,
     (testCase) => {
       const result = testCase.result()
       if (result.state === 'failed') {
-        return result.errors.map(e => e.message)
+        return result.errors.map(e => mapError(e))
       }
       return result.state
     },
     (testSuite, suiteChildren) => {
-      const errors = testSuite.errors().map(error => error.message)
+      const errors = testSuite.errors()
       if (errors.length > 0) {
         return {
           ...suiteChildren,
-          __suite_errors__: errors,
+          __suite_errors__: errors.map(e => mapError(e)),
         }
       }
       return suiteChildren
     },
     (testModule, moduleChildren) => {
-      const errors = testModule.errors().map(error => error.message)
+      const errors = testModule.errors()
       if (errors.length > 0) {
         return {
           ...moduleChildren,
-          __module_errors__: errors,
+          __module_errors__: errors.map(e => mapError(e)),
         }
       }
       return moduleChildren
@@ -660,14 +672,14 @@ export function buildTestProjectTree(testModules: TestModule[], onTestCase?: (re
   return projectTree
 }
 
-export function buildErrorProjectTree(testModules: TestModule[]) {
+export function buildErrorProjectTree(testModules: TestModule[], options?: { stackTrace?: boolean }) {
   const projectTree: Record<string, Record<string, any>> = {}
 
   for (const testModule of testModules) {
     const projectName = testModule.project.name
     projectTree[projectName] = {
       ...projectTree[projectName],
-      ...buildErrorTree([testModule]),
+      ...buildErrorTree([testModule], options),
     }
   }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I was debugging https://github.com/vitest-dev/vitest/pull/9795 and I thought something like this could be useful, but it turned out not much. Got some other parts cleaned up a bit, so pushing it here anyways.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
