### PR TITLE
feat: add @vitest/coverage-v8 and @vitest/coverage-istanbul as optional peer dependencies

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -139,6 +139,8 @@
     "@vitest/browser-playwright": "workspace:*",
     "@vitest/browser-preview": "workspace:*",
     "@vitest/browser-webdriverio": "workspace:*",
+    "@vitest/coverage-istanbul": "workspace:*",
+    "@vitest/coverage-v8": "workspace:*",
     "@vitest/ui": "workspace:*",
     "happy-dom": "*",
     "jsdom": "*",
@@ -161,6 +163,12 @@
       "optional": true
     },
     "@vitest/browser-webdriverio": {
+      "optional": true
+    },
+    "@vitest/coverage-istanbul": {
+      "optional": true
+    },
+    "@vitest/coverage-v8": {
       "optional": true
     },
     "@vitest/ui": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,6 +1017,12 @@ importers:
       '@vitest/browser-webdriverio':
         specifier: workspace:*
         version: link:../browser-webdriverio
+      '@vitest/coverage-istanbul':
+        specifier: workspace:*
+        version: link:../coverage-istanbul
+      '@vitest/coverage-v8':
+        specifier: workspace:*
+        version: link:../coverage-v8
       '@vitest/expect':
         specifier: workspace:*
         version: link:../expect


### PR DESCRIPTION
Fixes #10015

## Problem

In pnpm's strict isolation mode (default in pnpm 10), packages can only resolve modules listed in their own dependency tree. Since `@vitest/coverage-v8` and `@vitest/coverage-istanbul` are not declared as peer dependencies of `vitest`, pnpm doesn't link them — even when the consuming project has them installed — causing a runtime `Cannot find package '@vitest/coverage-v8'` error when `coverage.provider` is configured.

This works in npm/yarn due to hoisting, but breaks under strict isolation.

## Fix

Add both coverage providers as optional peer dependencies, following the same pattern already used for `@vitest/browser-*` and `@vitest/ui`.

```json
"@vitest/coverage-v8": "workspace:*",
"@vitest/coverage-istanbul": "workspace:*",
```

With optional in `peerDependenciesMeta`:

```json
"@vitest/coverage-v8": { "optional": true },
"@vitest/coverage-istanbul": { "optional": true },
```

Users no longer need the `packageExtensions` workaround in `pnpm-workspace.yaml`.