### PR TITLE
test: standardize failure messages for matcher tests

### DIFF
--- a/test/core/test/matchers/toBe.test.ts
+++ b/test/core/test/matchers/toBe.test.ts
@@ -1,0 +1,135 @@
+import { stripVTControlCharacters } from 'node:util'
+import { processError } from '@vitest/utils/error'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Captures the error thrown by the provided function and returns a snapshot-friendly
+ * object with the error message, diff, actual and expected values.
+ * Part of #9074 — standardize matcher failure messages.
+ */
+function getError(f: () => unknown) {
+  try {
+    f()
+  }
+  catch (error) {
+    const e = processError(error, { expand: true })
+    return {
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
+      expected: e.expected,
+      actual: e.actual,
+    }
+  }
+  return expect.unreachable()
+}
+
+describe('toBe', () => {
+  it('passes when values are strictly equal', () => {
+    expect(1).toBe(1)
+    expect('hello').toBe('hello')
+    expect(true).toBe(true)
+    expect(null).toBe(null)
+    expect(undefined).toBe(undefined)
+    const obj = {}
+    expect(obj).toBe(obj)
+  })
+
+  it('fails with correct message when values are not strictly equal (primitives)', () => {
+    expect(getError(() => expect(1).toBe(2))).toMatchInlineSnapshot(`
+      {
+        "actual": "1",
+        "diff": "- Expected
+      + Received
+
+      - 2
+      + 1",
+        "expected": "2",
+        "message": "expected 1 to be 2 // Object.is equality",
+      }
+    `)
+  })
+
+  it('fails with correct message for string mismatch', () => {
+    expect(getError(() => expect('foo').toBe('bar'))).toMatchInlineSnapshot(`
+      {
+        "actual": "foo",
+        "diff": "Expected: "bar"
+      Received: "foo"",
+        "expected": "bar",
+        "message": "expected 'foo' to be 'bar' // Object.is equality",
+      }
+    `)
+  })
+
+  it('fails with correct message for boolean mismatch', () => {
+    expect(getError(() => expect(true).toBe(false))).toMatchInlineSnapshot(`
+      {
+        "actual": "true",
+        "diff": "- Expected
+      + Received
+
+      - false
+      + true",
+        "expected": "false",
+        "message": "expected true to be false // Object.is equality",
+      }
+    `)
+  })
+
+  it('fails with suggestion to use toStrictEqual when objects are structurally equal', () => {
+    expect(getError(() => expect({ a: 1 }).toBe({ a: 1 }))).toMatchInlineSnapshot(`
+      {
+        "actual": "Object {
+        "a": 1,
+      }",
+        "diff": "Compared values have no visual difference.",
+        "expected": "Object {
+        "a": 1,
+      }",
+        "message": "expected { a: 1 } to be { a: 1 } // Object.is equality
+
+      If it should pass with deep equality, replace "toBe" with "toStrictEqual"
+
+      Expected: { a: 1 }
+      Received: serializes to the same string
+      ",
+      }
+    `)
+  })
+
+  it('fails with suggestion to use toEqual when arrays are deeply equal', () => {
+    expect(getError(() => expect([1, 2, 3]).toBe([1, 2, 3]))).toMatchInlineSnapshot(`
+      {
+        "actual": "Array [
+        1,
+        2,
+        3,
+      ]",
+        "diff": "Compared values have no visual difference.",
+        "expected": "Array [
+        1,
+        2,
+        3,
+      ]",
+        "message": "expected [ 1, 2, 3 ] to be [ 1, 2, 3 ] // Object.is equality
+
+      If it should pass with deep equality, replace "toBe" with "toStrictEqual"
+
+      Expected: [ 1, 2, 3 ]
+      Received: serializes to the same string
+      ",
+      }
+    `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect(1).not.toBe(1))).toMatchInlineSnapshot(`
+      {
+        "actual": "1",
+        "diff": undefined,
+        "expected": "1",
+        "message": "expected 1 not to be 1 // Object.is equality",
+      }
+    `)
+  })
+})

--- a/test/core/test/matchers/toBe.test.ts
+++ b/test/core/test/matchers/toBe.test.ts
@@ -1,27 +1,5 @@
-import { stripVTControlCharacters } from 'node:util'
-import { processError } from '@vitest/utils/error'
 import { describe, expect, it } from 'vitest'
-
-/**
- * Captures the error thrown by the provided function and returns a snapshot-friendly
- * object with the error message, diff, actual and expected values.
- * Part of #9074 — standardize matcher failure messages.
- */
-function getError(f: () => unknown) {
-  try {
-    f()
-  }
-  catch (error) {
-    const e = processError(error, { expand: true })
-    return {
-      message: stripVTControlCharacters(e.message),
-      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
-      expected: e.expected,
-      actual: e.actual,
-    }
-  }
-  return expect.unreachable()
-}
+import { getError } from './utils'
 
 describe('toBe', () => {
   it('passes when values are strictly equal', () => {
@@ -97,7 +75,7 @@ describe('toBe', () => {
     `)
   })
 
-  it('fails with suggestion to use toEqual when arrays are deeply equal', () => {
+  it('fails with suggestion to use toStrictEqual when arrays are deeply equal', () => {
     expect(getError(() => expect([1, 2, 3]).toBe([1, 2, 3]))).toMatchInlineSnapshot(`
       {
         "actual": "Array [

--- a/test/core/test/matchers/toBeGreaterThan.test.ts
+++ b/test/core/test/matchers/toBeGreaterThan.test.ts
@@ -1,0 +1,166 @@
+import { stripVTControlCharacters } from 'node:util'
+import { processError } from '@vitest/utils/error'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Captures the error thrown by the provided function and returns a snapshot-friendly
+ * object with the error message, diff, actual and expected values.
+ * Part of #9074 — standardize matcher failure messages.
+ */
+function getError(f: () => unknown) {
+  try {
+    f()
+  }
+  catch (error) {
+    const e = processError(error, { expand: true })
+    return {
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
+      expected: e.expected,
+      actual: e.actual,
+    }
+  }
+  return expect.unreachable()
+}
+
+describe('toBeGreaterThan', () => {
+  it('passes when actual is greater than expected', () => {
+    expect(2).toBeGreaterThan(1)
+    expect(0).toBeGreaterThan(-1)
+    expect(BigInt(5)).toBeGreaterThan(BigInt(3))
+  })
+
+  it('fails with correct message when actual is not greater than expected', () => {
+    expect(getError(() => expect(1).toBeGreaterThan(2))).toMatchInlineSnapshot(`
+      {
+        "actual": "1",
+        "diff": undefined,
+        "expected": "2",
+        "message": "expected 1 to be greater than 2",
+      }
+    `)
+  })
+
+  it('fails with correct message when actual equals expected', () => {
+    expect(getError(() => expect(2).toBeGreaterThan(2))).toMatchInlineSnapshot(`
+      {
+        "actual": "2",
+        "diff": undefined,
+        "expected": "2",
+        "message": "expected 2 to be greater than 2",
+      }
+    `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect(5).not.toBeGreaterThan(3))).toMatchInlineSnapshot(`
+      {
+        "actual": "5",
+        "diff": undefined,
+        "expected": "3",
+        "message": "expected 5 to be not greater than 3",
+      }
+    `)
+  })
+})
+
+describe('toBeGreaterThanOrEqual', () => {
+  it('passes when actual is greater than or equal to expected', () => {
+    expect(2).toBeGreaterThanOrEqual(1)
+    expect(2).toBeGreaterThanOrEqual(2)
+    expect(BigInt(5)).toBeGreaterThanOrEqual(BigInt(5))
+  })
+
+  it('fails with correct message when actual is less than expected', () => {
+    expect(getError(() => expect(1).toBeGreaterThanOrEqual(2))).toMatchInlineSnapshot(`
+      {
+        "actual": "1",
+        "diff": undefined,
+        "expected": "2",
+        "message": "expected 1 to be greater than or equal to 2",
+      }
+    `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect(5).not.toBeGreaterThanOrEqual(5))).toMatchInlineSnapshot(`
+      {
+        "actual": "5",
+        "diff": undefined,
+        "expected": "5",
+        "message": "expected 5 to be not greater than or equal to 5",
+      }
+    `)
+  })
+})
+
+describe('toBeLessThan', () => {
+  it('passes when actual is less than expected', () => {
+    expect(1).toBeLessThan(2)
+    expect(-1).toBeLessThan(0)
+    expect(BigInt(3)).toBeLessThan(BigInt(5))
+  })
+
+  it('fails with correct message when actual is not less than expected', () => {
+    expect(getError(() => expect(2).toBeLessThan(1))).toMatchInlineSnapshot(`
+      {
+        "actual": "2",
+        "diff": undefined,
+        "expected": "1",
+        "message": "expected 2 to be less than 1",
+      }
+    `)
+  })
+
+  it('fails with correct message when actual equals expected', () => {
+    expect(getError(() => expect(2).toBeLessThan(2))).toMatchInlineSnapshot(`
+      {
+        "actual": "2",
+        "diff": undefined,
+        "expected": "2",
+        "message": "expected 2 to be less than 2",
+      }
+    `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect(1).not.toBeLessThan(5))).toMatchInlineSnapshot(`
+      {
+        "actual": "1",
+        "diff": undefined,
+        "expected": "5",
+        "message": "expected 1 to be not less than 5",
+      }
+    `)
+  })
+})
+
+describe('toBeLessThanOrEqual', () => {
+  it('passes when actual is less than or equal to expected', () => {
+    expect(1).toBeLessThanOrEqual(2)
+    expect(2).toBeLessThanOrEqual(2)
+    expect(BigInt(3)).toBeLessThanOrEqual(BigInt(5))
+  })
+
+  it('fails with correct message when actual is greater than expected', () => {
+    expect(getError(() => expect(3).toBeLessThanOrEqual(2))).toMatchInlineSnapshot(`
+      {
+        "actual": "3",
+        "diff": undefined,
+        "expected": "2",
+        "message": "expected 3 to be less than or equal to 2",
+      }
+    `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect(2).not.toBeLessThanOrEqual(5))).toMatchInlineSnapshot(`
+      {
+        "actual": "2",
+        "diff": undefined,
+        "expected": "5",
+        "message": "expected 2 to be not less than or equal to 5",
+      }
+    `)
+  })
+})

--- a/test/core/test/matchers/toBeGreaterThan.test.ts
+++ b/test/core/test/matchers/toBeGreaterThan.test.ts
@@ -1,27 +1,5 @@
-import { stripVTControlCharacters } from 'node:util'
-import { processError } from '@vitest/utils/error'
 import { describe, expect, it } from 'vitest'
-
-/**
- * Captures the error thrown by the provided function and returns a snapshot-friendly
- * object with the error message, diff, actual and expected values.
- * Part of #9074 — standardize matcher failure messages.
- */
-function getError(f: () => unknown) {
-  try {
-    f()
-  }
-  catch (error) {
-    const e = processError(error, { expand: true })
-    return {
-      message: stripVTControlCharacters(e.message),
-      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
-      expected: e.expected,
-      actual: e.actual,
-    }
-  }
-  return expect.unreachable()
-}
+import { getError } from './utils'
 
 describe('toBeGreaterThan', () => {
   it('passes when actual is greater than expected', () => {

--- a/test/core/test/matchers/toContain.test.ts
+++ b/test/core/test/matchers/toContain.test.ts
@@ -1,27 +1,5 @@
-import { stripVTControlCharacters } from 'node:util'
-import { processError } from '@vitest/utils/error'
 import { describe, expect, it } from 'vitest'
-
-/**
- * Captures the error thrown by the provided function and returns a snapshot-friendly
- * object with the error message, diff, actual and expected values.
- * Part of #9074 — standardize matcher failure messages.
- */
-function getError(f: () => unknown) {
-  try {
-    f()
-  }
-  catch (error) {
-    const e = processError(error, { expand: true })
-    return {
-      message: stripVTControlCharacters(e.message),
-      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
-      expected: e.expected,
-      actual: e.actual,
-    }
-  }
-  return expect.unreachable()
-}
+import { getError } from './utils'
 
 describe('toContain', () => {
   it('passes when array contains element', () => {

--- a/test/core/test/matchers/toContain.test.ts
+++ b/test/core/test/matchers/toContain.test.ts
@@ -1,0 +1,90 @@
+import { stripVTControlCharacters } from 'node:util'
+import { processError } from '@vitest/utils/error'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Captures the error thrown by the provided function and returns a snapshot-friendly
+ * object with the error message, diff, actual and expected values.
+ * Part of #9074 — standardize matcher failure messages.
+ */
+function getError(f: () => unknown) {
+  try {
+    f()
+  }
+  catch (error) {
+    const e = processError(error, { expand: true })
+    return {
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
+      expected: e.expected,
+      actual: e.actual,
+    }
+  }
+  return expect.unreachable()
+}
+
+describe('toContain', () => {
+  it('passes when array contains element', () => {
+    expect([1, 2, 3]).toContain(2)
+    expect(['a', 'b', 'c']).toContain('b')
+  })
+
+  it('passes when string contains substring', () => {
+    expect('hello world').toContain('world')
+    expect('foobar').toContain('oo')
+  })
+
+  it('fails with correct message when array does not contain element', () => {
+    expect(getError(() => expect([1, 2, 3]).toContain(4))).toMatchInlineSnapshot(`
+      {
+        "actual": "Array [
+        1,
+        2,
+        3,
+      ]",
+        "diff": undefined,
+        "expected": "undefined",
+        "message": "expected [ 1, 2, 3 ] to include 4",
+      }
+    `)
+  })
+
+  it('fails with correct message when string does not contain substring', () => {
+    expect(getError(() => expect('hello world').toContain('xyz'))).toMatchInlineSnapshot(`
+    {
+      "actual": "hello world",
+      "diff": "Expected: "xyz"
+    Received: "hello world"",
+      "expected": "xyz",
+      "message": "expected 'hello world' to contain 'xyz'",
+    }
+  `)
+  })
+
+  it('fails with negation message when array contains element', () => {
+    expect(getError(() => expect([1, 2, 3]).not.toContain(2))).toMatchInlineSnapshot(`
+    {
+      "actual": "Array [
+      1,
+      2,
+      3,
+    ]",
+      "diff": undefined,
+      "expected": "undefined",
+      "message": "expected [ 1, 2, 3 ] to not include 2",
+    }
+  `)
+  })
+
+  it('fails with negation message when string contains substring', () => {
+    expect(getError(() => expect('hello world').not.toContain('world'))).toMatchInlineSnapshot(`
+          {
+            "actual": "hello world",
+            "diff": "Expected: "world"
+          Received: "hello world"",
+            "expected": "world",
+            "message": "expected 'hello world' not to contain 'world'",
+          }
+        `)
+  })
+})

--- a/test/core/test/matchers/toEqual.test.ts
+++ b/test/core/test/matchers/toEqual.test.ts
@@ -1,27 +1,5 @@
-import { stripVTControlCharacters } from 'node:util'
-import { processError } from '@vitest/utils/error'
 import { describe, expect, it } from 'vitest'
-
-/**
- * Captures the error thrown by the provided function and returns a snapshot-friendly
- * object with the error message, diff, actual and expected values.
- * Part of #9074 — standardize matcher failure messages.
- */
-function getError(f: () => unknown) {
-  try {
-    f()
-  }
-  catch (error) {
-    const e = processError(error, { expand: true })
-    return {
-      message: stripVTControlCharacters(e.message),
-      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
-      expected: e.expected,
-      actual: e.actual,
-    }
-  }
-  return expect.unreachable()
-}
+import { getError } from './utils'
 
 describe('toEqual', () => {
   it('passes when values are deeply equal', () => {

--- a/test/core/test/matchers/toEqual.test.ts
+++ b/test/core/test/matchers/toEqual.test.ts
@@ -1,0 +1,141 @@
+import { stripVTControlCharacters } from 'node:util'
+import { processError } from '@vitest/utils/error'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Captures the error thrown by the provided function and returns a snapshot-friendly
+ * object with the error message, diff, actual and expected values.
+ * Part of #9074 — standardize matcher failure messages.
+ */
+function getError(f: () => unknown) {
+  try {
+    f()
+  }
+  catch (error) {
+    const e = processError(error, { expand: true })
+    return {
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
+      expected: e.expected,
+      actual: e.actual,
+    }
+  }
+  return expect.unreachable()
+}
+
+describe('toEqual', () => {
+  it('passes when values are deeply equal', () => {
+    expect({ a: 1 }).toEqual({ a: 1 })
+    expect([1, 2, 3]).toEqual([1, 2, 3])
+    expect({ a: { b: { c: 1 } } }).toEqual({ a: { b: { c: 1 } } })
+    expect(new Date('2023-01-01')).toEqual(new Date('2023-01-01'))
+  })
+
+  it('fails with correct message for object mismatch', () => {
+    expect(getError(() => expect({ a: 1 }).toEqual({ a: 2 }))).toMatchInlineSnapshot(`
+      {
+        "actual": "Object {
+        "a": 1,
+      }",
+        "diff": "- Expected
+      + Received
+
+        {
+      -   "a": 2,
+      +   "a": 1,
+        }",
+        "expected": "Object {
+        "a": 2,
+      }",
+        "message": "expected { a: 1 } to deeply equal { a: 2 }",
+      }
+    `)
+  })
+
+  it('fails with correct message for array mismatch', () => {
+    expect(getError(() => expect([1, 2, 3]).toEqual([1, 2, 4]))).toMatchInlineSnapshot(`
+    {
+      "actual": "Array [
+      1,
+      2,
+      3,
+    ]",
+      "diff": "- Expected
+    + Received
+
+      [
+        1,
+        2,
+    -   4,
+    +   3,
+      ]",
+      "expected": "Array [
+      1,
+      2,
+      4,
+    ]",
+      "message": "expected [ 1, 2, 3 ] to deeply equal [ 1, 2, 4 ]",
+    }
+  `)
+  })
+
+  it('fails with correct message for primitive mismatch', () => {
+    expect(getError(() => expect('foo').toEqual('bar'))).toMatchInlineSnapshot(`
+          {
+            "actual": "foo",
+            "diff": "Expected: "bar"
+          Received: "foo"",
+            "expected": "bar",
+            "message": "expected 'foo' to deeply equal 'bar'",
+          }
+        `)
+  })
+
+  it('fails with correct message for nested object mismatch', () => {
+    expect(getError(() => expect({ a: { b: { c: 1 } } }).toEqual({ a: { b: { c: 2 } } }))).toMatchInlineSnapshot(`
+          {
+            "actual": "Object {
+            "a": Object {
+              "b": Object {
+                "c": 1,
+              },
+            },
+          }",
+            "diff": "- Expected
+          + Received
+
+            {
+              "a": {
+                "b": {
+          -       "c": 2,
+          +       "c": 1,
+                },
+              },
+            }",
+            "expected": "Object {
+            "a": Object {
+              "b": Object {
+                "c": 2,
+              },
+            },
+          }",
+            "message": "expected { a: { b: { c: 1 } } } to deeply equal { a: { b: { c: 2 } } }",
+          }
+        `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect({ a: 1 }).not.toEqual({ a: 1 }))).toMatchInlineSnapshot(`
+        {
+          "actual": "Object {
+          "a": 1,
+        }",
+          "diff": "Compared values have no visual difference.",
+          "expected": "Object {
+          "a": 1,
+        }",
+          "message": "expected { a: 1 } to not deeply equal { a: 1 }",
+        }
+      `)
+  })
+})

--- a/test/core/test/matchers/toHaveLength.test.ts
+++ b/test/core/test/matchers/toHaveLength.test.ts
@@ -1,0 +1,96 @@
+import { stripVTControlCharacters } from 'node:util'
+import { processError } from '@vitest/utils/error'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Captures the error thrown by the provided function and returns a snapshot-friendly
+ * object with the error message, diff, actual and expected values.
+ * Part of #9074 — standardize matcher failure messages.
+ */
+function getError(f: () => unknown) {
+  try {
+    f()
+  }
+  catch (error) {
+    const e = processError(error, { expand: true })
+    return {
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
+      expected: e.expected,
+      actual: e.actual,
+    }
+  }
+  return expect.unreachable()
+}
+
+describe('toHaveLength', () => {
+  it('passes for arrays with correct length', () => {
+    expect([1, 2, 3]).toHaveLength(3)
+    expect([]).toHaveLength(0)
+  })
+
+  it('passes for strings with correct length', () => {
+    expect('hello').toHaveLength(5)
+    expect('').toHaveLength(0)
+  })
+
+  it('passes for objects with length property', () => {
+    expect({ length: 5 }).toHaveLength(5)
+  })
+
+  it('fails with correct message for array length mismatch', () => {
+    expect(getError(() => expect([1, 2, 3]).toHaveLength(5))).toMatchInlineSnapshot(`
+      {
+        "actual": "3",
+        "diff": "- Expected
+      + Received
+
+      - 5
+      + 3",
+        "expected": "5",
+        "message": "expected [ 1, 2, 3 ] to have a length of 5 but got 3",
+      }
+    `)
+  })
+
+  it('fails with correct message for string length mismatch', () => {
+    expect(getError(() => expect('hello').toHaveLength(3))).toMatchInlineSnapshot(`
+      {
+        "actual": "5",
+        "diff": "- Expected
+      + Received
+
+      - 3
+      + 5",
+        "expected": "3",
+        "message": "expected 'hello' to have a length of 3 but got 5",
+      }
+    `)
+  })
+
+  it('fails with correct message for empty array when length is expected to be non-zero', () => {
+    expect(getError(() => expect([]).toHaveLength(1))).toMatchInlineSnapshot(`
+      {
+        "actual": "0",
+        "diff": "- Expected
+      + Received
+
+      - 1
+      + 0",
+        "expected": "1",
+        "message": "expected [] to have a length of 1 but got +0",
+      }
+    `)
+  })
+
+  it('fails with negation message', () => {
+    expect(getError(() => expect([1, 2, 3]).not.toHaveLength(3))).toMatchInlineSnapshot(`
+      {
+        "actual": "3",
+        "diff": undefined,
+        "expected": "3",
+        "message": "expected [ 1, 2, 3 ] to not have a length of 3",
+      }
+    `)
+  })
+})

--- a/test/core/test/matchers/toHaveLength.test.ts
+++ b/test/core/test/matchers/toHaveLength.test.ts
@@ -1,27 +1,5 @@
-import { stripVTControlCharacters } from 'node:util'
-import { processError } from '@vitest/utils/error'
 import { describe, expect, it } from 'vitest'
-
-/**
- * Captures the error thrown by the provided function and returns a snapshot-friendly
- * object with the error message, diff, actual and expected values.
- * Part of #9074 — standardize matcher failure messages.
- */
-function getError(f: () => unknown) {
-  try {
-    f()
-  }
-  catch (error) {
-    const e = processError(error, { expand: true })
-    return {
-      message: stripVTControlCharacters(e.message),
-      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
-      expected: e.expected,
-      actual: e.actual,
-    }
-  }
-  return expect.unreachable()
-}
+import { getError } from './utils'
 
 describe('toHaveLength', () => {
   it('passes for arrays with correct length', () => {

--- a/test/core/test/matchers/utils.ts
+++ b/test/core/test/matchers/utils.ts
@@ -1,0 +1,24 @@
+import { stripVTControlCharacters } from 'node:util'
+import { processError } from '@vitest/utils/error'
+import { expect } from 'vitest'
+
+/**
+ * Captures the error thrown by the provided function and returns a snapshot-friendly
+ * object with the error message, diff, actual and expected values.
+ * Part of #9074 — standardize matcher failure messages.
+ */
+export function getError(f: () => unknown) {
+  try {
+    f()
+  }
+  catch (error) {
+    const e = processError(error, { expand: true })
+    return {
+      message: stripVTControlCharacters(e.message),
+      diff: e.diff ? stripVTControlCharacters(e.diff) : undefined,
+      expected: e.expected,
+      actual: e.actual,
+    }
+  }
+  return expect.unreachable()
+}


### PR DESCRIPTION
## Summary

Part of #9074

## Changes

Adds a new `test/core/test/matchers/` directory with dedicated test files for individual matchers. Each file tests both passing cases and failure cases, with comprehensive inline snapshots that assert the exact failure message format, diff output, and `actual`/`expected` values.

This uses the same `getError` pattern already established in `jest-expect.test.ts` (via `processError` from `@vitest/utils/error`) to capture and snapshot the full error structure.

### Matchers covered:

- **`toBe`** — primitives, objects, arrays, negation, deep equality suggestion messages
- **`toEqual`** — objects, arrays, primitives, nested objects, negation
- **`toContain`** — arrays and strings (both positive and negation)
- **`toHaveLength`** — arrays, strings, objects with `length` property
- **`toBeGreaterThan` / `toBeGreaterThanOrEqual`**
- **`toBeLessThan` / `toBeLessThanOrEqual`**

## Testing

All new tests pass (120 tests across 3 environments: threads, forks, vmThreads):

```
Test Files  15 passed (15)
     Tests  120 passed (120)
```

Existing tests in `jest-expect.test.ts` continue to pass without changes.