### PR TITLE
docs: fix precedence typo in test API docs

### DIFF
--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -223,7 +223,7 @@ Whether this test run concurrently with other concurrent tests in the suite.
 - **Default:** `true`
 - **Alias:** [`test.sequential`](#test-sequential)
 
-Whether tests run sequentially. When both `concurrent` and `sequential` are specified, `concurrent` takes precendence.
+Whether tests run sequentially. When both `concurrent` and `sequential` are specified, `concurrent` takes precedence.
 
 ### skip
 


### PR DESCRIPTION
### Description

- fix "precendence" -> "precedence" in the test API documentation

Resolves N/A

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] This is a trivial docs-only typo fix.
- [x] No pnpm-lock.yaml changes were made.
- [x] Allow edits by maintainers is enabled.

### Tests
- [x] Not run (docs-only typo fix).

### Documentation
- [x] No new functionality was introduced.

### Changesets
- [x] The PR title uses the docs prefix and describes the docs-only change.

### Guideline alignment
- CONTRIBUTING: https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md
- PR template: https://github.com/vitest-dev/vitest/blob/main/.github/PULL_REQUEST_TEMPLATE.md
