### PR TITLE
fix(expect): preserve _poll.assert_once flag across assertion failures

### DIFF
--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -17,12 +17,18 @@ function element<T extends HTMLElement | SVGElement | null | Locator>(elementOrL
   }
 
   const expectElement = expect.poll<HTMLElement | SVGElement | null>(function element(this: object) {
+    // Capture the matcher name early to set assert_once flag before any early returns
+    // This is critical for screenshot comparisons which should only run once
+    const name = chai.util.flag(this, '_name') as string
+    if (name === 'toMatchScreenshot' && !chai.util.flag(this, '_poll.assert_once')) {
+      chai.util.flag(this, '_poll.assert_once', true)
+    }
+
     if (elementOrLocator instanceof Element || elementOrLocator == null) {
       return elementOrLocator
     }
 
     const isNot = chai.util.flag(this, 'negate') as boolean
-    const name = chai.util.flag(this, '_name') as string
     // special case for `toBeInTheDocument` matcher
     if (isNot && name === 'toBeInTheDocument') {
       return elementOrLocator.query()
@@ -31,11 +37,6 @@ function element<T extends HTMLElement | SVGElement | null | Locator>(elementOrL
       // we know that `toHaveLength` requires multiple elements,
       // but types generally expect a single one
       return elementOrLocator.elements() as unknown as HTMLElement
-    }
-
-    if (name === 'toMatchScreenshot' && !chai.util.flag(this, '_poll.assert_once')) {
-      // `toMatchScreenshot` should only run once after the element resolves
-      chai.util.flag(this, '_poll.assert_once', true)
     }
 
     // element selector uses prettyDOM under the hood, which is an expensive call

--- a/packages/browser/src/node/commands/screenshotMatcher/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/index.ts
@@ -27,8 +27,7 @@ interface ScreenshotData {
  * - `unstable-screenshot`: page never stabilized within timeout
  * - `missing-reference`: no baseline exists to compare against
  * - `update-reference`: snapshot update was requested (run with `--update`)
- * - `matched-immediately`: screenshot matched reference on first capture (no retries)
- * - `matched-after-comparison`: screenshot matched after another comparison
+ * - `matched-after-comparison`: screenshot matched reference after comparison
  * - `mismatch`: screenshot differs from reference
  */
 type MatchOutcome
@@ -45,7 +44,6 @@ type MatchOutcome
     type: 'update-reference'
     reference: ScreenshotData
   }
-  | { type: 'matched-immediately' }
   | { type: 'matched-after-comparison' }
   | {
     type: 'mismatch'
@@ -175,11 +173,6 @@ async function determineOutcome(
     }
   }
 
-  // first capture matched reference (used as baseline) - no further comparison needed
-  if (retries === 0) {
-    return { type: 'matched-immediately' }
-  }
-
   const comparisonResult = await comparator(
     reference,
     screenshot,
@@ -302,7 +295,6 @@ function buildOutput(
     }
 
     case 'update-reference':
-    case 'matched-immediately':
     case 'matched-after-comparison':
       return { pass: true, outcome: outcome.type }
 

--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -136,6 +136,8 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
 
             let executionPhase: 'fn' | 'assertion' = 'fn'
             let hasTimedOut = false
+            // Store _poll.assert_once value before assertion phase to prevent chai from clearing it
+            let shouldAssertOnce = false
 
             const timerId = setTimeout(() => {
               hasTimedOut = true
@@ -154,6 +156,10 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                   const obj = await fn()
                   chai.util.flag(assertion, 'object', obj)
 
+                  // Capture _poll.assert_once flag before entering assertion phase
+                  // This prevents chai from clearing the flag during assertion failure
+                  shouldAssertOnce = !!chai.util.flag(assertion, '_poll.assert_once')
+
                   executionPhase = 'assertion'
                   const output = await assertionFunction.call(assertion, ...args)
                   await onSettled?.({ assertion, status: 'pass' })
@@ -161,9 +167,14 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
                   return output
                 }
                 catch (err) {
-                  if (isLastAttempt || (executionPhase === 'assertion' && chai.util.flag(assertion, '_poll.assert_once'))) {
+                  if (isLastAttempt || (executionPhase === 'assertion' && shouldAssertOnce)) {
                     await onSettled?.({ assertion, status: 'fail' })
                     throwWithCause(err, STACK_TRACE_ERROR)
+                  }
+
+                  // Re-set the flag to ensure it persists across retries
+                  if (shouldAssertOnce) {
+                    chai.util.flag(assertion, '_poll.assert_once', true)
                   }
 
                   await delay(interval, setTimeout)


### PR DESCRIPTION
## Summary

This PR fixes two issues with `expect.element().toMatchScreenshot()`:

### Issue 1: `_poll.assert_once` flag being cleared by chai

When a custom comparator returns `{ pass: false }`, the test would timeout instead of failing immediately.

**Root Cause**: The `_poll.assert_once` flag is used to indicate that the assertion should only run once after the element is resolved. However, chai may reset flags when an assertion fails, causing the flag check to return `undefined` on subsequent retry attempts. This results in vitest retrying indefinitely until timeout instead of failing immediately.

**Fix**: 
- Capture the `_poll.assert_once` flag value before entering the assertion phase and store it in a local variable that chai cannot modify
- Use this stored value in the catch block to determine whether to fail immediately
- Re-set the flag before retry to ensure it persists
- Move flag setting before early returns in expect-element.ts

### Issue 2: `matched-immediately` outcome bypassing final comparison

When `retries === 0` (page stable on first screenshot), vitest would return `matched-immediately` without calling the comparator with `createDiff=true`.

**Root Cause**: The stability check uses `createDiff=false` (pixel-level comparison), while the final comparison uses `createDiff=true` (SSIM or custom metrics). Stability does NOT guarantee match with reference - a page can be stable (two consecutive screenshots identical) but still differ from the reference.

**Fix**: Remove the `matched-immediately` outcome and always call the comparator with `createDiff=true` for the final comparison, ensuring consistent behavior regardless of how quickly the page stabilized.

## Changes

1. `packages/vitest/src/integrations/chai/poll.ts`:
   - Added `shouldAssertOnce` local variable to capture flag before assertion phase
   - Modified catch block to use stored value instead of chai's flag
   - Re-set the flag after catching error to ensure persistence

2. `packages/browser/src/client/tester/expect-element.ts`:
   - Moved `_poll.assert_once` flag setting before early returns

3. `packages/browser/src/node/commands/screenshotMatcher/index.ts`:
   - Removed `matched-immediately` outcome type
   - Removed early return when `retries === 0`
   - Updated `buildOutput` function
   - Updated documentation comments

## Test Plan

1. Create a custom screenshot comparator that returns `{ pass: false }`
2. Use `expect.element().toMatchScreenshot()` with this comparator
3. Verify the test fails immediately with the comparator's error message instead of timing out
4. Verify that all fixtures generate `actual.png` regardless of stability speed

Fixes #10204