### PR TITLE
fix: drop vite 8.beta support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Install
         run: |
-          yq -i '.overrides.vite = "npm:vite@beta"' pnpm-workspace.yaml
+          yq -i '.overrides.vite = "npm:vite@8"' pnpm-workspace.yaml
           git add . && git commit -m "ci" && pnpm i --prefer-offline --no-frozen-lockfile
 
       - uses: ./.github/actions/setup-playwright

--- a/packages/mocker/package.json
+++ b/packages/mocker/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "msw": "^2.4.9",
-    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "msw": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -139,7 +139,7 @@
     "@vitest/ui": "workspace:*",
     "happy-dom": "*",
     "jsdom": "*",
-    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@edge-runtime/vm": {
@@ -192,7 +192,7 @@
     "tinyexec": "^1.0.2",
     "tinyglobby": "catalog:",
     "tinyrainbow": "catalog:",
-    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "why-is-node-running": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vitest/issues/9859

Vite 8.0.0 is now `latest` so let's drop the beta support as it was planned. Supporting Vite's beta version was always meant to be experimental, so no breaking changes here. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
