### PR TITLE
fix(browser): keep `waitForConnection` in sync across socket reconnects

### DIFF
--- a/packages/browser/src/client/client.ts
+++ b/packages/browser/src/client/client.ts
@@ -128,34 +128,65 @@ function createClient() {
     },
   )
 
-  let openPromise: Promise<void>
+  // A single persistent promise that survives reconnects: callers awaiting
+  // `waitForConnection()` follow the current attempt across drops, instead of
+  // being stuck on a failed first socket.
+  let resolveOpen!: () => void
+  let rejectOpen!: (error: Error) => void
+  let openSettled = false
+  let openPromise: Promise<void> = createOpenPromise()
+  let connectTimeoutId: ReturnType<typeof setTimeout> | undefined
+
+  function createOpenPromise() {
+    openSettled = false
+    return new Promise<void>((resolve, reject) => {
+      resolveOpen = () => {
+        openSettled = true
+        resolve()
+      }
+      rejectOpen = (error) => {
+        openSettled = true
+        reject(error)
+      }
+    })
+  }
 
   function reconnect(reset = false) {
     if (reset) {
       tries = reconnectTries
+    }
+    if (openSettled) {
+      openPromise = createOpenPromise()
     }
     ctx.ws = new WebSocket(ENTRY_URL)
     registerWS()
   }
 
   function registerWS() {
-    openPromise = new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(
-          new Error(
-            `Cannot connect to the server in ${connectTimeout / 1000} seconds`,
-          ),
-        )
-      }, connectTimeout)
-      if (ctx.ws.OPEN === ctx.ws.readyState) {
-        resolve()
+    if (connectTimeoutId !== undefined) {
+      clearTimeout(connectTimeoutId)
+    }
+    connectTimeoutId = setTimeout(() => {
+      rejectOpen(
+        new Error(
+          `Cannot connect to the server in ${connectTimeout / 1000} seconds`,
+        ),
+      )
+    }, connectTimeout)
+    if (ctx.ws.OPEN === ctx.ws.readyState) {
+      tries = reconnectTries
+      clearTimeout(connectTimeoutId)
+      connectTimeoutId = undefined
+      resolveOpen()
+    }
+    // still have a listener even if it's already open to update tries
+    ctx.ws.addEventListener('open', () => {
+      tries = reconnectTries
+      if (connectTimeoutId !== undefined) {
+        clearTimeout(connectTimeoutId)
+        connectTimeoutId = undefined
       }
-      // still have a listener even if it's already open to update tries
-      ctx.ws.addEventListener('open', () => {
-        tries = reconnectTries
-        resolve()
-        clearTimeout(timeout)
-      })
+      resolveOpen()
     })
     ctx.ws.addEventListener('message', (v) => {
       onMessage(v.data)
@@ -163,7 +194,18 @@ function createClient() {
     ctx.ws.addEventListener('close', () => {
       tries -= 1
       if (autoReconnect && tries > 0) {
+        if (connectTimeoutId !== undefined) {
+          clearTimeout(connectTimeoutId)
+          connectTimeoutId = undefined
+        }
         setTimeout(reconnect, reconnectInterval)
+      }
+      else if (!openSettled) {
+        if (connectTimeoutId !== undefined) {
+          clearTimeout(connectTimeoutId)
+          connectTimeoutId = undefined
+        }
+        rejectOpen(new Error('WebSocket connection closed before opening'))
       }
     })
   }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10166

In browser mode, the tester could hang forever if the first websocket attempt stayed in `CONNECTING` long enough for callers to start awaiting `waitForConnection()`, dropped before `open`, and Vitest reconnected. Existing waiters stayed attached to the old (unresolved) per-attempt `openPromise`, while reconnect created a brand new one — so the tester iframe never processed `prepare`/`execute`.

`packages/browser/src/client/client.ts` now uses a single persistent promise plus shared `resolveOpen`/`rejectOpen` handles that survive reconnects.

- `registerWS()` no longer creates a new promise on every attempt — it only re-arms the connect timeout and the open/close listeners. The open listener resolves the existing waiters.
- `reconnect()` rebuilds the promise only after it has been settled (so subsequent runs after a successful connection still get a fresh promise).
- The connect timeout is cleared on every state transition (open / close-with-pending-reconnect / settled) to avoid leaking a `rejectOpen` from a stale attempt.
- If retries are exhausted before the socket opens, the promise rejects with a clear `'WebSocket connection closed before opening'` instead of silently hanging.

TODO
- [x] fix `waitForConnection` to survive reconnects
- [x] dogfood — reproduced and verified end-to-end against @jkieboom's [`vitest-waitforconnection-repro`](https://github.com/jkieboom/vitest-waitforconnection-repro) by patching the same code into the installed `node_modules/@vitest/browser/dist/client.js`:

  | Case | Without fix | With fix |
  |---|---|---|
  | `control` | exit 0 (~1.3s) | exit 0 (~4.1s) |
  | `broken` (proxy drops first WS after 1.5s) | **timeout / hang** | **exit 0 (~5.3s)** |

  The harness's `success` flag flipped from `true` (bug reproduces) to `false` (bug no longer reproduces) — the expected outcome.
- [x] in-tree test — skipped intentionally: reproducing this race in `test/browser` requires a controllable WebSocket reverse proxy fixture (holding the first upgrade in `CONNECTING` for ~1.5s, then dropping it before handshake), which is significantly larger than the ~30 LOC fix. Happy to add one if maintainers prefer.
- [x] docs — no public API change
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. <!-- see TODO above -->
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->