### PR TITLE
fix(browser): simplify orchestrator otel carrier

### DIFF
--- a/packages/browser/src/node/serverOrchestrator.ts
+++ b/packages/browser/src/node/serverOrchestrator.ts
@@ -45,7 +45,7 @@ export async function resolveOrchestrator(
     __VITEST_TYPE__: '"orchestrator"',
     __VITEST_SESSION_ID__: JSON.stringify(sessionId),
     __VITEST_TESTER_ID__: '"none"',
-    __VITEST_OTEL_CARRIER__: url.searchParams.get('otelCarrier') ?? 'null',
+    __VITEST_OTEL_CARRIER__: JSON.stringify(session?.otelCarrier ?? null),
     __VITEST_PROVIDED_CONTEXT__: JSON.stringify(stringify(browserProject.project.getProvidedContext())),
     __VITEST_API_TOKEN__: JSON.stringify(globalServer.vitest.config.api.token),
   })

--- a/packages/vitest/src/node/browser/sessions.ts
+++ b/packages/vitest/src/node/browser/sessions.ts
@@ -1,3 +1,4 @@
+import type { OTELCarrier } from '../../utils/traces'
 import type { TestProject } from '../project'
 import type { BrowserServerStateSession } from '../types/browser'
 import { createDefer } from '@vitest/utils/helpers'
@@ -15,7 +16,12 @@ export class BrowserSessions {
     this.sessions.delete(sessionId)
   }
 
-  createSession(sessionId: string, project: TestProject, pool: { reject: (error: Error) => void }): Promise<void> {
+  createSession(
+    sessionId: string,
+    project: TestProject,
+    pool: { reject: (error: Error) => void },
+    options?: { otelCarrier?: OTELCarrier },
+  ): Promise<void> {
     // this promise only waits for the WS connection with the orchestrator to be established
     const defer = createDefer<void>()
 
@@ -25,6 +31,7 @@ export class BrowserSessions {
 
     this.sessions.set(sessionId, {
       project,
+      otelCarrier: options?.otelCarrier,
       connected: () => {
         defer.resolve()
         clearTimeout(timeout)

--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -631,14 +631,12 @@ export class TestProject {
     const url = new URL('/__vitest_test__/', origin)
     url.searchParams.set('sessionId', sessionId)
     const otelCarrier = this.vitest._traces.getContextCarrier()
-    if (otelCarrier) {
-      url.searchParams.set('otelCarrier', JSON.stringify(otelCarrier))
-    }
     this.vitest._browserSessions.sessionIds.add(sessionId)
     const sessionPromise = this.vitest._browserSessions.createSession(
       sessionId,
       this,
       pool,
+      { otelCarrier },
     )
     const pagePromise = this.browser.provider.openPage(
       sessionId,

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -6,6 +6,7 @@ import type { Plugin, ViteDevServer } from 'vite'
 import type { BrowserCommands, CDPSession } from 'vitest/browser'
 import type { BrowserTraceViewMode } from '../../runtime/config'
 import type { BrowserTesterOptions } from '../../types/browser'
+import type { OTELCarrier } from '../../utils/traces'
 import type { TestProject } from '../project'
 import type { ApiConfig, ProjectConfig } from './config'
 
@@ -354,6 +355,7 @@ export interface BrowserCommandContext {
 
 export interface BrowserServerStateSession {
   project: TestProject
+  otelCarrier?: OTELCarrier
   connected: () => void
   fail: (v: Error) => void
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Related https://github.com/vitest-dev/vitest/pull/9180

It looks like I had a weird indirection to propagate `otelCarrier` to orchestrator https://github.com/vitest-dev/vitest/pull/9180. 

Previously it did:
- browser pool opens `?otelCarrier=...` as orchestrator page (along with `?sessionId=...`)
- orchestrator page middleware then extract `?otelCarrier` from request, which then inject back to shell html

This now becomes:
- browser pool open orchestrator page as usual `?sessionId=...`. we record `otelCarrier` on server side session object.
- orchestrator page middleware then picks up `otelCarrier` associated with `sessionId` on the server side.

### How to test

Manually verified running `examples/opentelemetry`

<details><summary>screenshot</summary>

<img width="1365" height="851" alt="image" src="https://github.com/user-attachments/assets/599ac634-a654-4a91-9ba6-f9310410ac30" />

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
