### PR TITLE
docs: fix reusable wording in migration guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -193,7 +193,7 @@ To improve user experience, Vitest will now start running the matched files when
 $ vitest --standalone math.test.ts
 ```
 
-This allows users to create re-usable `package.json` scripts for standalone mode.
+This allows users to create reusable `package.json` scripts for standalone mode.
 
 ::: code-group
 ```json [package.json]


### PR DESCRIPTION
## Summary

Fix the migration guide wording by changing `re-usable` to `reusable`.

## Related issue

N/A, trivial docs wording fix.

## Guideline alignment

Single-file documentation-only change with no behavior impact.

## Validation/testing note

Not run; docs-only change.

## AI disclosure

Codex assisted with identifying and drafting this trivial wording fix. I reviewed the change before opening the PR.