### PR TITLE
fix(coverage): `exclude` to not inherit negation globs from `test.include`

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -540,7 +540,7 @@ export function resolveConfig(
     ),
 
     // Exclude test files
-    ...resolved.include,
+    ...resolved.include.filter(pattern => !pattern.startsWith('!')),
 
     // Configs
     resolved.config && slash(resolved.config),

--- a/test/coverage-test/test/include-exclude.unit.test.ts
+++ b/test/coverage-test/test/include-exclude.unit.test.ts
@@ -59,6 +59,19 @@ test('include without actual glob', async () => {
   expect.soft(isIncluded('src-file-in-root.js')).toBe(false)
 })
 
+test('test.include with negations', async () => {
+  const isIncluded = await init({
+    include: ['src/**'],
+    testInclude: ['!something'],
+  })
+
+  expect.soft(isIncluded('src/component.js')).toBe(true)
+  expect.soft(isIncluded('src/nested/component.ts')).toBe(true)
+
+  expect.soft(isIncluded('top-level.ts')).toBe(false)
+  expect.soft(isIncluded('utils/math.ts')).toBe(false)
+})
+
 test('no include defaults to match all files', async () => {
   const isIncluded = await init({
     exclude: [],
@@ -131,10 +144,10 @@ test('files outside project when allowExternal: true', async () => {
   expect(isIncluded(resolve(process.cwd(), '../../package-b/src/two.ts'))).toBe(false)
 })
 
-async function init(options: Partial<CoverageOptions>) {
+async function init(options: Partial<CoverageOptions> & { testInclude?: string[] }) {
   const vitest = await createVitest('test', {
     config: false,
-    include: ['dont-match-anything'],
+    include: ['dont-match-anything', ...(options.testInclude || [])],
     coverage: {
       ...options,
       enabled: true,
@@ -143,7 +156,7 @@ async function init(options: Partial<CoverageOptions>) {
   }, {}, { stdout: new Writable() })
 
   onTestFinished(() => vitest.close())
-  await vitest.init()
+  await vitest.standalone()
 
   const provider = vitest.coverageProvider as unknown as BaseCoverageProvider
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vitest/issues/10164

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
