### PR TITLE
fix: add `@vitest/coverage-v8` and `@vitest/coverage-istanbul` as optional dependency

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -139,6 +139,8 @@
     "@vitest/browser-playwright": "workspace:*",
     "@vitest/browser-preview": "workspace:*",
     "@vitest/browser-webdriverio": "workspace:*",
+    "@vitest/coverage-istanbul": "workspace:*",
+    "@vitest/coverage-v8": "workspace:*",
     "@vitest/ui": "workspace:*",
     "happy-dom": "*",
     "jsdom": "*",
@@ -161,6 +163,12 @@
       "optional": true
     },
     "@vitest/browser-webdriverio": {
+      "optional": true
+    },
+    "@vitest/coverage-istanbul": {
+      "optional": true
+    },
+    "@vitest/coverage-v8": {
       "optional": true
     },
     "@vitest/ui": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,6 +1017,12 @@ importers:
       '@vitest/browser-webdriverio':
         specifier: workspace:*
         version: link:../browser-webdriverio
+      '@vitest/coverage-istanbul':
+        specifier: workspace:*
+        version: link:../coverage-istanbul
+      '@vitest/coverage-v8':
+        specifier: workspace:*
+        version: link:../coverage-v8
       '@vitest/expect':
         specifier: workspace:*
         version: link:../expect


### PR DESCRIPTION
### Description

The @vitest/coverage-v8 package is now listed as an optional peer dependency. This allows users to opt-in to v8 coverage without requiring it as a hard dependency, while satisfying package manager hoisting and linking requirements such as pnpm and Bazel.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
