### PR TITLE
fix(browser): replace duplicate manual mock routes

### DIFF
--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -293,10 +293,13 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
         return true
       }
+      const key = predicateKey(sessionId, moduleUrl.href)
       const ids = sessionIds.get(sessionId) || []
-      ids.push(moduleUrl.href)
-      sessionIds.set(sessionId, ids)
-      idPredicates.set(predicateKey(sessionId, moduleUrl.href), predicate)
+      if (!ids.includes(moduleUrl.href)) {
+        ids.push(moduleUrl.href)
+        sessionIds.set(sessionId, ids)
+      }
+      idPredicates.set(key, predicate)
       return predicate
     }
 
@@ -307,6 +310,11 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     return {
       register: async (sessionId: string, module: MockedModule): Promise<void> => {
         const page = this.getPage(sessionId)
+        const key = predicateKey(sessionId, new URL(module.url, 'http://localhost').href)
+        const existingPredicate = idPredicates.get(key)
+        if (existingPredicate) {
+          await page.context().unroute(existingPredicate)
+        }
         await page.context().route(createPredicate(sessionId, module.url), async (route) => {
           if (module.type === 'manual') {
             const exports = Object.keys(await module.resolve())

--- a/test/browser/fixtures/mocking/src/manual-repro/aaa-probe.spec.ts
+++ b/test/browser/fixtures/mocking/src/manual-repro/aaa-probe.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/manual-repro/modal', () => ({
+  useModalStore() {},
+}))
+
+vi.mock('./modal', () => ({
+  useModalStore() {},
+}))
+
+import { probe } from './probe'
+
+describe('manual repro probe', () => {
+  it('passes with duplicate manual mocks for the same module', async () => {
+    expect(probe).toBe(true)
+  })
+})

--- a/test/browser/fixtures/mocking/src/manual-repro/modal.ts
+++ b/test/browser/fixtures/mocking/src/manual-repro/modal.ts
@@ -1,0 +1,1 @@
+export function useModalStore() {}

--- a/test/browser/fixtures/mocking/src/manual-repro/probe.ts
+++ b/test/browser/fixtures/mocking/src/manual-repro/probe.ts
@@ -1,0 +1,5 @@
+import { useModalStore } from '~/manual-repro/modal'
+
+useModalStore()
+
+export const probe = true

--- a/test/browser/fixtures/mocking/src/manual-repro/target.ts
+++ b/test/browser/fixtures/mocking/src/manual-repro/target.ts
@@ -1,0 +1,5 @@
+import { useModalStore } from '~/manual-repro/modal'
+
+useModalStore()
+
+export const target = true

--- a/test/browser/fixtures/mocking/src/manual-repro/zzz-target.spec.ts
+++ b/test/browser/fixtures/mocking/src/manual-repro/zzz-target.spec.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { target } from './target'
+
+describe('manual repro target', () => {
+  it('passes without registering a mock', async () => {
+    expect(target).toBe(true)
+  })
+})

--- a/test/browser/fixtures/mocking/vitest.config.ts
+++ b/test/browser/fixtures/mocking/vitest.config.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url'
+import type { TestSpecification } from 'vitest/node'
 import { defineConfig } from 'vitest/config'
 import { instances, provider } from '../../settings'
 
@@ -8,12 +9,28 @@ export default defineConfig({
     needsInterop: ['@vitest/cjs-lib'],
   },
   cacheDir: fileURLToPath(new URL("./node_modules/.vite", import.meta.url)),
+  resolve: {
+    alias: {
+      '~/': new URL('./src/', import.meta.url).pathname,
+    },
+  },
   test: {
     browser: {
       enabled: true,
       provider,
       instances,
       headless: true,
+    },
+    sequence: {
+      sequencer: class {
+        sort(specifications: TestSpecification[]) {
+          return specifications.sort((left, right) => left.moduleId.localeCompare(right.moduleId))
+        }
+
+        shard(specifications: TestSpecification[]) {
+          return specifications
+        }
+      },
     },
   },
 })

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -78,3 +78,23 @@ test('mocking out of root', async () => {
     expect(vitest.stdout).toReportPassedTest('basic.test.js', browser)
   })
 })
+
+test('manual mocks do not leak across browser files when alias and relative ids target the same module', async () => {
+  const result = await runVitest({
+    root: 'fixtures/mocking',
+  }, ['src/manual-repro/aaa-probe.spec.ts', 'src/manual-repro/zzz-target.spec.ts'])
+
+  onTestFailed(() => {
+    console.error(result.stdout)
+    console.error(result.stderr)
+  })
+
+  expect(result.stderr).toReportNoErrors()
+
+  instances.forEach(({ browser }) => {
+    expect(result.stdout).toReportPassedTest('src/manual-repro/aaa-probe.spec.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/manual-repro/zzz-target.spec.ts', browser)
+  })
+
+  expect(result.exitCode).toBe(0)
+}, 60_000)


### PR DESCRIPTION
## Summary
- replace an existing Playwright browser mock route when the same session registers another manual mock for the same resolved URL
- keep only one tracked route id per sessionId + url, so clearing mocks removes the active route instead of leaving the first predicate behind
- add a browser regression fixture/spec covering the ~/modal plus ./modal duplicate-manual-mock case from the public repro

Closes #9957

## Testing
- corepack pnpm build
- PROVIDER=playwright BROWSER=chromium corepack pnpm --dir test/browser exec vitest run --config vitest.config.unit.mts specs/mocking.test.ts -t 'manual mocks do not leak across browser files when alias and relative ids target the same module'
- git diff --check