### PR TITLE
docs: fix typo in heading of method definition for "toHaveBeenCalledExactlyOnceWith"

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1079,7 +1079,7 @@ test('calls mock1 after mock2', () => {
 })
 ```
 
-## toHaveBeenCalledExactlyOnceWit
+## toHaveBeenCalledExactlyOnceWith
 
 - **Type**: `(...args: any[]) => Awaitable<void>`
 


### PR DESCRIPTION
### Description

Trivial fix of a typo in the documentation of the `toHaveBeenCalledExactlyOnceWith` method.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- ~~It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.~~
- ~~Ideally, include a test that fails without this PR but passes with it.~~
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- ~~Run the tests with `pnpm test:ci`.~~

### Documentation
- ~~If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.~~

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
