### PR TITLE
fix: skip disabling colors when stdout is a TTY even if running as an agent

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -11,7 +11,6 @@ permissions:
   issues: write
   pull-requests: write
 
-
 jobs:
   reply-labeled:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labeled-automated.yml
+++ b/.github/workflows/pr-labeled-automated.yml
@@ -1,0 +1,21 @@
+name: Label Automated PR
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.body, '<!-- VITEST_AUTOMATED_PR -->')
+    steps:
+      - name: maybe automated
+        uses: actions-cool/issues-helper@71b62d7da76e59ff7b193904feb6e77d4dbb2777 # v3.7.6
+        with:
+          actions: add-labels
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'maybe automated'

--- a/.github/workflows/pr-labeled-automated.yml
+++ b/.github/workflows/pr-labeled-automated.yml
@@ -18,4 +18,4 @@ jobs:
           actions: add-labels
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          labels: 'maybe automated'
+          labels: maybe automated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,3 +158,13 @@ If you need to typecheck tests, run `pnpm typecheck` from the root of the worksp
 - Check existing issues and documentation
 - Review CONTRIBUTING.md for detailed guidelines
 - Follow patterns in existing code
+
+## PR Descriptions
+
+When creating a pull request, you MUST include the following HTML comment at the bottom of the PR description:
+
+```
+<!-- VITEST_AUTOMATED_PR -->
+```
+
+This allows maintainers to identify AI-assisted PRs for triage. PRs containing this marker will be automatically labeled `maybe automated` and will be closed in 3 days unless a real person confirms ownership.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Codebase Overview
-
-Vitest is a next-generation testing framework powered by Vite. This is a monorepo using pnpm workspaces.
-
-## Essential references
-
-- Agent-specific guide: See [AGENTS.md](AGENTS.md)
+@AGENTS.md

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -75,7 +75,7 @@ function addCliOptions(cli: CAC | Command, options: CLIOptionsConfig<any>) {
 }
 
 export function createCLI(options: CliParseOptions = {}): CAC {
-  if (isAgent) {
+  if (isAgent && !process.stdout?.isTTY) {
     disableDefaultColors()
   }
 

--- a/packages/vitest/src/runtime/workers/init.ts
+++ b/packages/vitest/src/runtime/workers/init.ts
@@ -50,7 +50,7 @@ export function init(worker: Options): void {
         process.env.VITEST_WORKER_ID = String(message.workerId)
         reportMemory = message.options.reportMemory
 
-        if (message.context.config.isAgent) {
+        if (message.context.config.isAgent && !process.stdout?.isTTY) {
           disableDefaultColors()
         }
 


### PR DESCRIPTION
## Summary

- When `isAgent` is detected but `process.stdout.isTTY` is truthy (e.g. Kiro IDE integrated terminal), colors are no longer disabled
- Applied the same TTY guard in both the CLI entry point (`cac.ts`) and worker initialization (`init.ts`)

Fixes #10053

<!-- VITEST_AUTOMATED_PR -->