### PR TITLE
refactor: inline snapshot package

### DIFF
--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -344,7 +344,7 @@ Custom serializers control how values are _rendered_ into snapshot strings, but 
 A domain adapter implements four methods and is generic over two types — `Captured` (what the value actually is) and `Expected` (what the stored snapshot parses into):
 
 ```ts
-import type { DomainMatchResult, DomainSnapshotAdapter } from '@vitest/snapshot'
+import type { DomainMatchResult, DomainSnapshotAdapter } from 'vitest'
 
 const myAdapter: DomainSnapshotAdapter<Captured, Expected> = {
   name: 'my-domain',
@@ -420,7 +420,7 @@ expect(value).toMatchMyDomainInlineSnapshot(`key=value`)
 A minimal adapter that stores objects as `key=value` lines, with regex pattern and subset key match support ([full source](https://github.com/vitest-dev/vitest/blob/main/test/snapshots/test/fixtures/domain/basic.ts)):
 
 ```ts [kv-adapter.ts]
-import type { DomainMatchResult, DomainSnapshotAdapter } from '@vitest/snapshot'
+import type { DomainMatchResult, DomainSnapshotAdapter } from 'vitest'
 
 type KVCaptured = Record<string, string>
 type KVExpected = Record<string, string | RegExp>

--- a/packages/browser/src/client/tester/aria.ts
+++ b/packages/browser/src/client/tester/aria.ts
@@ -1,9 +1,9 @@
 import type { MatchersObject } from '@vitest/expect'
-import type { DomainMatchResult, DomainSnapshotAdapter } from '@vitest/snapshot'
 import type {
   AriaNode,
   AriaTemplateNode,
 } from 'ivya/aria'
+import type { DomainMatchResult, DomainSnapshotAdapter } from 'vitest'
 import * as aria from 'ivya/aria'
 import { Snapshots } from 'vitest'
 import { getBrowserState } from '../utils'

--- a/packages/snapshot/package.json
+++ b/packages/snapshot/package.json
@@ -22,18 +22,21 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "__vitest_source__": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./environment": {
+      "__vitest_source__": "./src/environment.ts",
       "types": "./dist/environment.d.ts",
       "default": "./dist/environment.js"
     },
     "./manager": {
+      "__vitest_source__": "./src/manager.ts",
       "types": "./dist/manager.d.ts",
       "default": "./dist/manager.js"
     },
-    "./*": "./*"
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -97,10 +97,6 @@
       "types": "./dist/reporters.d.ts",
       "default": "./dist/reporters.js"
     },
-    "./snapshot": {
-      "types": "./dist/snapshot.d.ts",
-      "default": "./dist/snapshot.js"
-    },
     "./runtime": {
       "types": "./dist/runtime.d.ts",
       "default": "./dist/runtime.js"
@@ -189,7 +185,6 @@
     "@vitest/mocker": "workspace:*",
     "@vitest/pretty-format": "workspace:*",
     "@vitest/runner": "workspace:*",
-    "@vitest/snapshot": "workspace:*",
     "@vitest/spy": "workspace:*",
     "@vitest/utils": "workspace:*",
     "es-module-lexer": "^2.0.0",
@@ -221,6 +216,7 @@
     "@types/picomatch": "^4.0.2",
     "@types/prompts": "^2.4.9",
     "@types/sinonjs__fake-timers": "^15.0.1",
+    "@vitest/snapshot": "workspace:*",
     "acorn": "8.11.3",
     "acorn-walk": "catalog:",
     "birpc": "catalog:",

--- a/packages/vitest/rollup.config.js
+++ b/packages/vitest/rollup.config.js
@@ -41,8 +41,6 @@ const entries = {
   'workers/vmForks': 'src/runtime/workers/vmForks.ts',
 
   'workers/runVmTests': 'src/runtime/runVmTests.ts',
-
-  'snapshot': 'src/public/snapshot.ts',
 }
 
 const dtsEntries = {
@@ -56,7 +54,6 @@ const dtsEntries = {
   'config': 'src/public/config.ts',
   'coverage': 'src/public/coverage.ts',
   'reporters': 'src/public/reporters.ts',
-  'snapshot': 'src/public/snapshot.ts',
   'worker': 'src/public/worker.ts',
   'module-evaluator': 'src/runtime/moduleRunner/moduleEvaluator.ts',
 }
@@ -68,6 +65,7 @@ const external = [
   'worker_threads',
   'node:worker_threads',
   'node:fs',
+  'node:fs/promises',
   'node:os',
   'node:stream',
   'node:vm',
@@ -86,8 +84,6 @@ const external = [
   '@vitest/utils/source-map',
   '@vitest/runner/utils',
   '@vitest/runner/types',
-  '@vitest/snapshot/environment',
-  '@vitest/snapshot/manager',
   /@vitest\/utils\/\w+/,
 
   '#module-evaluator',

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -155,6 +155,8 @@ export type {
 export type { CancelReason } from '@vitest/runner'
 
 export type {
+  DomainMatchResult,
+  DomainSnapshotAdapter,
   SnapshotData,
   SnapshotMatchOptions,
   SnapshotResult,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1050,9 +1050,6 @@ importers:
       '@vitest/runner':
         specifier: workspace:*
         version: link:../runner
-      '@vitest/snapshot':
-        specifier: workspace:*
-        version: link:../snapshot
       '@vitest/spy':
         specifier: workspace:*
         version: link:../spy
@@ -1144,6 +1141,9 @@ importers:
       '@types/sinonjs__fake-timers':
         specifier: ^15.0.1
         version: 15.0.1
+      '@vitest/snapshot':
+        specifier: workspace:*
+        version: link:../snapshot
       acorn:
         specifier: 8.11.3
         version: 8.11.3(patch_hash=62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4)

--- a/test/core/test/exports.test.ts
+++ b/test/core/test/exports.test.ts
@@ -168,9 +168,6 @@ it('exports snapshot', async ({ skip, task }) => {
         "builtinEnvironments": "object",
         "populateGlobal": "function",
       },
-      "./snapshot": {
-        "VitestSnapshotEnvironment": "function",
-      },
       "./suite": {
         "createChainable": "function",
         "createTaskCollector": "function",

--- a/test/snapshots/test/fixtures/domain/basic.ts
+++ b/test/snapshots/test/fixtures/domain/basic.ts
@@ -1,4 +1,4 @@
-import type { DomainMatchResult, DomainSnapshotAdapter } from '@vitest/snapshot'
+import type { DomainMatchResult, DomainSnapshotAdapter } from 'vitest'
 
 // Key-value domain adapter: each snapshot is multiple lines of `key=value`.
 // Values can be literal strings or `/regex/` patterns in the stored snapshot.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["esnext"],
+    "customConditions": ["__vitest_source__"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
@@ -10,8 +11,6 @@
       "@vitest/utils": ["./packages/utils/src/index.ts"],
       "@vitest/utils/*": ["./packages/utils/src/*"],
       "@vitest/spy": ["./packages/spy/src/index.ts"],
-      "@vitest/snapshot": ["./packages/snapshot/src/index.ts"],
-      "@vitest/snapshot/*": ["./packages/snapshot/src/*"],
       "@vitest/expect": ["./packages/expect/src/index.ts"],
       "@vitest/mocker": ["./packages/mocker/src/index.ts"],
       "@vitest/mocker/node": ["./packages/mocker/src/node/index.ts"],


### PR DESCRIPTION
In an effort to reduce the amount of packages fetched by Vitest and to simplify working in the repository, we are inlining certain dependencies. This PR inlines `snapshot` package (it will still be published) and removes deprecated `vitest/snapshot` entry point.