### PR TITLE
fix(snapshot): increase default snapshot max output length

### DIFF
--- a/packages/pretty-format/USAGE.md
+++ b/packages/pretty-format/USAGE.md
@@ -117,6 +117,9 @@ Snapshots use `@vitest/pretty-format` with snapshot-specific defaults such as:
 - `escapeString: false`
 - `escapeRegex: true`
 - `printFunctionName: false`
+- `maxOutputLength: 2 ** 27`
+
+Snapshots use a more generous safety cap than the package default. The default `maxOutputLength` is tuned for general-purpose formatting such as logs and error messages, while snapshot users may intentionally persist large serialized values to dedicated files. Users can still opt into a smaller cap through `test.snapshotFormat.maxOutputLength`.
 
 Default snapshot plugin stack:
 

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -112,6 +112,10 @@ export default class SnapshotState {
     this._snapshotFormat = {
       printBasicPrototype: false,
       escapeString: false,
+      // more generous safety cap 128MB (same as Node's util.inspect)
+      // instead of tighter pretty-format default 1MB
+      // since users can purposely save large snapshot to a dedicated file.
+      maxOutputLength: 2 ** 27,
       ...options.snapshotFormat,
     }
     this._environment = options.snapshotEnvironment

--- a/test/snapshots/test/options.test.ts
+++ b/test/snapshots/test/options.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, test } from "vitest";
-import { runInlineTests } from "../../test-utils";
+import { describe, expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
 
-describe("maxOutputLength", () => {
-  test("default", async () => {
+describe('maxOutputLength', () => {
+  test('default', async () => {
     const result = await runInlineTests(
       {
-        "basic.test.ts": `
+        'basic.test.ts': `
           import { expect, test } from 'vitest'
 
           test('large snapshot', () => {
@@ -14,12 +14,12 @@ describe("maxOutputLength", () => {
         `,
       },
       {
-        update: "all",
+        update: 'all',
       },
-    );
+    )
 
-    expect(result.stderr).toMatchInlineSnapshot(`""`);
-    const snapshot = result.fs.readFile("__snapshots__/basic.test.ts.snap");
+    expect(result.stderr).toMatchInlineSnapshot(`""`)
+    const snapshot = result.fs.readFile('__snapshots__/basic.test.ts.snap')
     expect(snapshot.slice(-50)).toMatchInlineSnapshot(`
       " "i": 499998,
         },
@@ -29,14 +29,14 @@ describe("maxOutputLength", () => {
       ]
       \`;
       "
-    `);
-    expect(snapshot.length).toMatchInlineSnapshot(`12888992`);
-  });
+    `)
+    expect(snapshot.length).toMatchInlineSnapshot(`12888992`)
+  })
 
-  test("override", async () => {
+  test('override', async () => {
     const result = await runInlineTests(
       {
-        "basic.test.ts": `
+        'basic.test.ts': `
           import { expect, test } from 'vitest'
 
           test('large snapshot', () => {
@@ -45,15 +45,15 @@ describe("maxOutputLength", () => {
         `,
       },
       {
-        update: "all",
+        update: 'all',
         snapshotFormat: {
           maxOutputLength: 50,
         },
       },
-    );
+    )
 
-    expect(result.stderr).toMatchInlineSnapshot(`""`);
-    expect(result.fs.readFile("__snapshots__/basic.test.ts.snap")).toMatchInlineSnapshot(`
+    expect(result.stderr).toMatchInlineSnapshot(`""`)
+    expect(result.fs.readFile('__snapshots__/basic.test.ts.snap')).toMatchInlineSnapshot(`
       "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
       exports[\`large snapshot 1\`] = \`
@@ -75,6 +75,6 @@ describe("maxOutputLength", () => {
       ]
       \`;
       "
-    `);
-  });
-});
+    `)
+  })
+})

--- a/test/snapshots/test/options.test.ts
+++ b/test/snapshots/test/options.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { runInlineTests } from "../../test-utils";
+
+describe("maxOutputLength", () => {
+  test("default", async () => {
+    const result = await runInlineTests(
+      {
+        "basic.test.ts": `
+          import { expect, test } from 'vitest'
+
+          test('large snapshot', () => {
+            expect(Array.from({ length: 500_000 }, (_, i) => ({ i }))).toMatchSnapshot()
+          })
+        `,
+      },
+      {
+        update: "all",
+      },
+    );
+
+    expect(result.stderr).toMatchInlineSnapshot(`""`);
+    const snapshot = result.fs.readFile("__snapshots__/basic.test.ts.snap");
+    expect(snapshot.slice(-50)).toMatchInlineSnapshot(`
+      " "i": 499998,
+        },
+        {
+          "i": 499999,
+        },
+      ]
+      \`;
+      "
+    `);
+    expect(snapshot.length).toMatchInlineSnapshot(`12888992`);
+  });
+
+  test("override", async () => {
+    const result = await runInlineTests(
+      {
+        "basic.test.ts": `
+          import { expect, test } from 'vitest'
+
+          test('large snapshot', () => {
+            expect(Array.from({ length: 8 }, (_, i) => ({ i }))).toMatchSnapshot()
+          })
+        `,
+      },
+      {
+        update: "all",
+        snapshotFormat: {
+          maxOutputLength: 50,
+        },
+      },
+    );
+
+    expect(result.stderr).toMatchInlineSnapshot(`""`);
+    expect(result.fs.readFile("__snapshots__/basic.test.ts.snap")).toMatchInlineSnapshot(`
+      "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+      exports[\`large snapshot 1\`] = \`
+      [
+        {
+          "i": 0,
+        },
+        {
+          "i": 1,
+        },
+        {
+          "i": 2,
+        },
+        [Object],
+        [Object],
+        [Object],
+        [Object],
+        [Object],
+      ]
+      \`;
+      "
+    `);
+  });
+});


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10146#issuecomment-4248517121

Having snapshot limited to 1MB wasn't intended since users can purposefully snapshot large data. The original scope of https://github.com/vitest-dev/vitest/pull/9949 was meant for diff/error logging which are generally fine to be lossful while snapshot should be lossless.

This PR bumped to 128MB for snapshot in `packages/snapshot` level. 128MB is reasonable safety gate matching Node's util inspect.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
