### PR TITLE
feat(reporter): support html reporter single file output

### DIFF
--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -1,4 +1,4 @@
-import type { ModuleGraphData, RunnerTestFile, SerializedConfig } from 'vitest'
+import type { ModuleGraphData, RunnerTask, RunnerTestFile, SerializedConfig } from 'vitest'
 import type { HTMLOptions, Reporter, Vitest } from 'vitest/node'
 import { existsSync, promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -101,6 +101,11 @@ export default class HTMLReporter implements Reporter {
     }))
 
     await Promise.all(promises)
+
+    if (this.options.singleFile) {
+      await inlineAttachments(result.files)
+    }
+
     await this.writeReport(stringify(result))
   }
 
@@ -136,7 +141,7 @@ export default class HTMLReporter implements Reporter {
 
     // copy attachments
     // TODO: unify attachmentsDir and html outputFile, so both live together without extra copy
-    if (existsSync(this.ctx.config.attachmentsDir)) {
+    if (!this.options.singleFile && existsSync(this.ctx.config.attachmentsDir)) {
       const destAttachmentsDir = resolve(this.reporterDir, 'data')
       await fs.rm(destAttachmentsDir, { recursive: true, force: true })
       await fs.mkdir(destAttachmentsDir, { recursive: true })
@@ -168,6 +173,31 @@ export default class HTMLReporter implements Reporter {
       await fs.rm(destCoverageDir, { recursive: true, force: true })
       await fs.mkdir(destCoverageDir, { recursive: true })
       await fs.cp(coverageHtmlDir, destCoverageDir, { recursive: true })
+    }
+  }
+}
+
+async function inlineAttachments(files: RunnerTestFile[]): Promise<void> {
+  for (const file of files) {
+    await inlineTaskAttachments(file)
+  }
+}
+
+async function inlineTaskAttachments(task: RunnerTask): Promise<void> {
+  if ('tasks' in task) {
+    for (const child of task.tasks) {
+      await inlineTaskAttachments(child)
+    }
+  }
+  if ('artifacts' in task) {
+    for (const artifact of task.artifacts) {
+      for (const attachment of artifact.attachments ?? []) {
+        if (attachment.path) {
+          const buffer = await fs.readFile(attachment.path)
+          attachment.body = buffer.toString('base64')
+          attachment.path = undefined
+        }
+      }
     }
   }
 }

--- a/packages/vitest/src/node/reporters/html.ts
+++ b/packages/vitest/src/node/reporters/html.ts
@@ -1,3 +1,4 @@
 export interface HTMLOptions {
   outputFile?: string
+  singleFile?: boolean
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/6425
- Plan https://gist.github.com/hi-ogawa/a12115ae69358e9a68ad7f9ede0923fd

I was hoping the same service worker trick as https://github.com/vitest-dev/viewer might work, but it requires at least two `index.html` and `sw.js`. So manual assets/data inlining logic needs to live inside html reporter itself.

It should be doable but we need a few independent new logic, namely:
- inlining SPA 
- inlining `html.meta.json.gz`
- inlining attachments from `path` to `body`
- inlining MPA (for coverage iframe) (this will be a separate follow-up)
  - actually coverage spa reporter should make this simpler

Interestingly, the logic required for SPA and MPA inlining are specfic to Vitest html report, so I might look for existing tools or just vibe-code from scratch.


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
