### PR TITLE
fix: export UserConsoleLog type from vitest/node

### DIFF
--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -1,5 +1,5 @@
 import type { Reporter, TestRunEndReason } from '../types/reporter'
-import type { UserConsoleLog } from '../types/general'
+import type { UserConsoleLog } from '../../types/general'
 import type { BaseOptions, BaseReporter } from './base'
 import type { BlobOptions } from './blob'
 import type { DefaultReporterOptions } from './default'

--- a/packages/vitest/src/node/reporters/index.ts
+++ b/packages/vitest/src/node/reporters/index.ts
@@ -1,4 +1,5 @@
 import type { Reporter, TestRunEndReason } from '../types/reporter'
+import type { UserConsoleLog } from '../types/general'
 import type { BaseOptions, BaseReporter } from './base'
 import type { BlobOptions } from './blob'
 import type { DefaultReporterOptions } from './default'
@@ -33,7 +34,7 @@ export {
   TreeReporter,
   VerboseReporter,
 }
-export type { BaseReporter, Reporter, TestRunEndReason }
+export type { BaseReporter, Reporter, TestRunEndReason, UserConsoleLog }
 
 export type { BenchmarkBuiltinReporters } from './benchmark'
 export {

--- a/packages/vitest/src/public/node.ts
+++ b/packages/vitest/src/public/node.ts
@@ -70,6 +70,7 @@ export type {
   ReportedHookContext,
   Reporter,
   TestRunEndReason,
+  UserConsoleLog,
 } from '../node/reporters'
 export type { HTMLOptions } from '../node/reporters/html'
 export type { JsonOptions } from '../node/reporters/json'


### PR DESCRIPTION
## Summary

Fixes #10305

This PR exports the `UserConsoleLog` type from `vitest/node` so custom reporters can import it instead of redeclaring it locally.

## Problem

The `Reporter.onUserConsoleLog(log)` callback receives a `UserConsoleLog`, but the type isn't exported from `vitest/node`. Custom reporters written in TypeScript have to redeclare the interface locally:

```ts
interface UserConsoleLog {
  content: string;
  origin?: string;
  browser?: boolean;
  type: "stdout" | "stderr";
  taskId?: string;
  time: number;
  size: number;
}
```

This is brittle: if the upstream shape changes, the reporter silently diverges.

## Solution

Export `UserConsoleLog` from `vitest/node` alongside other reporter types like `Reporter`, `BaseReporter`, and `TestRunEndReason`.

**After this PR:**
```ts
import type { UserConsoleLog } from 'vitest/node'
```

## Changes

- `packages/vitest/src/node/reporters/index.ts`
  - Import `UserConsoleLog` from `../types/general`
  - Add `UserConsoleLog` to type exports
- `packages/vitest/src/public/node.ts`
  - Add `UserConsoleLog` to the re-exported types from `../node/reporters`

## Testing

The type is already defined in `packages/vitest/src/types/general.ts` and used internally. This PR only adds the export path.

<!-- VITEST_AUTOMATED_PR -->