### PR TITLE
fix(browser): fix iframe leak in the orchestrator

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -80,7 +80,7 @@ export class IframeOrchestrator {
       return
     }
 
-    this.iframes.forEach(iframe => iframe.remove())
+    this.iframes.forEach(iframe => this.removeIframe(iframe))
     this.iframes.clear()
 
     for (let i = 0; i < options.files.length; i++) {
@@ -140,7 +140,7 @@ export class IframeOrchestrator {
       // because we called "cleanup" in the previous run
       // the iframe is not removed immediately to let the user see the last test
       this.recreateNonIsolatedIframe = false
-      this.iframes.get(ID_ALL)!.remove()
+      this.removeIframe(this.iframes.get(ID_ALL)!)
       this.iframes.delete(ID_ALL)
       debug('recreate non-isolated iframe')
     }
@@ -180,7 +180,7 @@ export class IframeOrchestrator {
     const file = spec.filepath
 
     if (this.iframes.has(file)) {
-      this.iframes.get(file)!.remove()
+      this.removeIframe(this.iframes.get(file)!)
       this.iframes.delete(file)
     }
 
@@ -234,8 +234,7 @@ export class IframeOrchestrator {
           )))
         }
         else if (this.iframes.has(iframeId)) {
-          const events = this.iframeEvents.get(iframe)
-          if (events?.size) {
+          if (this.pendingAborts.get(iframe)?.size) {
             this.dispatchIframeError(new Error(this.createWarningMessage(iframeId, 'during a test')))
           }
           else {
@@ -402,41 +401,58 @@ export class IframeOrchestrator {
     }
   }
 
-  private iframeEvents = new WeakMap<HTMLIFrameElement, Set<string>>()
+  private pendingAborts = new WeakMap<HTMLIFrameElement, Set<(error: Error) => void>>()
+
+  private removeIframe(iframe: HTMLIFrameElement) {
+    // Reject any pending sendEventToIframe so suspended async callers release the
+    // detached iframe; otherwise its document/listeners stay retained in the renderer.
+    const aborts = this.pendingAborts.get(iframe)
+    if (aborts) {
+      const error = new Error('Iframe was removed before responding to the event.')
+      for (const abort of aborts) {
+        abort(error)
+      }
+    }
+    iframe.remove()
+  }
 
   private async sendEventToIframe(event: IframeChannelOutgoingEvent): Promise<void> {
     const iframe = this.iframes.get(event.iframeId)
     if (!iframe) {
       throw new Error(`Cannot find iframe with id ${event.iframeId}`)
     }
-    let events = this.iframeEvents.get(iframe)
-    if (!events) {
-      events = new Set()
-      this.iframeEvents.set(iframe, events)
+    let aborts = this.pendingAborts.get(iframe)
+    if (!aborts) {
+      aborts = new Set()
+      this.pendingAborts.set(iframe, aborts)
     }
-    events.add(event.event)
 
     channel.postMessage(event)
     return new Promise<void>((resolve, reject) => {
-      const cleanupEvents = () => {
+      const cleanup = () => {
         channel.removeEventListener('message', onReceived)
         this.eventTarget.removeEventListener('iframeerror', onError)
+        aborts!.delete(abort)
       }
 
       function onReceived(e: MessageEvent) {
         if (e.data.iframeId === event.iframeId && e.data.event === `response:${event.event}`) {
+          cleanup()
           resolve()
-          cleanupEvents()
-          events!.delete(event.event)
         }
       }
 
       function onError(e: Event) {
+        cleanup()
         reject((e as CustomEvent).detail)
-        cleanupEvents()
-        events!.delete(event.event)
       }
 
+      function abort(error: Error) {
+        cleanup()
+        reject(error)
+      }
+
+      aborts.add(abort)
       this.eventTarget.addEventListener('iframeerror', onError)
       channel.addEventListener('message', onReceived)
     })


### PR DESCRIPTION
Fix a renderer-process leak in `IframeOrchestrator` that retained detached iframes and ultimately crashed Chromium during long browser-mode runs.

Background — I'm one of the core developers of [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js/), which runs an extensive suite of Vitest-based tests. [`unit-test` part](https://github.com/mapbox/mapbox-gl-js/blob/main/vitest.config.unit.ts) of them (~2900 tests across ~190 files) has been increasingly flaky over at least a year, getting worse with increased test coverage, to the point that recently the CI job failed half of the time.

After multiple days of debugging, tracing various leads and eliminating theories, we've finally tracked it down to an iframe leak in the Vitest orchestrator. Disclosing that the fix was made using Claude Opus 4.7, but it's minimal enough to be easily reviewed by a human. ~~We've verified that the fix makes Vitest stop accumulating resources (documents, frames & listeners) during that test run.~~ **Edit** Apologies, converting to draft while we verify correctly that this 100% fixes the issue.

I haven't added a test for this because it's a hard thing to test — it only manifests on long-running browser tests in a slow CI environment, and a more targeted unit test would require rewriting the orchestrator more substantially to hook into it from the test suite. Perhaps the change is minimal enough so that it's fine to just make sure the existing suite passes? Let me know how to make this easier for you to merge.

### Description

When an iframe is force-removed mid-flight (next-batch reset, isolated retry), any in-flight `sendEventToIframe` Promise never settles — the `response:<event>` postMessage from the now-removed iframe never arrives. The async function awaiting it stays suspended forever, and its closure pins the detached iframe, its Document, and all attached event listeners. JS heap stays small (~150 MB), but Chromium-internal frame-graph state grows unbounded across files and eventually crosses a renderer-internal limit, killing the renderer with no JS event of any kind firing — surfacing as the long-standing flake `Browser connection was closed while running tests. Was the page closed unexpectedly?`.

**The fix.** Track per-iframe abort callbacks in a `WeakMap` and reject pending `sendEventToIframe` promises when the iframe is removed, releasing the closures and unwinding the detached frame state.

- New `pendingAborts: WeakMap<HTMLIFrameElement, Set<abort>>` — replaces the prior `iframeEvents` map (1:1 with pending promises, so the two are merged into one).
- New `removeIframe(iframe)` helper drains the pending aborts before calling `iframe.remove()`. All three direct `iframe.remove()` call sites in `IframeOrchestrator` go through it.
- `sendEventToIframe` registers an `abort` callback; `onReceived`, `onError`, and `abort` all funnel through one `cleanup()` that removes the channel/eventTarget listeners and the pending entry.

**Evidence.** Diagnosed via CDP `Performance.getMetrics` polling on a flaky CI run: at the death edge, `Documents` climbed 13 → 51, `Frames` 8 → 27, and `JSEventListeners` ran away from ~200 to **1744 in the final second** before the renderer was killed — while JS heap stayed at 144 MB / 4 GB (3.5%). A `HeapProfiler.collectGarbage` workaround every 5 s held all those counters at baseline and the run passed, confirming the retainers were GC-eligible if pressure was relieved. A heap snapshot then pinned the retainer to a single suspended `prepareIframe` async generator awaiting `sendEventToIframe({event: 'prepare'})`, with its closure capturing `{iframe: <detached>, iframeId, otelContext, startTime}` and a never-settled Promise as a GC root.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
