### PR TITLE
feat(browser): support custom `kind` in `page.mark`

### DIFF
--- a/docs/api/browser/context.md
+++ b/docs/api/browser/context.md
@@ -82,11 +82,11 @@ export const page: {
   /**
    * Add a trace marker when browser tracing is enabled.
    */
-  mark(name: string, options?: { stack?: string; kind?: MarkKind }): Promise<void>
+  mark(name: string, options?: { stack?: string; kind?: BrowserTraceEntryKind }): Promise<void>
   /**
    * Group multiple operations under a trace marker when browser tracing is enabled.
    */
-  mark<T>(name: string, body: () => T | Promise<T>, options?: { stack?: string; kind?: MarkKind }): Promise<T>
+  mark<T>(name: string, body: () => T | Promise<T>, options?: { stack?: string; kind?: BrowserTraceEntryKind }): Promise<T>
   /**
    * Extend default `page` object with custom methods.
    */
@@ -127,11 +127,11 @@ The `path` is also ignored in that case.
 ### mark
 
 ```ts
-function mark(name: string, options?: { stack?: string; kind?: MarkKind }): Promise<void>
+function mark(name: string, options?: { stack?: string; kind?: BrowserTraceEntryKind }): Promise<void>
 function mark<T>(
   name: string,
   body: () => T | Promise<T>,
-  options?: { stack?: string; kind?: MarkKind },
+  options?: { stack?: string; kind?: BrowserTraceEntryKind },
 ): Promise<T>
 ```
 

--- a/docs/api/browser/context.md
+++ b/docs/api/browser/context.md
@@ -82,11 +82,11 @@ export const page: {
   /**
    * Add a trace marker when browser tracing is enabled.
    */
-  mark(name: string, options?: { stack?: string }): Promise<void>
+  mark(name: string, options?: { stack?: string; kind?: Kind }): Promise<void>
   /**
    * Group multiple operations under a trace marker when browser tracing is enabled.
    */
-  mark<T>(name: string, body: () => T | Promise<T>, options?: { stack?: string }): Promise<T>
+  mark<T>(name: string, body: () => T | Promise<T>, options?: { stack?: string; kind?: Kind }): Promise<T>
   /**
    * Extend default `page` object with custom methods.
    */
@@ -127,17 +127,19 @@ The `path` is also ignored in that case.
 ### mark
 
 ```ts
-function mark(name: string, options?: { stack?: string }): Promise<void>
+function mark(name: string, options?: { stack?: string; kind?: Kind }): Promise<void>
 function mark<T>(
   name: string,
   body: () => T | Promise<T>,
-  options?: { stack?: string },
+  options?: { stack?: string; kind?: Kind },
 ): Promise<T>
 ```
 
 Adds a named marker to the trace timeline for the current test.
 
 Pass `options.stack` to override the callsite location in trace metadata. This is useful for wrapper libraries that need to preserve the end-user source location.
+
+Pass `options.kind` to categorize your marker as specific type, for example as `'action'`.
 
 If you pass a callback, Vitest creates a trace group with this name, runs the callback, and closes the group automatically.
 
@@ -151,7 +153,7 @@ await page.mark('after submit')
 await page.mark('submit flow', async () => {
   await page.getByRole('textbox', { name: 'Email' }).fill('john@example.com')
   await page.getByRole('button', { name: 'Submit' }).click()
-})
+}, { kind: 'action' })
 ```
 
 ::: tip

--- a/docs/api/browser/context.md
+++ b/docs/api/browser/context.md
@@ -82,11 +82,11 @@ export const page: {
   /**
    * Add a trace marker when browser tracing is enabled.
    */
-  mark(name: string, options?: { stack?: string; kind?: Kind }): Promise<void>
+  mark(name: string, options?: { stack?: string; kind?: MarkKind }): Promise<void>
   /**
    * Group multiple operations under a trace marker when browser tracing is enabled.
    */
-  mark<T>(name: string, body: () => T | Promise<T>, options?: { stack?: string; kind?: Kind }): Promise<T>
+  mark<T>(name: string, body: () => T | Promise<T>, options?: { stack?: string; kind?: MarkKind }): Promise<T>
   /**
    * Extend default `page` object with custom methods.
    */
@@ -127,11 +127,11 @@ The `path` is also ignored in that case.
 ### mark
 
 ```ts
-function mark(name: string, options?: { stack?: string; kind?: Kind }): Promise<void>
+function mark(name: string, options?: { stack?: string; kind?: MarkKind }): Promise<void>
 function mark<T>(
   name: string,
   body: () => T | Promise<T>,
-  options?: { stack?: string; kind?: Kind },
+  options?: { stack?: string; kind?: MarkKind },
 ): Promise<T>
 ```
 

--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -846,7 +846,7 @@ The `path` is also ignored in that case.
 ### mark
 
 ```ts
-function mark(name: string, options?: { stack?: string; kind?: Kind }): Promise<void>
+function mark(name: string, options?: { stack?: string; kind?: MarkKind }): Promise<void>
 ```
 
 Adds a named marker to the trace timeline and uses the current locator as marker context.

--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -846,12 +846,14 @@ The `path` is also ignored in that case.
 ### mark
 
 ```ts
-function mark(name: string, options?: { stack?: string }): Promise<void>
+function mark(name: string, options?: { stack?: string; kind?: Kind }): Promise<void>
 ```
 
 Adds a named marker to the trace timeline and uses the current locator as marker context.
 
 Pass `options.stack` to override the callsite location in trace metadata. This is useful for wrapper libraries that need to preserve the end-user source location.
+
+Pass `options.kind` to categorize your marker as specific type, for example as `'action'`.
 
 ```ts
 import { page } from 'vitest/browser'

--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -846,7 +846,7 @@ The `path` is also ignored in that case.
 ### mark
 
 ```ts
-function mark(name: string, options?: { stack?: string; kind?: MarkKind }): Promise<void>
+function mark(name: string, options?: { stack?: string; kind?: BrowserTraceEntryKind }): Promise<void>
 ```
 
 Adds a named marker to the trace timeline and uses the current locator as marker context.

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -42,12 +42,20 @@ export interface ScreenshotOptions extends SelectorOptions {
   save?: boolean
 }
 
+export type MarkKind = 'action' | 'expect' | 'mark' | 'lifecycle'
+
 export interface MarkOptions {
   /**
    * Optional stack string used to resolve marker location.
    * Useful for wrapper libraries that need to forward the end-user callsite.
    */
   stack?: string
+
+  /**
+   * Optional marker kind that's used to categorize the marker in the trace viewer.
+   * @default 'mark'
+   */
+  kind?: MarkKind
 }
 
 interface StandardScreenshotComparators {

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -42,7 +42,7 @@ export interface ScreenshotOptions extends SelectorOptions {
   save?: boolean
 }
 
-export type MarkKind = 'action' | 'expect' | 'mark' | 'lifecycle'
+export type BrowserTraceEntryKind = 'action' | 'expect' | 'mark' | 'lifecycle'
 
 export interface MarkOptions {
   /**
@@ -55,7 +55,7 @@ export interface MarkOptions {
    * Optional marker kind that's used to categorize the marker in the trace viewer.
    * @default 'mark'
    */
-  kind?: MarkKind
+  kind?: BrowserTraceEntryKind
 }
 
 interface StandardScreenshotComparators {

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -391,7 +391,7 @@ export const page: BrowserPage = {
             // TODO: support nested trace
             recordBrowserTraceEntry(currentTest, {
               name,
-              kind: 'mark',
+              kind: options?.kind ?? 'mark',
               status,
               startTime,
               duration: now() - startTime,
@@ -413,7 +413,7 @@ export const page: BrowserPage = {
       if (hasActiveTraceView) {
         recordBrowserTraceEntry(currentTest, {
           name,
-          kind: 'mark',
+          kind: bodyOrOptions?.kind ?? 'mark',
           stack: bodyOrOptions?.stack ?? error?.stack,
         })
       }

--- a/packages/browser/src/client/tester/locators.ts
+++ b/packages/browser/src/client/tester/locators.ts
@@ -222,7 +222,7 @@ export abstract class Locator {
       if (hasActiveTraceView) {
         recordBrowserTraceEntry(currentTest, {
           name,
-          kind: 'mark',
+          kind: options?.kind ?? 'mark',
           element: this.serialize(),
           stack: options?.stack ?? error?.stack,
         })

--- a/packages/browser/src/client/tester/trace.ts
+++ b/packages/browser/src/client/tester/trace.ts
@@ -1,4 +1,5 @@
 import type { Task } from '@vitest/runner'
+import type { BrowserTraceEntryKind } from 'vitest/browser'
 import type { SerializedLocator } from './locators'
 import { getBrowserState, now } from '../utils'
 
@@ -9,7 +10,6 @@ export interface BrowserTraceData {
   entries: BrowserTraceEntry[]
 }
 
-export type BrowserTraceEntryKind = 'action' | 'expect' | 'mark' | 'lifecycle'
 export type BrowserTraceEntryStatus = 'pass' | 'fail'
 export type BrowserTraceSelectorResolution = 'matched' | 'missing' | 'error'
 

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -122,10 +122,10 @@ function formatTraceTiming(step: BrowserTraceEntry) {
 }
 
 function formatStepName(step: BrowserTraceEntry) {
-  if (step.kind === 'lifecycle' && step.name === 'vitest:onAfterRetryTask') {
+  if (step.name === 'vitest:onAfterRetryTask') {
     return 'test finished'
   }
-  if (step.kind === 'action' && step.name.startsWith('vitest:')) {
+  if (step.name.startsWith('vitest:')) {
     return step.name.slice('vitest:'.length)
   }
   return step.name

--- a/test/browser/fixtures/trace/mark.test.ts
+++ b/test/browser/fixtures/trace/mark.test.ts
@@ -35,3 +35,12 @@ test('mark function', async () => {
     document.body.innerHTML = '<button>Hello</button>'
   })
 })
+
+test('kind', async () => {
+  document.body.innerHTML = '<button>Hello</button>'
+
+  await page.mark('action marker', { kind: 'action' })
+  await page.mark('expect marker', { kind: 'expect' })
+  await page.mark('lifecycle group', { kind: 'lifecycle' })
+  await page.mark('lifecycle group', { kind: 'mark' })
+})

--- a/test/browser/specs/trace.test.ts
+++ b/test/browser/specs/trace.test.ts
@@ -100,6 +100,7 @@ test('trace view artifacts', async () => {
         },
         "mark.test.ts": {
           "helper": "passed",
+          "kind": "passed",
           "locator.mark": "passed",
           "mark function": "passed",
           "page.mark": "passed",
@@ -370,6 +371,45 @@ test('trace view artifacts', async () => {
                   {
                     "kind": "lifecycle",
                     "location": "mark.test.ts:23",
+                    "name": "vitest:onAfterRetryTask",
+                    "snapshot": {},
+                    "status": "pass",
+                  },
+                ],
+              },
+            ],
+            "kind": [
+              {
+                "entries": [
+                  {
+                    "element": {
+                      "_pwSelector": "internal:role=button",
+                      "locator": "getByRole('button')",
+                      "selector": "html > body > button",
+                    },
+                    "kind": "action",
+                    "location": "mark.test.ts:41",
+                    "name": "action marker",
+                    "snapshot": {
+                      "selectorResolution": "matched",
+                    },
+                  },
+                  {
+                    "kind": "expect",
+                    "location": "mark.test.ts:42",
+                    "name": "expect marker",
+                    "snapshot": {},
+                  },
+                  {
+                    "kind": "lifecycle",
+                    "location": "mark.test.ts:43",
+                    "name": "lifecycle group",
+                    "snapshot": {},
+                    "status": "pass",
+                  },
+                  {
+                    "kind": "lifecycle",
+                    "location": "mark.test.ts:39",
                     "name": "vitest:onAfterRetryTask",
                     "snapshot": {},
                     "status": "pass",
@@ -1423,6 +1463,43 @@ test('trace view artifacts', async () => {
                   {
                     "kind": "lifecycle",
                     "location": "mark.test.ts:23",
+                    "name": "vitest:onAfterRetryTask",
+                    "snapshot": {},
+                    "status": "pass",
+                  },
+                ],
+              },
+            ],
+            "kind": [
+              {
+                "entries": [
+                  {
+                    "kind": "action",
+                    "location": "mark.test.ts:42",
+                    "name": "action marker",
+                    "snapshot": {},
+                  },
+                  {
+                    "kind": "expect",
+                    "location": "mark.test.ts:43",
+                    "name": "expect marker",
+                    "snapshot": {},
+                  },
+                  {
+                    "kind": "lifecycle",
+                    "location": "mark.test.ts:44",
+                    "name": "lifecycle group",
+                    "snapshot": {},
+                  },
+                  {
+                    "kind": "mark",
+                    "location": "mark.test.ts:45",
+                    "name": "lifecycle group",
+                    "snapshot": {},
+                  },
+                  {
+                    "kind": "lifecycle",
+                    "location": "mark.test.ts:39",
                     "name": "vitest:onAfterRetryTask",
                     "snapshot": {},
                     "status": "pass",

--- a/test/browser/specs/trace.test.ts
+++ b/test/browser/specs/trace.test.ts
@@ -382,30 +382,28 @@ test('trace view artifacts', async () => {
               {
                 "entries": [
                   {
-                    "element": {
-                      "_pwSelector": "internal:role=button",
-                      "locator": "getByRole('button')",
-                      "selector": "html > body > button",
-                    },
                     "kind": "action",
-                    "location": "mark.test.ts:41",
+                    "location": "mark.test.ts:42",
                     "name": "action marker",
-                    "snapshot": {
-                      "selectorResolution": "matched",
-                    },
+                    "snapshot": {},
                   },
                   {
                     "kind": "expect",
-                    "location": "mark.test.ts:42",
+                    "location": "mark.test.ts:43",
                     "name": "expect marker",
                     "snapshot": {},
                   },
                   {
                     "kind": "lifecycle",
-                    "location": "mark.test.ts:43",
+                    "location": "mark.test.ts:44",
                     "name": "lifecycle group",
                     "snapshot": {},
-                    "status": "pass",
+                  },
+                  {
+                    "kind": "mark",
+                    "location": "mark.test.ts:45",
+                    "name": "lifecycle group",
+                    "snapshot": {},
                   },
                   {
                     "kind": "lifecycle",


### PR DESCRIPTION
### Description

Allow users to defined custom `kind` for their markers. For example custom actions may want to show up as actions:

<img width="474" height="287" alt="image" src="https://github.com/user-attachments/assets/af24aca3-3815-4e2f-8115-808a35b50c1a" />


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
