### PR TITLE
fix: loosen vi.mock(import(...)) factory types to accept vi.fn()

### DIFF
--- a/packages/mocker/src/types.ts
+++ b/packages/mocker/src/types.ts
@@ -2,9 +2,15 @@
 
 type Awaitable<T> = T | PromiseLike<T>
 
+type Mockable<T> = T extends (...args: any[]) => any
+  ? T | ((...args: any[]) => any)
+  : T extends object
+    ? { [K in keyof T]?: Mockable<T[K]> }
+    : T
+
 export type ModuleMockFactoryWithHelper<M = unknown> = (
   importOriginal: <T extends M = M>() => Promise<T>,
-) => Awaitable<Partial<M>>
+) => Awaitable<Mockable<M>>
 export type ModuleMockFactory = () => any
 export interface ModuleMockOptions {
   spy?: boolean

--- a/test/unit/src/mockedClassInstance.ts
+++ b/test/unit/src/mockedClassInstance.ts
@@ -1,0 +1,7 @@
+export class Logger {
+  #config = {}
+  info(msg: string): void { void msg }
+  warn(msg: string): void { void msg }
+}
+
+export default new Logger()

--- a/test/unit/test/mocking/vi-mock.test-d.ts
+++ b/test/unit/test/mocking/vi-mock.test-d.ts
@@ -1,0 +1,13 @@
+import { test, vi } from 'vitest'
+
+vi.mock(import('../../src/mockedClassInstance.js'), () => ({
+  default: { info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock(import('../../src/mockedA.js'), () => ({
+  mockedA: vi.fn(),
+}))
+
+test('vi.mock with import() accepts vi.fn() for class instance with private fields', () => {})
+
+test('vi.mock with import() accepts partial module mock', () => {})


### PR DESCRIPTION
### Description

Be able to mock a module where the path is stricter than a string literal - meaning when renaming or moving modules, the mock path references are updated too (and not missed!)

```
// logger.js
class Logger {
  info(msg: string): void {
    console.log(msg);
  }
}

// The module path is just a string, invisible to refactoring tools
vi.mock("./logger.js", () => ({
  default: { info: vi.fn() },
}));

// Ideal, but... fails typecheck as Mock<Procedure> is not assignable to Logger['info']
vi.mock(import("./logger.js"), () => ({
  default: { info: vi.fn() },
}));
```

Resolves #10224 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.
(I get 6 failures even from a clean checkout, but the same 6 failures after my change is applied)

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.
(Not sure if this type change warrants a docs update)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

### LLM Usage

I used OpenCode with Opus 4.6. Mainly when playing with few ways that `Mockable` can be written and how it reads - it's not the most readable code :/ the best I could get it.
