### PR TITLE
fix: show in-flight `expect.poll` on test timeout error

### DIFF
--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -1,6 +1,5 @@
 import type { Test } from '@vitest/runner/types'
 import type { Assertion } from './types'
-import { processError } from '@vitest/utils/error'
 import { noop } from '@vitest/utils/helpers'
 
 export function createAssertionMessage(
@@ -86,10 +85,11 @@ export function recordAsyncExpect(
 }
 
 function handleTestError(test: Test, err: unknown) {
-  test.result ||= { state: 'fail' }
-  test.result.state = 'fail'
-  test.result.errors ||= []
-  test.result.errors.push(processError(err))
+  // test.result ||= { state: 'fail' }
+  // test.result.state = 'fail'
+  // test.result.errors ||= []
+  // test.result.errors.push(processError(err))
+  test.context.recordError(err)
 }
 
 /** wrap assertion function to support `expect.soft` and provide assertion name as `_name` */

--- a/packages/runner/src/context.ts
+++ b/packages/runner/src/context.ts
@@ -8,6 +8,7 @@ import type {
   TestContext,
   WriteableTestContext,
 } from './types/tasks'
+import { processError } from '@vitest/utils/error'
 import { getSafeTimers } from '@vitest/utils/timers'
 import { manageArtifactAttachment, recordArtifact, recordAsyncOperation } from './artifact'
 import { PendingError } from './errors'
@@ -240,6 +241,44 @@ export function createTestContext(
     )
   }
 
+  function recordError(error: unknown) {
+    test.result ||= { state: 'fail' }
+    test.result.state = 'fail'
+    test.result.errors ||= []
+    test.result.errors.push(processError(error))
+  }
+  context.recordError = recordError
+
+  function recordErrorOnTimeout(createError: () => unknown) {
+    const addError = () => {
+      // as cause?
+      // const timeoutError = context.signal.reason as Error;
+      // if (!timeoutError.cause) {
+      //   timeoutError.cause = createError()
+      // }
+
+      // or as stack?
+      const timeoutError = context.signal.reason as Error
+      if (timeoutError && timeoutError.stack) {
+        copyStackTrace(timeoutError, createError() as any)
+      }
+
+      // or as dedicated error?
+      // recordError(createError())
+    }
+    context.signal.addEventListener('abort', addError)
+    const deregister = () => {
+      context.signal.removeEventListener('abort', addError)
+    }
+    if (Symbol.dispose) {
+      Object.assign(deregister, {
+        [Symbol.dispose]: deregister,
+      })
+    }
+    return deregister as any
+  }
+  context.recordErrorOnTimeout = recordErrorOnTimeout
+
   return runner.extendTaskContext?.(context) || context
 }
 
@@ -256,4 +295,11 @@ function makeTimeoutError(isHook: boolean, timeout: number, stackTraceError?: Er
     error.stack = stackTraceError.stack.replace(error.message, stackTraceError.message)
   }
   return error
+}
+
+function copyStackTrace(target: Error, source: Error) {
+  if (source.stack !== undefined) {
+    target.stack = source.stack.replace(source.message, target.message)
+  }
+  return target
 }

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -1233,6 +1233,9 @@ export interface TestContext {
     (message: string, type?: string, attachment?: TestAttachment): Promise<TestAnnotation>
     (message: string, attachment?: TestAttachment): Promise<TestAnnotation>
   }
+
+  readonly recordError: (error: unknown) => void
+  readonly recordErrorOnTimeout: (createError: () => unknown) => (() => void) & Disposable
 }
 
 export type OnTestFailedHandler = (context: TestContext) => Awaitable<void>

--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -106,6 +106,12 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
         // extracting inline snapshot location to validate and update new snapshots.
         return function __VITEST_POLL_CHAIN__(this: any, ...args: any[]) {
           const STACK_TRACE_ERROR = new Error('STACK_TRACE_ERROR')
+          const deregister = test.context.recordErrorOnTimeout(() => {
+            return copyStackTrace(
+              new Error('expect.poll did not succeed in time.'),
+              STACK_TRACE_ERROR,
+            )
+          })
           const promise = async () => {
             chai.util.flag(assertion, '_name', key)
             chai.util.flag(assertion, 'error', STACK_TRACE_ERROR)
@@ -174,6 +180,7 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
               }
             }
             finally {
+              deregister()
               clearTimeout(timerId)
             }
           }

--- a/test/test-utils/cli.ts
+++ b/test/test-utils/cli.ts
@@ -78,6 +78,8 @@ export class Cli {
         return resolve()
       }
 
+      // TODO: can use recordErrorOnTimeout to ensure this error message is surfaced
+      // when test timeout kicked in first.
       const timeout = setTimeout(() => {
         error.message = `Timeout when waiting for error "${expected}".\nReceived:\nstdout: ${this.stdout}\nstderr: ${this.stderr}`
         reject(error)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- closes https://github.com/vitest-dev/vitest/issues/10136

I found a case where I want to surface what's pending on test timeout and this is possible by hooking in to `context.signal`. My scenario wasn't actually `expect.poll` but something similar to our test-util's `waitForOutput`.

This PR adds such helper-ish method as `context.recordErrorOnTimeout` and also this can be used for surfacing in-flight `expect.poll`, which I think can be useful too.

What's convenient about `context.recordErrorOnTimeout` is that it allows custom async assertion to not need to estimate and hard-code right own timeout to be triggered before test timeout.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
