### PR TITLE
fix(pnp): don't crash because of optional otel

### DIFF
--- a/packages/vitest/src/utils/traces.ts
+++ b/packages/vitest/src/utils/traces.ts
@@ -51,7 +51,11 @@ export class Traces {
 
   constructor(options: TracesOptions) {
     if (options.enabled) {
-      const apiInit = import('@opentelemetry/api').then((api) => {
+      // @ts-expect-error injected global
+			const id = typeof __vitest_browser__ === 'undefined'
+        ? '@opentelemetry/api'
+        : '/@id/@opentelemetry/api'
+      const apiInit = import(/* @vite-ignore */ id).then((api) => {
         const otel = {
           tracer: api.trace.getTracer(options.tracerName || 'vitest'),
           context: api.context,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #9799

This makes it so tests _run_ in pnp, but I couldn't manage to enable OTEL with pnp at all 

Also didn't test yet if normal scripts work