### PR TITLE
test: add `TextDecoder/TextEncoder` to custom environment example to fix Vite 8

### DIFF
--- a/test/core/test/environments/custom-env.test.ts
+++ b/test/core/test/environments/custom-env.test.ts
@@ -2,6 +2,11 @@
 
 import { expect, test } from 'vitest'
 
+test('TextDecoder and TextEncoder are available', () => {
+  expect(typeof TextDecoder).toBe('function')
+  expect(typeof TextEncoder).toBe('function')
+})
+
 test('custom env is defined', () => {
   expect(expect.getState().environment).toBe('custom')
   expect((globalThis as any).testEnvironment).toBe('custom')

--- a/test/core/vitest-environment-custom/index.ts
+++ b/test/core/vitest-environment-custom/index.ts
@@ -19,6 +19,8 @@ export default <Environment>{
       AbortController,
       EventTarget,
       Event,
+      TextDecoder,
+      TextEncoder,
     })
     return {
       getVmContext() {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/9987

Vite 8 now access `TextDecoder` in module runner https://github.com/vitejs/vite/pull/21985 and it breaks custom vm environment test case. For now, this just fixes on custom environment example side. Our builtin environment (node, jsdom, etc) fills globals including `TextDecoder`, so this is only custom environment issue. Not sure if this (Vite 8 change) should be taken as breaking change or not. Probably we can wait. Otherwise, maybe need to fill more context around here 

https://github.com/vitest-dev/vitest/blob/8f40655d6482d30babf8b3c64468ea9e64be0d41/packages/vitest/src/runtime/workers/vm.ts#L81-L82

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
