### PR TITLE
fix(runner): propagate chainable flags in describe.for

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -707,13 +707,13 @@ function createSuite() {
   }
 
   suiteFn.for = function <T>(
-    this: {
-      withContext: () => SuiteAPI
-      setContext: (key: string, value: boolean | undefined) => SuiteAPI
-    },
+    this: SuiteAPI,
     cases: ReadonlyArray<T>,
     ...args: any[]
   ) {
+    const context = getChainableContext(this)
+    const suite = context.withContext()
+
     if (Array.isArray(cases) && args.length) {
       cases = formatTemplateString(cases, args)
     }

--- a/test/core/test/test-for-suite.test.ts
+++ b/test/core/test/test-for-suite.test.ts
@@ -36,9 +36,10 @@ describe.for([
 
 // Regression test: describe.concurrent.for should propagate the concurrent flag
 // to the generated suites, matching how describe.for and test.concurrent.for behave.
-describe.concurrent.for([1, 2, 3])('concurrent %i', (item) => {
+describe.concurrent.for([1, 2])('concurrent %i', (item) => {
   test('is marked concurrent', ({ task }) => {
     expect(task.suite!.concurrent).toBe(true)
+    expect(task.concurrent).toBe(true)
     expect(item).toBeGreaterThan(0)
   })
 })

--- a/test/core/test/test-for-suite.test.ts
+++ b/test/core/test/test-for-suite.test.ts
@@ -33,3 +33,12 @@ describe.for([
     expect(a + b).matchSnapshot()
   })
 })
+
+// Regression test: describe.concurrent.for should propagate the concurrent flag
+// to the generated suites, matching how describe.for and test.concurrent.for behave.
+describe.concurrent.for([1, 2, 3])('concurrent %i', item => {
+  test('is marked concurrent', ({ task }) => {
+    expect(task.suite!.concurrent).toBe(true)
+    expect(item).toBeGreaterThan(0)
+  })
+})

--- a/test/core/test/test-for-suite.test.ts
+++ b/test/core/test/test-for-suite.test.ts
@@ -36,7 +36,7 @@ describe.for([
 
 // Regression test: describe.concurrent.for should propagate the concurrent flag
 // to the generated suites, matching how describe.for and test.concurrent.for behave.
-describe.concurrent.for([1, 2, 3])('concurrent %i', item => {
+describe.concurrent.for([1, 2, 3])('concurrent %i', (item) => {
   test('is marked concurrent', ({ task }) => {
     expect(task.suite!.concurrent).toBe(true)
     expect(item).toBeGreaterThan(0)


### PR DESCRIPTION
Closes #10181

## Problem

`describe.concurrent.for` (and other chainable modifiers like `.only`, `.skip`) were not being propagated to the generated suites.

`suiteFn.each` correctly calls `getChainableContext(this).withContext()` to capture any chained flags before iterating. `suiteFn.for` was missing this — it referenced the outer `suite` variable directly, so modifiers like `concurrent` were silently dropped.

## Fix

Apply the same pattern used in `suiteFn.each`:

```ts
const context = getChainableContext(this)
const suite = context.withContext()
```

This ensures that `describe.concurrent.for`, `describe.only.for`, `describe.skip.for`, etc. all behave consistently.

## Test

Added a regression test to `test/core/test/test-for-suite.test.ts` that verifies `task.suite.concurrent` is `true` when using `describe.concurrent.for`.