### PR TITLE
fix: support import.meta.env reassignment

### DIFF
--- a/packages/vitest/src/node/plugins/metaEnvReplacer.ts
+++ b/packages/vitest/src/node/plugins/metaEnvReplacer.ts
@@ -1,10 +1,27 @@
 import type { Plugin } from 'vite'
 import { cleanUrl } from '@vitest/utils/helpers'
+import { ancestor as walkAst } from 'acorn-walk'
 import MagicString from 'magic-string'
-import { stripLiteral } from 'strip-literal'
+import { parseAst } from 'vite'
 
-// so people can reassign envs at runtime
-// import.meta.env.VITE_NAME = 'app' -> process.env.VITE_NAME = 'app'
+const metaEnvAccessor = `Object.assign(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env)`
+
+function isImportMetaEnv(node: any): boolean {
+  return node?.type === 'MemberExpression'
+    && !node.computed
+    && node.property?.type === 'Identifier'
+    && node.property.name === 'env'
+    && node.object?.type === 'MetaProperty'
+    && node.object.meta?.name === 'import'
+    && node.object.property?.name === 'meta'
+}
+
+function getMetaEnvAssignmentExpression(rightSide: string): string {
+  return `void 0, ((__vitest_meta_env__, __vitest_env_value__) => { if (__vitest_env_value__ && typeof __vitest_env_value__ === 'object') { Object.assign(__vitest_meta_env__, __vitest_env_value__) } return __vitest_meta_env__ })(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env, ${rightSide})`
+}
+
+// Rewrite import.meta.env access so property writes keep mutating the worker env proxy.
+// Direct `import.meta.env = ...` assignments are handled as their own AST case.
 export function MetaEnvReplacerPlugin(): Plugin {
   return {
     name: 'vitest:meta-env-replacer',
@@ -15,21 +32,47 @@ export function MetaEnvReplacerPlugin(): Plugin {
       }
 
       let s: MagicString | null = null
-      const cleanCode = stripLiteral(code)
-      const envs = cleanCode.matchAll(/\bimport\.meta\.env\b/g)
+      const ast = parseAst(code)
+      const assignmentRanges: Array<{ start: number; end: number }> = []
 
-      for (const env of envs) {
-        s ||= new MagicString(code)
+      walkAst(ast as any, {
+        MemberExpression(node, ancestors) {
+          if (!isImportMetaEnv(node)) {
+            return
+          }
 
-        const startIndex = env.index!
-        const endIndex = startIndex + env[0].length
+          const parent = ancestors[ancestors.length - 2] as any
 
-        s.overwrite(
-          startIndex,
-          endIndex,
-          `Object.assign(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env)`,
-        )
-      }
+          if (
+            parent?.type === 'AssignmentExpression'
+            && parent.operator === '='
+            && parent.left === node
+          ) {
+            s ||= new MagicString(code)
+            assignmentRanges.push({
+              start: parent.start,
+              end: parent.end,
+            })
+            s.overwrite(
+              parent.start,
+              parent.end,
+              getMetaEnvAssignmentExpression(code.slice(parent.right.start, parent.right.end)),
+            )
+            return
+          }
+
+          if (assignmentRanges.some(range => node.start >= range.start && node.end <= range.end)) {
+            return
+          }
+
+          s ||= new MagicString(code)
+          s.overwrite(
+            node.start,
+            node.end,
+            metaEnvAccessor,
+          )
+        },
+      })
 
       if (s) {
         return {

--- a/packages/vitest/src/node/plugins/metaEnvReplacer.ts
+++ b/packages/vitest/src/node/plugins/metaEnvReplacer.ts
@@ -36,7 +36,7 @@ export function MetaEnvReplacerPlugin(): Plugin {
       const assignmentRanges: Array<{ start: number; end: number }> = []
 
       walkAst(ast as any, {
-        MemberExpression(node, ancestors) {
+        MemberExpression(node, _state, ancestors) {
           if (!isImportMetaEnv(node)) {
             return
           }

--- a/test/browser/test/env.test.ts
+++ b/test/browser/test/env.test.ts
@@ -10,6 +10,19 @@ test('can reassign env locally', () => {
   expect(import.meta.env.VITEST_ENV).toBe('TEST')
 })
 
+test('can reassign import.meta.env directly', () => {
+  const key = 'VITEST_IMPORT_META_ENV_ASSIGNMENT'
+
+  delete import.meta.env[key]
+
+  import.meta.env = import.meta.env || {}
+  import.meta.env[key] = 'true'
+
+  expect(import.meta.env[key]).toBe('true')
+
+  delete import.meta.env[key]
+})
+
 test('can reassign env everywhere', () => {
   import.meta.env.AUTH_TOKEN = '123'
   expect(getAuthToken()).toBe('123')

--- a/test/browser/test/env.test.ts
+++ b/test/browser/test/env.test.ts
@@ -15,6 +15,7 @@ test('can reassign import.meta.env directly', () => {
 
   delete import.meta.env[key]
 
+  // @ts-expect-error -- vitest rewrites this assignment at runtime via MetaEnvReplacerPlugin
   import.meta.env = import.meta.env || {}
   import.meta.env[key] = 'true'
 

--- a/test/core/test/env-jsdom.test.ts
+++ b/test/core/test/env-jsdom.test.ts
@@ -29,6 +29,7 @@ test('can reassign import.meta.env directly', () => {
 
   delete process.env[key]
 
+  // @ts-expect-error -- vitest rewrites this assignment at runtime via MetaEnvReplacerPlugin
   import.meta.env = import.meta.env || {}
   import.meta.env[key] = 'true'
 

--- a/test/core/test/env-jsdom.test.ts
+++ b/test/core/test/env-jsdom.test.ts
@@ -24,6 +24,20 @@ test('can reassign env locally', () => {
   expect(import.meta.env.VITEST_ENV).toBe('TEST')
 })
 
+test('can reassign import.meta.env directly', () => {
+  const key = 'VITEST_IMPORT_META_ENV_ASSIGNMENT'
+
+  delete process.env[key]
+
+  import.meta.env = import.meta.env || {}
+  import.meta.env[key] = 'true'
+
+  expect(import.meta.env[key]).toBe('true')
+  expect(process.env[key]).toBe('true')
+
+  delete process.env[key]
+})
+
 test('can reassign env everywhere', () => {
   import.meta.env.AUTH_TOKEN = '123'
   expect(getAuthToken()).toBe('123')

--- a/test/core/test/env.test.ts
+++ b/test/core/test/env.test.ts
@@ -27,6 +27,7 @@ test('can reassign import.meta.env directly', () => {
 
   delete process.env[key]
 
+  // @ts-expect-error -- vitest rewrites this assignment at runtime via MetaEnvReplacerPlugin
   import.meta.env = import.meta.env || {}
   import.meta.env[key] = 'true'
 

--- a/test/core/test/env.test.ts
+++ b/test/core/test/env.test.ts
@@ -22,6 +22,20 @@ test('can reassign env locally', () => {
   expect(import.meta.env.VITEST_ENV).toBe('TEST')
 })
 
+test('can reassign import.meta.env directly', () => {
+  const key = 'VITEST_IMPORT_META_ENV_ASSIGNMENT'
+
+  delete process.env[key]
+
+  import.meta.env = import.meta.env || {}
+  import.meta.env[key] = 'true'
+
+  expect(import.meta.env[key]).toBe('true')
+  expect(process.env[key]).toBe('true')
+
+  delete process.env[key]
+})
+
 test('can reassign env everywhere', () => {
   import.meta.env.AUTH_TOKEN = '123'
   expect(getAuthToken()).toBe('123')


### PR DESCRIPTION
Fixes #10091

`import.meta.env = ...` currently gets rewritten into a non-assignable expression, which causes a parse error before the test file can run.

This change handles direct `import.meta.env = ...` assignments as a dedicated AST rewrite while keeping the existing proxy-based rewrite for other `import.meta.env` access. That lets whole-object reassignment parse correctly and still keeps property reads/writes aligned with Vitest's worker env proxy.

Changes:
- rewrite direct `import.meta.env = ...` assignments to merge object values into the worker env proxy and return the proxy object
- keep the existing `import.meta.env` access rewrite for non-assignment cases
- add regression tests for direct `import.meta.env` reassignment in:
  - `test/core/test/env.test.ts`
  - `test/core/test/env-jsdom.test.ts`
  - `test/browser/test/env.test.ts`

Verification:
- `pnpm exec eslint packages/vitest/src/node/plugins/metaEnvReplacer.ts test/core/test/env.test.ts test/core/test/env-jsdom.test.ts test/browser/test/env.test.ts`
- `pnpm exec vitest run test/env.test.ts test/env-jsdom.test.ts`

I added the browser regression test, but I wasn't able to run the browser-side verification locally because this workspace picks up a parent PostCSS config that requires `autoprefixer` outside the Vitest repo checkout.

