### PR TITLE
fix(browser): guard against toJSON in createSafeRpc proxy

### DIFF
--- a/packages/browser/src/client/tester/rpc.ts
+++ b/packages/browser/src/client/tester/rpc.ts
@@ -37,7 +37,7 @@ export function createSafeRpc(
 ): VitestBrowserClient['rpc'] {
   return new Proxy(client.rpc, {
     get(target, p, handler) {
-      if (p === 'then') {
+      if (p === 'then' || p === 'toJSON') {
         return
       }
       const sendCall = get(target, p, handler)


### PR DESCRIPTION
## Problem

When `JSON.stringify()` is called on an object that holds a reference to the `createSafeRpc` proxy (e.g. inside test utilities or framework integrations), JavaScript looks up the `toJSON` property on the proxy. The proxy's `get` trap forwards this to the birpc runtime as a remote call. Since no `toJSON` function exists on the remote, birpc logs:

```
[birpc] function "toJSON" not found
```

as an unhandled rejection, which can surface as a confusing error in browser mode tests.

## Fix

Add `toJSON` alongside the existing `then` guard in the `get` trap so that `JSON.stringify` falls back to default serialization instead of triggering a remote call:

```ts
if (p === 'then' || p === 'toJSON') {
  return undefined
}
```

The `then` guard was already there to prevent the proxy from being mistaken for a Promise. The `toJSON` guard follows the same pattern for the same reason — stop well-known JS protocols from leaking into the RPC layer.