### PR TITLE
fix: clamp slowTestThreshold to max 32-bit int for setTimeout

### DIFF
--- a/packages/vitest/src/node/reporters/summary.ts
+++ b/packages/vitest/src/node/reporters/summary.ts
@@ -148,7 +148,7 @@ export class SummaryReporter implements Reporter {
 
     const timeout = setTimeout(() => {
       hook.visible = true
-    }, this.ctx.config.slowTestThreshold).unref()
+    }, Math.min(this.ctx.config.slowTestThreshold, 2_147_483_647)).unref()
 
     hook.onFinish = () => clearTimeout(timeout)
   }
@@ -185,7 +185,7 @@ export class SummaryReporter implements Reporter {
 
     const timeout = setTimeout(() => {
       slowTest.visible = true
-    }, this.ctx.config.slowTestThreshold).unref()
+    }, Math.min(this.ctx.config.slowTestThreshold, 2_147_483_647)).unref()
 
     slowTest.onFinish = () => {
       slowTest.hook?.onFinish()


### PR DESCRIPTION
Fixes #10155

## Problem

When `slowTestThreshold` is set to `Infinity` (e.g., to suppress slow test warnings), Node.js `setTimeout` throws a `TimeoutOverflowWarning` because `Infinity` exceeds the 32-bit signed integer limit, falling back to 1ms timeout. This causes slow test indicators to flash immediately instead of being suppressed.

## Fix

Clamp the `slowTestThreshold` value to `2_147_483_647` (max 32-bit signed integer) before passing it to `setTimeout` in both `onHookStart` and `onTestStart` methods of the `SummaryReporter`.