### PR TITLE
fix: properly re-evaluate actual modules of mocked external

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
@@ -135,7 +135,7 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
 
           // if module is invalidated, the worker will be recreated,
           // so cached is always true in a single worker
-          if (options?.cached) {
+          if (!isImportActual && options?.cached) {
             return { cache: true }
           }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1311,6 +1311,9 @@ importers:
       test-dep-invalid:
         specifier: link:./deps/dep-invalid
         version: link:deps/dep-invalid
+      test-dep-simple:
+        specifier: file:./deps/dep-simple
+        version: file:test/cli/deps/dep-simple
       tinyspy:
         specifier: 'catalog:'
         version: 4.0.4
@@ -9781,6 +9784,9 @@ packages:
 
   test-dep-error@file:test/browser/deps/test-dep-error:
     resolution: {directory: test/browser/deps/test-dep-error, type: directory}
+
+  test-dep-simple@file:test/cli/deps/dep-simple:
+    resolution: {directory: test/cli/deps/dep-simple, type: directory}
 
   text-decoder@1.1.1:
     resolution: {integrity: sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==}
@@ -19162,6 +19168,8 @@ snapshots:
       test-dep-conditions-indirect: file:test/config/deps/test-dep-conditions-indirect
 
   test-dep-error@file:test/browser/deps/test-dep-error: {}
+
+  test-dep-simple@file:test/cli/deps/dep-simple: {}
 
   text-decoder@1.1.1:
     dependencies:

--- a/test/cli/deps/dep-simple/index.js
+++ b/test/cli/deps/dep-simple/index.js
@@ -1,0 +1,1 @@
+export default 'test-dep-simple'

--- a/test/cli/deps/dep-simple/package.json
+++ b/test/cli/deps/dep-simple/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-dep-simple",
+  "type": "module",
+  "private": true,
+  "exports": "./index.js"
+}

--- a/test/cli/package.json
+++ b/test/cli/package.json
@@ -30,6 +30,7 @@
     "obug": "^2.1.1",
     "playwright": "catalog:",
     "test-dep-invalid": "link:./deps/dep-invalid",
+    "test-dep-simple": "file:./deps/dep-simple",
     "tinyspy": "catalog:",
     "typescript": "catalog:",
     "unplugin-swc": "^1.5.9",

--- a/test/cli/test/mocking.test.ts
+++ b/test/cli/test/mocking.test.ts
@@ -391,3 +391,152 @@ test('mock works without loading original', () => {
     }
   `)
 })
+
+test.for([
+  'node',
+  'playwright',
+  'webdriverio',
+])('repeating mock, importActual, and resetModules (%s)', async (mode) => {
+  const { stderr, errorTree } = await runInlineTests({
+    // external
+    './external.test.ts': `
+import { expect, test, vi } from "vitest"
+
+test("external", async () => {
+  vi.doMock(import("test-dep-simple"), async (importActual) => {
+    const lib = await importActual();
+    return lib;
+  })
+  const lib1: any = await import("test-dep-simple")
+  expect(lib1.default).toBe("test-dep-simple")
+
+  vi.resetModules();
+  vi.doMock(import("test-dep-simple"), async (importActual) => {
+    const lib = await importActual();
+    return lib;
+  })
+  const lib2: any = await import("test-dep-simple")
+  expect(lib2.default).toBe("test-dep-simple")
+  expect.soft(lib1 !== lib2).toBe(true)
+
+  vi.resetModules();
+  vi.doMock(import("test-dep-simple"), async () => ({ mocked: true }));
+  const lib3 = await import("test-dep-simple");
+  expect(lib3).toMatchObject({ mocked: true })
+
+  const lib4 = await vi.importActual("test-dep-simple");
+  expect(lib4.default).toBe("test-dep-simple")
+  const lib5 = await vi.importActual("test-dep-simple");
+  expect(lib4).toBe(lib5)
+});
+    `,
+    // builtin module
+    './builtin.test.ts': `
+import { expect, test, vi } from "vitest"
+
+test("builtin", async () => {
+  vi.doMock(import("node:path"), async (importActual) => {
+    const lib = await importActual();
+    return lib;
+  })
+  const lib1: any = await import("node:path")
+  expect(lib1).toHaveProperty('join')
+
+  vi.resetModules();
+  vi.doMock(import("node:path"), async (importActual) => {
+    const lib = await importActual();
+    return lib;
+  })
+  const lib2: any = await import("node:path")
+  expect(lib2).toHaveProperty('join')
+  expect.soft(lib1 !== lib2).toBe(true)
+
+  vi.resetModules();
+  vi.doMock(import("node:path"), async () => ({ mocked: true }));
+  const lib3 = await import("node:path");
+  expect(lib3).toMatchObject({ mocked: true })
+
+  const lib4 = await vi.importActual("node:path");
+  expect(lib4).toHaveProperty('join')
+  const lib5 = await vi.importActual("node:path");
+  expect(lib4).toBe(lib5)
+});
+    `,
+    // local module
+    './local.test.ts': `
+import { expect, test, vi } from "vitest"
+
+test("local", async () => {
+  vi.doMock(import("./local.js"), async (importActual) => {
+    const lib = await importActual();
+    return lib;
+  })
+  const lib1: any = await import("./local.js")
+  expect(lib1).toHaveProperty('local')
+
+  vi.resetModules();
+  vi.doMock(import("./local.js"), async (importActual) => {
+    const lib = await importActual();
+    return lib;
+  })
+  const lib2: any = await import("./local.js")
+  expect(lib2).toHaveProperty('local')
+  expect.soft(lib1 !== lib2).toBe(true)
+
+  vi.resetModules();
+  vi.doMock(import("./local.js"), async () => ({ mocked: true }));
+  const lib3 = await import("./local.js");
+  expect(lib3).toMatchObject({ mocked: true })
+
+  const lib4 = await vi.importActual("./local.js");
+  expect(lib4).toHaveProperty('local')
+  const lib5 = await vi.importActual("./local.js");
+  expect(lib4).toBe(lib5)
+});
+    `,
+    './local.js': `export const local = 'local'`,
+  }, modeToConfig(mode))
+
+  if (mode === 'webdriverio' || mode === 'playwright') {
+    // browser mode doesn't support resetModules nor node builtin
+    expect(errorTree()).toMatchInlineSnapshot(`
+      {
+        "builtin.test.ts": {
+          "builtin": [
+            "Cannot convert a Symbol value to a string",
+          ],
+        },
+        "external.test.ts": {
+          "external": [
+            "expected false to be true // Object.is equality",
+            "expected { default: 'test-dep-simple', …(1) } to match object { mocked: true }
+      (1 matching property omitted from actual)",
+          ],
+        },
+        "local.test.ts": {
+          "local": [
+            "expected false to be true // Object.is equality",
+            "expected { local: 'local', …(1) } to match object { mocked: true }
+      (1 matching property omitted from actual)",
+          ],
+        },
+      }
+    `)
+    return
+  }
+
+  expect(stderr).toMatchInlineSnapshot(`""`)
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "builtin.test.ts": {
+        "builtin": "passed",
+      },
+      "external.test.ts": {
+        "external": "passed",
+      },
+      "local.test.ts": {
+        "local": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9888#issuecomment-4079246258

The test case includes three distinct cases: external, builtin, and local module. The failure was only for external. The issue is quite complicated and the fix looks too surgical, but this is sound since Vitest's `cached` heuristics was purely for optimization to skip rpc whose `fetch` itself also has `cached` logic on its own. The fix avoids Vitest side `cached` heuristics so that `importActual` for external can be refetched properly (where others case already didn't hit cached return and being refetched).

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
