### PR TITLE
fix(mocker): clear mockedIds and queue in invalidate()

### DIFF
--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -56,6 +56,8 @@ export class ModuleMocker implements TestModuleMocker {
     await this.rpc.invalidate(ids)
     await this.interceptor.invalidate()
     this.registry.clear()
+    this.mockedIds.clear()
+    this.queue.clear()
   }
 
   public async importActual<T>(id: string, importer: string): Promise<T> {

--- a/test/browser/fixtures/mocking-invalidate/1_mocked.test.ts
+++ b/test/browser/fixtures/mocking-invalidate/1_mocked.test.ts
@@ -1,0 +1,9 @@
+import { expect, test, vi } from 'vitest'
+import { add } from './src/math'
+
+vi.mock('./src/math')
+
+test('add is mocked in this file', () => {
+  vi.mocked(add).mockReturnValue(99)
+  expect(add(1, 2)).toBe(99)
+})

--- a/test/browser/fixtures/mocking-invalidate/2_not-mocked.test.ts
+++ b/test/browser/fixtures/mocking-invalidate/2_not-mocked.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { add } from './src/math'
+
+test('add is not mocked after previous file invalidated its mocks', () => {
+  expect(add(1, 2)).toBe(3)
+})

--- a/test/browser/fixtures/mocking-invalidate/src/math.ts
+++ b/test/browser/fixtures/mocking-invalidate/src/math.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b
+}

--- a/test/browser/fixtures/mocking-invalidate/vitest.config.ts
+++ b/test/browser/fixtures/mocking-invalidate/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    isolate: false,
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+    },
+  },
+})

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -79,3 +79,24 @@ test('mocking out of root', async () => {
     expect(vitest.stdout).toReportPassedTest('basic.test.js', browser)
   })
 })
+
+test('mocks do not leak between files when isolate is false (fix #9957)', async () => {
+  const result = await runVitest({
+    root: 'fixtures/mocking-invalidate',
+    isolate: false,
+  })
+
+  onTestFailed(() => {
+    console.error(result.stdout)
+    console.error(result.stderr)
+  })
+
+  expect(result.stderr).toReportNoErrors()
+
+  instances.forEach(({ browser }) => {
+    expect(result.stdout).toReportPassedTest('1_mocked.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('2_not-mocked.test.ts', browser)
+  })
+
+  expect(result.exitCode).toBe(0)
+})


### PR DESCRIPTION
## What

`ModuleMocker.invalidate()` clears `registry` and calls `interceptor.invalidate()`, but never clears `mockedIds` or `queue`. This leaves stale state between test files when `isolate: false` is used.

## Why this matters

Two concrete problems from the stale state:

1. **Stale `mockedIds`** — on the next call to `invalidate()` (for the following test file), `ids` is non-empty with IDs from the previous file. The early-return guard `if (!ids.length) return` never fires, causing the mocker to re-send already-invalidated IDs to `rpc.invalidate()`. This can trigger server-side errors or unexpected cache behavior.

2. **Stale `queue`** — if a `queueMock()` promise is still in-flight when `invalidate()` returns, it can complete afterward and call `interceptor.register(module)`, adding a mock back into the interceptor during the next file's execution. This is the root cause of mocks visibly leaking across files.

`reset()` already clears all three (`registry`, `mockedIds`, `queue`) — `invalidate()` should mirror that behavior.

## Fix

```diff
   public async invalidate(): Promise<void> {
     const ids = Array.from(this.mockedIds)
     if (!ids.length) {
       return
     }
     await this.rpc.invalidate(ids)
     await this.interceptor.invalidate()
     this.registry.clear()
+    this.mockedIds.clear()
+    this.queue.clear()
   }
```

## Test

Adds `test/browser/fixtures/mocking-invalidate/` with two sequenced files (`isolate: false`):

- `1_mocked.test.ts` — mocks `./src/math` and verifies the mock is active
- `2_not-mocked.test.ts` — imports the same module without mocking, asserts it returns the real value

Without the fix, leftover `mockedIds` / in-flight `queue` items from file 1 can corrupt file 2's state. The new spec in `test/browser/specs/mocking.test.ts` runs this fixture and asserts both files pass with no stderr output.

Fixes #9957