### PR TITLE
fix(cli): respect `FORCE_COLOR` over agent detection

### DIFF
--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -7,7 +7,7 @@ import cac from 'cac'
 import { normalize } from 'pathe'
 import c, { disableDefaultColors } from 'tinyrainbow'
 import { version } from '../../../package.json' with { type: 'json' }
-import { isAgent } from '../../utils/env'
+import { isAgent, isForceColor } from '../../utils/env'
 import { benchCliOptionsConfig, cliOptionsConfig, collectCliOptionsConfig } from './cli-config'
 import { setupTabCompletions } from './completions'
 
@@ -75,7 +75,7 @@ function addCliOptions(cli: CAC | Command, options: CLIOptionsConfig<any>) {
 }
 
 export function createCLI(options: CliParseOptions = {}): CAC {
-  if (isAgent) {
+  if (isAgent && !isForceColor()) {
     disableDefaultColors()
   }
 

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -3,7 +3,7 @@ import type { TestProject } from '../project'
 import type { ApiConfig } from '../types/config'
 import { resolve } from 'node:path'
 import { configDefaults } from '../../defaults'
-import { isAgent } from '../../utils/env'
+import { isAgent, isForceColor } from '../../utils/env'
 
 export function serializeConfig(project: TestProject): SerializedConfig {
   const { config, globalConfig } = project
@@ -155,6 +155,6 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       config.slowTestThreshold
       ?? globalConfig.slowTestThreshold
       ?? configDefaults.slowTestThreshold,
-    isAgent,
+    disableColors: isAgent && !isForceColor(),
   }
 }

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -156,7 +156,7 @@ export interface SerializedConfig {
   strictTags: boolean
   mergeReportsLabel: string | undefined
   slowTestThreshold: number | undefined
-  isAgent: boolean
+  disableColors: boolean
 }
 
 export interface SerializedCoverageConfig {

--- a/packages/vitest/src/runtime/workers/init.ts
+++ b/packages/vitest/src/runtime/workers/init.ts
@@ -50,7 +50,7 @@ export function init(worker: Options): void {
         process.env.VITEST_WORKER_ID = String(message.workerId)
         reportMemory = message.options.reportMemory
 
-        if (message.context.config.isAgent) {
+        if (message.context.config.disableColors) {
           disableDefaultColors()
         }
 

--- a/packages/vitest/src/utils/env.ts
+++ b/packages/vitest/src/utils/env.ts
@@ -12,4 +12,5 @@ export const isDeno: boolean
 export const isWindows: boolean = (isNode || isDeno) && process.platform === 'win32'
 export const isBrowser: boolean = typeof window !== 'undefined'
 export const isTTY: boolean = ((isNode || isDeno) && process.stdout?.isTTY && !isCI)
+export const isForceColor = (): boolean => 'FORCE_COLOR' in process.env
 export { isAgent, isCI, provider as stdProvider } from 'std-env'

--- a/test/config/test/console-color.test.ts
+++ b/test/config/test/console-color.test.ts
@@ -44,6 +44,17 @@ test('agent', async () => {
   expect.soft(stdout).not.toContain('\x1B[46m RUN')
 })
 
+test('agent with FORCE_COLOR=1', async () => {
+  // FORCE_COLOR opts back into colours even when isAgent is detected, both in the CLI process and in workers
+  const { stdout } = await runVitestCli({
+    preserveAnsi: true,
+    nodeOptions: { env: { AI_AGENT: 'copilot', FORCE_COLOR: '1' } },
+  }, '--root', 'fixtures/console-color', '--reporter', 'default')
+
+  expect.soft(stdout).toContain('\x1B[33mtrue\x1B[39m\n')
+  expect.soft(stdout).toContain('\x1B[46m RUN')
+})
+
 test.skipIf(process.platform === 'win32')('without color, forks pool in non-TTY parent', async () => {
   const { stdout } = await runVitest({
     root: 'fixtures/console-color',


### PR DESCRIPTION
### Description

Vitest's CLI calls `disableDefaultColors()` whenever `std-env`'s `isAgent` returns true, with no way for the user to opt back in. This strips ANSI from all reporter output even when the user has explicitly requested colours via `FORCE_COLOR=1` — every other CLI that follows the `FORCE_COLOR` / `NO_COLOR` convention treats those as opt-in overrides, so vitest should too.

### Fix

- `packages/vitest/src/node/cli/cac.ts`: skip the auto-disable when `FORCE_COLOR` is set. This matches the convention used by chalk, picocolors, supports-color, etc.
- `test/config/test/console-color.test.ts`: add a regression case `agent with FORCE_COLOR=1` next to the existing `agent` test. Asserts that the ` RUN ` banner is rendered with ANSI when `AI_AGENT` and `FORCE_COLOR` are both set, fails on `main` (no ANSI emitted) and passes with this fix.

### Test plan

- [x] New `agent with FORCE_COLOR=1` fails on `main`, passes with this fix.
- [x] Existing `agent` still passes (no-colour assertion is preserved when `FORCE_COLOR` is unset).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] No public API change. The new behaviour follows the standard `FORCE_COLOR` / `NO_COLOR` convention, so no docs change is needed.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with \`feat:\`, \`fix:\`, \`perf:\`, \`docs:\`, or \`chore:\`.

<!-- VITEST_AUTOMATED_PR -->