### PR TITLE
fix(browser): throw on duplicate vitest installation in projects mode

### DIFF
--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -96,6 +96,18 @@ Since Vitest defaults to the `node` environment (which uses `viteEnvironment: 's
 You can learn more about Vite environments and Vitest environments in [`environment`](/config/environment).
 :::
 
+## Duplicate Vitest Installation
+
+When running browser-mode tests via [`projects`](/guide/projects) in a monorepo, Vitest may detect that `vitest` or `@vitest/browser` resolves to two different physical copies (one used by the root runner, another used by a sub-package). Two copies cannot share the in-memory state needed to drive the browser, which previously caused the test run to hang silently. Vitest now throws a clear error instead, naming both paths and the affected project.
+
+The most common cause is a peer dependency (typically `@types/node` or `vite`) resolving to different versions across packages. Even when `vitest` is pinned to the exact same version everywhere, pnpm will create two `.pnpm/` snapshots with different peer-dep hashes, and Node loads each as a distinct module.
+
+### Fix
+
+1. Run `pnpm why vitest` (or `npm ls vitest`) and look for the diverging peer dep.
+2. **Recommended**: declare `vitest` and `@vitest/browser*` only in the root `package.json`. Sub-packages should keep their own `vitest.config.ts` but inherit the hoisted Vitest install.
+3. If a sub-package must declare `vitest` directly, pin the diverging peer dep in the root `pnpm.overrides` / `resolutions` and run `pnpm dedupe` so a single copy is shared.
+
 ## Segfaults and Native Code Errors
 
 Running [native NodeJS modules](https://nodejs.org/api/addons.html) in `pool: 'threads'` can run into cryptic errors coming from the native code.

--- a/packages/browser/src/node/duplicateInstallation.ts
+++ b/packages/browser/src/node/duplicateInstallation.ts
@@ -1,0 +1,77 @@
+import { realpathSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'pathe'
+import c from 'tinyrainbow'
+
+export interface DuplicateInstallationMismatch {
+  name: string
+  running: string
+  project: string
+}
+
+const TRACKED_PACKAGES = ['@vitest/browser', 'vitest'] as const
+
+export function resolvePackageDir(name: string, fromDir: string): string | undefined {
+  try {
+    const require = createRequire(join(fromDir, '_'))
+    const pkgDir = dirname(require.resolve(`${name}/package.json`))
+    try {
+      return realpathSync.native(pkgDir)
+    }
+    catch {
+      return pkgDir
+    }
+  }
+  catch {
+    return undefined
+  }
+}
+
+export function findDuplicateInstallations(
+  runningFrom: string,
+  projectRoot: string,
+): DuplicateInstallationMismatch[] {
+  const mismatches: DuplicateInstallationMismatch[] = []
+  for (const name of TRACKED_PACKAGES) {
+    const running = resolvePackageDir(name, runningFrom)
+    const project = resolvePackageDir(name, projectRoot)
+    if (running && project && running !== project) {
+      mismatches.push({ name, running, project })
+    }
+  }
+  return mismatches
+}
+
+export function formatDuplicateInstallationError(
+  mismatches: DuplicateInstallationMismatch[],
+  projectIdentifier: string,
+): string {
+  const lines = mismatches.map(m =>
+    `  - ${c.bold(m.name)}\n    running:  ${m.running}\n    project:  ${m.project}`,
+  ).join('\n')
+
+  return (
+    `[vitest] Detected duplicate installations of Vitest packages for project "${projectIdentifier}".\n`
+    + `This is unsupported in browser mode with \`projects\` and will cause tests to hang.\n\n`
+    + `${lines}\n\n`
+    + `To fix this:\n`
+    + `  1. Run \`pnpm why vitest\` (or \`npm ls vitest\`) to find why a package is duplicated.\n`
+    + `     A common cause is a peer dependency (e.g. \`@types/node\`, \`vite\`) resolving\n`
+    + `     to different versions across packages.\n`
+    + `  2. Recommended: declare \`vitest\` and \`@vitest/browser*\` only in the root\n`
+    + `     package.json, not in each sub-package, so they are hoisted as a single copy.\n`
+    + `  3. Otherwise, force a single version with \`pnpm.overrides\` / \`resolutions\`\n`
+    + `     for the diverging peer dependency, then run \`pnpm dedupe\`.\n\n`
+    + `See https://vitest.dev/guide/common-errors.html#duplicate-vitest-installation`
+  )
+}
+
+export function assertSingleInstallation(projectRoot: string, projectName: string): void {
+  const runningFrom = dirname(fileURLToPath(import.meta.url))
+  const mismatches = findDuplicateInstallations(runningFrom, projectRoot)
+  if (!mismatches.length) {
+    return
+  }
+  throw new Error(formatDuplicateInstallationError(mismatches, projectName || projectRoot))
+}

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -5,6 +5,7 @@ import c from 'tinyrainbow'
 import { createViteLogger, createViteServer } from 'vitest/node'
 import { version } from '../../package.json'
 import { distRoot } from './constants'
+import { assertSingleInstallation } from './duplicateInstallation'
 import BrowserPlugin from './plugin'
 import { ParentBrowserProject } from './projectParent'
 import { setupBrowserRpc } from './rpc'
@@ -38,6 +39,8 @@ export const createBrowserServer: BrowserServerFactory = async (options) => {
       ),
     )
   }
+
+  assertSingleInstallation(project.config.root, project.name)
 
   const server = new ParentBrowserProject(project, '/')
 

--- a/test/unit/test/browserDuplicateInstallation.test.ts
+++ b/test/unit/test/browserDuplicateInstallation.test.ts
@@ -1,0 +1,120 @@
+import type { Stats } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  findDuplicateInstallations,
+  formatDuplicateInstallationError,
+  resolvePackageDir,
+} from '../../../packages/browser/src/node/duplicateInstallation'
+
+let tmp: string
+
+function makeFakePackage(root: string, name: string, version = '1.0.0'): string {
+  const dir = join(root, 'node_modules', name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name, version, exports: { './package.json': './package.json' } }),
+  )
+  return dir
+}
+
+function symlinkPackage(root: string, name: string, target: string): void {
+  const dir = join(root, 'node_modules')
+  mkdirSync(dir, { recursive: true })
+  symlinkSync(target, join(dir, name), 'junction')
+}
+
+function isCaseInsensitive(): boolean {
+  let stats: Stats | undefined
+  try {
+    stats = statSync(__dirname.toUpperCase())
+  }
+  catch {
+    return false
+  }
+  return stats != null
+}
+
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'vitest-dup-detect-'))
+})
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('findDuplicateInstallations', () => {
+  it('returns no mismatches when both roots resolve a tracked package to the same physical copy via symlinks', () => {
+    const physical = join(tmp, 'sym-same/physical')
+    const realPkg = makeFakePackage(physical, 'vitest')
+    const a = join(tmp, 'sym-same/a')
+    const b = join(tmp, 'sym-same/b')
+    mkdirSync(a, { recursive: true })
+    mkdirSync(b, { recursive: true })
+    symlinkPackage(a, 'vitest', realPkg)
+    symlinkPackage(b, 'vitest', realPkg)
+
+    expect(findDuplicateInstallations(a, b)).toEqual([])
+  })
+
+  it('flags a tracked package when the two roots resolve it to physically distinct copies', () => {
+    const a = join(tmp, 'distinct/a')
+    const b = join(tmp, 'distinct/b')
+    makeFakePackage(a, 'vitest')
+    makeFakePackage(b, 'vitest')
+
+    const mismatches = findDuplicateInstallations(a, b)
+    expect(mismatches).toHaveLength(1)
+    expect(mismatches[0].name).toBe('vitest')
+    expect(mismatches[0].running).not.toBe(mismatches[0].project)
+  })
+
+  it('canonicalizes path casing on case-insensitive filesystems', () => {
+    if (!isCaseInsensitive()) {
+      return
+    }
+    const root = join(tmp, 'casing/root')
+    makeFakePackage(root, 'vitest')
+
+    const upper = resolve(root).replace(/^([a-z]):/i, (_, letter) => `${letter.toUpperCase()}:`)
+    const lower = resolve(root).replace(/^([a-z]):/i, (_, letter) => `${letter.toLowerCase()}:`)
+    expect(findDuplicateInstallations(upper, lower)).toEqual([])
+  })
+
+  it('flags @vitest/browser independently from vitest', () => {
+    const a = join(tmp, 'browser/a')
+    const b = join(tmp, 'browser/b')
+    makeFakePackage(a, '@vitest/browser')
+    makeFakePackage(b, '@vitest/browser')
+
+    const mismatches = findDuplicateInstallations(a, b)
+    expect(mismatches.map(m => m.name)).toEqual(['@vitest/browser'])
+  })
+})
+
+describe('resolvePackageDir', () => {
+  it('returns undefined when the package is not installed under fromDir', () => {
+    expect(resolvePackageDir('definitely-not-a-real-package-xyz', tmp)).toBeUndefined()
+  })
+})
+
+describe('formatDuplicateInstallationError', () => {
+  it('mentions the project identifier and every mismatch', () => {
+    const message = formatDuplicateInstallationError(
+      [
+        { name: 'vitest', running: '/run/vitest', project: '/proj/vitest' },
+        { name: '@vitest/browser', running: '/run/browser', project: '/proj/browser' },
+      ],
+      'my-project',
+    )
+    expect(message).toContain('"my-project"')
+    expect(message).toContain('/run/vitest')
+    expect(message).toContain('/proj/vitest')
+    expect(message).toContain('/run/browser')
+    expect(message).toContain('/proj/browser')
+    expect(message).toContain('common-errors.html#duplicate-vitest-installation')
+  })
+})


### PR DESCRIPTION
### Description

- Refs #9164
- Refs #10261
- Supersedes #10262

In a monorepo using `projects` with browser mode, two physically distinct copies of `vitest` / `@vitest/browser` make the run hang silently. This PR detects the condition at startup and throws an actionable error.

### Reproduction (deterministic, pnpm 10.32, Node 24+)

```bash
git clone https://github.com/Andrei486/vitest-project-repro
cd vitest-project-repro
sed -i 's|"vitest": "latest"|"vitest": "5.0.0-beta.1"|; s|"@vitest/browser-playwright": "latest"|"@vitest/browser-playwright": "5.0.0-beta.1"|' package.json packages/*/package.json
pnpm install:all
```

Two distinct `.pnpm/` snapshots materialise:

```
node_modules/.pnpm/vitest@5.0.0-beta.1_@vitest_<hash>/                ← root (carries @vitest/browser-playwright peer)
packages/browser/node_modules/.pnpm/vitest@5.0.0-beta.1_vite@7.2.6/   ← sub-project
packages/normal/node_modules/.pnpm/vitest@5.0.0-beta.1_vite@7.2.6/    ← sub-project
```

Same version, different peer-dep hashes (`@vitest/browser-playwright` is declared at root only). Without this PR, `pnpm test` hangs at `Browser connection was closed` with the cryptic stack from #10261.

### Detection

`packages/browser/src/node/duplicateInstallation.ts` exposes:

- `resolvePackageDir(name, fromDir)` — resolves a package's dir via `createRequire` and canonicalises with `realpathSync.native` so symlinked workspaces (pnpm/Yarn) and Windows path-casing do not produce false positives.
- `findDuplicateInstallations(runningFrom, projectRoot)` — pure helper returning the list of mismatched packages.
- `formatDuplicateInstallationError(...)` — pure formatter.
- `assertSingleInstallation(projectRoot, projectName)` — thin wrapper over the above, called at the top of `createBrowserServer` after the existing version-mismatch warning.

### Validation

- `test/unit/test/browserDuplicateInstallation.test.ts` — 6 unit tests with real `fs.symlinkSync` fixtures covering: same physical copy via symlinks, distinct copies, Windows casing, scoped vs unscoped packages, and the error formatter.
- End-to-end on the repro above: `findDuplicateInstallations` correctly identifies both diverging snapshots from `packages/browser` and `packages/normal`; `assertSingleInstallation` throws with the documented message instead of letting the run hang.

### Documentation

`docs/guide/common-errors.md` adds a `Duplicate Vitest Installation` section. The thrown error links to it.