### PR TITLE
fix: guard process.memoryUsage call with typeof check for browser compatibility

### DIFF
--- a/docs/config/logheapusage.md
+++ b/docs/config/logheapusage.md
@@ -10,3 +10,7 @@ outline: deep
 - **CLI:** `--logHeapUsage`, `--logHeapUsage=false`
 
 Show heap usage after each test. Useful for debugging memory leaks.
+
+:::info
+In environments where `process.memoryUsage` is not available (e.g. browser mode), this option is silently ignored.
+:::

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -89,7 +89,7 @@ export class TestRunner implements VitestTestRunner {
   }
 
   async onAfterRunSuite(suite: Suite): Promise<void> {
-    if (this.config.logHeapUsage && typeof process !== 'undefined') {
+    if (this.config.logHeapUsage && typeof process?.memoryUsage === 'function') {
       suite.result!.heap = process.memoryUsage().heapUsed
     }
 
@@ -122,7 +122,7 @@ export class TestRunner implements VitestTestRunner {
   }
 
   onAfterRunTask(test: Task): void {
-    if (this.config.logHeapUsage && typeof process !== 'undefined') {
+    if (this.config.logHeapUsage && typeof process?.memoryUsage === 'function') {
       test.result!.heap = process.memoryUsage().heapUsed
     }
 

--- a/test/cli/test/reported-tasks.test.ts
+++ b/test/cli/test/reported-tasks.test.ts
@@ -2,7 +2,7 @@ import type { RunnerTestFile } from 'vitest'
 import type { TestCase, TestCollection, TestModule, TestProject, Vitest } from 'vitest/node'
 import { resolve } from 'pathe'
 import { it as baseTest, expect } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { runInlineTests, runVitest } from '../../test-utils'
 
 const root = resolve(__dirname, '..', 'fixtures', 'reported-tasks')
 
@@ -364,3 +364,26 @@ function findTest(children: TestCollection, name: string): TestCase {
   }
   return testCase
 }
+
+it('logHeapUsage does not throw when process.memoryUsage is unavailable', async () => {
+  const { stderr } = await runInlineTests(
+    {
+      'setup.ts': `
+        // Simulate browser environment where process.memoryUsage is not available
+        process.memoryUsage = undefined as any
+      `,
+      'basic.test.ts': `
+        import { test, expect } from 'vitest'
+        test('basic', () => {
+          expect(1 + 1).toBe(2)
+        })
+      `,
+    },
+    {
+      logHeapUsage: true,
+      setupFiles: ['setup.ts'],
+    },
+  )
+
+  expect(stderr).toBe('')
+})


### PR DESCRIPTION
Fixes UnhandledRejection when logHeapUsage is true in browser environments where process is a polyfill without memoryUsage.


### Description

Guard process.memoryUsage calls with a typeof check before invoking it, preventing an UnhandledRejection crash when logHeapUsage: true is set in environments where process is a polyfill without memoryUsage (e.g. browser mode).                                             
                                                                                                                                          
Resolves #6500                                                                                                                        

  The previous check (typeof process !== 'undefined') only verified that process existed, but not that memoryUsage was actually a         
  function. In browser environments, process is polyfilled but memoryUsage is not available, causing the call to throw. The fix changes
  both guards in onAfterRunSuite and onAfterRunTask to typeof process?.memoryUsage === 'function'.                                        

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
