### PR TITLE
refactor: remove redundant task from error print options

### DIFF
--- a/packages/vitest/src/node/logger.ts
+++ b/packages/vitest/src/node/logger.ts
@@ -1,4 +1,3 @@
-import type { Task } from '@vitest/runner'
 import type { Writable } from 'node:stream'
 import type { TypeCheckError } from '../typecheck/typechecker'
 import type { Vitest } from './core'
@@ -17,7 +16,6 @@ export interface ErrorOptions {
   project?: TestProject
   verbose?: boolean
   screenshotPaths?: string[]
-  task?: Task
   showCodeFrame?: boolean
 }
 

--- a/packages/vitest/src/node/printError.ts
+++ b/packages/vitest/src/node/printError.ts
@@ -90,7 +90,7 @@ export function printError(
 
       // browser stack trace needs to be processed differently,
       // so there is a separate method for that
-      if (options.task?.file.pool === 'browser' && project.browser) {
+      if (project.browser) {
         return project.browser.parseErrorStacktrace(error, {
           frameFilter: project.config.onStackTrace,
           ignoreStackEntries: options.fullStack ? [] : undefined,

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -965,7 +965,6 @@ export abstract class BaseReporter implements Reporter {
         project: this.ctx.getProjectByName(tasks[0].file.projectName || ''),
         verbose: this.verbose,
         screenshotPaths,
-        task: tasks[0],
       })
 
       if (tasks[0].type === 'test' && tasks[0].annotations.length) {

--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -1,4 +1,4 @@
-import type { File, TestAnnotation } from '@vitest/runner'
+import type { TestAnnotation } from '@vitest/runner'
 import type { SerializedError } from '@vitest/utils'
 import type { Vitest } from '../core'
 import type { TestProject } from '../project'
@@ -127,7 +127,6 @@ export class GithubActionsReporter implements Reporter {
       project: TestProject
       title: string
       error: unknown
-      file?: File
     }>()
     for (const error of errors) {
       projectErrors.push({
@@ -150,14 +149,13 @@ export class GithubActionsReporter implements Reporter {
             project,
             title: project.name ? `[${project.name}] ${title}` : title,
             error,
-            file,
           })
         }
       }
     }
 
     // format errors via `printError`
-    for (const { project, title, error, file } of projectErrors) {
+    for (const { project, title, error } of projectErrors) {
       const result = capturePrintError(error, this.ctx, { project })
       const stack = result?.nearest
       if (!stack) {

--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -158,7 +158,7 @@ export class GithubActionsReporter implements Reporter {
 
     // format errors via `printError`
     for (const { project, title, error, file } of projectErrors) {
-      const result = capturePrintError(error, this.ctx, { project, task: file })
+      const result = capturePrintError(error, this.ctx, { project })
       const stack = result?.nearest
       if (!stack) {
         continue

--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -399,7 +399,7 @@ export class JUnitReporter implements Reporter {
                   const result = capturePrintError(
                     error,
                     this.ctx,
-                    { project: this.ctx.getProjectByName(task.file?.projectName ?? ''), task },
+                    { project: this.ctx.getProjectByName(task.file?.projectName ?? '') },
                   )
                   await this.baseLog(
                     escapeXML(stripVTControlCharacters(result.output.trim())),


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- related https://github.com/vitest-dev/vitest/pull/10253

It looks like `ErrorOptions.task` is used only for checking browser environment, but this should be redundant with `ErrorOptions.project`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
