### PR TITLE
fix(web-worker): support MessagePort objects referenced inside postMessage data (fix #9927)

### DIFF
--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -31,16 +31,14 @@ function createClonedMessageEvent(
   debug('clone worker message %o', data)
   const origin = typeof location === 'undefined' ? undefined : location.origin
   const ports = transfer?.filter((t): t is MessagePort => t instanceof MessagePort)
-  const transferWithoutPorts = transfer?.filter( // `ports` must be excluded from the `transfer` option passed to `structuredClone` to keep the MessagePort objects working correctly in the same thread.
-    t => !(t instanceof MessagePort),
-  )
 
   if (typeof structuredClone === 'function' && clone === 'native') {
     debug('create message event, using native structured clone')
+    const { data: clonedData, ports: clonedPorts } = structuredClone({ data, ports }, { transfer })
     return new MessageEvent('message', {
-      data: structuredClone(data, { transfer: transferWithoutPorts }),
+      data: clonedData,
       origin,
-      ports,
+      ports: clonedPorts,
     })
   }
   if (clone !== 'none') {

--- a/packages/web-worker/src/utils.ts
+++ b/packages/web-worker/src/utils.ts
@@ -34,6 +34,24 @@ function createClonedMessageEvent(
 
   if (typeof structuredClone === 'function' && clone === 'native') {
     debug('create message event, using native structured clone')
+    // A real Worker serializes `data` across realms and exposes the
+    // MessagePorts from `transfer` as `event.ports` on the receiving side.
+    // @vitest/web-worker runs both sides in a single realm, so we use
+    // `structuredClone` to emulate that transfer boundary.
+    //
+    // `MessageEvent.ports` must be the *cloned* ports returned by
+    // `structuredClone`, not the originals from `transfer`: once transferred,
+    // the originals are detached and can no longer communicate — e.g.
+    // `port1.postMessage(...)` on the caller side would not trigger
+    // `port2.onmessage` on a detached `port2`.
+    //
+    // `data` and `ports` must also be cloned in the *same* `structuredClone`
+    // call. A transferred object is detached immediately, so we cannot clone
+    // `data` first and then clone `ports` (or vice versa) — the second call
+    // would see already-detached ports. Passing them together as a single
+    // input also makes `structuredClone` deduplicate by identity, so a port
+    // referenced from inside `data` and from `transfer` resolves to the same
+    // transferred instance in the cloned graph.
     const { data: clonedData, ports: clonedPorts } = structuredClone({ data, ports }, { transfer })
     return new MessageEvent('message', {
       data: clonedData,

--- a/test/core/src/web-worker/worker.ts
+++ b/test/core/src/web-worker/worker.ts
@@ -1,6 +1,11 @@
 self.onmessage = (e) => {
   self.postMessage(`${e.data} world`)
 
+  const portPassedAsData = e.data?.port
+  if (portPassedAsData) {
+    portPassedAsData.postMessage(`Reply via port in data`)
+  }
+
   const port = e.ports[0]
   if (port) {
     port.postMessage(`${e.data} world via port`)

--- a/test/core/test/web-worker-node.test.ts
+++ b/test/core/test/web-worker-node.test.ts
@@ -226,7 +226,7 @@ cloneTypes.forEach((clone) => {
       process.env.VITEST_WEB_WORKER_CLONE = undefined
     })
 
-    it('transfers MessagePort objects to worker as event.ports', async () => {
+    it('transfers a MessagePort object in the transfer list to worker as event.ports[0]', async () => {
       expect.assertions(1)
 
       const worker = new MyWorker()
@@ -237,6 +237,19 @@ cloneTypes.forEach((clone) => {
       })
       worker.postMessage('hello', [channel.port2])
       await expect(promise).resolves.toBe('hello world via port')
+    })
+
+    it('transfers a MessagePort object in the data argument to worker and the passed port works', async () => {
+      expect.assertions(1)
+
+      const worker = new MyWorker()
+      const channel = new MessageChannel()
+      const promise = new Promise<string>((resolve, reject) => {
+        channel.port1.onmessage = e => resolve(e.data as string)
+        channel.port1.onmessageerror = reject
+      })
+      worker.postMessage({ port: channel.port2 }, [channel.port2])
+      await expect(promise).resolves.toBe('Reply via port in data')
     })
   })
 })

--- a/test/core/test/web-worker-node.test.ts
+++ b/test/core/test/web-worker-node.test.ts
@@ -239,7 +239,8 @@ cloneTypes.forEach((clone) => {
       await expect(promise).resolves.toBe('hello world via port')
     })
 
-    it('transfers a MessagePort object in the data argument to worker and the passed port works', async () => {
+    // Skipped for 'ponyfill' because it does not support transferring MessagePort objects.
+    it.skipIf(clone === 'ponyfill')('transfers a MessagePort object in the data argument to worker and the passed port works', async () => {
       expect.assertions(1)
 
       const worker = new MyWorker()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes `MessagePort` object transfer to cover the following case that was reported in #9927
```javascript
// Main thread
const channel = new MessageChannel();
worker.postMessage({ port: channel.port1 }, [channel.port1]);

// Worker thread
self.onmessage = (e) => {
  e.data.port.postMessage("some data")
}
```
keeping supporting the following case that was done by #9078.
```javascript
// Main thread
const channel = new MessageChannel();
worker.postMessage({}, [channel.port1]);

// Worker thread
self.onmessage = (e) => {
  e.ports[0].postMessage(`some data`)
}

```


Resolves #9927

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
