### PR TITLE
feat(coverage): default to text reporter `skipFull` if agent detected

### DIFF
--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -133,6 +133,10 @@ You can also pass custom coverage reporters. See [Guide - Custom Coverage Report
 
 You can check your coverage report in Vitest UI: check [Vitest UI Coverage](/guide/coverage#vitest-ui) for more details.
 
+::: tip AI coding agents
+When Vitest detects it is running inside an AI coding agent, it automatically adds the `text-summary` reporter and sets `skipFull: true` on the `text` reporter to reduce output and minimize token usage.
+:::
+
 ## coverage.reportOnFailure {#coverage-reportonfailure}
 
 - **Type:** `boolean`

--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -508,3 +508,12 @@ This is integrated with builtin coverage reporters with HTML output (`html`, `ht
 
 <img alt="html coverage in Vitest UI" img-light src="/ui-coverage-1-light.png">
 <img alt="html coverage in Vitest UI" img-dark src="/ui-coverage-1-dark.png">
+
+## Coverage in Agent Environments
+
+When Vitest detects it is running inside an AI coding agent, it automatically adjusts the default `text` reporter to reduce output and minimize token usage:
+
+- `skipFull: true` is set on the `text` reporter, so files with 100% coverage are omitted from the terminal output.
+- The [`text-summary`](/config/coverage#coverage-reporter) reporter is added automatically, so the agent always sees a concise totals table even when `skipFull` hides all individual files.
+
+These adjustments only apply when the `text` reporter is already part of the active reporter list (it is included in the default). Explicitly configured reporters are never removed.

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -428,6 +428,11 @@ export function resolveConfig(
   }
 
   resolved.coverage.reporter = resolveCoverageReporters(resolved.coverage.reporter)
+  for (const reporter of resolved.coverage.reporter) {
+    if (isAgent && reporter[0] === 'text') {
+      reporter[1] = { skipFull: true, ...reporter[1] }
+    }
+  }
   if (resolved.coverage.changed === undefined && resolved.changed !== undefined) {
     resolved.coverage.changed = resolved.changed
   }

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -428,9 +428,15 @@ export function resolveConfig(
   }
 
   resolved.coverage.reporter = resolveCoverageReporters(resolved.coverage.reporter)
-  for (const reporter of resolved.coverage.reporter) {
-    if (isAgent && reporter[0] === 'text') {
-      reporter[1] = { skipFull: true, ...reporter[1] }
+  if (isAgent) {
+    // default to `skipFull` and add `text-summary` reporter when `text` reporter is used on agents
+    const text = resolved.coverage.reporter.find(([name]) => name === 'text')
+    const textSummary = resolved.coverage.reporter.find(([name]) => name === 'text-summary')
+    if (text) {
+      (text as any)[1] = { skipFull: true, ...text[1] as any }
+      if (!textSummary) {
+        resolved.coverage.reporter.push(['text-summary', {}])
+      }
     }
   }
   if (resolved.coverage.changed === undefined && resolved.changed !== undefined) {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- (slightly) related https://github.com/vitest-dev/vitest/issues/8411

I was prototyping a new [`text-agent` coverage reporter](https://github.com/hi-ogawa/vitest/commit/9a29d7edf120ce24e0c70bf5b82f818af0d0243a), which skips 100% coverage just like test `agent` reporter (https://github.com/vitest-dev/vitest/pull/9779) skips passing tests. But then I noticed `text` coverage reporter already supports `skipFull` which does mostly same.

This PR auto enables `skipFull ` when the agent is detected. 
(EDIT: and also auto configure `text-summary`, so it has aggregated stats to avoid ended up with empty output.)

- without agent

```
~/code/others/vitest $ pnpm -C examples/fastify test --coverage 
...
 DEV  v4.1.2 /home/hiroshi/code/others/vitest/examples/fastify
      Coverage enabled with v8

 ✓ test/app.test.ts (3 tests) 55ms
   ✓ with HTTP injection 15ms
   ✓ with a running server 13ms
   ✓ with axios 25ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  19:18:31
   Duration  465ms (transform 39ms, setup 0ms, import 294ms, tests 55ms, environment 0ms)

 % Coverage report from v8
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |     100 |      100 |     100 |     100 |                   
 fastify      |     100 |      100 |     100 |     100 |                   
  mockData.ts |     100 |      100 |     100 |     100 |                   
 fastify/src  |     100 |      100 |     100 |     100 |                   
  app.ts      |     100 |      100 |     100 |     100 |                   
--------------|---------|----------|---------|---------|-------------------
 PASS  Waiting for file changes...
       press h to show help, press q to quit
```

- with agent 

```
~/code/others/vitest $ AI_AGENT=true pnpm -C examples/fastify test --coverage 
...
 RUN  v4.1.2 /home/hiroshi/code/others/vitest/examples/fastify
      Coverage enabled with v8


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  19:18:37
   Duration  295ms (transform 35ms, setup 0ms, import 129ms, tests 49ms, environment 0ms)

 % Coverage report from v8
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
--------------|---------|----------|---------|---------|-------------------
=============================== Coverage summary ===============================
Statements   : 100% ( 4/4 )
Branches     : 100% ( 0/0 )
Functions    : 100% ( 1/1 )
Lines        : 100% ( 4/4 )
================================================================================
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
