### PR TITLE
feat(reporter): include config name in GitHub Actions summary header

### DIFF
--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -177,7 +177,7 @@ export class GithubActionsReporter implements Reporter {
     }
 
     if (this.options.jobSummary.enabled === true && this.options.jobSummary.outputPath) {
-      const summary = renderSummary(collectSummaryData(testModules), this.options.jobSummary.fileLinks)
+      const summary = renderSummary(collectSummaryData(testModules), this.options.jobSummary.fileLinks, this.ctx.config.name)
 
       try {
         writeFileSync(
@@ -438,12 +438,13 @@ function renderStats({ fileStats, testsStats }: SummaryData): string {
   return output
 }
 
-const SUMMARY_HEADER = '## Vitest Test Report\n'
+const SUMMARY_HEADER = '## Vitest Test Report'
 
-function renderSummary(summaryData: SummaryData, fileLinks?: JobSummaryOptions['fileLinks']): string {
+function renderSummary(summaryData: SummaryData, fileLinks?: JobSummaryOptions['fileLinks'], configName?: string): string {
   const fileLinkCreator = createGitHubFileLinkCreator(fileLinks)
 
-  let summary = `${SUMMARY_HEADER}${renderStats(summaryData)}`
+  const header = configName ? `${SUMMARY_HEADER} (${configName})\n` : `${SUMMARY_HEADER}\n`
+  let summary = `${header}${renderStats(summaryData)}`
 
   if (summaryData.flakyTests.length > 0) {
     summary += '\n### Flaky Tests\n\nThese tests passed only after one or more retries, indicating potential instability.\n'

--- a/test/cli/test/reporters/github-actions.test.ts
+++ b/test/cli/test/reporters/github-actions.test.ts
@@ -207,5 +207,32 @@ describe(GithubActionsReporter, () => {
         "
       `)
     })
+    it('includes config name in header when set', async ({ onTestFinished }) => {
+      const outputPath = resolve(tmpdir(), randomUUID())
+
+      onTestFinished(async () => {
+        await rm(outputPath).catch(() => {
+          console.error(`Could not remove ${outputPath}`)
+        })
+      })
+
+      await runVitest({
+        name: 'my-app',
+        reporters: new GithubActionsReporter({
+          jobSummary: {
+            outputPath,
+            fileLinks: {
+              commitHash: 'aaa',
+              repository: 'owner/repo',
+            },
+          },
+        }),
+        root: './fixtures/reporters/github-actions',
+      })
+
+      const summary = await readFile(outputPath, 'utf8')
+
+      expect(summary).toContain('## Vitest Test Report (my-app)')
+    })
   })
 })


### PR DESCRIPTION
### Description

When `name` is set in the vitest config, append it to the job summary header so monorepo setups with multiple test suites can be distinguished at a glance.

Before:
```
## Vitest Test Report
```

After (when `name: 'my-app'` is set in config):
```
## Vitest Test Report (my-app)
```

Resolves #9992

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.

### Tests
- [x] Added a test in `test/cli/test/reporters/github-actions.test.ts` that verifies the config name appears in the summary header.

### Documentation
No new API surface — `name` is an existing config field.