### PR TITLE
fix(cli): use createColors instead of disableDefaultColors in agent environments

### DIFF
--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -5,11 +5,18 @@ import type { CLIOption, CLIOptions as CLIOptionsConfig } from './cli-config'
 import { toArray } from '@vitest/utils/helpers'
 import cac from 'cac'
 import { normalize } from 'pathe'
-import c, { disableDefaultColors } from 'tinyrainbow'
+import { createColors } from 'tinyrainbow'
 import { version } from '../../../package.json' with { type: 'json' }
 import { isAgent } from '../../utils/env'
 import { benchCliOptionsConfig, cliOptionsConfig, collectCliOptionsConfig } from './cli-config'
 import { setupTabCompletions } from './completions'
+
+// Use an isolated color instance for Vitest's own CLI output when running
+// inside an agent environment (Claude Code, Cursor, etc.). This avoids
+// mutating the shared tinyrainbow singleton via disableDefaultColors(), which
+// would also disable colors in user code under test that imports tinyrainbow.
+// See: https://github.com/vitest-dev/vitest/issues/10046
+const c = createColors({ force: !isAgent })
 
 function addCommand(cli: CAC | Command, name: string, option: CLIOption<any>) {
   const commandName = option.alias || name
@@ -75,10 +82,6 @@ function addCliOptions(cli: CAC | Command, options: CLIOptionsConfig<any>) {
 }
 
 export function createCLI(options: CliParseOptions = {}): CAC {
-  if (isAgent) {
-    disableDefaultColors()
-  }
-
   const cli = cac('vitest')
 
   cli.version(version)

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -11,12 +11,14 @@ import { isAgent } from '../../utils/env'
 import { benchCliOptionsConfig, cliOptionsConfig, collectCliOptionsConfig } from './cli-config'
 import { setupTabCompletions } from './completions'
 
-// Use an isolated color instance for Vitest's own CLI output when running
-// inside an agent environment (Claude Code, Cursor, etc.). This avoids
-// mutating the shared tinyrainbow singleton via disableDefaultColors(), which
-// would also disable colors in user code under test that imports tinyrainbow.
+// Use an isolated color instance for Vitest's own CLI output.
+// In agent environments (Claude Code, Cursor, etc.) we explicitly disable
+// colors for Vitest's reporter output (force: false) WITHOUT mutating the
+// shared tinyrainbow singleton via disableDefaultColors(). This prevents
+// user code under test that imports tinyrainbow from losing its colors too.
+// In non-agent environments we let tinyrainbow auto-detect support (force: undefined).
 // See: https://github.com/vitest-dev/vitest/issues/10046
-const c = createColors({ force: !isAgent })
+const c = isAgent ? createColors({ force: false }) : createColors()
 
 function addCommand(cli: CAC | Command, name: string, option: CLIOption<any>) {
   const commandName = option.alias || name


### PR DESCRIPTION
## Summary

Fixes #10046

### Problem

When Vitest detects an agent environment (`isAgent=true`, e.g. Claude Code, Cursor, Copilot), `createCLI()` calls `disableDefaultColors()` from tinyrainbow. This mutates tinyrainbow's **shared default-export singleton** via `Object.assign()`, turning all color functions into identity functions.

Since both Vitest and user code under test resolve to the same singleton instance, any test asserting on ANSI-colored output from tinyrainbow silently fails in agent environments:

```ts
// user test
it('should produce yellow warning', () => {
  expect(warn('oops')).toContain('\x1b[33m⚠\x1b[39m') // fails — color.yellow is now a no-op
})
```

### Fix

Replace `disableDefaultColors()` with `createColors({ force: !isAgent })` to produce an **isolated** color instance for Vitest's own CLI output. The default singleton is no longer mutated, so user code's tinyrainbow imports are unaffected.

`createColors()` has been part of tinyrainbow's public API since v1 and is already in the lockfile.

### Before / After

| Environment | Before | After |
|---|---|---|
| Normal TTY | colors enabled (singleton) | colors enabled (isolated) |
| Agent (Claude Code, etc.) | `disableDefaultColors()` nukes singleton | isolated instance has colors disabled, singleton intact |
| User code tinyrainbow | silently broken in agent env | always works |