### PR TITLE
fix: make `expect(..., message)` consistent as error message prefix

### DIFF
--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -82,10 +82,6 @@ class JestExtendError extends Error {
   }
 }
 
-function formatCustomMessage(message: string, customMessage: string | undefined) {
-  return (customMessage != null ? `${customMessage}: ` : '') + message
-}
-
 function JestExtendPlugin(
   c: Chai.ChaiStatic,
   expect: ExpectStatic,
@@ -110,8 +106,9 @@ function JestExtendPlugin(
             const thenable = result as PromiseLike<SyncExpectationResult>
             return thenable.then(({ pass, message, actual, expected, meta }) => {
               if ((pass && isNot) || (!pass && !isNot)) {
+                const errorMessage = (customMessage ? `${customMessage}: ` : '') + message()
                 throw new JestExtendError(
-                  formatCustomMessage(message(), customMessage),
+                  errorMessage,
                   actual,
                   expected,
                   { assertionName: expectAssertionName, meta },
@@ -123,8 +120,9 @@ function JestExtendPlugin(
           const { pass, message, actual, expected, meta } = result as SyncExpectationResult
 
           if ((pass && isNot) || (!pass && !isNot)) {
+            const errorMessage = (customMessage ? `${customMessage}: ` : '') + message()
             throw new JestExtendError(
-              formatCustomMessage(message(), customMessage),
+              errorMessage,
               actual,
               expected,
               { assertionName: expectAssertionName, meta },

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -70,6 +70,13 @@ interface VitestErrorContext {
   meta?: object
 }
 
+function formatCustomMessage(customMessage: string | undefined, message: () => string) {
+  const generatedMessage = message()
+  return customMessage
+    ? `${customMessage}: ${generatedMessage}`
+    : generatedMessage
+}
+
 class JestExtendError extends Error {
   constructor(
     message: string,
@@ -106,9 +113,7 @@ function JestExtendPlugin(
             const thenable = result as PromiseLike<SyncExpectationResult>
             return thenable.then(({ pass, message, actual, expected, meta }) => {
               if ((pass && isNot) || (!pass && !isNot)) {
-                const errorMessage = customMessage != null
-                  ? customMessage
-                  : message()
+                const errorMessage = formatCustomMessage(customMessage, message)
                 throw new JestExtendError(
                   errorMessage,
                   actual,
@@ -122,9 +127,7 @@ function JestExtendPlugin(
           const { pass, message, actual, expected, meta } = result as SyncExpectationResult
 
           if ((pass && isNot) || (!pass && !isNot)) {
-            const errorMessage = customMessage != null
-              ? customMessage
-              : message()
+            const errorMessage = formatCustomMessage(customMessage, message)
             throw new JestExtendError(
               errorMessage,
               actual,

--- a/packages/expect/src/jest-extend.ts
+++ b/packages/expect/src/jest-extend.ts
@@ -70,13 +70,6 @@ interface VitestErrorContext {
   meta?: object
 }
 
-function formatCustomMessage(customMessage: string | undefined, message: () => string) {
-  const generatedMessage = message()
-  return customMessage
-    ? `${customMessage}: ${generatedMessage}`
-    : generatedMessage
-}
-
 class JestExtendError extends Error {
   constructor(
     message: string,
@@ -87,6 +80,10 @@ class JestExtendError extends Error {
   ) {
     super(message)
   }
+}
+
+function formatCustomMessage(message: string, customMessage: string | undefined) {
+  return (customMessage != null ? `${customMessage}: ` : '') + message
 }
 
 function JestExtendPlugin(
@@ -113,9 +110,8 @@ function JestExtendPlugin(
             const thenable = result as PromiseLike<SyncExpectationResult>
             return thenable.then(({ pass, message, actual, expected, meta }) => {
               if ((pass && isNot) || (!pass && !isNot)) {
-                const errorMessage = formatCustomMessage(customMessage, message)
                 throw new JestExtendError(
-                  errorMessage,
+                  formatCustomMessage(message(), customMessage),
                   actual,
                   expected,
                   { assertionName: expectAssertionName, meta },
@@ -127,9 +123,8 @@ function JestExtendPlugin(
           const { pass, message, actual, expected, meta } = result as SyncExpectationResult
 
           if ((pass && isNot) || (!pass && !isNot)) {
-            const errorMessage = formatCustomMessage(customMessage, message)
             throw new JestExtendError(
-              errorMessage,
+              formatCustomMessage(message(), customMessage),
               actual,
               expected,
               { assertionName: expectAssertionName, meta },

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -210,6 +210,7 @@ function toMatchSnapshotImpl(options: {
   hint?: string
   isInline?: boolean
   inlineSnapshot?: string
+  includeAssertionMessage?: boolean
 }): SyncExpectationResult {
   const { assertion } = options
   validateAssertion(assertion)
@@ -221,7 +222,9 @@ function toMatchSnapshotImpl(options: {
     message: options.hint,
     isInline: options.isInline,
     inlineSnapshot: options.inlineSnapshot,
-    errorMessage: chai.util.flag(assertion, 'message'),
+    errorMessage: options.includeAssertionMessage === false
+      ? undefined
+      : chai.util.flag(assertion, 'message'),
     // pass `assertionName` for inline snapshot stack probing
     assertionName,
     // set by async assertion (e.g. resolves/rejects) for inline snapshot stack probing
@@ -235,6 +238,7 @@ async function toMatchFileSnapshotImpl(options: {
   received: unknown
   filepath: string
   hint?: string
+  includeAssertionMessage?: boolean
 }): Promise<SyncExpectationResult> {
   const { assertion } = options
   validateAssertion(assertion)
@@ -246,7 +250,9 @@ async function toMatchFileSnapshotImpl(options: {
   return getSnapshotClient().match({
     received: options.received,
     message: options.hint,
-    errorMessage: chai.util.flag(assertion, 'message'),
+    errorMessage: options.includeAssertionMessage === false
+      ? undefined
+      : chai.util.flag(assertion, 'message'),
     rawSnapshot: {
       file: rawSnapshotFile,
       content: rawSnapshotContent ?? undefined,
@@ -303,6 +309,7 @@ export const Snapshots = {
     return toMatchSnapshotImpl({
       assertion: this.__vitest_assertion__,
       received,
+      includeAssertionMessage: false,
       ...normalizeArguments(propertiesOrHint, hint),
     })
   },
@@ -337,6 +344,7 @@ export const Snapshots = {
       assertion: this.__vitest_assertion__,
       received,
       isInline: true,
+      includeAssertionMessage: false,
       ...normalizeInlineArguments(propertiesOrInlineSnapshot, inlineSnapshotOrHint, hint),
     })
   },
@@ -371,6 +379,7 @@ export const Snapshots = {
       received,
       filepath,
       hint,
+      includeAssertionMessage: false,
     })
   },
 }

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -239,7 +239,6 @@ function toMatchSnapshotImpl(options: {
     message: options.hint,
     isInline: options.isInline,
     inlineSnapshot: options.inlineSnapshot,
-    errorMessage: undefined,
     // pass `assertionName` for inline snapshot stack probing
     assertionName,
     // set by async assertion (e.g. resolves/rejects) for inline snapshot stack probing
@@ -269,7 +268,6 @@ async function toMatchFileSnapshotImpl(options: {
   const result = getSnapshotClient().match({
     received: options.received,
     message: options.hint,
-    errorMessage: undefined,
     rawSnapshot: {
       file: rawSnapshotFile,
       content: rawSnapshotContent ?? undefined,
@@ -327,6 +325,8 @@ export const Snapshots = {
     return toMatchSnapshotImpl({
       assertion: this.__vitest_assertion__,
       received,
+      // `expect.extend` handles expect(..., custom) message,
+      // so avoid doubly prepend the message for custom snapshot matcher.
       includeAssertionMessage: false,
       ...normalizeArguments(propertiesOrHint, hint),
     })

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -68,6 +68,20 @@ function getTest(obj: Chai.Assertion) {
   return test as Test
 }
 
+function withAssertionMessage(
+  result: SyncExpectationResult,
+  assertionMessage: string | undefined,
+): SyncExpectationResult {
+  if (!assertionMessage) {
+    return result
+  }
+
+  return {
+    ...result,
+    message: () => `${assertionMessage}: ${result.message()}`,
+  }
+}
+
 function validateAssertion(assertion: Chai.Assertion): void {
   if (chai.util.flag(assertion, 'negate')) {
     throw new Error(`${getAssertionName(assertion)} cannot be used with "not"`)
@@ -216,21 +230,23 @@ function toMatchSnapshotImpl(options: {
   validateAssertion(assertion)
   const assertionName = getAssertionName(assertion)
   const test = getTest(assertion)
-  return getSnapshotClient().match({
+  const assertionMessage = options.includeAssertionMessage === false
+    ? undefined
+    : chai.util.flag(assertion, 'message')
+  const result = getSnapshotClient().match({
     received: options.received,
     properties: options.properties,
     message: options.hint,
     isInline: options.isInline,
     inlineSnapshot: options.inlineSnapshot,
-    errorMessage: options.includeAssertionMessage === false
-      ? undefined
-      : chai.util.flag(assertion, 'message'),
+    errorMessage: undefined,
     // pass `assertionName` for inline snapshot stack probing
     assertionName,
     // set by async assertion (e.g. resolves/rejects) for inline snapshot stack probing
     error: chai.util.flag(assertion, 'error'),
     ...getTestNames(test),
   })
+  return withAssertionMessage(result, assertionMessage)
 }
 
 async function toMatchFileSnapshotImpl(options: {
@@ -247,18 +263,20 @@ async function toMatchFileSnapshotImpl(options: {
   const snapshotState = getSnapshotClient().getSnapshotState(testNames.filepath)
   const rawSnapshotFile = await snapshotState.environment.resolveRawPath(testNames.filepath, options.filepath)
   const rawSnapshotContent = await snapshotState.environment.readSnapshotFile(rawSnapshotFile)
-  return getSnapshotClient().match({
+  const assertionMessage = options.includeAssertionMessage === false
+    ? undefined
+    : chai.util.flag(assertion, 'message')
+  const result = getSnapshotClient().match({
     received: options.received,
     message: options.hint,
-    errorMessage: options.includeAssertionMessage === false
-      ? undefined
-      : chai.util.flag(assertion, 'message'),
+    errorMessage: undefined,
     rawSnapshot: {
       file: rawSnapshotFile,
       content: rawSnapshotContent ?? undefined,
     },
     ...testNames,
   })
+  return withAssertionMessage(result, assertionMessage)
 }
 
 function assertMatchResult(result: SyncExpectationResult): void {

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -68,20 +68,6 @@ function getTest(obj: Chai.Assertion) {
   return test as Test
 }
 
-function withAssertionMessage(
-  result: SyncExpectationResult,
-  assertionMessage: string | undefined,
-): SyncExpectationResult {
-  if (!assertionMessage) {
-    return result
-  }
-
-  return {
-    ...result,
-    message: () => `${assertionMessage}: ${result.message()}`,
-  }
-}
-
 function validateAssertion(assertion: Chai.Assertion): void {
   if (chai.util.flag(assertion, 'negate')) {
     throw new Error(`${getAssertionName(assertion)} cannot be used with "not"`)
@@ -103,7 +89,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
           received: utils.flag(this, 'object'),
           ...normalizeArguments(propertiesOrHint, hint),
         })
-        return assertMatchResult(result)
+        return assertMatchResult(result, chai.util.flag(this, 'message'))
       }),
     )
   }
@@ -122,7 +108,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         filepath,
         hint,
       })
-      const assertPromise = resultPromise.then(result => assertMatchResult(result))
+      const assertPromise = resultPromise.then(result => assertMatchResult(result, chai.util.flag(this, 'message')))
       return recordAsyncExpect(
         getTest(this),
         assertPromise,
@@ -148,7 +134,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         isInline: true,
         ...normalizeInlineArguments(propertiesOrInlineSnapshot, inlineSnapshotOrHint, hint),
       })
-      return assertMatchResult(result)
+      return assertMatchResult(result, chai.util.flag(this, 'message'))
     }),
   )
   utils.addMethod(
@@ -163,7 +149,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         received: getError(received, promise),
         ...normalizeArguments(propertiesOrHint, hint),
       })
-      return assertMatchResult(result)
+      return assertMatchResult(result, chai.util.flag(this, 'message'))
     }),
   )
   utils.addMethod(
@@ -183,7 +169,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         isInline: true,
         ...normalizeInlineArguments(undefined, inlineSnapshotOrHint, hint),
       })
-      return assertMatchResult(result)
+      return assertMatchResult(result, chai.util.flag(this, 'message'))
     }),
   )
   utils.addMethod(chai.expect, 'addSnapshotSerializer', addSerializer)
@@ -224,16 +210,12 @@ function toMatchSnapshotImpl(options: {
   hint?: string
   isInline?: boolean
   inlineSnapshot?: string
-  includeAssertionMessage?: boolean
 }): SyncExpectationResult {
   const { assertion } = options
   validateAssertion(assertion)
   const assertionName = getAssertionName(assertion)
   const test = getTest(assertion)
-  const assertionMessage = options.includeAssertionMessage === false
-    ? undefined
-    : chai.util.flag(assertion, 'message')
-  const result = getSnapshotClient().match({
+  return getSnapshotClient().match({
     received: options.received,
     properties: options.properties,
     message: options.hint,
@@ -245,7 +227,6 @@ function toMatchSnapshotImpl(options: {
     error: chai.util.flag(assertion, 'error'),
     ...getTestNames(test),
   })
-  return withAssertionMessage(result, assertionMessage)
 }
 
 async function toMatchFileSnapshotImpl(options: {
@@ -253,7 +234,6 @@ async function toMatchFileSnapshotImpl(options: {
   received: unknown
   filepath: string
   hint?: string
-  includeAssertionMessage?: boolean
 }): Promise<SyncExpectationResult> {
   const { assertion } = options
   validateAssertion(assertion)
@@ -262,10 +242,7 @@ async function toMatchFileSnapshotImpl(options: {
   const snapshotState = getSnapshotClient().getSnapshotState(testNames.filepath)
   const rawSnapshotFile = await snapshotState.environment.resolveRawPath(testNames.filepath, options.filepath)
   const rawSnapshotContent = await snapshotState.environment.readSnapshotFile(rawSnapshotFile)
-  const assertionMessage = options.includeAssertionMessage === false
-    ? undefined
-    : chai.util.flag(assertion, 'message')
-  const result = getSnapshotClient().match({
+  return getSnapshotClient().match({
     received: options.received,
     message: options.hint,
     rawSnapshot: {
@@ -274,12 +251,14 @@ async function toMatchFileSnapshotImpl(options: {
     },
     ...testNames,
   })
-  return withAssertionMessage(result, assertionMessage)
 }
 
-function assertMatchResult(result: SyncExpectationResult): void {
+function assertMatchResult(result: SyncExpectationResult, assertionMessage?: string): void {
   if (!result.pass) {
-    throw Object.assign(new Error(result.message()), {
+    const message = assertionMessage
+      ? `${assertionMessage}: ${result.message()}`
+      : result.message()
+    throw Object.assign(new Error(message), {
       actual: result.actual,
       expected: result.expected,
       diffOptions: {
@@ -325,9 +304,6 @@ export const Snapshots = {
     return toMatchSnapshotImpl({
       assertion: this.__vitest_assertion__,
       received,
-      // `expect.extend` handles expect(..., custom) message,
-      // so avoid doubly prepend the message for custom snapshot matcher.
-      includeAssertionMessage: false,
       ...normalizeArguments(propertiesOrHint, hint),
     })
   },
@@ -362,7 +338,6 @@ export const Snapshots = {
       assertion: this.__vitest_assertion__,
       received,
       isInline: true,
-      includeAssertionMessage: false,
       ...normalizeInlineArguments(propertiesOrInlineSnapshot, inlineSnapshotOrHint, hint),
     })
   },
@@ -397,7 +372,6 @@ export const Snapshots = {
       received,
       filepath,
       hint,
-      includeAssertionMessage: false,
     })
   },
 }

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -108,7 +108,9 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         filepath,
         hint,
       })
-      const assertPromise = resultPromise.then(result => assertMatchResult(result, chai.util.flag(this, 'message')))
+      const assertPromise = resultPromise.then(result =>
+        assertMatchResult(result, chai.util.flag(this, 'message'))
+      )
       return recordAsyncExpect(
         getTest(this),
         assertPromise,
@@ -253,12 +255,10 @@ async function toMatchFileSnapshotImpl(options: {
   })
 }
 
-function assertMatchResult(result: SyncExpectationResult, assertionMessage?: string): void {
+function assertMatchResult(result: SyncExpectationResult, message?: string): void {
   if (!result.pass) {
-    const message = assertionMessage
-      ? `${assertionMessage}: ${result.message()}`
-      : result.message()
-    throw Object.assign(new Error(message), {
+    const errorMessage = (message != null ? `${message}: ` : '') + result.message()
+    throw Object.assign(new Error(errorMessage), {
       actual: result.actual,
       expected: result.expected,
       diffOptions: {

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -109,7 +109,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
         hint,
       })
       const assertPromise = resultPromise.then(result =>
-        assertMatchResult(result, chai.util.flag(this, 'message'))
+        assertMatchResult(result, chai.util.flag(this, 'message')),
       )
       return recordAsyncExpect(
         getTest(this),
@@ -255,9 +255,9 @@ async function toMatchFileSnapshotImpl(options: {
   })
 }
 
-function assertMatchResult(result: SyncExpectationResult, message?: string): void {
+function assertMatchResult(result: SyncExpectationResult, customMessage?: string): void {
   if (!result.pass) {
-    const errorMessage = (message != null ? `${message}: ` : '') + result.message()
+    const errorMessage = (customMessage ? `${customMessage}: ` : '') + result.message()
     throw Object.assign(new Error(errorMessage), {
       actual: result.actual,
       expected: result.expected,

--- a/test/core/test/expect-poll.test.ts
+++ b/test/core/test/expect-poll.test.ts
@@ -122,6 +122,12 @@ test('toBeDefined', async () => {
   }))
 })
 
+test('custom message', async () => {
+  await expect(() =>
+    expect.poll(() => 1, { timeout: 100, interval: 10, message: 'custom' }).toBe(2),
+  ).rejects.toMatchInlineSnapshot(`[AssertionError: custom: expected 1 to be 2 // Object.is equality]`)
+})
+
 test('should set _isLastPollAttempt flag on last call', async () => {
   const fn = vi.fn(function (this: object) {
     return chai.util.flag(this, '_isLastPollAttempt')

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -394,7 +394,6 @@ describe('Temporal equality', () => {
   })
 })
 
-// TODO: test expect.poll(..., { message })
 describe('expect with custom message', () => {
   describe('built-in matchers', () => {
     test('sync matcher throws custom message on failure', () => {

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -395,7 +395,7 @@ describe('Temporal equality', () => {
 })
 
 // TODO: test expect.poll(..., { message })
-describe.only('expect with custom message', () => {
+describe('expect with custom message', () => {
   describe('built-in matchers', () => {
     test('sync matcher throws custom message on failure', () => {
       expect(() => expect(1, 'custom message').toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: custom message: expected 1 to be 2 // Object.is equality]`)
@@ -416,7 +416,6 @@ describe.only('expect with custom message', () => {
     })
   })
 
-  // TODO: should prepend like chai above
   describe('custom matchers with expect.extend', () => {
     test('sync custom matcher throws custom message on failure', ({ expect }) => {
       expect.extend({
@@ -428,7 +427,7 @@ describe.only('expect with custom message', () => {
           }
         },
       })
-      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrowErrorMatchingInlineSnapshot(`[Error: custom message]`)
+      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrowErrorMatchingInlineSnapshot(`[Error: custom message: bar is foo]`)
     })
 
     test('sync custom matcher passes with custom message when assertion succeeds', ({ expect }) => {
@@ -455,7 +454,7 @@ describe.only('expect with custom message', () => {
         },
       })
       const asyncAssertion = (expect(Promise.resolve('bar'), 'custom async message') as any).toBeFoo()
-      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message]`)
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message: bar is not foo]`)
     })
 
     test('async custom matcher with not throws custom message on failure', async ({ expect }) => {
@@ -469,7 +468,7 @@ describe.only('expect with custom message', () => {
         },
       })
       const asyncAssertion = (expect(Promise.resolve('foo'), 'custom async message') as any).not.toBeFoo()
-      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message]`)
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message: foo is not foo]`)
     })
   })
 

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -394,27 +394,29 @@ describe('Temporal equality', () => {
   })
 })
 
-describe('expect with custom message', () => {
+// TODO: test expect.poll(..., { message })
+describe.only('expect with custom message', () => {
   describe('built-in matchers', () => {
     test('sync matcher throws custom message on failure', () => {
-      expect(() => expect(1, 'custom message').toBe(2)).toThrow('custom message')
+      expect(() => expect(1, 'custom message').toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: custom message: expected 1 to be 2 // Object.is equality]`)
     })
 
     test('async rejects matcher throws custom message on failure', async ({ expect }) => {
       const asyncAssertion = expect(Promise.reject(new Error('test error')), 'custom async message').rejects.toBe(2)
-      await expect(asyncAssertion).rejects.toThrow('custom async message')
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[AssertionError: custom async message: expected Error: test error to be 2 // Object.is equality]`)
     })
 
     test('async resolves matcher throws custom message on failure', async ({ expect }) => {
       const asyncAssertion = expect(Promise.resolve(1), 'custom async message').resolves.toBe(2)
-      await expect(asyncAssertion).rejects.toThrow('custom async message')
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[AssertionError: custom async message: expected 1 to be 2 // Object.is equality]`)
     })
 
     test('not matcher throws custom message on failure', () => {
-      expect(() => expect(1, 'custom message').not.toBe(1)).toThrow('custom message')
+      expect(() => expect(1, 'custom message').not.toBe(1)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: custom message: expected 1 not to be 1 // Object.is equality]`)
     })
   })
 
+  // TODO: should prepend like chai above
   describe('custom matchers with expect.extend', () => {
     test('sync custom matcher throws custom message on failure', ({ expect }) => {
       expect.extend({
@@ -426,7 +428,7 @@ describe('expect with custom message', () => {
           }
         },
       })
-      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrow('custom message')
+      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrowErrorMatchingInlineSnapshot(`[Error: custom message]`)
     })
 
     test('sync custom matcher passes with custom message when assertion succeeds', ({ expect }) => {
@@ -453,7 +455,7 @@ describe('expect with custom message', () => {
         },
       })
       const asyncAssertion = (expect(Promise.resolve('bar'), 'custom async message') as any).toBeFoo()
-      await expect(asyncAssertion).rejects.toThrow('custom async message')
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message]`)
     })
 
     test('async custom matcher with not throws custom message on failure', async ({ expect }) => {
@@ -467,17 +469,17 @@ describe('expect with custom message', () => {
         },
       })
       const asyncAssertion = (expect(Promise.resolve('foo'), 'custom async message') as any).not.toBeFoo()
-      await expect(asyncAssertion).rejects.toThrow('custom async message')
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message]`)
     })
   })
 
   describe('edge cases', () => {
     test('empty custom message falls back to default matcher message', () => {
-      expect(() => expect(1, '').toBe(2)).toThrow('expected 1 to be 2 // Object.is equality')
+      expect(() => expect(1, '').toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 1 to be 2 // Object.is equality]`)
     })
 
     test('undefined custom message falls back to default matcher message', () => {
-      expect(() => expect(1, undefined as any).toBe(2)).toThrow('expected 1 to be 2 // Object.is equality')
+      expect(() => expect(1, undefined as any).toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 1 to be 2 // Object.is equality]`)
     })
   })
 })

--- a/test/snapshots/test/custom-matcher.test.ts
+++ b/test/snapshots/test/custom-matcher.test.ts
@@ -436,6 +436,65 @@ test('builtin properties mismatch', () => {
   }, {
     update: 'none',
   })
+  expect(result.stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  basic.test.ts > custom snapshot matcher
+    Error: outer message: Snapshot \`custom snapshot matcher 1\` mismatched
+
+    Expected: ""wrong""
+    Received: ""abcde""
+
+     ❯ basic.test.ts:15:41
+         13|
+         14| test('custom snapshot matcher', () => {
+         15|   expect('abcdefghij', 'outer message').toMatchTrimmedInlineSnapshot(\`…
+           |                                         ^
+         16| })
+         17|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯
+
+     FAIL  basic.test.ts > builtin
+    Error: outer message: Snapshot \`builtin 1\` mismatched
+
+    Expected: ""wrong""
+    Received: ""abcdefghij""
+
+     ❯ basic.test.ts:19:41
+         17|
+         18| test('builtin', () => {
+         19|   expect('abcdefghij', 'outer message').toMatchInlineSnapshot(\`"wrong"…
+           |                                         ^
+         20| })
+         21|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯
+
+     FAIL  basic.test.ts > builtin properties mismatch
+    Error: outer message: Snapshot properties mismatched
+
+    - Expected
+    + Received
+
+      {
+    -   "value": Any<String>,
+    +   "value": 1,
+      }
+
+     ❯ basic.test.ts:23:41
+         21|
+         22| test('builtin properties mismatch', () => {
+         23|   expect({ value: 1 }, 'outer message').toMatchSnapshot({
+           |                                         ^
+         24|     value: expect.any(String),
+         25|   })
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯
+
+    "
+  `)
   expect(result.errorTree()).toMatchInlineSnapshot(`
     Object {
       "basic.test.ts": Object {

--- a/test/snapshots/test/custom-matcher.test.ts
+++ b/test/snapshots/test/custom-matcher.test.ts
@@ -422,110 +422,31 @@ expect.extend({
 test('custom snapshot matcher', () => {
   expect('abcdefghij', 'outer message').toMatchTrimmedInlineSnapshot(\`"wrong"\`)
 })
-`,
-  })
 
-  expect(result.stderr).toMatchInlineSnapshot(`
-    "
-    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
-
-     FAIL  basic.test.ts > custom snapshot matcher
-    Error: outer message: Snapshot \`custom snapshot matcher 1\` mismatched
-
-    Expected: ""wrong""
-    Received: ""abcde""
-
-     ❯ basic.test.ts:15:41
-         13|
-         14| test('custom snapshot matcher', () => {
-         15|   expect('abcdefghij', 'outer message').toMatchTrimmedInlineSnapshot(\`…
-           |                                         ^
-         16| })
-         17|
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
-
-    "
-  `)
-  expect(result.errorTree()).toMatchInlineSnapshot(`
-    Object {
-      "basic.test.ts": Object {
-        "custom snapshot matcher": Array [
-          "outer message: Snapshot \`custom snapshot matcher 1\` mismatched",
-        ],
-      },
-    }
-  `)
-})
-
-test('outer expect message is prefixed for built-in snapshot matchers', async () => {
-  const result = await runInlineTests({
-    'basic.test.ts': `
-import { test, expect } from 'vitest'
-
-test('inline snapshot', () => {
+test('builtin', () => {
   expect('abcdefghij', 'outer message').toMatchInlineSnapshot(\`"wrong"\`)
 })
 
-test('properties snapshot', () => {
+test('builtin properties mismatch', () => {
   expect({ value: 1 }, 'outer message').toMatchSnapshot({
     value: expect.any(String),
   })
 })
 `,
+  }, {
+    update: 'none',
   })
-
-  expect(result.stderr).toMatchInlineSnapshot(`
-    "
-    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
-
-     FAIL  basic.test.ts > inline snapshot
-    Error: outer message: Snapshot \`inline snapshot 1\` mismatched
-
-    Expected: ""wrong""
-    Received: ""abcdefghij""
-
-     ❯ basic.test.ts:5:41
-          3|
-          4| test('inline snapshot', () => {
-          5|   expect('abcdefghij', 'outer message').toMatchInlineSnapshot(\`"wrong"…
-           |                                         ^
-          6| })
-          7|
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
-
-     FAIL  basic.test.ts > properties snapshot
-    Error: outer message: Snapshot properties mismatched
-
-    - Expected
-    + Received
-
-      {
-    -   "value": Any<String>,
-    +   "value": 1,
-      }
-
-     ❯ basic.test.ts:9:41
-          7|
-          8| test('properties snapshot', () => {
-          9|   expect({ value: 1 }, 'outer message').toMatchSnapshot({
-           |                                         ^
-         10|     value: expect.any(String),
-         11|   })
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
-
-    "
-  `)
   expect(result.errorTree()).toMatchInlineSnapshot(`
     Object {
       "basic.test.ts": Object {
-        "inline snapshot": Array [
-          "outer message: Snapshot \`inline snapshot 1\` mismatched",
+        "builtin": Array [
+          "outer message: Snapshot \`builtin 1\` mismatched",
         ],
-        "properties snapshot": Array [
+        "builtin properties mismatch": Array [
           "outer message: Snapshot properties mismatched",
+        ],
+        "custom snapshot matcher": Array [
+          "outer message: Snapshot \`custom snapshot matcher 1\` mismatched",
         ],
       },
     }

--- a/test/snapshots/test/custom-matcher.test.ts
+++ b/test/snapshots/test/custom-matcher.test.ts
@@ -457,3 +457,77 @@ test('custom snapshot matcher', () => {
     }
   `)
 })
+
+test('outer expect message is prefixed for built-in snapshot matchers', async () => {
+  const result = await runInlineTests({
+    'basic.test.ts': `
+import { test, expect } from 'vitest'
+
+test('inline snapshot', () => {
+  expect('abcdefghij', 'outer message').toMatchInlineSnapshot(\`"wrong"\`)
+})
+
+test('properties snapshot', () => {
+  expect({ value: 1 }, 'outer message').toMatchSnapshot({
+    value: expect.any(String),
+  })
+})
+`,
+  })
+
+  expect(result.stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  basic.test.ts > inline snapshot
+    Error: outer message: Snapshot \`inline snapshot 1\` mismatched
+
+    Expected: ""wrong""
+    Received: ""abcdefghij""
+
+     ❯ basic.test.ts:5:41
+          3|
+          4| test('inline snapshot', () => {
+          5|   expect('abcdefghij', 'outer message').toMatchInlineSnapshot(\`"wrong"…
+           |                                         ^
+          6| })
+          7|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
+
+     FAIL  basic.test.ts > properties snapshot
+    Error: outer message: Snapshot properties mismatched
+
+    - Expected
+    + Received
+
+      {
+    -   "value": Any<String>,
+    +   "value": 1,
+      }
+
+     ❯ basic.test.ts:9:41
+          7|
+          8| test('properties snapshot', () => {
+          9|   expect({ value: 1 }, 'outer message').toMatchSnapshot({
+           |                                         ^
+         10|     value: expect.any(String),
+         11|   })
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
+
+    "
+  `)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    Object {
+      "basic.test.ts": Object {
+        "inline snapshot": Array [
+          "outer message: Snapshot \`inline snapshot 1\` mismatched",
+        ],
+        "properties snapshot": Array [
+          "outer message: Snapshot properties mismatched",
+        ],
+      },
+    }
+  `)
+})

--- a/test/snapshots/test/custom-matcher.test.ts
+++ b/test/snapshots/test/custom-matcher.test.ts
@@ -403,3 +403,57 @@ test('raw file snapshot', async () => {
   `)
   expect(result.fs.readFile('raw.txt')).toMatchInlineSnapshot(`"crazy long"`)
 })
+
+test('outer expect message is prefixed by jest-extend for Snapshots wrappers', async () => {
+  const result = await runInlineTests({
+    'basic.test.ts': `
+import { test, expect, Snapshots } from 'vitest'
+
+const {
+  toMatchInlineSnapshot,
+} = Snapshots
+
+expect.extend({
+  toMatchTrimmedInlineSnapshot(received: string, inlineSnapshot?: string) {
+    return toMatchInlineSnapshot.call(this, received.slice(0, 5), inlineSnapshot)
+  },
+})
+
+test('custom snapshot matcher', () => {
+  expect('abcdefghij', 'outer message').toMatchTrimmedInlineSnapshot(\`"wrong"\`)
+})
+`,
+  })
+
+  expect(result.stderr).toMatchInlineSnapshot(`
+    "
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+     FAIL  basic.test.ts > custom snapshot matcher
+    Error: outer message: Snapshot \`custom snapshot matcher 1\` mismatched
+
+    Expected: ""wrong""
+    Received: ""abcde""
+
+     ❯ basic.test.ts:15:41
+         13|
+         14| test('custom snapshot matcher', () => {
+         15|   expect('abcdefghij', 'outer message').toMatchTrimmedInlineSnapshot(\`…
+           |                                         ^
+         16| })
+         17|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+    "
+  `)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    Object {
+      "basic.test.ts": Object {
+        "custom snapshot matcher": Array [
+          "outer message: Snapshot \`custom snapshot matcher 1\` mismatched",
+        ],
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

Minor behavior nit. Current behavior is:

```ts
expect(1, 'custom').toBe(2)
// AssertionError: custom: expected 1 to be 2 // Object.is equality

expect('bar', 'custom').toBeFoo()
// Error: custom

expect('value', 'custom').toMatchSnapshot()
// Error: Snapshot `...` mismatched

expect({ value: 1 }, 'custom').toMatchSnapshot({
  value: expect.any(String),
})
// Error: custom
```

This PR aligns custom matcher and built-in snapshot behavior to follow Chai style:

```ts
expect(1, 'custom').toBe(2)
// AssertionError: custom: expected 1 to be 2 // Object.is equality

expect('bar', 'custom').toBeFoo()
// Error: custom: <matcher-generated-message>

expect('value', 'custom').toMatchSnapshot()
// Error: custom: Snapshot `...` mismatched

expect({ value: 1 }, 'custom').toMatchSnapshot({
  value: expect.any(String),
})
// Error: custom: Snapshot properties mismatched
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
