### PR TITLE
feat(reporter): add --junitIncludeConsoleOutput CLI flag

### DIFF
--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -111,6 +111,13 @@ Specify reporters (default, agent, blob, verbose, dot, json, tap, tap-flat, juni
 
 Write test results to a file when supporter reporter is also specified, use cac's dot notation for individual outputs of multiple reporters (example: `--outputFile.tap=./tap.txt`)
 
+### junitIncludeConsoleOutput
+
+- **CLI:** `--junitIncludeConsoleOutput`
+- **Config:** [junitIncludeConsoleOutput](/config/#junitincludeconsoleoutput)
+
+Include console output for each test in the JUnit reporter
+
 ### coverage.provider
 
 - **CLI:** `--coverage.provider <name>`

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -114,7 +114,7 @@ Write test results to a file when supporter reporter is also specified, use cac'
 ### junitIncludeConsoleOutput
 
 - **CLI:** `--junitIncludeConsoleOutput`
-- **Config:** [junitIncludeConsoleOutput](/config/#junitincludeconsoleoutput)
+- **Config:** [junitIncludeConsoleOutput](/config/junitincludeconsoleoutput)
 
 Include console output for each test in the JUnit reporter
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -152,6 +152,9 @@ export const cliOptionsConfig: VitestCLIOptions = {
       'Write test results to a file when supporter reporter is also specified, use cac\'s dot notation for individual outputs of multiple reporters (example: `--outputFile.tap=./tap.txt`)',
     subcommands: null,
   },
+  junitIncludeConsoleOutput: {
+    description: 'Include console output for each test in the JUnit reporter',
+  },
   coverage: {
     description: 'Enable coverage report',
     argument: '', // empty string means boolean

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -737,6 +737,15 @@ export function resolveConfig(
     }
   }
 
+  if (resolved.junitIncludeConsoleOutput != null) {
+    for (const reporter of resolved.reporters) {
+      if (Array.isArray(reporter) && reporter[0] === 'junit') {
+        const reporterOptions = reporter[1] as Record<string, unknown>
+        reporterOptions.includeConsoleOutput ??= resolved.junitIncludeConsoleOutput
+      }
+    }
+  }
+
   if (resolved.changed) {
     resolved.passWithNoTests ??= true
   }

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -419,6 +419,12 @@ export interface InlineConfig {
     | (Partial<Record<BuiltinReporters, string>> & Record<string, string>)
 
   /**
+   * Include console output for each test in the JUnit reporter.
+   * @default true
+   */
+  junitIncludeConsoleOutput?: boolean
+
+  /**
    * Default timeout of a test in milliseconds
    *
    * @default 5000


### PR DESCRIPTION
## Summary

Closes #9812

The JUnit reporter already supports an `includeConsoleOutput` option in its config, but there was no way to toggle it from the CLI. This PR adds a dedicated `--junitIncludeConsoleOutput` flag, following the same convention as the existing `--outputFile` flag.

## Usage

```sh
# Disable console output capture in the JUnit report:
vitest --reporter=junit --junitIncludeConsoleOutput=false
vitest --reporter=junit --no-junitIncludeConsoleOutput

# Explicitly enable (this is the default):
vitest --reporter=junit --junitIncludeConsoleOutput
```

## Changes

- `packages/vitest/src/node/types/config.ts` — adds `junitIncludeConsoleOutput?: boolean` to `InlineConfig`
- `packages/vitest/src/node/cli/cli-config.ts` — registers the CLI option
- `packages/vitest/src/node/config/resolveConfig.ts` — propagates the flag into the JUnit reporter's options (using `??=` so an explicit reporter-level config still takes priority)
- `docs/guide/cli-generated.md` — adds the documentation entry