### PR TITLE
fix(browser): guard against toJSON in createSafeRpc proxy

### DIFF
--- a/packages/browser/src/client/tester/rpc.ts
+++ b/packages/browser/src/client/tester/rpc.ts
@@ -37,7 +37,7 @@ export function createSafeRpc(
 ): VitestBrowserClient['rpc'] {
   return new Proxy(client.rpc, {
     get(target, p, handler) {
-      if (p === 'then') {
+      if (p === 'then' || p === 'toJSON') {
         return
       }
       const sendCall = get(target, p, handler)


### PR DESCRIPTION
## Problem

When `JSON.stringify()` is called on an object that holds a reference to the `createSafeRpc` proxy (e.g. inside test utilities or framework integrations), JavaScript looks up the `toJSON` property on the proxy. The `get` trap intercepts this and forwards it to the birpc runtime as a remote procedure call. Since no `toJSON` function is registered on the remote, this produces an unhandled rejection:

```
[birpc] function "toJSON" not found
```

This is the same class of issue as the existing `'then'` guard, which prevents the proxy from being mistaken for a thenable.

## Fix

Extend the early-return guard to also cover `'toJSON'`:

```ts
if (p === 'then' || p === 'toJSON') {
  return
}
```

Returning `undefined` for `toJSON` tells `JSON.stringify` to use the default serialization path and avoids the spurious RPC call.

Fixes #10214