### PR TITLE
fix: negated project filtering (!) broken on browser projects

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1592,6 +1592,27 @@ export class Vitest {
       return regexp.test(name)
     })
   }
+
+  /**
+   * Check if the project with a given name is explicitly excluded by a negated pattern.
+   * This is used to filter out browser instances when their parent project is excluded.
+   */
+  isProjectExcludedByNegatedPattern(name: string): boolean {
+    const projects = this._config?.project || this._cliOptions?.project
+    if (!projects || !projects.length) {
+      return false
+    }
+    return toArray(projects).some((project) => {
+      // Only check negated patterns (starting with !)
+      if (project[0] !== '!') {
+        return false
+      }
+      // Remove the ! prefix and check if the name matches the pattern
+      const pattern = project.slice(1)
+      const regexp = wildcardPatternToRegExp(pattern)
+      return regexp.test(name)
+    })
+  }
 }
 
 function assert(condition: unknown, property: string, name: string = property): asserts condition {

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -217,6 +217,11 @@ export async function resolveBrowserProjects(
       return
     }
     const originalName = project.config.name
+    // if original name is explicitly excluded by a negated pattern, exclude all instances
+    if (vitest.isProjectExcludedByNegatedPattern(originalName)) {
+      removeProjects.add(project)
+      return
+    }
     // if original name is in the --project=name filter, keep all instances
     const filteredInstances = vitest.matchesProjectFilter(originalName)
       ? instances


### PR DESCRIPTION
## Description

When running vitest against a config with multiple vitest projects, filtering out browser projects with the negation/`!` operator did not work correctly.

## Bug Report

Fixes #9977

### Problem

When using `--project !browser` to exclude browser projects, the browser instances (like `chromium`, `firefox`, etc.) were still being included in the test run.

### Root Cause

In `resolveBrowserProjects`, when the original project name didn't match the filter, it would fall through to filter individual instances. However, with negated patterns like `!browser`, the instance names (e.g., `chromium`) would match the pattern (since they're not `browser`), causing them to be incorrectly included.

### Solution

Added a new method `isProjectExcludedByNegatedPattern` in the Vitest class that checks if a project name is explicitly excluded by any negated pattern (starting with `!`). 

When resolving browser projects, if the original project name is excluded by a negated pattern, all its instances are now also excluded.

### Changes

- Added `isProjectExcludedByNegatedPattern` method to `packages/vitest/src/node/core.ts`
- Updated `resolveBrowserProjects` in `packages/vitest/src/node/projects/resolveProjects.ts` to check for negated pattern exclusion before filtering instances

---

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update