### PR TITLE
docs: add example & fix for Unhandled Promise Rejection in common errors guide

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -135,10 +135,15 @@ Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#ev
 test('unhandled rejection example', async () => {
   Promise.reject(new Error('Test error'))
 })
+
+
 This may result in an error like:
 
 UnhandledPromiseRejectionWarning: Error: Test error
+
+
 Fix
+
 test('handled rejection example', async () => {
   await Promise.reject(new Error('Test error')).catch(() => {})
 })

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -129,3 +129,16 @@ This error happens when a Promise is rejected but no error handler
 This behavior comes from JavaScript itself and is not specific to Vitest.
 
 Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).
+### Example
+
+```ts
+test('unhandled rejection example', async () => {
+  Promise.reject(new Error('Test error'))
+})
+This may result in an error like:
+
+UnhandledPromiseRejectionWarning: Error: Test error
+Fix
+test('handled rejection example', async () => {
+  await Promise.reject(new Error('Test error')).catch(() => {})
+})

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -121,3 +121,11 @@ export default defineConfig({
 vitest --pool=forks
 ```
 :::
+## Unhandled Promise Rejection
+
+This error happens when a Promise is rejected but no error handler
+(`.catch` or `await`) is attached before the event loop finishes.
+
+This behavior comes from JavaScript itself and is not specific to Vitest.
+
+Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).


### PR DESCRIPTION
Added a section in the Common Errors guide explaining the Unhandled Promise Rejection error in JavaScript/Node.js.

Includes example test code showing unhandled vs handled promise rejections.

Shows how .catch(() => {}) can be used to handle errors.

Linked to the official [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection)
 for reference.

This helps readers understand why the error occurs and how to fix it in Vitest tests.
