### PR TITLE
fix: --project negation excludes browser instances

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1643,6 +1643,24 @@ export class Vitest {
       return regexp.test(name)
     })
   }
+
+  /**
+   * Check if the project with a given name is explicitly excluded
+   * by a negation pattern (e.g. `--project='!name'`).
+   */
+  isExcludedByProjectFilter(name: string): boolean {
+    const projects = this._config?.project || this._cliOptions?.project
+    if (!projects || !projects.length) {
+      return false
+    }
+    return toArray(projects).some((project) => {
+      if (!project.startsWith('!')) {
+        return false
+      }
+      const positivePattern = project.slice(1)
+      return wildcardPatternToRegExp(positivePattern).test(name)
+    })
+  }
 }
 
 function assert(condition: unknown, property: string, name: string = property): asserts condition {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1644,10 +1644,7 @@ export class Vitest {
     })
   }
 
-  /**
-   * Check if the project with a given name is explicitly excluded
-   * by a negation pattern (e.g. `--project='!name'`).
-   */
+  /** @internal */
   isExcludedByProjectFilter(name: string): boolean {
     const projects = this._config?.project || this._cliOptions?.project
     if (!projects || !projects.length) {

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -211,23 +211,20 @@ export async function resolveBrowserProjects(
     if (!project.config.browser.enabled) {
       return
     }
+    const originalName = project.config.name
     const instances = project.config.browser.instances || []
-    if (instances.length === 0) {
+    if (instances.length === 0 || vitest.isExcludedByProjectFilter(originalName)) {
       removeProjects.add(project)
       return
     }
-    const originalName = project.config.name
-    // if original name is explicitly excluded by a negation filter, exclude all instances
     // if original name matches a positive filter, keep all instances
     // otherwise, filter instances individually (user may target a specific instance name)
-    const filteredInstances = vitest.isExcludedByProjectFilter(originalName)
-      ? []
-      : vitest.matchesProjectFilter(originalName)
-        ? instances
-        : instances.filter((instance) => {
-            const newName = instance.name! // name is set in "workspace" plugin
-            return vitest.matchesProjectFilter(newName)
-          })
+    const filteredInstances = vitest.matchesProjectFilter(originalName)
+      ? instances
+      : instances.filter((instance) => {
+          const newName = instance.name! // name is set in "workspace" plugin
+          return vitest.matchesProjectFilter(newName)
+        })
 
     // every project was filtered out
     if (!filteredInstances.length) {

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -217,13 +217,17 @@ export async function resolveBrowserProjects(
       return
     }
     const originalName = project.config.name
-    // if original name is in the --project=name filter, keep all instances
-    const filteredInstances = vitest.matchesProjectFilter(originalName)
-      ? instances
-      : instances.filter((instance) => {
-          const newName = instance.name! // name is set in "workspace" plugin
-          return vitest.matchesProjectFilter(newName)
-        })
+    // if original name is explicitly excluded by a negation filter, exclude all instances
+    // if original name matches a positive filter, keep all instances
+    // otherwise, filter instances individually (user may target a specific instance name)
+    const filteredInstances = vitest.isExcludedByProjectFilter(originalName)
+      ? []
+      : vitest.matchesProjectFilter(originalName)
+        ? instances
+        : instances.filter((instance) => {
+            const newName = instance.name! // name is set in "workspace" plugin
+            return vitest.matchesProjectFilter(newName)
+          })
 
     // every project was filtered out
     if (!filteredInstances.length) {

--- a/test/cli/test/config/browser-configs.test.ts
+++ b/test/cli/test/config/browser-configs.test.ts
@@ -317,6 +317,65 @@ test('browser instances with empty include array should get parent include patte
   expect(projects[1].config.include).toEqual(['**/*.test.{js,ts}'])
 })
 
+test('negation filter excludes all browser instances', async () => {
+  const { projects } = await vitest({ project: '!myproject' }, {
+    projects: [
+      {
+        test: {
+          name: 'myproject',
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+              { browser: 'webkit' },
+            ],
+          },
+        },
+      },
+      {
+        test: {
+          name: 'other',
+        },
+      },
+    ],
+  })
+  expect(projects.map(p => p.name)).toEqual([
+    'other',
+  ])
+})
+
+test('negation wildcard filter excludes all matching browser instances', async () => {
+  const { projects } = await vitest({ project: '!my*' }, {
+    projects: [
+      {
+        test: {
+          name: 'myproject',
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [
+              { browser: 'chromium' },
+              { browser: 'firefox' },
+            ],
+          },
+        },
+      },
+      {
+        test: {
+          name: 'other',
+        },
+      },
+    ],
+  })
+  expect(projects.map(p => p.name)).toEqual([
+    'other',
+  ])
+})
+
 test('filter for the global browser project includes all browser instances', async () => {
   const { projects } = await vitest({ project: 'myproject' }, {
     projects: [


### PR DESCRIPTION
## Description

`--project='!name'` did not exclude browser project instances because they have derived names like `name (chromium)`. The instance-level filtering would re-check each derived name against the negation regex, which didn't match, so the instances passed through.

When the original project name is explicitly excluded by a negation filter, all its browser instances are now excluded without falling through to per-instance filtering.

Fixes #10130

## Reproduction

https://github.com/felamaslen/vitest-project-exclude-repro

## Changes

- **`core.ts`**: Added `isExcludedByProjectFilter()` which checks if a name is explicitly matched by a negation pattern (e.g. `--project='!name'`)
- **`resolveProjects.ts`**: When the original project name is excluded by negation, return empty instances instead of falling through to per-instance filtering