### PR TITLE
fix(reporter): include failure screenshot attachments in JUnit report

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -283,6 +283,16 @@ export class JUnitReporter implements Reporter {
                 },
               )
             }
+
+            if (task.type === 'test') {
+              for (const artifact of task.artifacts) {
+                if (artifact.type === 'internal:failureScreenshot' && artifact.attachments.length) {
+                  await this.writeElement('system-out', {}, async () => {
+                    await this.baseLog(`[[ATTACHMENT|${artifact.attachments[0].originalPath}]]`)
+                  })
+                }
+              }
+            }
           }
         },
       )

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -288,7 +288,7 @@ export class JUnitReporter implements Reporter {
               for (const artifact of task.artifacts) {
                 if (artifact.type === 'internal:failureScreenshot' && artifact.attachments.length) {
                   await this.writeElement('system-out', {}, async () => {
-                    await this.baseLog(`[[ATTACHMENT|${artifact.attachments[0].originalPath}]]`)
+                    await this.baseLog(`[[ATTACHMENT|${artifact.attachments[0]!.originalPath}]]`)
                   })
                 }
               }

--- a/test/cli/test/reporters/reporters.test.ts
+++ b/test/cli/test/reporters/reporters.test.ts
@@ -1,5 +1,5 @@
-import type { TestModule } from 'vitest/node'
 import type { RunnerTestCase, RunnerTestFile, RunnerTestSuite } from 'vitest'
+import type { TestModule } from 'vitest/node'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { createFileTask } from '@vitest/runner/utils'
 import { normalize, resolve } from 'pathe'

--- a/test/cli/test/reporters/reporters.test.ts
+++ b/test/cli/test/reporters/reporters.test.ts
@@ -1,5 +1,7 @@
 import type { TestModule } from 'vitest/node'
+import type { RunnerTestCase, RunnerTestFile, RunnerTestSuite } from 'vitest'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { createFileTask } from '@vitest/runner/utils'
 import { normalize, resolve } from 'pathe'
 import { beforeEach, expect, test, vi } from 'vitest'
 import { JsonReporter, JUnitReporter, TapFlatReporter, TapReporter } from 'vitest/node'
@@ -221,6 +223,70 @@ test('JUnit reporter with outputFile object in non-existing directory', async ()
 
   // Cleanup
   rmSync(outputFile)
+})
+
+test('JUnit reporter emits [[ATTACHMENT]] for failure screenshots', async () => {
+  const reporter = new JUnitReporter({ hostname: 'hostname' })
+  const context = getContext()
+
+  const file: RunnerTestFile = createFileTask('/vitest/test/shot.test.ts', '/vitest/test', '')
+  file.mode = 'run'
+  file.result = { state: 'fail', duration: 10 }
+
+  const suite: RunnerTestSuite = {
+    id: `${file.id}_0`,
+    type: 'suite',
+    name: 'screenshots',
+    fullName: `${file.fullName} > screenshots`,
+    fullTestName: `${file.fullTestName} > screenshots`,
+    mode: 'run',
+    meta: {},
+    file,
+    result: { state: 'fail', duration: 10 },
+    tasks: [],
+  }
+
+  const failedTest: RunnerTestCase = {
+    id: `${suite.id}_0`,
+    type: 'test',
+    name: 'failing test',
+    fullName: `${suite.fullName} > failing test`,
+    fullTestName: `${suite.fullTestName} > failing test`,
+    mode: 'run',
+    fails: undefined,
+    meta: {},
+    file,
+    suite,
+    annotations: [],
+    artifacts: [
+      {
+        type: 'internal:failureScreenshot',
+        attachments: [
+          {
+            name: 'screenshot',
+            path: '/screenshots/shot.png',
+            originalPath: '/screenshots/shot.png',
+          } as any,
+        ],
+      },
+    ],
+    // result has state=fail but no errors array, so capturePrintError is not called
+    result: {
+      state: 'fail',
+      errors: [],
+      duration: 5,
+    },
+    timeout: 0,
+    context: null as any,
+  }
+
+  suite.tasks = [failedTest]
+  file.tasks = [suite]
+
+  await reporter.onInit(context.vitest)
+  await reporter.onTestRunEnd([{ task: file } as TestModule])
+
+  expect(context.output).toContain('[[ATTACHMENT|/screenshots/shot.png]]')
 })
 
 test('json reporter', async () => {


### PR DESCRIPTION
Fixes #9904

When browser mode is configured with `screenshotFailures: true`, screenshots are captured on test failures and stored as `internal:failureScreenshot` artifacts on the task. However, the JUnit reporter was not referencing these screenshots in its XML output, making it impossible for CI systems to correlate failures with their screenshots.

This PR emits a `<system-out>` element containing `[[ATTACHMENT|/path/to/screenshot.png]]` for each failure screenshot artifact on a failed test case. The `[[ATTACHMENT|...]]` convention is widely supported by CI systems (GitLab, Jenkins, GitHub Actions test report parsers, etc.).

## Changes

- `packages/vitest/src/node/reporters/junit.ts` — after emitting `<failure>` elements, iterate over `task.artifacts` for `internal:failureScreenshot` artifacts and emit their path via `<system-out>[[ATTACHMENT|...]]</system-out>`
- `test/cli/test/reporters/reporters.test.ts` — add unit test verifying the `[[ATTACHMENT|...]]` is emitted in the JUnit output when a failed test has a failure screenshot artifact