### PR TITLE
fix(browser): use resolve instead of join for screenshotDirectory path resolution

### DIFF
--- a/packages/browser/src/node/commands/screenshotMatcher/utils.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/utils.ts
@@ -136,7 +136,7 @@ export function resolveOptions(
     root,
     screenshotDirectory: relative(
       root,
-      join(root, context.project.config.browser.screenshotDirectory ?? '__screenshots__'),
+      resolve(root, context.project.config.browser.screenshotDirectory ?? '__screenshots__'),
     ),
     attachmentsDir: relative(root, context.project.config.attachmentsDir),
     testFileDirectory: relative(root, dirname(context.testPath)),

--- a/test/browser/specs/to-match-screenshot.test.ts
+++ b/test/browser/specs/to-match-screenshot.test.ts
@@ -107,7 +107,7 @@ describe.runIf(provider.name === 'playwright')('screenshotDirectory', () => {
       expect(referencePath).not.toContain('custom-screenshots/Users')
       expect(referencePath).not.toContain('custom-screenshots/home')
 
-      expect(fs.existsFile(referencePath)).toBe(true)
+      expect(() => fs.statFile(referencePath)).not.toThrow()
 
       fs.editFile(testFilename, content => `${content}\n`)
 

--- a/test/browser/specs/to-match-screenshot.test.ts
+++ b/test/browser/specs/to-match-screenshot.test.ts
@@ -55,6 +55,70 @@ async function runBrowserTests(
   })
 }
 
+async function runBrowserTestsWithScreenshotDir(
+  structure: TestFsStructure,
+  screenshotDir: string,
+  config: ViteUserConfig['test'] = {},
+) {
+  return runInlineTests({
+    ...structure,
+    'vitest.config.js': `
+      import { playwright } from '@vitest/browser-playwright'
+      export default {
+        test: {
+          browser: {
+            enabled: true,
+            screenshotFailures: false,
+            screenshotDirectory: ${JSON.stringify(screenshotDir)},
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: ${JSON.stringify(browser)} }],
+          },
+          reporters: ['verbose'],
+          ...${JSON.stringify(config)},
+        },
+      }`,
+  }, {
+    $cliOptions: {
+      watch: true,
+    },
+  })
+}
+
+describe.runIf(provider.name === 'playwright')('screenshotDirectory', () => {
+  test(
+    'stores screenshots in the configured directory when screenshotDirectory is explicitly set',
+    async () => {
+      const { fs, stderr, vitest } = await runBrowserTestsWithScreenshotDir(
+        {
+          [testFilename]: testContent,
+          'utils.ts': utilsContent,
+        },
+        'custom-screenshots',
+        {
+          update: 'new',
+        },
+      )
+
+      const [referencePath] = extractToMatchScreenshotPaths(stderr, testName)
+
+      // The reference screenshot should be inside the custom directory, not contain absolute path segments
+      expect(referencePath).toContain('custom-screenshots/')
+      expect(referencePath).not.toContain('custom-screenshots/Users')
+      expect(referencePath).not.toContain('custom-screenshots/home')
+
+      expect(fs.existsFile(referencePath)).toBe(true)
+
+      fs.editFile(testFilename, content => `${content}\n`)
+
+      vitest.resetOutput()
+      await vitest.waitForStdout('Test Files  1 passed')
+
+      expect(vitest.stdout).toContain('✓ |chromium| basic.test.ts > screenshot-snapshot')
+    },
+  )
+})
+
 describe.runIf(provider.name === 'playwright')('--watch', () => {
   test(
     'fails when creating a snapshot for the first time and does NOT update it afterwards',


### PR DESCRIPTION
### Description

When `browser.screenshotDirectory` is explicitly set in config, `resolveConfig` pre-resolves it to an absolute path ([resolveConfig.ts#L812-L817](https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/config/resolveConfig.ts#L812-L817)). The `toMatchScreenshot` path resolver in `screenshotMatcher/utils.ts` then calls `join(root, absolutePath)`, which concatenates the paths literally — unlike `resolve`, `join` does not recognize when the second argument is already absolute.

This produces malformed screenshot paths like:
```
src/__tests__/Users/username/project/__screenshots__/test.tsx/screenshot.png
```

The fix replaces `join` with `resolve` on [utils.ts line 139](https://github.com/vitest-dev/vitest/blob/main/packages/browser/src/node/commands/screenshotMatcher/utils.ts#L139), which correctly handles both relative (default fallback) and absolute (pre-resolved config) paths.

The bug only triggers when `screenshotDirectory` is explicitly set. The default fallback (`?? '__screenshots__'`) produces a relative string, so `join` works correctly in that case.

Resolves #8604

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- N/A (no new functionality introduced)

### Changesets
- fix: use `resolve` instead of `join` for `screenshotDirectory` path resolution in `toMatchScreenshot`