### PR TITLE
fix(ui): fix jsx/tsx syntax highlight

### DIFF
--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -29,8 +29,10 @@ const modeMap: Record<string, any> = {
   ts: { name: 'javascript', typescript: true },
   mts: { name: 'javascript', typescript: true },
   cts: { name: 'javascript', typescript: true },
-  jsx: { name: 'javascript', jsx: true },
-  tsx: { name: 'javascript', typescript: true, jsx: true },
+  // jsx: { name: 'javascript', jsx: true },
+  // tsx: { name: 'javascript', typescript: true, jsx: true },
+  jsx: { name: 'text/jsx' },
+  tsx: { name: 'text/typescript-jsx' },
 }
 
 const el = ref<HTMLTextAreaElement>()

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -29,8 +29,6 @@ const modeMap: Record<string, any> = {
   ts: { name: 'javascript', typescript: true },
   mts: { name: 'javascript', typescript: true },
   cts: { name: 'javascript', typescript: true },
-  // jsx: { name: 'javascript', jsx: true },
-  // tsx: { name: 'javascript', typescript: true, jsx: true },
   jsx: { name: 'text/jsx' },
   tsx: { name: 'text/typescript-jsx' },
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I was testing trace view on https://github.com/vuetifyjs/vuetify and it looks like tsx syntax highlight is broken.

Following code mirror doc https://codemirror.net/5/mode/jsx/index.html, this looks like the way.

- After 

<img width="1920" height="1048" alt="image" src="https://github.com/user-attachments/assets/d8b3f810-f92d-45ba-becd-7e1455992d7f" />

- Before

<img width="1920" height="1048" alt="image" src="https://github.com/user-attachments/assets/836aeb69-6e64-42f5-b5db-2bbcd7dc7b7c" />


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
