### PR TITLE
fix: preserve this context in defineHelper

### DIFF
--- a/packages/vitest/src/integrations/vi.ts
+++ b/packages/vitest/src/integrations/vi.ts
@@ -612,8 +612,8 @@ function createVitest(): VitestUtils {
     waitFor,
     waitUntil,
     defineHelper: (fn) => {
-      return function __VITEST_HELPER__(...args: any[]): any {
-        const result = fn(...args)
+      return function __VITEST_HELPER__(this: any, ...args: any[]): any {
+        const result = fn.call(this, ...args)
         if (result && typeof result === 'object' && typeof result.then === 'function') {
           return (async function __VITEST_HELPER__() {
             return await result


### PR DESCRIPTION
### Description

The `vi.defineHelper` function drops the `this` context, even though the type signature of `defineHelper` (`<F>(fn: F) => F`) suggests that the call signature is preserved exactly. This change simply calls the wrapped function with the same `this` that the wrapper receives.

I intended to add a test, but I wasn't able to understand the existing tests well enough to be sure I was doing it right. At the very least, no existing tests suddenly started failing.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
