### PR TITLE
fix: type regression in vi.mocked() static class methods

### DIFF
--- a/packages/spy/src/types.ts
+++ b/packages/spy/src/types.ts
@@ -462,12 +462,10 @@ type DeepPartialMock<T extends Procedure | Constructable = Procedure> = Mock<
 export type MaybeMockedConstructor<T> = T extends Constructable
   ? Mock<T>
   : T
-export type MockedFunction<T extends Procedure | Constructable> = Mock<T> & {
-  [K in keyof T]: T[K];
-}
-export type PartiallyMockedFunction<T extends Procedure | Constructable> = PartialMock<T> & {
-  [K in keyof T]: T[K];
-}
+export type MockedFunction<T extends Procedure | Constructable> = Mock<T>
+  & MockedObject<T>
+export type PartiallyMockedFunction<T extends Procedure | Constructable> = PartialMock<T>
+  & MockedObject<T>
 export type MockedFunctionDeep<T extends Procedure | Constructable> = Mock<T>
   & MockedObjectDeep<T>
 export type PartiallyMockedFunctionDeep<T extends Procedure | Constructable> = DeepPartialMock<T>

--- a/test/core/test/vi.spec.ts
+++ b/test/core/test/vi.spec.ts
@@ -151,6 +151,10 @@ describe('testing vi utils', () => {
       public getBar(): string {
         return this.bar
       }
+
+      static getBaz(): string {
+        return 'baz'
+      }
     }
     class FooMock implements Mocked<Foo> {
       readonly barMock: Mock<() => string> = vi.fn()
@@ -168,6 +172,8 @@ describe('testing vi utils', () => {
     if (0) {
       vi.mocked(Foo).mockImplementation(FooMock)
       vi.mocked(Foo).mockImplementation(Foo)
+      vi.mocked(Foo).getBaz.mockImplementation(() => 'baz')
+      vi.mocked(Foo, { partial: true }).getBaz.mockImplementation(() => 'baz')
     }
   })
 


### PR DESCRIPTION
### Description

Fixes typeing regression in `vitest@4+`'s `vi.mocked()`

* Fixes `vi.mocked(...)` typing for static class methods by preserving mocked method members on shallow mocked constructors. 
* Adds a regression test covering mockImplementation() on a static class method to prevent future type regressions.


Resolves #9172

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
