### PR TITLE
feat(expect): throw error when expect() is called without a matcher

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -23,7 +23,7 @@ import {
   subsetEquality,
   typeEquality,
 } from './jest-utils'
-import { createAssertionMessage, recordAsyncExpect, wrapAssertion } from './utils'
+import { createAssertionMessage, markExpectCalled, recordAsyncExpect, wrapAssertion } from './utils'
 
 // polyfill globals because expect can be used in node environment
 declare class Node {
@@ -1077,12 +1077,14 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const obj = utils.flag(this, 'object')
 
       if (utils.flag(this, 'poll')) {
+        markExpectCalled(utils, this)
         throw new SyntaxError(
           `expect.poll() is not supported in combination with .resolves`,
         )
       }
 
       if (typeof obj?.then !== 'function') {
+        markExpectCalled(utils, this)
         throw new TypeError(
           `You must provide a Promise to expect() when using .resolves, not '${typeof obj}'.`,
         )
@@ -1098,6 +1100,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
           return (...args: any[]) => {
             utils.flag(this, '_name', key)
+            markExpectCalled(utils, this)
             const promise = Promise.resolve(obj).then(
               (value: any) => {
                 utils.flag(this, 'object', value)
@@ -1150,12 +1153,14 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const wrapper = typeof obj === 'function' ? obj() : obj // for jest compat
 
       if (utils.flag(this, 'poll')) {
+        markExpectCalled(utils, this)
         throw new SyntaxError(
           `expect.poll() is not supported in combination with .rejects`,
         )
       }
 
       if (typeof wrapper?.then !== 'function') {
+        markExpectCalled(utils, this)
         throw new TypeError(
           `You must provide a Promise to expect() when using .rejects, not '${typeof wrapper}'.`,
         )
@@ -1171,6 +1176,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
           return (...args: any[]) => {
             utils.flag(this, '_name', key)
+            markExpectCalled(utils, this)
             const promise = Promise.resolve(wrapper).then(
               (value: any) => {
                 const _error = new AssertionError(

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -82,6 +82,8 @@ export interface MatcherState {
   }
   soft?: boolean
   poll?: boolean
+  /** @internal */
+  pendingExpects?: Array<{ called: boolean; error: Error }>
   /**
    * The same assertion instance that chai plugins receive.
    * @experimental

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -3,6 +3,16 @@ import type { Assertion } from './types'
 import { processError } from '@vitest/utils/error'
 import { noop } from '@vitest/utils/helpers'
 
+export function markExpectCalled(
+  utils: Chai.ChaiUtils,
+  assertion: object,
+): void {
+  const state = utils.flag(assertion, '_vitest_expect_state') as { called: boolean } | undefined
+  if (state) {
+    state.called = true
+  }
+}
+
 export function createAssertionMessage(
   util: Chai.ChaiUtils,
   assertion: Chai.Assertion,
@@ -102,6 +112,10 @@ export function wrapAssertion(
     // private
     if (name !== 'withTest') {
       utils.flag(this, '_name', name)
+    }
+
+    if (name !== 'withTest' && name !== 'withContext') {
+      markExpectCalled(utils, this)
     }
 
     if (!utils.flag(this, 'soft')) {

--- a/packages/vitest/src/integrations/chai/index.ts
+++ b/packages/vitest/src/integrations/chai/index.ts
@@ -22,7 +22,22 @@ export function createExpect(test?: Test | TaskPopulated): ExpectStatic {
     const _test = test || getCurrentTest()
     if (_test) {
       // @ts-expect-error internal
-      return assert.withTest(_test) as Assertion
+      const assertion = assert.withTest(_test) as Assertion
+      const pending = { called: false } as { called: boolean; error: Error }
+      const error = new Error('`expect()` was called without a matcher')
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(error, expect)
+      }
+      pending.error = error
+      chai.util.flag(assertion as any, '_vitest_expect_state', pending)
+      const state = getState(expect)
+      if (!state.pendingExpects) {
+        setState({ pendingExpects: [pending] }, expect)
+      }
+      else {
+        state.pendingExpects.push(pending)
+      }
+      return assertion
     }
     else {
       return assert

--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -1,6 +1,6 @@
 import type { Assertion, ExpectStatic } from '@vitest/expect'
 import type { Test } from '@vitest/runner'
-import { chai } from '@vitest/expect'
+import { chai, markExpectCalled } from '@vitest/expect'
 import { delay, getSafeTimers } from '@vitest/utils/timers'
 import { getWorkerState } from '../../runtime/utils'
 import { vi } from '../vi'
@@ -79,6 +79,8 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
         if (key === 'assert') {
           return assertionFunction
         }
+
+        markExpectCalled(chai.util, assertion)
 
         if (typeof key === 'string' && unsupported.includes(key)) {
           throw new SyntaxError(

--- a/packages/vitest/src/integrations/chai/setup.ts
+++ b/packages/vitest/src/integrations/chai/setup.ts
@@ -4,6 +4,7 @@ import {
   JestAsymmetricMatchers,
   JestChaiExpect,
   JestExtend,
+  markExpectCalled,
 } from '@vitest/expect'
 import { SnapshotPlugin } from '../snapshot/chai'
 
@@ -12,3 +13,9 @@ chai.use(JestChaiExpect)
 chai.use(ChaiStyleAssertions)
 chai.use(SnapshotPlugin)
 chai.use(JestAsymmetricMatchers)
+
+const _assert = chai.Assertion.prototype.assert
+chai.Assertion.prototype.assert = function (this: any, ...args: any[]) {
+  markExpectCalled(chai.util, this)
+  return (_assert as any).apply(this, args)
+}

--- a/packages/vitest/src/integrations/snapshot/chai.ts
+++ b/packages/vitest/src/integrations/snapshot/chai.ts
@@ -1,7 +1,7 @@
 import type { AsyncExpectationResult, ChaiPlugin, ExpectationResult, MatcherState, SyncExpectationResult } from '@vitest/expect'
 import type { Test } from '@vitest/runner'
 import type { DomainSnapshotAdapter } from '@vitest/snapshot'
-import { chai, createAssertionMessage, equals, iterableEquality, recordAsyncExpect, subsetEquality, wrapAssertion } from '@vitest/expect'
+import { chai, createAssertionMessage, equals, iterableEquality, markExpectCalled, recordAsyncExpect, subsetEquality, wrapAssertion } from '@vitest/expect'
 import { getNames } from '@vitest/runner/utils'
 import {
   addSerializer,
@@ -101,6 +101,7 @@ export const SnapshotPlugin: ChaiPlugin = (chai, utils) => {
     function (this: Chai.Assertion, filepath: string, hint?: string) {
       // set name manually since it's not wrapped by wrapAssertion
       utils.flag(this, '_name', 'toMatchFileSnapshot')
+      markExpectCalled(utils, this)
       // validate early synchronously just not to break some existing tests
       validateAssertion(this)
       const resultPromise = toMatchFileSnapshotImpl({

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -177,6 +177,7 @@ export class TestRunner implements VitestTestRunner {
         isExpectingAssertionsError: null,
         expectedAssertionsNumber: null,
         expectedAssertionsNumberErrorGen: null,
+        pendingExpects: [],
         currentTestName: getTestName(test),
         snapshotState: this.snapshotClient.getSnapshotState(test.file.filepath),
       },
@@ -191,6 +192,7 @@ export class TestRunner implements VitestTestRunner {
       expectedAssertionsNumberErrorGen,
       isExpectingAssertions,
       isExpectingAssertionsError,
+      pendingExpects,
     }
       = test.context._local
         ? test.context.expect.getState()
@@ -206,6 +208,13 @@ export class TestRunner implements VitestTestRunner {
     }
     if (this.config.expect.requireAssertions && assertionCalls === 0) {
       throw this.assertionsErrors.get(test)
+    }
+    if (pendingExpects) {
+      for (const pending of pendingExpects) {
+        if (!pending.called) {
+          throw pending.error
+        }
+      }
     }
   }
 

--- a/test/core/test/chai-style-assertions.test.ts
+++ b/test/core/test/chai-style-assertions.test.ts
@@ -230,7 +230,7 @@ describe('Chai-style assertions', () => {
         spy()
       }
       catch {}
-      expect(spy).to.not.have.returned
+      expect(spy).not.toHaveReturned()
     })
   })
 

--- a/test/core/test/expect.test.ts
+++ b/test/core/test/expect.test.ts
@@ -8,14 +8,18 @@ import { describe, expect, expectTypeOf, test, vi } from 'vitest'
 
 describe('expect.soft', () => {
   test('types', () => {
-    expectTypeOf(expect.soft(7)).toEqualTypeOf(expect(7))
-    expectTypeOf(expect.soft(5)).toHaveProperty('toBe')
-    expectTypeOf(expect.soft(7)).not.toHaveProperty('toCustom')
+    const soft = expect.soft(7)
+    const regular = expect(7)
+    expectTypeOf(soft).toEqualTypeOf(regular)
+    expectTypeOf(soft).toHaveProperty('toBe')
+    expectTypeOf(soft).not.toHaveProperty('toCustom')
+    soft.toBe(7)
+    regular.toBe(7)
   })
 
   test('return value', () => {
-    expect(expect.soft('test')).toHaveProperty('toBe')
-    expect(expect.soft('test')).toHaveProperty('toEqual')
+    expect.soft('test').toBe('test')
+    expect.soft('test').toEqual('test')
   })
 
   test('with extend', () => {
@@ -29,7 +33,7 @@ describe('expect.soft', () => {
         }
       },
     })
-    expect(expect.soft('test')).toHaveProperty('toBeFoo')
+    ;(expect.soft('foo') as any).toBeFoo()
   })
 
   test('should have multiple error', () => {

--- a/test/core/test/jest-expect.test.ts
+++ b/test/core/test/jest-expect.test.ts
@@ -428,6 +428,28 @@ describe('jest-expect', () => {
     expect(1).toBe(1)
   })
 
+  it.fails('expect without matcher throws at end of test', () => {
+    expect(1)
+  })
+
+  it('expect with matcher does not throw', () => {
+    expect(1).toBe(1)
+  })
+
+  it('expect with .resolves matcher does not throw', async () => {
+    await expect(Promise.resolve(1)).resolves.toBe(1)
+  })
+
+  it('expect with .rejects matcher does not throw', async () => {
+    await expect(Promise.reject(new Error('err'))).rejects.toThrow('err')
+  })
+
+  it.fails('multiple expect without matcher throws', () => {
+    expect(1)
+    expect(2)
+    expect(3).toBe(3)
+  })
+
   it.fails('toBe with null/undefined values', () => {
     expect(undefined).toBe(true)
     expect(null).toBe(true)

--- a/test/core/test/local-context.test.ts
+++ b/test/core/test/local-context.test.ts
@@ -49,10 +49,10 @@ describe('custom matcher are inherited by local context', () => {
 
   it('basic', ({ expect: localExpect }) => {
     // as assertion
-    expect(expect('test')).toHaveProperty('toEqual_testCustom')
-    expect(expect.soft('test')).toHaveProperty('toEqual_testCustom')
-    expect(localExpect('test')).toHaveProperty('toEqual_testCustom')
-    expect(localExpect.soft('test')).toHaveProperty('toEqual_testCustom')
+    ;(expect('test') as any).toEqual_testCustom('test')
+    ;(expect.soft('test') as any).toEqual_testCustom('test')
+    ;(localExpect('test') as any).toEqual_testCustom('test')
+    ;(localExpect.soft('test') as any).toEqual_testCustom('test')
 
     // as asymmetric matcher
     expect(expect).toHaveProperty('toEqual_testCustom')


### PR DESCRIPTION
### Description

Resolves #10110

When `expect(value)` is called without a subsequent matcher (`.toBe()`, `.toEqual()`, etc.), the test silently passes — giving a false sense of coverage. This PR throws an error at the end of the test when any `expect()` call had no matcher invoked on it.

```ts
test('example', () => {
  expect(someValue) // Error: `expect()` was called without a matcher
})
```

Implementation tracks each `expect()` call via `chai.util.flag` and checks at test end whether a matcher was invoked. A centralized `markExpectCalled()` helper covers all assertion paths (vitest matchers, chai-native, `.resolves`/`.rejects`, poll, snapshots).

The new check also caught several pre-existing test bugs: `.returned` accessed as a property instead of called as a method, dangling `expect()` calls used purely for type checking, and `toHaveProperty` checks that created inner unmatched expects.

AI tool (Claude) was used to assist with implementation.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
