### PR TITLE
fix(coverage-v8): silence uncovered parse failures

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -28,6 +28,12 @@ const FILE_PROTOCOL = 'file://'
 
 const debug = createDebug('vitest:coverage')
 
+export const providerInternals = {
+  parseCoverageAst(code: string): ReturnType<typeof parseAstAsync> {
+    return parseAstAsync(code)
+  },
+}
+
 export class V8CoverageProvider extends BaseCoverageProvider implements CoverageProvider {
   name = 'v8' as const
   version: string = version
@@ -200,10 +206,12 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
     let ast
 
     try {
-      ast = await parseAstAsync(result.code)
+      ast = await providerInternals.parseCoverageAst(result.code)
     }
     catch (error) {
-      this.ctx.logger.error(`Failed to parse ${filename}. Excluding it from coverage.\n`, error)
+      if (debug.enabled) {
+        debug('Failed to parse %s. Excluding it from coverage. %O', filename, error)
+      }
       return {}
     }
 

--- a/test/coverage-test/test/parse-failures.unit.test.ts
+++ b/test/coverage-test/test/parse-failures.unit.test.ts
@@ -1,0 +1,29 @@
+import { configDefaults } from 'vitest/config'
+import { afterEach, expect, test, vi } from 'vitest'
+import { providerInternals, V8CoverageProvider } from '../../../packages/coverage-v8/src/provider.ts'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('v8 provider excludes parse failures without logging an error', async () => {
+  const parseCoverageAst = vi.spyOn(providerInternals, 'parseCoverageAst').mockRejectedValue(new Error('Parse failed with 1 error'))
+  const provider = new V8CoverageProvider() as any
+  const error = vi.fn()
+
+  provider.ctx = {
+    logger: { error },
+  }
+  provider.options = configDefaults.coverage
+
+  const result = await provider.remapCoverage(
+    'file:///fixtures/src/example.ts',
+    0,
+    { code: 'export const value = (name: string) => name' },
+    [],
+  )
+
+  expect(result).toEqual({})
+  expect(parseCoverageAst).toHaveBeenCalledWith('export const value = (name: string) => name')
+  expect(error).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- stop writing caught uncovered-file parse failures to stderr in `@vitest/coverage-v8`
- route the parse call through a small internal helper so the catch path can be regression-tested directly
- add a unit regression for the parse-failure exclusion path and keep the nearby virtual-files coverage test green

Fixes #9972

## Testing
- `corepack pnpm --dir packages/coverage-v8 run build`
- `corepack pnpm --dir test/coverage-test exec vitest run test/parse-failures.unit.test.ts test/mixed-versions-warning.unit.test.ts --project unit`
- `corepack pnpm --dir test/coverage-test exec vitest run test/virtual-files.test.ts --project v8`