### PR TITLE
fix(runner): correct per-test duration for concurrent tests

### DIFF
--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -613,6 +613,10 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   const suite = test.suite || test.file
   const $ = runner.trace!
 
+  // Track when test actually starts executing (after acquiring concurrency slot)
+  // to measure accurate duration when tests run concurrently
+  let executionStart = start
+
   const repeats = test.repeats ?? 0
   for (let repeatCount = 0; repeatCount <= repeats; repeatCount++) {
     const retry = getRetryCount(test.retry)
@@ -638,6 +642,10 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
             runner,
             [test.context, suite],
           ))
+
+          // Capture start time right before test execution to measure actual test duration
+          // instead of including time spent waiting for concurrency slots
+          executionStart = now()
 
           if (runner.runTask) {
             await $('test.callback', () => limitMaxConcurrency(() => runner.runTask!(test)))
@@ -728,7 +736,7 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
           state: 'skip',
           note: test.result?.note,
           pending: true,
-          duration: now() - start,
+          duration: now() - executionStart,
         }
         updateTask('test-finished', test, runner)
         setCurrentTest(undefined)
@@ -777,7 +785,7 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   cleanupRunningTest()
   setCurrentTest(undefined)
 
-  test.result.duration = now() - start
+  test.result.duration = now() - executionStart
 
   await runner.onAfterRunTask?.(test)
 


### PR DESCRIPTION
## Description

Fixes incorrect test duration reporting when tests run concurrently with maxConcurrency.

### Problem
When tests run concurrently (e.g., with `describe.concurrent` and `maxConcurrency: 1`), the reported per-test duration includes time spent waiting for a concurrency slot, not just the actual test execution time. This causes tests that take ~10s each to be reported as taking ~20s each.

### Solution
Capture the start time right before the test function executes (after acquiring the concurrency slot) instead of at the beginning of `runTest`. This ensures the duration reflects actual test execution time.

### Changes
- Added `executionStart` variable to track when test actually starts executing
- Set `executionStart` right before `limitMaxConcurrency` call
- Use `executionStart` for duration calculation instead of `start`

Fixes #10069