### PR TITLE
fix(browser): take failure screenshot if `toMatchScreenshot` can't capture a stable screenshot

### DIFF
--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -120,5 +120,9 @@ export default async function toMatchScreenshot(
           ]
             .filter(element => element !== null)
             .join('\n'),
+    meta: {
+      assertion: 'toMatchScreenshot',
+      outcome: result.outcome,
+    },
   }
 }

--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -121,7 +121,6 @@ export default async function toMatchScreenshot(
             .filter(element => element !== null)
             .join('\n'),
     meta: {
-      assertion: 'toMatchScreenshot',
       outcome: result.outcome,
     },
   }

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -156,14 +156,16 @@ export function createBrowserRunner(
     }
 
     onTaskFinished = async (task: Task) => {
+      const lastErrorMeta = task.result?.errors?.at(-1)?.meta
       if (
         this.config.browser.screenshotFailures
         && document.body.clientHeight > 0
         && task.result?.state === 'fail'
         && task.type === 'test'
-        && task.artifacts.every(
-          artifact => artifact.type !== 'internal:toMatchScreenshot',
-        )
+        && !(
+          lastErrorMeta
+          && Reflect.get(lastErrorMeta, 'assertion') === 'toMatchScreenshot'
+          && Reflect.get(lastErrorMeta, 'outcome') !== 'unstable-screenshot')
       ) {
         const screenshot = await page.screenshot({
           timeout: this.config.browser.providerOptions?.actionTimeout ?? 5_000,

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -156,16 +156,16 @@ export function createBrowserRunner(
     }
 
     onTaskFinished = async (task: Task) => {
-      const lastErrorMeta = task.result?.errors?.at(-1)?.meta
+      const lastErrorContext = task.result?.errors?.at(-1)?.context
       if (
         this.config.browser.screenshotFailures
         && document.body.clientHeight > 0
         && task.result?.state === 'fail'
         && task.type === 'test'
         && !(
-          lastErrorMeta
-          && Reflect.get(lastErrorMeta, 'assertion') === 'toMatchScreenshot'
-          && Reflect.get(lastErrorMeta, 'outcome') !== 'unstable-screenshot')
+          lastErrorContext
+          && Reflect.get(lastErrorContext, 'assertionName') === 'toMatchScreenshot'
+          && Reflect.get(lastErrorContext, 'meta')?.outcome !== 'unstable-screenshot')
       ) {
         const screenshot = await page.screenshot({
           timeout: this.config.browser.providerOptions?.actionTimeout ?? 5_000,

--- a/packages/browser/src/node/commands/screenshotMatcher/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/index.ts
@@ -273,6 +273,7 @@ function buildOutput(
     case 'unstable-screenshot':
       return {
         pass: false,
+        outcome: outcome.type,
         reference: outcome.reference && {
           path: outcome.reference.path,
           width: outcome.reference.image.metadata.width,
@@ -286,6 +287,7 @@ function buildOutput(
     case 'missing-reference': {
       return {
         pass: false,
+        outcome: outcome.type,
         reference: {
           path: outcome.reference.path,
           width: outcome.reference.image.metadata.width,
@@ -302,11 +304,12 @@ function buildOutput(
     case 'update-reference':
     case 'matched-immediately':
     case 'matched-after-comparison':
-      return { pass: true }
+      return { pass: true, outcome: outcome.type }
 
     case 'mismatch':
       return {
         pass: false,
+        outcome: outcome.type,
         reference: {
           path: outcome.reference.path,
           width: outcome.reference.image.metadata.width,
@@ -333,6 +336,7 @@ function buildOutput(
 
       return {
         pass: false,
+        outcome: null as never,
         actual: null,
         reference: null,
         diff: null,

--- a/packages/browser/src/shared/screenshotMatcher/types.ts
+++ b/packages/browser/src/shared/screenshotMatcher/types.ts
@@ -17,6 +17,10 @@ interface ScreenshotData { path: string; width: number; height: number }
 export type ScreenshotMatcherOutput = Promise<
   {
     pass: false
+    outcome:
+      | 'unstable-screenshot'
+      | 'missing-reference'
+      | 'mismatch'
     reference: ScreenshotData | null
     actual: ScreenshotData | null
     diff: ScreenshotData | null
@@ -24,5 +28,9 @@ export type ScreenshotMatcherOutput = Promise<
   }
   | {
     pass: true
+    outcome:
+      | 'update-reference'
+      | 'matched-immediately'
+      | 'matched-after-comparison'
   }
 >

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -65,7 +65,7 @@ function getMatcherState(
 }
 
 class JestExtendError extends Error {
-  constructor(message: string, public actual?: any, public expected?: any) {
+  constructor(message: string, public actual?: any, public expected?: any, public meta?: object) {
     super(message)
   }
 }
@@ -92,23 +92,23 @@ function JestExtendPlugin(
             && typeof (result as any).then === 'function'
           ) {
             const thenable = result as PromiseLike<SyncExpectationResult>
-            return thenable.then(({ pass, message, actual, expected }) => {
+            return thenable.then(({ pass, message, actual, expected, meta }) => {
               if ((pass && isNot) || (!pass && !isNot)) {
                 const errorMessage = customMessage != null
                   ? customMessage
                   : message()
-                throw new JestExtendError(errorMessage, actual, expected)
+                throw new JestExtendError(errorMessage, actual, expected, meta)
               }
             })
           }
 
-          const { pass, message, actual, expected } = result as SyncExpectationResult
+          const { pass, message, actual, expected, meta } = result as SyncExpectationResult
 
           if ((pass && isNot) || (!pass && !isNot)) {
             const errorMessage = customMessage != null
               ? customMessage
               : message()
-            throw new JestExtendError(errorMessage, actual, expected)
+            throw new JestExtendError(errorMessage, actual, expected, meta)
           }
         }
 

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -65,8 +65,19 @@ function getMatcherState(
 }
 
 class JestExtendError extends Error {
-  constructor(message: string, public actual?: any, public expected?: any, public meta?: object) {
+  context?: {
+    assertionName: string
+    meta?: object
+  }
+
+  constructor(message: string, public actual?: any, public expected?: any) {
     super(message)
+  }
+
+  setContext(assertionName: string, meta?: object): this {
+    this.context = { assertionName, meta }
+
+    return this
   }
 }
 
@@ -97,7 +108,7 @@ function JestExtendPlugin(
                 const errorMessage = customMessage != null
                   ? customMessage
                   : message()
-                throw new JestExtendError(errorMessage, actual, expected, meta)
+                throw new JestExtendError(errorMessage, actual, expected).setContext(expectAssertionName, meta)
               }
             })
           }
@@ -108,7 +119,7 @@ function JestExtendPlugin(
             const errorMessage = customMessage != null
               ? customMessage
               : message()
-            throw new JestExtendError(errorMessage, actual, expected, meta)
+            throw new JestExtendError(errorMessage, actual, expected).setContext(expectAssertionName, meta)
           }
         }
 

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -65,19 +65,13 @@ function getMatcherState(
 }
 
 class JestExtendError extends Error {
-  context?: {
-    assertionName: string
-    meta?: object
-  }
-
-  constructor(message: string, public actual?: any, public expected?: any) {
+  constructor(
+    message: string,
+    public actual?: any,
+    public expected?: any,
+    public context?: { assertionName: string; meta?: object },
+  ) {
     super(message)
-  }
-
-  setContext(assertionName: string, meta?: object): this {
-    this.context = { assertionName, meta }
-
-    return this
   }
 }
 
@@ -108,7 +102,12 @@ function JestExtendPlugin(
                 const errorMessage = customMessage != null
                   ? customMessage
                   : message()
-                throw new JestExtendError(errorMessage, actual, expected).setContext(expectAssertionName, meta)
+                throw new JestExtendError(
+                  errorMessage,
+                  actual,
+                  expected,
+                  { assertionName: expectAssertionName, meta },
+                )
               }
             })
           }
@@ -119,7 +118,12 @@ function JestExtendPlugin(
             const errorMessage = customMessage != null
               ? customMessage
               : message()
-            throw new JestExtendError(errorMessage, actual, expected).setContext(expectAssertionName, meta)
+            throw new JestExtendError(
+              errorMessage,
+              actual,
+              expected,
+              { assertionName: expectAssertionName, meta },
+            )
           }
         }
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -91,6 +91,7 @@ export interface SyncExpectationResult {
   message: () => string
   actual?: any
   expected?: any
+  meta?: object
 }
 
 export type AsyncExpectationResult = Promise<SyncExpectationResult>

--- a/test/browser/specs/failure-screenshot.test.ts
+++ b/test/browser/specs/failure-screenshot.test.ts
@@ -1,0 +1,100 @@
+import type { TestFsStructure } from '../../test-utils'
+import { describe, expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
+import utilsContent from '../fixtures/expect-dom/utils?raw'
+import { instances, provider } from '../settings'
+
+const testFilename = 'basic.test.ts'
+
+async function runBrowserTests(
+  structure: TestFsStructure,
+) {
+  return runInlineTests({
+    ...structure,
+    'vitest.config.js': `
+      import { ${provider.name} } from '@vitest/browser-${provider.name}'
+      export default {
+        test: {
+          browser: {
+            enabled: true,
+            screenshotFailures: true,
+            provider: ${provider.name}(),
+            ui: false,
+            headless: true,
+            instances: ${JSON.stringify(instances.slice(0, 1) /* logic not bound to browser instance */)},
+          },
+          reporters: ['verbose'],
+          update: 'new',
+        },
+      }`,
+  })
+}
+
+describe('failure screenshots', () => {
+  describe('`toMatchScreenshot`', () => {
+    test('usually does NOT produce a failure screenshot', async () => {
+      const { stderr } = await runBrowserTests(
+        {
+          [testFilename]: /* ts */`
+            import { page } from 'vitest/browser'
+            import { test } from 'vitest'
+            import { render } from './utils'
+
+            test('screenshot-initial', async ({ expect }) => {
+              render('<div data-testid="el">Test</div>')
+              await expect(page.getByTestId('el')).toMatchScreenshot()
+            })
+          `,
+          'utils.ts': utilsContent,
+        },
+      )
+
+      expect(stderr).toContain('No existing reference screenshot found; a new one was created.')
+      expect(stderr).not.toContain('Failure screenshot:')
+    })
+
+    test('unstable screenshot fails produces a failure screenshot', async () => {
+      const { stderr } = await runBrowserTests(
+        {
+          [testFilename]: /* ts */`
+            import { page } from 'vitest/browser'
+            import { test } from 'vitest'
+            import { render } from './utils'
+
+            test('screenshot-unstable', async ({ expect }) => {
+              render('<div data-testid="el">Test</div>')
+              await expect(page.getByTestId('el')).toMatchScreenshot({ timeout: 1 })
+            })
+          `,
+          'utils.ts': utilsContent,
+        },
+      )
+
+      expect(stderr).toContain('Could not capture a stable screenshot within 1ms.')
+      expect(stderr).toContain('Failure screenshot:')
+    })
+
+    test('`expect.soft` produces a failure screenshot', async () => {
+      const { stderr } = await runBrowserTests(
+        {
+          [testFilename]: /* ts */`
+            import { page } from 'vitest/browser'
+            import { test } from 'vitest'
+            import { render } from './utils'
+
+            test('screenshot-soft-then-fail', async ({ expect }) => {
+              render('<div data-testid="el">Test</div>')
+              await expect.soft(page.getByTestId('el')).toMatchScreenshot()
+              expect(1).toBe(2)
+            })
+          `,
+          'utils.ts': utilsContent,
+        },
+      )
+
+      expect(stderr).toContain('No existing reference screenshot found; a new one was created.')
+      expect(stderr).toContain('expected 1 to be 2')
+      expect(stderr).toContain('Failure screenshot:')
+    })
+  })
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #9690

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
