### PR TITLE
chore: update funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [vitest-dev, sheremet-va, antfu, patak-dev]
+github: [vitest-dev]
 open_collective: vitest

--- a/README.md
+++ b/README.md
@@ -93,30 +93,6 @@ $ npx vitest
   </a>
 </p>
 
-### Vladimir Sponsors
-
-<p align="center">
-  <a href="https://cdn.jsdelivr.net/gh/sheremet-va/static/sponsors.svg">
-    <img src='https://cdn.jsdelivr.net/gh/sheremet-va/static/sponsors.svg' alt="vladimir's sponsors"/>
-  </a>
-</p>
-
-### Anthony Fu Sponsors
-
-<p align="center">
-  <a href="https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg">
-    <img src='https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg' alt="anthony's sponsors"/>
-  </a>
-</p>
-
-### Patak Sponsors
-
-<p align="center">
-  <a href="https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg">
-    <img src='https://cdn.jsdelivr.net/gh/patak-dev/static/sponsors.svg' alt="patak's sponsors"/>
-  </a>
-</p>
-
 ## Credits
 
 Thanks to:


### PR DESCRIPTION
Removes me/Anthony/patak from readme and funding keeping only the official team channels.

We also need to align sponsors in readme/docs, but that could be a follow up