### PR TITLE
docs: add Unhandled Promise Rejection section to common errors guide

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -121,29 +121,27 @@ export default defineConfig({
 vitest --pool=forks
 ```
 :::
+
 ## Unhandled Promise Rejection
 
-This error happens when a Promise is rejected but no error handler
-(`.catch` or `await`) is attached before the event loop finishes.
+This error happens when a Promise is rejected but no error handler (`.catch` or `await`) is attached before the event loop finishes.
 
 This behavior comes from JavaScript itself and is not specific to Vitest.
 
 Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).
+
 ### Example
 
 ```ts
 test('unhandled rejection example', async () => {
   Promise.reject(new Error('Test error'))
 })
+```
 
+This may result in an `UnhandledPromiseRejectionWarning` error. To fix this, catch the error inside the test body:
 
-This may result in an error like:
-
-UnhandledPromiseRejectionWarning: Error: Test error
-
-
-Fix
-
+```ts
 test('handled rejection example', async () => {
   await Promise.reject(new Error('Test error')).catch(() => {})
 })
+```

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -135,10 +135,15 @@ Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#ev
 test('unhandled rejection example', async () => {
   Promise.reject(new Error('Test error'))
 })
+
+
 This may result in an error like:
 
 UnhandledPromiseRejectionWarning: Error: Test error
+
+
 Fix
+
 test('handled rejection example', async () => {
   await Promise.reject(new Error('Test error')).catch(() => {})
 })

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -129,3 +129,16 @@ This error happens when a Promise is rejected but no error handler
 This behavior comes from JavaScript itself and is not specific to Vitest.
 
 Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).
+### Example
+
+```ts
+test('unhandled rejection example', async () => {
+  Promise.reject(new Error('Test error'))
+})
+This may result in an error like:
+
+UnhandledPromiseRejectionWarning: Error: Test error
+Fix
+test('handled rejection example', async () => {
+  await Promise.reject(new Error('Test error')).catch(() => {})
+})

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -124,24 +124,44 @@ vitest --pool=forks
 
 ## Unhandled Promise Rejection
 
-This error happens when a Promise is rejected but no error handler (`.catch` or `await`) is attached before the event loop finishes.
+This error happens when a Promise rejects but no `.catch()` handler or `await` is attached to it before the microtask queue flushes. This behavior comes from JavaScript itself and is not specific to Vitest. Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).
 
-This behavior comes from JavaScript itself and is not specific to Vitest.
-
-Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).
-
-### Example
+A common cause is calling an async function without `await`ing it:
 
 ```ts
-test('unhandled rejection example', async () => {
-  Promise.reject(new Error('Test error'))
+async function fetchUser(id) {
+  const res = await fetch(`/api/users/${id}`)
+  if (!res.ok) {
+    throw new Error(`User ${id} not found`) // [!code highlight]
+  }
+  return res.json()
+}
+
+test('fetches user', async () => {
+  fetchUser(123) // [!code error]
 })
 ```
 
-This may result in an `UnhandledPromiseRejectionWarning` error. To fix this, catch the error inside the test body:
+Because `fetchUser()` is not `await`ed, its rejection has no handler and Vitest reports:
+
+```
+Unhandled Rejection: Error: User 123 not found
+```
+
+### Fix
+
+`await` the promise so Vitest can catch the error:
 
 ```ts
-test('handled rejection example', async () => {
-  await Promise.reject(new Error('Test error')).catch(() => {})
+test('fetches user', async () => {
+  await fetchUser(123) // [!code ++]
+})
+```
+
+If you expect the call to throw, use [`expect().rejects`](/api/expect#rejects):
+
+```ts
+test('rejects for missing user', async () => {
+  await expect(fetchUser(123)).rejects.toThrow('User 123 not found')
 })
 ```

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -121,3 +121,11 @@ export default defineConfig({
 vitest --pool=forks
 ```
 :::
+## Unhandled Promise Rejection
+
+This error happens when a Promise is rejected but no error handler
+(`.catch` or `await`) is attached before the event loop finishes.
+
+This behavior comes from JavaScript itself and is not specific to Vitest.
+
+Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).


### PR DESCRIPTION
Added a new section explaining the "Unhandled Promise Rejection" error
in the Common Errors guide.

This clarifies that the error originates from JavaScript/Node.js when
a rejected Promise does not have a handler attached.