### PR TITLE
refactor!: inline `expect` package

### DIFF
--- a/packages/browser/src/client/tester/aria.ts
+++ b/packages/browser/src/client/tester/aria.ts
@@ -1,9 +1,12 @@
-import type { MatchersObject } from '@vitest/expect'
 import type {
   AriaNode,
   AriaTemplateNode,
 } from 'ivya/aria'
-import type { DomainMatchResult, DomainSnapshotAdapter } from 'vitest'
+import type {
+  DomainMatchResult,
+  DomainSnapshotAdapter,
+  MatchersObject,
+} from 'vitest'
 import * as aria from 'ivya/aria'
 import { Snapshots } from 'vitest'
 import { getBrowserState } from '../utils'

--- a/packages/browser/src/client/tester/expect/index.ts
+++ b/packages/browser/src/client/tester/expect/index.ts
@@ -1,4 +1,4 @@
-import type { MatchersObject } from '@vitest/expect'
+import type { MatchersObject } from 'vitest'
 import toBeChecked from './toBeChecked'
 import toBeEmptyDOMElement from './toBeEmptyDOMElement'
 import { toBeDisabled, toBeEnabled } from './toBeEnabled'

--- a/packages/browser/src/client/tester/expect/toBeChecked.ts
+++ b/packages/browser/src/client/tester/expect/toBeChecked.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getAriaChecked, getAriaCheckedRoles, getAriaRole } from 'ivya/utils'
 import { getElementFromUserInput, isInputElement, toSentence } from './utils'
@@ -23,7 +23,7 @@ const supportedRoles = getAriaCheckedRoles()
 export default function toBeChecked(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBeChecked, this)
 
   const isValidInput = () => {

--- a/packages/browser/src/client/tester/expect/toBeEmptyDOMElement.ts
+++ b/packages/browser/src/client/tester/expect/toBeEmptyDOMElement.ts
@@ -13,14 +13,14 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput } from './utils'
 
 export default function toBeEmptyDOMElement(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBeEmptyDOMElement, this)
 
   return {

--- a/packages/browser/src/client/tester/expect/toBeEnabled.ts
+++ b/packages/browser/src/client/tester/expect/toBeEnabled.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getAriaDisabled } from 'ivya/utils'
 import { getElementFromUserInput, getTag } from './utils'
@@ -21,7 +21,7 @@ import { getElementFromUserInput, getTag } from './utils'
 export function toBeDisabled(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBeDisabled, this)
   const isDisabled = isElementDisabled(htmlElement)
   return {
@@ -45,7 +45,7 @@ export function toBeDisabled(
 export function toBeEnabled(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBeEnabled, this)
   const isDisabled = isElementDisabled(htmlElement)
   return {

--- a/packages/browser/src/client/tester/expect/toBeInTheDocument.ts
+++ b/packages/browser/src/client/tester/expect/toBeInTheDocument.ts
@@ -13,14 +13,14 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { queryElementFromUserInput } from './utils'
 
 export default function toBeInTheDocument(
   this: MatcherState,
   actual: Element | Locator | null,
-): ExpectationResult {
+): MatcherResult {
   let htmlElement: null | HTMLElement | SVGElement = null
 
   if (actual !== null || !this.isNot) {

--- a/packages/browser/src/client/tester/expect/toBeInViewport.ts
+++ b/packages/browser/src/client/tester/expect/toBeInViewport.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput } from './utils'
 
@@ -21,7 +21,7 @@ export default function toBeInViewport(
   this: MatcherState,
   actual: Element | Locator,
   options?: { ratio?: number },
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBeInViewport, this)
 
   const expectedRatio = options?.ratio ?? 0

--- a/packages/browser/src/client/tester/expect/toBeInvalid.ts
+++ b/packages/browser/src/client/tester/expect/toBeInvalid.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput, getTag } from './utils'
 
@@ -43,7 +43,7 @@ function isElementInvalid(element: HTMLElement | SVGElement) {
 export function toBeInvalid(
   this: MatcherState,
   element: HTMLElement | SVGElement | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(element, toBeInvalid, this)
 
   const isInvalid = isElementInvalid(htmlElement)
@@ -69,7 +69,7 @@ export function toBeInvalid(
 export function toBeValid(
   this: MatcherState,
   element: HTMLElement | SVGElement | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(element, toBeInvalid, this)
 
   const isValid = !isElementInvalid(htmlElement)

--- a/packages/browser/src/client/tester/expect/toBePartiallyChecked.ts
+++ b/packages/browser/src/client/tester/expect/toBePartiallyChecked.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getAriaChecked as ivyaGetAriaChecked } from 'ivya/utils'
 import { getElementFromUserInput, isInputElement } from './utils'
@@ -21,7 +21,7 @@ import { getElementFromUserInput, isInputElement } from './utils'
 export default function toBePartiallyChecked(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBePartiallyChecked, this)
 
   const isValidInput = () => {

--- a/packages/browser/src/client/tester/expect/toBeRequired.ts
+++ b/packages/browser/src/client/tester/expect/toBeRequired.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput, getTag } from './utils'
 
@@ -69,7 +69,7 @@ function isElementRequiredByARIA(element: HTMLElement | SVGElement) {
 export default function toBeRequired(
   this: MatcherState,
   element: HTMLElement | SVGElement | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(element, toBeRequired, this)
 
   const isRequired

--- a/packages/browser/src/client/tester/expect/toBeVisible.ts
+++ b/packages/browser/src/client/tester/expect/toBeVisible.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { beginAriaCaches, endAriaCaches, isElementVisible as ivyaIsVisible } from 'ivya/utils'
 import { server } from 'vitest/browser'
@@ -22,7 +22,7 @@ import { getElementFromUserInput } from './utils'
 export default function toBeVisible(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toBeVisible, this)
   const isInDocument
     = htmlElement.ownerDocument === htmlElement.getRootNode({ composed: true })

--- a/packages/browser/src/client/tester/expect/toContainElement.ts
+++ b/packages/browser/src/client/tester/expect/toContainElement.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput } from './utils'
 
@@ -21,7 +21,7 @@ export default function toContainElement(
   this: MatcherState,
   actual: Element | Locator,
   expectedElement: Element | Locator | null,
-): ExpectationResult {
+): MatcherResult {
   const containerElement = getElementFromUserInput(actual, toContainElement, this)
   const childElement = expectedElement !== null
     ? getElementFromUserInput(expectedElement, toContainElement, this)

--- a/packages/browser/src/client/tester/expect/toContainHTML.ts
+++ b/packages/browser/src/client/tester/expect/toContainHTML.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput } from './utils'
 
@@ -27,7 +27,7 @@ export default function toContainHTML(
   this: MatcherState,
   actual: Element | Locator,
   htmlText: string,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toContainHTML, this)
 
   if (typeof htmlText !== 'string') {

--- a/packages/browser/src/client/tester/expect/toHaveAccessibleDescription.ts
+++ b/packages/browser/src/client/tester/expect/toHaveAccessibleDescription.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementAccessibleDescription } from 'ivya/utils'
 import { getElementFromUserInput, getMessage } from './utils'
@@ -22,7 +22,7 @@ export default function toHaveAccessibleDescription(
   this: MatcherState,
   actual: Element | Locator,
   expectedAccessibleDescription?: string | RegExp,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveAccessibleDescription, this)
   const actualAccessibleDescription = getElementAccessibleDescription(htmlElement, false)
   const defaultView = htmlElement.ownerDocument.defaultView || window

--- a/packages/browser/src/client/tester/expect/toHaveAccessibleErrorMessage.ts
+++ b/packages/browser/src/client/tester/expect/toHaveAccessibleErrorMessage.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementAccessibleErrorMessage } from 'ivya/utils'
 import { getElementFromUserInput, getMessage, redent } from './utils'
@@ -22,7 +22,7 @@ export default function toHaveAccessibleErrorMessage(
   this: MatcherState,
   actual: Element | Locator,
   expectedAccessibleErrorMessage?: string | RegExp,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveAccessibleErrorMessage, this)
   const actualAccessibleErrorMessage = getElementAccessibleErrorMessage(htmlElement) ?? ''
   const defaultView = htmlElement.ownerDocument.defaultView || window

--- a/packages/browser/src/client/tester/expect/toHaveAccessibleName.ts
+++ b/packages/browser/src/client/tester/expect/toHaveAccessibleName.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementAccessibleName } from 'ivya/utils'
 import { getElementFromUserInput, getMessage } from './utils'
@@ -22,7 +22,7 @@ export default function toHaveAccessibleName(
   this: MatcherState,
   actual: Element | Locator,
   expectedAccessibleName?: string | RegExp,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveAccessibleName, this)
   const actualAccessibleName = getElementAccessibleName(htmlElement, false)
   const missingExpectedValue = arguments.length === 1

--- a/packages/browser/src/client/tester/expect/toHaveAttribute.ts
+++ b/packages/browser/src/client/tester/expect/toHaveAttribute.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput, getMessage } from './utils'
 
@@ -22,7 +22,7 @@ export default function toHaveAttribute(
   actual: Element | Locator,
   attribute: string,
   expectedValue?: string,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveAttribute, this)
   const isExpectedValuePresent = expectedValue !== undefined
   const hasAttribute = htmlElement.hasAttribute(attribute)

--- a/packages/browser/src/client/tester/expect/toHaveClass.ts
+++ b/packages/browser/src/client/tester/expect/toHaveClass.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput, getMessage } from './utils'
 
@@ -21,7 +21,7 @@ export default function toHaveClass(
   this: MatcherState,
   actual: Element | Locator,
   ...params: (string | RegExp)[] | [string, options?: { exact: boolean }]
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveClass, this)
   const { expectedClassNames, options } = getExpectedClassNamesAndOptions(params)
 

--- a/packages/browser/src/client/tester/expect/toHaveDisplayValue.ts
+++ b/packages/browser/src/client/tester/expect/toHaveDisplayValue.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput, getMessage, getTag, isInputElement } from './utils'
 
@@ -21,7 +21,7 @@ export default function toHaveDisplayValue(
   this: MatcherState,
   actual: Element | Locator,
   expectedValue: string | RegExp | Array<string | RegExp>,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveDisplayValue, this)
   const tagName = getTag(htmlElement)
 

--- a/packages/browser/src/client/tester/expect/toHaveFocus.ts
+++ b/packages/browser/src/client/tester/expect/toHaveFocus.ts
@@ -13,14 +13,14 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getElementFromUserInput } from './utils'
 
 export default function toHaveFocus(
   this: MatcherState,
   actual: Element | Locator,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveFocus, this)
 
   return {

--- a/packages/browser/src/client/tester/expect/toHaveFormValues.ts
+++ b/packages/browser/src/client/tester/expect/toHaveFormValues.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { cssEscape } from 'ivya/utils'
 import { arrayAsSetComparison, getElementFromUserInput, getSingleElementValue, getTag } from './utils'
@@ -22,7 +22,7 @@ export default function toHaveFormValues(
   this: MatcherState,
   actual: Element | Locator,
   expectedValues: Record<string, unknown>,
-): ExpectationResult {
+): MatcherResult {
   const formElement = getElementFromUserInput(actual, toHaveFormValues, this)
 
   const defaultView = formElement.ownerDocument.defaultView || window

--- a/packages/browser/src/client/tester/expect/toHaveRole.ts
+++ b/packages/browser/src/client/tester/expect/toHaveRole.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { beginAriaCaches, endAriaCaches, getAriaRole } from 'ivya/utils'
 import { getElementFromUserInput, getMessage } from './utils'
@@ -22,7 +22,7 @@ export default function toHaveRole(
   this: MatcherState,
   actual: Element | Locator,
   expectedRole: string,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveRole, this)
   beginAriaCaches()
   const actualRole = getAriaRole(htmlElement)

--- a/packages/browser/src/client/tester/expect/toHaveSelection.ts
+++ b/packages/browser/src/client/tester/expect/toHaveSelection.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { arrayAsSetComparison, getElementFromUserInput, getMessage, getTag } from './utils'
 
@@ -21,7 +21,7 @@ export default function toHaveSelection(
   this: MatcherState,
   element: HTMLElement | SVGElement | Locator,
   expectedSelection: string,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(element, toHaveSelection, this)
 
   const expectsSelection = expectedSelection !== undefined

--- a/packages/browser/src/client/tester/expect/toHaveStyle.ts
+++ b/packages/browser/src/client/tester/expect/toHaveStyle.ts
@@ -1,4 +1,4 @@
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { server } from 'vitest/browser'
 import { getElementFromUserInput } from './utils'
@@ -44,7 +44,7 @@ export default function toHaveStyle(
   this: MatcherState,
   actual: Element | Locator,
   css: string | Record<string, unknown>,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveStyle, this)
   const { getComputedStyle } = htmlElement.ownerDocument.defaultView!
 

--- a/packages/browser/src/client/tester/expect/toHaveTextContent.ts
+++ b/packages/browser/src/client/tester/expect/toHaveTextContent.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { getMessage, getNodeFromUserInput, matches, normalize } from './utils'
 
@@ -22,7 +22,7 @@ export default function toHaveTextContent(
   actual: Element | Locator,
   matcher: string | RegExp,
   options: { normalizeWhitespace?: boolean } = { normalizeWhitespace: true },
-): ExpectationResult {
+): MatcherResult {
   const node = getNodeFromUserInput(actual, toHaveTextContent, this)
 
   const textContent = options.normalizeWhitespace

--- a/packages/browser/src/client/tester/expect/toHaveValue.ts
+++ b/packages/browser/src/client/tester/expect/toHaveValue.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { ExpectationResult, MatcherState } from '@vitest/expect'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
 import { arrayAsSetComparison, getElementFromUserInput, getMessage, getSingleElementValue, isInputElement } from './utils'
 
@@ -21,7 +21,7 @@ export default function toHaveValue(
   this: MatcherState,
   actual: Element | Locator,
   expectedValue?: string,
-): ExpectationResult {
+): MatcherResult {
   const htmlElement = getElementFromUserInput(actual, toHaveValue, this)
 
   if (

--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -1,5 +1,5 @@
-import type { AsyncExpectationResult, MatcherState } from '@vitest/expect'
 import type { VisualRegressionArtifact } from '@vitest/runner'
+import type { MatcherResult, MatcherState } from 'vitest'
 import type { ScreenshotMatcherOptions } from '../../../../context'
 import type { ScreenshotMatcherArguments, ScreenshotMatcherOutput } from '../../../shared/screenshotMatcher/types'
 import type { Locator } from '../locators'
@@ -16,7 +16,7 @@ export default async function toMatchScreenshot(
   options: ScreenshotMatcherOptions = typeof nameOrOptions === 'object'
     ? nameOrOptions
     : {},
-): AsyncExpectationResult {
+): Promise<MatcherResult> {
   if (this.isNot) {
     throw new Error('\'toMatchScreenshot\' cannot be used with "not"')
   }

--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -1,5 +1,5 @@
 import type { VisualRegressionArtifact } from '@vitest/runner'
-import type { MatcherResult, MatcherState } from 'vitest'
+import type { AsyncMatcherResult, MatcherState } from 'vitest'
 import type { ScreenshotMatcherOptions } from '../../../../context'
 import type { ScreenshotMatcherArguments, ScreenshotMatcherOutput } from '../../../shared/screenshotMatcher/types'
 import type { Locator } from '../locators'
@@ -16,7 +16,7 @@ export default async function toMatchScreenshot(
   options: ScreenshotMatcherOptions = typeof nameOrOptions === 'object'
     ? nameOrOptions
     : {},
-): Promise<MatcherResult> {
+): AsyncMatcherResult {
   if (this.isNot) {
     throw new Error('\'toMatchScreenshot\' cannot be used with "not"')
   }

--- a/packages/browser/src/client/tester/expect/utils.ts
+++ b/packages/browser/src/client/tester/expect/utils.ts
@@ -13,7 +13,7 @@
  * copies or substantial portions of the Software.
  */
 
-import type { MatcherState } from '@vitest/expect'
+import type { MatcherState } from 'vitest'
 import { Locator } from '../locators'
 
 export function queryElementFromUserInput(

--- a/packages/browser/src/client/tester/locators.ts
+++ b/packages/browser/src/client/tester/locators.ts
@@ -317,7 +317,7 @@ export abstract class Locator {
   public element(): HTMLElement | SVGElement {
     const element = this.query()
     if (!element) {
-      throw utils.getElementError(this._pwSelector || this.selector, this._container || document.body)
+      throw utils.getElementError(this, this._container || document.body)
     }
     return element
   }
@@ -379,14 +379,14 @@ export abstract class Locator {
       }
       if (elements.length > 1) {
         if (strict) {
-          throw createStrictModeViolationError(this._pwSelector || this.selector, elements)
+          throw createStrictModeViolationError(this, elements)
         }
         return elements[0]
       }
       const elapsed = now() - startTime
       const isLastCall = timeout != null && elapsed >= timeout
       if (isLastCall) {
-        throw utils.getElementError(this._pwSelector || this.selector, this._container || document.body)
+        throw utils.getElementError(this, this._container || document.body)
       }
       const interval = waitForIntervals[Math.min(intervalIndex++, waitForIntervals.length - 1)]
       const nextInterval = timeout != null
@@ -432,7 +432,7 @@ export interface SerializedLocator {
 }
 
 function createStrictModeViolationError(
-  selector: string,
+  locator: Locator,
   matches: Element[],
 ) {
   const infos = matches.slice(0, 10).map(m => ({
@@ -447,6 +447,6 @@ function createStrictModeViolationError(
     lines.push('\n    ...')
   }
   return new Error(
-    `strict mode violation: ${asLocator('javascript', selector)} resolved to ${matches.length} elements:${lines.join('')}\n`,
+    `strict mode violation: ${locator.asLocator()} resolved to ${matches.length} elements:${lines.join('')}\n`,
   )
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -23,10 +23,11 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "__vitest_source__": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": "./*"
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -186,12 +186,13 @@
     }
   },
   "dependencies": {
-    "@vitest/expect": "workspace:*",
+    "@types/chai": "catalog:",
     "@vitest/mocker": "workspace:*",
     "@vitest/pretty-format": "workspace:*",
     "@vitest/runner": "workspace:*",
     "@vitest/spy": "workspace:*",
     "@vitest/utils": "workspace:*",
+    "chai": "catalog:",
     "es-module-lexer": "^2.0.0",
     "expect-type": "^1.3.0",
     "magic-string": "catalog:",
@@ -221,6 +222,7 @@
     "@types/picomatch": "^4.0.2",
     "@types/prompts": "^2.4.9",
     "@types/sinonjs__fake-timers": "^15.0.1",
+    "@vitest/expect": "workspace:*",
     "@vitest/snapshot": "workspace:*",
     "acorn": "8.11.3",
     "acorn-walk": "catalog:",

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -66,6 +66,7 @@ export type { ExpectTypeOf } from '../typecheck/expectTypeOf'
 export type { BrowserTesterOptions } from '../types/browser'
 export type {
   AfterSuiteRunMeta,
+  ExpectPollOptions,
   LabelColor,
   ModuleGraphData,
   ParsedStack,
@@ -91,12 +92,12 @@ export type {
   Assertion,
   AsymmetricMatchersContaining,
   DeeplyAllowMatchers,
-  ExpectPollOptions,
   ExpectStatic,
   JestAssertion,
   RawMatcherFn as Matcher,
   ExpectationResult as MatcherResult,
   Matchers,
+  MatchersObject,
   MatcherState,
 } from '@vitest/expect'
 export {

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -66,7 +66,6 @@ export type { ExpectTypeOf } from '../typecheck/expectTypeOf'
 export type { BrowserTesterOptions } from '../types/browser'
 export type {
   AfterSuiteRunMeta,
-  ExpectPollOptions,
   LabelColor,
   ModuleGraphData,
   ParsedStack,

--- a/packages/vitest/src/public/index.ts
+++ b/packages/vitest/src/public/index.ts
@@ -91,6 +91,7 @@ export type {
 export type {
   Assertion,
   AsymmetricMatchersContaining,
+  AsyncExpectationResult as AsyncMatcherResult,
   DeeplyAllowMatchers,
   ExpectStatic,
   JestAssertion,
@@ -99,6 +100,7 @@ export type {
   Matchers,
   MatchersObject,
   MatcherState,
+  SyncExpectationResult as SyncMatcherResult,
 } from '@vitest/expect'
 export {
   afterAll,

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -51,3 +51,9 @@ export interface AsyncLeak {
   stack: string
   type: string
 }
+
+export interface ExpectPollOptions {
+  interval?: number
+  timeout?: number
+  message?: string
+}

--- a/packages/vitest/src/types/general.ts
+++ b/packages/vitest/src/types/general.ts
@@ -51,9 +51,3 @@ export interface AsyncLeak {
   stack: string
   type: string
 }
-
-export interface ExpectPollOptions {
-  interval?: number
-  timeout?: number
-  message?: string
-}

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -3,7 +3,7 @@ import type { Plugin as PrettyFormatPlugin } from '@vitest/pretty-format'
 import type { Test } from '@vitest/runner'
 import type { SnapshotState } from '@vitest/snapshot'
 import type { BenchmarkResult } from '../runtime/types/benchmark'
-import type { UserConsoleLog } from './general'
+import type { ExpectPollOptions, UserConsoleLog } from './general'
 
 interface SnapshotMatcher<T> {
   <U extends { [P in keyof T]: any }>(
@@ -22,17 +22,11 @@ interface InlineSnapshotMatcher<T> {
   (hint?: string): void
 }
 
-declare module '@vitest/expect' {
+declare module 'vitest' {
   interface MatcherState {
     environment: string
     snapshotState: SnapshotState
     task?: Readonly<Test>
-  }
-
-  interface ExpectPollOptions {
-    interval?: number
-    timeout?: number
-    message?: string
   }
 
   interface ExpectStatic {

--- a/packages/vitest/src/types/global.ts
+++ b/packages/vitest/src/types/global.ts
@@ -3,7 +3,7 @@ import type { Plugin as PrettyFormatPlugin } from '@vitest/pretty-format'
 import type { Test } from '@vitest/runner'
 import type { SnapshotState } from '@vitest/snapshot'
 import type { BenchmarkResult } from '../runtime/types/benchmark'
-import type { ExpectPollOptions, UserConsoleLog } from './general'
+import type { UserConsoleLog } from './general'
 
 interface SnapshotMatcher<T> {
   <U extends { [P in keyof T]: any }>(
@@ -27,6 +27,12 @@ declare module 'vitest' {
     environment: string
     snapshotState: SnapshotState
     task?: Readonly<Test>
+  }
+
+  interface ExpectPollOptions {
+    interval?: number
+    timeout?: number
+    message?: string
   }
 
   interface ExpectStatic {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,9 @@ importers:
 
   packages/vitest:
     dependencies:
+      '@types/chai':
+        specifier: 'catalog:'
+        version: 5.2.2
       '@vitest/browser-playwright':
         specifier: workspace:*
         version: link:../browser-playwright
@@ -1041,9 +1044,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: workspace:*
         version: link:../coverage-v8
-      '@vitest/expect':
-        specifier: workspace:*
-        version: link:../expect
       '@vitest/mocker':
         specifier: workspace:*
         version: link:../mocker
@@ -1062,6 +1062,9 @@ importers:
       '@vitest/utils':
         specifier: workspace:*
         version: link:../utils
+      chai:
+        specifier: 'catalog:'
+        version: 6.2.2
       es-module-lexer:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1144,6 +1147,9 @@ importers:
       '@types/sinonjs__fake-timers':
         specifier: ^15.0.1
         version: 15.0.1
+      '@vitest/expect':
+        specifier: workspace:*
+        version: link:../expect
       '@vitest/snapshot':
         specifier: workspace:*
         version: link:../snapshot

--- a/test/snapshots/test/fixtures/domain/basic-extend.ts
+++ b/test/snapshots/test/fixtures/domain/basic-extend.ts
@@ -1,5 +1,5 @@
 import { expect, Snapshots } from "vitest"
-import type { MatchersObject } from "@vitest/expect"
+import type { MatchersObject } from "vitest"
 import { kvAdapter } from "./basic"
 
 interface CustomMatchers<R = unknown> {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,6 @@
       "@vitest/utils": ["./packages/utils/src/index.ts"],
       "@vitest/utils/*": ["./packages/utils/src/*"],
       "@vitest/spy": ["./packages/spy/src/index.ts"],
-      "@vitest/expect": ["./packages/expect/src/index.ts"],
       "@vitest/mocker": ["./packages/mocker/src/index.ts"],
       "@vitest/mocker/node": ["./packages/mocker/src/node/index.ts"],
       "@vitest/mocker/browser": ["./packages/mocker/src/browser/index.ts"],


### PR DESCRIPTION
In an effort to reduce the amount of packages fetched by Vitest and to simplify working in the repository, we are inlining certain dependencies. This PR inlines `expect` package (it will still be published)

We have to include `chai` in vitest's dependencies now.