### PR TITLE
fix(browser): throw on duplicate vitest installation in projects mode

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -96,6 +96,18 @@ Since Vitest defaults to the `node` environment (which uses `viteEnvironment: 's
 You can learn more about Vite environments and Vitest environments in [`environment`](/config/environment).
 :::
 
+## Duplicate Vitest Installation
+
+When running browser-mode tests via [`projects`](/guide/projects) in a monorepo, Vitest may detect that `vitest` or `@vitest/browser` resolves to two different physical copies (one used by the root runner, another used by a sub-package). Two copies cannot share the in-memory state needed to drive the browser, which previously caused the test run to hang silently. Vitest now throws a clear error instead, naming both paths and the affected project.
+
+The most common cause is a peer dependency (typically `@types/node` or `vite`) resolving to different versions across packages. Even when `vitest` is pinned to the exact same version everywhere, pnpm will create two `.pnpm/` snapshots with different peer-dep hashes, and Node loads each as a distinct module.
+
+### Fix
+
+1. Run `pnpm why vitest` (or `npm ls vitest`) and look for the diverging peer dep.
+2. **Recommended**: declare `vitest` and `@vitest/browser*` only in the root `package.json`. Sub-packages should keep their own `vitest.config.ts` but inherit the hoisted Vitest install.
+3. If a sub-package must declare `vitest` directly, pin the diverging peer dep in the root `pnpm.overrides` / `resolutions` and run `pnpm dedupe` so a single copy is shared.
+
 ## Segfaults and Native Code Errors
 
 Running [native NodeJS modules](https://nodejs.org/api/addons.html) in `pool: 'threads'` can run into cryptic errors coming from the native code.

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -134,7 +134,7 @@ function assertSingleInstallation(projectRoot: string, projectName: string): voi
   const projectBrowserDir = resolvePackageDir('@vitest/browser', projectRoot)
   const projectVitestDir = resolvePackageDir('vitest', projectRoot)
 
-  const mismatches: { name: string, running: string, project: string }[] = []
+  const mismatches: { name: string; running: string; project: string }[] = []
   if (runningBrowserDir && projectBrowserDir && projectBrowserDir !== runningBrowserDir) {
     mismatches.push({ name: '@vitest/browser', running: runningBrowserDir, project: projectBrowserDir })
   }

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -1,6 +1,9 @@
 import type { BrowserCommand, BrowserProviderOption, BrowserServerFactory } from 'vitest/node'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
 import { MockerRegistry } from '@vitest/mocker'
 import { interceptorPlugin } from '@vitest/mocker/node'
+import { dirname, join } from 'pathe'
 import c from 'tinyrainbow'
 import { createViteLogger, createViteServer } from 'vitest/node'
 import { version } from '../../package.json'
@@ -38,6 +41,8 @@ export const createBrowserServer: BrowserServerFactory = async (options) => {
       ),
     )
   }
+
+  assertSingleInstallation(project.config.root, project.name)
 
   const server = new ParentBrowserProject(project, '/')
 
@@ -110,6 +115,54 @@ export const createBrowserServer: BrowserServerFactory = async (options) => {
   setupBrowserRpc(server, mockerRegistry)
 
   return server
+}
+
+function resolvePackageDir(name: string, fromDir: string): string | undefined {
+  try {
+    const require = createRequire(join(fromDir, '_'))
+    return dirname(require.resolve(`${name}/package.json`))
+  }
+  catch {
+    return undefined
+  }
+}
+
+function assertSingleInstallation(projectRoot: string, projectName: string): void {
+  const runningFrom = dirname(fileURLToPath(import.meta.url))
+  const runningBrowserDir = resolvePackageDir('@vitest/browser', runningFrom)
+  const runningVitestDir = resolvePackageDir('vitest', runningFrom)
+  const projectBrowserDir = resolvePackageDir('@vitest/browser', projectRoot)
+  const projectVitestDir = resolvePackageDir('vitest', projectRoot)
+
+  const mismatches: { name: string, running: string, project: string }[] = []
+  if (runningBrowserDir && projectBrowserDir && projectBrowserDir !== runningBrowserDir) {
+    mismatches.push({ name: '@vitest/browser', running: runningBrowserDir, project: projectBrowserDir })
+  }
+  if (runningVitestDir && projectVitestDir && projectVitestDir !== runningVitestDir) {
+    mismatches.push({ name: 'vitest', running: runningVitestDir, project: projectVitestDir })
+  }
+  if (!mismatches.length) {
+    return
+  }
+
+  const lines = mismatches.map(m =>
+    `  - ${c.bold(m.name)}\n    running:  ${m.running}\n    project:  ${m.project}`,
+  ).join('\n')
+
+  throw new Error(
+    `[vitest] Detected duplicate installations of Vitest packages for project "${projectName || projectRoot}".\n`
+    + `This is unsupported in browser mode with \`projects\` and will cause tests to hang.\n\n`
+    + `${lines}\n\n`
+    + `To fix this:\n`
+    + `  1. Run \`pnpm why vitest\` (or \`npm ls vitest\`) to find why a package is duplicated.\n`
+    + `     A common cause is a peer dependency (e.g. \`@types/node\`, \`vite\`) resolving\n`
+    + `     to different versions across packages.\n`
+    + `  2. Recommended: declare \`vitest\` and \`@vitest/browser*\` only in the root\n`
+    + `     package.json, not in each sub-package, so they are hoisted as a single copy.\n`
+    + `  3. Otherwise, force a single version with \`pnpm.overrides\` / \`resolutions\`\n`
+    + `     for the diverging peer dependency, then run \`pnpm dedupe\`.\n\n`
+    + `See https://vitest.dev/guide/common-errors.html#duplicate-vitest-installation`,
+  )
 }
 
 export function defineBrowserProvider<T extends object = object>(options: Omit<


### PR DESCRIPTION
### Description

- Refs https://github.com/vitest-dev/vitest/issues/9164
- Refs https://github.com/vitest-dev/vitest/issues/10261

When running browser-mode tests via `projects` in a monorepo, duplicated copies of `vitest` / `@vitest/browser` cause the test run to hang silently. This PR throws a clear, actionable error instead.

#9164 and #10261 both report the same symptom: in a monorepo using `projects`, browser tests intermittently fail to start and the run hangs. The maintainer could not reproduce reliably (#9164 was closed for `needs reproduction`), and #10261 reopens the same scenario on v5 beta.

The root cause was identified by @anilanar in #9164: pnpm creates two `.pnpm/` snapshots for the **same** `vitest` version when a peer dependency (e.g. `@types/node`, `vite`, `@vitest/browser-playwright`) resolves to different versions across packages. Even though the version is identical, Node loads each as a distinct module, so state registered by the orchestrator in copy A is invisible to copy B that the project's `vitest.config.ts` resolves.

I confirmed this on the [Andrei486/vitest-project-repro](https://github.com/Andrei486/vitest-project-repro) repository:

```
ROOT             → .pnpm/vitest@4.0.15_@vitest+browser-playwright@4.0.15/.../vitest
packages/browser → .pnpm/vitest@4.0.15/.../vitest                              ← different
packages/normal  → .pnpm/vitest@4.0.15/.../vitest
```

A real fix (forcing all projects to share a single `vitest` resolution, or moving the orchestrator out-of-process) is invasive and risky. As a first step this PR opts for **early detection with an actionable error** so users stop hitting silent hangs.

- `packages/browser/src/node/index.ts`: in `createBrowserServer`, after the existing version-mismatch warning, resolve `vitest` and `@vitest/browser` from each project root and compare to the running paths. If they differ, throw an error naming both paths, the affected project, and the recommended fixes (`pnpm why vitest`, hoist to root, override the diverging peer dep).
- `docs/guide/common-errors.md`: add a `Duplicate Vitest Installation` section explaining the cause and the fix steps; the thrown error links here.

TODO
- [x] detect duplicate `vitest` / `@vitest/browser` resolutions per project
- [x] dogfood — confirmed the resolution check distinguishes the two physical copies on Andrei486/vitest-project-repro:

  ```
  ROOT             → .pnpm/vitest@4.0.15_@vitest+browser-playwright@4.0.15/.../vitest
  packages/browser → .pnpm/vitest@4.0.15/.../vitest                              ← different
  ```

  With this change the runner now throws the actionable error message instead of hanging silently.
- [x] in-tree test — skipped intentionally: reproducing requires a fixture that materialises two physically distinct `.pnpm/` snapshots of `vitest`, which is significantly larger than the ~40 LOC detection. Happy to add one if maintainers prefer.
- [x] docs — added `Duplicate Vitest Installation` section in `docs/guide/common-errors.md`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. <!-- see TODO above -->
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->