### PR TITLE
fix: test `tags` options should overwrite inherited suite options + inherit suite options in `task` API

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -340,7 +340,9 @@ function createSuiteCollector(
       }, {} as TestOptions)
 
     const testOwnMeta = options.meta
+    const parentOptions = collectorContext.currentSuite?.options
     options = {
+      ...parentOptions,
       ...tagsOptions,
       ...options,
     }
@@ -441,11 +443,6 @@ function createSuiteCollector(
     timeoutOrTest?: number | TestFunction,
   ) {
     let { options, handler } = parseArguments(optionsOrFn, timeoutOrTest)
-
-    // inherit repeats, retry, timeout from suite
-    if (typeof suiteOptions === 'object') {
-      options = Object.assign({}, suiteOptions, options)
-    }
 
     const concurrent = this.concurrent ?? options?.concurrent
     if (concurrent != null) {

--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -442,7 +442,7 @@ function createSuiteCollector(
     optionsOrFn?: TestOptions | TestFunction,
     timeoutOrTest?: number | TestFunction,
   ) {
-    let { options, handler } = parseArguments(optionsOrFn, timeoutOrTest)
+    const { options, handler } = parseArguments(optionsOrFn, timeoutOrTest)
 
     const concurrent = this.concurrent ?? options?.concurrent
     if (concurrent != null) {

--- a/test/e2e/test/test-tags.test.ts
+++ b/test/e2e/test/test-tags.test.ts
@@ -654,7 +654,6 @@ test('concurrent false tag option opts out of sequence.concurrent', async () => 
     {
       "basic.test.js": {
         "test 1": {
-          "concurrent": true,
           "mode": "run",
           "tags": [
             "non-concurrent-tag",
@@ -662,7 +661,6 @@ test('concurrent false tag option opts out of sequence.concurrent', async () => 
           "timeout": 5000,
         },
         "test 2": {
-          "concurrent": true,
           "mode": "run",
           "tags": [
             "non-concurrent-tag",
@@ -1753,6 +1751,61 @@ test('multiple tags with meta are merged with priority order', async () => {
       "highOnly": true,
       "lowOnly": true,
       "shared": "high",
+    }
+  `)
+})
+
+test('tag options override inherited suite options', async () => {
+  const { stderr, buildTree } = await runInlineTests({
+    'basic.test.js': `
+      describe('with suite options', { timeout: 1000, repeats: 1, concurrent: true }, () => {
+        test('tag wins', { tags: ['my-tag'] }, () => {})
+        test('explicit test wins', { tags: ['my-tag'], timeout: 9999 }, () => {})
+      })
+      describe('without suite options', () => {
+        test('tag applies', { tags: ['my-tag'] }, () => {})
+      })
+    `,
+    'vitest.config.js': {
+      test: {
+        globals: true,
+        tags: [{ name: 'my-tag', timeout: 5000, repeats: 2, concurrent: false }],
+      },
+    },
+  })
+  expect(stderr).toBe('')
+  expect(buildOptionsTree(buildTree)).toMatchInlineSnapshot(`
+    {
+      "basic.test.js": {
+        "with suite options": {
+          "explicit test wins": {
+            "mode": "run",
+            "repeats": 2,
+            "tags": [
+              "my-tag",
+            ],
+            "timeout": 9999,
+          },
+          "tag wins": {
+            "mode": "run",
+            "repeats": 2,
+            "tags": [
+              "my-tag",
+            ],
+            "timeout": 5000,
+          },
+        },
+        "without suite options": {
+          "tag applies": {
+            "mode": "run",
+            "repeats": 2,
+            "tags": [
+              "my-tag",
+            ],
+            "timeout": 5000,
+          },
+        },
+      },
     }
   `)
 })

--- a/test/unit/test/task-collector.test.ts
+++ b/test/unit/test/task-collector.test.ts
@@ -50,7 +50,7 @@ describe('collector.extend should preserve handler wrapping', () => {
   })
 })
 
-describe('raw suite.task inherits suite options', { concurrent: true, repeats: 1, retry: 2, timeout: 1234 }, () => {
+describe('suite.task inherits suite options', { meta: { yay: true } as any, concurrent: true, repeats: 1, retry: 2, timeout: 1234 }, () => {
   const customTest = TestRunner.createTaskCollector(function (
     this: object,
     name: string,
@@ -60,10 +60,23 @@ describe('raw suite.task inherits suite options', { concurrent: true, repeats: 1
   })
 
   customTest('inherits options from current suite', ({ task }) => {
-    expect(task.concurrent).toBe(true)
-    expect(task.repeats).toBe(1)
-    expect(task.retry).toBe(2)
-    expect(task.timeout).toBe(1234)
+    expect({
+      concurrent: task.concurrent,
+      meta: task.meta,
+      repeats: task.repeats,
+      retry: task.retry,
+      timeout: task.timeout,
+    }).toMatchInlineSnapshot(`
+      {
+        "concurrent": true,
+        "meta": {
+          "yay": true,
+        },
+        "repeats": 1,
+        "retry": 2,
+        "timeout": 1234,
+      }
+    `)
   })
 })
 

--- a/test/unit/test/task-collector.test.ts
+++ b/test/unit/test/task-collector.test.ts
@@ -50,6 +50,23 @@ describe('collector.extend should preserve handler wrapping', () => {
   })
 })
 
+describe('raw suite.task inherits suite options', { concurrent: true, repeats: 1, retry: 2, timeout: 1234 }, () => {
+  const customTest = TestRunner.createTaskCollector(function (
+    this: object,
+    name: string,
+    fn: () => void,
+  ) {
+    TestRunner.getCurrentSuite().task(name, { ...this, handler: fn })
+  })
+
+  customTest('inherits options from current suite', ({ task }) => {
+    expect(task.concurrent).toBe(true)
+    expect(task.repeats).toBe(1)
+    expect(task.retry).toBe(2)
+    expect(task.timeout).toBe(1234)
+  })
+})
+
 describe('empty tests and suites are todos', () => {
   describe('suite should be todo')
   test('test should be todo')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10199
- Closes https://github.com/vitest-dev/vitest/pull/10203 (supersedes)

I was reviewing https://github.com/vitest-dev/vitest/pull/10203 and it looks like grabbing `collectorContext.currentSuite?.options` seems like a right fix. Here is why:

---

This fixes suite option merging during test collection. Tests now merge options in the intended priority order: 

> inherited suite options < then tag-derived options < explicit task options. 

This ensures tag options can override inherited suite defaults while still allowing the test’s own options to win.

By using `collectorContext.currentSuite?.options` inside `task` function, this also makes the advanced raw task API consistent with normal `test()` collection: tasks registered through `TestRunner.getCurrentSuite().task(...)` now inherit options from the current suite. This matches the documented custom task collector behavior that should act like a test collector. Notably some properties are already inherited based on context such as `task.meta`.

A regression test was added for custom task collectors using the raw task API to verify inherited `concurrent`, `repeats`, `retry`, and `timeout` options.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
