### PR TITLE
fix(browser-playwright): clear stale mock routes for duplicate URLs

### DIFF
--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -261,7 +261,15 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
   private createMocker(): BrowserModuleMocker {
     const idPredicates = new Map<string, (url: URL) => boolean>()
-    const sessionIds = new Map<string, string[]>()
+    const sessionIds = new Map<string, Set<string>>()
+
+    function predicateKey(sessionId: string, url: string) {
+      return `${sessionId}:${url}`
+    }
+
+    function normalizeUrl(url: string) {
+      return new URL(url, 'http://localhost').href
+    }
 
     function createPredicate(sessionId: string, url: string) {
       const moduleUrl = new URL(url, 'http://localhost')
@@ -293,20 +301,36 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
         return true
       }
-      const ids = sessionIds.get(sessionId) || []
-      ids.push(moduleUrl.href)
+      const ids = sessionIds.get(sessionId) || new Set<string>()
+      ids.add(moduleUrl.href)
       sessionIds.set(sessionId, ids)
       idPredicates.set(predicateKey(sessionId, moduleUrl.href), predicate)
       return predicate
     }
 
-    function predicateKey(sessionId: string, url: string) {
-      return `${sessionId}:${url}`
+    async function unregisterPredicate(page: Page, sessionId: string, url: string): Promise<void> {
+      const normalizedUrl = normalizeUrl(url)
+      const key = predicateKey(sessionId, normalizedUrl)
+      const predicate = idPredicates.get(key)
+      if (!predicate) {
+        return
+      }
+
+      await page.context().unroute(predicate).finally(() => {
+        idPredicates.delete(key)
+
+        const ids = sessionIds.get(sessionId)
+        ids?.delete(normalizedUrl)
+        if (!ids?.size) {
+          sessionIds.delete(sessionId)
+        }
+      })
     }
 
     return {
       register: async (sessionId: string, module: MockedModule): Promise<void> => {
         const page = this.getPage(sessionId)
+        await unregisterPredicate(page, sessionId, module.url)
         await page.context().route(createPredicate(sessionId, module.url), async (route) => {
           if (module.type === 'manual') {
             const exports = Object.keys(await module.resolve())
@@ -373,24 +397,13 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
       },
       delete: async (sessionId: string, id: string): Promise<void> => {
         const page = this.getPage(sessionId)
-        const key = predicateKey(sessionId, id)
-        const predicate = idPredicates.get(key)
-        if (predicate) {
-          await page.context().unroute(predicate).finally(() => idPredicates.delete(key))
-        }
+        await unregisterPredicate(page, sessionId, id)
       },
       clear: async (sessionId: string): Promise<void> => {
         const page = this.getPage(sessionId)
-        const ids = sessionIds.get(sessionId) || []
-        const promises = ids.map((id) => {
-          const key = predicateKey(sessionId, id)
-          const predicate = idPredicates.get(key)
-          if (predicate) {
-            return page.context().unroute(predicate).finally(() => idPredicates.delete(key))
-          }
-          return null
-        })
-        await Promise.all(promises).finally(() => sessionIds.delete(sessionId))
+        const ids = sessionIds.get(sessionId)
+        const promises = [...(ids || [])].map(id => unregisterPredicate(page, sessionId, id))
+        await Promise.all(promises)
       },
     }
   }

--- a/test/browser/fixtures/manual-mock-alias-leak/src/modal.ts
+++ b/test/browser/fixtures/manual-mock-alias-leak/src/modal.ts
@@ -1,0 +1,1 @@
+export function useModalStore() {}

--- a/test/browser/fixtures/manual-mock-alias-leak/src/probe.spec.ts
+++ b/test/browser/fixtures/manual-mock-alias-leak/src/probe.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/modal', () => ({
+  useModalStore() {},
+}))
+
+vi.mock('./modal', () => ({
+  useModalStore() {},
+}))
+
+import { probe } from './probe'
+
+describe('probe', () => {
+  it('passes with duplicate manual mocks for the same module', () => {
+    expect(probe).toBe(true)
+  })
+})

--- a/test/browser/fixtures/manual-mock-alias-leak/src/probe.ts
+++ b/test/browser/fixtures/manual-mock-alias-leak/src/probe.ts
@@ -1,0 +1,5 @@
+import { useModalStore } from '~/modal'
+
+useModalStore()
+
+export const probe = true

--- a/test/browser/fixtures/manual-mock-alias-leak/src/target.spec.ts
+++ b/test/browser/fixtures/manual-mock-alias-leak/src/target.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { target } from './target'
+
+describe('target', () => {
+  it('passes without registering a mock', () => {
+    expect(target).toBe(true)
+  })
+})

--- a/test/browser/fixtures/manual-mock-alias-leak/src/target.ts
+++ b/test/browser/fixtures/manual-mock-alias-leak/src/target.ts
@@ -1,0 +1,5 @@
+import { useModalStore } from '~/modal'
+
+useModalStore()
+
+export const target = true

--- a/test/browser/fixtures/manual-mock-alias-leak/vitest.config.ts
+++ b/test/browser/fixtures/manual-mock-alias-leak/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~/': `${new URL('src/', import.meta.url).pathname}`,
+    },
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+    },
+    fileParallelism: false,
+    maxWorkers: 1,
+    include: ['src/**/*.spec.ts'],
+  },
+})

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -78,3 +78,23 @@ test('mocking out of root', async () => {
     expect(vitest.stdout).toReportPassedTest('basic.test.js', browser)
   })
 })
+
+test('manual mocks do not leak across browser spec files when the same module is mocked via different ids', async () => {
+  const result = await runVitest({
+    root: 'fixtures/manual-mock-alias-leak',
+  })
+
+  onTestFailed(() => {
+    console.error(result.stdout)
+    console.error(result.stderr)
+  })
+
+  expect(result.stderr).toReportNoErrors()
+
+  instances.forEach(({ browser }) => {
+    expect(result.stdout).toReportPassedTest('src/probe.spec.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/target.spec.ts', browser)
+  })
+
+  expect(result.exitCode).toBe(0)
+})


### PR DESCRIPTION
### Description

Problem
When two mocked ids resolve to the same module URL in Browser Mode, the Playwright provider registers two routes for the same logical module but only keeps the latest predicate reference. Cleanup then removes only the last route, so an older manual mock can leak into the next spec file.

Reproduction / Observation
Resolves #9957.

The new `test/browser/fixtures/manual-mock-alias-leak` fixture reproduces this with two spec files:
1. `probe.spec.ts` registers manual mocks for `~/modal` and `./modal`, which both resolve to the same file.
2. `target.spec.ts` imports `~/modal` without mocking it.

Before this change, the second spec could hit a stale route from the first spec and fail with `[birpc] rpc is closed, cannot call "resolveManualMock"`.

Root cause
`packages/browser-playwright/src/playwright.ts` tracks predicates by `sessionId:url`, but duplicate registrations for the same resolved URL overwrite the stored predicate while leaving the previous Playwright route installed. `delete()` and `clear()` can then only unroute the latest handler, so the earlier manual mock survives into the next file.

Change
- store per-session mock URLs in a `Set` instead of an array
- normalize URLs before unregistering them
- unroute any existing predicate before registering a new route for the same resolved URL
- add a browser fixture and regression test that cover two ids resolving to one manual mock URL across spec files

Why this fix
The provider already treats `sessionId + resolved URL` as the identity for a mock route. Replacing any existing route for that identity is the smallest change that makes cleanup reliable without changing mock resolution semantics.

Risk
The change is limited to Playwright Browser Mode route bookkeeping. It only affects duplicate registrations for the same resolved URL within one session; other providers and non-duplicate routes are unchanged.

Validation
- `pnpm --filter @vitest/browser-playwright run build`
- `BROWSER=chromium pnpm -C test/browser run test-fixtures --root ./fixtures/manual-mock-alias-leak`
- `BROWSER=chromium pnpm -C test/browser exec vitest --no-watch --config=vitest.config.unit.mts specs/mocking.test.ts -t "manual mocks do not leak across browser spec files when the same module is mocked via different ids"`
- `BROWSER=chromium pnpm -C test/browser exec vitest --no-watch --config=vitest.config.unit.mts specs/mocking.test.ts`
- `pnpm exec eslint --no-warn-ignored packages/browser-playwright/src/playwright.ts test/browser/specs/mocking.test.ts`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-a-pull-request-branch-created-from-a-fork/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. (not applicable: bugfix only)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.