### PR TITLE
fix: preserve coverage report when html reporter overlaps

### DIFF
--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -159,6 +159,12 @@ export default class HTMLReporter implements Reporter {
     if (this.ctx.config.coverage.enabled && this.ctx.config.coverage.htmlDir) {
       const coverageHtmlDir = this.ctx.config.coverage.htmlDir
       const destCoverageDir = resolve(this.reporterDir, 'coverage')
+      if (coverageHtmlDir === destCoverageDir) {
+        // skip and preserve already generated coverage report.
+        // this can happen when users configures `outputFile`
+        // next to `coverage.reportsDirectory`.
+        return
+      }
       await fs.rm(destCoverageDir, { recursive: true, force: true })
       await fs.mkdir(destCoverageDir, { recursive: true })
       await fs.cp(coverageHtmlDir, destCoverageDir, { recursive: true })

--- a/test/cli/test/reporters/html.test.ts
+++ b/test/cli/test/reporters/html.test.ts
@@ -118,6 +118,7 @@ test('basic', () => {});
       ],
     },
   })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
   expect(result.errorTree()).toMatchInlineSnapshot(`
     {
       "basic.test.ts": {
@@ -126,4 +127,46 @@ test('basic', () => {});
     }
   `)
   expect(result.fs.statFile('html/index.html').isFile()).toBe(true)
+})
+
+it('html and coverage already next each other', async () => {
+  const result = await runInlineTests({
+    'basic.ts': `
+export const add = (a: number, b: number) => a + b;
+`,
+    'basic.test.ts': `
+import { test, expect } from "vitest";
+import { add } from "./basic";
+test('add', () => {
+  expect(add(1, 2)).toBe(3);
+});
+`,
+  }, {
+    reporters: [
+      'default',
+      ['html', { outputFile: './custom-dir/index.html' }],
+    ],
+    coverage: {
+      enabled: true,
+      reporter: ['html'],
+      reportsDirectory: './custom-dir/coverage',
+    },
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "add": "passed",
+      },
+    }
+  `)
+  expect({
+    html: result.fs.statFile('custom-dir/index.html').isFile(),
+    coverage: result.fs.statFile('custom-dir/coverage/index.html').isFile(),
+  }).toMatchInlineSnapshot(`
+    {
+      "coverage": true,
+      "html": true,
+    }
+  `)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9880

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
