### PR TITLE
fix: use "black" foreground for labeled terminal message to ensure contrast

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -25,6 +25,7 @@ import {
 import { benchmarkConfigDefaults, configDefaults } from '../../defaults'
 import { isAgent, isCI, stdProvider } from '../../utils/env'
 import { getWorkersCountByPercentage } from '../../utils/workers'
+import { withLabel } from '../reporters/renderers/utils'
 import { BaseSequencer } from '../sequencers/BaseSequencer'
 import { RandomSequencer } from '../sequencers/RandomSequencer'
 
@@ -157,12 +158,10 @@ export function resolveConfig(
       && viteConfig.test!.environment !== 'happy-dom'
     ) {
       logger.console.warn(
-        c.yellow(
-          `${c.inverse(c.yellow(' Vitest '))} Your config.test.environment ("${
-            viteConfig.test.environment
-          }") conflicts with --dom flag ("happy-dom"), ignoring "${
-            viteConfig.test.environment
-          }"`,
+        withLabel(
+          'yellow',
+          'Vitest',
+          `Your config.test.environment ("${viteConfig.test.environment}") conflicts with --dom flag ("happy-dom"), ignoring "${viteConfig.test.environment}"`,
         ),
       )
     }

--- a/packages/vitest/src/node/packageInstaller.ts
+++ b/packages/vitest/src/node/packageInstaller.ts
@@ -33,7 +33,7 @@ export class VitestPackageInstaller {
     }
 
     process.stderr.write(
-      withLabel('red', 'MISSING DEPENDENCY', `Cannot find dependency '${dependency}'`),
+      withLabel('red', 'MISSING DEPENDENCY', `Cannot find dependency '${dependency}'\n\n`),
     )
 
     if (!isTTY) {

--- a/packages/vitest/src/node/packageInstaller.ts
+++ b/packages/vitest/src/node/packageInstaller.ts
@@ -3,6 +3,7 @@ import url from 'node:url'
 import { isPackageExists } from 'local-pkg'
 import c from 'tinyrainbow'
 import { isTTY } from '../utils/env'
+import { withLabel } from './reporters/renderers/utils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
@@ -32,11 +33,7 @@ export class VitestPackageInstaller {
     }
 
     process.stderr.write(
-      c.red(
-        `${c.inverse(
-          c.red(' MISSING DEPENDENCY '),
-        )} Cannot find dependency '${dependency}'\n\n`,
-      ),
+      withLabel('red', 'MISSING DEPENDENCY', `Cannot find dependency '${dependency}'`),
     )
 
     if (!isTTY) {

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -269,7 +269,8 @@ export function formatProjectName(project?: Pick<TestProject, 'name' | 'color'>,
 }
 
 export function withLabel(color: 'red' | 'green' | 'blue' | 'cyan' | 'yellow', label: string, message?: string) {
-  return `${c.bold(c.inverse(c[color](` ${label} `)))} ${message ? c[color](message) : ''}`
+  const bgColor = `bg${color.charAt(0).toUpperCase()}${color.slice(1)}` as `bg${Capitalize<typeof color>}`
+  return `${c.bold(c.black(c[bgColor](` ${label} `)))} ${message ? c[color](message) : ''}`
 }
 
 export function padSummaryTitle(str: string): string {

--- a/packages/vitest/src/node/reporters/renderers/utils.ts
+++ b/packages/vitest/src/node/reporters/renderers/utils.ts
@@ -269,8 +269,7 @@ export function formatProjectName(project?: Pick<TestProject, 'name' | 'color'>,
 }
 
 export function withLabel(color: 'red' | 'green' | 'blue' | 'cyan' | 'yellow', label: string, message?: string) {
-  const bgColor = `bg${color.charAt(0).toUpperCase()}${color.slice(1)}` as `bg${Capitalize<typeof color>}`
-  return `${c.bold(c[bgColor](` ${label} `))} ${message ? c[color](message) : ''}`
+  return `${c.bold(c.inverse(c[color](` ${label} `)))} ${message ? c[color](message) : ''}`
 }
 
 export function padSummaryTitle(str: string): string {

--- a/scripts/demo-with-label.ts
+++ b/scripts/demo-with-label.ts
@@ -1,0 +1,8 @@
+// pnpm dlx tsx scripts/demo-with-label.ts
+import { withLabel } from '../packages/vitest/src/node/reporters/renderers/utils.ts'
+
+console.log(withLabel('red', 'ERROR', 'This is an error message'))
+console.log(withLabel('green', 'SUCCESS', 'This is a success message'))
+console.log(withLabel('blue', 'INFO', 'This is an info message'))
+console.log(withLabel('cyan', 'DEBUG', 'This is a debug message'))
+console.log(withLabel('yellow', 'WARNING', 'This is a warning message'))


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10037

I feel like bg vs invert was brought up before, but I don't remember. From what I can guess from current state, it makes sense `withLabel` helper to use `inverse` since it's for our hard-coded status label + message pattern. On the other hand, `formatProjectName` can keep use "bg + black fg" pattern as it's not a status label.
 
---

I tested with the OP's terminal https://codeberg.org/dnkl/foot

- Before

<img width="600" alt="image" src="https://github.com/user-attachments/assets/59f3dc84-793e-4397-92a4-7ac158f82a70" />

- After

<img width="600" alt="image" src="https://github.com/user-attachments/assets/628bd310-83da-4235-bfe7-318805a5f799" />

Also on ghostty (left main, right this PR)

<img width="1244" height="629" alt="image" src="https://github.com/user-attachments/assets/5859c802-5dd1-4676-803d-4b68e79f6521" />

On Vscode doesn't change before and after, so invert vs bg behavior is under terminal implementation's control and they can adjust by their own heuristics.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/50167074-a154-4c26-b619-14fd6f9b78eb" />


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
