### PR TITLE
fix(browser): remove orphaned Playwright route when same module is mocked via multiple ids (fix #9957)

### DIFF
--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -261,9 +261,9 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
   private createMocker(): BrowserModuleMocker {
     const idPredicates = new Map<string, (url: URL) => boolean>()
-    const sessionIds = new Map<string, string[]>()
+    const sessionIds = new Map<string, Set<string>>()
 
-    function createPredicate(sessionId: string, url: string) {
+    function createPredicate(url: string) {
       const moduleUrl = new URL(url, 'http://localhost')
       const predicate = (url: URL) => {
         if (url.searchParams.has('_vitest_original')) {
@@ -293,11 +293,7 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
         return true
       }
-      const ids = sessionIds.get(sessionId) || []
-      ids.push(moduleUrl.href)
-      sessionIds.set(sessionId, ids)
-      idPredicates.set(predicateKey(sessionId, moduleUrl.href), predicate)
-      return predicate
+      return { url: moduleUrl.href, predicate }
     }
 
     function predicateKey(sessionId: string, url: string) {
@@ -307,7 +303,17 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     return {
       register: async (sessionId: string, module: MockedModule): Promise<void> => {
         const page = this.getPage(sessionId)
-        await page.context().route(createPredicate(sessionId, module.url), async (route) => {
+        const { url: moduleUrl, predicate } = createPredicate(module.url)
+        const key = predicateKey(sessionId, moduleUrl)
+        const existingPredicate = idPredicates.get(key)
+        if (existingPredicate) {
+          await page.context().unroute(existingPredicate)
+        }
+        const ids = sessionIds.get(sessionId) ?? new Set<string>()
+        ids.add(moduleUrl)
+        sessionIds.set(sessionId, ids)
+        idPredicates.set(key, predicate)
+        await page.context().route(predicate, async (route) => {
           if (module.type === 'manual') {
             const exports = Object.keys(await module.resolve())
             const body = createManualModuleSource(module.url, exports)
@@ -381,8 +387,8 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
       },
       clear: async (sessionId: string): Promise<void> => {
         const page = this.getPage(sessionId)
-        const ids = sessionIds.get(sessionId) || []
-        const promises = ids.map((id) => {
+        const ids = sessionIds.get(sessionId) ?? new Set<string>()
+        const promises = [...ids].map((id) => {
           const key = predicateKey(sessionId, id)
           const predicate = idPredicates.get(key)
           if (predicate) {

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -273,7 +273,11 @@ export function createBrowserRunner(
         }
         catch {}
       }
-      return rpc().onCollected(this.method, files)
+      const result = await rpc().onCollected(this.method, files)
+      if (this.method === 'collect') {
+        await mocker.invalidate()
+      }
+      return result
     }
 
     onTestAnnotate = (test: Test, annotation: TestAnnotation): Promise<TestAnnotation> => {

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -273,11 +273,7 @@ export function createBrowserRunner(
         }
         catch {}
       }
-      const result = await rpc().onCollected(this.method, files)
-      if (this.method === 'collect') {
-        await mocker.invalidate()
-      }
-      return result
+      return rpc().onCollected(this.method, files)
     }
 
     onTestAnnotate = (test: Test, annotation: TestAnnotation): Promise<TestAnnotation> => {

--- a/test/browser/fixtures/mocking/src/aaa-dual-id-probe.test.ts
+++ b/test/browser/fixtures/mocking/src/aaa-dual-id-probe.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest'
+import { loadModalSource } from './dual-id/consumer'
+
+vi.mock('~/dual-id/modal', () => ({
+  readModalSource: () => 'mocked modal',
+}))
+
+vi.mock('./dual-id/modal', () => ({
+  readModalSource: () => 'mocked modal',
+}))
+
+test('dual-id mock is active in the file that registered it', () => {
+  expect(loadModalSource()).not.toBe('actual modal')
+})

--- a/test/browser/fixtures/mocking/src/dual-id/consumer.ts
+++ b/test/browser/fixtures/mocking/src/dual-id/consumer.ts
@@ -1,0 +1,5 @@
+import { readModalSource } from '~/dual-id/modal'
+
+export function loadModalSource() {
+  return readModalSource()
+}

--- a/test/browser/fixtures/mocking/src/dual-id/modal.ts
+++ b/test/browser/fixtures/mocking/src/dual-id/modal.ts
@@ -1,0 +1,3 @@
+export function readModalSource() {
+  return 'actual modal'
+}

--- a/test/browser/fixtures/mocking/src/zzz-dual-id-target.test.ts
+++ b/test/browser/fixtures/mocking/src/zzz-dual-id-target.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { loadModalSource } from './dual-id/consumer'
+
+test('dual-id mock from the previous file does not leak into this one', () => {
+  expect(loadModalSource()).toBe('actual modal')
+})

--- a/test/browser/fixtures/mocking/vitest.config.ts
+++ b/test/browser/fixtures/mocking/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config'
 import { instances, provider } from '../../settings'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   optimizeDeps: {
     include: ['@vitest/cjs-lib'],
     needsInterop: ['@vitest/cjs-lib'],

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -29,6 +29,8 @@ test.each([true/* , false */])('mocking works correctly - isolated %s', async (i
     expect(result.stdout).toReportPassedTest('import-actual-in-mock.test.ts', browser)
     expect(result.stdout).toReportPassedTest('import-actual-query.test.ts', browser)
     expect(result.stdout).toReportPassedTest('import-mock.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/aaa-dual-id-probe.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/zzz-dual-id-target.test.ts', browser)
     expect(result.stdout).toReportPassedTest('mocked-do-mock-factory.test.ts', browser)
     expect(result.stdout).toReportPassedTest('import-actual-dep.test.ts', browser)
   })

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -36,6 +36,26 @@ test.each([true/* , false */])('mocking works correctly - isolated %s', async (i
   expect(result.exitCode).toBe(0)
 })
 
+test('manual mocks do not leak across browser files when alias and relative ids resolve to the same module', async () => {
+  const result = await runVitest({
+    root: 'fixtures/mocking',
+  }, ['src/aaa-dual-id-probe.test.ts', 'src/zzz-dual-id-target.test.ts'])
+
+  onTestFailed(() => {
+    console.error(result.stdout)
+    console.error(result.stderr)
+  })
+
+  expect(result.stderr).toReportNoErrors()
+
+  instances.forEach(({ browser }) => {
+    expect(result.stdout).toReportPassedTest('src/aaa-dual-id-probe.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/zzz-dual-id-target.test.ts', browser)
+  })
+
+  expect(result.exitCode).toBe(0)
+}, 60_000)
+
 test('mocking dependency correctly invalidates it on rerun', async () => {
   const { vitest, ctx } = await runVitest({
     root: 'fixtures/mocking-watch',


### PR DESCRIPTION
Fixes #9957.

### Description

If you call `vi.mock('~/modal')` and `vi.mock('./modal')` in the same test file, and both aliases resolve to the same URL, `createMocker()` in `playwright.ts` registers two Playwright routes. The second call overwrites the predicate in `idPredicates` without removing the first route. When `clear()` runs at the end of the file, it only finds the second predicate -- the first route stays attached to the browser context.

That orphaned route fires when the next test file loads the same module. Its handler calls `module.resolve()` through a birpc channel that belongs to the previous session, which is already closed. That's where `[birpc] rpc is closed` comes from.

**`playwright.ts`**: before registering a route for a session+URL, check `idPredicates` for an existing predicate and `unroute()` it first. Switched `sessionIds` from `string[]` to `Set<string>` so URL entries can't duplicate and `clear()` removes each route exactly once.

### Testing

Added `test/browser/fixtures/mocking/src/dual-id/` with a source module, a consumer that imports it via the alias, and two test files. The probe registers the module through both `~/dual-id/modal` and `./dual-id/modal`. The target (same browser session, runs after) asserts the real implementation is visible. Without this fix, the target crashes with `[birpc] rpc is closed`; with it, the mock is cleaned up between files.

```
PROVIDER=playwright BROWSER=chromium corepack pnpm -C test/browser exec vitest run --config vitest.config.unit.mts specs/mocking.test.ts -t 'manual mocks do not leak'
```