### PR TITLE
docs: fix misleading mock reset example in mocking timers section

### DIFF
--- a/docs/guide/mocking/timers.md
+++ b/docs/guide/mocking/timers.md
@@ -24,7 +24,7 @@ describe('delayed execution', () => {
     vi.useFakeTimers()
   })
   afterEach(() => {
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
   it('should execute the function', () => {
     executeAfterTwoHours(mock)


### PR DESCRIPTION
Replaced vi.restoreAllMocks() with vi.clearAllMocks() in afterEach to ensure all mocks are cleared after each test.

### Description

**Current Behavior:**
The documentation suggests using `vi.restoreAllMocks()` to clean up after tests involving fake timers and mock functions. This is misleading because `vi.restoreAllMocks()` does not reset the call counts of `vi.fn()` instances, leading to state leakage between test cases.

**Proposed Change:**
Update the code snippets to use `vi.clearAllMocks()` (or `vi.resetAllMocks()`). This ensures that `toHaveBeenCalledTimes` assertions work correctly in suites with multiple tests.
```diff
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
```

**Reasoning:**
Developers often copy-paste these examples. Using `clearAllMocks` is the correct way to handle recurring mock functions like `const mock = vi.fn()`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
Not run. This is a docs-only change.