### PR TITLE
fix: don't resolve `setupFiles` from parent directory

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -13,7 +13,7 @@ import crypto from 'node:crypto'
 import { pathToFileURL } from 'node:url'
 import { slash, toArray } from '@vitest/utils/helpers'
 import { resolveModule } from 'local-pkg'
-import { normalize, relative, resolve } from 'pathe'
+import { join, normalize, relative, resolve } from 'pathe'
 import c from 'tinyrainbow'
 import { mergeConfig } from 'vite'
 import {
@@ -29,13 +29,17 @@ import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
 
 function resolvePath(path: string, root: string) {
-  // local-pkg resolves resolveModule("./file.js", { paths: ["/some/root"] })
-  // into "/some/file.js" but we want "/some/root/file.js".
-  if (path[0] === '/' || path[0] === '.') {
-    return resolve(root, path)
-  }
+  // local-pkg (mlly)'s resolveModule("./file", { paths: ["/some/root"] }) tries
+  // /some/file
+  // /some/file.js
+  // /some/root/file
+  // /some/root/file.js
+  // etc.
+  // but we don't want to resolve files from parent directories,
+  // so we ensure passing "/" suffix such as "/some/root/"
+  // https://github.com/unjs/mlly/blob/401d42983f6f3a9112658d67b0a92ba4fb1d7efa/src/resolve.ts#L104-L110
   return normalize(
-    /* @__PURE__ */ resolveModule(path, { paths: [root] })
+    /* @__PURE__ */ resolveModule(path, { paths: [join(root, '/')] })
     ?? resolve(root, path),
   )
 }

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -29,6 +29,11 @@ import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
 
 function resolvePath(path: string, root: string) {
+  // local-pkg resolves resolveModule("./file.js", { paths: ["/some/root"] })
+  // into "/some/file.js" but we want "/some/root/file.js".
+  if (path[0] === '/' || path[0] === '.') {
+    return resolve(root, path)
+  }
   return normalize(
     /* @__PURE__ */ resolveModule(path, { paths: [root] })
     ?? resolve(root, path),

--- a/test/cli/fixtures/setup-files-resolve/nested-bare/basic.test.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested-bare/basic.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "vitest";
+
+test("basic", () => {
+  expect((globalThis as any).__testSetupResolve).toBe("ok");
+});

--- a/test/cli/fixtures/setup-files-resolve/nested-bare/setup.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested-bare/setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).__testSetupResolve = "ok";

--- a/test/cli/fixtures/setup-files-resolve/nested-bare/vitest.config.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested-bare/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["setup.ts"],
+  },
+});

--- a/test/cli/fixtures/setup-files-resolve/nested-no-ext/basic.test.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested-no-ext/basic.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "vitest";
+
+test("basic", () => {
+  expect((globalThis as any).__testSetupResolve).toBe("ok");
+});

--- a/test/cli/fixtures/setup-files-resolve/nested-no-ext/setup.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested-no-ext/setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).__testSetupResolve = "ok";

--- a/test/cli/fixtures/setup-files-resolve/nested-no-ext/vitest.config.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested-no-ext/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./setup"],
+  },
+});

--- a/test/cli/fixtures/setup-files-resolve/nested/basic.test.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested/basic.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "vitest";
+
+test("basic", () => {
+  expect((globalThis as any).__testSetupResolve).toBe("ok");
+});

--- a/test/cli/fixtures/setup-files-resolve/nested/setup.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested/setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).__testSetupResolve = "ok";

--- a/test/cli/fixtures/setup-files-resolve/nested/vitest.config.ts
+++ b/test/cli/fixtures/setup-files-resolve/nested/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./setup.ts"],
+  },
+});

--- a/test/cli/fixtures/setup-files-resolve/setup.ts
+++ b/test/cli/fixtures/setup-files-resolve/setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).__testSetupResolve = "not-this";

--- a/test/cli/test/setup-files.test.ts
+++ b/test/cli/test/setup-files.test.ts
@@ -41,3 +41,31 @@ describe('setup files with forceRerunTrigger', () => {
     expect(stdout).toContain('1 passed')
   })
 })
+
+it('setup files resolution in nested folder', async () => {
+  const result = await runVitest({
+    root: 'fixtures/setup-files-resolve/nested',
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "basic": "passed",
+      },
+    }
+  `)
+})
+
+it('setup files resolution in nested folder without extension', async () => {
+  const result = await runVitest({
+    root: 'fixtures/setup-files-resolve/nested-no-ext',
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "basic": "passed",
+      },
+    }
+  `)
+})

--- a/test/cli/test/setup-files.test.ts
+++ b/test/cli/test/setup-files.test.ts
@@ -69,3 +69,17 @@ it('setup files resolution in nested folder without extension', async () => {
     }
   `)
 })
+
+it('setup files resolution in nested folder with bare name', async () => {
+  const result = await runVitest({
+    root: 'fixtures/setup-files-resolve/nested-bare',
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "basic": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9955

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
