### PR TITLE
feat(browser): export aria tree utils

### DIFF
--- a/docs/api/browser/context.md
+++ b/docs/api/browser/context.md
@@ -275,7 +275,11 @@ export const utils: {
    * @experimental
    */
   aria: {
-    // TODO
+    generateAriaTree(rootElement: Element): AriaNode
+    renderAriaTree(root: AriaNode): string
+    renderAriaTemplate(template: AriaTemplateNode): string
+    parseAriaTemplate(text: string): AriaTemplateNode
+    matchAriaTree(root: AriaNode, template: AriaTemplateNode): { pass: boolean; resolved: string }
   }
 }
 ```

--- a/docs/api/browser/context.md
+++ b/docs/api/browser/context.md
@@ -270,6 +270,13 @@ export const utils: {
    * Creates "Cannot find element" error. Useful for custom locators.
    */
   getElementError(selector: string, container?: Element): Error
+  /**
+   * Utilities for generating and working with ARIA trees and templates.
+   * @experimental
+   */
+  aria: {
+    // TODO
+  }
 }
 ```
 
@@ -340,3 +347,22 @@ utils.configurePrettyDOM({
 ::: tip
 This feature is inspired by Testing Library's [`defaultIgnore`](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaultignore) configuration.
 :::
+
+### aria <Version type="experimental">5.0.0</Version> {#aria}
+
+The `aria` namespace exposes low-level utilities used by Vitest's ARIA snapshot matchers.
+
+```ts
+import { utils } from 'vitest/browser'
+
+document.body.innerHTML = `
+  <h1>Hello, World!</h1>
+  <button aria-hidden="true">Hidden</button>
+  <button>Visible</button>
+`
+const tree = utils.aria.generateAriaTree(document.body)
+const yaml = utils.aria.renderAriaNode(tree)
+console.log(yaml)
+// - heading "Hello, World!" [level=1]
+// - button "Visible""
+```

--- a/docs/guide/browser/aria-snapshots.md
+++ b/docs/guide/browser/aria-snapshots.md
@@ -30,6 +30,8 @@ await expect.element(page.getByRole('navigation')).toMatchAriaInlineSnapshot(`
 
 This catches accessibility regressions: missing labels, broken roles, incorrect heading levels, and more — things that DOM snapshots would miss. Even if the underlying HTML structure changes, the assertion would not fail as long as content matches semantically.
 
+For advanced cases, you can also generate and inspect the ARIA tree through `utils.aria` from `vitest/browser`. See the [Context API](/api/browser/context#aria) for details.
+
 ## Snapshot Workflow
 
 ARIA snapshots use the same Vitest snapshot workflow as other snapshot assertions. File snapshots, inline snapshots, `--update` / `-u`, watch mode updates, and CI snapshot behavior all work the same way.

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -2,7 +2,7 @@ import { SerializedConfig } from 'vitest'
 import { StringifyOptions, CDPSession, BrowserCommands } from 'vitest/internal/browser'
 import { ARIARole } from './aria-role.js'
 import {} from './matchers.js'
-import { __vendorIvyaAriaTypes } from '@vitest/browser/internal/vendor-types'
+import { __ivyaAriaTypes } from '@vitest/browser/internal/vendor-types'
 
 export type BufferEncoding =
   | 'ascii'
@@ -942,15 +942,15 @@ export const utils: {
    */
   aria: {
     /** Captures the ARIA tree for a DOM subtree. */
-    generateAriaTree: typeof __vendorIvyaAriaTypes.generateAriaTree
+    generateAriaTree: typeof __ivyaAriaTypes.generateAriaTree
     /** Renders a captured ARIA tree to the textual snapshot format. */
-    renderAriaTree: typeof __vendorIvyaAriaTypes.renderAriaTree
+    renderAriaTree: typeof __ivyaAriaTypes.renderAriaTree
     /** Renders an ARIA template back to text. */
-    renderAriaTemplate: typeof __vendorIvyaAriaTypes.renderAriaTemplate
+    renderAriaTemplate: typeof __ivyaAriaTypes.renderAriaTemplate
     /** Parses textual ARIA snapshot syntax into a template tree. */
-    parseAriaTemplate: typeof __vendorIvyaAriaTypes.parseAriaTemplate
+    parseAriaTemplate: typeof __ivyaAriaTypes.parseAriaTemplate
     /** Matches a captured ARIA tree against a parsed template. */
-    matchAriaTree: typeof __vendorIvyaAriaTypes.matchAriaTree
+    matchAriaTree: typeof __ivyaAriaTypes.matchAriaTree
   }
 }
 

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -940,7 +940,18 @@ export const utils: {
    * Utilities for generating and working with ARIA trees and templates.
    * @experimental
    */
-  aria: typeof __vendorIvyaAriaTypes
+  aria: {
+    /** Captures the ARIA tree for a DOM subtree. */
+    generateAriaTree: typeof __vendorIvyaAriaTypes.generateAriaTree
+    /** Renders a captured ARIA tree to the textual snapshot format. */
+    renderAriaTree: typeof __vendorIvyaAriaTypes.renderAriaTree
+    /** Renders an ARIA template back to text. */
+    renderAriaTemplate: typeof __vendorIvyaAriaTypes.renderAriaTemplate
+    /** Parses textual ARIA snapshot syntax into a template tree. */
+    parseAriaTemplate: typeof __vendorIvyaAriaTypes.parseAriaTemplate
+    /** Matches a captured ARIA tree against a parsed template. */
+    matchAriaTree: typeof __vendorIvyaAriaTypes.matchAriaTree
+  }
 }
 
 export const locators: BrowserLocators

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -2,6 +2,7 @@ import { SerializedConfig } from 'vitest'
 import { StringifyOptions, CDPSession, BrowserCommands } from 'vitest/internal/browser'
 import { ARIARole } from './aria-role.js'
 import {} from './matchers.js'
+import { __vendorIvyaAriaTypes } from '@vitest/browser/internal/vendor-types'
 
 export type BufferEncoding =
   | 'ascii'
@@ -935,8 +936,11 @@ export const utils: {
    */
   getElementError(selector: string, container?: Element): Error
 
-  // TODO: bundle import("ivya/aria")
-  aria: unknown
+  /**
+   * TODO
+   * @experimental
+   */
+  aria: typeof __vendorIvyaAriaTypes
 }
 
 export const locators: BrowserLocators

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -936,6 +936,7 @@ export const utils: {
    */
   getElementError(selector: string, container?: Element): Error
 
+  // TODO: add jsdoc in ivya side exports
   /**
    * Utilities for generating and working with ARIA trees and templates.
    *

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -937,7 +937,12 @@ export const utils: {
   getElementError(selector: string, container?: Element): Error
 
   /**
-   * TODO
+   * Utilities for generating and working with ARIA trees and templates.
+   *
+   * This surface is currently based on Vitest's internal `ivya/aria`
+   * integration and is exposed primarily for advanced browser utilities
+   * and custom tooling.
+   *
    * @experimental
    */
   aria: typeof __vendorIvyaAriaTypes

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -934,6 +934,9 @@ export const utils: {
    * Creates "Cannot find element" error. Useful for custom locators.
    */
   getElementError(selector: string, container?: Element): Error
+
+  // TODO: bundle import("ivya/aria")
+  aria: unknown
 }
 
 export const locators: BrowserLocators

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -936,14 +936,8 @@ export const utils: {
    */
   getElementError(selector: string, container?: Element): Error
 
-  // TODO: add jsdoc in ivya side exports
   /**
    * Utilities for generating and working with ARIA trees and templates.
-   *
-   * This surface is currently based on Vitest's internal `ivya/aria`
-   * integration and is exposed primarily for advanced browser utilities
-   * and custom tooling.
-   *
    * @experimental
    */
   aria: typeof __vendorIvyaAriaTypes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,6 +44,10 @@
     "./utils": {
       "default": "./dummy.js"
     },
+    "./internal/vendor-types": {
+      "types": "./dist/vendor-types.d.ts",
+      "default": "./dummy.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -157,4 +157,36 @@ export default () =>
       external,
       plugins: dtsUtilsClient.dts(),
     },
+    {
+      input: {
+        'vendor-types': './src/vendor-types.ts',
+      },
+      output: {
+        dir: 'dist',
+        entryFileNames: '[name].ts',
+        format: 'esm',
+      },
+      external,
+      plugins: [
+        ...dtsUtils.isolatedDecl(),
+        ...plugins,
+      ],
+    },
+    {
+      input: {
+        'vendor-types': './dist/.types/vendor-types.d.ts',
+      },
+      output: {
+        dir: 'dist',
+        entryFileNames: '[name].d.ts',
+        format: 'esm',
+      },
+      external,
+      plugins: [
+        resolve({
+          preferBuiltins: true,
+        }),
+        dtsUtils.dts(),
+      ],
+    },
   ])

--- a/packages/browser/src/client/tester/aria.ts
+++ b/packages/browser/src/client/tester/aria.ts
@@ -6,7 +6,9 @@ import type {
 } from 'ivya/aria'
 import * as aria from 'ivya/aria'
 import { Snapshots } from 'vitest'
-import { __INTERNAL } from 'vitest/internal/browser'
+import { getBrowserState } from '../utils'
+
+getBrowserState().aria = aria
 
 const {
   generateAriaTree,
@@ -15,8 +17,6 @@ const {
   renderAriaTemplate,
   renderAriaTree,
 } = aria
-
-__INTERNAL._aria = aria
 
 const ariaSnapshotAdapter: DomainSnapshotAdapter<AriaNode, AriaTemplateNode> = {
   name: 'aria',

--- a/packages/browser/src/client/tester/aria.ts
+++ b/packages/browser/src/client/tester/aria.ts
@@ -4,14 +4,19 @@ import type {
   AriaNode,
   AriaTemplateNode,
 } from 'ivya/aria'
-import {
+import * as aria from 'ivya/aria'
+import { Snapshots } from 'vitest'
+import { __INTERNAL } from 'vitest/internal/browser'
+
+const {
   generateAriaTree,
   matchAriaTree,
   parseAriaTemplate,
   renderAriaTemplate,
   renderAriaTree,
-} from 'ivya/aria'
-import { Snapshots } from 'vitest'
+} = aria
+
+__INTERNAL._aria = aria
 
 const ariaSnapshotAdapter: DomainSnapshotAdapter<AriaNode, AriaTemplateNode> = {
   name: 'aria',

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -556,4 +556,7 @@ export const utils = {
   debug,
   getElementLocatorSelectors,
   configurePrettyDOM,
+  get aria() {
+    return __INTERNAL._aria
+  },
 }

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -557,6 +557,6 @@ export const utils = {
   getElementLocatorSelectors,
   configurePrettyDOM,
   get aria() {
-    return __INTERNAL._aria
+    return getBrowserState().aria
   },
 }

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -95,6 +95,7 @@ export interface BrowserRunnerState {
     send: (method: string, params?: Record<string, unknown>) => Promise<unknown>
     emit: (event: string, payload: unknown) => void
   }
+  aria: typeof import('ivya/aria')
 }
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/browser/src/vendor-types.ts
+++ b/packages/browser/src/vendor-types.ts
@@ -1,1 +1,1 @@
-export type * as __vendorIvyaAriaTypes from 'ivya/aria'
+export type * as __ivyaAriaTypes from 'ivya/aria'

--- a/packages/browser/src/vendor-types.ts
+++ b/packages/browser/src/vendor-types.ts
@@ -1,0 +1,1 @@
+export type * as __vendorIvyaAriaTypes from 'ivya/aria'

--- a/packages/vitest/src/public/browser.ts
+++ b/packages/vitest/src/public/browser.ts
@@ -55,6 +55,7 @@ export const __INTERNAL: {
   _asLocator: (lang: 'javascript', selector: string) => string
   _createLocator: (selector: string) => any
   _extendedMethods: Set<string>
+  _aria?: unknown
 } = {
   _extendedMethods: new Set(),
 } as any

--- a/packages/vitest/src/public/browser.ts
+++ b/packages/vitest/src/public/browser.ts
@@ -55,7 +55,6 @@ export const __INTERNAL: {
   _asLocator: (lang: 'javascript', selector: string) => string
   _createLocator: (selector: string) => any
   _extendedMethods: Set<string>
-  _aria?: unknown
 } = {
   _extendedMethods: new Set(),
 } as any

--- a/test/browser/test/utils.test.ts
+++ b/test/browser/test/utils.test.ts
@@ -206,3 +206,17 @@ test('filterNode with wildcard selector filters nested content', async () => {
     </div>"
   `)
 })
+
+test('aria tree utils', () => {
+  document.body.innerHTML = `
+    <h1>Hello, World!</h1>
+    <button aria-hidden="true">Hidden</button>
+    <button>Visible</button>
+  `
+  const { generateAriaTree, renderAriaTree } = utils.aria
+  expect(`\n${renderAriaTree(generateAriaTree(document.body))}`).toMatchInlineSnapshot(`
+    "
+    - heading "Hello, World!" [level=1]
+    - button "Visible""
+  `)
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
       "@vitest/browser-playwright": ["./packages/browser-playwright/src/index.ts"],
       "@vitest/browser": ["./packages/browser/src/node/index.ts"],
       "@vitest/browser/client": ["./packages/browser/src/client/client.ts"],
+      "@vitest/browser/internal/vendor-types": ["./packages/browser/src/vendor-types.ts"],
       "~/*": ["./packages/ui/client/*"],
       "vitest": ["./packages/vitest/src/public/index.ts"],
       "vitest/internal/browser": ["./packages/vitest/src/public/browser.ts"],


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- (marginally) related https://github.com/vitest-dev/vitest/issues/10158

This PR exposes `ivya/aria` exports  via `import { utils } from "vitest/browser"`. This can be useful as a standalone primitive of "node to aria tree" serialization similar to `prettyDOM` does for "ndoe to html like" serialization.

```js
import { utils } from 'vitest/browser'

document.body.innerHTML = `
  <h1>Hello, World!</h1>
  <button aria-hidden="true">Hidden</button>
  <button>Visible</button>
`
const tree = utils.aria.generateAriaTree(document.body)
const yaml = utils.aria.renderAriaNode(tree)
console.log(yaml)
// - heading "Hello, World!" [level=1]
// - button "Visible""
```

The wiring is a bit mess like `__INTERNAL` and `@vitest/browser/internal/vendor-types`, but seems necessary to avoid duplicating modules and also hand-rolling same type definition. For example, I noticed `type AriaRole` is currently manually written in `packages/browser/aria-role.d.ts` but this can also come from `ivya` with similar tricks.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
