### PR TITLE
chore(browser): diagnostic logging for playwright trace flake (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,16 @@ jobs:
 
       - name: Test Browser (playwright)
         run: pnpm run test:browser:playwright
+        env:
+          VITEST_TRACE_DBG_FILE: ${{ runner.temp }}/trace-dbg.log
+
+      - name: Upload trace-dbg log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: trace-dbg-${{ matrix.os }}-node-${{ matrix.node_version }}
+          path: ${{ runner.temp }}/trace-dbg.log
+          if-no-files-found: ignore
 
       - name: Test Browser (webdriverio)
         run: pnpm run test:browser:webdriverio

--- a/packages/browser-playwright/src/commands/dbg.ts
+++ b/packages/browser-playwright/src/commands/dbg.ts
@@ -1,0 +1,6 @@
+import type { BrowserCommand } from 'vitest/node'
+import { traceDbg } from '../dbg'
+
+export const logTraceDbg: BrowserCommand<[{ msg: string }]> = (_ctx, { msg }) => {
+  traceDbg(msg)
+}

--- a/packages/browser-playwright/src/commands/index.ts
+++ b/packages/browser-playwright/src/commands/index.ts
@@ -1,5 +1,6 @@
 import { clear } from './clear'
 import { click, dblClick, tripleClick } from './click'
+import { logTraceDbg } from './dbg'
 import { dragAndDrop } from './dragAndDrop'
 import { fill } from './fill'
 import { hover } from './hover'
@@ -47,4 +48,5 @@ export default {
   __vitest_groupTraceStart: groupTraceStart as typeof groupTraceStart,
   __vitest_groupTraceEnd: groupTraceEnd as typeof groupTraceEnd,
   __vitest_viewport: viewport as typeof viewport,
+  __vitest_logTraceDbg: logTraceDbg as typeof logTraceDbg,
 }

--- a/packages/browser-playwright/src/commands/trace.ts
+++ b/packages/browser-playwright/src/commands/trace.ts
@@ -4,6 +4,7 @@ import type { BrowserCommand, BrowserCommandContext, BrowserProvider } from 'vit
 import type { PlaywrightBrowserProvider } from '../playwright'
 import { unlink } from 'node:fs/promises'
 import { basename, dirname, relative, resolve } from 'pathe'
+import { traceDbg } from '../dbg'
 import { getDescribedLocator } from './utils'
 
 export const startTracing: BrowserCommand<[]> = async ({ context, project, provider, sessionId }) => {
@@ -40,6 +41,7 @@ export const startChunkTrace: BrowserCommand<[{ name: string; title: string }]> 
     }
     const path = resolveTracesPath(command, name)
     provider.pendingTraces.set(path, sessionId)
+    traceDbg(`PROVIDER start name=${name} path=${path} session=${sessionId} pendingSize=${provider.pendingTraces.size}`)
     await context.tracing.startChunk({ name, title })
     return
   }
@@ -53,6 +55,7 @@ export const stopChunkTrace: BrowserCommand<[{ name: string }]> = async (
   if (isPlaywrightProvider(context.provider)) {
     const path = resolveTracesPath(context, name)
     context.provider.pendingTraces.delete(path)
+    traceDbg(`PROVIDER stop  name=${name} path=${path} session=${context.sessionId} pendingSize=${context.provider.pendingTraces.size}`)
     await context.context.tracing.stopChunk({ path })
     return { tracePath: path }
   }

--- a/packages/browser-playwright/src/dbg.ts
+++ b/packages/browser-playwright/src/dbg.ts
@@ -1,0 +1,12 @@
+import { appendFileSync } from 'node:fs'
+
+export function traceDbg(message: string): void {
+  const file = process.env.VITEST_TRACE_DBG_FILE
+  if (!file) {
+    return
+  }
+  try {
+    appendFileSync(file, `${Date.now()} ${message}\n`)
+  }
+  catch {}
+}

--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -35,6 +35,7 @@ import c from 'tinyrainbow'
 import { createDebugger, isCSSRequest } from 'vitest/node'
 import commands from './commands'
 import { distRoot } from './constants'
+import { traceDbg } from './dbg'
 
 const debug = createDebugger('vitest:browser:playwright')
 
@@ -140,6 +141,7 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
   }
 
   private onSIGTERM = () => {
+    traceDbg(`SIGTERM browser=${this.browserName} hasBrowser=${!!this.browser} pendingTraces=${this.pendingTraces.size} contexts=${this.contexts.size} pages=${this.pages.size}`)
     if (!this.browser) {
       return
     }
@@ -555,6 +557,8 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
   async close(): Promise<void> {
     process.off('SIGTERM', this.onSIGTERM)
 
+    const closeStart = Date.now()
+    traceDbg(`CLOSE start browser=${this.browserName} contexts=${this.contexts.size} pages=${this.pages.size} pendingTraces=${this.pendingTraces.size}`)
     debug?.('[%s] closing provider', this.browserName)
     this.closing = true
     if (this.browserPromise) {
@@ -573,6 +577,7 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     }
     this.contexts.clear()
     await browser?.close()
+    traceDbg(`CLOSE done  browser=${this.browserName} elapsed=${Date.now() - closeStart}ms`)
     debug?.('[%s] provider is closed', this.browserName)
   }
 }

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -85,6 +85,9 @@ export function createBrowserRunner(
         && !(trace === 'on-all-retries' && retry === 0)
         && !(trace === 'on-first-retry' && retry !== 1)
       const shouldTraceView = this.config.browser.traceView.enabled
+      void this.commands.triggerCommand('__vitest_logTraceDbg', [{
+        msg: `BEFORE id=${test.id} name=${getTestName(test)} retry=${retry} repeats=${repeats} mode=${trace} shouldTrace=${shouldTrace} activeIds.size=${getBrowserState().activeTraceTaskIds.size} prevState=${test.result?.state ?? 'n/a'}`,
+      }]).catch(() => {})
       if (!shouldTraceView && !shouldTrace) {
         getBrowserState().activeTraceTaskIds.delete(test.id)
         getBrowserState().browserTraceAttempts.delete(test.id)
@@ -140,6 +143,9 @@ export function createBrowserRunner(
         getBrowserState().browserTraceAttempts.delete(test.id)
       }
       const hasActiveTrace = getBrowserState().activeTraceTaskIds.has(test.id)
+      void this.commands.triggerCommand('__vitest_logTraceDbg', [{
+        msg: `AFTER  id=${test.id} retry=${retry} repeats=${repeats} hasActive=${hasActiveTrace} state=${test.result?.state ?? 'n/a'} err=${test.result?.errors?.[0]?.message ?? ''}`,
+      }]).catch(() => {})
       if (!hasActiveTrace) {
         return
       }
@@ -152,6 +158,9 @@ export function createBrowserRunner(
         this.traces.set(test.id, [])
       }
       const traces = this.traces.get(test.id)!
+      void this.commands.triggerCommand('__vitest_logTraceDbg', [{
+        msg: `STOP   id=${test.id} name=${name} retry=${retry} repeats=${repeats}`,
+      }]).catch(() => {})
       const { tracePath } = await this.commands.triggerCommand(
         '__vitest_stopChunkTrace',
         [{ name }],


### PR DESCRIPTION
## Purpose

This is a **draft** to gather diagnostic data on intermittent failures observed in the browser-mode CI matrix. Not intended for merge.

## What we're after

- Extra `webkit-repeated-retried-tests-0-2.trace.zip` under `on-first-retry` mode (gate should evaluate `false` for `retry === 2`, but the file appears anyway).
- 360 s timeouts on `playwright-trace.test.ts`, `runner.test.ts > stack trace points to correct file ...`, `benchmark.test.ts` ending with `[vitest-pool]: Timeout terminating threads worker ...`. The shape suggests a browser session that does not release on teardown.

The flakes do not reproduce locally on Windows nor in a Docker Linux container with CPU pressure, which is consistent with environment-specific timing.

## Approach

Earlier revisions of this draft instrumented the same surfaces with `console.log` and `console.error`, both of which got captured into stdout / stderr snapshots of unrelated e2e tests (`merge-reports.test.ts`, `list.test.ts`, `runner.test.ts > timeout hooks`) and broke them. This revision routes everything to a file via a no-op-by-default helper, so the diagnostic can never pollute another test.

`packages/browser-playwright/src/dbg.ts` (new):
```ts
export function traceDbg(msg: string): void {
  const f = process.env.VITEST_TRACE_DBG_FILE
  if (!f) return
  appendFileSync(f, `${Date.now()} ${msg}\n`)
}
```

`packages/browser-playwright/src/commands/dbg.ts` (new): registers `__vitest_logTraceDbg`, so the in-browser runner can ship entries to the parent process through the existing RPC channel without ever touching browser-side `console`.

The runner emits `BEFORE`, `AFTER`, `STOP` entries around `onBeforeTryTask`/`onAfterRetryTask`, wrapped in `.catch(() => {})` so the diagnostic cannot fail a test. The provider emits `PROVIDER start/stop`, `SIGTERM`, `CLOSE start/done` from `commands/trace.ts` and `playwright.ts`. Each entry is timestamped.

`.github/workflows/ci.yml` sets `VITEST_TRACE_DBG_FILE: ${{ runner.temp }}/trace-dbg.log` for the `test-browser` job and uploads the file as `trace-dbg-{os}-node-{ver}` artifact (with `if-no-files-found: ignore` so unrelated paths do not break).

## Plan

1. Run CI on this branch.
2. Download the `trace-dbg-*` artifact for the failing job.
3. Walk the timeline around `webkit-repeated-retried-tests-0-2` (or around the first hang for the 360 s timeout) to identify the offending state transition.
4. Open a separate, properly scoped fix PR.
5. Close this draft.