### PR TITLE
docs(reporters): add example usage for .vitest output directory

### DIFF
--- a/docs/guide/advanced/reporters.md
+++ b/docs/guide/advanced/reporters.md
@@ -53,6 +53,19 @@ export default defineConfig({
 })
 ```
 
+### Example using `.vitest` directory for reporter outputs
+
+```ts
+export default defineConfig({
+  test: {
+    reporters: ['junit'],
+    outputFile: {
+      junit: './.vitest/junit/report.xml'
+    }
+  }
+})
+
+
 ## Reported Tasks
 
 Reported [events](/api/advanced/reporters) receive tasks for [tests](/api/advanced/test-case), [suites](/api/advanced/test-suite) and [modules](/api/advanced/test-module):


### PR DESCRIPTION
Adds a small example demonstrating how to configure reporter output to use the `.vitest` directory.

This helps make the reporter output convention more practical and easier to adopt for users.