### PR TITLE
fix(snapshot): show focused diff for toMatchProperties mismatches

### DIFF
--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -155,10 +155,21 @@ export class SnapshotClient {
       }
       if (!propertiesPass) {
         expectedSnapshot.markAsChecked()
+        // Filter actual to only include keys present in properties,
+        // so the diff focuses on mismatched values rather than showing
+        // unrelated keys as additions.
+        const filteredActual: Record<string, unknown> = {}
+        if (typeof received === 'object' && received !== null) {
+          for (const key of Object.keys(properties as object)) {
+            if (key in (received as Record<string, unknown>)) {
+              filteredActual[key] = (received as Record<string, unknown>)[key]
+            }
+          }
+        }
         return {
           pass: false,
           message: () => errorMessage || 'Snapshot properties mismatched',
-          actual: received,
+          actual: filteredActual,
           expected: properties,
         }
       }


### PR DESCRIPTION
Fixes #9985

When `toMatchSnapshot(properties)` fails due to a property mismatch, the diff previously showed the full received object with all its keys as additions, making it hard to identify the actual mismatched values.

For example, with `expect({ x: 'world', y: 10 }).toMatchSnapshot({ y: 5 })`, the diff showed:
```
{
-  "y": 5,
+  "x": "world",
+  "y": 10,
}
```

This made `x` look like an error when it's actually irrelevant to the properties check.

**Fix:** Filter the `actual` value to only include keys present in the expected `properties` object before returning the error. The diff now focuses on the values that actually differ:
```
{
-  "y": 5,
+  "y": 10,
}
```