### PR TITLE
fix: fix `defineHelper` for webkit async stack trace + update playwright 1.59.0

### DIFF
--- a/docs/guide/browser/trace-view.md
+++ b/docs/guide/browser/trace-view.md
@@ -126,9 +126,3 @@ Under the hood, Playwright still records its own low-level action events as usua
 Keep in mind that plain assertions like `expect(value).toBe(...)` run in Node, not the browser, so they won't show up in the trace.
 
 For anything not covered automatically, you can use `page.mark()` or `locator.mark()` to add your own trace groups — see [Trace markers](#trace-markers) above.
-
-::: warning
-
-Currently a source view of a trace can be only displayed properly when viewing it on the machine generated a trace with `playwright show-trace` CLI. This is expected to be fixed soon (see https://github.com/microsoft/playwright/pull/39307).
-
-:::

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@vitest/browser-playwright": "latest",
     "jsdom": "latest",
-    "playwright": "^1.58.2",
+    "playwright": "^1.59.0",
     "vite": "latest",
     "vitest": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^7.6.1",
     "@antfu/ni": "^28.3.0",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.59.0",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^7.6.1",
     "@antfu/ni": "^28.3.0",
-    "@playwright/test": "^1.59.0",
+    "@playwright/test": "catalog:",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/packages/browser-playwright/package.json
+++ b/packages/browser-playwright/package.json
@@ -59,7 +59,7 @@
     "tinyrainbow": "catalog:"
   },
   "devDependencies": {
-    "playwright": "^1.58.2",
+    "playwright": "catalog:",
     "vitest": "workspace:*"
   }
 }

--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -233,7 +233,11 @@ export function parseStacktrace(
     : parseV8Stacktrace(stack)
 
   // remove assertion helper's internal stacks
-  const helperIndex = stacks.findLastIndex(s => s.method === '__VITEST_HELPER__' || s.method === 'async*__VITEST_HELPER__')
+  const helperIndex = stacks.findLastIndex(s =>
+    s.method === '__VITEST_HELPER__'
+    || s.method === 'async*__VITEST_HELPER__'
+    || s.method === 'async __VITEST_HELPER__',
+  )
   if (helperIndex >= 0) {
     stacks = stacks.slice(helperIndex + 1)
   }

--- a/packages/utils/src/source-map.ts
+++ b/packages/utils/src/source-map.ts
@@ -235,7 +235,9 @@ export function parseStacktrace(
   // remove assertion helper's internal stacks
   const helperIndex = stacks.findLastIndex(s =>
     s.method === '__VITEST_HELPER__'
+    // firefox
     || s.method === 'async*__VITEST_HELPER__'
+    // webkit
     || s.method === 'async __VITEST_HELPER__',
   )
   if (helperIndex >= 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@jridgewell/trace-mapping':
       specifier: 0.3.31
       version: 0.3.31
+    '@playwright/test':
+      specifier: ^1.59.0
+      version: 1.59.0
     '@rolldown/plugin-babel':
       specifier: ^0.2.1
       version: 0.2.1
@@ -106,8 +109,8 @@ catalogs:
       specifier: ^2.0.3
       version: 2.0.3
     playwright:
-      specifier: ^1.58.2
-      version: 1.58.2
+      specifier: ^1.59.0
+      version: 1.59.0
     sinon:
       specifier: ^21.0.3
       version: 21.0.3
@@ -198,7 +201,7 @@ importers:
         specifier: ^28.3.0
         version: 28.3.0
       '@playwright/test':
-        specifier: ^1.59.0
+        specifier: 'catalog:'
         version: 1.59.0
       '@rollup/plugin-commonjs':
         specifier: ^29.0.2
@@ -407,8 +410,8 @@ importers:
         specifier: latest
         version: 29.0.1(@noble/hashes@1.8.0)
       playwright:
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.59.0
+        version: 1.59.0
       vite:
         specifier: 7.1.5
         version: 7.1.5(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -589,8 +592,8 @@ importers:
         version: 3.1.0
     devDependencies:
       playwright:
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: 'catalog:'
+        version: 1.59.0
       vitest:
         specifier: workspace:*
         version: link:../vitest
@@ -1234,8 +1237,8 @@ importers:
         specifier: link:./cjs-lib
         version: link:cjs-lib
       playwright:
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: 'catalog:'
+        version: 1.59.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1319,7 +1322,7 @@ importers:
         version: 2.1.1
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.59.0
       test-dep-invalid:
         specifier: link:./deps/dep-invalid
         version: link:deps/dep-invalid
@@ -8874,18 +8877,8 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.59.0:
     resolution: {integrity: sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -18133,15 +18126,7 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
-
   playwright-core@1.59.0: {}
-
-  playwright@1.58.2:
-    dependencies:
-      playwright-core: 1.58.2
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.59.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
         specifier: ^28.3.0
         version: 28.3.0
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.59.0
+        version: 1.59.0
       '@rollup/plugin-commonjs':
         specifier: ^29.0.2
         version: 29.0.2(rollup@4.59.0)
@@ -4509,8 +4509,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.59.0':
+    resolution: {integrity: sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8879,8 +8879,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.59.0:
+    resolution: {integrity: sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.0:
+    resolution: {integrity: sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -13057,9 +13067,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.59.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.59.0
 
   '@polka/url@1.0.0-next.24': {}
 
@@ -18125,9 +18135,17 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
+  playwright-core@1.59.0: {}
+
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.59.0:
+    dependencies:
+      playwright-core: 1.59.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ catalog:
   '@iconify/vue': ^5.0.0
   '@jridgewell/remapping': ^2.3.5
   '@jridgewell/trace-mapping': 0.3.31
+  '@playwright/test': ^1.59.0
   '@rolldown/plugin-babel': ^0.2.1
   '@types/chai': ^5.2.2
   '@types/estree': ^1.0.8
@@ -76,7 +77,7 @@ catalog:
   msw: ^2.12.10
   obug: ^2.1.1
   pathe: ^2.0.3
-  playwright: ^1.58.2
+  playwright: ^1.59.0
   sinon: ^21.0.3
   sinon-chai: ^4.0.1
   sirv: ^3.0.2

--- a/test/browser/docker-compose.yaml
+++ b/test/browser/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   playwright:
-    image: mcr.microsoft.com/playwright:v1.58.2-noble
-    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677 --host 0.0.0.0"
+    image: mcr.microsoft.com/playwright:v1.59.0-noble
+    command: /bin/sh -c "npx -y playwright@1.59.0 run-server --port 6677 --host 0.0.0.0"
     init: true
     ipc: host
     user: pwuser
@@ -15,8 +15,8 @@ services:
   # Run it by:
   #   pnpm run docker up playwright-host
   playwright-host:
-    image: mcr.microsoft.com/playwright:v1.58.2-noble
-    command: /bin/sh -c "npx -y playwright@1.58.1 run-server --port 6677"
+    image: mcr.microsoft.com/playwright:v1.59.0-noble
+    command: /bin/sh -c "npx -y playwright@1.59.0 run-server --port 6677"
     init: true
     ipc: host
     user: pwuser

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -39,7 +39,7 @@
     "@vitest/browser-webdriverio": "workspace:*",
     "@vitest/bundled-lib": "link:./bundled-lib",
     "@vitest/cjs-lib": "link:./cjs-lib",
-    "playwright": "^1.58.2",
+    "playwright": "catalog:",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "test-dep-error": "file:./deps/test-dep-error",

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -40,7 +40,10 @@ export const instances: BrowserInstanceOption[] = process.env.BROWSER
   ? [
       {
         browser: process.env.BROWSER as any,
-        headless: process.env.BROWSER === 'safari' ? false : undefined,
+        headless:
+          wsEndpoint
+            ? true
+            : process.env.BROWSER === 'safari' ? false : undefined,
       },
     ]
   : provider.name === 'playwright'

--- a/test/browser/specs/assertion-helper.test.ts
+++ b/test/browser/specs/assertion-helper.test.ts
@@ -35,15 +35,11 @@ test('vi.defineHelper hides internal stack traces', async () => {
       `)
     }
     else if (name === 'webkit') {
-      // async stack trace is incomplete on webkit
-      // waiting for https://github.com/WebKit/WebKit/pull/57832 to land on playwright
-      // bun has already landed https://github.com/oven-sh/bun/pull/22517
       expect.soft(tree).toMatchInlineSnapshot(`
         {
           "basic.test.ts": {
             "async": [
               "expected 'async' to deeply equal 'x'
-            at basic.test.ts:9:20
             at basic.test.ts:26:21",
             ],
             "soft": [
@@ -52,7 +48,6 @@ test('vi.defineHelper hides internal stack traces', async () => {
             ],
             "soft async": [
               "expected 'soft async' to deeply equal 'x'
-            at basic.test.ts:18:25
             at basic.test.ts:34:25",
             ],
             "sync": [

--- a/test/browser/specs/assertion-helper.test.ts
+++ b/test/browser/specs/assertion-helper.test.ts
@@ -43,7 +43,8 @@ test('vi.defineHelper hides internal stack traces', async () => {
           "basic.test.ts": {
             "async": [
               "expected 'async' to deeply equal 'x'
-            at basic.test.ts:9:20",
+            at basic.test.ts:9:20
+            at basic.test.ts:26:21",
             ],
             "soft": [
               "expected 'soft' to deeply equal 'x'
@@ -51,7 +52,8 @@ test('vi.defineHelper hides internal stack traces', async () => {
             ],
             "soft async": [
               "expected 'soft async' to deeply equal 'x'
-            at basic.test.ts:18:25",
+            at basic.test.ts:18:25
+            at basic.test.ts:34:25",
             ],
             "sync": [
               "expected 'sync' to deeply equal 'x'

--- a/test/browser/test/userEvent.test.ts
+++ b/test/browser/test/userEvent.test.ts
@@ -698,11 +698,7 @@ describe.each(inputLike)('userEvent.fill', async (getInput) => {
     expect(value()).toBe('Another Value')
   })
 
-  test.skipIf(
-    server.provider === 'preview'
-    // failing since playwright 1.59.0 https://github.com/microsoft/playwright/issues/39983
-    || (server.provider === 'playwright' && server.browser === 'webkit'),
-  )('fill input in shadow root', async () => {
+  test.skipIf(server.provider === 'preview')('fill input in shadow root', async () => {
     const input = getInput()
     const shadowRoot = createShadowRoot()
     shadowRoot.appendChild(input)
@@ -714,6 +710,11 @@ describe.each(inputLike)('userEvent.fill', async (getInput) => {
     }
 
     await userEvent.fill(input, 'Hello')
+    if (input.tagName === 'DIV' && server.provider === 'playwright' && server.browser === 'webkit') {
+      // broken since playwright 1.59.0 https://github.com/microsoft/playwright/issues/39983
+      expect(value()).toBe('')
+      return
+    }
     expect(value()).toBe('Hello')
   })
 })

--- a/test/browser/test/userEvent.test.ts
+++ b/test/browser/test/userEvent.test.ts
@@ -698,7 +698,11 @@ describe.each(inputLike)('userEvent.fill', async (getInput) => {
     expect(value()).toBe('Another Value')
   })
 
-  test.skipIf(server.provider === 'preview')('fill input in shadow root', async () => {
+  test.skipIf(
+    server.provider === 'preview'
+    // failing since playwright 1.59.0 https://github.com/microsoft/playwright/issues/39983
+    || (server.provider === 'playwright' && server.browser === 'webkit'),
+  )('fill input in shadow root', async () => {
     const input = getInput()
     const shadowRoot = createShadowRoot()
     shadowRoot.appendChild(input)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Extracted from https://github.com/vitest-dev/vitest/pull/9958

Webkit now has better async stack trace support now, so bumping it manually with minor fix.

Here is how `vi.defineHelper` looks:

```sh
$ BROWSER=webkit BROWSER_WS_ENDPOINT=true pnpm -C test/browser/ test-fixtures --
root fixtures/assertion-helper 

> @vitest/test-browser@ test-fixtures /home/hiroshi/code/others/vitest-wt1/test/browser
> vitest --root fixtures/assertion-helper


 DEV  v4.1.2 /home/hiroshi/code/others/vitest-wt1/test/browser/fixtures/assertion-helper

 ❯  webkit  basic.test.ts (4 tests | 4 failed) 29ms
   × sync 5ms
   × async 21ms
   × soft 0ms
   × soft async 2ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   webkit  basic.test.ts:21:6 > sync
AssertionError: expected 'sync' to deeply equal 'x'

Expected: "x"
Received: "sync"

 ❯ basic.test.ts:22:10
     20|
     21| test('sync', () => {
     22|   myEqual('sync', 'x')
       |          ^
     23| })
     24|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

 FAIL   webkit  basic.test.ts:25:6 > async
AssertionError: expected 'async' to deeply equal 'x'

Expected: "x"
Received: "async"

 ❯ basic.test.ts:26:21
     24|
     25| test('async', async () => {
     26|   await myEqualAsync('async', 'x')
       |                     ^
     27| })
     28|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯

 FAIL   webkit  basic.test.ts:29:6 > soft
AssertionError: expected 'soft' to deeply equal 'x'

Expected: "x"
Received: "soft"

 ❯ basic.test.ts:30:14
     28|
     29| test('soft', () => {
     30|   myEqualSoft('soft', 'x')
       |              ^
     31| })
     32|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯

 FAIL   webkit  basic.test.ts:33:6 > soft async
AssertionError: expected 'soft async' to deeply equal 'x'

Expected: "x"
Received: "soft async"

 ❯ basic.test.ts:34:25
     32|
     33| test('soft async', async () => {
     34|   await myEqualSoftAsync('soft async', 'x')
       |                         ^
     35| })
     36|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯


 Test Files  1 failed (1)
      Tests  4 failed (4)
   Start at  11:55:12
   Duration  1.23s (transform 0ms, setup 0ms, import 11ms, tests 29ms, environment 0ms)

 FAIL  Tests failed. Watching for file changes...
       press h to show help, press q to quit
 ELIFECYCLE  Command failed with exit code 1.
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
