### PR TITLE
fix(expect): race fn() against timeout in expect.poll() to abort slow callbacks

### DIFF
--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -89,8 +89,19 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
             let executionPhase: 'fn' | 'assertion' = 'fn'
             let hasTimedOut = false
 
+            // A promise that rejects when the timeout fires. Raced against fn()
+            // so that a slow fn() is aborted early rather than allowed to block
+            // beyond the configured timeout.
+            let _rejectOnTimeout!: (e: Error) => void
+            const timeoutAbortPromise = new Promise<never>((_, reject) => {
+              _rejectOnTimeout = reject
+            })
+
             const timerId = setTimeout(() => {
               hasTimedOut = true
+              _rejectOnTimeout(
+                new Error(`expect.poll() timed out after ${timeout}ms`),
+              )
             }, timeout)
 
             chai.util.flag(assertion, '_name', key)
@@ -107,7 +118,9 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
 
                 try {
                   executionPhase = 'fn'
-                  const obj = await fn()
+                  // Race fn() against the timeout so that a slow fn() doesn't
+                  // block the loop past the configured timeout.
+                  const obj = await Promise.race([fn(), timeoutAbortPromise])
                   chai.util.flag(assertion, 'object', obj)
 
                   executionPhase = 'assertion'
@@ -117,7 +130,7 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                   return output
                 }
                 catch (err) {
-                  if (isLastAttempt || (executionPhase === 'assertion' && chai.util.flag(assertion, '_poll.assert_once'))) {
+                  if (isLastAttempt || hasTimedOut || (executionPhase === 'assertion' && chai.util.flag(assertion, '_poll.assert_once'))) {
                     await onSettled?.({ assertion, status: 'fail' })
                     throwWithCause(err, STACK_TRACE_ERROR)
                   }

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -45,6 +45,28 @@ test('timeout', async () => {
   }))
 })
 
+test('timeout aborts slow fn() calls early', async () => {
+  // When fn() takes longer than the configured timeout, expect.poll() should
+  // fail within roughly `timeout` ms rather than waiting for the slow fn() to
+  // complete each iteration.
+  const start = Date.now()
+  await expect(async () => {
+    await expect
+      .poll(
+        async () => {
+          // fn() deliberately takes much longer than the timeout
+          await new Promise(r => setTimeout(r, 5000))
+          return undefined
+        },
+        { timeout: 100 },
+      )
+      .toBe(1)
+  }).rejects.toThrow()
+  const elapsed = Date.now() - start
+  // Should fail well within 1s, not after waiting for each 5-second fn() call
+  expect(elapsed).toBeLessThan(1000)
+})
+
 test('interval', async () => {
   const fn = vi.fn(() => true)
   await expect(async () => {


### PR DESCRIPTION
Fixes #9844

## Problem

When the `fn` callback passed to `expect.poll()` takes longer than the configured `timeout`, the poll loop does not notice until `fn()` eventually resolves. This causes the overall poll to run well beyond its timeout window.

### Example

```ts
test('stuck', async () => {
  await expect
    .poll(
      async () => {
        await new Promise(r => setTimeout(r, 5000)) // much longer than timeout
      },
      { timeout: 100 },
    )
    .toBe(1)
})
```

Before this fix the test above would take ~5 s (one full `fn()` call) rather than ~100 ms.

## Root Cause

The timeout was implemented using a `setTimeout` that sets a `hasTimedOut` flag:

```ts
const timerId = setTimeout(() => {
  hasTimedOut = true
}, timeout)
// ...
const obj = await fn() // blocks until fn() resolves — ignores hasTimedOut
```

The flag is checked at the **start** of each loop iteration, but `await fn()` blocks the entire iteration. If `fn()` takes longer than the timeout, the flag goes unnoticed until `fn()` finishes.

## Fix

Create a promise that rejects when the timeout fires and race it against `fn()`:

```ts
const timeoutAbortPromise = new Promise<never>((_, reject) => {
  _rejectOnTimeout = reject
})
setTimeout(() => {
  hasTimedOut = true
  _rejectOnTimeout(new Error('expect.poll() timed out after Xms'))
}, timeout)

// Inside the loop:
const obj = await Promise.race([fn(), timeoutAbortPromise])
```

As soon as the timeout fires, `Promise.race` rejects and the loop exits — regardless of how slow `fn()` is.

## Changes

- `packages/vitest/src/integrations/chai/poll.ts` – use `Promise.race` to abort slow `fn()` calls
- `test/core/test/expect-poll.test.ts` – add regression test for slow `fn()` timeout