### PR TITLE
fix(expect): remove `JestExtendError.context` from verbose error reporting

### DIFF
--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -156,7 +156,8 @@ export function createBrowserRunner(
     }
 
     onTaskFinished = async (task: Task) => {
-      const lastErrorContext = task.result?.errors?.at(-1)?.context
+      // check custom matcher metadata in JestExtendError
+      const lastErrorContext = task.result?.errors?.at(-1)?.__vitest_error_context__
       if (
         this.config.browser.screenshotFailures
         && document.body.clientHeight > 0

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -64,12 +64,18 @@ function getMatcherState(
   }
 }
 
+interface VitestErrorContext {
+  assertionName: string
+  meta?: object
+}
+
 class JestExtendError extends Error {
   constructor(
     message: string,
     public actual?: any,
     public expected?: any,
-    public context?: { assertionName: string; meta?: object },
+    /** @internal */
+    public __vitest_error_context__?: VitestErrorContext,
   ) {
     super(message)
   }

--- a/packages/vitest/src/node/printError.ts
+++ b/packages/vitest/src/node/printError.ts
@@ -283,6 +283,7 @@ const skipErrorProperties = new Set([
   'VITEST_TEST_NAME',
   'VITEST_TEST_PATH',
   '__vitest_rollup_error__',
+  '__vitest_error_context__',
   ...Object.getOwnPropertyNames(Error.prototype),
   ...Object.getOwnPropertyNames(Object.prototype),
 ])

--- a/test/cli/test/expect-extend.test.ts
+++ b/test/cli/test/expect-extend.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
+
+// JestExtendError's internal context property shouldn't show up as "Serialized Error"
+test('expect.extend error message', async () => {
+  const result = await runInlineTests({
+    './basic.test.js': `
+import { expect, test } from 'vitest';
+
+expect.extend({
+  toMyEqual(actual, expected) {
+    const pass = actual === expected;
+    return { pass, message: () => 'my matcher failed', actual, expected };
+  },
+});
+
+test('fail', () => {
+  expect(123).toMyEqual(456);
+});
+`,
+  }, {
+    reporters: 'verbose',
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  basic.test.js > fail
+    Error: my matcher failed
+
+    - Expected
+    + Received
+
+    - 456
+    + 123
+
+     ❯ basic.test.js:12:15
+         10|
+         11| test('fail', () => {
+         12|   expect(123).toMyEqual(456);
+           |               ^
+         13| });
+         14|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    Serialized Error: { __vitest_error_context__: { assertionName: 'toMyEqual', meta: undefined } }
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+    "
+  `)
+  expect(result.testTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.js": {
+        "fail": "failed",
+      },
+    }
+  `)
+})

--- a/test/cli/test/expect-extend.test.ts
+++ b/test/cli/test/expect-extend.test.ts
@@ -42,8 +42,6 @@ test('fail', () => {
          13| });
          14|
 
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-    Serialized Error: { __vitest_error_context__: { assertionName: 'toMyEqual', meta: undefined } }
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
 
     "


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- follow up to https://github.com/vitest-dev/vitest/pull/9847

I just noticed `JestExtendError.context` now shows up on verbose reporter as a big `Serialized Error` section. For now, this should be treated as internal and get excluded as yet another `skipErrorProperties`.

Reproduction: https://stackblitz.com/edit/vitest-dev-vitest-ffwl7esz?file=test%2Frepro.test.ts

```js
expect.extend({
  toAlwaysFail() {
    return { pass: false, message: () => 'always fails' };
  },
});

test('demo', () => {
  expect(1).toAlwaysFail();
});
```

```sh
 FAIL  test/repro.test.ts > demo
Error: always fails
 ❯ test/repro.test.ts:10:13
      8|
      9| test('demo', () => {
     10|   expect(1).toAlwaysFail();
       |             ^
     11| });
     12|
 ❯ new Promise ../../../blitz.4c73681d.js:31:30606

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { context: { assertionName: 'toAlwaysFail', meta: undefined } }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
