### PR TITLE
ci: use `pull_request_target` for PR comment and label task

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -3,7 +3,7 @@ name: Issue Labeled
 on:
   issues:
     types: [labeled]
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 # for actions-cool/issues-helper to update issues
@@ -43,7 +43,7 @@ jobs:
 
             *These measures help us reduce maintenance burden and keep the team's work efficient. See our [AI contributions policy](https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md#ai-contributions) for more context.*
       - name: maybe automated (pr)
-        if: github.event.label.name == 'maybe automated' && github.event_name == 'pull_request'
+        if: github.event.label.name == 'maybe automated' && github.event_name == 'pull_request_target'
         uses: actions-cool/issues-helper@71b62d7da76e59ff7b193904feb6e77d4dbb2777 # v3.7.6
         with:
           actions: create-comment

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,7 +9,6 @@ on:
 # for actions-cool/issues-helper to update issues
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   reply-labeled:

--- a/.github/workflows/pr-labeled-automated.yml
+++ b/.github/workflows/pr-labeled-automated.yml
@@ -1,7 +1,7 @@
 name: Label Automated PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 permissions:

--- a/.github/workflows/pr-labeled-automated.yml
+++ b/.github/workflows/pr-labeled-automated.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited]
 
 permissions:
-  pull-requests: write
+  issues: write
 
 jobs:
   label:


### PR DESCRIPTION
I saw the label reply failure in https://github.com/vitest-dev/vitest/actions/runs/24005274886/job/70007823876?pr=10072. I asked Codex to fix it and the fix seems legit.

Also Vite has some workflow using `pull_request_target` https://github.com/vitejs/vite/blob/cc41398c2cf0bb5061cf0ca5dc3b408ae7e41191/.github/workflows/pull-request-template-check.yml#L8

---

VITEST_AUTOMATED_PR :robot: 

## Summary

This updates two PR-mutation workflows:

- switch their PR event handling from `pull_request` to `pull_request_target`
- narrow their token permissions to `issues: write`

Affected files:

- `.github/workflows/issue-labeled.yml`
- `.github/workflows/pr-labeled-automated.yml`

## Why

Both workflows mutate pull request state for forked PRs:

- `issue-labeled.yml` posts a PR comment after a label is added
- `pr-labeled-automated.yml` adds the `maybe automated` label when the PR body contains the required marker

GitHub documents two relevant constraints for fork PRs:

- For forked pull requests, the `GITHUB_TOKEN` used with `pull_request` runs is read-only: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories
- `pull_request_target` runs in the base-branch context and is intended for workflows that need to label or comment on pull requests from forks: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

GitHub also notes that `pull_request_target` workflows run in the context of the base branch and therefore require care not to execute untrusted PR code, which fits these jobs because they only inspect event payload data and call the GitHub API through `actions-cool/issues-helper`: https://docs.github.com/actions/security-guides/security-hardening-for-github-actions

## Permissions

These workflows do not need `pull-requests: write`.

`actions-cool/issues-helper` uses the Issues API for both operations on PRs:

- create comment: `octokit.issues.createComment(...)`
- add label: `octokit.issues.addLabels(...)`

Because pull requests are issue-backed for comments and labels, `issues: write` is sufficient here and is a narrower permission set than `pull-requests: write`.

## Failure mode

These restrictions line up with the observed failures:

- `reply-labeled` failed trying to create a PR comment with `Resource not accessible by integration`
- `label` failed trying to add a label with the same error
