### PR TITLE
fix: advance fake timers with `expect.poll` interval

### DIFF
--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -3,6 +3,7 @@ import type { Test } from '@vitest/runner'
 import { chai } from '@vitest/expect'
 import { delay, getSafeTimers } from '@vitest/utils/timers'
 import { getWorkerState } from '../../runtime/utils'
+import { vi } from '../vi'
 
 // these matchers are not supported because they don't make sense with poll
 const unsupported = [
@@ -123,6 +124,9 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                   }
 
                   await delay(interval, setTimeout)
+                  if (vi.isFakeTimers()) {
+                    vi.advanceTimersByTime(interval)
+                  }
                 }
               }
             }

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -66,6 +66,21 @@ test('fake timers don\'t break it', async () => {
   expect(diff >= 100).toBe(true)
 })
 
+test('fake timers are advanced on each poll interval', async ({ onTestFinished }) => {
+  vi.useFakeTimers()
+  onTestFinished(() => {
+    vi.useRealTimers()
+  })
+
+  let didAdvance = false
+
+  setTimeout(() => {
+    didAdvance = true
+  }, 50)
+
+  await expect.poll(() => didAdvance, { interval: 100 }).toBe(true)
+})
+
 test('custom matcher works correctly', async () => {
   const fn = vi.fn()
   let idx = 0


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- closes https://github.com/vitest-dev/vitest/issues/10020

This fix is fine as alignment with `waitFor/waitUntil`, but I wonder if we should encourage `setTimerTickMode("nextTimerAsync")` in the future.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
