### PR TITLE
fix(expect): race slow async poll fn against timeout deadline

### DIFF
--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -88,9 +88,18 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
 
             let executionPhase: 'fn' | 'assertion' = 'fn'
             let hasTimedOut = false
+            let lastAssertionError: unknown = null
+
+            let rejectOnTimeout!: (err: Error & { _isPollTimeout: true }) => void
+            const deadlinePromise = new Promise<never>((_, reject) => {
+              rejectOnTimeout = reject
+            })
 
             const timerId = setTimeout(() => {
               hasTimedOut = true
+              rejectOnTimeout(
+                Object.assign(new Error('Matcher did not succeed in time.'), { _isPollTimeout: true as const }),
+              )
             }, timeout)
 
             chai.util.flag(assertion, '_name', key)
@@ -107,7 +116,12 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
 
                 try {
                   executionPhase = 'fn'
-                  const obj = await fn()
+                  // On non-last attempts, race fn() against the deadline so a slow
+                  // async poll function cannot outlive the configured timeout.
+                  // On the last attempt we let fn() run to give it one final chance.
+                  const obj = isLastAttempt
+                    ? await fn()
+                    : await Promise.race([fn(), deadlinePromise])
                   chai.util.flag(assertion, 'object', obj)
 
                   executionPhase = 'assertion'
@@ -117,6 +131,16 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                   return output
                 }
                 catch (err) {
+                  if ((err as any)?._isPollTimeout === true) {
+                    await onSettled?.({ assertion, status: 'fail' })
+                    if (lastAssertionError != null) {
+                      throwWithCause(lastAssertionError, STACK_TRACE_ERROR)
+                    }
+                    throw copyStackTrace(err as Error, STACK_TRACE_ERROR)
+                  }
+
+                  lastAssertionError = err
+
                   if (isLastAttempt || (executionPhase === 'assertion' && chai.util.flag(assertion, '_poll.assert_once'))) {
                     await onSettled?.({ assertion, status: 'fail' })
                     throwWithCause(err, STACK_TRACE_ERROR)

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -147,3 +147,34 @@ test('should handle failure on last attempt', async () => {
     }),
   }))
 })
+
+test('slow async fn is interrupted when timeout expires', async () => {
+  const start = Date.now()
+  await expect(async () => {
+    await expect.poll(
+      async () => { await new Promise(r => setTimeout(r, 10_000)) },
+      { timeout: 100 },
+    ).toBe(1)
+  }).rejects.toThrow('Matcher did not succeed in time.')
+  expect(Date.now() - start).toBeLessThan(1000)
+})
+
+test('slow async fn timeout surfaces last assertion error when available', async () => {
+  let calls = 0
+  await expect(async () => {
+    await expect.poll(
+      async () => {
+        calls++
+        // First call is fast so an assertion error is recorded; subsequent calls are slow
+        if (calls > 1) {
+          await new Promise(r => setTimeout(r, 10_000))
+        }
+        return 42
+      },
+      { timeout: 150, interval: 10 },
+    ).toBe(1)
+  }).rejects.toThrow(expect.objectContaining({
+    message: 'expected 42 to be 1 // Object.is equality',
+    cause: expect.objectContaining({ message: 'Matcher did not succeed in time.' }),
+  }))
+})


### PR DESCRIPTION
## Summary

Closes #9844

When the `expect.poll` callback is a slow async function, `await fn()` blocks for the full duration of `fn` regardless of the configured `timeout`. The timeout flag fired correctly but could not interrupt the in-flight `await`, so tests took orders of magnitude longer than expected (or hung until the global test timeout).

**Root cause:** the poll loop did `await fn()` unconditionally — no race against the deadline.

**Fix:** create a deadline `Promise` that rejects when the timeout fires and use `Promise.race([fn(), deadlinePromise])` on non-last-attempt iterations. The last attempt still `await`s `fn()` directly to preserve the existing "one final chance" semantics (`_isLastPollAttempt`). When the deadline wins, the last recorded assertion error (if any) is surfaced with the expected `cause` message so output is consistent with the normal timeout path.

## Behaviour before / after

```ts
// fn takes 1000 ms, timeout is 100 ms
test('why 2000', async () => {
  await expect.poll(
    async () => { await new Promise(r => setTimeout(r, 1000)) },
    { timeout: 100 },
  ).toBe(1)
})
```

| | Before | After |
|---|---|---|
| `why 2000` | fails after ~2075 ms | fails after ~100 ms ✅ |
| `stuck` (fn: 10 s) | hangs until 5 s test timeout | fails after ~100 ms ✅ |
| existing fast-fn tests | ✅ | ✅ |
| `should handle success on last attempt` | ✅ | ✅ (last-chance preserved) |

## Test plan

- [x] Added `slow async fn is interrupted when timeout expires` — asserts the test fails in < 1 s with `"Matcher did not succeed in time."`
- [x] Added `slow async fn timeout surfaces last assertion error when available` — asserts the last assertion message is preserved when fn slows down after the first fast call
- [x] All existing `expect-poll` tests still pass across `threads`, `vmThreads`, and `forks` pools