### PR TITLE
fix: allow resolves to accept promise thunks (fix #10281)

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1816,6 +1816,8 @@ describe('toSatisfy()', () => {
 
 `resolves` is intended to remove boilerplate when asserting asynchronous code. Use it to unwrap value from the pending promise and assert its value with usual assertions. If the promise rejects, the assertion will fail.
 
+You can also pass a function that returns a promise. Vitest will call the function and unwrap the returned promise before applying the matcher.
+
 It returns the same `Assertions` object, but all matchers now return `Promise`, so you would need to `await` it. Also works with `chai` assertions.
 
 For example, if you have a function, that makes an API call and returns some data, you may use this code to assert its return value:

--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -1075,6 +1075,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       utils.flag(this, 'error', error)
       const test: Test = utils.flag(this, 'vitest-test')
       const obj = utils.flag(this, 'object')
+      const wrapper = typeof obj === 'function' ? obj() : obj // for jest compat
 
       if (utils.flag(this, 'poll')) {
         throw new SyntaxError(
@@ -1082,9 +1083,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         )
       }
 
-      if (typeof obj?.then !== 'function') {
+      if (typeof wrapper?.then !== 'function') {
         throw new TypeError(
-          `You must provide a Promise to expect() when using .resolves, not '${typeof obj}'.`,
+          `You must provide a Promise to expect() when using .resolves, not '${typeof wrapper}'.`,
         )
       }
 
@@ -1098,7 +1099,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
           return (...args: any[]) => {
             utils.flag(this, '_name', key)
-            const promise = Promise.resolve(obj).then(
+            const promise = Promise.resolve(wrapper).then(
               (value: any) => {
                 utils.flag(this, 'object', value)
                 return result.call(this, ...args)

--- a/test/unit/test/expect.test.ts
+++ b/test/unit/test/expect.test.ts
@@ -410,6 +410,10 @@ describe('expect with custom message', () => {
       await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[AssertionError: custom async message: expected 1 to be 2 // Object.is equality]`)
     })
 
+    test('async resolves matcher accepts a promise-returning function', async ({ expect }) => {
+      await expect(() => Promise.resolve(1)).resolves.toBe(1)
+    })
+
     test('not matcher throws custom message on failure', () => {
       expect(() => expect(1, 'custom message').not.toBe(1)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: custom message: expected 1 not to be 1 // Object.is equality]`)
     })


### PR DESCRIPTION
### Description

Allows `.resolves` to accept a promise-returning function, matching `.rejects` and the maintainer-supported direction in #10281. The function result is used as the promise before applying the async matcher.

Resolves #10281

AI assistance disclosure: this PR was prepared with Hermes Agent (gpt-5.5).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-projects/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] `CI=true pnpm --filter test-unit test:threads test/expect.test.ts -t 'promise-returning function|custom message'`
- [x] `pnpm exec eslint packages/expect/src/jest-expect.ts test/unit/test/expect.test.ts`
- [x] `pnpm --filter @vitest/expect build`
- [x] `git diff --check`

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command. (Updated `docs/api/expect.md` for `.resolves` promise-returning functions.)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->

