### PR TITLE
feat(dev): Match filters against absolute paths of test files

### DIFF
--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -443,7 +443,10 @@ export class TestProject {
     if (filters.length) {
       return testFiles.filter((t) => {
         const testFile = relative(dir, t).toLocaleLowerCase()
+        const absoluteTestFile = slash(t).toLocaleLowerCase()
         return filters.some((f) => {
+          const normalizedFilter = slash(f).toLocaleLowerCase()
+
           // if filter is a full file path, we should include it if it's in the same folder
           if (isAbsolute(f) && t.startsWith(f)) {
             return true
@@ -453,8 +456,9 @@ export class TestProject {
             ? join(relative(dir, f), '/')
             : relative(dir, f)
           return (
-            testFile.includes(f.toLocaleLowerCase())
+            testFile.includes(normalizedFilter)
             || testFile.includes(relativePath.toLocaleLowerCase())
+            || absoluteTestFile.includes(normalizedFilter)
           )
         })
       })

--- a/test/cli/test/list.test.ts
+++ b/test/cli/test/list.test.ts
@@ -145,6 +145,17 @@ test('correctly filters by file', async () => {
   expect(exitCode).toBe(0)
 })
 
+test('correctly filters by file with prefixed project path', async () => {
+  const prefixedPath = `${slash(process.cwd()).split('/').slice(-3).join('/')}/fixtures/list/math.test.ts`
+  const { stdout, exitCode } = await runVitestCli('list', prefixedPath, '-r=./fixtures/list')
+  expect(stdout).toMatchInlineSnapshot(`
+    "math.test.ts > 1 plus 1
+    math.test.ts > failing test
+    "
+  `)
+  expect(exitCode).toBe(0)
+})
+
 test('correctly filters by file when using --filesOnly', async () => {
   const { stdout, exitCode } = await runVitestCli('list', 'math.test.ts', '-r=./fixtures/list', '--filesOnly')
   expect(stdout).toMatchInlineSnapshot(`

--- a/test/cli/test/reporters/default.test.ts
+++ b/test/cli/test/reporters/default.test.ts
@@ -110,7 +110,7 @@ describe('default reporter', async () => {
     // one file
     vitest.write('p')
     await vitest.waitForStdout('Input filename pattern')
-    vitest.write('a')
+    vitest.write('a.te')
     await vitest.waitForStdout('a.test.ts')
     vitest.write('\n')
     await vitest.waitForStdout('Filename pattern: a')


### PR DESCRIPTION
Hey 🌞 This is my first contribution. Please let me know what I need to fix to land it (or if this change is not wanted).

`jest` has this feature and since we've changed to `vitest` it's the only thing I keep missing from `jest`.

### Description

This simplifies running specific tests in monorepo setups. Imagine you have
a repo with several components like this:

components/backend/..
components/frontend/..

Each of the components contains a vitest config. If you cd into components/backend
and run `vitest components/backend/some/test/file.spec.ts`, it won't work
with relative paths, because the `component/backend/` part of the path is not recognized.

This PR matches the filters against the absolute path of a file too, so the example
works as expected.

> Why would you add the path in the first place? 

My editor offers a `copy relative path` feature that I'm using to feed the test
to `vitest`.

I've tested this PR locally with my companies project and it works 👍 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

*Note from the author: Do we need to document this?*

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
