### PR TITLE
fix(reporter): pass project label colors to HTML reporter

### DIFF
--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -16,7 +16,7 @@ interface HTMLReportMetadata {
   paths: string[]
   files: RunnerTestFile[]
   config: SerializedConfig
-  projects: string[]
+  projects: { name: string; color?: string }[]
   moduleGraph: Record<string, Record<string, ModuleGraphData>>
   unhandledErrors: unknown[]
   // filename -> source
@@ -50,10 +50,10 @@ export function createStaticClient(): VitestClient {
       return metadata.config
     },
     getResolvedProjectNames: () => {
-      return metadata.projects
+      return metadata.projects.map(p => p.name)
     },
     getResolvedProjectLabels: () => {
-      return []
+      return metadata.projects
     },
     getModuleGraph: async (projectName, id) => {
       return metadata.moduleGraph[projectName]?.[id]

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -30,7 +30,7 @@ interface HTMLReportData {
   paths: string[]
   files: RunnerTestFile[]
   config: SerializedConfig
-  projects: string[]
+  projects: { name: string; color?: string }[]
   moduleGraph: Record<string, Record<string, ModuleGraphData>>
   unhandledErrors: unknown[]
   // filename -> source
@@ -71,7 +71,7 @@ export default class HTMLReporter implements Reporter {
       files: this.ctx.state.getFiles(),
       config: this.ctx.getRootProject().serializedConfig,
       unhandledErrors: this.ctx.state.getUnhandledErrors(),
-      projects: this.ctx.projects.map(p => p.name),
+      projects: this.ctx.projects.map(p => ({ name: p.name, color: p.color })),
       moduleGraph: {},
       sources: {},
     }


### PR DESCRIPTION
The HTML reporter serialized only project names, discarding the color config. The static client then returned an empty array for getResolvedProjectLabels. Now both the metadata and the static client carry { name, color } objects, matching the live UI behavior.

Closes #10141

### Description

### Description

The HTML reporter only serialized project names as plain strings, discarding the `color` config. The static client also returned an empty array for `getResolvedProjectLabels`. This caused custom project label colors (defined in vitest config) to not render in the HTML report, even though the live UI displayed them correctly.

This PR changes `projects` in the HTML metadata from `string[]` to `{ name, color }[]`, and wires up the static client to return the actual label data.

Resolves #10141

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by GitHub organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
