### PR TITLE
docs(snapshot): gotchas for custom async inline snaphsot matcher

### DIFF
--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -262,7 +262,7 @@ File snapshot matchers must be `async` — `toMatchFileSnapshot` returns a `Prom
 :::
 
 ::: warning
-If your custom inline snapshot matcher is `async` (i.e. it `await`s before calling `toMatchInlineSnapshot`), Vitest cannot automatically infer the call location for inline snapshot rewriting. You must capture the call site manually **before** any `await`, by setting the `'error'` flag on the chai assertion:
+When custom inline snapshot matcher is aynchronous, Vitest cannot automatically infer the call location for inline snapshot rewriting. You must capture the call site by setting the `'error'` flag on the chai assertion object:
 
 ```ts
 import { expect, chai, Snapshots } from 'vitest'
@@ -271,15 +271,14 @@ const { toMatchInlineSnapshot } = Snapshots
 
 expect.extend({
   async toMatchTransformedInlineSnapshot(received: string, inlineSnapshot?: string) {
-    // capture call site before any await
-    chai.util.flag(this, 'error', new Error())
+    // capture call site synchronously at the top of matcher implementation
+    chai.util.flag(this.assertion, 'error', new Error())
     const transformed = await transform(received)
     return toMatchInlineSnapshot.call(this, transformed, inlineSnapshot)
   },
 })
 ```
 
-Without this, inline snapshot auto-update will point to the wrong line.
 :::
 
 For TypeScript, extend the `Assertion` interface:

--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -261,6 +261,27 @@ For inline snapshot matchers, the snapshot argument must be the last parameter (
 File snapshot matchers must be `async` — `toMatchFileSnapshot` returns a `Promise`. Remember to `await` the result in the matcher and in your test.
 :::
 
+::: warning
+If your custom inline snapshot matcher is `async` (i.e. it `await`s before calling `toMatchInlineSnapshot`), Vitest cannot automatically infer the call location for inline snapshot rewriting. You must capture the call site manually **before** any `await`, by setting the `'error'` flag on the chai assertion:
+
+```ts
+import { expect, chai, Snapshots } from 'vitest'
+
+const { toMatchInlineSnapshot } = Snapshots
+
+expect.extend({
+  async toMatchTransformedInlineSnapshot(received: string, inlineSnapshot?: string) {
+    // capture call site before any await
+    chai.util.flag(this, 'error', new Error())
+    const transformed = await transform(received)
+    return toMatchInlineSnapshot.call(this, transformed, inlineSnapshot)
+  },
+})
+```
+
+Without this, inline snapshot auto-update will point to the wrong line.
+:::
+
 For TypeScript, extend the `Assertion` interface:
 
 ```ts

--- a/test/snapshots/test/custom-matcher.test.ts
+++ b/test/snapshots/test/custom-matcher.test.ts
@@ -85,9 +85,8 @@ test('custom snapshot matcher', async () => {
     .replace('`popopo`', '`popopo-edit`')
     .replace('`pepepe`', '`pepepe-edit`')
     .replace('`hihihi`', '`hihihi-edit`')
-    .replace('`hehehe`', '`hehehe-edit`')
     .replace('`huhuhu`', '`huhuhu-edit`')
-  )
+    .replace('`hehehe`', '`hehehe-edit`'))
 
   result = await runVitest({ root, update: 'none' })
   expect(result.stderr).toMatchInlineSnapshot(`

--- a/test/snapshots/test/custom-matcher.test.ts
+++ b/test/snapshots/test/custom-matcher.test.ts
@@ -57,11 +57,19 @@ test('custom snapshot matcher', async () => {
           "reversed": "eheheh",
         }
       \`)
+
+    expect(\`huhuhu\`).toMatchCustomAsyncInlineSnapshot(\`
+        Object {
+          "length": 6,
+          "reversed": "uhuhuh",
+        }
+      \`)
     "
   `)
   expect(result.errorTree()).toMatchInlineSnapshot(`
     Object {
       "basic.test.ts": Object {
+        "async inline": "passed",
         "file": "passed",
         "inline": "passed",
         "properties 1": "passed",
@@ -77,12 +85,14 @@ test('custom snapshot matcher', async () => {
     .replace('`popopo`', '`popopo-edit`')
     .replace('`pepepe`', '`pepepe-edit`')
     .replace('`hihihi`', '`hihihi-edit`')
-    .replace('`hehehe`', '`hehehe-edit`'))
+    .replace('`hehehe`', '`hehehe-edit`')
+    .replace('`huhuhu`', '`huhuhu-edit`')
+  )
 
   result = await runVitest({ root, update: 'none' })
   expect(result.stderr).toMatchInlineSnapshot(`
     "
-    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
+    ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
 
      FAIL  basic.test.ts > file
     Error: [custom error] Snapshot \`file 1\` mismatched
@@ -97,15 +107,15 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-ahahah",
       }
 
-     ❯ basic.test.ts:50:25
-         48|
-         49| test('file', () => {
-         50|   expect(\`hahaha-edit\`).toMatchCustomSnapshot()
+     ❯ basic.test.ts:66:25
+         64|
+         65| test('file', () => {
+         66|   expect(\`hahaha-edit\`).toMatchCustomSnapshot()
            |                         ^
-         51| })
-         52|
+         67| })
+         68|
 
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/6]⎯
 
      FAIL  basic.test.ts > properties 1
     Error: [custom error] Snapshot properties mismatched
@@ -119,15 +129,15 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-opopop",
       }
 
-     ❯ basic.test.ts:54:25
-         52|
-         53| test('properties 1', () => {
-         54|   expect(\`popopo-edit\`).toMatchCustomSnapshot({ length: 6 })
+     ❯ basic.test.ts:70:25
+         68|
+         69| test('properties 1', () => {
+         70|   expect(\`popopo-edit\`).toMatchCustomSnapshot({ length: 6 })
            |                         ^
-         55| })
-         56|
+         71| })
+         72|
 
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/6]⎯
 
      FAIL  basic.test.ts > properties 2
     Error: [custom error] Snapshot properties mismatched
@@ -141,15 +151,15 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-epepep",
       }
 
-     ❯ basic.test.ts:58:25
-         56|
-         57| test('properties 2', () => {
-         58|   expect(\`pepepe-edit\`).toMatchCustomSnapshot({ length: expect.toSatis…
+     ❯ basic.test.ts:74:25
+         72|
+         73| test('properties 2', () => {
+         74|   expect(\`pepepe-edit\`).toMatchCustomSnapshot({ length: expect.toSatis…
            |                         ^
-         59| })
-         60|
+         75| })
+         76|
 
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/6]⎯
 
      FAIL  basic.test.ts > raw
     Error: [custom error] Snapshot \`raw 1\` mismatched
@@ -164,15 +174,15 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-ihihih",
       }
 
-     ❯ basic.test.ts:62:3
-         60|
-         61| test('raw', async () => {
-         62|   await expect(\`hihihi-edit\`).toMatchCustomFileSnapshot('./__snapshots…
+     ❯ basic.test.ts:78:3
+         76|
+         77| test('raw', async () => {
+         78|   await expect(\`hihihi-edit\`).toMatchCustomFileSnapshot('./__snapshots…
            |   ^
-         63| })
-         64|
+         79| })
+         80|
 
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/6]⎯
 
      FAIL  basic.test.ts > inline
     Error: [custom error] Snapshot \`inline 1\` mismatched
@@ -187,21 +197,47 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-eheheh",
       }
 
-     ❯ basic.test.ts:66:25
-         64|
-         65| test('inline', () => {
-         66|   expect(\`hehehe-edit\`).toMatchCustomInlineSnapshot(\`
+     ❯ basic.test.ts:82:25
+         80|
+         81| test('inline', () => {
+         82|   expect(\`hehehe-edit\`).toMatchCustomInlineSnapshot(\`
            |                         ^
-         67|     Object {
-         68|       "length": 6,
+         83|     Object {
+         84|       "length": 6,
 
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/5]⎯
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/6]⎯
+
+     FAIL  basic.test.ts > async inline
+    Error: [custom error] Snapshot \`async inline 1\` mismatched
+
+    - Expected
+    + Received
+
+      Object {
+    -   "length": 6,
+    +   "length": 11,
+    -   "reversed": "uhuhuh",
+    +   "reversed": "tide-uhuhuh",
+      }
+
+     ❯ basic.test.ts:91:3
+         89|
+         90| test('async inline', async () => {
+         91|   await expect(\`huhuhu-edit\`).toMatchCustomAsyncInlineSnapshot(\`
+           |   ^
+         92|     Object {
+         93|       "length": 6,
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/6]⎯
 
     "
   `)
   expect(result.errorTree()).toMatchInlineSnapshot(`
     Object {
       "basic.test.ts": Object {
+        "async inline": Array [
+          "[custom error] Snapshot \`async inline 1\` mismatched",
+        ],
         "file": Array [
           "[custom error] Snapshot \`file 1\` mismatched",
         ],
@@ -239,13 +275,13 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-opopop",
       }
 
-     ❯ basic.test.ts:54:25
-         52|
-         53| test('properties 1', () => {
-         54|   expect(\`popopo-edit\`).toMatchCustomSnapshot({ length: 6 })
+     ❯ basic.test.ts:70:25
+         68|
+         69| test('properties 1', () => {
+         70|   expect(\`popopo-edit\`).toMatchCustomSnapshot({ length: 6 })
            |                         ^
-         55| })
-         56|
+         71| })
+         72|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
 
@@ -261,13 +297,13 @@ test('custom snapshot matcher', async () => {
     +   "reversed": "tide-epepep",
       }
 
-     ❯ basic.test.ts:58:25
-         56|
-         57| test('properties 2', () => {
-         58|   expect(\`pepepe-edit\`).toMatchCustomSnapshot({ length: expect.toSatis…
+     ❯ basic.test.ts:74:25
+         72|
+         73| test('properties 2', () => {
+         74|   expect(\`pepepe-edit\`).toMatchCustomSnapshot({ length: expect.toSatis…
            |                         ^
-         59| })
-         60|
+         75| })
+         76|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
 
@@ -312,11 +348,19 @@ test('custom snapshot matcher', async () => {
           "reversed": "tide-eheheh",
         }
       \`)
+
+    expect(\`huhuhu-edit\`).toMatchCustomAsyncInlineSnapshot(\`
+        Object {
+          "length": 11,
+          "reversed": "tide-uhuhuh",
+        }
+      \`)
     "
   `)
   expect(result.errorTree()).toMatchInlineSnapshot(`
     Object {
       "basic.test.ts": Object {
+        "async inline": "passed",
         "file": "passed",
         "inline": "passed",
         "properties 1": Array [

--- a/test/snapshots/test/fixtures/custom-matcher/basic.test.ts
+++ b/test/snapshots/test/fixtures/custom-matcher/basic.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, Snapshots } from 'vitest'
+import { expect, test, Snapshots, chai } from 'vitest'
 
 const {
   toMatchFileSnapshot,
@@ -11,6 +11,7 @@ interface CustomMatchers<R = unknown> {
   toMatchCustomSnapshot: (properties?: object) => R
   toMatchCustomInlineSnapshot: (snapshot?: string) => R
   toMatchCustomFileSnapshot: (filepath: string) => Promise<R>
+  toMatchCustomAsyncInlineSnapshot: (snapshot?: string) => Promise<R>
 }
 
 declare module 'vitest' {
@@ -44,6 +45,21 @@ expect.extend({
     const result = await toMatchFileSnapshot.call(this, actualCustom, filepath)
     return { ...result, message: () => `[custom error] ${result.message()}` }
   },
+  async toMatchCustomAsyncInlineSnapshot(
+    actual: string,
+    inlineSnapshot?: string,
+  ) {
+    chai.util.flag(this.assertion, 'error', new Error("__STACK_TRACE__"))
+    await Promise.resolve()
+    const inner = async () => {
+      await Promise.resolve()
+      const actualCustom = formatCustom(actual)
+      const result = toMatchInlineSnapshot.call(this, actualCustom, inlineSnapshot)
+      return { ...result, message: () => `[custom error] ${result.message()}` }
+    }
+    const result = await inner();
+    return result;
+  }
 })
 
 test('file', () => {
@@ -67,6 +83,15 @@ test('inline', () => {
     Object {
       "length": 6,
       "reversed": "eheheh",
+    }
+  `)
+})
+
+test('async inline', async () => {
+  await expect(`huhuhu`).toMatchCustomAsyncInlineSnapshot(`
+    Object {
+      "length": 6,
+      "reversed": "uhuhuh",
     }
   `)
 })

--- a/test/snapshots/test/fixtures/custom-matcher/basic.test.ts
+++ b/test/snapshots/test/fixtures/custom-matcher/basic.test.ts
@@ -49,7 +49,7 @@ expect.extend({
     actual: string,
     inlineSnapshot?: string,
   ) {
-    chai.util.flag(this.assertion, 'error', new Error("__STACK_TRACE__"))
+    chai.util.flag(this.assertion, 'error', new Error())
     await Promise.resolve()
     const inner = async () => {
       await Promise.resolve()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- closes https://github.com/vitest-dev/vitest/issues/10106

Currently users need to manually setup chai `error` flag at the top of custom matcher. We could technically do the same if we capture `new Error` automatically in `__VITEST_EXTEND_ASSERTION__`, but I'm a bit hesitant to do unconditionally as it might hit perf.

https://github.com/vitest-dev/vitest/blob/6342b35f27e9fdeed929bd970038231a79ab9ab7/packages/expect/src/jest-extend.ts#L93-L96

For now, I'd suggest using `chai.util.flag(this.assertion, 'error', new Error))` manually for custom inline snapshot matcher since they kinda already looks official-ish API.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
