### PR TITLE
fix(pretty-format): limit output for large object

### DIFF
--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -443,10 +443,8 @@ export const DEFAULT_OPTIONS: Options = {
   highlight: false,
   indent: 2,
   maxDepth: Number.POSITIVE_INFINITY,
-  // Prevent hitting Node's string length limit (~512MB) on pathological object
-  // graphs with shared references that fan out exponentially. 100K is generous
-  // enough for normal formatting but well below the ~2**27 danger zone.
-  maxOutputLength: 100_000,
+  // Prevent hitting Node's string length limit (~512MB)
+  maxOutputLength: 1_000_000,
   maxWidth: Number.POSITIVE_INFINITY,
   min: false,
   plugins: [],

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -212,9 +212,11 @@ function printComplexValue(
     return printer(val.toJSON(), config, indentation, depth, refs, true)
   }
 
+  let result: string
+
   const toStringed = toString.call(val)
   if (toStringed === '[object Arguments]') {
-    return hitMaxDepth
+    result = hitMaxDepth
       ? '[Arguments]'
       : `${min ? '' : 'Arguments '}[${printListItems(
         val,
@@ -225,8 +227,8 @@ function printComplexValue(
         printer,
       )}]`
   }
-  if (isToStringedArrayType(toStringed)) {
-    return hitMaxDepth
+  else if (isToStringedArrayType(toStringed)) {
+    result = hitMaxDepth
       ? `[${val.constructor.name}]`
       : `${
         min
@@ -236,8 +238,8 @@ function printComplexValue(
               : `${val.constructor.name} `
       }[${printListItems(val, config, indentation, depth, refs, printer)}]`
   }
-  if (toStringed === '[object Map]') {
-    return hitMaxDepth
+  else if (toStringed === '[object Map]') {
+    result = hitMaxDepth
       ? '[Map]'
       : `Map {${printIteratorEntries(
         val.entries(),
@@ -249,8 +251,8 @@ function printComplexValue(
         ' => ',
       )}}`
   }
-  if (toStringed === '[object Set]') {
-    return hitMaxDepth
+  else if (toStringed === '[object Set]') {
+    result = hitMaxDepth
       ? '[Set]'
       : `Set {${printIteratorValues(
         val.values(),
@@ -261,25 +263,36 @@ function printComplexValue(
         printer,
       )}}`
   }
-
   // Avoid failure to serialize global window object in jsdom test environment.
   // For example, not even relevant if window is prop of React element.
-  return hitMaxDepth || isWindow(val)
-    ? `[${getConstructorName(val)}]`
-    : `${
-      min
-        ? ''
-        : !config.printBasicPrototype && getConstructorName(val) === 'Object'
-            ? ''
-            : `${getConstructorName(val)} `
-    }{${printObjectProperties(
-      val,
-      config,
-      indentation,
-      depth,
-      refs,
-      printer,
-    )}}`
+  else {
+    result = hitMaxDepth || isWindow(val)
+      ? `[${getConstructorName(val)}]`
+      : `${
+        min
+          ? ''
+          : !config.printBasicPrototype && getConstructorName(val) === 'Object'
+              ? ''
+              : `${getConstructorName(val)} `
+      }{${printObjectProperties(
+        val,
+        config,
+        indentation,
+        depth,
+        refs,
+        printer,
+      )}}`
+  }
+
+  // Post-hoc budget check
+  // Accumulate output length and if exceeded, force no recursion by patching maxDepth.
+  // Inspired by node's util.inspect bail out heuristics.
+  config.budget.used += result.length
+  if (config.budget.used > config.budget.max) {
+    config.maxDepth = -1
+  }
+
+  return result
 }
 
 const ErrorPlugin: NewPlugin = {
@@ -298,7 +311,7 @@ const ErrorPlugin: NewPlugin = {
       ...rest,
     }
     const name = val.name !== 'Error' ? val.name : getConstructorName(val as any)
-    return hitMaxDepth
+    const result = hitMaxDepth
       ? `[${name}]`
       : `${name} {${printIteratorEntries(
         Object.entries(entries).values(),
@@ -308,6 +321,11 @@ const ErrorPlugin: NewPlugin = {
         refs,
         printer,
       )}}`
+    config.budget.used += result.length
+    if (config.budget.used > config.budget.max) {
+      config.maxDepth = -1
+    }
+    return result
   },
 }
 
@@ -425,6 +443,10 @@ export const DEFAULT_OPTIONS: Options = {
   highlight: false,
   indent: 2,
   maxDepth: Number.POSITIVE_INFINITY,
+  // Prevent hitting Node's string length limit (~512MB) on pathological object
+  // graphs with shared references that fan out exponentially. 100K is generous
+  // enough for normal formatting but well below the ~2**27 danger zone.
+  maxOutputLength: 100_000,
   maxWidth: Number.POSITIVE_INFINITY,
   min: false,
   plugins: [],
@@ -509,6 +531,7 @@ function getConfig(options?: OptionsReceived): Config {
     printShadowRoot: options?.printShadowRoot ?? true,
     spacingInner: options?.min ? ' ' : '\n',
     spacingOuter: options?.min ? '' : '\n',
+    budget: { used: 0, max: options?.maxOutputLength ?? DEFAULT_OPTIONS.maxOutputLength },
   }
 }
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -212,11 +212,9 @@ function printComplexValue(
     return printer(val.toJSON(), config, indentation, depth, refs, true)
   }
 
-  let result: string
-
   const toStringed = toString.call(val)
   if (toStringed === '[object Arguments]') {
-    result = hitMaxDepth
+    return hitMaxDepth
       ? '[Arguments]'
       : `${min ? '' : 'Arguments '}[${printListItems(
         val,
@@ -227,8 +225,8 @@ function printComplexValue(
         printer,
       )}]`
   }
-  else if (isToStringedArrayType(toStringed)) {
-    result = hitMaxDepth
+  if (isToStringedArrayType(toStringed)) {
+    return hitMaxDepth
       ? `[${val.constructor.name}]`
       : `${
         min
@@ -238,8 +236,8 @@ function printComplexValue(
               : `${val.constructor.name} `
       }[${printListItems(val, config, indentation, depth, refs, printer)}]`
   }
-  else if (toStringed === '[object Map]') {
-    result = hitMaxDepth
+  if (toStringed === '[object Map]') {
+    return hitMaxDepth
       ? '[Map]'
       : `Map {${printIteratorEntries(
         val.entries(),
@@ -251,8 +249,8 @@ function printComplexValue(
         ' => ',
       )}}`
   }
-  else if (toStringed === '[object Set]') {
-    result = hitMaxDepth
+  if (toStringed === '[object Set]') {
+    return hitMaxDepth
       ? '[Set]'
       : `Set {${printIteratorValues(
         val.values(),
@@ -263,36 +261,25 @@ function printComplexValue(
         printer,
       )}}`
   }
+
   // Avoid failure to serialize global window object in jsdom test environment.
   // For example, not even relevant if window is prop of React element.
-  else {
-    result = hitMaxDepth || isWindow(val)
-      ? `[${getConstructorName(val)}]`
-      : `${
-        min
-          ? ''
-          : !config.printBasicPrototype && getConstructorName(val) === 'Object'
-              ? ''
-              : `${getConstructorName(val)} `
-      }{${printObjectProperties(
-        val,
-        config,
-        indentation,
-        depth,
-        refs,
-        printer,
-      )}}`
-  }
-
-  // Post-hoc budget check
-  // Accumulate output length and if exceeded, force no recursion by patching maxDepth.
-  // Inspired by node's util.inspect bail out heuristics.
-  config.budget.used += result.length
-  if (config.budget.used > config.budget.max) {
-    config.maxDepth = 0
-  }
-
-  return result
+  return hitMaxDepth || isWindow(val)
+    ? `[${getConstructorName(val)}]`
+    : `${
+      min
+        ? ''
+        : !config.printBasicPrototype && getConstructorName(val) === 'Object'
+            ? ''
+            : `${getConstructorName(val)} `
+    }{${printObjectProperties(
+      val,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer,
+    )}}`
 }
 
 const ErrorPlugin: NewPlugin = {
@@ -393,29 +380,44 @@ function printer(
   refs: Refs,
   hasCalledToJSON?: boolean,
 ): string {
+  let result: string
+
   const plugin = findPlugin(config.plugins, val)
   if (plugin !== null) {
-    return printPlugin(plugin, val, config, indentation, depth, refs)
+    result = printPlugin(plugin, val, config, indentation, depth, refs)
+  }
+  else {
+    const basicResult = printBasicValue(
+      val,
+      config.printFunctionName,
+      config.escapeRegex,
+      config.escapeString,
+    )
+    if (basicResult !== null) {
+      result = basicResult
+    }
+    else {
+      result = printComplexValue(
+        val,
+        config,
+        indentation,
+        depth,
+        refs,
+        hasCalledToJSON,
+      )
+    }
   }
 
-  const basicResult = printBasicValue(
-    val,
-    config.printFunctionName,
-    config.escapeRegex,
-    config.escapeString,
-  )
-  if (basicResult !== null) {
-    return basicResult
+  // Check string length budget:
+  // accumulate output length and if exceeded,
+  // force no further recursion by patching maxDepth.
+  // Inspired by Node's util.inspect bail out approach.
+  config.budget.used += result.length
+  if (config.budget.used > config.budget.max) {
+    config.maxDepth = 0
   }
 
-  return printComplexValue(
-    val,
-    config,
-    indentation,
-    depth,
-    refs,
-    hasCalledToJSON,
-  )
+  return result
 }
 
 const DEFAULT_THEME: Theme = {

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -412,8 +412,8 @@ function printer(
   // accumulate output length and if exceeded,
   // force no further recursion by patching maxDepth.
   // Inspired by Node's util.inspect bail out approach.
-  config.budget.used += result.length
-  if (config.budget.used > config.budget.max) {
+  config.outputLength += result.length
+  if (config.outputLength > config.maxOutputLength) {
     config.maxDepth = 0
   }
 
@@ -527,7 +527,8 @@ function getConfig(options?: OptionsReceived): Config {
     printShadowRoot: options?.printShadowRoot ?? true,
     spacingInner: options?.min ? ' ' : '\n',
     spacingOuter: options?.min ? '' : '\n',
-    budget: { used: 0, max: options?.maxOutputLength ?? DEFAULT_OPTIONS.maxOutputLength },
+    maxOutputLength: options?.maxOutputLength ?? DEFAULT_OPTIONS.maxOutputLength,
+    outputLength: 0,
   }
 }
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -289,7 +289,7 @@ function printComplexValue(
   // Inspired by node's util.inspect bail out heuristics.
   config.budget.used += result.length
   if (config.budget.used > config.budget.max) {
-    config.maxDepth = -1
+    config.maxDepth = 0
   }
 
   return result
@@ -323,7 +323,7 @@ const ErrorPlugin: NewPlugin = {
       )}}`
     config.budget.used += result.length
     if (config.budget.used > config.budget.max) {
-      config.maxDepth = -1
+      config.maxDepth = 0
     }
     return result
   },

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -441,7 +441,7 @@ export const DEFAULT_OPTIONS: Options = {
   indent: 2,
   maxDepth: Number.POSITIVE_INFINITY,
   // Practical default hard-limit to avoid too long string being generated
-  // (Node's limit is 512MB)
+  // (Node's limit is buffer.constants.MAX_STRING_LENGTH ~ 512MB)
   maxOutputLength: 1_000_000,
   maxWidth: Number.POSITIVE_INFINITY,
   min: false,

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -311,7 +311,7 @@ const ErrorPlugin: NewPlugin = {
       ...rest,
     }
     const name = val.name !== 'Error' ? val.name : getConstructorName(val as any)
-    const result = hitMaxDepth
+    return hitMaxDepth
       ? `[${name}]`
       : `${name} {${printIteratorEntries(
         Object.entries(entries).values(),
@@ -321,11 +321,6 @@ const ErrorPlugin: NewPlugin = {
         refs,
         printer,
       )}}`
-    config.budget.used += result.length
-    if (config.budget.used > config.budget.max) {
-      config.maxDepth = 0
-    }
-    return result
   },
 }
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -443,7 +443,8 @@ export const DEFAULT_OPTIONS: Options = {
   highlight: false,
   indent: 2,
   maxDepth: Number.POSITIVE_INFINITY,
-  // Prevent hitting Node's string length limit (~512MB)
+  // Practical default hard-limit to avoid too long string being generated
+  // (Node's limit is 512MB)
   maxOutputLength: 1_000_000,
   maxWidth: Number.POSITIVE_INFINITY,
   min: false,

--- a/packages/pretty-format/src/types.ts
+++ b/packages/pretty-format/src/types.ts
@@ -72,7 +72,8 @@ export interface Config {
   printShadowRoot: boolean
   spacingInner: string
   spacingOuter: string
-  budget: { used: number; max: number }
+  maxOutputLength: number
+  outputLength: number
 }
 
 export type Printer = (

--- a/packages/pretty-format/src/types.ts
+++ b/packages/pretty-format/src/types.ts
@@ -45,6 +45,7 @@ export interface PrettyFormatOptions {
   indent?: number
   maxDepth?: number
   maxWidth?: number
+  maxOutputLength?: number
   min?: boolean
   printBasicPrototype?: boolean
   printFunctionName?: boolean
@@ -71,6 +72,7 @@ export interface Config {
   printShadowRoot: boolean
   spacingInner: string
   spacingOuter: string
+  budget: { used: number; max: number }
 }
 
 export type Printer = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1464,6 +1464,9 @@ importers:
       '@vitest/mocker':
         specifier: workspace:*
         version: link:../../packages/mocker
+      '@vitest/pretty-format':
+        specifier: workspace:*
+        version: link:../../packages/pretty-format
       '@vitest/runner':
         specifier: workspace:*
         version: link:../../packages/runner

--- a/test/core/package.json
+++ b/test/core/package.json
@@ -22,6 +22,7 @@
     "@test/vite-external": "link:./projects/vite-external",
     "@vitest/expect": "workspace:*",
     "@vitest/mocker": "workspace:*",
+    "@vitest/pretty-format": "workspace:*",
     "@vitest/runner": "workspace:*",
     "@vitest/test-dep-cjs": "file:./deps/dep-cjs",
     "@vitest/test-dep-nested-cjs": "file:./deps/dep-nested-cjs",

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -153,8 +153,8 @@ describe('maxOutputLength', () => {
 
     // depending on object/array shape, output can exceed the limit 1mb
     // but the output size is proportional to the amount of objects and the size of array.
-    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`999009`)
-    expect(format(createObjectGraph(20000).cats).length).toMatchInlineSnapshot(`1497738`)
+    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`936779`)
+    expect(format(createObjectGraph(20000).cats).length).toMatchInlineSnapshot(`1236779`)
   })
 
   test('early elements expanded, later elements folded after budget trips', () => {
@@ -175,9 +175,7 @@ describe('maxOutputLength', () => {
         Object {
           "i": 3,
         },
-        Object {
-          "i": 4,
-        },
+        [Object],
         [Object],
         [Object],
         [Object],

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -14,8 +14,14 @@ describe('maxOutputLength budget', () => {
     //       |-> dog1
     //       |-> dog2
     //       |-> ...
-    interface Owner { dogs: Pet[]; cats: Pet[] }
-    interface Pet { name: string; owner: Owner }
+    interface Owner {
+      dogs: Pet[]
+      cats: Pet[]
+    }
+    interface Pet {
+      name: string
+      owner: Owner
+    }
     const owner: Owner = { dogs: [], cats: [] }
     for (let i = 0; i < n; i++) {
       owner.dogs.push({ name: `dog${i}`, owner })
@@ -132,10 +138,24 @@ describe('maxOutputLength budget', () => {
   })
 
   test('budget prevents blowup on large graphs', () => {
-    // TODO: use number that actually breaks on main
-    const owner = createObjectGraph(100)
-    const result = format(owner.cats)
-    expect(result.length).toBeLessThan(100_000)
+    // quickly hit the kill switch due to quadratic growth
+    expect([1, 5, 10, 15, 20, 30, 100].map(n => format(createObjectGraph(n).cats).length))
+      .toMatchInlineSnapshot(`
+      [
+        216,
+        2744,
+        9729,
+        21044,
+        27554,
+        27169,
+        27309,
+      ]
+    `)
+
+    // depending on object/array shape, output can exceed the limit 100_000,
+    // but the size should be proportional to the amount of objects and the size of array.
+    expect(format(createObjectGraph(1000).cats).length).toMatchInlineSnapshot(`99009`)
+    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`389799`)
   })
 
   test('early elements expanded, later elements folded after budget trips', () => {

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -2,140 +2,169 @@ import { format } from '@vitest/pretty-format'
 import { describe, expect, test } from 'vitest'
 
 describe('maxOutputLength budget', () => {
-  // https://github.com/vitest-dev/vitest/issues/9329
-  // Object graphs with shared references that fan out can cause exponential
-  // output growth, hitting Node's string length limit. The budget (maxOutputLength)
-  // guards against this amplification by setting maxDepth = 0 once exceeded.
-
-  // Recursive types show why pretty-format can't terminate:
-  // expanding a Child means expanding its Parent, which contains all Children again.
-  type Parent = { children: Child[] }
-  type Child = { id: number; parent: Parent }
-
-  function createGraph(n: number) {
-    //  format(children) --> child(0) --> parent --> child(0)  [Circular]
-    //                        |            |
-    //                        |            +--> child(1) --> parent  (not ancestor, re-expand!)
-    //                        |            |                  +--> child(0) --> parent ...
-    //                        |            |                  +--> child(1)  [Circular]
-    //                        |            |                  +--> child(2) --> parent ...
-    //                        |            +--> child(2) --> parent  (same explosion)
-    //                       ...
-    //                       child(1) --> parent  (same explosion again from sibling)
-    //
-    // `parent` is never an ancestor when visiting via a sibling child,
-    // so [Circular] doesn't apply and each child fully re-expands it.
-    const parent: Parent = { children: [] }
+  function createObjectGraph(n: number) {
+    // owner
+    //  |-> cats
+    //       |-> cat0 -> owner
+    //       |-> cat1 -> owner
+    //       |-> cat2
+    //       |-> ...
+    //  |-> dogs
+    //       |-> dog0
+    //       |-> dog1
+    //       |-> dog2
+    //       |-> ...
+    interface Owner { dogs: Pet[]; cats: Pet[] }
+    interface Pet { name: string; owner: Owner }
+    const owner: Owner = { dogs: [], cats: [] }
     for (let i = 0; i < n; i++) {
-      parent.children.push({ id: i, parent })
+      owner.dogs.push({ name: `dog${i}`, owner })
     }
-    return parent
+    for (let i = 0; i < n; i++) {
+      owner.cats.push({ name: `cat${i}`, owner })
+    }
+    return owner
   }
 
-  test('print graph', () => {
-    const parent = createGraph(3)
-    expect(format(parent)).toMatchInlineSnapshot(`
+  test('quadratic growth example depending on format root', () => {
+    const owner = createObjectGraph(3)
+
+    // when starting from owner, each pet is expanded once, so no amplification, just linear growth.
+    expect(format(owner)).toMatchInlineSnapshot(`
       "Object {
-        "children": Array [
+        "cats": Array [
           Object {
-            "id": 0,
-            "parent": [Circular],
+            "name": "cat0",
+            "owner": [Circular],
           },
           Object {
-            "id": 1,
-            "parent": [Circular],
+            "name": "cat1",
+            "owner": [Circular],
           },
           Object {
-            "id": 2,
-            "parent": [Circular],
+            "name": "cat2",
+            "owner": [Circular],
+          },
+        ],
+        "dogs": Array [
+          Object {
+            "name": "dog0",
+            "owner": [Circular],
+          },
+          Object {
+            "name": "dog1",
+            "owner": [Circular],
+          },
+          Object {
+            "name": "dog2",
+            "owner": [Circular],
           },
         ],
       }"
     `)
-    expect(format(parent.children)).toMatchInlineSnapshot(`
+
+    // when starting from owner.cats, each cat re-expands the full dogs list via owner.
+    // this exhibits quadratic growth, which is what the budget is designed to prevent.
+    expect(format(owner.cats)).toMatchInlineSnapshot(`
       "Array [
         Object {
-          "id": 0,
-          "parent": Object {
-            "children": [Circular],
+          "name": "cat0",
+          "owner": Object {
+            "cats": [Circular],
+            "dogs": Array [
+              Object {
+                "name": "dog0",
+                "owner": [Circular],
+              },
+              Object {
+                "name": "dog1",
+                "owner": [Circular],
+              },
+              Object {
+                "name": "dog2",
+                "owner": [Circular],
+              },
+            ],
           },
         },
         Object {
-          "id": 1,
-          "parent": Object {
-            "children": [Circular],
+          "name": "cat1",
+          "owner": Object {
+            "cats": [Circular],
+            "dogs": Array [
+              Object {
+                "name": "dog0",
+                "owner": [Circular],
+              },
+              Object {
+                "name": "dog1",
+                "owner": [Circular],
+              },
+              Object {
+                "name": "dog2",
+                "owner": [Circular],
+              },
+            ],
           },
         },
         Object {
-          "id": 2,
-          "parent": Object {
-            "children": [Circular],
+          "name": "cat2",
+          "owner": Object {
+            "cats": [Circular],
+            "dogs": Array [
+              Object {
+                "name": "dog0",
+                "owner": [Circular],
+              },
+              Object {
+                "name": "dog1",
+                "owner": [Circular],
+              },
+              Object {
+                "name": "dog2",
+                "owner": [Circular],
+              },
+            ],
           },
         },
       ]"
     `)
-    // const result = format(parent)
-    // expect(result.length).toBeLessThan(100_000)
   })
 
-  // test('custom maxOutputLength limits output', () => {
-  //   const children = createGraph(50)
-  //   const small = format(children, { maxOutputLength: 5_000 })
-  //   const large = format(children, { maxOutputLength: 50_000 })
-  //   expect(small.length).toBeLessThan(large.length)
-  // })
-
-  // test('abbreviated objects use [ClassName] form after budget exceeded', () => {
-  //   const children = createGraph(20)
-  //   const result = format(children, { maxOutputLength: 1_000 })
-  //   // Once budget trips, remaining objects render as [Object] / [Array]
-  //   expect(result).toContain('[Object]')
-  // })
+  test('budget prevents blowup on large graphs', () => {
+    // TODO: use number that actually breaks on main
+    const owner = createObjectGraph(100)
+    const result = format(owner.cats)
+    expect(result.length).toBeLessThan(100_000)
+  })
 
   test('early elements expanded, later elements folded after budget trips', () => {
-    // Visualizes the kill-switch: once budget is exceeded, maxDepth is set to 0
-    // and all subsequent objects render as [ClassName] while earlier ones are full.
-    const arr = Array.from({ length: 5 }, (_, i) => ({ id: i, nested: { x: i } }))
+    // First few objects are fully expanded, but once budget is exceeded,
+    // maxDepth = 0 means no more expansion.
+    const arr = Array.from({ length: 10 }, (_, i) => ({ i }))
     expect(format(arr, { maxOutputLength: 100 })).toMatchInlineSnapshot(`
       "Array [
         Object {
-          "id": 0,
-          "nested": Object {
-            "x": 0,
-          },
+          "i": 0,
         },
         Object {
-          "id": 1,
-          "nested": Object {
-            "x": 1,
-          },
+          "i": 1,
+        },
+        Object {
+          "i": 2,
+        },
+        Object {
+          "i": 3,
+        },
+        Object {
+          "i": 4,
         },
         [Object],
         [Object],
         [Object],
+        [Object],
+        [Object],
       ]"
-    `)
-  })
-
-  test('does not affect simple values', () => {
-    // Flat arrays of primitives should format normally — no amplification.
-    expect(format([1, 2, 3], { maxOutputLength: 100 })).toMatchInlineSnapshot(`
-      "Array [
-        1,
-        2,
-        3,
-      ]"
-    `)
-  })
-
-  test('does not affect normal circular references', () => {
-    const obj: any = { a: 1 }
-    obj.self = obj
-    expect(format(obj, { maxOutputLength: 100 })).toMatchInlineSnapshot(`
-      "Object {
-        "a": 1,
-        "self": [Circular],
-      }"
     `)
   })
 })

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -1,0 +1,95 @@
+import { format } from '@vitest/pretty-format'
+import { describe, expect, test } from 'vitest'
+
+describe('maxOutputLength budget', () => {
+  // https://github.com/vitest-dev/vitest/issues/9329
+  // Object graphs with shared references that fan out can cause exponential
+  // output growth, hitting Node's string length limit. The budget (maxOutputLength)
+  // guards against this amplification by setting maxDepth = 0 once exceeded.
+
+  function createSharedRefGraph(n: number) {
+    // N columns each referencing the same shared model/events objects.
+    // When formatting `groups` (not the root model), columnModel is NOT
+    // an ancestor — so [Circular] doesn't apply and each column fully
+    // re-expands the shared model, causing exponential blowup.
+    const model = { columns: [] as any[], groups: [] as any[] }
+    const events = { model, listeners: [] }
+    for (let i = 0; i < n; i++) {
+      const col = { id: `col${i}`, model, events }
+      model.columns.push(col)
+      if (i % 3 === 0) {
+        model.groups.push(col)
+      }
+    }
+    return model
+  }
+
+  test('terminates on exponential shared-reference graph', () => {
+    const model = createSharedRefGraph(100)
+    // Without budget this would hit Node's string length limit.
+    // With default budget (100_000) it completes quickly.
+    const result = format(model.groups)
+    expect(result.length).toBeLessThan(100_000)
+  })
+
+  test('custom maxOutputLength limits output', () => {
+    const model = createSharedRefGraph(50)
+    const small = format(model.groups, { maxOutputLength: 5_000 })
+    const large = format(model.groups, { maxOutputLength: 50_000 })
+    expect(small.length).toBeLessThan(large.length)
+  })
+
+  test('abbreviated objects use [ClassName] form after budget exceeded', () => {
+    const model = createSharedRefGraph(20)
+    const result = format(model.groups, { maxOutputLength: 1_000 })
+    // Once budget trips, remaining objects render as [Object] / [Array]
+    expect(result).toContain('[Object]')
+  })
+
+  test('early elements expanded, later elements folded after budget trips', () => {
+    // Visualizes the kill-switch: once budget is exceeded, maxDepth is set to 0
+    // and all subsequent objects render as [ClassName] while earlier ones are full.
+    const arr = Array.from({ length: 5 }, (_, i) => ({ id: i, nested: { x: i } }))
+    expect(format(arr, { maxOutputLength: 100 })).toMatchInlineSnapshot(`
+      "Array [
+        Object {
+          "id": 0,
+          "nested": Object {
+            "x": 0,
+          },
+        },
+        Object {
+          "id": 1,
+          "nested": Object {
+            "x": 1,
+          },
+        },
+        [Object],
+        [Object],
+        [Object],
+      ]"
+    `)
+  })
+
+  test('does not affect simple values', () => {
+    // Flat arrays of primitives should format normally — no amplification.
+    expect(format([1, 2, 3], { maxOutputLength: 100 })).toMatchInlineSnapshot(`
+      "Array [
+        1,
+        2,
+        3,
+      ]"
+    `)
+  })
+
+  test('does not affect normal circular references', () => {
+    const obj: any = { a: 1 }
+    obj.self = obj
+    expect(format(obj, { maxOutputLength: 100 })).toMatchInlineSnapshot(`
+      "Object {
+        "a": 1,
+        "self": [Circular],
+      }"
+    `)
+  })
+})

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -139,23 +139,22 @@ describe('maxOutputLength', () => {
 
   test('budget prevents blowup on large graphs', () => {
     // quickly hit the kill switch due to quadratic growth
-    expect([1, 5, 10, 15, 20, 30, 100].map(n => format(createObjectGraph(n).cats).length))
+    expect([10, 20, 30, 1000, 2000, 3000].map(n => format(createObjectGraph(n).cats).length))
       .toMatchInlineSnapshot(`
-      [
-        216,
-        2744,
-        9729,
-        21044,
-        27554,
-        27169,
-        27309,
-      ]
-    `)
+        [
+          9729,
+          36659,
+          80789,
+          273009,
+          374009,
+          299009,
+        ]
+      `)
 
-    // depending on object/array shape, output can exceed the limit 100_000,
+    // depending on object/array shape, output can exceed the limit 1mb
     // but the output size is proportional to the amount of objects and the size of array.
-    expect(format(createObjectGraph(1000).cats).length).toMatchInlineSnapshot(`99009`)
-    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`389799`)
+    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`999009`)
+    expect(format(createObjectGraph(20000).cats).length).toMatchInlineSnapshot(`1497738`)
   })
 
   test('early elements expanded, later elements folded after budget trips', () => {

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -1,7 +1,7 @@
 import { format } from '@vitest/pretty-format'
 import { describe, expect, test } from 'vitest'
 
-describe('maxOutputLength budget', () => {
+describe('maxOutputLength', () => {
   function createObjectGraph(n: number) {
     // owner
     //  |-> cats

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -7,44 +7,90 @@ describe('maxOutputLength budget', () => {
   // output growth, hitting Node's string length limit. The budget (maxOutputLength)
   // guards against this amplification by setting maxDepth = 0 once exceeded.
 
-  function createSharedRefGraph(n: number) {
-    // N columns each referencing the same shared model/events objects.
-    // When formatting `groups` (not the root model), columnModel is NOT
-    // an ancestor — so [Circular] doesn't apply and each column fully
-    // re-expands the shared model, causing exponential blowup.
-    const model = { columns: [] as any[], groups: [] as any[] }
-    const events = { model, listeners: [] }
+  // Recursive types show why pretty-format can't terminate:
+  // expanding a Child means expanding its Parent, which contains all Children again.
+  type Parent = { children: Child[] }
+  type Child = { id: number; parent: Parent }
+
+  function createGraph(n: number) {
+    //  format(children) --> child(0) --> parent --> child(0)  [Circular]
+    //                        |            |
+    //                        |            +--> child(1) --> parent  (not ancestor, re-expand!)
+    //                        |            |                  +--> child(0) --> parent ...
+    //                        |            |                  +--> child(1)  [Circular]
+    //                        |            |                  +--> child(2) --> parent ...
+    //                        |            +--> child(2) --> parent  (same explosion)
+    //                       ...
+    //                       child(1) --> parent  (same explosion again from sibling)
+    //
+    // `parent` is never an ancestor when visiting via a sibling child,
+    // so [Circular] doesn't apply and each child fully re-expands it.
+    const parent: Parent = { children: [] }
     for (let i = 0; i < n; i++) {
-      const col = { id: `col${i}`, model, events }
-      model.columns.push(col)
-      if (i % 3 === 0) {
-        model.groups.push(col)
-      }
+      parent.children.push({ id: i, parent })
     }
-    return model
+    return parent
   }
 
-  test('terminates on exponential shared-reference graph', () => {
-    const model = createSharedRefGraph(100)
-    // Without budget this would hit Node's string length limit.
-    // With default budget (100_000) it completes quickly.
-    const result = format(model.groups)
-    expect(result.length).toBeLessThan(100_000)
+  test('print graph', () => {
+    const parent = createGraph(3)
+    expect(format(parent)).toMatchInlineSnapshot(`
+      "Object {
+        "children": Array [
+          Object {
+            "id": 0,
+            "parent": [Circular],
+          },
+          Object {
+            "id": 1,
+            "parent": [Circular],
+          },
+          Object {
+            "id": 2,
+            "parent": [Circular],
+          },
+        ],
+      }"
+    `)
+    expect(format(parent.children)).toMatchInlineSnapshot(`
+      "Array [
+        Object {
+          "id": 0,
+          "parent": Object {
+            "children": [Circular],
+          },
+        },
+        Object {
+          "id": 1,
+          "parent": Object {
+            "children": [Circular],
+          },
+        },
+        Object {
+          "id": 2,
+          "parent": Object {
+            "children": [Circular],
+          },
+        },
+      ]"
+    `)
+    // const result = format(parent)
+    // expect(result.length).toBeLessThan(100_000)
   })
 
-  test('custom maxOutputLength limits output', () => {
-    const model = createSharedRefGraph(50)
-    const small = format(model.groups, { maxOutputLength: 5_000 })
-    const large = format(model.groups, { maxOutputLength: 50_000 })
-    expect(small.length).toBeLessThan(large.length)
-  })
+  // test('custom maxOutputLength limits output', () => {
+  //   const children = createGraph(50)
+  //   const small = format(children, { maxOutputLength: 5_000 })
+  //   const large = format(children, { maxOutputLength: 50_000 })
+  //   expect(small.length).toBeLessThan(large.length)
+  // })
 
-  test('abbreviated objects use [ClassName] form after budget exceeded', () => {
-    const model = createSharedRefGraph(20)
-    const result = format(model.groups, { maxOutputLength: 1_000 })
-    // Once budget trips, remaining objects render as [Object] / [Array]
-    expect(result).toContain('[Object]')
-  })
+  // test('abbreviated objects use [ClassName] form after budget exceeded', () => {
+  //   const children = createGraph(20)
+  //   const result = format(children, { maxOutputLength: 1_000 })
+  //   // Once budget trips, remaining objects render as [Object] / [Array]
+  //   expect(result).toContain('[Object]')
+  // })
 
   test('early elements expanded, later elements folded after budget trips', () => {
     // Visualizes the kill-switch: once budget is exceeded, maxDepth is set to 0

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -153,7 +153,7 @@ describe('maxOutputLength budget', () => {
     `)
 
     // depending on object/array shape, output can exceed the limit 100_000,
-    // but the size should be proportional to the amount of objects and the size of array.
+    // but the output size is proportional to the amount of objects and the size of array.
     expect(format(createObjectGraph(1000).cats).length).toMatchInlineSnapshot(`99009`)
     expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`389799`)
   })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9329
- Research note https://gist.github.com/hi-ogawa/ccb71b96c5b57e867cd3b42c4db81834

Several approaches is mentioned in the note above. This PR took the simplest approach inspired by Node's `util.inspect`. See [2nd approach in the note](https://gist.github.com/hi-ogawa/ccb71b96c5b57e867cd3b42c4db81834#implemented-solution-post-hoc-output-budget-in-printer-nodejs-style).

This doesn't necessarily supersede https://github.com/vitest-dev/vitest/pull/9920 since that's more about heuristics of improving the error diff for obvious case. This PR is only about implementing the guard for worst case.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
