### PR TITLE
fix(blob): skip import edges to fileless modules to prevent merge-reports crash

### DIFF
--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -274,7 +274,7 @@ function serializeEnvironmentModuleGraph(
 
     const importedIds: number[] = []
     for (const importedNode of mod.importedModules) {
-      if (importedNode.id) {
+      if (importedNode.id && importedNode.file) {
         importedIds.push(getIdIndex(importedNode.id))
       }
     }
@@ -320,7 +320,10 @@ function deserializeEnvironmentModuleGraph(
     const moduleNode = nodesById.get(moduleId)!
     importedIds.forEach((importedIdIndex) => {
       const importedId = serialized.idTable[importedIdIndex]
-      const importedNode = nodesById.get(importedId)!
+      const importedNode = nodesById.get(importedId)
+      if (!importedNode) {
+        return
+      }
       moduleNode.importedModules.add(importedNode)
       importedNode.importers.add(moduleNode)
     })

--- a/test/e2e/fixtures/reporters/merge-reports/fileless-edge.test.ts
+++ b/test/e2e/fixtures/reporters/merge-reports/fileless-edge.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('#mocks/not-on-disk.ts', () => ({ someExport: { mocked: true } }))
+// @ts-expect-error — file does not exist, mock factory satisfies the import
+import { someExport } from '#mocks/not-on-disk.ts'
+
+describe('fileless edge repro', () => {
+  it('consumes the mock', () => {
+    expect(someExport).toEqual({ mocked: true })
+  })
+})

--- a/test/e2e/fixtures/reporters/merge-reports/package.json
+++ b/test/e2e/fixtures/reporters/merge-reports/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "imports": {
+    "#mocks/*": "./src/mocks/*"
+  }
+}

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -424,6 +424,23 @@ test.for([
   `)
 })
 
+test('merge reports does not crash with fileless module edges', async () => {
+  await runVitest({
+    root: './fixtures/reporters/merge-reports',
+    include: ['fileless-edge.test.ts'],
+    reporters: [['blob', { outputFile: './.vitest-reports/fileless-run.json' }]],
+  })
+
+  const { stderr, exitCode } = await runVitest({
+    root: './fixtures/reporters/merge-reports',
+    mergeReports: reportsDir,
+    reporters: [['default', { isTTY: false }]],
+  })
+
+  expect(stderr).not.toContain('Cannot read properties of undefined')
+  expect(exitCode).toBe(0)
+})
+
 async function getSerializedModuleGraph(ctx: Vitest) {
   const files = ctx.state.getFiles().slice().sort((a, b) => a.filepath.localeCompare(b.filepath))
   const moduleGraphs = Object.fromEntries(


### PR DESCRIPTION
Fixes #10173

## Problem
`serializeEnvironmentModuleGraph` skips modules without `file` but still
records import edges whose target has an `id` but no `file`. On
deserialize, `nodesById.get(importedId)` returns `undefined` for those
targets and `.importers.add()` throws:

TypeError: Cannot read properties of undefined (reading 'importers')

This became visible with Vite 8 which exposes more fileless modules
(virtual/id-only) than Vite 6.

## Fix
Two-part fix:

1. **Serializer** — only emit edges whose target also has a `file`,
   keeping serializer and deserializer in sync:
```ts
   if (importedNode.id && importedNode.file) {
```

2. **Deserializer** — null-guard as safety net for blobs produced by
   older Vitest versions before this fix:
```ts
   const importedNode = nodesById.get(importedId)
   if (!importedNode) return
```