### PR TITLE
feat(expect): warn on toEqual comparing non-plain objects with empty Object.keys

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -563,6 +563,10 @@ expect(new Error('hi')).toEqual(new Error('hi', { cause: 'x' }))
 To test if something was thrown, use [`toThrow`](#tothrow) assertion.
 :::
 
+:::warning
+Some built-in objects (e.g. `Response`, `Request`) expose their data through getters instead of enumerable keys. Since `toEqual` relies on `Object.keys()`, these properties are not compared, which may cause false-negatives. Vitest emits a `console.warn` when this is detected. Consider comparing the relevant properties directly in that case.
+:::
+
 ## toStrictEqual
 
 - **Type:** `(received: any) => Awaitable<void>`

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -17,6 +17,7 @@ import {
   generateToBeMessage,
   getObjectSubset,
   isError,
+  isNonPlainEmptyObject,
   iterableEquality,
   equals as jestEquals,
   sparseArrayEquality,
@@ -105,6 +106,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
   def('toEqual', function (expected) {
     const actual = utils.flag(this, 'object')
+
+    if (isNonPlainEmptyObject(actual)) {
+      console.warn(
+        `toEqual: comparing two non-plain objects whose Object.keys() returns []. This may result in a false-negative — the objects are not actually compared. Consider using a custom matcher or accessing the properties explicitly.`,
+      )
+    }
+
     const equal = jestEquals(actual, expected, [
       ...customTesters,
       iterableEquality,

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -107,7 +107,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def('toEqual', function (expected) {
     const actual = utils.flag(this, 'object')
 
-    if (isNonPlainEmptyObject(actual)) {
+    if (isNonPlainEmptyObject(actual) && isNonPlainEmptyObject(expected)) {
       console.warn(
         `toEqual: comparing two non-plain objects whose Object.keys() returns []. This may result in a false-negative — the objects are not actually compared. Consider using a custom matcher or accessing the properties explicitly.`,
       )

--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -741,6 +741,7 @@ export function isPlainObject(value: unknown): value is Record<string | symbol, 
 export function isNonPlainEmptyObject(value: unknown): boolean {
   return value != null
     && typeof value === 'object'
+    && !Array.isArray(value)
     && !isPlainObject(value)
     && Object.keys(value).length === 0
 }

--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -730,6 +730,21 @@ export function pluralize(word: string, count: number): string {
   return `${count} ${word}${count === 1 ? '' : 's'}`
 }
 
+export function isPlainObject(value: unknown): value is Record<string | symbol, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+export function isNonPlainEmptyObject(value: unknown): boolean {
+  return value != null
+    && typeof value === 'object'
+    && !isPlainObject(value)
+    && Object.keys(value).length === 0
+}
+
 export function getObjectKeys(object: object): Array<string | symbol> {
   return [
     ...Object.keys(object),

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -2105,6 +2105,12 @@ it('diff', () => {
 })
 
 describe('toEqual warns on non-plain objects with empty Object.keys', () => {
+  // Uses private fields to guarantee Object.keys() === [] on all platforms
+  class HiddenState {
+    #value: string
+    constructor(value: string) { this.#value = value }
+  }
+
   let warnSpy: ReturnType<typeof vi.spyOn>
 
   beforeAll(() => {
@@ -2113,9 +2119,7 @@ describe('toEqual warns on non-plain objects with empty Object.keys', () => {
   })
 
   it('warns with a message mentioning toEqual and false-negative when comparing two non-plain objects with no enumerable keys', () => {
-    const r1 = new Response('a', { status: 200 })
-    const r2 = new Response('b', { status: 404 })
-    expect(r1).toEqual(r2)
+    expect(new HiddenState('a')).toEqual(new HiddenState('b'))
     expect(warnSpy).toHaveBeenCalledOnce()
     expect(warnSpy.mock.calls[0][0]).toContain('toEqual')
     expect(warnSpy.mock.calls[0][0]).toContain('false-negative')
@@ -2135,8 +2139,7 @@ describe('toEqual warns on non-plain objects with empty Object.keys', () => {
 
   it('does not warn when only one side is a non-plain empty object', () => {
     warnSpy.mockClear()
-    const r = new Response('a', { status: 200 })
-    expect(() => expect(r).toEqual({})).toThrow()
+    expect(() => expect(new HiddenState('a')).toEqual({ key: 'value' })).toThrow()
     expect(warnSpy).not.toHaveBeenCalled()
   })
 

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -2103,3 +2103,49 @@ it('diff', () => {
   snapshotError(() => expect({ hello: 'world' }).toBeUndefined())
   snapshotError(() => expect({ hello: 'world' }).toBeNull())
 })
+
+describe('toEqual warns on non-plain objects with empty Object.keys', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeAll(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    return () => warnSpy.mockRestore()
+  })
+
+  it('warns with a message mentioning toEqual and false-negative when comparing two non-plain objects with no enumerable keys', () => {
+    const r1 = new Response('a', { status: 200 })
+    const r2 = new Response('b', { status: 404 })
+    expect(r1).toEqual(r2)
+    expect(warnSpy).toHaveBeenCalledOnce()
+    expect(warnSpy.mock.calls[0][0]).toContain('toEqual')
+    expect(warnSpy.mock.calls[0][0]).toContain('false-negative')
+  })
+
+  it('does not warn for plain empty objects', () => {
+    warnSpy.mockClear()
+    expect({}).toEqual({})
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when comparing objects with enumerable keys', () => {
+    warnSpy.mockClear()
+    expect({ a: 1 }).toEqual({ a: 1 })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when only one side is a non-plain empty object', () => {
+    warnSpy.mockClear()
+    const r = new Response('a', { status: 200 })
+    expect(() => expect(r).toEqual({})).toThrow()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn for class instances with enumerable keys', () => {
+    warnSpy.mockClear()
+    class Foo {
+      x = 1
+    }
+    expect(new Foo()).toEqual(new Foo())
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/test/core/test/jest-utils.test.ts
+++ b/test/core/test/jest-utils.test.ts
@@ -1,0 +1,87 @@
+import { isNonPlainEmptyObject, isPlainObject } from '@vitest/expect'
+import { describe, expect, it } from 'vitest'
+
+describe('isPlainObject', () => {
+  it('returns true for plain object literal', () => {
+    expect(isPlainObject({})).toBe(true)
+  })
+
+  it('returns true for Object.create(null)', () => {
+    expect(isPlainObject(Object.create(null))).toBe(true)
+  })
+
+  it('returns true for object created with new Object()', () => {
+    expect(isPlainObject(new Object())).toBe(true)
+  })
+
+  it('returns false for class instances', () => {
+    class Foo {}
+    expect(isPlainObject(new Foo())).toBe(false)
+  })
+
+  it('returns false for built-in objects like Response', () => {
+    expect(isPlainObject(new Response('body', { status: 200 }))).toBe(false)
+  })
+
+  it('returns false for Date', () => {
+    expect(isPlainObject(new Date())).toBe(false)
+  })
+
+  it('returns false for Map', () => {
+    expect(isPlainObject(new Map())).toBe(false)
+  })
+
+  it('returns false for Set', () => {
+    expect(isPlainObject(new Set())).toBe(false)
+  })
+
+  it('returns false for Array', () => {
+    expect(isPlainObject([])).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isPlainObject(null)).toBe(false)
+  })
+
+  it('returns false for primitive values', () => {
+    expect(isPlainObject(42)).toBe(false)
+    expect(isPlainObject('string')).toBe(false)
+    expect(isPlainObject(true)).toBe(false)
+    expect(isPlainObject(undefined)).toBe(false)
+  })
+})
+
+describe('isNonPlainEmptyObject', () => {
+  it('returns true for a non-plain object with no enumerable keys', () => {
+    expect(isNonPlainEmptyObject(new Response('a', { status: 200 }))).toBe(true)
+  })
+
+  it('returns true for a class instance with no enumerable keys', () => {
+    class Foo {}
+    expect(isNonPlainEmptyObject(new Foo())).toBe(true)
+  })
+
+  it('returns false for a plain empty object', () => {
+    expect(isNonPlainEmptyObject({})).toBe(false)
+  })
+
+  it('returns false for Object.create(null)', () => {
+    expect(isNonPlainEmptyObject(Object.create(null))).toBe(false)
+  })
+
+  it('returns false for a non-plain object with enumerable keys', () => {
+    class Foo {
+      x = 1
+    }
+    expect(isNonPlainEmptyObject(new Foo())).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isNonPlainEmptyObject(null)).toBe(false)
+  })
+
+  it('returns false for primitive values', () => {
+    expect(isNonPlainEmptyObject(42)).toBe(false)
+    expect(isNonPlainEmptyObject('string')).toBe(false)
+  })
+})

--- a/test/core/test/jest-utils.test.ts
+++ b/test/core/test/jest-utils.test.ts
@@ -53,7 +53,12 @@ describe('isPlainObject', () => {
 
 describe('isNonPlainEmptyObject', () => {
   it('returns true for a non-plain object with no enumerable keys', () => {
-    expect(isNonPlainEmptyObject(new Response('a', { status: 200 }))).toBe(true)
+    class HiddenState {
+      // eslint-disable-next-line ts/no-unused-private-class-members
+      #value: string
+      constructor(value: string) { this.#value = value }
+    }
+    expect(isNonPlainEmptyObject(new HiddenState('a'))).toBe(true)
   })
 
   it('returns true for a class instance with no enumerable keys', () => {

--- a/test/core/test/jest-utils.test.ts
+++ b/test/core/test/jest-utils.test.ts
@@ -76,6 +76,10 @@ describe('isNonPlainEmptyObject', () => {
     expect(isNonPlainEmptyObject(new Foo())).toBe(false)
   })
 
+  it('returns false for empty arrays', () => {
+    expect(isNonPlainEmptyObject([])).toBe(false)
+  })
+
   it('returns false for null', () => {
     expect(isNonPlainEmptyObject(null)).toBe(false)
   })


### PR DESCRIPTION
### Description
                                                                                                                                        
  Adds `isPlainObject` and `isNonPlainEmptyObject` helpers to `jest-utils` and emits a `console.warn` in `toEqual` when the actual value  
  is a non-plain object with no enumerable keys, preventing silent false-negatives (e.g. `Response`).                                     
                                                                                                                                          
  **Example of the false-negative this addresses:**
  ```ts
  // This test passes silently today, but should not:
  const r1 = new Response("hoge", { status: 200 })
  const r2 = new Response(null, { status: 404 })
  expect(r1).toEqual(r2) // ⚠ no properties compared                                                                                      
   ```
Resolves #9542    

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
