### PR TITLE
fix: project color label on html reporter

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -4,7 +4,7 @@ import type {
   RunnerTaskEventPack,
   RunnerTaskResultPack,
   RunnerTestFile,
-  SerializedConfig,
+  SerializedRootConfig,
   TestAnnotation,
 } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
@@ -67,7 +67,7 @@ export const client = (function createVitestClient() {
   }
 })()
 
-export const config = shallowRef<Partial<SerializedConfig>>({} as any)
+export const config = shallowRef<Partial<SerializedRootConfig>>({} as any)
 export const status = ref<WebSocketStatus>('CONNECTING')
 export const availableProjects = shallowRef<string[]>([])
 
@@ -171,12 +171,15 @@ watch(
     ws.addEventListener('open', async () => {
       status.value = 'OPEN'
       client.state.filesMap.clear()
-      let [files, _config, errors, projects] = await Promise.all([
+      let [files, _config, errors] = await Promise.all([
         client.rpc.getFiles(),
         client.rpc.getConfig(),
         client.rpc.getUnhandledErrors(),
-        client.rpc.getResolvedProjectLabels(),
       ])
+      const projects = _config.projects.map(project => ({
+        name: project.name || '',
+        color: project.color,
+      }))
       if (_config.standalone) {
         const filenames = await client.rpc.getTestFiles()
         files = filenames.map(([{ name, root }, filepath]) => {

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -78,7 +78,7 @@ export function createStaticClient(): VitestClient {
     saveTestFile: asyncNoop,
     getProvidedContext: () => ({}),
     getTestFiles: asyncNoop,
-  } as WebSocketHandlers
+  } as Omit<WebSocketHandlers, 'getResolvedProjectLabels'>
 
   ctx.rpc = rpc as any as BirpcReturn<WebSocketHandlers, WebSocketEvents>
 

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -3,7 +3,7 @@ import type { BirpcReturn } from 'birpc'
 import type {
   ModuleGraphData,
   RunnerTestFile,
-  SerializedConfig,
+  SerializedRootConfig,
   WebSocketEvents,
   WebSocketHandlers,
 } from 'vitest'
@@ -15,8 +15,7 @@ import { StateManager } from '../../../../ws-client/src/state'
 interface HTMLReportMetadata {
   paths: string[]
   files: RunnerTestFile[]
-  config: SerializedConfig
-  projects: string[]
+  config: SerializedRootConfig
   moduleGraph: Record<string, Record<string, ModuleGraphData>>
   unhandledErrors: unknown[]
   // filename -> source
@@ -48,12 +47,6 @@ export function createStaticClient(): VitestClient {
     },
     getConfig: () => {
       return metadata.config
-    },
-    getResolvedProjectNames: () => {
-      return metadata.projects
-    },
-    getResolvedProjectLabels: () => {
-      return []
     },
     getModuleGraph: async (projectName, id) => {
       return metadata.moduleGraph[projectName]?.[id]

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -1,4 +1,4 @@
-import type { ModuleGraphData, RunnerTestFile, SerializedConfig } from 'vitest'
+import type { ModuleGraphData, RunnerTestFile, SerializedRootConfig } from 'vitest'
 import type { HTMLOptions, Reporter, Vitest } from 'vitest/node'
 import { existsSync, promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -29,8 +29,7 @@ function getOutputFile(config: PotentialConfig | undefined) {
 interface HTMLReportData {
   paths: string[]
   files: RunnerTestFile[]
-  config: SerializedConfig
-  projects: string[]
+  config: SerializedRootConfig
   moduleGraph: Record<string, Record<string, ModuleGraphData>>
   unhandledErrors: unknown[]
   // filename -> source
@@ -69,9 +68,8 @@ export default class HTMLReporter implements Reporter {
     const result: HTMLReportData = {
       paths: this.ctx.state.getPaths(),
       files: this.ctx.state.getFiles(),
-      config: this.ctx.getRootProject().serializedConfig,
+      config: this.ctx.serializedRootConfig,
       unhandledErrors: this.ctx.state.getUnhandledErrors(),
-      projects: this.ctx.projects.map(p => p.name),
       moduleGraph: {},
       sources: {},
     }

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -7,7 +7,7 @@ import type { Vitest } from '../node/core'
 import type { TestCase, TestModule } from '../node/reporters/reported-tasks'
 import type { TestSpecification } from '../node/test-specification'
 import type { Reporter } from '../node/types/reporter'
-import type { LabelColor, ModuleGraphData, UserConsoleLog } from '../types/general'
+import type { ModuleGraphData, UserConsoleLog } from '../types/general'
 import type {
   ExternalResult,
   TransformResultWithSource,
@@ -98,10 +98,7 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
           await ctx.rerunTask(id)
         },
         getConfig() {
-          return ctx.getRootProject().serializedConfig
-        },
-        getResolvedProjectLabels(): { name: string; color?: LabelColor }[] {
-          return ctx.projects.map(p => ({ name: p.name, color: p.color }))
+          return ctx.serializedRootConfig
         },
         async getExternalResult(moduleId: string, testFileTaskId: string) {
           const testModule = ctx.state.getReportedEntityById(testFileTaskId) as TestModule | undefined

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -7,7 +7,7 @@ import type { Vitest } from '../node/core'
 import type { TestCase, TestModule } from '../node/reporters/reported-tasks'
 import type { TestSpecification } from '../node/test-specification'
 import type { Reporter } from '../node/types/reporter'
-import type { ModuleGraphData, UserConsoleLog } from '../types/general'
+import type { LabelColor, ModuleGraphData, UserConsoleLog } from '../types/general'
 import type {
   ExternalResult,
   TransformResultWithSource,
@@ -99,6 +99,9 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
         },
         getConfig() {
           return ctx.serializedRootConfig
+        },
+        getResolvedProjectLabels(): { name: string; color?: LabelColor }[] {
+          return ctx.projects.map(p => ({ name: p.name, color: p.color }))
         },
         async getExternalResult(moduleId: string, testFileTaskId: string) {
           const testModule = ctx.state.getReportedEntityById(testFileTaskId) as TestModule | undefined

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -1,9 +1,9 @@
 import type { File, TaskEventPack, TaskResultPack, TestAnnotation, TestArtifact } from '@vitest/runner'
 import type { Awaitable } from '@vitest/utils'
 import type { BirpcReturn } from 'birpc'
-import type { SerializedConfig } from '../runtime/config'
+import type { SerializedRootConfig } from '../runtime/config'
 import type { SerializedTestSpecification } from '../runtime/types/utils'
-import type { LabelColor, ModuleGraphData, UserConsoleLog } from '../types/general'
+import type { ModuleGraphData, UserConsoleLog } from '../types/general'
 import type { ModuleDefinitionDurationsDiagnostic, UntrackedModuleDefinitionDiagnostic } from '../types/module-locations'
 
 interface SourceMap {
@@ -39,8 +39,7 @@ export interface WebSocketHandlers {
   getFiles: () => File[]
   getTestFiles: () => Promise<SerializedTestSpecification[]>
   getPaths: () => string[]
-  getConfig: () => SerializedConfig
-  getResolvedProjectLabels: () => { name: string; color?: LabelColor }[]
+  getConfig: () => SerializedRootConfig
   getModuleGraph: (
     projectName: string,
     id: string,

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -3,7 +3,7 @@ import type { Awaitable } from '@vitest/utils'
 import type { BirpcReturn } from 'birpc'
 import type { SerializedRootConfig } from '../runtime/config'
 import type { SerializedTestSpecification } from '../runtime/types/utils'
-import type { ModuleGraphData, UserConsoleLog } from '../types/general'
+import type { LabelColor, ModuleGraphData, UserConsoleLog } from '../types/general'
 import type { ModuleDefinitionDurationsDiagnostic, UntrackedModuleDefinitionDiagnostic } from '../types/module-locations'
 
 interface SourceMap {
@@ -40,6 +40,10 @@ export interface WebSocketHandlers {
   getTestFiles: () => Promise<SerializedTestSpecification[]>
   getPaths: () => string[]
   getConfig: () => SerializedRootConfig
+  /**
+   * @deprecated Use `getConfig().projects` instead.
+   */
+  getResolvedProjectLabels: () => { name: string; color?: LabelColor }[]
   getModuleGraph: (
     projectName: string,
     id: string,

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -1,5 +1,7 @@
+import type { SerializedConfig, SerializedRootConfig } from '../../runtime/config'
+import type { Vitest } from '../core'
 import type { TestProject } from '../project'
-import type { ApiConfig, SerializedConfig } from '../types/config'
+import type { ApiConfig } from '../types/config'
 import { configDefaults } from '../../defaults'
 import { isAgent } from '../../utils/env'
 
@@ -46,6 +48,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
     disableConsoleIntercept: config.disableConsoleIntercept,
     root: config.root,
     name: config.name,
+    color: config.color,
     globals: config.globals,
     snapshotEnvironment: config.snapshotEnvironment,
     passWithNoTests: config.passWithNoTests,
@@ -149,5 +152,14 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       ?? globalConfig.slowTestThreshold
       ?? configDefaults.slowTestThreshold,
     isAgent,
+  }
+}
+
+export function serializeRootConfig(
+  vitest: Vitest,
+): SerializedRootConfig {
+  return {
+    ...serializeConfig(vitest.getRootProject()),
+    projects: vitest.projects.map(project => serializeConfig(project)),
   }
 }

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -1,5 +1,4 @@
-import type { SerializedConfig, SerializedRootConfig } from '../../runtime/config'
-import type { Vitest } from '../core'
+import type { SerializedConfig } from '../../runtime/config'
 import type { TestProject } from '../project'
 import type { ApiConfig } from '../types/config'
 import { configDefaults } from '../../defaults'
@@ -152,14 +151,5 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       ?? globalConfig.slowTestThreshold
       ?? configDefaults.slowTestThreshold,
     isAgent,
-  }
-}
-
-export function serializeRootConfig(
-  vitest: Vitest,
-): SerializedRootConfig {
-  return {
-    ...serializeConfig(vitest.getRootProject()),
-    projects: vitest.projects.map(project => serializeConfig(project)),
   }
 }

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -34,7 +34,6 @@ import { BrowserSessions } from './browser/sessions'
 import { VitestCache } from './cache'
 import { FileSystemModuleCache } from './cache/fsModuleCache'
 import { resolveConfig } from './config/resolveConfig'
-import { serializeRootConfig } from './config/serializeConfig'
 import { getCoverageProvider } from './coverage'
 import { createFetchModuleFunction } from './environments/fetchModule'
 import { ServerModuleRunner } from './environments/serverRunner'
@@ -505,14 +504,10 @@ export class Vitest {
   }
 
   public get serializedRootConfig(): SerializedRootConfig {
-    const config = serializeRootConfig(this)
-    if (!this.configOverride) {
-      return config
+    return {
+      ...this.getRootProject().serializedConfig,
+      projects: this.projects.map(project => project.serializedConfig),
     }
-    return deepMerge(
-      config,
-      this.configOverride,
-    )
   }
 
   public getProjectByName(name: string): TestProject {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -3,7 +3,7 @@ import type { Awaitable } from '@vitest/utils'
 import type { Writable } from 'node:stream'
 import type { ViteDevServer } from 'vite'
 import type { ModuleRunner } from 'vite/module-runner'
-import type { SerializedCoverageConfig } from '../runtime/config'
+import type { SerializedCoverageConfig, SerializedRootConfig } from '../runtime/config'
 import type { ArgumentsType, ProvidedContext, UserConsoleLog } from '../types/general'
 import type { SourceModuleDiagnostic, SourceModuleLocations } from '../types/module-locations'
 import type { CliOptions } from './cli/cli-api'
@@ -34,6 +34,7 @@ import { BrowserSessions } from './browser/sessions'
 import { VitestCache } from './cache'
 import { FileSystemModuleCache } from './cache/fsModuleCache'
 import { resolveConfig } from './config/resolveConfig'
+import { serializeRootConfig } from './config/serializeConfig'
 import { getCoverageProvider } from './coverage'
 import { createFetchModuleFunction } from './environments/fetchModule'
 import { ServerModuleRunner } from './environments/serverRunner'
@@ -501,6 +502,17 @@ export class Vitest {
       throw new Error(`Root project is not initialized. This means that the Vite server was not established yet and the the workspace config is not resolved.`)
     }
     return this.coreWorkspaceProject
+  }
+
+  public get serializedRootConfig(): SerializedRootConfig {
+    const config = serializeRootConfig(this)
+    if (!this.configOverride) {
+      return config
+    }
+    return deepMerge(
+      config,
+      this.configOverride,
+    )
   }
 
   public getProjectByName(name: string): TestProject {

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -40,6 +40,7 @@ export type {
   RuntimeConfig,
   SerializedConfig,
   SerializedCoverageConfig,
+  SerializedRootConfig,
 } from '../runtime/config'
 
 export { VitestEvaluatedModules as EvaluatedModules } from '../runtime/moduleRunner/evaluatedModules'

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -3,12 +3,14 @@ import type { PrettyFormatOptions } from '@vitest/pretty-format'
 import type { SequenceHooks, SequenceSetupFiles, SerializableRetry, TestTagDefinition } from '@vitest/runner'
 import type { SnapshotEnvironment, SnapshotUpdateState } from '@vitest/snapshot'
 import type { SerializedDiffOptions } from '@vitest/utils/diff'
+import type { LabelColor } from '../types/general'
 
 /**
  * Config that tests have access to.
  */
 export interface SerializedConfig {
   name: string | undefined
+  color?: LabelColor
   globals: boolean
   base: string | undefined
   snapshotEnvironment?: string
@@ -156,6 +158,10 @@ export interface SerializedCoverageConfig {
   htmlDir: string | undefined
   enabled: boolean
   customProviderModule: string | undefined
+}
+
+export interface SerializedRootConfig extends SerializedConfig {
+  projects: SerializedConfig[]
 }
 
 export type RuntimeConfig = Pick<

--- a/test/cli/test/reporters/__snapshots__/html.test.ts.snap
+++ b/test/cli/test/reporters/__snapshots__/html.test.ts.snap
@@ -109,9 +109,6 @@ exports[`html reporter > resolves to "failing" status for test file "json-fail" 
   "paths": [
     "<rootDir>/test/cli/fixtures/reporters/json-fail.test.ts",
   ],
-  "projects": [
-    "",
-  ],
   "sources": {
     "<rootDir>/test/cli/fixtures/reporters/json-fail.test.ts": "import { expect, test } from 'vitest'
 
@@ -217,9 +214,6 @@ exports[`html reporter > resolves to "passing" status for test file "all-passing
   },
   "paths": [
     "<rootDir>/test/cli/fixtures/reporters/all-passing-or-skipped.test.ts",
-  ],
-  "projects": [
-    "",
   ],
   "sources": {
     "<rootDir>/test/cli/fixtures/reporters/all-passing-or-skipped.test.ts": "import { expect, test } from 'vitest'

--- a/test/cli/test/reporters/html.test.ts
+++ b/test/cli/test/reporters/html.test.ts
@@ -170,3 +170,57 @@ test('add', () => {
     }
   `)
 })
+
+it('projects', async () => {
+  const result = await runInlineTests({
+    'basic.test.ts': /* ts */`
+import { test } from "vitest";
+test('basic', () => {});
+`,
+  }, {
+    reporters: ['default', 'html'],
+    projects: [
+      {
+        test: {
+          name: {
+            label: 'project1',
+            color: 'black',
+          },
+        },
+      },
+      {
+        test: {
+          name: {
+            label: 'project2',
+            color: 'white',
+          },
+        },
+      },
+    ],
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+    {
+      "project1": {
+        "basic.test.ts": {
+          "basic": "passed",
+        },
+      },
+      "project2": {
+        "basic.test.ts": {
+          "basic": "passed",
+        },
+      },
+    }
+  `)
+  expect(result.ctx?.serializedRootConfig.projects).toMatchObject([
+    {
+      name: 'project1',
+      color: 'black',
+    },
+    {
+      name: 'project2',
+      color: 'white',
+    },
+  ])
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10141

Introducing `SerializedRootConfig` since UI needs more than per-project level `SerializedConfig`. 

The fix verified in https://stackblitz.com/edit/vitest-dev-vitest-6yspi7fu?file=package.json

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
