### PR TITLE
fix(vitest): rerun only failed tests with the `f` watch shortcut

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1291,30 +1291,51 @@ export class Vitest {
 
   /** @internal */
   async rerunFailed(): Promise<void> {
-    const failedFiles = this.state.getFailedFilepaths()
+    let failedFiles = this.state.getFailedFilepaths()
     if (!failedFiles.length) {
       await this.rerunFiles(failedFiles, 'rerun failed', false)
       return
     }
 
+    if (this.filenamePattern) {
+      const filteredFiles = await this.globTestSpecifications(this.filenamePattern)
+      const allowed = new Set(filteredFiles.map(f => f.moduleId))
+      failedFiles = failedFiles.filter(file => allowed.has(file))
+      if (!failedFiles.length) {
+        await this.rerunFiles(failedFiles, 'rerun failed', false)
+        return
+      }
+    }
+
     const trigger = 'rerun failed'
-    const specifications = failedFiles.flatMap((filepath) => {
-      const fileTasks = this.state.getFiles([filepath])
-      const failedTestIds = fileTasks.flatMap(file =>
-        getTasks(file)
+    const specifications: TestSpecification[] = []
+    for (const filepath of failedFiles) {
+      const projectSpecs = this.getModuleSpecifications(filepath)
+      for (const file of this.state.getFiles([filepath])) {
+        if (file.result?.state !== 'fail') {
+          continue
+        }
+        const projectName = file.projectName || ''
+        const spec = projectSpecs.find(s => s.project.name === projectName)
+        if (!spec) {
+          continue
+        }
+        const failedTestIds = getTasks(file)
           .filter(task => task.type === 'test' && task.result?.state === 'fail')
-          .map(task => task.id),
-      )
-      return this.getModuleSpecifications(filepath).map((spec) => {
+          .map(task => task.id)
         // If the file failed to collect, there are no test ids: rerun the whole file.
         if (!failedTestIds.length) {
-          return spec
+          specifications.push(spec)
         }
-        return new TestSpecification(spec.project, spec.moduleId, spec.pool, {
-          testIds: failedTestIds,
-        })
-      })
-    })
+        else {
+          specifications.push(
+            new TestSpecification(spec.project, spec.moduleId, spec.pool, {
+              testIds: failedTestIds,
+            }),
+          )
+        }
+      }
+    }
 
     await Promise.all([
       this.report('onWatcherRerun', failedFiles, trigger),

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -11,7 +11,6 @@ import type { VitestFetchFunction } from './environments/fetchModule'
 import type { ProcessPool } from './pool'
 import type { Report } from './reporters/report'
 import type { TestModule } from './reporters/reported-tasks'
-import type { TestSpecification } from './test-specification'
 import type { ResolvedConfig, TestProjectConfiguration, UserConfig, VitestRunMode } from './types/config'
 import type { CoverageProvider, ResolvedCoverageOptions } from './types/coverage'
 import type { Reporter } from './types/reporter'
@@ -54,6 +53,7 @@ import { VitestSpecifications } from './specifications'
 import { StateManager } from './state'
 import { populateProjectsTags } from './tags'
 import { TestRun } from './test-run'
+import { TestSpecification } from './test-specification'
 import { loadVCSProvider } from './vcs/vcs'
 import { VitestWatcher } from './watcher'
 
@@ -1291,7 +1291,37 @@ export class Vitest {
 
   /** @internal */
   async rerunFailed(): Promise<void> {
-    await this.rerunFiles(this.state.getFailedFilepaths(), 'rerun failed', false)
+    const failedFiles = this.state.getFailedFilepaths()
+    if (!failedFiles.length) {
+      await this.rerunFiles(failedFiles, 'rerun failed', false)
+      return
+    }
+
+    const trigger = 'rerun failed'
+    const specifications = failedFiles.flatMap((filepath) => {
+      const fileTasks = this.state.getFiles([filepath])
+      const failedTestIds = fileTasks.flatMap(file =>
+        getTasks(file)
+          .filter(task => task.type === 'test' && task.result?.state === 'fail')
+          .map(task => task.id),
+      )
+      return this.getModuleSpecifications(filepath).map((spec) => {
+        // If the file failed to collect, there are no test ids: rerun the whole file.
+        if (!failedTestIds.length) {
+          return spec
+        }
+        return new TestSpecification(spec.project, spec.moduleId, spec.pool, {
+          testIds: failedTestIds,
+        })
+      })
+    })
+
+    await Promise.all([
+      this.report('onWatcherRerun', failedFiles, trigger),
+      ...this._onUserTestsRerun.map(fn => fn(specifications)),
+    ])
+    await this.runFiles(specifications, false)
+    await this.report('onWatcherStart', this.state.getFiles(failedFiles))
   }
 
   /**

--- a/test/e2e/test/rerun-failed.test.ts
+++ b/test/e2e/test/rerun-failed.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
+
+test('rerunFailed only re-runs the failed tests, not the whole files', async () => {
+  const { ctx } = await runInlineTests({
+    'a.test.ts': `
+      import { test, expect } from 'vitest'
+      test('passes', () => { expect(1).toBe(1) })
+      test('fails', () => { expect(1).toBe(2) })
+    `,
+  }, { watch: true })
+
+  const fileBefore = ctx!.state.getFiles()[0]
+  const [passBefore, failBefore] = fileBefore.tasks
+  expect(passBefore.result?.state).toBe('pass')
+  expect(failBefore.result?.state).toBe('fail')
+
+  await ctx!.rerunFailed()
+
+  const fileAfter = ctx!.state.getFiles()[0]
+  const [passAfter, failAfter] = fileAfter.tasks
+  expect(passAfter.mode).toBe('skip')
+  expect(failAfter.mode).toBe('run')
+  expect(failAfter.result?.state).toBe('fail')
+
+  await ctx!.close()
+})
+
+test('rerunFailed falls back to whole-file rerun when collection failed', async () => {
+  const { ctx } = await runInlineTests({
+    'broken.test.ts': `
+      throw new Error('collection error')
+    `,
+  }, { watch: true })
+
+  const fileBefore = ctx!.state.getFiles()[0]
+  expect(fileBefore.result?.state).toBe('fail')
+
+  await ctx!.rerunFailed()
+
+  const fileAfter = ctx!.state.getFiles()[0]
+  expect(fileAfter.result?.state).toBe('fail')
+
+  await ctx!.close()
+})

--- a/test/e2e/test/rerun-failed.test.ts
+++ b/test/e2e/test/rerun-failed.test.ts
@@ -26,6 +26,82 @@ test('rerunFailed only re-runs the failed tests, not the whole files', async () 
   await ctx!.close()
 })
 
+test('rerunFailed respects active filenamePattern', async () => {
+  const { ctx } = await runInlineTests({
+    'a.test.ts': `
+      import { test, expect } from 'vitest'
+      test('a fails', () => { expect(1).toBe(2) })
+    `,
+    'b.test.ts': `
+      import { test, expect } from 'vitest'
+      test('b fails', () => { expect(1).toBe(2) })
+    `,
+  }, { watch: true })
+
+  expect(ctx!.state.getFailedFilepaths()).toHaveLength(2)
+
+  await ctx!.changeFilenamePattern('a.test.ts')
+
+  const bStartBefore = ctx!.state.getFiles().find(f => f.name.includes('b.test.ts'))!.result?.startTime
+
+  await ctx!.rerunFailed()
+
+  const files = ctx!.state.getFiles()
+  const aFile = files.find(f => f.name.includes('a.test.ts'))!
+  const bFile = files.find(f => f.name.includes('b.test.ts'))!
+  // a was rerun, b was not (filtered out by filenamePattern)
+  expect(aFile.tasks[0].mode).toBe('run')
+  expect(bFile.result?.startTime).toBe(bStartBefore)
+
+  await ctx!.close()
+})
+
+test('rerunFailed scopes test ids per project in workspace mode', async () => {
+  const { ctx } = await runInlineTests({
+    'shared.test.ts': `
+      import { test, expect } from 'vitest'
+      test('passes in p2 only', () => {
+        if (process.env.PROJ === 'p1') {
+          expect(1).toBe(2)
+        }
+        else {
+          expect(1).toBe(1)
+        }
+      })
+    `,
+    'vitest.config.ts': `
+      export default {
+        test: {
+          projects: [
+            { test: { name: 'p1', env: { PROJ: 'p1' } } },
+            { test: { name: 'p2', env: { PROJ: 'p2' } } },
+          ],
+        },
+      }
+    `,
+  }, { watch: true })
+
+  const filesBefore = ctx!.state.getFiles()
+  expect(filesBefore).toHaveLength(2)
+  const p1Before = filesBefore.find(f => f.projectName === 'p1')!
+  const p2Before = filesBefore.find(f => f.projectName === 'p2')!
+  expect(p1Before.result?.state).toBe('fail')
+  expect(p2Before.result?.state).toBe('pass')
+  const p2StartBefore = p2Before.result?.startTime
+
+  await ctx!.rerunFailed()
+
+  const filesAfter = ctx!.state.getFiles()
+  const p1After = filesAfter.find(f => f.projectName === 'p1')!
+  const p2After = filesAfter.find(f => f.projectName === 'p2')!
+  // p1 was rerun (its failing test stays 'run'); p2 was untouched.
+  expect(p1After.tasks[0].mode).toBe('run')
+  expect(p1After.result?.state).toBe('fail')
+  expect(p2After.result?.startTime).toBe(p2StartBefore)
+
+  await ctx!.close()
+})
+
 test('rerunFailed falls back to whole-file rerun when collection failed', async () => {
   const { ctx } = await runInlineTests({
     'broken.test.ts': `


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10247

In watch mode, pressing the `f` shortcut (which calls `Vitest#rerunFailed`) reran every test inside files that had at least one failure, instead of rerunning only the failed tests.

This change makes `rerunFailed` build a `TestSpecification` per failed file with `testIds` populated from the tasks whose `result.state === 'fail'`. The runner already supports filtering by `testIds` in `interpretTaskModes`, so non-failed tests in the same file are now skipped — the same pattern already used by `TestCase#rerun` and `TestSuite#rerun` in `reported-tasks.ts`.

If a file failed during collection (no test-level failures available), the original whole-file rerun behaviour is preserved as a fallback.

Task IDs are deterministic (hash of relative path + project name + position), so they remain stable across reruns of unchanged files.

TODO
- [x] fix `rerunFailed` to filter by failed test ids
- [x] preserve fallback to whole-file rerun on collection failure
- [x] test (`test/e2e/test/rerun-failed.test.ts`) — verified locally that it passes with the fix and fails without it (`expected 'run' to be 'skip'`)
- [x] docs — no public API change; aligns `rerunFailed` with the documented "rerun only failed tests" shortcut behaviour
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->