### PR TITLE
fix: provide `vi.advanceTimers` to the preview provider

### DIFF
--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -2,7 +2,7 @@ import type {
   Options as TestingLibraryOptions,
   UserEvent as TestingLibraryUserEvent,
 } from '@testing-library/user-event'
-import type { RunnerTask } from 'vitest'
+import { vi, type RunnerTask } from 'vitest'
 import type {
   BrowserLocators,
   BrowserPage,
@@ -142,8 +142,11 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
   return userEvent
 }
 
-function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options: TestingLibraryOptions): UserEvent {
-  let userEvent = userEventBase.setup(options)
+function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options?: TestingLibraryOptions): UserEvent {
+  let userEvent = userEventBase.setup({
+    advanceTimers: (delay) => vi.advanceTimersByTimeAsync(delay),
+    ...options,
+  })
   let clipboardData: DataTransfer | undefined
 
   function toElement(element: Element | Locator) {
@@ -155,7 +158,10 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options:
       return createPreviewUserEvent(userEventBase, options)
     },
     async cleanup() {
-      userEvent = userEventBase.setup(options ?? {})
+      userEvent = userEventBase.setup({
+        advanceTimers: (delay) => vi.advanceTimersByTimeAsync(delay),
+        ...options,
+      })
     },
     async click(element) {
       await userEvent.click(toElement(element))

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -2,7 +2,7 @@ import type {
   Options as TestingLibraryOptions,
   UserEvent as TestingLibraryUserEvent,
 } from '@testing-library/user-event'
-import { vi, type RunnerTask } from 'vitest'
+import type { RunnerTask } from 'vitest'
 import type {
   BrowserLocators,
   BrowserPage,
@@ -16,6 +16,7 @@ import type { StringifyOptions } from 'vitest/internal/browser'
 import type { IframeViewportEvent } from '../client'
 import type { BrowserRunnerState } from '../utils'
 import type { Locator as LocatorAPI } from './locators/index'
+import { vi } from 'vitest'
 import { __INTERNAL, stringify } from 'vitest/internal/browser'
 import { ensureAwaited, getBrowserState, getWorkerState } from '../utils'
 import { convertToSelector, isLocator, processTimeoutOptions, resolveUserEventWheelOptions } from './tester-utils'
@@ -144,7 +145,7 @@ export function createUserEvent(__tl_user_event_base__?: TestingLibraryUserEvent
 
 function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options?: TestingLibraryOptions): UserEvent {
   let userEvent = userEventBase.setup({
-    advanceTimers: (delay) => vi.advanceTimersByTimeAsync(delay),
+    advanceTimers: delay => vi.advanceTimersByTimeAsync(delay),
     ...options,
   })
   let clipboardData: DataTransfer | undefined
@@ -159,7 +160,7 @@ function createPreviewUserEvent(userEventBase: TestingLibraryUserEvent, options?
     },
     async cleanup() {
       userEvent = userEventBase.setup({
-        advanceTimers: (delay) => vi.advanceTimersByTimeAsync(delay),
+        advanceTimers: delay => vi.advanceTimersByTimeAsync(delay),
         ...options,
       })
     },


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Related #9882

Configuring global `userEvent` also makes sense in my opinion, since locator methods always use it, so I'm not closing the issue

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
