### PR TITLE
feat(coverage): istanbul to support `instrumenter` option

### DIFF
--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -418,21 +418,17 @@ interface CoverageInstrumenter {
 <!-- eslint-skip -->
 ```ts
 import { defineConfig } from 'vitest/config'
-import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest'
+import { createInstrumenter } from '@vitest/some-custom-instrumenter'
 
 export default defineConfig({
   test: {
     coverage: {
       provider: 'istanbul',
-      instrumenter: options => createOxcInstrumenter(options),
+      instrumenter: options => createInstrumenter(options),
     }
   }
 })
-```
 
-Known implementations:
-
-- [`oxc-coverage-instrument`](https://github.com/fallow-rs/oxc-coverage-instrument): Oxc-based instrumenter with a dedicated `oxc-coverage-instrument/vitest` entry point.
 
 ## coverage.customProviderModule
 

--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -390,7 +390,7 @@ Watermarks for statements, lines, branches and functions. See [istanbul document
 
 Concurrency limit used when processing the coverage results.
 
-## coverage.instrumenter
+## coverage.instrumenter <Version type="experimental">4.1.5</Version> {#coverage-instrumenter}
 
 - **Type:** `(options: InstrumenterOptions) => CoverageInstrumenter`
 - **Available for providers:** `'istanbul'`

--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -390,6 +390,50 @@ Watermarks for statements, lines, branches and functions. See [istanbul document
 
 Concurrency limit used when processing the coverage results.
 
+## coverage.instrumenter
+
+- **Type:** `(options: InstrumenterOptions) => CoverageInstrumenter`
+- **Available for providers:** `'istanbul'`
+
+Factory for a custom instrumenter to use in place of the default `istanbul-lib-instrument`. Vitest calls the factory once during initialization and reuses the returned instrumenter for every file. The rest of the Istanbul pipeline (collection, merging, reporting) is unchanged.
+
+The factory receives an `InstrumenterOptions` object with Vitest's runtime coverage settings, and must return an object implementing the `CoverageInstrumenter` interface. Both types are exported from `vitest/node`.
+
+<!-- eslint-skip -->
+```ts
+interface InstrumenterOptions {
+  coverageVariable: string
+  coverageGlobalScope: string
+  coverageGlobalScopeFunc: boolean
+  ignoreClassMethods: string[]
+}
+
+interface CoverageInstrumenter {
+  instrumentSync: (code: string, filename: string, inputSourceMap?: any) => string
+  lastSourceMap: () => any
+  lastFileCoverage: () => any
+}
+```
+
+<!-- eslint-skip -->
+```ts
+import { defineConfig } from 'vitest/config'
+import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'istanbul',
+      instrumenter: options => createOxcInstrumenter(options),
+    }
+  }
+})
+```
+
+Known implementations:
+
+- [`oxc-coverage-instrument`](https://github.com/fallow-rs/oxc-coverage-instrument): Oxc-based instrumenter with a dedicated `oxc-coverage-instrument/vitest` entry point.
+
 ## coverage.customProviderModule
 
 - **Type:** `string`

--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -428,7 +428,7 @@ export default defineConfig({
     }
   }
 })
-
+```
 
 ## coverage.customProviderModule
 

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -34,6 +34,8 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
     if (this.options.instrumenter) {
       this.instrumenter = this.options.instrumenter({
         coverageVariable: COVERAGE_STORE_KEY,
+        coverageGlobalScope: 'globalThis',
+        coverageGlobalScopeFunc: false,
         ignoreClassMethods: this.options.ignoreClassMethods,
       }) as Instrumenter
     }

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -31,27 +31,32 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
   initialize(ctx: Vitest): void {
     this._initialize(ctx)
 
-    this.instrumenter = createInstrumenter({
-      produceSourceMap: true,
-      autoWrap: false,
-      esModules: true,
-      compact: false,
-      coverageVariable: COVERAGE_STORE_KEY,
-      coverageGlobalScope: 'globalThis',
-      coverageGlobalScopeFunc: false,
-      ignoreClassMethods: this.options.ignoreClassMethods,
-      parserPlugins: [
-        ...istanbulDefaults.instrumenter.parserPlugins,
-        ['importAttributes', { deprecatedAssertSyntax: true }],
-      ],
-      generatorOpts: {
-        // @ts-expect-error missing type
-        importAttributesKeyword: 'with',
-      },
+    if (this.options.instrumenter) {
+      this.instrumenter = this.options.instrumenter(this.options) as Instrumenter
+    }
+    else {
+      this.instrumenter = createInstrumenter({
+        produceSourceMap: true,
+        autoWrap: false,
+        esModules: true,
+        compact: false,
+        coverageVariable: COVERAGE_STORE_KEY,
+        coverageGlobalScope: 'globalThis',
+        coverageGlobalScopeFunc: false,
+        ignoreClassMethods: this.options.ignoreClassMethods,
+        parserPlugins: [
+          ...istanbulDefaults.instrumenter.parserPlugins,
+          ['importAttributes', { deprecatedAssertSyntax: true }],
+        ],
+        generatorOpts: {
+          // @ts-expect-error missing type
+          importAttributesKeyword: 'with',
+        },
 
-      // Custom option from the patched istanbul-lib-instrument: https://github.com/istanbuljs/istanbuljs/pull/835
-      ignoreLines: true,
-    })
+        // Custom option from the patched istanbul-lib-instrument: https://github.com/istanbuljs/istanbuljs/pull/835
+        ignoreLines: true,
+      })
+    }
   }
 
   requiresTransform(id: string): boolean {

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -32,7 +32,10 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
     this._initialize(ctx)
 
     if (this.options.instrumenter) {
-      this.instrumenter = this.options.instrumenter(this.options) as Instrumenter
+      this.instrumenter = this.options.instrumenter({
+        coverageVariable: COVERAGE_STORE_KEY,
+        ignoreClassMethods: this.options.ignoreClassMethods,
+      }) as Instrumenter
     }
     else {
       this.instrumenter = createInstrumenter({

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -356,11 +356,11 @@ interface Thresholds {
  */
 export interface CoverageInstrumenter {
   /** Instrument source code synchronously. Returns the instrumented code string. */
-  instrumentSync(code: string, filename: string, inputSourceMap?: any): string
+  instrumentSync: (code: string, filename: string, inputSourceMap?: any) => string
   /** Get the source map of the last instrumented file. */
-  lastSourceMap(): any
+  lastSourceMap: () => any
   /** Get the Istanbul-compatible file coverage object of the last instrumented file. */
-  lastFileCoverage(): any
+  lastFileCoverage: () => any
 }
 
 /** @deprecated Use `CoverageOptions` instead */

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -294,8 +294,7 @@ export interface CoverageOptions {
    *     }
    *   }
    * })
-   * ```
-   */
+   * 
   instrumenter?: (options: InstrumenterOptions) => CoverageInstrumenter
 
   /**

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -294,7 +294,7 @@ export interface CoverageOptions {
    *     }
    *   }
    * })
-   * 
+   *
    * @experimental
    */
   instrumenter?: (options: InstrumenterOptions) => CoverageInstrumenter

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -274,11 +274,9 @@ export interface CoverageOptions {
   /**
    * Custom instrumenter factory to use instead of the default `istanbul-lib-instrument`.
    *
-   * The factory receives the resolved coverage options and must return an object
-   * implementing the `Instrumenter` interface:
-   * - `instrumentSync(code, filename, inputSourceMap?)` — returns instrumented code
-   * - `lastSourceMap()` — returns the source map of the last instrumented file
-   * - `lastFileCoverage()` — returns the coverage object of the last instrumented file
+   * The factory receives options including `coverageVariable` (the global variable
+   * name Vitest uses to store coverage data) and must return an object implementing
+   * the `CoverageInstrumenter` interface.
    *
    * This allows using faster instrumenters (e.g., oxc-coverage-instrument, SWC) while
    * keeping the Istanbul coverage pipeline for collection, merging, and reporting.
@@ -292,13 +290,13 @@ export interface CoverageOptions {
    *   test: {
    *     coverage: {
    *       provider: 'istanbul',
-   *       instrumenter: (options) => createOxcInstrumenter(options),
+   *       instrumenter: options => createOxcInstrumenter(options),
    *     }
    *   }
    * })
    * ```
    */
-  instrumenter?: (options: ResolvedCoverageOptions) => CoverageInstrumenter
+  instrumenter?: (options: InstrumenterOptions) => CoverageInstrumenter
 
   /**
    * Directory of HTML coverage output to be served in UI mode and HTML reporter.
@@ -345,6 +343,16 @@ interface Thresholds {
 
   /** Thresholds for lines */
   lines?: number
+}
+
+/**
+ * Options passed to the custom instrumenter factory.
+ */
+export interface InstrumenterOptions {
+  /** Global variable name that Vitest uses to store coverage data at runtime. */
+  coverageVariable: string
+  /** Class method names to exclude from function coverage. */
+  ignoreClassMethods: string[]
 }
 
 /**

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -274,9 +274,9 @@ export interface CoverageOptions {
   /**
    * Custom instrumenter factory to use instead of the default `istanbul-lib-instrument`.
    *
-   * The factory receives options including `coverageVariable` (the global variable
-   * name Vitest uses to store coverage data) and must return an object implementing
-   * the `CoverageInstrumenter` interface.
+   * The factory receives the same runtime coverage options Vitest passes to its
+   * built-in Istanbul instrumenter and must return an object implementing the
+   * `CoverageInstrumenter` interface.
    *
    * This allows using faster instrumenters (e.g., oxc-coverage-instrument, SWC) while
    * keeping the Istanbul coverage pipeline for collection, merging, and reporting.
@@ -351,6 +351,10 @@ interface Thresholds {
 export interface InstrumenterOptions {
   /** Global variable name that Vitest uses to store coverage data at runtime. */
   coverageVariable: string
+  /** Global scope where the coverage variable is attached at runtime. */
+  coverageGlobalScope: string
+  /** Whether the coverage global scope should be resolved through an evaluated function. */
+  coverageGlobalScopeFunc: boolean
   /** Class method names to exclude from function coverage. */
   ignoreClassMethods: string[]
 }

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -272,6 +272,35 @@ export interface CoverageOptions {
   ignoreClassMethods?: string[]
 
   /**
+   * Custom instrumenter factory to use instead of the default `istanbul-lib-instrument`.
+   *
+   * The factory receives the resolved coverage options and must return an object
+   * implementing the `Instrumenter` interface:
+   * - `instrumentSync(code, filename, inputSourceMap?)` — returns instrumented code
+   * - `lastSourceMap()` — returns the source map of the last instrumented file
+   * - `lastFileCoverage()` — returns the coverage object of the last instrumented file
+   *
+   * This allows using faster instrumenters (e.g., oxc-coverage-instrument, SWC) while
+   * keeping the Istanbul coverage pipeline for collection, merging, and reporting.
+   *
+   * @example
+   * ```ts
+   * import { defineConfig } from 'vitest/config'
+   * import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest'
+   *
+   * export default defineConfig({
+   *   test: {
+   *     coverage: {
+   *       provider: 'istanbul',
+   *       instrumenter: (options) => createOxcInstrumenter(options),
+   *     }
+   *   }
+   * })
+   * ```
+   */
+  instrumenter?: (options: ResolvedCoverageOptions) => CoverageInstrumenter
+
+  /**
    * Directory of HTML coverage output to be served in UI mode and HTML reporter.
    * This is automatically configured for builtin reporter with html output (`html`, `html-spa`, and `lcov` reporters).
    * Use this option to override with custom coverage reporting location.
@@ -316,6 +345,22 @@ interface Thresholds {
 
   /** Thresholds for lines */
   lines?: number
+}
+
+/**
+ * Interface for custom coverage instrumenters.
+ *
+ * Matches the subset of istanbul-lib-instrument's `Instrumenter` that Vitest
+ * actually uses. Implement this to plug in a faster instrumenter while keeping
+ * the Istanbul coverage pipeline for collection, merging, and reporting.
+ */
+export interface CoverageInstrumenter {
+  /** Instrument source code synchronously. Returns the instrumented code string. */
+  instrumentSync(code: string, filename: string, inputSourceMap?: any): string
+  /** Get the source map of the last instrumented file. */
+  lastSourceMap(): any
+  /** Get the Istanbul-compatible file coverage object of the last instrumented file. */
+  lastFileCoverage(): any
 }
 
 /** @deprecated Use `CoverageOptions` instead */

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -295,6 +295,8 @@ export interface CoverageOptions {
    *   }
    * })
    * 
+   * @experimental
+   */
   instrumenter?: (options: InstrumenterOptions) => CoverageInstrumenter
 
   /**

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -152,6 +152,7 @@ export type {
 } from '../node/types/config'
 export type {
   BaseCoverageOptions,
+  CoverageInstrumenter,
   CoverageIstanbulOptions,
   CoverageOptions,
   CoverageProvider,

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -160,6 +160,7 @@ export type {
   CoverageReporter,
   CoverageV8Options,
   CustomProviderOptions,
+  InstrumenterOptions,
   ReportContext,
   ResolvedCoverageOptions,
 } from '../node/types/coverage'

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -1,5 +1,5 @@
 import type { defineConfig } from 'vitest/config'
-import type { CoverageInstrumenter, CoverageProviderModule, ResolvedCoverageOptions, Vitest } from 'vitest/node'
+import type { CoverageInstrumenter, CoverageProviderModule, InstrumenterOptions, ResolvedCoverageOptions, Vitest } from 'vitest/node'
 import { assertType, test } from 'vitest'
 
 type NarrowToTestConfig<T> = T extends { test?: any } ? NonNullable<T['test']> : never
@@ -213,7 +213,7 @@ test('custom instrumenter', () => {
   // Custom instrumenter factory function
   assertType<Coverage>({
     provider: 'istanbul',
-    instrumenter: (_options) => ({
+    instrumenter: _options => ({
       instrumentSync: (code, _filename, _sourceMap?) => code,
       lastSourceMap: () => ({}),
       lastFileCoverage: () => ({}),
@@ -226,8 +226,8 @@ test('custom instrumenter', () => {
   })
 
   // Verify CoverageInstrumenter type can be used as return type
-  const factory = (_options: ResolvedCoverageOptions): CoverageInstrumenter => ({
-    instrumentSync: (code) => code,
+  const factory: (opts: InstrumenterOptions) => CoverageInstrumenter = _opts => ({
+    instrumentSync: code => code,
     lastSourceMap: () => null,
     lastFileCoverage: () => ({}),
   })

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -1,5 +1,5 @@
 import type { defineConfig } from 'vitest/config'
-import type { CoverageProviderModule, ResolvedCoverageOptions, Vitest } from 'vitest/node'
+import type { CoverageInstrumenter, CoverageProviderModule, ResolvedCoverageOptions, Vitest } from 'vitest/node'
 import { assertType, test } from 'vitest'
 
 type NarrowToTestConfig<T> = T extends { test?: any } ? NonNullable<T['test']> : never
@@ -206,5 +206,33 @@ test('reporters, mixed variations', () => {
       ['html', { verbose: true, subdir: 'string' }],
       ['custom-reporter-4', { some: 'option', width: 123 }],
     ],
+  })
+})
+
+test('custom instrumenter', () => {
+  // Custom instrumenter factory function
+  assertType<Coverage>({
+    provider: 'istanbul',
+    instrumenter: (_options) => ({
+      instrumentSync: (code, _filename, _sourceMap?) => code,
+      lastSourceMap: () => ({}),
+      lastFileCoverage: () => ({}),
+    }),
+  })
+
+  // Without instrumenter (default behavior)
+  assertType<Coverage>({
+    provider: 'istanbul',
+  })
+
+  // Verify CoverageInstrumenter type can be used as return type
+  const factory = (_options: ResolvedCoverageOptions): CoverageInstrumenter => ({
+    instrumentSync: (code) => code,
+    lastSourceMap: () => null,
+    lastFileCoverage: () => ({}),
+  })
+  assertType<Coverage>({
+    provider: 'istanbul',
+    instrumenter: factory,
   })
 })

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -231,6 +231,14 @@ test('custom instrumenter', () => {
     lastSourceMap: () => null,
     lastFileCoverage: () => ({}),
   })
+
+  assertType<InstrumenterOptions>({
+    coverageVariable: '__VITEST_COVERAGE__',
+    coverageGlobalScope: 'globalThis',
+    coverageGlobalScopeFunc: false,
+    ignoreClassMethods: ['test-method'],
+  })
+
   assertType<Coverage>({
     provider: 'istanbul',
     instrumenter: factory,

--- a/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
+++ b/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
@@ -1,47 +1,42 @@
-import { createInstrumenter } from 'istanbul-lib-instrument'
 import { expect } from 'vitest'
-import { sum } from '../fixtures/src/math'
-import { coverageTest, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
+import { normalizeURL, runVitest, test } from '../utils'
 
-test('custom instrumenter is used when provided', async () => {
+test('custom instrumenter receives correct options', async () => {
+  let receivedOptions: any = null
+
   await runVitest({
     include: [normalizeURL(import.meta.url)],
     coverage: {
       reporter: 'json',
-      instrumenter: () => {
-        // Use the default istanbul instrumenter but through the custom interface,
-        // proving the pluggable architecture works end-to-end.
-        const defaultInstrumenter = createInstrumenter({
-          produceSourceMap: true,
-          autoWrap: false,
-          esModules: true,
-          compact: false,
-          coverageVariable: '__VITEST_COVERAGE__',
-          coverageGlobalScope: 'globalThis',
-          coverageGlobalScopeFunc: false,
-        })
+      ignoreClassMethods: ['test-method'],
+      instrumenter: options => {
+        receivedOptions = options
 
+        // Return a passthrough instrumenter — no actual instrumentation,
+        // just verifying the factory is called with the right options.
         return {
-          instrumentSync: (code: string, filename: string, sourceMap?: any) =>
-            defaultInstrumenter.instrumentSync(code, filename, sourceMap),
-          lastSourceMap: () =>
-            defaultInstrumenter.lastSourceMap(),
-          lastFileCoverage: () =>
-            defaultInstrumenter.lastFileCoverage(),
+          instrumentSync: code => code,
+          lastSourceMap: () => ({}),
+          lastFileCoverage: () => ({
+            path: 'test.ts',
+            statementMap: {},
+            fnMap: {},
+            branchMap: {},
+            s: {},
+            f: {},
+            b: {},
+          }),
         }
       },
     },
-  })
+  }, { throwOnError: false })
 
-  // Coverage should work with the custom instrumenter
-  const coverageMap = await readCoverageMap()
-  const files = coverageMap.files()
-  expect(files.length).toBeGreaterThan(0)
+  // The custom instrumenter factory should have been called
+  expect(receivedOptions).not.toBeNull()
 
-  const mathCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/math.ts')
-  expect(Object.keys(mathCoverage.fnMap).length).toBeGreaterThan(0)
-})
+  // It should receive the coverage variable used by Vitest internally
+  expect(receivedOptions.coverageVariable).toBe('__VITEST_COVERAGE__')
 
-coverageTest('cover math module', () => {
-  expect(sum(1, 2)).toBe(3)
+  // It should receive the ignoreClassMethods option
+  expect(receivedOptions.ignoreClassMethods).toEqual(['test-method'])
 })

--- a/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
+++ b/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
@@ -9,7 +9,7 @@ test('custom instrumenter receives correct options', async () => {
     coverage: {
       reporter: 'json',
       ignoreClassMethods: ['test-method'],
-      instrumenter: options => {
+      instrumenter: (options) => {
         receivedOptions = options
 
         // Return a passthrough instrumenter — no actual instrumentation,

--- a/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
+++ b/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
@@ -1,42 +1,34 @@
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
 import { normalizeURL, runVitest, test } from '../utils'
 
 test('custom instrumenter receives correct options', async () => {
-  let receivedOptions: any = null
+  const instrumenter = vi.fn().mockReturnValue({
+    instrumentSync: code => code,
+    lastSourceMap: () => ({}),
+    lastFileCoverage: () => ({
+      path: 'test.ts',
+      statementMap: {},
+      fnMap: {},
+      branchMap: {},
+      s: {},
+      f: {},
+      b: {},
+    }),
+  })
 
   await runVitest({
     include: [normalizeURL(import.meta.url)],
     coverage: {
       reporter: 'json',
       ignoreClassMethods: ['test-method'],
-      instrumenter: (options) => {
-        receivedOptions = options
-
-        // Return a passthrough instrumenter — no actual instrumentation,
-        // just verifying the factory is called with the right options.
-        return {
-          instrumentSync: code => code,
-          lastSourceMap: () => ({}),
-          lastFileCoverage: () => ({
-            path: 'test.ts',
-            statementMap: {},
-            fnMap: {},
-            branchMap: {},
-            s: {},
-            f: {},
-            b: {},
-          }),
-        }
-      },
+      instrumenter,
     },
   }, { throwOnError: false })
 
-  // The custom instrumenter factory should have been called
-  expect(receivedOptions).not.toBeNull()
-
-  // It should receive the coverage variable used by Vitest internally
-  expect(receivedOptions.coverageVariable).toBe('__VITEST_COVERAGE__')
-
-  // It should receive the ignoreClassMethods option
-  expect(receivedOptions.ignoreClassMethods).toEqual(['test-method'])
+  expect(instrumenter).toHaveBeenCalledWith({
+    coverageVariable: '__VITEST_COVERAGE__',
+    coverageGlobalScope: 'globalThis',
+    coverageGlobalScopeFunc: false,
+    ignoreClassMethods: ['test-method'],
+  })
 })

--- a/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
+++ b/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
@@ -3,7 +3,7 @@ import { normalizeURL, runVitest, test } from '../utils'
 
 test('custom instrumenter receives correct options', async () => {
   const instrumenter = vi.fn().mockReturnValue({
-    instrumentSync: code => code,
+    instrumentSync: (code: string) => code,
     lastSourceMap: () => ({}),
     lastFileCoverage: () => ({
       path: 'test.ts',

--- a/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
+++ b/test/coverage-test/test/custom-instrumenter.istanbul.test.ts
@@ -1,0 +1,47 @@
+import { createInstrumenter } from 'istanbul-lib-instrument'
+import { expect } from 'vitest'
+import { sum } from '../fixtures/src/math'
+import { coverageTest, normalizeURL, readCoverageMap, runVitest, test } from '../utils'
+
+test('custom instrumenter is used when provided', async () => {
+  await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    coverage: {
+      reporter: 'json',
+      instrumenter: () => {
+        // Use the default istanbul instrumenter but through the custom interface,
+        // proving the pluggable architecture works end-to-end.
+        const defaultInstrumenter = createInstrumenter({
+          produceSourceMap: true,
+          autoWrap: false,
+          esModules: true,
+          compact: false,
+          coverageVariable: '__VITEST_COVERAGE__',
+          coverageGlobalScope: 'globalThis',
+          coverageGlobalScopeFunc: false,
+        })
+
+        return {
+          instrumentSync: (code: string, filename: string, sourceMap?: any) =>
+            defaultInstrumenter.instrumentSync(code, filename, sourceMap),
+          lastSourceMap: () =>
+            defaultInstrumenter.lastSourceMap(),
+          lastFileCoverage: () =>
+            defaultInstrumenter.lastFileCoverage(),
+        }
+      },
+    },
+  })
+
+  // Coverage should work with the custom instrumenter
+  const coverageMap = await readCoverageMap()
+  const files = coverageMap.files()
+  expect(files.length).toBeGreaterThan(0)
+
+  const mathCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/math.ts')
+  expect(Object.keys(mathCoverage.fnMap).length).toBeGreaterThan(0)
+})
+
+coverageTest('cover math module', () => {
+  expect(sum(1, 2)).toBe(3)
+})


### PR DESCRIPTION
## Summary

Adds a `coverage.instrumenter` option to `@vitest/coverage-istanbul` that allows plugging in a custom instrumenter instead of the default `istanbul-lib-instrument`. This is the approach @AriPerkkio suggested in #8292.

## Changes

- **`packages/vitest/src/node/types/coverage.ts`** — `CoverageInstrumenter` + `InstrumenterOptions` interfaces, `instrumenter` factory option
- **`packages/coverage-istanbul/src/provider.ts`** — use custom instrumenter in `initialize()` when provided, passes `coverageVariable` + `ignoreClassMethods`
- **`packages/vitest/src/public/node.ts`** — export `CoverageInstrumenter` and `InstrumenterOptions` from `vitest/node`
- **`test/coverage-test/test/configuration-options.test-d.ts`** — type tests
- **`test/coverage-test/test/custom-instrumenter.istanbul.test.ts`** — integration test

## Motivation

The Istanbul coverage pipeline (collection, merging, reporting) is battle-tested. The bottleneck is instrumentation. This PR decouples it, letting users swap in faster instrumenters.

Example with [oxc-coverage-instrument](https://github.com/fallow-rs/oxc-coverage-instrument) v0.3.0:

```typescript
import { defineConfig } from 'vitest/config'
import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest'

export default defineConfig({
  test: {
    coverage: {
      provider: 'istanbul',
      instrumenter: (options) => createOxcInstrumenter(options),
    }
  }
})
```

Performance (single `instrumentSync` call, same Node.js process):

| File | istanbul-lib | oxc v0.3.0 | Speedup |
|:-----|:-------------|:-----------|:--------|
| react (107 KB) | 51 ms | **2.1 ms** | 24x |
| lodash (531 KB) | 168 ms | **8.4 ms** | 20x |
| three.js (1.2 MB) | 837 ms | **35 ms** | 24x |

## Test plan

- [x] Type tests for `instrumenter` option and `CoverageInstrumenter` interface
- [x] Integration test with custom instrumenter
- [x] `CoverageInstrumenter` + `InstrumenterOptions` exported from `vitest/node`
- [x] Default behavior unchanged when `instrumenter` is not provided
- [x] Lint passes

## AI disclosure

This PR was developed with AI assistance (Claude).

Closes #8292