### PR TITLE
feat: allow scoping `slowTestThreshold` to project or a tag

### DIFF
--- a/docs/config/slowtestthreshold.md
+++ b/docs/config/slowtestthreshold.md
@@ -3,7 +3,7 @@ title: slowTestThreshold | Config
 outline: deep
 ---
 
-# slowTestThreshold <CRoot />
+# slowTestThreshold
 
 - **Type**: `number`
 - **Default**: `300`

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -384,6 +384,7 @@ function createSuiteCollector(
       annotations: [],
       artifacts: [],
       tags: testTags,
+      slowTestThreshold: options.slowTestThreshold,
     }
     const handler = options.handler
     if (task.mode === 'run' && !handler) {

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -340,6 +340,11 @@ export interface Test<ExtraContext = object> extends TaskPopulated {
    */
   artifacts: TestArtifact[]
   fullTestName: string
+  /**
+   * Threshold in milliseconds for a test to be considered slow.
+   * Overrides the global `slowTestThreshold` config option.
+   */
+  slowTestThreshold?: number
 }
 
 export type Task = Test | Suite | File
@@ -582,6 +587,11 @@ export interface TestOptions {
    * Custom test metadata available to reporters.
    */
   meta?: Partial<TaskMeta>
+  /**
+   * Threshold in milliseconds for a test to be considered slow.
+   * Overrides the global `slowTestThreshold` config option.
+   */
+  slowTestThreshold?: number
 }
 
 export interface TestTags {}

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "types": ["node"],
     "isolatedDeclarations": true
   },
   "include": ["./src/**/*.ts"],

--- a/packages/ui/client/composables/explorer/filter.ts
+++ b/packages/ui/client/composables/explorer/filter.ts
@@ -222,7 +222,7 @@ function* filterParents(
 function matchState(task: Task, filter: Filter) {
   if (filter.slow) {
     if (task.type === 'test') {
-      const threshold = config.value.slowTestThreshold
+      const threshold = task.slowTestThreshold ?? config.value.slowTestThreshold
       if (typeof threshold === 'number' && typeof task.result?.duration === 'number' && task.result.duration > threshold) {
         return true
       }

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -43,7 +43,7 @@ export function isSlowTestTask(task: Task) {
     return false
   }
 
-  const threshold = config.value.slowTestThreshold
+  const threshold = task.slowTestThreshold ?? config.value.slowTestThreshold
   return typeof threshold === 'number' && duration > threshold
 }
 

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -203,7 +203,7 @@ export abstract class BaseReporter implements Reporter {
   protected printTestCase(moduleState: TestModuleState, test: TestCase): void {
     const testResult = test.result()
 
-    const { duration = 0 } = test.diagnostic() || {}
+    const diagnostic = test.diagnostic()
     const padding = this.getTestIndentation(test.task)
     const suffix = this.getTestCaseSuffix(test)
 
@@ -212,7 +212,7 @@ export abstract class BaseReporter implements Reporter {
     }
 
     // also print slow tests
-    else if (duration > this.ctx.config.slowTestThreshold) {
+    else if (diagnostic?.slow) {
       this.log(` ${padding}${c.yellow(c.dim(F_CHECK))} ${this.getTestName(test.task, separator)} ${suffix}`)
     }
 
@@ -372,7 +372,9 @@ export abstract class BaseReporter implements Reporter {
       return ''
     }
 
-    const color = duration > this.ctx.config.slowTestThreshold
+    const slowTestThreshold = ('slowTestThreshold' in task && task.slowTestThreshold)
+      || this.ctx.config.slowTestThreshold
+    const color = duration > slowTestThreshold
       ? c.yellow
       : c.green
 

--- a/packages/vitest/src/node/reporters/reported-tasks.ts
+++ b/packages/vitest/src/node/reporters/reported-tasks.ts
@@ -216,7 +216,8 @@ export class TestCase extends ReportedTaskImplementation {
       return undefined
     }
     const duration = result.duration || 0
-    const slow = duration > this.project.globalConfig.slowTestThreshold
+    const slowTestThreshold = this.task.slowTestThreshold ?? this.project.globalConfig.slowTestThreshold
+    const slow = duration > slowTestThreshold
     return {
       slow,
       heap: result.heap,
@@ -576,6 +577,11 @@ export interface TaskOptions {
    * Only tests have a `timeout` option.
    */
   readonly timeout: number | undefined
+  /**
+   * Threshold in milliseconds for a test to be considered slow.
+   * Only tests have a `slowTestThreshold` option.
+   */
+  readonly slowTestThreshold: number | undefined
   readonly mode: 'run' | 'only' | 'skip' | 'todo'
 }
 
@@ -591,6 +597,7 @@ function buildOptions(
     repeats: task.repeats,
     tags: task.tags,
     timeout: task.type === 'test' ? task.timeout : undefined,
+    slowTestThreshold: task.type === 'test' ? task.slowTestThreshold : undefined,
     // runner types are too broad, but the public API should be more strict
     // the queued state exists only on Files and this method is called
     // only for tests and suites

--- a/packages/vitest/src/node/reporters/summary.ts
+++ b/packages/vitest/src/node/reporters/summary.ts
@@ -183,9 +183,10 @@ export class SummaryReporter implements Reporter {
       onFinish: () => {},
     }
 
+    const slowTestThreshold = test.options.slowTestThreshold ?? this.ctx.config.slowTestThreshold
     const timeout = setTimeout(() => {
       slowTest.visible = true
-    }, this.ctx.config.slowTestThreshold).unref()
+    }, slowTestThreshold).unref()
 
     slowTest.onFinish = () => {
       slowTest.hook?.onFinish()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #10120

This is not finished yet, we need to figure out the logistics of the global `slowTestThreshold` (it wasn't even project-level before)

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
