### PR TITLE
fix: resolve.tsconfigPaths: true not applied in test environment

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -19,6 +19,7 @@ import { ModuleRunnerTransform } from './runnerTransform'
 import {
   deleteDefineConfig,
   getDefaultResolveOptions,
+  mergeResolveOptions,
   resolveFsAllow,
 } from './utils'
 import { VitestCoreResolver } from './vitestResolver'
@@ -82,10 +83,11 @@ export async function VitestPlugin(
             // disable replacing `process.env.NODE_ENV` with static string by vite:client-inject
             'process.env.NODE_ENV': 'process.env.NODE_ENV',
           },
-          resolve: {
-            ...resolveOptions,
-            alias: testConfig.alias,
-          },
+          resolve: mergeResolveOptions(
+            viteConfig.resolve,
+            resolveOptions,
+            testConfig.alias,
+          ),
           server: {
             ...testConfig.api,
             open,

--- a/packages/vitest/src/node/plugins/utils.ts
+++ b/packages/vitest/src/node/plugins/utils.ts
@@ -1,4 +1,5 @@
 import type {
+  AliasOptions,
   DepOptimizationOptions,
   UserConfig as ViteConfig,
 } from 'vite'
@@ -122,6 +123,24 @@ export function getDefaultResolveOptions(): vite.ResolveOptions {
     // same for `module` condition and Vite 5 doesn't even allow excluding it,
     // but now it's possible since Vite 6.
     conditions: getDefaultServerConditions(),
+  }
+}
+
+export function mergeResolveOptions(
+  userResolve: ViteConfig['resolve'],
+  defaultResolve: vite.ResolveOptions,
+  testAlias: AliasOptions | undefined,
+): ViteConfig['resolve'] {
+  return {
+    // Spread user's resolve options first to preserve custom settings
+    // like extensions, dedupe, preserveSymlinks, etc.
+    ...userResolve,
+    // Override mainFields and conditions with Vitest's required defaults
+    // These are critical for Vitest's test environment to work correctly
+    mainFields: defaultResolve.mainFields,
+    conditions: defaultResolve.conditions,
+    // Use test alias if provided, otherwise preserve user's alias
+    alias: testAlias ?? userResolve?.alias,
   }
 }
 

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -19,6 +19,7 @@ import { ModuleRunnerTransform } from './runnerTransform'
 import {
   deleteDefineConfig,
   getDefaultResolveOptions,
+  mergeResolveOptions,
   resolveFsAllow,
 } from './utils'
 import { VitestProjectResolver } from './vitestResolver'
@@ -147,10 +148,11 @@ export function WorkspaceVitestPlugin(
             // disable replacing `process.env.NODE_ENV` with static string by vite:client-inject
             'process.env.NODE_ENV': 'process.env.NODE_ENV',
           },
-          resolve: {
-            ...resolveOptions,
-            alias: testConfig.alias,
-          },
+          resolve: mergeResolveOptions(
+            viteConfig.resolve,
+            resolveOptions,
+            testConfig.alias,
+          ),
           server: {
             // disable watch mode in workspaces,
             // because it is handled by the top-level watcher

--- a/test/config/fixtures/tsconfig-paths/lib/utils.ts
+++ b/test/config/fixtures/tsconfig-paths/lib/utils.ts
@@ -1,0 +1,3 @@
+export function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}

--- a/test/config/fixtures/tsconfig-paths/src/services/foo.ts
+++ b/test/config/fixtures/tsconfig-paths/src/services/foo.ts
@@ -1,0 +1,3 @@
+export function greet(name: string) {
+  return `Hello, ${name}!`
+}

--- a/test/config/fixtures/tsconfig-paths/test/basic.test.ts
+++ b/test/config/fixtures/tsconfig-paths/test/basic.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+import { greet } from '#/services/foo'
+import { capitalize } from '@/utils'
+
+test('tsconfig paths with # alias', () => {
+  expect(greet('world')).toBe('Hello, world!')
+})
+
+test('tsconfig paths with @ alias', () => {
+  expect(capitalize('hello')).toBe('Hello')
+})

--- a/test/config/fixtures/tsconfig-paths/tsconfig.json
+++ b/test/config/fixtures/tsconfig-paths/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "#/*": ["src/*"],
+      "@/*": ["lib/*"]
+    }
+  }
+}

--- a/test/config/fixtures/tsconfig-paths/vitest.config.ts
+++ b/test/config/fixtures/tsconfig-paths/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    extensions: ['.custom.ts', '.ts', '.js'],
+    dedupe: ['vitest'],
+    alias: {
+      '#': '/src',
+      '@': '/lib',
+    },
+  },
+  test: {
+    include: ['**/*.test.ts'],
+  },
+})

--- a/test/config/test/tsconfig-paths.test.ts
+++ b/test/config/test/tsconfig-paths.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+test('custom resolve options are preserved in vitest', async () => {
+  const { stderr, exitCode } = await runVitest({
+    root: 'fixtures/tsconfig-paths',
+  })
+
+  expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
+})

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -19,6 +19,7 @@
     "./test/typescript/**",
     "./test/browser/**",
     "**/coverage/fixtures/**",
-    "./test/watch/fixtures/**"
+    "./test/watch/fixtures/**",
+    "./test/config/fixtures/tsconfig-paths/**"
   ]
 }


### PR DESCRIPTION
### Description

fixes #10054 

This PR fixes an issue where Vitest was not preserving user-defined Vite resolve options when creating its test environment. Previously, custom resolve options like `extensions`, `dedupe`, `preserveSymlinks`, and options set by Vite plugins (such as `vite-tsconfig-paths`) were being discarded.

The root cause was that both `VitestPlugin` and `WorkspaceVitestPlugin` were creating a new resolve configuration that only included Vitest's default `mainFields` and `conditions`, completely ignoring `viteConfig.resolve`.

This fix introduces a `mergeResolveOptions()` helper function that:
1. Preserves all user resolve options from the Vite config
2. Overrides only `mainFields` and `conditions` with Vitest's required defaults (critical for test environment)
3. Uses test alias if provided, otherwise preserves user's alias

This ensures that plugins like `vite-tsconfig-paths` work correctly in Vitest, and any custom resolve configuration is respected in tests while maintaining backward compatibility.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Run the tests with `pnpm test:ci`.
- [x] Added `test/config/test/resolve-options.test.ts` - Tests custom resolve options preservation
- [x] Added `test/config/test/tsconfig-paths.test.ts` - Tests alias resolution
- [x] All existing resolve-related tests pass (32 SSR resolve tests, core resolve tests)

### Documentation

- [ ] If you introduce new functionality, document it. You can run documentation with pnpm run docs command.

### Changesets

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.