### PR TITLE
fix(pretty-format): fix output limit over counting

### DIFF
--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -414,9 +414,9 @@ function printer(
   // N levels of nesting). Nodes at the same depth produce disjoint spans
   // in the output string, so each bucket accurately reflects output at
   // that level. Total output is bounded by maxDepth × maxOutputLength.
-  config.outputLengthPerDepth[depth] ??= 0
-  config.outputLengthPerDepth[depth] += result.length
-  if (config.outputLengthPerDepth[depth] > config.maxOutputLength) {
+  config._outputLengthPerDepth[depth] ??= 0
+  config._outputLengthPerDepth[depth] += result.length
+  if (config._outputLengthPerDepth[depth] > config.maxOutputLength) {
     config.maxDepth = 0
   }
 
@@ -531,7 +531,7 @@ function getConfig(options?: OptionsReceived): Config {
     spacingInner: options?.min ? ' ' : '\n',
     spacingOuter: options?.min ? '' : '\n',
     maxOutputLength: options?.maxOutputLength ?? DEFAULT_OPTIONS.maxOutputLength,
-    outputLengthPerDepth: [],
+    _outputLengthPerDepth: [],
   }
 }
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -408,12 +408,12 @@ function printer(
     }
   }
 
-  // Check string length budget:
-  // accumulate output length and if exceeded,
-  // force no further recursion by patching maxDepth.
-  // Inspired by Node's util.inspect bail out approach.
-  config.outputLength += result.length
-  if (config.outputLength > config.maxOutputLength) {
+  // Per-depth output budget (inspired by Node's util.inspect).
+  // Each depth level tracks output independently, so nested results
+  // don't inflate a single counter. See node/lib/internal/util/inspect.js#L1486.
+  config.outputLengthPerDepth[depth] ??= 0
+  config.outputLengthPerDepth[depth] += result.length
+  if (config.outputLengthPerDepth[depth] > config.maxOutputLength) {
     config.maxDepth = 0
   }
 
@@ -528,7 +528,7 @@ function getConfig(options?: OptionsReceived): Config {
     spacingInner: options?.min ? ' ' : '\n',
     spacingOuter: options?.min ? '' : '\n',
     maxOutputLength: options?.maxOutputLength ?? DEFAULT_OPTIONS.maxOutputLength,
-    outputLength: 0,
+    outputLengthPerDepth: [],
   }
 }
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -410,7 +410,10 @@ function printer(
 
   // Per-depth output budget (inspired by Node's util.inspect).
   // Each depth level tracks output independently, so nested results
-  // don't inflate a single counter. See node/lib/internal/util/inspect.js#L1486.
+  // don't inflate a single counter (which would undercount by ~Nx for
+  // N levels of nesting). Nodes at the same depth produce disjoint spans
+  // in the output string, so each bucket accurately reflects output at
+  // that level. Total output is bounded by maxDepth × maxOutputLength.
   config.outputLengthPerDepth[depth] ??= 0
   config.outputLengthPerDepth[depth] += result.length
   if (config.outputLengthPerDepth[depth] > config.maxOutputLength) {

--- a/packages/pretty-format/src/types.ts
+++ b/packages/pretty-format/src/types.ts
@@ -45,6 +45,13 @@ export interface PrettyFormatOptions {
   indent?: number
   maxDepth?: number
   maxWidth?: number
+  /**
+   * Approximate per-depth-level budget for output length.
+   * When the accumulated output at any single depth level exceeds this value,
+   * further nesting is collapsed. This is a heuristic safety valve, not a hard
+   * limit — total output can reach up to roughly `maxDepth × maxOutputLength`.
+   * @default 1_000_000
+   */
   maxOutputLength?: number
   min?: boolean
   printBasicPrototype?: boolean
@@ -73,8 +80,11 @@ export interface Config {
   spacingInner: string
   spacingOuter: string
   maxOutputLength: number
-  // track total printed string length per depth as we print
-  outputLengthPerDepth: number[]
+  /**
+   * Per-depth budget accumulator for {@link maxOutputLength}.
+   * @internal
+   */
+  _outputLengthPerDepth: number[]
 }
 
 export type Printer = (

--- a/packages/pretty-format/src/types.ts
+++ b/packages/pretty-format/src/types.ts
@@ -73,7 +73,8 @@ export interface Config {
   spacingInner: string
   spacingOuter: string
   maxOutputLength: number
-  outputLength: number
+  // track total printed string length per depth as we print
+  outputLengthPerDepth: number[]
 }
 
 export type Printer = (

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -145,16 +145,16 @@ describe('maxOutputLength', () => {
           9729,
           36659,
           80789,
-          273009,
-          374009,
-          299009,
+          1056011,
+          1074009,
+          1088009,
         ]
       `)
 
     // depending on object/array shape, output can exceed the limit 1mb
     // but the output size is proportional to the amount of objects and the size of array.
-    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`936779`)
-    expect(format(createObjectGraph(20000).cats).length).toMatchInlineSnapshot(`1236779`)
+    expect(format(createObjectGraph(10000).cats).length).toMatchInlineSnapshot(`1377439`)
+    expect(format(createObjectGraph(20000).cats).length).toMatchInlineSnapshot(`1497738`)
   })
 
   test('budget should not truncate output shorter than maxOutputLength', () => {
@@ -162,11 +162,11 @@ describe('maxOutputLength', () => {
     const full = format(data, { maxOutputLength: Infinity })
     const limited = format(data, { maxOutputLength: full.length })
     // this invariant should hold for any input
-    // expect(limited.length).toBe(full.length)
+    expect(limited.length).toBe(full.length)
     expect({ limited: limited.length, full: full.length }).toMatchInlineSnapshot(`
       {
         "full": 4349,
-        "limited": 2399,
+        "limited": 4349,
       }
     `)
   })
@@ -189,7 +189,9 @@ describe('maxOutputLength', () => {
         Object {
           "i": 3,
         },
-        [Object],
+        Object {
+          "i": 4,
+        },
         [Object],
         [Object],
         [Object],

--- a/test/core/test/pretty-format.test.ts
+++ b/test/core/test/pretty-format.test.ts
@@ -157,6 +157,20 @@ describe('maxOutputLength', () => {
     expect(format(createObjectGraph(20000).cats).length).toMatchInlineSnapshot(`1236779`)
   })
 
+  test('budget should not truncate output shorter than maxOutputLength', () => {
+    const data = Array.from({ length: 50 }, (_, i) => ({ a: { b: { c: i } } }))
+    const full = format(data, { maxOutputLength: Infinity })
+    const limited = format(data, { maxOutputLength: full.length })
+    // this invariant should hold for any input
+    // expect(limited.length).toBe(full.length)
+    expect({ limited: limited.length, full: full.length }).toMatchInlineSnapshot(`
+      {
+        "full": 4349,
+        "limited": 2399,
+      }
+    `)
+  })
+
   test('early elements expanded, later elements folded after budget trips', () => {
     // First few objects are fully expanded, but once budget is exceeded,
     // maxDepth = 0 means no more expansion.


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9964
- Follow up to https://github.com/vitest-dev/vitest/pull/9949

Previous approach's single `outputLength` counter had an issue that it over counts deeper children multiple times due to tree structure. Pictoricaly it looks like:

```
total output: [================================================================]

depth 1:      [==========A==========]  [==========B==========]  [=====C=====]
depth 2:      [=a1=] [=a2=] [=a3=]     [==b1==] [==b2==]        [=c1=]
depth 3:      [x][y]  [z]              [p] [q]                   [r]
```

A different idea in this PR is to accumulate print length per depth and trigger `maxDepth = 0` bail out at any depth. And this is indeed what Node actually does https://github.com/nodejs/node/blob/61102cdbb3d59155ad5bb4fc9419627a31e63f7a/lib/internal/util/inspect.js#L1486-L1498 (My last agent research note said this but I totally overlooked :facepalm:)

However notably neither of approach is an exact total length tracking and they are only heuristics that get skewed by input object's nesting structure and depth factor. Rough estimation of length limit guarantee is

- PR 9949: `Actual format length limit ~= maxOutputLength / Average depth`
  - This is because the output of children at depth `n` contributes to `outputLength` counter for `n` times
- This PR: `Actual format length limit ~= maxOutputLength * Average depth`
  - This is because `outputLengthPerDepth` is per depth accumulation.

I'm not entirely sure the practical impact between two, so this is entirely an educated guess, but this PR has chosen the 2nd approach instead of bumping up limit with 1st approach.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
