### PR TITLE
docs(browser): explain locator differences from testing-library

### DIFF
--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -13,8 +13,7 @@ The locator API uses a fork of [Playwright's locators](https://playwright.dev/do
 This page covers API usage. To better understand locators and their usage, read [Playwright's "Locators" documentation](https://playwright.dev/docs/locators).
 :::
 
-## How locators differ from testing-library
-
+::: tip Difference from `testing-library`
 Vitest's `page.getBy*` methods return a locator object, not a DOM element. This makes locator queries composable and allows Vitest to retry interactions and assertions when needed.
 
 Compared to testing-library queries:
@@ -35,6 +34,7 @@ const deleteButton = page
 await deleteButton.click()
 await expect.element(deleteButton).toBeEnabled()
 ```
+:::
 
 ## getByRole
 

--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -13,6 +13,29 @@ The locator API uses a fork of [Playwright's locators](https://playwright.dev/do
 This page covers API usage. To better understand locators and their usage, read [Playwright's "Locators" documentation](https://playwright.dev/docs/locators).
 :::
 
+## How locators differ from testing-library
+
+Vitest's `page.getBy*` methods return a locator object, not a DOM element. This makes locator queries composable and allows Vitest to retry interactions and assertions when needed.
+
+Compared to testing-library queries:
+
+- Use locator chaining (`.getBy*`, `.filter`, `.nth`) instead of `within(...)`.
+- Keep locators around and interact with them later (`await locator.click()`), instead of resolving elements up front.
+- Single-element escape hatches like `.element()` and `.query()` are strict and throw if multiple elements match.
+
+```ts
+import { expect } from 'vitest'
+import { page } from 'vitest/browser'
+
+const deleteButton = page
+  .getByRole('row')
+  .filter({ hasText: 'Vitest' })
+  .getByRole('button', { name: /delete/i })
+
+await deleteButton.click()
+await expect.element(deleteButton).toBeEnabled()
+```
+
 ## getByRole
 
 ```ts


### PR DESCRIPTION
Summary

Add a dedicated “How locators differ from testing-library” section to the browser locators docs.
Explain that Vitest’s page.getBy* APIs return locator objects, not DOM nodes, and how that affects chaining, retries, and escape hatches.
Provide a concrete example using chained getByRole + filter to show the locator-centric style.
Motivation

Users coming from @testing-library/* often assume locators behave like testing-library queries (e.g. with within(...)) and are unsure how to map their existing patterns. Making this difference explicit in the docs reduces migration friction and makes it easier to adopt browser mode idiomatically.

Issue

Closes #8529.
