### PR TITLE
feat(coverage): allow perFile to accept an object for separate per-fi…

### DIFF
--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -233,12 +233,48 @@ Global threshold for statements.
 
 ### coverage.thresholds.perFile
 
-- **Type:** `boolean`
+- **Type:** `boolean | { lines?: number; functions?: number; branches?: number; statements?: number }`
 - **Default:** `false`
 - **Available for providers:** `'v8' | 'istanbul'`
 - **CLI:** `--coverage.thresholds.perFile`, `--coverage.thresholds.perFile=false`
 
 Check thresholds per file.
+
+When set to `true`, the global threshold values are reused for every file.
+
+When set to an object, the top-level threshold values still apply to the global coverage summary, and the nested `perFile` values apply to each individual file.
+
+### coverage.thresholds.perFile.lines
+
+- **Type:** `number`
+- **Available for providers:** `'v8' | 'istanbul'`
+- **CLI:** `--coverage.thresholds.perFile.lines=<number>`
+
+Per-file threshold for lines.
+
+### coverage.thresholds.perFile.functions
+
+- **Type:** `number`
+- **Available for providers:** `'v8' | 'istanbul'`
+- **CLI:** `--coverage.thresholds.perFile.functions=<number>`
+
+Per-file threshold for functions.
+
+### coverage.thresholds.perFile.branches
+
+- **Type:** `number`
+- **Available for providers:** `'v8' | 'istanbul'`
+- **CLI:** `--coverage.thresholds.perFile.branches=<number>`
+
+Per-file threshold for branches.
+
+### coverage.thresholds.perFile.statements
+
+- **Type:** `number`
+- **Available for providers:** `'v8' | 'istanbul'`
+- **CLI:** `--coverage.thresholds.perFile.statements=<number>`
+
+Per-file threshold for statements.
 
 ### coverage.thresholds.autoUpdate
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -195,12 +195,33 @@ Do not show files with 100% statement, branch, and function coverage (default: `
 
 Shortcut to set all coverage thresholds to 100 (default: `false`)
 
-### coverage.thresholds.perFile
+### coverage.thresholds.perFile.lines
 
-- **CLI:** `--coverage.thresholds.perFile`
-- **Config:** [coverage.thresholds.perFile](/config/coverage#coverage-thresholds-perfile)
+- **CLI:** `--coverage.thresholds.perFile.lines <number>`
+- **Config:** [coverage.thresholds.perFile.lines](/config/coverage#coverage-thresholds-perfile-lines)
 
-Check thresholds per file. See `--coverage.thresholds.lines`, `--coverage.thresholds.functions`, `--coverage.thresholds.branches` and `--coverage.thresholds.statements` for the actual thresholds (default: `false`)
+Per-file threshold for lines. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers
+
+### coverage.thresholds.perFile.functions
+
+- **CLI:** `--coverage.thresholds.perFile.functions <number>`
+- **Config:** [coverage.thresholds.perFile.functions](/config/coverage#coverage-thresholds-perfile-functions)
+
+Per-file threshold for functions. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers
+
+### coverage.thresholds.perFile.branches
+
+- **CLI:** `--coverage.thresholds.perFile.branches <number>`
+- **Config:** [coverage.thresholds.perFile.branches](/config/coverage#coverage-thresholds-perfile-branches)
+
+Per-file threshold for branches. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers
+
+### coverage.thresholds.perFile.statements
+
+- **CLI:** `--coverage.thresholds.perFile.statements <number>`
+- **Config:** [coverage.thresholds.perFile.statements](/config/coverage#coverage-thresholds-perfile-statements)
+
+Per-file threshold for statements. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers
 
 ### coverage.thresholds.autoUpdate
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -215,7 +215,30 @@ export const cliOptionsConfig: VitestCLIOptions = {
         subcommands: {
           perFile: {
             description:
-              'Check thresholds per file. See `--coverage.thresholds.lines`, `--coverage.thresholds.functions`, `--coverage.thresholds.branches` and `--coverage.thresholds.statements` for the actual thresholds (default: `false`)',
+              'Check thresholds per file. Use this flag to reuse the global threshold values for every file, or configure `--coverage.thresholds.perFile.<name>` to set separate per-file thresholds (default: `false`)',
+            argument: '',
+            subcommands: {
+              lines: {
+                description:
+                  'Per-file threshold for lines. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers',
+                argument: '<number>',
+              },
+              functions: {
+                description:
+                  'Per-file threshold for functions. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers',
+                argument: '<number>',
+              },
+              branches: {
+                description:
+                  'Per-file threshold for branches. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers',
+                argument: '<number>',
+              },
+              statements: {
+                description:
+                  'Per-file threshold for statements. Visit [istanbuljs](https://github.com/istanbuljs/nyc#coverage-thresholds) for more information. This option is not available for custom providers',
+                argument: '<number>',
+              },
+            },
           },
           autoUpdate: {
             description:

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -465,28 +465,53 @@ export class BaseCoverageProvider {
    * Check collected coverage against configured thresholds. Sets exit code to 1 when thresholds not reached.
    */
   private checkThresholds(allThresholds: ResolvedThreshold[]) {
+    const perFile = this.options.thresholds?.perFile
+
+    // When perFile is an object, resolve its threshold values for per-file checks.
+    // When perFile is true, the same global thresholds are reused per file.
+    const perFileThresholds: ResolvedThreshold['thresholds'] | null
+      = perFile && typeof perFile === 'object'
+        ? resolveGlobThresholds(perFile)
+        : null
+
     for (const { coverageMap, thresholds, name } of allThresholds) {
       if (
         thresholds.branches === undefined
         && thresholds.functions === undefined
         && thresholds.lines === undefined
         && thresholds.statements === undefined
+        && !perFileThresholds
       ) {
         continue
       }
 
-      // Construct list of coverage summaries where thresholds are compared against
-      const summaries = this.options.thresholds?.perFile
-        ? coverageMap.files().map((file: string) => ({
-            file,
-            summary: coverageMap.fileCoverageFor(file).toSummary(),
-          }))
-        : [{ file: null, summary: coverageMap.getCoverageSummary() }]
+      // Construct list of coverage summaries where thresholds are compared against.
+      // When perFile is an object, we need BOTH the global aggregate (checked against
+      // the top-level thresholds) AND each individual file (checked against perFileThresholds).
+      // When perFile is true, only per-file entries are produced using the same thresholds.
+      // Otherwise only the global aggregate is produced.
+      const summaries = perFileThresholds
+          ? [
+              { file: null, summary: coverageMap.getCoverageSummary(), activeThresholds: thresholds },
+              ...coverageMap.files().map((file: string) => ({
+                file,
+                summary: coverageMap.fileCoverageFor(file).toSummary(),
+                activeThresholds: perFileThresholds,
+              })),
+            ]
+          : perFile
+            ? coverageMap.files().map((file: string) => ({
+                file,
+                summary: coverageMap.fileCoverageFor(file).toSummary(),
+                activeThresholds: thresholds,
+              }))
+            : [{ file: null, summary: coverageMap.getCoverageSummary(), activeThresholds: thresholds }]
 
       // Check thresholds of each summary
-      for (const { summary, file } of summaries) {
+      for (const { summary, file, activeThresholds } of summaries) {
+
         for (const thresholdKey of THRESHOLD_KEYS) {
-          const threshold = thresholds[thresholdKey]
+          const threshold = activeThresholds[thresholdKey]
 
           if (threshold === undefined) {
             continue
@@ -510,7 +535,7 @@ export class BaseCoverageProvider {
               let errorMessage = `ERROR: Coverage for ${thresholdKey} (${coverage}%) does not meet ${name === GLOBAL_THRESHOLDS_KEY ? name : `"${name}"`
               } threshold (${threshold}%)`
 
-              if (this.options.thresholds?.perFile && file) {
+              if (perFile && file) {
                 errorMessage += ` for ${relative('./', file).replace(/\\/g, '/')}`
               }
 
@@ -532,7 +557,7 @@ export class BaseCoverageProvider {
               let errorMessage = `ERROR: Uncovered ${thresholdKey} (${uncovered}) exceed ${name === GLOBAL_THRESHOLDS_KEY ? name : `"${name}"`
               } threshold (${absoluteThreshold})`
 
-              if (this.options.thresholds?.perFile && file) {
+              if (perFile && file) {
                 errorMessage += ` for ${relative('./', file).replace(/\\/g, '/')}`
               }
 

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -491,25 +491,24 @@ export class BaseCoverageProvider {
       // When perFile is true, only per-file entries are produced using the same thresholds.
       // Otherwise only the global aggregate is produced.
       const summaries = perFileThresholds
-          ? [
-              { file: null, summary: coverageMap.getCoverageSummary(), activeThresholds: thresholds },
-              ...coverageMap.files().map((file: string) => ({
-                file,
-                summary: coverageMap.fileCoverageFor(file).toSummary(),
-                activeThresholds: perFileThresholds,
-              })),
-            ]
-          : perFile
-            ? coverageMap.files().map((file: string) => ({
-                file,
-                summary: coverageMap.fileCoverageFor(file).toSummary(),
-                activeThresholds: thresholds,
-              }))
-            : [{ file: null, summary: coverageMap.getCoverageSummary(), activeThresholds: thresholds }]
+        ? [
+            { file: null, summary: coverageMap.getCoverageSummary(), activeThresholds: thresholds },
+            ...coverageMap.files().map((file: string) => ({
+              file,
+              summary: coverageMap.fileCoverageFor(file).toSummary(),
+              activeThresholds: perFileThresholds,
+            })),
+          ]
+        : perFile
+          ? coverageMap.files().map((file: string) => ({
+              file,
+              summary: coverageMap.fileCoverageFor(file).toSummary(),
+              activeThresholds: thresholds,
+            }))
+          : [{ file: null, summary: coverageMap.getCoverageSummary(), activeThresholds: thresholds }]
 
       // Check thresholds of each summary
       for (const { summary, file, activeThresholds } of summaries) {
-
         for (const thresholdKey of THRESHOLD_KEYS) {
           const threshold = activeThresholds[thresholdKey]
 

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -294,8 +294,25 @@ interface Thresholds {
   /** Set global thresholds to `100` */
   100?: boolean
 
-  /** Check thresholds per file. */
-  perFile?: boolean
+  /**
+   * Check thresholds per file.
+   *
+   * When set to `true`, the same global threshold values (`lines`, `branches`, etc.)
+   * are enforced on each individual file.
+   *
+   * When set to an object, those specific threshold values are enforced per file
+   * while the top-level thresholds still apply globally.
+   *
+   * @example
+   * ```ts
+   * // Each file must have at least 50% coverage, globally at least 80%
+   * thresholds: {
+   *   lines: 80,
+   *   perFile: { lines: 50 },
+   * }
+   * ```
+   */
+  perFile?: boolean | { lines?: number; branches?: number; functions?: number; statements?: number }
 
   /**
    * Update threshold values automatically when current coverage is higher than earlier thresholds

--- a/test/core/test/cli-test.test.ts
+++ b/test/core/test/cli-test.test.ts
@@ -136,6 +136,16 @@ test('coverage autoUpdate accepts boolean values from CLI', async () => {
   expect(getCLIOptions('--coverage.thresholds.autoUpdate no').coverage.thresholds.autoUpdate).toBe(false)
 })
 
+test('coverage perFile object thresholds are parsed from CLI', async () => {
+  expect(getCLIOptions(`
+    --coverage.thresholds.perFile.lines 80
+    --coverage.thresholds.perFile.functions 70
+  `).coverage.thresholds.perFile).toEqual({
+    lines: 80,
+    functions: 70,
+  })
+})
+
 test('bench only options', async () => {
   expect(() =>
     parseArguments('--compare file.json').matchedCommand?.checkUnknownOptions(),

--- a/test/coverage-test/test/configuration-options.test-d.ts
+++ b/test/coverage-test/test/configuration-options.test-d.ts
@@ -34,7 +34,10 @@ test('provider options, generic', () => {
       '100': true,
       'lines': 1,
       'autoUpdate': true,
-      'perFile': true,
+      'perFile': {
+        lines: 40,
+        functions: 50,
+      },
       'statements': 100,
 
       '**/some-file.ts': {
@@ -58,7 +61,10 @@ test('provider options, generic', () => {
       '100': false,
       'lines': 1,
       'autoUpdate': true,
-      'perFile': true,
+      'perFile': {
+        branches: 60,
+        statements: 70,
+      },
       'statements': 100,
 
       '**/some-file.ts': {

--- a/test/coverage-test/test/threshold-per-file-object.test.ts
+++ b/test/coverage-test/test/threshold-per-file-object.test.ts
@@ -1,0 +1,87 @@
+import { expect } from 'vitest'
+import { sum } from '../fixtures/src/math'
+import { coverageTest, normalizeURL, runVitest, test } from '../utils'
+
+test('perFile as object enforces per-file thresholds while global thresholds still apply', async () => {
+  // math.ts has ~25% line coverage when only sum() is called.
+  // Global threshold (lines: 10%) passes — no global error.
+  // Per-file threshold (lines: 100%) fails — per-file error with filename.
+  const { exitCode, stderr } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    coverage: {
+      include: ['**/fixtures/src/math.ts'],
+      thresholds: {
+        lines: 10,
+        perFile: { lines: 100 },
+      },
+    },
+  }, { throwOnError: false })
+
+  expect(exitCode).toBe(1)
+  // global passes (25% >= 10%) — no global error
+  expect(stderr).not.toContain('does not meet global threshold (10%)')
+  // per-file fails (25% < 100%) — error includes the filename
+  expect(stderr).toContain('does not meet global threshold (100%)')
+  expect(stderr).toContain('math.ts')
+})
+
+test('perFile as object failing global threshold also reported', async () => {
+  // Global threshold (lines: 90%) fails.
+  // Per-file threshold (lines: 100%) also fails.
+  // Both errors should appear.
+  const { exitCode, stderr } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    coverage: {
+      include: ['**/fixtures/src/math.ts'],
+      thresholds: {
+        lines: 90,
+        perFile: { lines: 100 },
+      },
+    },
+  }, { throwOnError: false })
+
+  expect(exitCode).toBe(1)
+  // global fails
+  expect(stderr).toContain('does not meet global threshold (90%)')
+  // per-file also fails with filename
+  expect(stderr).toContain('does not meet global threshold (100%)')
+  expect(stderr).toContain('math.ts')
+})
+
+test('perFile as object with passing thresholds does not fail', async () => {
+  const { exitCode } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    coverage: {
+      include: ['**/fixtures/src/math.ts'],
+      thresholds: {
+        lines: 10,
+        perFile: { lines: 10 },
+      },
+    },
+  })
+
+  expect(exitCode).toBe(0)
+})
+
+test('perFile as object only checks the keys specified in the object', async () => {
+  // Only lines is specified in perFile — functions/branches/statements not checked per file
+  const { exitCode, stderr } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    coverage: {
+      include: ['**/fixtures/src/math.ts'],
+      thresholds: {
+        perFile: { lines: 100 },
+      },
+    },
+  }, { throwOnError: false })
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain('lines')
+  expect(stderr).not.toContain('functions')
+  expect(stderr).not.toContain('branches')
+  expect(stderr).not.toContain('statements')
+})
+
+coverageTest('cover some lines', () => {
+  expect(sum(1, 2)).toBe(3)
+})


### PR DESCRIPTION
Closes #10114

perFile: true currently re-uses the same global threshold values for per-file checks, forcing users to choose between a project-wide average and per-file minimums — they can't enforce both at once.

This PR allows perFile to accept a threshold object. When it does, both run simultaneously: the top-level thresholds apply to the global aggregate, and the perFile object thresholds apply to each individual file.


// Require 80% lines globally, but each file must have at least 50%
coverage: {
  thresholds: {
    lines: 80,
    perFile: { lines: 50 },
  },
}
The existing perFile: true behaviour is unchanged.

Changes
packages/vitest/src/node/types/coverage.ts — perFile type widened to boolean | { lines?, branches?, functions?, statements? } with JSDoc example
packages/vitest/src/node/coverage.ts — checkThresholds() builds summaries for both the global aggregate and per-file entries when perFile is an object, each checked against their respective thresholds
test/coverage-test/test/threshold-per-file-object.test.ts — four tests covering: per-file fails while global passes, both fail, both pass, and only specified keys are checked per file