### PR TITLE
fix(typecheck): log experimental feature warning once per run

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -28,6 +28,8 @@ import { getWorkersCountByPercentage } from '../../utils/workers'
 import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
 
+const loggedExperimentalWarnings = new Set<string>()
+
 function resolvePath(path: string, root: string) {
   // local-pkg (mlly)'s resolveModule("./file", { paths: ["/some/root"] }) tries
   // /some/file
@@ -796,7 +798,8 @@ export function resolveConfig(
   resolved.typecheck ??= {} as any
   resolved.typecheck.enabled ??= false
 
-  if (resolved.typecheck.enabled) {
+  if (resolved.typecheck.enabled && !loggedExperimentalWarnings.has('typecheck')) {
+    loggedExperimentalWarnings.add('typecheck')
     logger.console.warn(
       c.yellow(
         'Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.',

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -28,7 +28,7 @@ import { getWorkersCountByPercentage } from '../../utils/workers'
 import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
 
-const loggedExperimentalWarnings = new Set<string>()
+const loggedExperimentalWarnings = new WeakSet<Logger>()
 
 function resolvePath(path: string, root: string) {
   // local-pkg (mlly)'s resolveModule("./file", { paths: ["/some/root"] }) tries
@@ -798,8 +798,8 @@ export function resolveConfig(
   resolved.typecheck ??= {} as any
   resolved.typecheck.enabled ??= false
 
-  if (resolved.typecheck.enabled && !loggedExperimentalWarnings.has('typecheck')) {
-    loggedExperimentalWarnings.add('typecheck')
+  if (resolved.typecheck.enabled && !loggedExperimentalWarnings.has(logger)) {
+    loggedExperimentalWarnings.add(logger)
     logger.console.warn(
       c.yellow(
         'Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.',

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -153,28 +153,22 @@ it('throws an error if typechecker process exists', async () => {
   }
 })
 
-it('logs experimental typecheck warning once per run with multiple projects', async () => {
+it('logs experimental typecheck warning once for a run with multiple typecheck projects', async () => {
+  // Each project with typecheck.enabled triggers a separate resolveConfig call.
+  // Without dedup, PROJECT_COUNT warnings would be logged. Assert exactly one.
+  const PROJECT_COUNT = 5
   const { stderr } = await runVitest({
     root: resolve(import.meta.dirname, '..'),
-    projects: [
-      {
-        test: {
-          name: 'project-1',
-          dir: resolve(import.meta.dirname, '../test-d'),
-          typecheck: { enabled: true },
-        },
+    projects: Array.from({ length: PROJECT_COUNT }, (_, i) => ({
+      test: {
+        name: `typecheck-project-${i + 1}`,
+        dir: resolve(import.meta.dirname, '../test-d'),
+        typecheck: { enabled: true },
       },
-      {
-        test: {
-          name: 'project-2',
-          dir: resolve(import.meta.dirname, '../test-d'),
-          typecheck: { enabled: true },
-        },
-      },
-    ],
+    })),
   })
-  const count = (stderr.match(/Testing types with tsc and vue-tsc is an experimental feature/g) ?? []).length
-  expect(count).toBe(1)
+  const warningCount = (stderr.match(/Testing types with tsc and vue-tsc is an experimental feature/g) ?? []).length
+  expect(warningCount).toBe(1)
 })
 
 function removeLines(log: string) {

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -153,6 +153,30 @@ it('throws an error if typechecker process exists', async () => {
   }
 })
 
+it('logs experimental typecheck warning once per run with multiple projects', async () => {
+  const { stderr } = await runVitest({
+    root: resolve(import.meta.dirname, '..'),
+    projects: [
+      {
+        test: {
+          name: 'project-1',
+          dir: resolve(import.meta.dirname, '../test-d'),
+          typecheck: { enabled: true },
+        },
+      },
+      {
+        test: {
+          name: 'project-2',
+          dir: resolve(import.meta.dirname, '../test-d'),
+          typecheck: { enabled: true },
+        },
+      },
+    ],
+  })
+  const count = (stderr.match(/Testing types with tsc and vue-tsc is an experimental feature/g) ?? []).length
+  expect(count).toBe(1)
+})
+
 function removeLines(log: string) {
   return log.replace(/⎯{2,}/g, '⎯⎯')
 }


### PR DESCRIPTION
When using Vitest with multiple projects that have typecheck.enabled: true, the experimental feature warning is logged once per project config resolved. In a large monorepo this can mean 30+ identical warnings per run. Fixes #9823.

Changed the deduplication key from a string in a module-level Set to the Logger instance in a WeakSet. The logger is constructed per Vitest instance, so the warning fires once per run regardless of how many project configs are resolved - and correctly resets between separate runs.

Added a test: two projects with typecheck.enabled: true in a single run produce exactly one occurrence of the warning.

Noticed the same pattern in the benchmark() function in cac.ts. Left it out, out of scope.

AI assisted: Claude