### PR TITLE
fix: keep negated browser project filters grouped

### DIFF
--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -10,11 +10,12 @@ import type {
 import { existsSync, readdirSync, statSync } from 'node:fs'
 import os from 'node:os'
 import { limitConcurrency } from '@vitest/runner/utils'
-import { deepClone } from '@vitest/utils/helpers'
+import { deepClone, toArray } from '@vitest/utils/helpers'
 import { basename, dirname, relative, resolve } from 'pathe'
 import { glob, isDynamicPattern } from 'tinyglobby'
 import { mergeConfig } from 'vite'
 import { configFiles as defaultConfigFiles } from '../../constants'
+import { wildcardPatternToRegExp } from '../../utils/base'
 import { VitestFilteredOutProjectError } from '../errors'
 import { initializeProject, TestProject } from '../project'
 
@@ -217,11 +218,15 @@ export async function resolveBrowserProjects(
       return
     }
     const originalName = project.config.name
+    const projectWasExplicitlyExcluded = matchesNegatedProjectFilter(vitest, originalName)
     // if original name is in the --project=name filter, keep all instances
     const filteredInstances = vitest.matchesProjectFilter(originalName)
       ? instances
       : instances.filter((instance) => {
           const newName = instance.name! // name is set in "workspace" plugin
+          if (projectWasExplicitlyExcluded) {
+            return matchesPositiveProjectFilter(vitest, newName)
+          }
           return vitest.matchesProjectFilter(newName)
         })
 
@@ -267,6 +272,26 @@ export async function resolveBrowserProjects(
   })
 
   return resolvedProjects.filter(project => !removeProjects.has(project))
+}
+
+function matchesPositiveProjectFilter(vitest: Vitest, name: string): boolean {
+  const projects = toArray(vitest.config.project)
+  return projects.some((project) => {
+    if (project.startsWith('!')) {
+      return false
+    }
+    return wildcardPatternToRegExp(project).test(name)
+  })
+}
+
+function matchesNegatedProjectFilter(vitest: Vitest, name: string): boolean {
+  const projects = toArray(vitest.config.project)
+  return projects.some((project) => {
+    if (!project.startsWith('!')) {
+      return false
+    }
+    return wildcardPatternToRegExp(project.slice(1)).test(name)
+  })
 }
 
 function cloneConfig(project: TestProject, { browser, ...config }: BrowserInstanceOption) {

--- a/test/cli/test/config/browser-configs.test.ts
+++ b/test/cli/test/config/browser-configs.test.ts
@@ -349,6 +349,36 @@ test('filter for the global browser project includes all browser instances', asy
   ])
 })
 
+test('negated filter for the global browser project excludes all browser instances', async () => {
+  const { projects } = await vitest({ project: '!myproject' }, {
+    projects: [
+      {
+        test: {
+          name: 'myproject',
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+              { browser: 'webkit' },
+            ],
+          },
+        },
+      },
+      {
+        test: {
+          name: 'skip',
+        },
+      },
+    ],
+  })
+  expect(projects.map(p => p.name)).toEqual([
+    'skip',
+  ])
+})
+
 test('can enable browser-cli options for multi-project workspace', async () => {
   const { projects } = await vitest(
     {


### PR DESCRIPTION
Fixes #9977.

## Summary
- keep explicitly negated browser project groups from re-admitting their expanded browser instances
- still allow expanded browser instance names back in when they are matched by a positive project filter
- add a regression test for `--project !myproject` with browser configs

## Testing
- corepack pnpm --filter @vitest/test-cli exec vitest run test/projects.test.ts -t "project filtering"
- corepack pnpm --filter @vitest/test-cli exec vitest run test/config/browser-configs.test.ts -t "filters projects|filters projects with a wildcard|filter for the global browser project includes all browser instances|negated filter for the global browser project excludes all browser instances"