### PR TITLE
docs: fix dependent example spelling

### DIFF
--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -293,15 +293,15 @@ import { test as baseTest, describe, expect } from 'vitest'
 
 const test = baseTest
   .extend('dependency', 'default')
-  .extend('dependant', ({ dependency }) => dependency)
+  .extend('dependent', ({ dependency }) => dependency)
 
 describe('use scoped values', () => {
   test.override({ dependency: 'new' })
 
-  test('uses scoped value', ({ dependant }) => {
-    // `dependant` uses the new overridden value that is scoped
+  test('uses scoped value', ({ dependent }) => {
+    // `dependent` uses the new overridden value that is scoped
     // to all tests in this suite
-    expect(dependant).toEqual({ dependency: 'new' })
+    expect(dependent).toEqual({ dependency: 'new' })
   })
 })
 ```


### PR DESCRIPTION
## Summary

Fix the spelling of `dependent` in the `test.extend` documentation example.

## Related issue

N/A. This is a trivial docs-only fix.

## Guideline alignment

- Followed the repository contributing guide: https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md
- The change is limited to one documentation example and does not affect behavior.

## Validation/testing

Not run. This is a docs-only change.

## AI assistance disclosure

Codex assisted with identifying and correcting this typo; the change was reviewed before submission.
