### PR TITLE
fix: Do not hoist imports whose names match class properties (fix #10093).

### DIFF
--- a/packages/mocker/src/node/esmWalker.ts
+++ b/packages/mocker/src/node/esmWalker.ts
@@ -311,6 +311,11 @@ function isRefIdentifier(id: Identifier, parent: _Node, parentStack: _Node[]) {
     return false
   }
 
+  // class property
+  if (parent.type === 'PropertyDefinition' && !parent.computed) {
+    return false
+  }
+
   // property key
   if (isStaticPropertyKey(id, parent)) {
     return false

--- a/packages/mocker/src/node/esmWalker.ts
+++ b/packages/mocker/src/node/esmWalker.ts
@@ -313,7 +313,8 @@ function isRefIdentifier(id: Identifier, parent: _Node, parentStack: _Node[]) {
 
   // class property
   if (parent.type === 'PropertyDefinition' && !parent.computed) {
-    return false
+    // Default values can still reference identifiers
+    return id === parent.value
   }
 
   // property key

--- a/packages/mocker/src/node/esmWalker.ts
+++ b/packages/mocker/src/node/esmWalker.ts
@@ -255,17 +255,13 @@ export function esmWalker(
   identifiers.forEach(([node, stack]) => {
     if (!isInScope(node.name, stack)) {
       const parent = stack[0]
-      const grandparent = stack[1]
       const hasBindingShortcut
         = isStaticProperty(parent)
           && parent.shorthand
           && (!isNodeInPattern(parent)
             || isInDestructuringAssignment(parent, parentStack))
 
-      const classDeclaration
-        = (parent.type === 'PropertyDefinition'
-          && grandparent?.type === 'ClassBody')
-        || (parent.type === 'ClassDeclaration' && node === parent.superClass)
+      const classDeclaration = (parent.type === 'ClassDeclaration' && node === parent.superClass)
 
       const classExpression
         = parent.type === 'ClassExpression' && node === parent.id

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -775,7 +775,6 @@ add(4);
         update = update
         del = () => __vi_import_0__.del()
         call = __vi_import_0__.call(4)
-        timeout = null
       }
       
       __vi_import_0__.remove(2);

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -754,6 +754,7 @@ class A {
   update = update
   del = () => del()
   call = call(4)
+  timeout = null
 }
 
 remove(2);
@@ -774,6 +775,7 @@ add(4);
         update = update
         del = () => __vi_import_0__.del()
         call = __vi_import_0__.call(4)
+        timeout = null
       }
       
       __vi_import_0__.remove(2);

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -746,11 +746,12 @@ const obj = {
     expect(
       hoistSimpleCodeWithoutMocks(
         `
-import { remove, add } from 'vue'
+import { remove, add, update } from 'vue'
 
 class A {
   remove = 1
   add = null
+  update = update
 }
 
 remove(2);
@@ -763,10 +764,12 @@ add(4);
       import {vi} from "vitest";
 
 
-
+      
+      const update = __vi_import_0__.update;
       class A {
         remove = 1
         add = null
+        update = update
       }
       
       __vi_import_0__.remove(2);

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -746,12 +746,14 @@ const obj = {
     expect(
       hoistSimpleCodeWithoutMocks(
         `
-import { remove, add, update } from 'vue'
+import { remove, add, update, del, call } from 'vue'
 
 class A {
   remove = 1
   add = null
   update = update
+  del = () => del()
+  call = call(4)
 }
 
 remove(2);
@@ -764,12 +766,14 @@ add(4);
       import {vi} from "vitest";
 
 
-      
+
       const update = __vi_import_0__.update;
       class A {
         remove = 1
         add = null
         update = update
+        del = () => __vi_import_0__.del()
+        call = __vi_import_0__.call(4)
       }
       
       __vi_import_0__.remove(2);

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -767,11 +767,10 @@ add(4);
 
 
 
-      const update = __vi_import_0__.update;
       class A {
         remove = 1
         add = null
-        update = update
+        update = __vi_import_0__.update
         del = () => __vi_import_0__.del()
         call = __vi_import_0__.call(4)
       }

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -754,7 +754,6 @@ class A {
   update = update
   del = () => del()
   call = call(4)
-  timeout = null
 }
 
 remove(2);

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -752,6 +752,9 @@ class A {
   remove = 1
   add = null
 }
+
+remove(2);
+add(4);
 `,
       ),
     ).toMatchInlineSnapshot(`
@@ -761,12 +764,13 @@ class A {
 
 
 
-      const add = __vi_import_0__.add;
-      const remove = __vi_import_0__.remove;
       class A {
         remove = 1
         add = null
-      }"
+      }
+      
+      __vi_import_0__.remove(2);
+      __vi_import_0__.add(4);"
     `)
   })
 


### PR DESCRIPTION
fix: Do not hoist imports whose names match class properties (fix #10093).

### Description

Fixes vitest hoisting imports when a class property shares the same name.

Resolves #10093

[Full reproduction](https://github.com/SunsetFi/vitest-class-method-name-collision/tree/main)

When vitest 4.1.3 encounters a class property that matches the name of an import, it attempts to hoist the import above the class property, often resulting in reference errors:

```ts
const { myMethodMock } = vi.hoisted(() => ({
  myMethodMock: vi.fn(),
}));

vi.mock("./MyClass", () => ({
  MyClass: class {
    // This line triggers the crash
    myMethod = myMethodMock;
    // This workaround fixes it:
    // ["myMethod"] = myMethodMock;
  },
}));

// This incorrectly gets hoisted above the MyClass mock,
// presumably because vitest sees the property name and thinks its accessing
// this function.
import { myMethod } from "./my-method";

describe("myMethod", () => {
  it("should call MyClass.myMethod", () => {
    myMethodMock.mockReturnValue("Mocked Hello, World!");
    const result = myMethod();
    expect(myMethodMock).toHaveBeenCalled();
    expect(result).toBe("Mocked Hello, World!");
  });
});
```

Since the property name is not a reference to the import, the hoisting is unnecessary, and hoisting itself causes a ReferenceError as it accesses the vite import of the module before the actual import is performed.

I am familiar with javascript parsing, but not too familiar with estree or vitest's internals.  This PR is mostly a hunch, and I am not sure of the full ramifications of the change.  However, it fixes the issue in my bug example repo.

There is a test at test/core/test/injector-mock.test.ts that seems to explicitly test for the faulty behavior.  That is, it looks for the `add` and `remove` variables being hoisted above the class even though the class does not reference them.  Fixing this bug caused this test to fail, as now there is no need to hoist the variables at all.  I tweaked the test to reference the imports, and checked that the imports are still referenced correctly.  However, I am not sure why this test existed in its original form, and I don't know if I'm missing some reason as to why this original behavior is actually the desired one.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.
- [x] Introduce a new test to check for this behavior

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
