### PR TITLE
fix(mocker): prevent race condition in resolveMocks()

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
+++ b/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
@@ -152,6 +152,9 @@ export class BareModuleMocker implements TestModuleMocker {
       return
     }
 
+    const pending = BareModuleMocker.pendingIds
+    BareModuleMocker.pendingIds = []
+
     const resolveMock = async (mock: PendingSuiteMock) => {
       const { id, url, external } = await this.resolveId(
         mock.id,
@@ -175,12 +178,10 @@ export class BareModuleMocker implements TestModuleMocker {
     // group consecutive mocks of the same action type together,
     // resolve in parallel inside each group, but run groups sequentially
     // to preserve mock/unmock ordering
-    const groups = groupByConsecutiveAction(BareModuleMocker.pendingIds)
+    const groups = groupByConsecutiveAction(pending)
     for (const group of groups) {
       await Promise.all(group.map(resolveMock))
     }
-
-    BareModuleMocker.pendingIds = []
   }
 
   // public method to avoid circular dependency


### PR DESCRIPTION
### Description

There could be a race condition when running tests in parallel and clearing mocks, causing tests to randomly fail. This PR addresses that possible issue.

`BareModuleMocker.pendingIds` is cleared after an `await` so maybe another test running in parallel cannot have access to mocks after that, triggering the issue referenced below. So it might be a good idea to make a local copy of the array and immediately clear the static one from `BareModuleMocker`.

The error is hard to reproduce, it only happens randomly in a docker container in my case.
Resolves #8339

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
