### PR TITLE
fix: use isAgent check, not just TTY, for watch mode

### DIFF
--- a/packages/vitest/src/defaults.ts
+++ b/packages/vitest/src/defaults.ts
@@ -5,7 +5,7 @@ import type {
   UserConfig,
 } from './node/types/config'
 import os from 'node:os'
-import { isCI } from './utils/env'
+import { isAgent, isCI } from './utils/env'
 
 export { defaultBrowserPort } from './constants'
 
@@ -93,7 +93,7 @@ export const configDefaults: Readonly<{
 }> = Object.freeze({
   allowOnly: !isCI,
   isolate: true,
-  watch: !isCI && process.stdin.isTTY,
+  watch: !isCI && process.stdin.isTTY && !isAgent,
   globals: false,
   environment: 'node' as const,
   clearMocks: false,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

We were previously using only the `isTTY` check. This adds an additional layer of protection in case the agent support TTY.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
