### PR TITLE
docs: document v5 migration changes for #9609 and #10170

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -20,39 +20,21 @@ When interpolating string values in `test.each`, `test.for`, `describe.each`, or
 This affects generated task names in reporter output, snapshots, and any tooling that matches tests by their generated title.
 
 ```ts
-test.each([
-  { name: 'basic' },
-])('$name', () => {})
+test.for([{ name: 'Alice' }])('I am $name', () => {})
 
 // Vitest 4:
-// ✓ 'basic'
+// ✓ I am 'Alice'
 
 // Vitest 5:
-// ✓ basic
-```
-
-The same applies to array indexes:
-
-```ts
-test.for([
-  ['basic'],
-])('$0', () => {})
-
-// Vitest 4:
-// ✓ 'basic'
-
-// Vitest 5:
-// ✓ basic
+// ✓ I am Alice
 ```
 
 If you need quotes in the generated title, add them to the title template:
 
 ```ts
-test.each([
-  { name: 'basic' },
-])('case "$name"', () => {})
+test.for([{ name: 'Alice' }])('I am "$name"', () => {})
 
-// ✓ case "basic"
+// ✓ I am "Alice"
 ```
 
 ### `chaiConfig.truncateThreshold` No Longer Controls Test Title Value Truncation

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -21,20 +21,15 @@ This affects generated task names in reporter output, snapshots, and any tooling
 
 ```ts
 test.for([{ name: 'Alice' }])('I am $name', () => {})
-
-// Vitest 4:
-// ✓ I am 'Alice'
-
-// Vitest 5:
-// ✓ I am Alice
+// Vitest 4 → I am 'Alice'
+// Vitest 5 → I am Alice
 ```
 
 If you need quotes in the generated title, add them to the title template:
 
 ```ts
 test.for([{ name: 'Alice' }])('I am "$name"', () => {})
-
-// ✓ I am "Alice"
+// → I am "Alice"
 ```
 
 ### `chaiConfig.truncateThreshold` No Longer Controls Test Title Value Truncation
@@ -50,7 +45,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    chaiConfig: {
+    chaiConfig: { // [!code --]
       truncateThreshold: 120, // [!code --]
     }, // [!code --]
     taskTitleValueFormatTruncate: 120, // [!code ++]

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -7,6 +7,77 @@ outline: deep
 
 [Migrating to Vitest 3.0](https://v3.vitest.dev/guide/migration) | [Migrating to Vitest 2.0](https://v2.vitest.dev/guide/migration)
 
+## Migrating to Vitest 5.0 {#vitest-5}
+
+::: warning Work in progress
+Vitest 5.0 is currently in beta. This section tracks breaking changes as they are merged and may change before the stable release.
+:::
+
+### String Values in `$` Test Titles Are No Longer Quoted
+
+When interpolating string values in `test.each`, `test.for`, `describe.each`, or `describe.for` titles with the `$` syntax, Vitest no longer wraps those string values in quotes.
+
+This affects generated task names in reporter output, snapshots, and any tooling that matches tests by their generated title.
+
+```ts
+test.each([
+  { name: 'basic' },
+])('$name', () => {})
+
+// Vitest 4:
+// ✓ 'basic'
+
+// Vitest 5:
+// ✓ basic
+```
+
+The same applies to array indexes:
+
+```ts
+test.for([
+  ['basic'],
+])('$0', () => {})
+
+// Vitest 4:
+// ✓ 'basic'
+
+// Vitest 5:
+// ✓ basic
+```
+
+If you need quotes in the generated title, add them to the title template:
+
+```ts
+test.each([
+  { name: 'basic' },
+])('case "$name"', () => {})
+
+// ✓ case "basic"
+```
+
+### `chaiConfig.truncateThreshold` No Longer Controls Test Title Value Truncation
+
+Vitest now formats interpolated task title values with its display formatter based on `@vitest/pretty-format`, instead of Chai/loupe formatting.
+
+Most output should stay similar, but generated titles or assertion output involving formatted values may have small formatting differences.
+
+If you used `chaiConfig.truncateThreshold` to control truncation in `test.each`, `test.for`, `describe.each`, or `describe.for` titles, use `taskTitleValueFormatTruncate` instead:
+
+```ts [vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    chaiConfig: {
+      truncateThreshold: 120, // [!code --]
+    }, // [!code --]
+    taskTitleValueFormatTruncate: 120, // [!code ++]
+  },
+})
+```
+
+`chaiConfig.truncateThreshold` still controls truncation in assertion error messages.
+
 ## Migrating to Vitest 4.0 {#vitest-4}
 
 ::: warning Prerequisites


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Starting `Migrating to Vitest 5.0` section so we can pile it up as we merge breaking changes.

This PR adds entries related to
- https://github.com/vitest-dev/vitest/pull/9609
- https://github.com/vitest-dev/vitest/pull/10170

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
