### PR TITLE
fix: force `poll` run to stop at timeout

### DIFF
--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -87,10 +87,14 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
             const { setTimeout, clearTimeout } = getSafeTimers()
 
             let executionPhase: 'fn' | 'assertion' = 'fn'
-            let hasTimedOut = false
+            const ac = new AbortController()
+
+            const timeoutPromise = new Promise((resolve) => {
+              ac.signal.addEventListener('abort', resolve)
+            })
 
             const timerId = setTimeout(() => {
-              hasTimedOut = true
+              ac.abort()
             }, timeout)
 
             chai.util.flag(assertion, '_name', key)
@@ -99,16 +103,20 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
 
             try {
               while (true) {
-                const isLastAttempt = hasTimedOut
-
-                if (isLastAttempt) {
-                  chai.util.flag(assertion, '_isLastPollAttempt', true)
-                }
-
                 try {
                   executionPhase = 'fn'
-                  const obj = await fn()
-                  chai.util.flag(assertion, 'object', obj)
+                  const fnPromise = Promise.resolve(fn())
+                  // @todo: what should happen here?
+                  fnPromise.catch(() => {})
+
+                  const result = await Promise.race([fnPromise, timeoutPromise])
+
+                  if (ac.signal.aborted) {
+                    chai.util.flag(assertion, '_isLastPollAttempt', true)
+                  }
+                  else {
+                    chai.util.flag(assertion, 'object', result)
+                  }
 
                   executionPhase = 'assertion'
                   const output = await assertionFunction.call(assertion, ...args)
@@ -117,12 +125,12 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                   return output
                 }
                 catch (err) {
-                  if (isLastAttempt || (executionPhase === 'assertion' && chai.util.flag(assertion, '_poll.assert_once'))) {
+                  if (ac.signal.aborted || (executionPhase === 'assertion' && chai.util.flag(assertion, '_poll.assert_once'))) {
                     await onSettled?.({ assertion, status: 'fail' })
                     throwWithCause(err, STACK_TRACE_ERROR)
                   }
 
-                  await delay(interval, setTimeout)
+                  await Promise.race([delay(interval, setTimeout), timeoutPromise])
                 }
               }
             }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #9844

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
