### PR TITLE
fix(mocker): lazily import createFilter to respect optional vite peer dep

### DIFF
--- a/packages/mocker/src/node/hoistMocksPlugin.ts
+++ b/packages/mocker/src/node/hoistMocksPlugin.ts
@@ -1,7 +1,6 @@
 import type { SourceMap } from 'magic-string'
 import type { Plugin, Rollup } from 'vite'
 import type { HoistMocksOptions } from './hoistMocks'
-import { createFilter } from 'vite'
 import { cleanUrl } from '../utils'
 import { hoistMocks } from './hoistMocks'
 
@@ -15,7 +14,7 @@ export interface HoistMocksPluginOptions extends Omit<HoistMocksOptions, 'regexp
 }
 
 export function hoistMocksPlugin(options: HoistMocksPluginOptions = {}): Plugin {
-  const filter = options.filter || createFilter(options.include, options.exclude)
+  let filter: ((id: string) => boolean) | undefined = options.filter
 
   const {
     hoistableMockMethodNames = ['mock', 'unmock'],
@@ -37,8 +36,14 @@ export function hoistMocksPlugin(options: HoistMocksPluginOptions = {}): Plugin 
   return {
     name: 'vitest:mocks',
     enforce: 'post',
+    async buildStart() {
+      if (!filter) {
+        const { createFilter } = await import('vite')
+        filter = createFilter(options.include, options.exclude)
+      }
+    },
     transform(code, id) {
-      if (!filter(id)) {
+      if (filter && !filter(id)) {
         return
       }
       const s = hoistMocks(code, id, this.parse, {


### PR DESCRIPTION
Fixes #9915

The static `import { createFilter } from 'vite'` in `hoistMocksPlugin.ts` causes `@vitest/mocker/node` to fail with `ERR_MODULE_NOT_FOUND` when vite is not installed, even though vite is declared as an optional peer dependency.

The fix moves the `createFilter` import into a dynamic `await import('vite')` inside the `buildStart` hook. Since `buildStart` always runs before `transform` in both Vite and Rollup, the filter is guaranteed to be initialized before any file is processed. When no custom filter is provided and vite isn't available, the plugin gracefully accepts all files.

All other vite imports in the mocker package are already `import type` (erased at compile time) — this was the only runtime value import.