### PR TITLE
fix: shallow diff between different primitive types

### DIFF
--- a/packages/utils/src/diff/index.ts
+++ b/packages/utils/src/diff/index.ts
@@ -97,7 +97,11 @@ export function diff(a: any, b: any, options?: DiffOptions): string | undefined 
   if (expectedType !== getType(b)) {
     const { aAnnotation, aColor, aIndicator, bAnnotation, bColor, bIndicator }
       = normalizeDiffOptions(options)
-    const formatOptions = getFormatOptions(FALLBACK_FORMAT_OPTIONS, options)
+    // depth can be minimized when diffing different type of values
+    // since the difference would manifest at the top level.
+    // this heuristics can help avoiding printing large objects for assertion failure patterns such as:
+    //   expect(shouldBeNullButMaybeHugeObject).toBeFalsy()
+    const formatOptions = getFormatOptions({ ...FALLBACK_FORMAT_OPTIONS, maxDepth: 1 }, options)
     let aDisplay = prettyFormat(a, formatOptions)
     let bDisplay = prettyFormat(b, formatOptions)
     // even if prettyFormat prints successfully big objects,


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9329

Another heuristics approach to save this failure pattern similar https://github.com/vitest-dev/vitest/pull/7133.

I think the robust solution would be to bake in truncate-and-bail-out logic inside `pretty-format`, which is likely do-able now. I'm interested to look into along with https://github.com/vitest-dev/vitest/pull/9609.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
