### PR TITLE
fix(snapshot): respect snapshot properties in mismatch diffs (#9985)

### DIFF
--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -1,7 +1,7 @@
 import type { RawSnapshotInfo } from './port/rawSnapshot'
 import type { SnapshotResult, SnapshotStateOptions } from './types'
 import SnapshotState from './port/state'
-import { deepMergeSnapshot } from './port/utils'
+import { deepMergeSnapshot, getSnapshotPropertiesSubset } from './port/utils'
 
 function createMismatchError(
   message: string,
@@ -158,7 +158,7 @@ export class SnapshotClient {
         return {
           pass: false,
           message: () => errorMessage || 'Snapshot properties mismatched',
-          actual: received,
+          actual: getSnapshotPropertiesSubset(received, properties),
           expected: properties,
         }
       }

--- a/packages/snapshot/src/port/utils.ts
+++ b/packages/snapshot/src/port/utils.ts
@@ -236,6 +236,101 @@ export function deepMergeSnapshot(target: any, source: any): any {
   return target
 }
 
+function getObjectKeys(object: object): Array<string | symbol> {
+  return [
+    ...Object.keys(object),
+    ...Object.getOwnPropertySymbols(object).filter(
+      symbol => Object.getOwnPropertyDescriptor(object, symbol)?.enumerable,
+    ),
+  ]
+}
+
+function hasPropertyInObject(object: object, key: string | symbol): boolean {
+  const shouldTerminate
+    = !object || typeof object !== 'object' || object === Object.prototype
+
+  if (shouldTerminate) {
+    return false
+  }
+
+  return (
+    Object.hasOwn(object, key)
+    || hasPropertyInObject(Object.getPrototypeOf(object), key)
+  )
+}
+
+function isSubsetLikeObject(value: unknown): value is object {
+  return isObject(value)
+    && !(value instanceof Date)
+    && !(value instanceof Set)
+    && !(value instanceof Map)
+    && !(value instanceof Error)
+    && !(value as any).$$typeof
+}
+
+function isTrackableObject(value: unknown): value is object {
+  return value !== null && (typeof value === 'object' || typeof value === 'function')
+}
+
+export function getSnapshotPropertiesSubset(
+  received: unknown,
+  properties: unknown,
+): unknown {
+  const seenReferences = new WeakMap<object, unknown>()
+
+  const project = (target: unknown, source: unknown): unknown => {
+    if (Array.isArray(target) && Array.isArray(source)) {
+      const projected: unknown[] = []
+      seenReferences.set(target, projected)
+
+      source.forEach((sourceValue, index) => {
+        if (!Object.hasOwn(target, index)) {
+          return
+        }
+
+        const targetValue = target[index]
+        projected[index] = isTrackableObject(targetValue) && seenReferences.has(targetValue)
+          ? seenReferences.get(targetValue)
+          : project(targetValue, sourceValue)
+      })
+
+      return projected
+    }
+
+    if (isSubsetLikeObject(target) && isSubsetLikeObject(source)) {
+      const projected = {}
+      seenReferences.set(target, projected)
+
+      if (
+        typeof target.constructor === 'function'
+        && typeof target.constructor.name === 'string'
+      ) {
+        Object.defineProperty(projected, 'constructor', {
+          enumerable: false,
+          value: target.constructor,
+        })
+      }
+
+      for (const key of getObjectKeys(source)) {
+        if (!hasPropertyInObject(target, key)) {
+          continue
+        }
+
+        const targetValue = (target as any)[key]
+        projected[key] = isTrackableObject(targetValue) && seenReferences.has(targetValue)
+          ? seenReferences.get(targetValue)
+          : project(targetValue, (source as any)[key])
+      }
+
+      return projected
+    }
+
+    return target
+  }
+
+  return project(received, properties)
+}
+
 export class DefaultMap<K, V> extends Map<K, V> {
   constructor(
     private defaultFn: (key: K) => V,

--- a/test/core/test/utils.spec.ts
+++ b/test/core/test/utils.spec.ts
@@ -3,7 +3,7 @@ import { assertTypes, deepClone, deepMerge, isNegativeNaN, objectAttr, toArray }
 import { parseSingleFFOrSafariStack } from '@vitest/utils/source-map'
 import { EvaluatedModules } from 'vite/module-runner'
 import { beforeAll, describe, expect, test } from 'vitest'
-import { deepMergeSnapshot } from '../../../packages/snapshot/src/port/utils'
+import { deepMergeSnapshot, getSnapshotPropertiesSubset } from '../../../packages/snapshot/src/port/utils'
 import { resetModules } from '../../../packages/vitest/src/runtime/utils'
 
 describe('assertTypes', () => {
@@ -102,6 +102,66 @@ describe('deepMerge', () => {
       foo: 88,
       array: [{}, 'test'],
     })
+  })
+
+  test('getSnapshotPropertiesSubset removes unrelated keys recursively', () => {
+    const received = {
+      user: {
+        name: 'alice',
+        age: 30,
+        address: {
+          city: 'Paris',
+          zip: 75000,
+        },
+      },
+      extra: true,
+      list: [
+        { id: 1, label: 'first' },
+        { id: 2, label: 'second' },
+      ],
+    }
+
+    expect(getSnapshotPropertiesSubset(received, {
+      user: {
+        age: expect.any(Number),
+        address: {
+          zip: expect.any(Number),
+        },
+      },
+      list: [
+        { id: 1 },
+      ],
+    })).toEqual({
+      user: {
+        age: 30,
+        address: {
+          zip: 75000,
+        },
+      },
+      list: [
+        { id: 1 },
+      ],
+    })
+  })
+
+  test('getSnapshotPropertiesSubset preserves circular references', () => {
+    const received: { nested: { self?: unknown; value: number }; extra: string } = {
+      nested: {
+        value: 1,
+      },
+      extra: 'ignored',
+    }
+    received.nested.self = received.nested
+
+    const subset = getSnapshotPropertiesSubset(received, {
+      nested: {
+        self: {
+          value: expect.any(Number),
+        },
+      },
+    }) as { nested: { self: unknown } }
+
+    expect(subset.nested.self).toBe(subset.nested)
   })
 })
 

--- a/test/snapshots/test/properties.test.ts
+++ b/test/snapshots/test/properties.test.ts
@@ -96,7 +96,6 @@ test('toMatchSnapshot and toMatchInlineSnapshot with properties', async () => {
       {
     -   "age": Any<Number>,
     +   "age": "thirty",
-    +   "name": "alice",
       }
 
      ❯ basic.test.ts:4:44
@@ -117,7 +116,6 @@ test('toMatchSnapshot and toMatchInlineSnapshot with properties', async () => {
 
       {
     -   "score": toSatisfy<[Function lessThan100]>,
-    +   "name": "bob",
     +   "score": 999,
       }
 
@@ -162,7 +160,6 @@ test('toMatchSnapshot and toMatchInlineSnapshot with properties', async () => {
       {
     -   "age": Any<Number>,
     +   "age": "twenty-five",
-    +   "name": "carol",
       }
 
      ❯ basic.test.ts:21:49
@@ -211,7 +208,6 @@ test('toMatchSnapshot and toMatchInlineSnapshot with properties', async () => {
       {
     -   "age": Any<Number>,
     +   "age": "thirty",
-    +   "name": "alice",
       }
 
      ❯ basic.test.ts:4:44
@@ -232,7 +228,6 @@ test('toMatchSnapshot and toMatchInlineSnapshot with properties', async () => {
 
       {
     -   "score": toSatisfy<[Function lessThan100]>,
-    +   "name": "bob",
     +   "score": 999,
       }
 
@@ -255,7 +250,6 @@ test('toMatchSnapshot and toMatchInlineSnapshot with properties', async () => {
       {
     -   "age": Any<Number>,
     +   "age": "twenty-five",
-    +   "name": "carol",
       }
 
      ❯ basic.test.ts:21:49


### PR DESCRIPTION
This keeps snapshot property mismatch output aligned with the actual subset being compared, so unrelated fields are not surfaced in the diff.

Validation:
- `corepack pnpm --filter @vitest/snapshot run build`
- `corepack pnpm --filter vitest run build`
- `corepack pnpm exec vitest run test/utils.spec.ts -t "getSnapshotPropertiesSubset"` in `test/core`
- `corepack pnpm exec vitest run test/properties.test.ts` in `test/snapshots`
- `corepack pnpm exec eslint packages/snapshot/src/client.ts packages/snapshot/src/port/utils.ts test/core/test/utils.spec.ts test/snapshots/test/properties.test.ts`