### PR TITLE
test: detect browser name in `configureVitest`

### DIFF
--- a/test/e2e/test/configureVitest.test.ts
+++ b/test/e2e/test/configureVitest.test.ts
@@ -1,5 +1,6 @@
 import type { ViteUserConfig } from 'vitest/config'
 import type { TestProject, TestUserConfig, VitestOptions } from 'vitest/node'
+import { playwright } from '@vitest/browser-playwright'
 import { expect, onTestFinished, test } from 'vitest'
 import { createVitest } from 'vitest/node'
 
@@ -247,6 +248,79 @@ test('adding a plugin with existing name throws and error', async () => {
     ],
   }),
   ).rejects.toThrow('Project name "project-1" is not unique. All projects should have unique names. Make sure your configuration is correct.')
+})
+
+test('can access browser.instances[].browser', async () => {
+  const browsers: string[] = []
+
+  await vitest({}, {
+    name: 'custom-project-name',
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [
+        { browser: 'chromium', name: 'custom-name-for-chromium-browser' },
+        { browser: 'webkit', name: 'custom-name-for-webkit-browser' },
+        { browser: 'firefox', name: 'custom-name-for-firefox-browser' },
+      ],
+    },
+  }, {
+    plugins: [
+      {
+        name: 'test',
+        configureVitest(context) {
+          browsers.push(context.project.config.browser.name)
+        },
+      },
+    ],
+  })
+
+  expect(browsers).toMatchInlineSnapshot(`
+    [
+      "chromium",
+      "webkit",
+      "firefox",
+    ]
+  `)
+})
+
+test('can access project\'s browser.instances[].browser', async () => {
+  const browsers: string[] = []
+
+  await vitest({}, {
+    projects: [
+      {
+        plugins: [
+          {
+            name: 'test',
+            configureVitest(context) {
+              browsers.push(context.project.config.browser.name)
+            },
+          },
+        ],
+        test: {
+          name: 'custom-project-name',
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            instances: [
+              { browser: 'chromium', name: 'custom-name-for-chromium-browser' },
+              { browser: 'webkit', name: 'custom-name-for-webkit-browser' },
+              { browser: 'firefox', name: 'custom-name-for-firefox-browser' },
+            ],
+          },
+        },
+      },
+    ],
+  })
+
+  expect(browsers).toMatchInlineSnapshot(`
+    [
+      "chromium",
+      "webkit",
+      "firefox",
+    ]
+  `)
 })
 
 async function throws(cliOptions: TestUserConfig) {

--- a/test/e2e/test/configureVitest.test.ts
+++ b/test/e2e/test/configureVitest.test.ts
@@ -251,7 +251,7 @@ test('adding a plugin with existing name throws and error', async () => {
 })
 
 test('can access browser.instances[].browser', async () => {
-  const browsers: string[] = []
+  const names: { browser: string; project: string }[] = []
 
   await vitest({}, {
     name: 'custom-project-name',
@@ -269,23 +269,32 @@ test('can access browser.instances[].browser', async () => {
       {
         name: 'test',
         configureVitest(context) {
-          browsers.push(context.project.config.browser.name)
+          names.push({ browser: context.project.config.browser.name, project: context.project.name })
         },
       },
     ],
   })
 
-  expect(browsers).toMatchInlineSnapshot(`
+  expect(names).toMatchInlineSnapshot(`
     [
-      "chromium",
-      "webkit",
-      "firefox",
+      {
+        "browser": "chromium",
+        "project": "custom-name-for-chromium-browser",
+      },
+      {
+        "browser": "webkit",
+        "project": "custom-name-for-webkit-browser",
+      },
+      {
+        "browser": "firefox",
+        "project": "custom-name-for-firefox-browser",
+      },
     ]
   `)
 })
 
 test('can access project\'s browser.instances[].browser', async () => {
-  const browsers: string[] = []
+  const names: { browser: string; project: string }[] = []
 
   await vitest({}, {
     projects: [
@@ -294,7 +303,7 @@ test('can access project\'s browser.instances[].browser', async () => {
           {
             name: 'test',
             configureVitest(context) {
-              browsers.push(context.project.config.browser.name)
+              names.push({ browser: context.project.config.browser.name, project: context.project.name })
             },
           },
         ],
@@ -314,11 +323,20 @@ test('can access project\'s browser.instances[].browser', async () => {
     ],
   })
 
-  expect(browsers).toMatchInlineSnapshot(`
+  expect(names).toMatchInlineSnapshot(`
     [
-      "chromium",
-      "webkit",
-      "firefox",
+      {
+        "browser": "chromium",
+        "project": "custom-name-for-chromium-browser",
+      },
+      {
+        "browser": "webkit",
+        "project": "custom-name-for-webkit-browser",
+      },
+      {
+        "browser": "firefox",
+        "project": "custom-name-for-firefox-browser",
+      },
     ]
   `)
 })


### PR DESCRIPTION
### Description

It's somewhat accidental that `browser.name` is resolved from `browser.instances[].browser` and not from `browser.instances[].name`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
