### PR TITLE
feat(typecheck): add ignoreExperimentalWarning option to suppress typecheck warning

### DIFF
--- a/docs/config/typecheck.md
+++ b/docs/config/typecheck.md
@@ -80,3 +80,10 @@ Path to custom tsconfig, relative to the project root.
 - **Default**: `10_000`
 
 Minimum time in milliseconds it takes to spawn the typechecker.
+
+## typecheck.ignoreExperimentalWarning
+
+- **Type**: `boolean`
+- **Default**: `false`
+
+Suppress the `Testing types with tsc and vue-tsc is an experimental feature` warning. Useful in monorepos where multiple Vitest instances each print the warning.

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -756,6 +756,13 @@ Path to a custom tsconfig file
 
 Minimum time in milliseconds it takes to spawn the typechecker
 
+### typecheck.ignoreExperimentalWarning
+
+- **CLI:** `--typecheck.ignoreExperimentalWarning`
+- **Config:** [typecheck.ignoreExperimentalWarning](/config/typecheck#typecheck-ignoreexperimentalwarning)
+
+Suppress the "Testing types is an experimental feature" warning
+
 ### project
 
 - **CLI:** `--project <name>`

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -694,6 +694,9 @@ export const cliOptionsConfig: VitestCLIOptions = {
         description: 'Minimum time in milliseconds it takes to spawn the typechecker',
         argument: '<time>',
       },
+      ignoreExperimentalWarning: {
+        description: 'Suppress the "Testing types is an experimental feature" warning',
+      },
       include: null,
       exclude: null,
     },

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -787,7 +787,7 @@ export function resolveConfig(
   resolved.typecheck ??= {} as any
   resolved.typecheck.enabled ??= false
 
-  if (resolved.typecheck.enabled) {
+  if (resolved.typecheck.enabled && !resolved.typecheck.ignoreExperimentalWarning) {
     logger.console.warn(
       c.yellow(
         'Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.',

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -998,6 +998,13 @@ export interface TypecheckConfig {
    * @default 10_000
    */
   spawnTimeout?: number
+  /**
+   * Suppress the "Testing types with tsc and vue-tsc is an experimental feature" warning.
+   * Useful in monorepos where the warning is printed once per project.
+   *
+   * @default false
+   */
+  ignoreExperimentalWarning?: boolean
 }
 
 export interface UserConfig extends InlineConfig {


### PR DESCRIPTION
Fixes #9823

When `typecheck.enabled` is `true`, Vitest prints a warning on every run:

```
Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.
```

This is useful when first setting up typecheck, but in established monorepos it gets noisy — one project can emit 33+ copies of the warning (as in the issue).

This PR adds a `typecheck.ignoreExperimentalWarning` boolean option (default `false`) that suppresses the warning when set to `true`.

## Changes

- `packages/vitest/src/node/types/config.ts` — added `ignoreExperimentalWarning?: boolean` to `TypecheckConfig`
- `packages/vitest/src/node/config/resolveConfig.ts` — guard warning behind `!resolved.typecheck.ignoreExperimentalWarning`
- `packages/vitest/src/node/cli/cli-config.ts` — registered `--typecheck.ignoreExperimentalWarning` CLI flag
- `docs/config/typecheck.md` — documented the new option
- `docs/guide/cli-generated.md` — added CLI reference entry

## Usage

```ts
// vitest.config.ts
export default defineConfig({
  test: {
    typecheck: {
      enabled: true,
      ignoreExperimentalWarning: true,
    },
  },
})
```

or via CLI:

```
vitest --typecheck --typecheck.ignoreExperimentalWarning
```