### PR TITLE
docs: clarify order of `before*` hooks cleanup functions

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -34,7 +34,7 @@ beforeEach(async () => {
 
 Here, the `beforeEach` ensures that user is added for each test.
 
-`beforeEach` can also return an optional cleanup function (equivalent to [`afterEach`](#aftereach)):
+`beforeEach` can also return an optional cleanup function. It's similar to [`afterEach`](#aftereach). The only difference is that it's executed after all other `afterEach` hooks:
 
 ```ts
 import { beforeEach } from 'vitest'
@@ -43,7 +43,7 @@ beforeEach(async () => {
   // called once before each test run
   await prepareSomething()
 
-  // clean up function, called once after each test run
+  // clean up function, called once after each test run, after afterEach hooks
   return async () => {
     await resetSomething()
   }
@@ -102,7 +102,7 @@ beforeAll(async () => {
 
 Here the `beforeAll` ensures that the mock data is set up before tests run.
 
-`beforeAll` can also return an optional cleanup function (equivalent to [`afterAll`](#afterall)):
+`beforeAll` can also return an optional cleanup function. It's similar to [`afterAll`](#afterall). The only difference is that it's executed after all other `afterAll` hooks:
 
 ```ts
 import { beforeAll } from 'vitest'
@@ -111,7 +111,7 @@ beforeAll(async () => {
   // called once before all tests run
   await startMocking()
 
-  // clean up function, called once after all tests run
+  // clean up function, called once after all tests run, after afterAll hooks
   return async () => {
     await stopMocking()
   }

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -137,10 +137,12 @@ The execution follows this order:
    - `beforeEach` hooks execute (in order defined, or based on [`sequence.hooks`](/config/sequence#sequence-hooks))
    - Test function executes
    - `afterEach` hooks execute (reverse order by default with `sequence.hooks: 'stack'`)
+   - Cleanup functions returned from `beforeEach` hooks execute (reverse order by default with `sequence.hooks: 'stack'`)
    - [`onTestFinished`](/api/hooks#ontestfinished) callbacks run (always in reverse order)
    - If test failed: [`onTestFailed`](/api/hooks#ontestfailed) callbacks run
    - Note: if `repeats` or `retry` are set, all of these steps are executed again
 6. **[`afterAll`](/api/hooks#afterall) hooks:** Run once after all tests in the suite complete
+7. **Cleanup functions returned from `beforeAll` hooks:** Run once after all tests in the suite complete
 
 **Example execution flow:**
 

--- a/docs/guide/lifecycle.md
+++ b/docs/guide/lifecycle.md
@@ -164,6 +164,11 @@ describe('User API', () => {
   beforeAll(() => {
     // Runs once before all tests in this suite
     console.log('beforeAll')
+
+    return function beforeAllCleanup() {
+      // Runs once afterAll hooks have run
+      console.log('beforeAllCleanup')
+    }
   })
 
   aroundEach(async (runTest) => {
@@ -176,6 +181,11 @@ describe('User API', () => {
   beforeEach(() => {
     // Runs before each test
     console.log('beforeEach')
+
+    return function beforeEachCleanup() {
+      // Runs after afterEach hooks have run
+      console.log('beforeEachCleanup')
+    }
   })
 
   test('creates user', () => {
@@ -208,13 +218,16 @@ describe('User API', () => {
 //     beforeEach
 //       test 1
 //     afterEach
+//     beforeEachCleanup
 //   aroundEach after
 //   aroundEach before
 //     beforeEach
 //       test 2
 //     afterEach
+//     beforeEachCleanup
 //   aroundEach after
 //   afterAll
+//   beforeAllCleanup
 // aroundAll after
 ```
 

--- a/test/unit/test/hooks-list.test.ts
+++ b/test/unit/test/hooks-list.test.ts
@@ -7,41 +7,80 @@ vi.setConfig({
   },
 })
 
-const hookOrder: number[] = []
+const hookOrder: string[] = []
 function callHook(hook: 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach', order: number) {
   vitest[hook](() => {
-    hookOrder.push(order)
+    hookOrder.push(`${hook} #${order}`)
   })
 }
 
 describe('hooks are called as list', () => {
-  callHook('beforeAll', 1)
+  vitest.beforeAll(() => {
+    hookOrder.push(`beforeAll #1`)
+
+    return function beforeAllCleanup() {
+      hookOrder.push(`beforeAllCleanup #1`)
+    }
+  })
   callHook('beforeAll', 2)
   callHook('beforeAll', 3)
 
-  callHook('afterAll', 4)
+  callHook('afterAll', 1)
   // will wait for it
   vitest.afterAll(async () => {
     await Promise.resolve()
-    hookOrder.push(5)
+    hookOrder.push(`afterAll #2`)
   })
-  callHook('afterAll', 6)
+  callHook('afterAll', 3)
 
-  callHook('beforeEach', 7)
-  callHook('beforeEach', 8)
-  callHook('beforeEach', 9)
+  vitest.beforeEach(() => {
+    hookOrder.push(`beforeEach #1`)
 
-  callHook('afterEach', 10)
-  callHook('afterEach', 11)
-  callHook('afterEach', 12)
+    return function beforeEachCleanup() {
+      hookOrder.push(`beforeEachCleanup #1`)
+    }
+  })
+
+  callHook('beforeEach', 2)
+  callHook('beforeEach', 3)
+
+  callHook('afterEach', 1)
+  callHook('afterEach', 2)
 
   test('before hooks pushed in order', () => {
-    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9])
+    expect(hookOrder).toEqual([
+      'beforeAll #1',
+      'beforeAll #2',
+      'beforeAll #3',
+
+      'beforeEach #1',
+      'beforeEach #2',
+      'beforeEach #3',
+    ])
   })
 })
 
 describe('previous suite run all hooks', () => {
   test('after all hooks run in defined order', () => {
-    expect(hookOrder).toEqual([1, 2, 3, 7, 8, 9, 10, 11, 12, 4, 5, 6])
+    expect(hookOrder).toEqual([
+      'beforeAll #1',
+      'beforeAll #2',
+      'beforeAll #3',
+
+      'beforeEach #1',
+      'beforeEach #2',
+      'beforeEach #3',
+
+      'afterEach #1',
+      'afterEach #2',
+
+      'beforeEachCleanup #1',
+
+      'afterAll #1',
+      'afterAll #2',
+      'afterAll #3',
+
+      'beforeAllCleanup #1',
+    ])
   })
 })

--- a/test/unit/test/hooks-stack.test.ts
+++ b/test/unit/test/hooks-stack.test.ts
@@ -7,37 +7,78 @@ vi.setConfig({
   },
 })
 
-const hookOrder: number[] = []
+const hookOrder: string[] = []
 function callHook(hook: 'beforeAll' | 'beforeEach' | 'afterAll' | 'afterEach', order: number) {
   vitest[hook](() => {
-    hookOrder.push(order)
+    hookOrder.push(`${hook} #${order}`)
   })
 }
 
 describe('hooks are called sequentially', () => {
-  callHook('beforeAll', 1)
-  callHook('afterAll', 4)
+  vitest.beforeAll(() => {
+    hookOrder.push(`beforeAll #1`)
 
+    return function beforeAllCleanup() {
+      hookOrder.push(`beforeAllCleanup #1`)
+    }
+  })
   callHook('beforeAll', 2)
+  callHook('afterAll', 1)
+
+  callHook('beforeAll', 3)
   // will wait for it
   vitest.afterAll(async () => {
     await Promise.resolve()
-    hookOrder.push(5)
+    hookOrder.push(`afterAll #2`)
   })
 
-  callHook('beforeEach', 7)
-  callHook('afterEach', 10)
+  vitest.beforeEach(() => {
+    hookOrder.push(`beforeEach #1`)
 
-  callHook('beforeEach', 8)
-  callHook('afterEach', 11)
+    return function beforeEachCleanup() {
+      hookOrder.push(`beforeEachCleanup #1`)
+    }
+  })
+
+  callHook('beforeEach', 2)
+  callHook('afterEach', 1)
+
+  callHook('beforeEach', 3)
+  callHook('afterEach', 2)
 
   test('before hooks pushed in order', () => {
-    expect(hookOrder).toEqual([1, 2, 7, 8])
+    expect(hookOrder).toEqual([
+      'beforeAll #1',
+      'beforeAll #2',
+      'beforeAll #3',
+
+      'beforeEach #1',
+      'beforeEach #2',
+      'beforeEach #3',
+    ])
   })
 })
 
 describe('previous suite run all hooks', () => {
   test('after all hooks run in reverse order', () => {
-    expect(hookOrder).toEqual([1, 2, 7, 8, 11, 10, 5, 4])
+    expect(hookOrder).toEqual([
+      'beforeAll #1',
+      'beforeAll #2',
+      'beforeAll #3',
+
+      'beforeEach #1',
+      'beforeEach #2',
+      'beforeEach #3',
+
+      'afterEach #2',
+      'afterEach #1',
+
+      'beforeEachCleanup #1',
+
+      'afterAll #2',
+      'afterAll #1',
+
+      'beforeAllCleanup #1',
+    ])
   })
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Callbacks returned from `before*` hooks execute always after `after*` hooks. They are not equivalent as documentation currently states.

https://stackblitz.com/~/edit/vitest-dev-vitest-xdy4r52x?file=example.test.ts&file=setupFile.ts&file=vite.config.ts&view=editor

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
