### PR TITLE
docs: fix mock state properties typo

### DIFF
--- a/docs/api/mock.md
+++ b/docs/api/mock.md
@@ -473,7 +473,7 @@ fn.mock.calls === [
 ```
 
 :::warning Objects are Stored by Reference
-Note that Vitest always stores objects by reference in all properies of the `mock` state. This means that if the properties were changed by your code, then some assertions like [`.toHaveBeenCalledWith`](/api/expect#tohavebeencalledwith) will not pass:
+Note that Vitest always stores objects by reference in all properties of the `mock` state. This means that if the properties were changed by your code, then some assertions like [`.toHaveBeenCalledWith`](/api/expect#tohavebeencalledwith) will not pass:
 
 ```ts
 const argument = {


### PR DESCRIPTION
### Description

- fix "properies" -> "properties" in the mock API documentation

Resolves N/A

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] This is a trivial docs-only typo fix.
- [x] No pnpm-lock.yaml changes were made.
- [x] Allow edits by maintainers is enabled.

### Tests
- [x] Not run (docs-only typo fix).

### Documentation
- [x] No new functionality was introduced.

### Changesets
- [x] The PR title uses the docs prefix and describes the docs-only change.

### Guideline alignment
- CONTRIBUTING: https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md
- PR template: https://github.com/vitest-dev/vitest/blob/main/.github/PULL_REQUEST_TEMPLATE.md
