### PR TITLE
fix: stale mock metadata breaks automocking with isolate:false

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -168,23 +168,39 @@ export class VitestModuleRunner
     if (mod.meta && 'mockedModule' in mod.meta) {
       const mockedModule = mod.meta.mockedModule as MockedModule
       const mockId = this.mocker.getMockPath(mod.id)
-      // bypass mock and force "importActual" behavior when:
-      // - mock was removed by doUnmock (stale mockedModule in meta)
-      // - self-import: mock factory/file is importing the module it's mocking
-      const isStale = !this.mocker.getDependencyMock(mod.id)
-      const isSelfImport = callstack.includes(mockId)
-        || callstack.includes(url)
-        || ('redirect' in mockedModule && callstack.includes(mockedModule.redirect))
-      if (isStale || isSelfImport) {
+      const currentMock = this.mocker.getDependencyMock(mod.id)
+      if (!currentMock) {
         const node = await this.fetchModule(injectQuery(url, '_vitest_original'))
         return this._cachedRequest(node.url, node, callstack, metadata)
       }
-      mocked = await this.mocker.requestWithMockedModule(
-        url,
-        mod,
-        callstack,
-        mockedModule,
-      )
+      const isSelfImport = callstack.includes(mockId)
+        || callstack.includes(url)
+        || ('redirect' in currentMock && callstack.includes(currentMock.redirect))
+      if (isSelfImport) {
+        const node = await this.fetchModule(injectQuery(url, '_vitest_original'))
+        return this._cachedRequest(node.url, node, callstack, metadata)
+      }
+      if (currentMock !== mockedModule) {
+        // Mock was replaced (e.g. manual → automock across test files with
+        // isolate:false). The module node's meta carries stale code (code: '')
+        // from the prior manual/redirect mock's fetchModule return. Re-fetch
+        // the actual module so requestWithMockedModule can evaluate real code.
+        const freshNode = await this.fetchModule(injectQuery(url, '_vitest_original'))
+        mocked = await this.mocker.requestWithMockedModule(
+          url,
+          freshNode,
+          callstack,
+          currentMock,
+        )
+      }
+      else {
+        mocked = await this.mocker.requestWithMockedModule(
+          url,
+          mod,
+          callstack,
+          currentMock,
+        )
+      }
     }
     else {
       mocked = await this.mocker.mockedRequest(url, mod, callstack)


### PR DESCRIPTION
When fetchModule returns early for a manual/redirect mock, it bakes `mockedModule` (with code: '') into the module node's meta. With isolate:false this metadata persists across test files. If a later file registers an automock for the same module, cachedRequest was using the stale manual mock from meta instead of the current automock from the registry, and requestWithMockedModule could not evaluate the module because the meta carried empty code.

Re-read the current mock from the registry and compare it against the one stored in meta. When they differ, re-fetch the actual module via _vitest_original so requestWithMockedModule receives a node with real code to automock against.

Regression introduced in a8216b00 (#9774).