### PR TITLE
docs(browser): clarify userEvent.keyboard provider limitations

### DIFF
--- a/docs/api/browser/interactivity.md
+++ b/docs/api/browser/interactivity.md
@@ -283,6 +283,16 @@ The `userEvent.keyboard` allows you to trigger keyboard strokes. If any input ha
 
 This API supports [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard).
 
+::: warning
+Vitest supports Testing Library's `keyboard` syntax, but special key behavior still depends on the active browser provider.
+
+- For the best cross-provider compatibility, prefer generic keys such as `{Shift}`, `{Enter}`, `{Escape}`, `{Backspace}`, `{Tab}`, arrow keys, and release syntax like `{/Shift}`.
+- Left/right and location-specific variants such as `{ShiftLeft}`, `{ShiftRight}`, `[Shift]`, or `[ShiftRight]` are not implemented consistently across `playwright`, `webdriverio`, and `preview`.
+- The `preview` provider dispatches DOM events directly, so `KeyboardEvent.code` and `KeyboardEvent.location` can differ from automation providers.
+
+If your test relies on special-key semantics, verify it against the provider you run in CI.
+:::
+
 ```ts
 import { userEvent } from 'vitest/browser'
 
@@ -299,7 +309,7 @@ References:
 
 - [Playwright `Keyboard` API](https://playwright.dev/docs/api/class-keyboard)
 - [WebdriverIO `action('key')` API](https://webdriver.io/docs/api/browser/action#key-input-source)
-- [testing-library `type` API](https://testing-library.com/docs/user-event/utility/#type)
+- [testing-library `keyboard` API](https://testing-library.com/docs/user-event/keyboard)
 
 ## userEvent.tab
 
@@ -350,6 +360,8 @@ If you don't rely on [special characters](https://testing-library.com/docs/user-
 The `type` method implements `@testing-library/user-event`'s [`type`](https://testing-library.com/docs/user-event/utility/#type) utility built on top of [`keyboard`](https://testing-library.com/docs/user-event/keyboard) API.
 
 This function allows you to type characters into an `input`/`textarea`/`contenteditable` element. It supports [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard).
+
+Special key caveats are the same as [`userEvent.keyboard`](#userevent-keyboard): generic key aliases are the most portable, while left/right-specific variants can differ between providers.
 
 If you just need to press characters without an input, use [`userEvent.keyboard`](#userevent-keyboard) API.
 

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -270,6 +270,8 @@ export interface UserEvent {
    * Type text on the keyboard. If any input is focused, it will receive the text,
    * otherwise it will be typed on the document. Uses provider's API under the hood.
    * **Supports** [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard) (e.g., `{Shift}`) even with `playwright` and `webdriverio` providers.
+   * For cross-provider compatibility, prefer generic aliases like `{Shift}`, `{Enter}`, `{Escape}`, or `{Tab}`.
+   * Left/right-specific variants such as `{ShiftLeft}` can differ between providers.
    * @example
    * await userEvent.keyboard('foo') // translates to: f, o, o
    * await userEvent.keyboard('{{a[[') // translates to: {, a, [
@@ -282,6 +284,7 @@ export interface UserEvent {
   /**
    * Types text into an element. Uses provider's API under the hood.
    * **Supports** [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard) (e.g., `{Shift}`) even with `playwright` and `webdriverio` providers.
+   * Provider-specific special key caveats are the same as for `userEvent.keyboard`.
    * This method can be significantly slower than `userEvent.fill`, so it should be used only when necessary.
    * @example
    * await userEvent.type(input, 'foo') // translates to: f, o, o

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -69,12 +69,10 @@ test('click with modifier', async () => {
   await expect.poll(() => el.textContent).toContain("[ok]")
 })
 
-// TODO: https://github.com/vitest-dev/vitest/issues/7118
-// https://testing-library.com/docs/user-event/keyboard
-// https://github.com/testing-library/user-event/blob/main/src/keyboard/keyMap.ts
-// https://playwright.dev/docs/api/class-keyboard
-// https://webdriver.io/docs/api/browser/keys/
-test('special keys', async () => {
+// Provider-specific behavior referenced in https://github.com/vitest-dev/vitest/issues/7118.
+// These assertions document the current limits of special-key support so docs can be explicit
+// about which aliases are portable and which ones depend on the active provider.
+test('special key aliases differ between providers', async () => {
   async function testKeyboard(text: string) {
     let data: any;
     function handler(e: KeyboardEvent) {


### PR DESCRIPTION
Closes #7118

## Summary
- document that `userEvent.keyboard` supports Testing Library syntax, but special key behavior still depends on the active browser provider
- recommend generic key aliases like `{Shift}`, `{Enter}`, `{Escape}`, `{Backspace}`, `{Tab}`, and `{/Shift}` for cross-provider compatibility
- keep the existing special-key fixture coverage, but rename/comment it so the provider-specific behavior is explicitly documented
- align the API docs in `packages/browser/context.d.ts` with the browser interactivity docs
- fix the `userEvent.keyboard` docs reference to point to Testing Library's `keyboard` docs

## Testing
- `pnpm run build`
- `cd test/browser && PROVIDER=playwright BROWSER=chromium BROWSER_NO_WEBKIT=true pnpm exec vitest --config=vitest.config.unit.mts specs/runner.test.ts -t "user-event"`
- `cd test/browser && PROVIDER=webdriverio BROWSER=chrome pnpm exec vitest --config=vitest.config.unit.mts specs/runner.test.ts -t "user-event" --testTimeout=60000`