### PR TITLE
fix: respect negated browser project filters

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -1012,8 +1012,9 @@ function hasBrowserChromium(vitest: Vitest, config: ResolvedConfig) {
   }
   return browser.instances.some((instance) => {
     const name = instance.name || (config.name ? `${config.name} (${instance.browser})` : instance.browser)
+    const names = config.name ? [name, config.name] : [name]
     // browser config is filtered out
-    if (!vitest.matchesProjectFilter(name)) {
+    if (!vitest.matchesProjectFilters(names)) {
       return false
     }
     return isChromiumName(browser.provider!.name, instance.browser)
@@ -1033,8 +1034,9 @@ function hasOnlyBrowserChromium(vitest: Vitest, config: ResolvedConfig) {
   }
   return browser.instances.every((instance) => {
     const name = instance.name || (config.name ? `${config.name} (${instance.browser})` : instance.browser)
+    const names = config.name ? [name, config.name] : [name]
     // browser config is filtered out
-    if (!vitest.matchesProjectFilter(name)) {
+    if (!vitest.matchesProjectFilters(names)) {
       return true // ignore this project
     }
     return isChromiumName(browser.provider!.name, instance.browser)

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1582,6 +1582,14 @@ export class Vitest {
    * Check if the project with a given name should be included.
    */
   matchesProjectFilter(name: string): boolean {
+    return this.matchesProjectFilters([name])
+  }
+
+  /**
+   * Check if the project group with the given names should be included.
+   * This is used for browser projects where the root project name also acts as an alias for nested instances.
+   */
+  matchesProjectFilters(names: string[]): boolean {
     const projects = this._config?.project || this._cliOptions?.project
     // no filters applied, any project can be included
     if (!projects || !projects.length) {
@@ -1589,7 +1597,9 @@ export class Vitest {
     }
     return toArray(projects).some((project) => {
       const regexp = wildcardPatternToRegExp(project)
-      return regexp.test(name)
+      return project[0] === '!'
+        ? names.every(name => regexp.test(name))
+        : names.some(name => regexp.test(name))
     })
   }
 }

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -85,9 +85,7 @@ export function WorkspaceVitestPlugin(
         // if projects don't match, we ignore the test project altogether
         // if some of them match, they will later be filtered again by `resolveWorkspace`
         if (filters.length) {
-          const hasProject = workspaceNames.some((name) => {
-            return project.vitest.matchesProjectFilter(name)
-          })
+          const hasProject = project.vitest.matchesProjectFilters(workspaceNames)
           if (!hasProject) {
             throw new VitestFilteredOutProjectError()
           }

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -222,7 +222,9 @@ export async function resolveBrowserProjects(
       ? instances
       : instances.filter((instance) => {
           const newName = instance.name! // name is set in "workspace" plugin
-          return vitest.matchesProjectFilter(newName)
+          return vitest.matchesProjectFilters(
+            originalName ? [newName, originalName] : [newName],
+          )
         })
 
     // every project was filtered out
@@ -467,9 +469,7 @@ export function getDefaultTestProject(vitest: Vitest): TestProject | null {
     return project
   }
   // check for the project name and browser names
-  const hasProjects = getPotentialProjectNames(project).some(p =>
-    vitest.matchesProjectFilter(p),
-  )
+  const hasProjects = vitest.matchesProjectFilters(getPotentialProjectNames(project))
   if (hasProjects) {
     return project
   }

--- a/test/cli/test/config/browser-configs.test.ts
+++ b/test/cli/test/config/browser-configs.test.ts
@@ -349,6 +349,35 @@ test('filter for the global browser project includes all browser instances', asy
   ])
 })
 
+test('negated filter for the global browser project excludes all browser instances', async () => {
+  const { projects } = await vitest({ project: '!browser' }, {
+    projects: [
+      {
+        test: {
+          name: 'browser',
+          browser: {
+            enabled: true,
+            provider: preview(),
+            headless: true,
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+            ],
+          },
+        },
+      },
+      {
+        test: {
+          name: 'node',
+        },
+      },
+    ],
+  })
+  expect(projects.map(p => p.name)).toEqual([
+    'node',
+  ])
+})
+
 test('can enable browser-cli options for multi-project workspace', async () => {
   const { projects } = await vitest(
     {


### PR DESCRIPTION
## Summary
- make browser project filtering treat the root project name as an alias for its generated browser instance names
- apply the grouped filter check during workspace resolution, browser-project expansion, and browser coverage config checks
- add a regression test covering `--project=!browser` for a workspace with browser instances

Closes #9977.

## Testing
- `corepack pnpm vitest run test/config/browser-configs.test.ts -t "filter for the global browser project|negated filter for the global browser project"`
- `corepack pnpm vitest run test/projects.test.ts -t "project filtering"`