### PR TITLE
feat: add `createReport` and `.vitest` report directory convention

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -687,3 +687,122 @@ Returns module's diagnostic. If [`testModule`](/api/advanced/test-module) is not
 ::: warning
 At the moment, the [browser](/guide/browser/) modules are not supported.
 :::
+
+## createReport <Version type="experimental">4.1.5</Version> {#createreport}
+
+```ts
+function createReport(scope: string): Report
+```
+
+Creates a report that is limited to the given scope. `Report` follows Vitest's rules around [Storing artifacts on file system](/guide/advanced/reporters.html#storing-artifacts-on-file-system).
+
+`Report` provides collection of utilities for writing test results, temporary files and other artifacts on the file system. It's especially intended for third party integrations like custom reporters.
+
+All operations of `Report` are limited to given `scope`. A single report cannot interfere with other reports. Internally Vitest creates `.vitest` directory where each `scope` creates their own directory. This convention of `.vitest` directory reduces the amount of entries end-users need to specify in their `.gitignore`.
+
+```ts
+import type { Report } from 'vitest/node'
+
+const scope = 'example-yaml-reporter'
+
+// Automatically creates `<project-root>/.vitest/example-yaml-reporter/`
+// directory if it does not exist already
+const report: Report = vitest.createReport(scope)
+```
+
+### Report.root
+
+```ts
+const root: string
+```
+
+The root directory for this scope.
+
+```ts
+const report = vitest.createReport('my-json-reporter')
+
+// Is <project-root>/.vitest/my-json-reporter
+const root = report.root
+```
+
+
+### Report.clean
+
+```ts
+function clean(): Promise<void>
+```
+
+Clean up the report directory for this scope.
+
+```ts
+const report = vitest.createReport('my-json-reporter')
+
+// Removes everything inside <project-root>/.vitest/my-json-reporter/
+await report.clean()
+```
+
+### Report.writeFile
+
+```ts
+function writeFile(
+  filename: string,
+  content: string | Uint8Array,
+  encoding?: BufferEncoding
+): Promise<void>
+```
+
+Write a file to the report directory for this scope. By default the file will be written with UTF-8 encoding. The filename is relative to the scope directory.
+
+```ts
+const report = vitest.createReport('my-json-reporter')
+
+// Writes file to .vitest/my-json-reporter/test-report.json
+await report.writeFile('test-report.json', JSON.stringify(results))
+```
+
+### Report.readFile
+
+```ts
+function readFile(filename: string, encoding?: BufferEncoding): Promise<string>
+```
+
+Read a file from the report directory for this scope.
+
+```ts
+const report = vitest.createReport('my-json-reporter')
+
+// Reads file from .vitest/my-json-reporter/test-report.json
+const content: string = await report.readFile('test-report.json')
+```
+
+### Report.readdir
+
+```ts
+function readdir(): Promise<string[]>
+```
+
+Read contents of the report directory for this scope.
+
+```ts
+const report = vitest.createReport('my-json-reporter')
+
+// Reads contents from .vitest/my-json-reporter
+const filenames: string[] = await report.readdir()
+```
+
+### Report.delete
+
+<!-- eslint-skip -->
+```ts
+function delete(filename: string): Promise<void>
+```
+
+Delete a file from the report directory for this scope.
+
+```ts
+const report = vitest.createReport('my-json-reporter')
+
+// Deletes file from .vitest/my-json-reporter/test-report.json
+await report.delete('test-report.json')
+```
+

--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -688,7 +688,7 @@ Returns module's diagnostic. If [`testModule`](/api/advanced/test-module) is not
 At the moment, the [browser](/guide/browser/) modules are not supported.
 :::
 
-## createReport <Version type="experimental">4.1.5</Version> {#createreport}
+## createReport <Version>5.0.0</Version> {#createreport}
 
 ```ts
 function createReport(scope: string): Report

--- a/docs/guide/advanced/reporters.md
+++ b/docs/guide/advanced/reporters.md
@@ -72,6 +72,33 @@ class MyReporter implements Reporter {
 }
 ```
 
+## Storing artifacts on file system
+
+::: tip
+Vitest provides [`vitest.createReport`](/api/advanced/vitest.html#createreport) that exposes collection of utilities for writing artifacts on file system conveniently.
+:::
+
+If your custom reporter needs to store any artifacts on file system it should place them inside `.vitest` directory. This directory is a convention that Vitest reporters and third party integrations can use to co-locate their results in a single directory. This way users of your custom reporter do not need to add multiple exclusion in their `.gitignore`. Only the `.vitest` is needed.
+
+Reporters and other integrations should respect following rules around `.vitest` directory:
+
+- `.vitest` directory is placed in [the `root` of the project](/config/root)
+- Reporter can create `.vitest` directory if it does not already exist
+- Reporter should never remove `.vitest` directory
+- Reporter should create their own directory inside `.vitest`, for example `.vitest/yaml-reporter/`
+- Reporter can remove their own specific directory inside `.vitest`, for example `.vitest/yaml-reporter/`
+
+```ansi
+.vitest
+│
+├── yaml-reporter
+│   ├── results.yaml
+│   └── summary.yaml
+│
+└── junit-reporter
+    └── report.xml
+```
+
 ## Exported Reporters
 
 `vitest` comes with a few [built-in reporters](/guide/reporters) that you can use out of the box.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -46,6 +46,13 @@ It is recommended that you install a copy of `vitest` in your `package.json`, us
 
 The `npx` tool will execute the specified command. By default, `npx` will first check if the command exists in the local project's binaries. If it is not found there, `npx` will look in the system's `$PATH` and execute it if found. If the command is not found in either location, `npx` will install it in a temporary location prior to execution.
 
+Vitest and third party integrations can use `.vitest` directory to store generated artifacts. It's recommended to add this in your `.gitignore`.
+
+``` sh [.gitignore]
+# Vitest reports and artifacts
+.vitest/
+```
+
 ## Writing Tests
 
 As an example, we will write a simple test that verifies the output of a function that adds two numbers.

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1670,7 +1670,6 @@ export class Vitest {
 
   /**
    * Create a report that's scoped to a specific reporter directory.
-   * @experimental
    */
   createReport(scope: string): Report {
     return createReport(this, scope)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -9,6 +9,7 @@ import type { SourceModuleDiagnostic, SourceModuleLocations } from '../types/mod
 import type { CliOptions } from './cli/cli-api'
 import type { VitestFetchFunction } from './environments/fetchModule'
 import type { ProcessPool } from './pool'
+import type { Report } from './reporters/report'
 import type { TestModule } from './reporters/reported-tasks'
 import type { TestSpecification } from './test-specification'
 import type { ResolvedConfig, TestProjectConfiguration, UserConfig, VitestRunMode } from './types/config'
@@ -46,6 +47,7 @@ import { TestProject } from './project'
 import { getDefaultTestProject, resolveBrowserProjects, resolveProjects } from './projects/resolveProjects'
 import { BlobReporter, readBlobs } from './reporters/blob'
 import { HangingProcessReporter } from './reporters/hanging-process'
+import { createReport } from './reporters/report'
 import { createBenchmarkReporters, createReporters } from './reporters/utils'
 import { VitestResolver } from './resolver'
 import { VitestSpecifications } from './specifications'
@@ -1664,6 +1666,14 @@ export class Vitest {
       const positivePattern = project.slice(1)
       return wildcardPatternToRegExp(positivePattern).test(name)
     })
+  }
+
+  /**
+   * Create a report that's scoped to a specific reporter directory.
+   * @experimental
+   */
+  createReport(scope: string): Report {
+    return createReport(this, scope)
   }
 }
 

--- a/packages/vitest/src/node/reporters/report.ts
+++ b/packages/vitest/src/node/reporters/report.ts
@@ -1,0 +1,133 @@
+import type { Vitest } from '../core'
+import * as fsSync from 'node:fs'
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+/** @experimental */
+export interface Report {
+  /**
+   * The root directory for this scope.
+   *
+   * ```ts
+   * const report = vitest.createReport('my-json-reporter');
+   *
+   * // Is <project-root>/.vitest/my-json-reporter
+   * const root = report.root
+   * ```
+   */
+  root: string
+
+  /**
+   * Clean up the report directory for this scope.
+   *
+   * By default, if `--merge-reports` is used, this method will not delete existing reports.
+   * To force deletion of existing reports, pass `true` as an argument.
+   *
+   * ```ts
+   * const report = vitest.createReport('my-json-reporter');
+   *
+   * // Removes everything inside <project-root>/.vitest/my-json-reporter/
+   * await report.clean()
+   * ```
+   */
+  clean: (force?: boolean) => Promise<void>
+
+  /**
+   * Write a file to the report directory for this scope.
+   * By default the file will be written with UTF-8 encoding.
+   * The filename is relative to the scope directory.
+   *
+   * ```ts
+   * const report = vitest.createReport('my-json-reporter');
+   *
+   * // Writes file to .vitest/my-json-reporter/test-report.json
+   * await report.writeFile('test-report.json', JSON.stringify(results))
+   * ```
+   */
+  writeFile: (filename: string, content: Parameters<typeof writeFile>[1], encoding?: BufferEncoding) => Promise<void>
+
+  /**
+   * Read a file from the report directory for this scope.
+   *
+   * ```ts
+   * const report = vitest.createReport('my-json-reporter');
+   *
+   * // Reads file from .vitest/my-json-reporter/test-report.json
+   * const content: string = await report.readFile('test-report.json')
+   * ```
+   */
+  readFile: (filename: string, encoding?: BufferEncoding) => Promise<string>
+
+  /**
+   * Read contents of the report directory for this scope.
+   *
+   * ```ts
+   * const report = vitest.createReport('my-json-reporter');
+   *
+   * // Reads contents from .vitest/my-json-reporter
+   * const filenames: string[] = await report.readdir()
+   * ```
+   */
+  readdir: () => Promise<string[]>
+
+  /**
+   * Delete a file from the report directory for this scope.
+   *
+   * ```ts
+   * const report = vitest.createReport('my-json-reporter');
+   *
+   * // Deletes file from .vitest/my-json-reporter/test-report.json
+   * await report.delete('test-report.json')
+   * ```
+   */
+  delete: (filename: string) => Promise<void>
+}
+
+export function createReport(ctx: Vitest, scope: string): Report {
+  const root = ctx.config.root
+  const vitestDir = resolve(root, '.vitest')
+  const reportDir = resolve(vitestDir, scope)
+
+  if (!fsSync.existsSync(vitestDir)) {
+    fsSync.mkdirSync(vitestDir)
+  }
+
+  if (!fsSync.existsSync(reportDir)) {
+    fsSync.mkdirSync(reportDir)
+  }
+
+  return {
+    root: reportDir,
+
+    async clean(force = false) {
+      if (fsSync.existsSync(reportDir)) {
+        // Do not delete results when run with --merge-reports, unless forced to.
+        // In test runs with --shard, it's possible that users do some other handling for
+        // the reports after 'vitest --merge-reports' run. For example upload all the '.vitest/attachments'.
+        if (ctx.config.mergeReports && !force) {
+          return
+        }
+
+        await rm(reportDir, { recursive: true, force: true })
+      }
+
+      await mkdir(reportDir)
+    },
+
+    async readFile(filename, encoding = 'utf8') {
+      return await readFile(resolve(vitestDir, scope, filename), encoding)
+    },
+
+    async readdir() {
+      return await readdir(resolve(vitestDir, scope))
+    },
+
+    async writeFile(filename, content, encoding = 'utf8') {
+      await writeFile(resolve(vitestDir, scope, filename), content, encoding)
+    },
+
+    async delete(filename) {
+      await rm(resolve(vitestDir, scope, filename), { recursive: true, force: true })
+    },
+  }
+}

--- a/packages/vitest/src/node/reporters/report.ts
+++ b/packages/vitest/src/node/reporters/report.ts
@@ -3,7 +3,6 @@ import * as fsSync from 'node:fs'
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
-/** @experimental */
 export interface Report {
   /**
    * The root directory for this scope.

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -72,9 +72,9 @@ export type {
 } from '../node/reporters'
 export type { HTMLOptions } from '../node/reporters/html'
 export type { JsonOptions } from '../node/reporters/json'
-
 export type { JUnitOptions } from '../node/reporters/junit'
 
+export type { Report } from '../node/reporters/report'
 export type {
   ModuleDiagnostic,
   TaskOptions,

--- a/test/cli/test/reporters/report.test.ts
+++ b/test/cli/test/reporters/report.test.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { normalize, resolve } from 'pathe'
+import { assert, expect, onTestFinished, test } from 'vitest'
+import { runVitest } from '../../../test-utils'
+
+test('creates .vitest when initialized', async () => {
+  const vitest = await run()
+  const directory = resolve(vitest.config.root, '.vitest')
+
+  rmSync(directory, { recursive: true, force: true })
+  vitest.createReport('example-reporter')
+
+  expect(existsSync(directory)).toBe(true)
+})
+
+test('sets root', async () => {
+  const vitest = await run()
+
+  const report = vitest.createReport('example-reporter')
+
+  expect(normalize(report.root)).toBe(
+    resolve(vitest.config.root, '.vitest', 'example-reporter'),
+  )
+})
+
+test('writeFile() creates file in scoped directory', async () => {
+  const vitest = await run()
+
+  const report = vitest.createReport('example-reporter')
+  await report.writeFile('example-report.txt', 'Example report here!')
+
+  expect(readFileSync(resolve(vitest.config.root, '.vitest', 'example-reporter', 'example-report.txt'), 'utf-8')).toBe('Example report here!')
+})
+
+test('readFile() reads a file in scoped directory', async () => {
+  const vitest = await run()
+
+  const report = vitest.createReport('example-reporter')
+  writeFileSync(resolve(vitest.config.root, '.vitest', 'example-reporter', 'example-report.txt'), 'Example report here!')
+
+  await expect(report.readFile('example-report.txt')).resolves.toBe('Example report here!')
+})
+
+test('readdir() reads contents of scoped directory', async () => {
+  const vitest = await run()
+
+  const report = vitest.createReport('example-reporter')
+  const scopedDir = resolve(vitest.config.root, '.vitest', 'example-reporter')
+  mkdirSync(scopedDir, { recursive: true })
+  writeFileSync(resolve(scopedDir, 'report-1'), 'anything')
+  writeFileSync(resolve(scopedDir, 'report-2'), 'anything')
+
+  await expect(report.readdir()).resolves.toMatchInlineSnapshot(`
+    [
+      "report-1",
+      "report-2",
+    ]
+  `)
+})
+
+test('delete() removes file in scoped directory', async () => {
+  const vitest = await run()
+
+  const report = vitest.createReport('example-reporter')
+  const scopedDir = resolve(vitest.config.root, '.vitest', 'example-reporter')
+  mkdirSync(scopedDir, { recursive: true })
+  writeFileSync(resolve(scopedDir, 'report-1'), 'anything')
+  writeFileSync(resolve(scopedDir, 'report-2'), 'anything')
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`
+    [
+      "report-1",
+      "report-2",
+    ]
+  `)
+
+  await report.delete('report-1')
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`
+    [
+      "report-2",
+    ]
+  `)
+})
+
+test('clean() clears only the scoped directory', async () => {
+  const vitest = await run()
+
+  // This directory should not be affected by scoped report writer
+  const unrelatedDir = resolve(vitest.config.root, '.vitest', 'unrelated-reporter')
+  mkdirSync(unrelatedDir, { recursive: true })
+  writeFileSync(resolve(unrelatedDir, 'report-1'), 'anything')
+
+  const report = vitest.createReport('example-reporter')
+  const scopedDir = resolve(vitest.config.root, '.vitest', 'example-reporter')
+  mkdirSync(scopedDir, { recursive: true })
+  writeFileSync(resolve(scopedDir, 'report-2'), 'anything')
+  writeFileSync(resolve(scopedDir, 'report-3'), 'anything')
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`
+    [
+      "report-2",
+      "report-3",
+    ]
+  `)
+  expect(readdirSync(unrelatedDir)).toMatchInlineSnapshot(`
+    [
+      "report-1",
+    ]
+  `)
+
+  await report.clean()
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`[]`)
+  expect(readdirSync(unrelatedDir)).toMatchInlineSnapshot(`
+    [
+      "report-1",
+    ]
+  `)
+})
+
+test('clean() does not clear results when --merge-reports is used, unless forced to', async () => {
+  const vitest = await run({ mergeReports: '.vitest/blob', watch: false, standalone: false })
+
+  const report = vitest.createReport('example-reporter')
+  const scopedDir = resolve(vitest.config.root, '.vitest', 'example-reporter')
+  mkdirSync(scopedDir, { recursive: true })
+  writeFileSync(resolve(scopedDir, 'report-1'), 'anything')
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`
+    [
+      "report-1",
+    ]
+  `)
+
+  await report.clean()
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`
+    [
+      "report-1",
+    ]
+  `)
+
+  await report.clean(true)
+
+  expect(readdirSync(scopedDir)).toMatchInlineSnapshot(`[]`)
+})
+
+async function run(options?: Partial<Parameters<typeof runVitest>[0]>) {
+  const vitest = await runVitest({
+    root: './fixtures/basic',
+    standalone: true,
+    watch: true,
+    ...options,
+  })
+
+  assert(vitest.ctx)
+  const root = vitest.ctx.config.root
+
+  onTestFinished(() => {
+    rmSync(resolve(root, '.vitest'), { recursive: true, force: true })
+  })
+
+  return vitest.ctx
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vitest/issues/9952

Once merged, I'll create follow-up issue for using `.vitest` in Vitest's built-in reporters (at least html?) and for other artifacts. Changing default values will be breaking change.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
