### PR TITLE
feat(node): export capturePrintError

### DIFF
--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -40,6 +40,7 @@ export { ThreadsPoolWorker } from '../node/pools/workers/threadsWorker'
 export { TypecheckPoolWorker } from '../node/pools/workers/typecheckWorker'
 export { VmForksPoolWorker } from '../node/pools/workers/vmForksWorker'
 export { VmThreadsPoolWorker } from '../node/pools/workers/vmThreadsWorker'
+export { capturePrintError } from '../node/printError'
 export type { SerializedTestProject, TestProject } from '../node/project'
 
 export {

--- a/test/unit/test/exports.test.ts
+++ b/test/unit/test/exports.test.ts
@@ -107,6 +107,7 @@ it('exports snapshot', async ({ skip, task }) => {
         "VitestPlugin": "function",
         "VmForksPoolWorker": "function",
         "VmThreadsPoolWorker": "function",
+        "capturePrintError": "function",
         "createDebugger": "function",
         "createMethodsRPC": "function",
         "createViteLogger": "function",


### PR DESCRIPTION
### Description

I'm trying to implement a custom reporter which uses GitHub check runs annotations based on the [github actions reporter ](https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/reporters/github-actions.ts) but I notice it has access to things which aren't publicly accessible.

The `task` type in `TestModule` is accessed by every other reporter so I'm not entirely sure why it's marked as `internal` as it seems strange that I shouldn't access it if I wanted to implement a custom reporter.

The `capturePrintError` is used by the junit and actions reporters so it would be useful for me to be able to use it too.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
