### PR TITLE
fix(junit): include unhandled errors in JUnit XML report

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -461,6 +461,7 @@ export class JUnitReporter implements Reporter {
 
   private async writeUnhandledErrorsTestsuite(
     unhandledErrors: ReadonlyArray<UnhandledError>,
+    testModules: ReadonlyArray<TestModule>,
   ): Promise<void> {
     await this.writeElement(
       'testsuite',
@@ -478,6 +479,11 @@ export class JUnitReporter implements Reporter {
         for (const error of unhandledErrors) {
           // Prefer error.type ("Uncaught Exception" / "Unhandled Rejection") over error.name for the title.
           const errorTitle = error.type || error.name || 'Unhandled Error'
+          // Match the error back to the project/task that owns it so capturePrintError
+          // resolves paths against the right project root in multi-project workspaces.
+          const owningModule = error.VITEST_TEST_PATH
+            ? testModules.find(m => m.task.filepath === error.VITEST_TEST_PATH)
+            : undefined
           await this.writeElement(
             'testcase',
             {
@@ -489,7 +495,10 @@ export class JUnitReporter implements Reporter {
               time: '0',
             },
             async () => {
-              await this.writeErrorElement('error', error, {})
+              await this.writeErrorElement('error', error, {
+                project: owningModule?.project,
+                task: owningModule?.task,
+              })
             },
           )
         }
@@ -608,7 +617,7 @@ export class JUnitReporter implements Reporter {
       }
 
       if (unhandledErrors.length) {
-        await this.writeUnhandledErrorsTestsuite(unhandledErrors)
+        await this.writeUnhandledErrorsTestsuite(unhandledErrors, testModules)
       }
     })
 

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -1,5 +1,7 @@
 import type { Task } from '@vitest/runner'
+import type { SerializedError } from '@vitest/utils'
 import type { Vitest } from '../core'
+import type { ErrorOptions } from '../logger'
 import type { Reporter } from '../types/reporter'
 import type { TestModule } from './reported-tasks'
 import { existsSync, promises as fs } from 'node:fs'
@@ -136,6 +138,15 @@ type TaskWithMeta = Task & {
   _classname?: string
   /** Top-level describe block name */
   _suitename?: string
+}
+
+/**
+ * Runtime additions on top of {@link SerializedError}: `type` is set by
+ * {@link state.catchError}, `VITEST_TEST_PATH` by the runtime error catcher.
+ */
+type UnhandledError = SerializedError & {
+  type?: string
+  VITEST_TEST_PATH?: string
 }
 
 function flattenTasks(task: Task, baseName = '', suiteName = '', ancestorSeparator = ' > '): TaskWithMeta[] {
@@ -384,25 +395,10 @@ export class JUnitReporter implements Reporter {
           if (task.result?.state === 'fail') {
             const errors = task.result.errors || []
             for (const error of errors) {
-              await this.writeElement(
-                'failure',
-                {
-                  message: error?.message,
-                  type: error?.name,
-                },
-                async () => {
-                  if (!error || !this.options.stackTrace) {
-                    return
-                  }
-
-                  const result = this.ctx.logger.formatError(error, {
-                    project: this.ctx.getProjectByName(task.file?.projectName ?? ''),
-                  })
-                  await this.baseLog(
-                    escapeXML(stripVTControlCharacters(result.output.trim())),
-                  )
-                },
-              )
+              await this.writeErrorElement('failure', error, {
+                project: this.ctx.getProjectByName(task.file?.projectName ?? ''),
+                task,
+              })
             }
           }
         },
@@ -440,7 +436,71 @@ export class JUnitReporter implements Reporter {
       .replace(/\{title\}/g, () => vars.title)
   }
 
-  async onTestRunEnd(testModules: ReadonlyArray<TestModule>): Promise<void> {
+  private async writeErrorElement(
+    elementName: 'failure' | 'error',
+    error: SerializedError | undefined,
+    errorOptions: ErrorOptions,
+  ): Promise<void> {
+    await this.writeElement(
+      elementName,
+      {
+        message: error?.message,
+        type: error?.name,
+      },
+      async () => {
+        if (!error || !this.options.stackTrace) {
+          return
+        }
+        const result = this.ctx.logger.formatError(error, errorOptions)
+        await this.baseLog(
+          escapeXML(stripVTControlCharacters(result.output.trim())),
+        )
+      },
+    )
+  }
+
+  private async writeUnhandledErrorsTestsuite(
+    unhandledErrors: ReadonlyArray<UnhandledError>,
+  ): Promise<void> {
+    await this.writeElement(
+      'testsuite',
+      {
+        name: 'vitest unhandled errors',
+        timestamp: new Date().toISOString(),
+        hostname: this.options.hostname || hostname(),
+        tests: unhandledErrors.length,
+        failures: 0,
+        errors: unhandledErrors.length,
+        skipped: 0,
+        time: '0',
+      },
+      async () => {
+        for (const error of unhandledErrors) {
+          // Prefer error.type ("Uncaught Exception" / "Unhandled Rejection") over error.name for the title.
+          const errorTitle = error.type || error.name || 'Unhandled Error'
+          await this.writeElement(
+            'testcase',
+            {
+              classname: 'vitest unhandled errors',
+              file: this.options.addFileAttribute && error.VITEST_TEST_PATH
+                ? relative(this.ctx.config.root, error.VITEST_TEST_PATH)
+                : undefined,
+              name: error.message ? `${errorTitle}: ${error.message}` : errorTitle,
+              time: '0',
+            },
+            async () => {
+              await this.writeErrorElement('error', error, {})
+            },
+          )
+        }
+      },
+    )
+  }
+
+  async onTestRunEnd(
+    testModules: ReadonlyArray<TestModule>,
+    unhandledErrors: ReadonlyArray<UnhandledError> = [],
+  ): Promise<void> {
     const files = testModules.map(testModule => testModule.task)
     const separator = this.options.ancestorSeparator ?? ' > '
 
@@ -516,10 +576,11 @@ export class JUnitReporter implements Reporter {
         name: this.options.suiteName || 'vitest tests',
         tests: 0,
         failures: 0,
-        errors: 0, // we cannot detect those
+        errors: unhandledErrors.length,
         time: 0,
       },
     )
+    stats.tests += unhandledErrors.length
 
     await this.writeElement('testsuites', { ...stats, time: executionTime(stats.time) }, async () => {
       for (let i = 0; i < transformed.length; i++) {
@@ -544,6 +605,10 @@ export class JUnitReporter implements Reporter {
             await this.writeTasks(file.tasks, filename, file.filepath)
           },
         )
+      }
+
+      if (unhandledErrors.length) {
+        await this.writeUnhandledErrorsTestsuite(unhandledErrors)
       }
     })
 

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -397,7 +397,6 @@ export class JUnitReporter implements Reporter {
             for (const error of errors) {
               await this.writeErrorElement('failure', error, {
                 project: this.ctx.getProjectByName(task.file?.projectName ?? ''),
-                task,
               })
             }
           }
@@ -476,14 +475,21 @@ export class JUnitReporter implements Reporter {
         time: '0',
       },
       async () => {
-        for (const error of unhandledErrors) {
-          // Prefer error.type ("Uncaught Exception" / "Unhandled Rejection") over error.name for the title.
+        // Stable order across runs — workers/projects report errors concurrently.
+        const sortedErrors = [...unhandledErrors].sort((a, b) => {
+          const ka = `${a.VITEST_TEST_PATH ?? ''}\0${a.type ?? ''}\0${a.name ?? ''}\0${a.message ?? ''}`
+          const kb = `${b.VITEST_TEST_PATH ?? ''}\0${b.type ?? ''}\0${b.name ?? ''}\0${b.message ?? ''}`
+          return ka < kb ? -1 : ka > kb ? 1 : 0
+        })
+        for (const error of sortedErrors) {
           const errorTitle = error.type || error.name || 'Unhandled Error'
-          // Match the error back to the project/task that owns it so capturePrintError
-          // resolves paths against the right project root in multi-project workspaces.
-          const owningModule = error.VITEST_TEST_PATH
-            ? testModules.find(m => m.task.filepath === error.VITEST_TEST_PATH)
-            : undefined
+          // Only attribute when the path resolves to exactly one module — when
+          // multiple projects share a file, errors lack a project identifier and
+          // we can't disambiguate without one (tracked for follow-up).
+          const matches = error.VITEST_TEST_PATH
+            ? testModules.filter(m => m.task.filepath === error.VITEST_TEST_PATH)
+            : []
+          const owningModule = matches.length === 1 ? matches[0] : undefined
           await this.writeElement(
             'testcase',
             {
@@ -497,7 +503,6 @@ export class JUnitReporter implements Reporter {
             async () => {
               await this.writeErrorElement('error', error, {
                 project: owningModule?.project,
-                task: owningModule?.task,
               })
             },
           )
@@ -591,13 +596,19 @@ export class JUnitReporter implements Reporter {
     )
     stats.tests += unhandledErrors.length
 
-    await this.writeElement('testsuites', { ...stats, time: executionTime(stats.time) }, async () => {
-      for (let i = 0; i < transformed.length; i++) {
-        const file = transformed[i]
+    // Plain byte compare (not localeCompare) so output is identical across machines and ICU versions.
+    const orderedSuites = transformed
+      .map((file, i) => {
         const filename = relative(this.ctx.config.root, file.filepath)
         // resolveSuiteNameTemplate needs the original file (before task flattening) to
         // search for top-level describe blocks, so pass files[i] directly.
         const suiteName = this.resolveSuiteNameTemplate(files[i], filename)
+        return { file, filename, suiteName }
+      })
+      .sort((a, b) => a.suiteName < b.suiteName ? -1 : a.suiteName > b.suiteName ? 1 : 0)
+
+    await this.writeElement('testsuites', { ...stats, time: executionTime(stats.time) }, async () => {
+      for (const { file, filename, suiteName } of orderedSuites) {
         await this.writeElement(
           'testsuite',
           {

--- a/test/e2e/fixtures/reporters/unhandled-errors-multi-project/space-1/test/reject.test.ts
+++ b/test/e2e/fixtures/reporters/unhandled-errors-multi-project/space-1/test/reject.test.ts
@@ -1,0 +1,6 @@
+import { it } from 'vitest'
+
+it('triggers a rejection from project 1', async () => {
+  void Promise.reject(new Error('rejection from space-1'))
+  await new Promise(resolve => setTimeout(resolve, 50))
+})

--- a/test/e2e/fixtures/reporters/unhandled-errors-multi-project/space-2/test/reject.test.ts
+++ b/test/e2e/fixtures/reporters/unhandled-errors-multi-project/space-2/test/reject.test.ts
@@ -1,0 +1,6 @@
+import { it } from 'vitest'
+
+it('triggers a rejection from project 2', async () => {
+  void Promise.reject(new Error('rejection from space-2'))
+  await new Promise(resolve => setTimeout(resolve, 50))
+})

--- a/test/e2e/fixtures/reporters/unhandled-errors-multi-project/vitest.config.ts
+++ b/test/e2e/fixtures/reporters/unhandled-errors-multi-project/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: ['space-1', 'space-2'],
+  },
+})

--- a/test/e2e/fixtures/reporters/unhandled-errors-multi/multi.test.ts
+++ b/test/e2e/fixtures/reporters/unhandled-errors-multi/multi.test.ts
@@ -1,0 +1,10 @@
+import { it } from 'vitest'
+
+it('triggers two rejections and one uncaught exception', async () => {
+  void Promise.reject(new Error('first rejection'))
+  void Promise.reject(new Error('second rejection'))
+  setTimeout(() => {
+    throw new Error('uncaught timer')
+  }, 0)
+  await new Promise(resolve => setTimeout(resolve, 50))
+})

--- a/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
+++ b/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
@@ -67,6 +67,17 @@ exports[`emits one <testcase> per unhandled error and titles them by error.type 
         </testcase>
     </testsuite>
     <testsuite name="vitest unhandled errors" timestamp="..." hostname="..." tests="3" failures="0" errors="3" skipped="0" time="...">
+        <testcase classname="vitest unhandled errors" name="Uncaught Exception: uncaught timer" time="...">
+            <error message="uncaught timer" type="Error">
+Error: uncaught timer
+ ❯ Timeout._onTimeout multi.test.ts:7:11
+
+This error originated in &quot;multi.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+The latest test that might&apos;ve caused the error is &quot;triggers two rejections and one uncaught exception&quot;. It might mean one of the following:
+- The error was thrown, while Vitest was running this test.
+- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
+            </error>
+        </testcase>
         <testcase classname="vitest unhandled errors" name="Unhandled Rejection: first rejection" time="...">
             <error message="first rejection" type="Error">
 Error: first rejection
@@ -82,17 +93,6 @@ The latest test that might&apos;ve caused the error is &quot;triggers two reject
             <error message="second rejection" type="Error">
 Error: second rejection
  ❯ multi.test.ts:5:23
-
-This error originated in &quot;multi.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
-The latest test that might&apos;ve caused the error is &quot;triggers two rejections and one uncaught exception&quot;. It might mean one of the following:
-- The error was thrown, while Vitest was running this test.
-- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
-            </error>
-        </testcase>
-        <testcase classname="vitest unhandled errors" name="Uncaught Exception: uncaught timer" time="...">
-            <error message="uncaught timer" type="Error">
-Error: uncaught timer
- ❯ Timeout._onTimeout multi.test.ts:7:11
 
 This error originated in &quot;multi.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
 The latest test that might&apos;ve caused the error is &quot;triggers two rejections and one uncaught exception&quot;. It might mean one of the following:

--- a/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
+++ b/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
@@ -59,6 +59,52 @@ Error: afterAll error
 "
 `;
 
+exports[`emits one <testcase> per unhandled error and titles them by error.type 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="4" failures="0" errors="3" time="...">
+    <testsuite name="multi.test.ts" timestamp="..." hostname="..." tests="1" failures="0" errors="0" skipped="0" time="...">
+        <testcase classname="multi.test.ts" name="triggers two rejections and one uncaught exception" time="...">
+        </testcase>
+    </testsuite>
+    <testsuite name="vitest unhandled errors" timestamp="..." hostname="..." tests="3" failures="0" errors="3" skipped="0" time="...">
+        <testcase classname="vitest unhandled errors" name="Unhandled Rejection: first rejection" time="...">
+            <error message="first rejection" type="Error">
+Error: first rejection
+ ❯ multi.test.ts:4:23
+
+This error originated in &quot;multi.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+The latest test that might&apos;ve caused the error is &quot;triggers two rejections and one uncaught exception&quot;. It might mean one of the following:
+- The error was thrown, while Vitest was running this test.
+- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
+            </error>
+        </testcase>
+        <testcase classname="vitest unhandled errors" name="Unhandled Rejection: second rejection" time="...">
+            <error message="second rejection" type="Error">
+Error: second rejection
+ ❯ multi.test.ts:5:23
+
+This error originated in &quot;multi.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+The latest test that might&apos;ve caused the error is &quot;triggers two rejections and one uncaught exception&quot;. It might mean one of the following:
+- The error was thrown, while Vitest was running this test.
+- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
+            </error>
+        </testcase>
+        <testcase classname="vitest unhandled errors" name="Uncaught Exception: uncaught timer" time="...">
+            <error message="uncaught timer" type="Error">
+Error: uncaught timer
+ ❯ Timeout._onTimeout multi.test.ts:7:11
+
+This error originated in &quot;multi.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+The latest test that might&apos;ve caused the error is &quot;triggers two rejections and one uncaught exception&quot;. It might mean one of the following:
+- The error was thrown, while Vitest was running this test.
+- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
+            </error>
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
 exports[`format error 1`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
 <testsuites name="vitest tests" tests="10" failures="8" errors="1" time="...">
@@ -164,6 +210,45 @@ __test_stdout__
 __test_stderr__
 
             </system-err>
+        </testcase>
+    </testsuite>
+</testsuites>
+"
+`;
+
+exports[`resolves unhandled errors to the owning project in a multi-project workspace 1`] = `
+"<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="4" failures="0" errors="2" time="...">
+    <testsuite name="space-1/test/reject.test.ts" timestamp="..." hostname="..." tests="1" failures="0" errors="0" skipped="0" time="...">
+        <testcase classname="space-1/test/reject.test.ts" file="space-1/test/reject.test.ts" name="triggers a rejection from project 1" time="...">
+        </testcase>
+    </testsuite>
+    <testsuite name="space-2/test/reject.test.ts" timestamp="..." hostname="..." tests="1" failures="0" errors="0" skipped="0" time="...">
+        <testcase classname="space-2/test/reject.test.ts" file="space-2/test/reject.test.ts" name="triggers a rejection from project 2" time="...">
+        </testcase>
+    </testsuite>
+    <testsuite name="vitest unhandled errors" timestamp="..." hostname="..." tests="2" failures="0" errors="2" skipped="0" time="...">
+        <testcase classname="vitest unhandled errors" file="space-1/test/reject.test.ts" name="Unhandled Rejection: rejection from space-1" time="...">
+            <error message="rejection from space-1" type="Error">
+Error: rejection from space-1
+ ❯ test/reject.test.ts:4:23
+
+This error originated in &quot;test/reject.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+The latest test that might&apos;ve caused the error is &quot;triggers a rejection from project 1&quot;. It might mean one of the following:
+- The error was thrown, while Vitest was running this test.
+- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
+            </error>
+        </testcase>
+        <testcase classname="vitest unhandled errors" file="space-2/test/reject.test.ts" name="Unhandled Rejection: rejection from space-2" time="...">
+            <error message="rejection from space-2" type="Error">
+Error: rejection from space-2
+ ❯ test/reject.test.ts:4:23
+
+This error originated in &quot;test/reject.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+The latest test that might&apos;ve caused the error is &quot;triggers a rejection from project 2&quot;. It might mean one of the following:
+- The error was thrown, while Vitest was running this test.
+- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
+            </error>
         </testcase>
     </testsuite>
 </testsuites>

--- a/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
+++ b/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
@@ -61,7 +61,7 @@ Error: afterAll error
 
 exports[`format error 1`] = `
 "<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites name="vitest tests" tests="9" failures="8" errors="0" time="...">
+<testsuites name="vitest tests" tests="10" failures="8" errors="1" time="...">
     <testsuite name="error.test.ts" timestamp="..." hostname="..." tests="9" failures="8" errors="0" skipped="0" time="...">
         <testcase classname="error.test.ts" name="stack" time="...">
             <failure message="throwSimple" type="Error">
@@ -122,6 +122,18 @@ Error: throwSuite
  ❯ throwSuite error.test.ts:48:9
  ❯ error.test.ts:4:3
             </failure>
+        </testcase>
+    </testsuite>
+    <testsuite name="vitest unhandled errors" timestamp="..." hostname="..." tests="1" failures="0" errors="1" skipped="0" time="...">
+        <testcase classname="vitest unhandled errors" name="Unhandled Rejection: throwSimple" time="...">
+            <error message="throwSimple" type="Error">
+Error: throwSimple
+ ❯ throwSimple error.test.ts:44:9
+ ❯ error.test.ts:16:16
+ ❯ error.test.ts:16:28
+
+This error originated in &quot;error.test.ts&quot; test file. It doesn&apos;t mean the error was thrown inside the file itself, but while it was running.
+            </error>
         </testcase>
     </testsuite>
 </testsuites>

--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -333,6 +333,17 @@ test('stackTrace set to false omits stack trace content from failure', async () 
   expect(xml).not.toContain('❯ error.test.ts')
 })
 
+test('addFileAttribute attaches source path to unhandled-error testcases', async () => {
+  const { stdout } = await runVitest({
+    reporters: [['junit', { addFileAttribute: true }]],
+    root,
+  }, ['error.test.ts'])
+  const xml = stabilizeReport(stdout)
+
+  // file= maps unhandled errors back to source for CircleCI / GitLab
+  expect(xml).toMatch(/<testcase classname="vitest unhandled errors" file="error\.test\.ts" name="Unhandled Rejection: throwSimple"/)
+})
+
 function executionTime(durationMS: number) {
   return (durationMS / 1000).toLocaleString('en-US', {
     useGrouping: false,

--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -4,6 +4,7 @@ import { runVitest, runVitestCli } from '#test-utils'
 import { createFileTask } from '@vitest/runner/utils'
 import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
+import { rolldownVersion } from 'vitest/node'
 
 const root = resolve(import.meta.dirname, '../../fixtures/reporters')
 
@@ -122,7 +123,13 @@ test('options.suiteName changes name property', async () => {
 })
 
 function stabilizeReport(report: string) {
-  return report.replaceAll(/(timestamp|hostname|time)=".*?"/g, '$1="..."')
+  let normalized = report.replaceAll(/(timestamp|hostname|time)=".*?"/g, '$1="..."')
+  // rolldown's source map for the inline async IIFE on error.test.ts:16 anchors
+  // one column later than rollup's; align to rollup so the snapshot stays bundler-agnostic.
+  if (rolldownVersion) {
+    normalized = normalized.replaceAll(' ❯ error.test.ts:16:29', ' ❯ error.test.ts:16:28')
+  }
+  return normalized
 }
 
 function stabilizeReportWOTime(report: string) {

--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -129,7 +129,21 @@ function stabilizeReport(report: string) {
   if (rolldownVersion) {
     normalized = normalized.replaceAll(' ❯ error.test.ts:16:29', ' ❯ error.test.ts:16:28')
   }
-  return normalized
+  return sortTestsuites(normalized)
+}
+
+// Projects in a multi-project run finish in non-deterministic order, so
+// the JUnit reporter emits <testsuite> blocks in completion order. Sort
+// them by name so snapshots stay stable across runs.
+function sortTestsuites(report: string) {
+  return report.replace(
+    /(<testsuites[^>]*>\n)([\s\S]*?)(\n<\/testsuites>)/,
+    (_, open, body, close) => {
+      const blocks = [...body.matchAll(/ {4}<testsuite name="([^"]*)"[\s\S]*?<\/testsuite>/g)]
+      blocks.sort((a, b) => a[1].localeCompare(b[1]))
+      return open + blocks.map(b => b[0]).join('\n') + close
+    },
+  )
 }
 
 function stabilizeReportWOTime(report: string) {

--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -129,21 +129,7 @@ function stabilizeReport(report: string) {
   if (rolldownVersion) {
     normalized = normalized.replaceAll(' ❯ error.test.ts:16:29', ' ❯ error.test.ts:16:28')
   }
-  return sortTestsuites(normalized)
-}
-
-// Projects in a multi-project run finish in non-deterministic order, so
-// the JUnit reporter emits <testsuite> blocks in completion order. Sort
-// them by name so snapshots stay stable across runs.
-function sortTestsuites(report: string) {
-  return report.replace(
-    /(<testsuites[^>]*>\n)([\s\S]*?)(\n<\/testsuites>)/,
-    (_, open, body, close) => {
-      const blocks = [...body.matchAll(/ {4}<testsuite name="([^"]*)"[\s\S]*?<\/testsuite>/g)]
-      blocks.sort((a, b) => a[1].localeCompare(b[1]))
-      return open + blocks.map(b => b[0]).join('\n') + close
-    },
-  )
+  return normalized
 }
 
 function stabilizeReportWOTime(report: string) {

--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -340,15 +340,20 @@ test('stackTrace set to false omits stack trace content from failure', async () 
   expect(xml).not.toContain('❯ error.test.ts')
 })
 
-test('addFileAttribute attaches source path to unhandled-error testcases', async () => {
+test('emits one <testcase> per unhandled error and titles them by error.type', async () => {
+  const { stdout } = await runVitest({
+    reporters: 'junit',
+    root: './fixtures/reporters/unhandled-errors-multi',
+  })
+  expect(stabilizeReport(stdout)).toMatchSnapshot()
+})
+
+test('resolves unhandled errors to the owning project in a multi-project workspace', async () => {
   const { stdout } = await runVitest({
     reporters: [['junit', { addFileAttribute: true }]],
-    root,
-  }, ['error.test.ts'])
-  const xml = stabilizeReport(stdout)
-
-  // file= maps unhandled errors back to source for CircleCI / GitLab
-  expect(xml).toMatch(/<testcase classname="vitest unhandled errors" file="error\.test\.ts" name="Unhandled Rejection: throwSimple"/)
+    root: './fixtures/reporters/unhandled-errors-multi-project',
+  })
+  expect(stabilizeReport(stdout)).toMatchSnapshot()
 })
 
 function executionTime(durationMS: number) {


### PR DESCRIPTION
### Description

Resolves #10242.

The JUnit reporter currently ignores process-level unhandled rejections / uncaught exceptions. The CLI prints `Errors 1 error`, the run summary marks the run as failed, and Vitest exits with code `1` — but `junit-report.xml` reports `failures="0" errors="0"` and contains only the passing `<testcase>` entries. CI systems gating on the JUnit artifact (Jenkins JUnit plugin, GitLab MR test widget, Azure Pipelines test tab, CircleCI test insights) therefore mark builds green even when the run actually failed.

#### Fix

`onTestRunEnd` already receives the captured `unhandledErrors` (per the `Reporter` interface) — the JUnit reporter just wasn't using them. This PR surfaces them:

- Top-level `<testsuites>` now reports `errors=N` and includes the count in `tests=`.
- A synthetic `<testsuite name="vitest unhandled errors">` is appended after the per-file suites, containing one `<testcase>` per error with an `<error>` element (semantically distinct from `<failure>`, which represents an assertion failure).
- The testcase title uses `error.type` (`"Uncaught Exception"` / `"Unhandled Rejection"`, set by `state.catchError`) when available, falling back to `error.name`.
- When `addFileAttribute: true` and the error has `VITEST_TEST_PATH` (set by the runtime error catcher), the synthetic testcase emits `file="<relative path>"` so CircleCI / GitLab can map the entry back to source.
- The owning project / task is matched back via `VITEST_TEST_PATH` so `capturePrintError` resolves stack-trace paths against the right project root in multi-project workspaces.
- A shared `writeErrorElement(elementName, error, errorOptions)` helper backs both the existing `<failure>` path and the new `<error>` path.

The synthetic suite is only emitted when there are unhandled errors — the happy path is unchanged.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

JUnit reporter suite specifically (relevant subset, all 25 passing):

```
CI=true pnpm -C test/e2e test reporters/junit.test.ts
```

Plus `pnpm typecheck` and `pnpm lint:fix` clean.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

N/A — this is a bug fix that aligns the JUnit XML output with the existing CLI failure summary; no new user-facing API or option.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

PR title prefixed with `fix(junit-reporter):` per convention.

<!-- VITEST_AUTOMATED_PR -->