### PR TITLE
fix: silence v8 uncovered parse failures

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -203,7 +203,11 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
       ast = await parseAstAsync(result.code)
     }
     catch (error) {
-      this.ctx.logger.error(`Failed to parse ${filename}. Excluding it from coverage.\n`, error)
+      debug(
+        'Failed to parse %s. Excluding it from coverage. %s',
+        filename,
+        error instanceof Error ? error.message : String(error),
+      )
       return {}
     }
 

--- a/test/coverage-test/test/parse-failures.unit.test.ts
+++ b/test/coverage-test/test/parse-failures.unit.test.ts
@@ -1,0 +1,35 @@
+import V8Provider from '@vitest/coverage-v8'
+import packageJson from '@vitest/coverage-v8/package.json'
+import { expect, test, vi } from 'vitest'
+import { configDefaults } from 'vitest/config'
+
+test('v8 provider silently excludes parse failures from uncovered file coverage', async () => {
+  const provider = await V8Provider.getProvider()
+  const error = vi.fn()
+
+  provider.initialize({
+    version: packageJson.version,
+    logger: { error, log: vi.fn(), warn: vi.fn() },
+    config: { ...configDefaults, root: process.cwd() },
+    _coverageOptions: configDefaults.coverage,
+    projects: [],
+  } as any)
+
+  const remappedCoverage = await (provider as any).remapCoverage(
+    'file:///virtual-uncovered.ts',
+    0,
+    {
+      code: `
+        import { something } from 'virtual:some-plugin'
+        export const loadRemote = async (name: string): Promise<unknown> => {
+          const module = await something(name)
+          return module
+        }
+      `,
+    },
+    [],
+  )
+
+  expect(remappedCoverage).toEqual({})
+  expect(error).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
### Description

Resolves #9972.

This keeps @vitest/coverage-v8 excluding uncovered files that rolldown cannot parse, but stops reporting those parse failures through logger.error, which was sending noisy stack traces to stderr.

### Tests

- corepack pnpm exec vitest run test/parse-failures.unit.test.ts --project unit
- corepack pnpm exec vitest run test/virtual-files.test.ts -t 'virtual files should be excluded' --project v8