### PR TITLE
fix(spy): support private method spy types (fix #10172)

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -259,6 +259,20 @@ export function fn<T extends Procedure | Constructable = Procedure>(
   }) as Mock<T>
 }
 
+type SpyOnValue<T extends object, K extends keyof any> = K extends keyof Required<T>
+  ? Required<T>[K]
+  : (T & Record<K, unknown>)[K]
+
+type SpyOnMethod<T extends object, K extends keyof any>
+  = SpyOnValue<T, K> extends Constructable | Procedure
+    ? SpyOnValue<T, K>
+    : never
+
+type SpyOnMethodKey<T extends object, K extends keyof any>
+  = SpyOnValue<T, K> extends Constructable | Procedure
+    ? K
+    : never
+
 export function spyOn<T extends object, S extends Properties<Required<T>>>(
   object: T,
   key: S,
@@ -275,7 +289,11 @@ export function spyOn<T extends object, M extends Classes<Required<T>> | Methods
 ): Required<T>[M] extends Constructable | Procedure
   ? Mock<Required<T>[M]>
   : never
-export function spyOn<T extends object, K extends keyof T>(
+export function spyOn<T extends object, K extends keyof any>(
+  object: T,
+  key: SpyOnMethodKey<T, K>,
+): Mock<SpyOnMethod<T, K>>
+export function spyOn<T extends object, K extends keyof any>(
   object: T,
   key: K,
   accessor?: 'get' | 'set',
@@ -317,14 +335,14 @@ export function spyOn<T extends object, K extends keyof T>(
     // but there's still a value on the object when called
     // https://github.com/vitest-dev/vitest/issues/9439
     if (original == null && accessType === 'value') {
-      original = object[key] as unknown as Procedure
+      original = object[key as unknown as keyof T] as unknown as Procedure
     }
   }
   else if (accessType !== 'value') {
-    original = () => object[key]
+    original = () => object[key as unknown as keyof T]
   }
   else {
-    original = object[key] as unknown as Procedure
+    original = object[key as unknown as keyof T] as unknown as Procedure
   }
 
   const originalImplementation = ssr && original ? original() : original

--- a/test/typescript/test-d/test.test-d.ts
+++ b/test/typescript/test-d/test.test-d.ts
@@ -44,6 +44,28 @@ describe('test', () => {
     // @ts-expect-error
     vi.spyOn(google, 'sheets').mockReturnValue({ foo: 1234 })
   })
+
+  test('spyOn private and protected methods compiles', () => {
+    class TestClass {
+      private privateMethod(): number {
+        return 42
+      }
+
+      protected protectedMethod(): string {
+        return '42'
+      }
+    }
+
+    const instance = new TestClass()
+    vi.spyOn(instance, 'privateMethod').mockReturnValue(1)
+    vi.spyOn(instance, 'protectedMethod').mockReturnValue('1')
+    // @ts-expect-error private method returns number
+    vi.spyOn(instance, 'privateMethod').mockReturnValue('1')
+    // @ts-expect-error protected method returns string
+    vi.spyOn(instance, 'protectedMethod').mockReturnValue(1)
+    // @ts-expect-error unknown methods are rejected
+    vi.spyOn(instance, 'unknownMethod')
+  })
 })
 
 expectTypeOf({ wolk: 'true' }).toHaveProperty('wolk')


### PR DESCRIPTION
### Description

Allows `vi.spyOn` to infer mock types for known TypeScript private/protected method names, matching the runtime behavior and TypeScript's bracket-access escape hatch while still rejecting unknown method names.

Fixes #10172

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-a-pull-request-branch-created-from-a-fork/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] `pnpm --filter @vitest/spy run build`
- [x] `CI=true pnpm -C test/typescript run types --typecheck.ignoreSourceErrors test-d/test.test-d.ts`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm typecheck`
- [x] `CI=true pnpm -C test/unit run test test/mocking/vi-spyOn.test.ts`

### Documentation
- [x] Not needed; this is a type overload fix covered by regression type tests.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

AI-assisted using Hermes Agent/Codex.

<!-- VITEST_AUTOMATED_PR -->
