### PR TITLE
fix(browser): keep waitForConnection in sync across socket reconnects

### DIFF
--- a/packages/browser/src/client/client.ts
+++ b/packages/browser/src/client/client.ts
@@ -5,6 +5,7 @@ import type { WebSocketBrowserEvents, WebSocketBrowserHandlers } from '../types'
 import type { IframeOrchestrator } from './orchestrator'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
+import { createWebSocketConnection } from './connection'
 import { getBrowserState } from './utils'
 
 const PAGE_TYPE = getBrowserState().type
@@ -59,19 +60,15 @@ function waitForOrchestrator() {
 }
 
 function createClient() {
-  const autoReconnect = true
-  const reconnectInterval = 2000
-  const reconnectTries = 10
-  const connectTimeout = 60000
+  const connection = createWebSocketConnection({ url: ENTRY_URL })
 
-  let tries = reconnectTries
-
-  const ctx: VitestBrowserClient = {
-    ws: new WebSocket(ENTRY_URL),
-    waitForConnection,
+  const ctx = {
+    waitForConnection: connection.waitForConnection,
   } as VitestBrowserClient
-
-  let onMessage: Function
+  Object.defineProperty(ctx, 'ws', {
+    get: () => connection.socket,
+    enumerable: true,
+  })
 
   ctx.rpc = createBirpc<WebSocketBrowserHandlers, WebSocketBrowserEvents>(
     {
@@ -110,8 +107,8 @@ function createClient() {
       },
     },
     {
-      post: msg => ctx.ws.send(msg),
-      on: fn => (onMessage = fn),
+      post: msg => connection.send(msg),
+      on: fn => connection.onMessage(fn as (data: unknown) => void),
       serialize: e =>
         stringify(e, (_, v) => {
           if (v instanceof Error) {
@@ -127,52 +124,6 @@ function createClient() {
       timeout: -1, // createTesters can take a while
     },
   )
-
-  let openPromise: Promise<void>
-
-  function reconnect(reset = false) {
-    if (reset) {
-      tries = reconnectTries
-    }
-    ctx.ws = new WebSocket(ENTRY_URL)
-    registerWS()
-  }
-
-  function registerWS() {
-    openPromise = new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(
-          new Error(
-            `Cannot connect to the server in ${connectTimeout / 1000} seconds`,
-          ),
-        )
-      }, connectTimeout)
-      if (ctx.ws.OPEN === ctx.ws.readyState) {
-        resolve()
-      }
-      // still have a listener even if it's already open to update tries
-      ctx.ws.addEventListener('open', () => {
-        tries = reconnectTries
-        resolve()
-        clearTimeout(timeout)
-      })
-    })
-    ctx.ws.addEventListener('message', (v) => {
-      onMessage(v.data)
-    })
-    ctx.ws.addEventListener('close', () => {
-      tries -= 1
-      if (autoReconnect && tries > 0) {
-        setTimeout(reconnect, reconnectInterval)
-      }
-    })
-  }
-
-  registerWS()
-
-  function waitForConnection() {
-    return openPromise
-  }
 
   return ctx
 }

--- a/packages/browser/src/client/connection.ts
+++ b/packages/browser/src/client/connection.ts
@@ -1,0 +1,125 @@
+export interface WebSocketConnectionOptions {
+  url: string
+  WebSocketCtor?: typeof WebSocket
+  autoReconnect?: boolean
+  reconnectInterval?: number
+  reconnectTries?: number
+  connectTimeout?: number
+}
+
+export interface WebSocketConnection {
+  readonly socket: WebSocket
+  send: (data: string) => void
+  waitForConnection: () => Promise<void>
+  onMessage: (handler: (data: unknown) => void) => void
+}
+
+export function createWebSocketConnection(options: WebSocketConnectionOptions): WebSocketConnection {
+  const {
+    url,
+    WebSocketCtor = WebSocket,
+    autoReconnect = true,
+    reconnectInterval = 2000,
+    reconnectTries = 10,
+    connectTimeout = 60000,
+  } = options
+
+  let triesLeft = reconnectTries
+  let socket = new WebSocketCtor(url)
+  let messageHandler: ((data: unknown) => void) | undefined
+
+  let resolveOpen!: () => void
+  let rejectOpen!: (error: Error) => void
+  let openSettled = false
+  let openPromise: Promise<void> = createOpenPromise()
+  let connectTimeoutId: ReturnType<typeof setTimeout> | undefined
+  let attemptAbort: AbortController | undefined
+
+  function createOpenPromise() {
+    openSettled = false
+    return new Promise<void>((resolve, reject) => {
+      resolveOpen = () => {
+        openSettled = true
+        resolve()
+      }
+      rejectOpen = (error) => {
+        openSettled = true
+        reject(error)
+      }
+    })
+  }
+
+  function clearConnectTimeout() {
+    if (connectTimeoutId !== undefined) {
+      clearTimeout(connectTimeoutId)
+      connectTimeoutId = undefined
+    }
+  }
+
+  function reconnect(reset = false) {
+    if (reset) {
+      triesLeft = reconnectTries
+    }
+    if (openSettled) {
+      openPromise = createOpenPromise()
+    }
+    socket = new WebSocketCtor(url)
+    registerSocket()
+  }
+
+  function registerSocket() {
+    attemptAbort?.abort()
+    const controller = new AbortController()
+    attemptAbort = controller
+    const { signal } = controller
+
+    clearConnectTimeout()
+    connectTimeoutId = setTimeout(() => {
+      if (signal.aborted) {
+        return
+      }
+      rejectOpen(
+        new Error(
+          `Cannot connect to the server in ${connectTimeout / 1000} seconds`,
+        ),
+      )
+    }, connectTimeout)
+
+    function onOpen() {
+      triesLeft = reconnectTries
+      clearConnectTimeout()
+      resolveOpen()
+    }
+
+    if (socket.readyState === socket.OPEN) {
+      onOpen()
+    }
+    socket.addEventListener('open', onOpen, { signal })
+    socket.addEventListener('message', (event) => {
+      messageHandler?.((event as MessageEvent).data)
+    }, { signal })
+    socket.addEventListener('close', () => {
+      triesLeft -= 1
+      clearConnectTimeout()
+      if (autoReconnect && triesLeft > 0) {
+        setTimeout(reconnect, reconnectInterval)
+      }
+      else if (!openSettled) {
+        rejectOpen(new Error('WebSocket connection closed before opening'))
+      }
+    }, { signal })
+  }
+
+  registerSocket()
+
+  return {
+    get socket() {
+      return socket
+    },
+    send: data => socket.send(data),
+    waitForConnection: () => openPromise,
+    onMessage: (handler) => {
+      messageHandler = handler
+    },
+  }
+}

--- a/test/unit/test/browserConnection.test.ts
+++ b/test/unit/test/browserConnection.test.ts
@@ -1,0 +1,141 @@
+import type { WebSocketConnection } from '../../../packages/browser/src/client/connection'
+import { afterEach, expect, it, vi } from 'vitest'
+import { createWebSocketConnection } from '../../../packages/browser/src/client/connection'
+
+class FakeWebSocket extends EventTarget {
+  static instances: FakeWebSocket[] = []
+  static reset(): void {
+    FakeWebSocket.instances = []
+  }
+
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  readonly CONNECTING = FakeWebSocket.CONNECTING
+  readonly OPEN = FakeWebSocket.OPEN
+  readonly CLOSING = FakeWebSocket.CLOSING
+  readonly CLOSED = FakeWebSocket.CLOSED
+
+  readonly url: string
+  readyState: number = FakeWebSocket.CONNECTING
+  sent: string[] = []
+
+  constructor(url: string) {
+    super()
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.dispatchClose()
+  }
+
+  dispatchOpen(): void {
+    this.readyState = FakeWebSocket.OPEN
+    this.dispatchEvent(new Event('open'))
+  }
+
+  dispatchClose(): void {
+    this.readyState = FakeWebSocket.CLOSED
+    this.dispatchEvent(new Event('close'))
+  }
+
+  dispatchMessage(data: unknown): void {
+    this.dispatchEvent(new MessageEvent('message', { data }))
+  }
+}
+
+afterEach(() => {
+  FakeWebSocket.reset()
+  vi.useRealTimers()
+})
+
+function newConnection(overrides?: { reconnectTries?: number }): WebSocketConnection {
+  return createWebSocketConnection({
+    url: 'ws://test.invalid/',
+    WebSocketCtor: FakeWebSocket as unknown as typeof WebSocket,
+    reconnectInterval: 10,
+    reconnectTries: overrides?.reconnectTries ?? 3,
+    connectTimeout: 60_000,
+  })
+}
+
+it('waitForConnection survives a drop-before-open and resolves on a later attempt', async () => {
+  vi.useFakeTimers()
+  const connection = newConnection()
+  const waiter = connection.waitForConnection()
+
+  expect(FakeWebSocket.instances).toHaveLength(1)
+  FakeWebSocket.instances[0].dispatchClose()
+
+  vi.advanceTimersByTime(20)
+  expect(FakeWebSocket.instances).toHaveLength(2)
+
+  FakeWebSocket.instances[1].dispatchOpen()
+  await expect(waiter).resolves.toBeUndefined()
+})
+
+it('ignores stale events from a replaced socket', async () => {
+  vi.useFakeTimers()
+  const connection = newConnection()
+  const waiter = connection.waitForConnection()
+
+  FakeWebSocket.instances[0].dispatchClose()
+  vi.advanceTimersByTime(20)
+  FakeWebSocket.instances[1].dispatchOpen()
+  await waiter
+
+  const messages: unknown[] = []
+  connection.onMessage(data => messages.push(data))
+
+  FakeWebSocket.instances[0].dispatchMessage('stale')
+  FakeWebSocket.instances[0].dispatchClose()
+  FakeWebSocket.instances[1].dispatchMessage('live')
+
+  expect(messages).toEqual(['live'])
+  expect(FakeWebSocket.instances).toHaveLength(2)
+})
+
+it('rejects with a clear error when retries are exhausted before any open', async () => {
+  vi.useFakeTimers()
+  const connection = newConnection({ reconnectTries: 2 })
+  const waiter = connection.waitForConnection()
+
+  FakeWebSocket.instances[0].dispatchClose()
+  vi.advanceTimersByTime(20)
+  FakeWebSocket.instances[1].dispatchClose()
+
+  await expect(waiter).rejects.toThrow('WebSocket connection closed before opening')
+})
+
+it('returns the same promise across reconnects until it settles', () => {
+  vi.useFakeTimers()
+  const connection = newConnection()
+  const first = connection.waitForConnection()
+
+  FakeWebSocket.instances[0].dispatchClose()
+  vi.advanceTimersByTime(20)
+  const second = connection.waitForConnection()
+
+  expect(second).toBe(first)
+})
+
+it('hands out a fresh promise after a successful connection has been awaited', async () => {
+  vi.useFakeTimers()
+  const connection = newConnection()
+  const first = connection.waitForConnection()
+  FakeWebSocket.instances[0].dispatchOpen()
+  await first
+
+  FakeWebSocket.instances[0].dispatchClose()
+  vi.advanceTimersByTime(20)
+  const next = connection.waitForConnection()
+
+  expect(next).not.toBe(first)
+})


### PR DESCRIPTION
### Description

- Closes #10166
- Supersedes #10251 (auto-closed)

In browser mode, the tester could hang forever if the first WebSocket attempt stayed in `CONNECTING` long enough for callers to start awaiting `waitForConnection()`, dropped before `open`, and Vitest reconnected. Existing waiters stayed attached to the old (unresolved) per-attempt `openPromise`, while reconnect created a brand new one — so the tester iframe never processed `prepare`/`execute`.

### Changes

- `packages/browser/src/client/connection.ts` (new): `createWebSocketConnection` factory encapsulating the WebSocket state machine. A single persistent `openPromise` is kept across reconnects through shared `resolveOpen` / `rejectOpen` handles, and per-attempt listeners are scoped to an `AbortController` so stale `open`/`close`/`message` events from a replaced socket cannot settle the current promise or mutate the retry counter. The factory accepts an injectable `WebSocketCtor` so the state machine is unit-testable in isolation.
- `packages/browser/src/client/client.ts`: now delegates the connection lifecycle to `createWebSocketConnection`, exposing `ctx.ws` via a getter that always reflects the current socket.
- `test/unit/test/browserConnection.test.ts` (new): 5 unit tests covering drop-before-open + late open, stale events from a replaced socket, retries exhausted before any open, persistent vs fresh promise semantics across reconnects.

### Why a separate factory

The previous version of this fix kept the state machine inline in `client.ts`, which meant the only way to validate the reconnect race was to dogfood against the user's reproduction. Extracting the state machine isolates the contract that was changed, makes the lifecycle invariants visible at the type level, and removes the WebSocket global from the unit-test surface.

### Tests
- [x] `pnpm typecheck && pnpm lint` clean.
- [x] `cd test/unit && CI=true pnpm test browserConnection` — 15/15 pass across `threads`, `vmThreads`, `forks`.
- [x] Dogfooded against [`vitest-waitforconnection-repro`](https://github.com/jkieboom/vitest-waitforconnection-repro): with the previous version of this fix the harness's `success` flag flipped from `true` (bug reproduces) to `false`. The current refactor preserves that fix while addressing the stale-listener concerns surfaced in internal review.

### Documentation
No public API change.