### PR TITLE
fix: register merge-reports as a CLI subcommand (fix vitest-dev#9674)

### DIFF
--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -193,6 +193,10 @@ export function createCLI(options: CliParseOptions = {}): CAC {
   )
 
   cli
+    .command('merge-reports [path]', undefined, options)
+    .action(mergeReports)
+
+  cli
     .command('[...filters]', undefined, options)
     .action((filters, options) => start('test', filters, options))
 
@@ -249,6 +253,12 @@ export function parseCLI(argv: string | string[], config: CliParseOptions = {}):
     options.passWithNoTests ??= true
     args = []
   }
+  if (arrayArgs[2] === 'merge-reports') {
+    options.mergeReports = args[0] || '.vitest-reports'
+    options.watch = false
+    options.run = true
+    args = []
+  }
   return {
     filter: args as string[],
     options,
@@ -276,6 +286,13 @@ async function run(cliFilters: string[], options: CliOptions): Promise<void> {
 async function benchmark(cliFilters: string[], options: CliOptions): Promise<void> {
   console.warn(c.yellow('Benchmarking is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.'))
   await start('benchmark', cliFilters, options)
+}
+
+async function mergeReports(path: string | undefined, options: CliOptions): Promise<void> {
+  options.mergeReports = path || '.vitest-reports'
+  options.watch = false
+  options.run = true
+  await start('test', [], options)
 }
 
 function normalizeCliOptions(cliFilters: string[], argv: CliOptions): CliOptions {

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -339,6 +339,18 @@ test('merge-reports', () => {
   expect(getCLIOptions('--merge-reports')).toEqual({ mergeReports: '.vitest-reports' })
   expect(getCLIOptions('--merge-reports=different-folder')).toEqual({ mergeReports: 'different-folder' })
   expect(getCLIOptions('--merge-reports different-folder')).toEqual({ mergeReports: 'different-folder' })
+
+  const defaultResult = parseCLI('vitest merge-reports')
+  expect(defaultResult.options.mergeReports).toBe('.vitest-reports')
+  expect(defaultResult.options.watch).toBe(false)
+  expect(defaultResult.options.run).toBe(true)
+  expect(defaultResult.filter).toEqual([])
+
+  const withPath = parseCLI('vitest merge-reports ./blobs')
+  expect(withPath.options.mergeReports).toBe('./blobs')
+  expect(withPath.options.watch).toBe(false)
+  expect(withPath.options.run).toBe(true)
+  expect(withPath.filter).toEqual([])
 })
 
 test('configure expect', () => {
@@ -508,6 +520,42 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'exclude': ['docs', 'demo'],
+      '--': [],
+      'color': true,
+    },
+  })
+
+  expect(parseCLI('vitest merge-reports')).toEqual({
+    filter: [],
+    options: {
+      'mergeReports': '.vitest-reports',
+      'watch': false,
+      'run': true,
+      '--': [],
+      'color': true,
+    },
+  })
+
+  expect(parseCLI('vitest merge-reports ./blobs')).toEqual({
+    filter: [],
+    options: {
+      'mergeReports': './blobs',
+      'watch': false,
+      'run': true,
+      '--': [],
+      'color': true,
+    },
+  })
+
+  expect(parseCLI('vitest merge-reports ./blobs --reporter=junit')).toEqual({
+    filter: [],
+    options: {
+      'mergeReports': './blobs',
+      'watch': false,
+      'run': true,
+      'reporter': [
+        'junit',
+      ],
       '--': [],
       'color': true,
     },


### PR DESCRIPTION
### Description

Resolves #9674 

`vitest merge-reports [path]` was not registered as a cac CLI subcommand.
When running `vitest merge-reports ./blobs --reporter=junit`, the parser
fell through to the catch-all `[...filters]` command, treating
`merge-reports` and `./blobs` as test filters. This caused:

- `mergeReports` option was never set
- Vitest started in normal test mode with no matching tests
- The process hung (watch mode by default)
- An empty report was generated

## Changes

- Register `merge-reports [path]` as a proper CLI command in `createCLI()`
- Add `mergeReports()` handler that sets `mergeReports`, `watch: false`, `run: true`
- Handle `merge-reports` in `parseCLI()` for programmatic API usage
- Add tests for the subcommand in `cli-test.test.ts`

## How to reproduce

```sh
vitest run --reporter=blob --outputFile=report.blob
vitest merge-reports . --reporter=junit --outputFile=report.xml
# Before fix: hangs + empty report. After fix: correctly merges blob reports.
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
