### PR TITLE
fix(test): clean trace fixtures + diagnostic logging for trace flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,16 @@ jobs:
 
       - name: Test Browser (playwright)
         run: pnpm run test:browser:playwright
+        env:
+          VITEST_TRACE_DBG_FILE: ${{ runner.temp }}/trace-dbg.log
+
+      - name: Upload trace-dbg log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: trace-dbg-${{ matrix.os }}-node-${{ matrix.node_version }}
+          path: ${{ runner.temp }}/trace-dbg.log
+          if-no-files-found: ignore
 
       - name: Test Browser (webdriverio)
         run: pnpm run test:browser:webdriverio

--- a/packages/browser-playwright/src/commands/dbg.ts
+++ b/packages/browser-playwright/src/commands/dbg.ts
@@ -1,0 +1,6 @@
+import type { BrowserCommand } from 'vitest/node'
+import { traceDbg } from '../dbg'
+
+export const logTraceDbg: BrowserCommand<[{ msg: string }]> = (_ctx, { msg }) => {
+  traceDbg(msg)
+}

--- a/packages/browser-playwright/src/commands/index.ts
+++ b/packages/browser-playwright/src/commands/index.ts
@@ -1,5 +1,6 @@
 import { clear } from './clear'
 import { click, dblClick, tripleClick } from './click'
+import { logTraceDbg } from './dbg'
 import { dragAndDrop } from './dragAndDrop'
 import { fill } from './fill'
 import { hover } from './hover'
@@ -47,4 +48,5 @@ export default {
   __vitest_groupTraceStart: groupTraceStart as typeof groupTraceStart,
   __vitest_groupTraceEnd: groupTraceEnd as typeof groupTraceEnd,
   __vitest_viewport: viewport as typeof viewport,
+  __vitest_logTraceDbg: logTraceDbg as typeof logTraceDbg,
 }

--- a/packages/browser-playwright/src/commands/trace.ts
+++ b/packages/browser-playwright/src/commands/trace.ts
@@ -4,6 +4,7 @@ import type { BrowserCommand, BrowserCommandContext, BrowserProvider } from 'vit
 import type { PlaywrightBrowserProvider } from '../playwright'
 import { unlink } from 'node:fs/promises'
 import { basename, dirname, relative, resolve } from 'pathe'
+import { traceDbg } from '../dbg'
 import { getDescribedLocator } from './utils'
 
 export const startTracing: BrowserCommand<[]> = async ({ context, project, provider, sessionId }) => {
@@ -40,6 +41,7 @@ export const startChunkTrace: BrowserCommand<[{ name: string; title: string }]> 
     }
     const path = resolveTracesPath(command, name)
     provider.pendingTraces.set(path, sessionId)
+    traceDbg(`PROVIDER start name=${name} path=${path} session=${sessionId} pendingSize=${provider.pendingTraces.size}`)
     await context.tracing.startChunk({ name, title })
     return
   }
@@ -53,6 +55,7 @@ export const stopChunkTrace: BrowserCommand<[{ name: string }]> = async (
   if (isPlaywrightProvider(context.provider)) {
     const path = resolveTracesPath(context, name)
     context.provider.pendingTraces.delete(path)
+    traceDbg(`PROVIDER stop  name=${name} path=${path} session=${context.sessionId} pendingSize=${context.provider.pendingTraces.size}`)
     await context.context.tracing.stopChunk({ path })
     return { tracePath: path }
   }

--- a/packages/browser-playwright/src/dbg.ts
+++ b/packages/browser-playwright/src/dbg.ts
@@ -1,0 +1,12 @@
+import { appendFileSync } from 'node:fs'
+
+export function traceDbg(message: string): void {
+  const file = process.env.VITEST_TRACE_DBG_FILE
+  if (!file) {
+    return
+  }
+  try {
+    appendFileSync(file, `${Date.now()} ${message}\n`)
+  }
+  catch {}
+}

--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -35,6 +35,7 @@ import c from 'tinyrainbow'
 import { createDebugger, isCSSRequest } from 'vitest/node'
 import commands from './commands'
 import { distRoot } from './constants'
+import { traceDbg } from './dbg'
 
 const debug = createDebugger('vitest:browser:playwright')
 
@@ -140,6 +141,7 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
   }
 
   private onSIGTERM = () => {
+    traceDbg(`SIGTERM browser=${this.browserName} hasBrowser=${!!this.browser} pendingTraces=${this.pendingTraces.size} contexts=${this.contexts.size} pages=${this.pages.size}`)
     if (!this.browser) {
       return
     }
@@ -555,6 +557,8 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
   async close(): Promise<void> {
     process.off('SIGTERM', this.onSIGTERM)
 
+    const closeStart = Date.now()
+    traceDbg(`CLOSE start browser=${this.browserName} contexts=${this.contexts.size} pages=${this.pages.size} pendingTraces=${this.pendingTraces.size}`)
     debug?.('[%s] closing provider', this.browserName)
     this.closing = true
     if (this.browserPromise) {
@@ -573,6 +577,7 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     }
     this.contexts.clear()
     await browser?.close()
+    traceDbg(`CLOSE done  browser=${this.browserName} elapsed=${Date.now() - closeStart}ms`)
     debug?.('[%s] provider is closed', this.browserName)
   }
 }

--- a/packages/browser-webdriverio/src/commands/index.ts
+++ b/packages/browser-webdriverio/src/commands/index.ts
@@ -29,4 +29,6 @@ export default {
   __vitest_hover: hover as typeof hover,
   __vitest_cleanup: keyboardCleanup as typeof keyboardCleanup,
   __vitest_viewport: viewport as typeof viewport,
+  // diagnostic-only: stub so the runner's RPC call does not error here.
+  __vitest_logTraceDbg: (() => {}) as () => void,
 }

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -85,6 +85,9 @@ export function createBrowserRunner(
         && !(trace === 'on-all-retries' && retry === 0)
         && !(trace === 'on-first-retry' && retry !== 1)
       const shouldTraceView = this.config.browser.traceView.enabled
+      void this.commands.triggerCommand('__vitest_logTraceDbg', [{
+        msg: `BEFORE id=${test.id} name=${getTestName(test)} retry=${retry} repeats=${repeats} mode=${trace} shouldTrace=${shouldTrace} activeIds.size=${getBrowserState().activeTraceTaskIds.size} prevState=${test.result?.state ?? 'n/a'}`,
+      }]).catch(() => {})
       if (!shouldTraceView && !shouldTrace) {
         getBrowserState().activeTraceTaskIds.delete(test.id)
         getBrowserState().browserTraceAttempts.delete(test.id)
@@ -140,6 +143,9 @@ export function createBrowserRunner(
         getBrowserState().browserTraceAttempts.delete(test.id)
       }
       const hasActiveTrace = getBrowserState().activeTraceTaskIds.has(test.id)
+      void this.commands.triggerCommand('__vitest_logTraceDbg', [{
+        msg: `AFTER  id=${test.id} retry=${retry} repeats=${repeats} hasActive=${hasActiveTrace} state=${test.result?.state ?? 'n/a'} err=${test.result?.errors?.[0]?.message ?? ''}`,
+      }]).catch(() => {})
       if (!hasActiveTrace) {
         return
       }
@@ -152,6 +158,9 @@ export function createBrowserRunner(
         this.traces.set(test.id, [])
       }
       const traces = this.traces.get(test.id)!
+      void this.commands.triggerCommand('__vitest_logTraceDbg', [{
+        msg: `STOP   id=${test.id} name=${name} retry=${retry} repeats=${repeats}`,
+      }]).catch(() => {})
       const { tracePath } = await this.commands.triggerCommand(
         '__vitest_stopChunkTrace',
         [{ name }],

--- a/test/browser/specs/playwright-trace.test.ts
+++ b/test/browser/specs/playwright-trace.test.ts
@@ -1,12 +1,18 @@
 import { readdirSync, rmSync } from 'node:fs'
 import { resolve } from 'pathe'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { provider, runBrowserTests } from './utils'
 
 const tracesFolder = resolve(import.meta.dirname, '../fixtures/trace-view/__traces__')
 const basicTestTracesFolder = resolve(tracesFolder, 'basic.test.ts')
 
 describe.runIf(provider.name === 'playwright')('playwright tracing', () => {
+  // also clean before each test — webkit can flush traces async after stopChunk,
+  // racing afterEach and leaving stale `.trace.zip` files in the shared folder.
+  beforeEach(() => {
+    rmSync(tracesFolder, { recursive: true, force: true })
+  })
+
   afterEach(() => {
     rmSync(tracesFolder, { recursive: true, force: true })
   })


### PR DESCRIPTION
### Description

Two parts in one draft PR. Part 1 is a defensive cleanup that fixes a recurring intermittent failure on `test/browser/specs/playwright-trace.test.ts`; part 2 is a no-op-by-default diagnostic that captures provider lifecycle and trace gate evaluation so the remaining 360s timeout flakes on the same file can be analysed from CI artifacts.

The flake is not specific to any PR — for example #10314 (a `waitForConnection` reconnect change with no relation to tracing) hit the same `on-all-retries` 360s timeout and `on-first-retries` snapshot mismatch on its run, so addressing this here benefits every PR's `Browsers: macos` job.

### Part 1 — beforeEach trace cleanup (the actual fix)

Diagnosis (captured against an instrumented build whose event log is included as artifact):

- the previous test (`on-all-retries`) legitimately writes `webkit-repeated-retried-tests-0-2.trace.zip` as part of its own assertions;
- `tracing.stopChunk({ path })` resolves before webkit on macOS has fully flushed the zip to disk;
- `afterEach`'s `rmSync` can race that flush and leave the file behind;
- the next test runs in the same shared `__traces__` directory and `readdirSync` picks up the leftover, failing the snapshot for ``vitest generates trace files when running with `on-first-retries` ``.

A defensive `beforeEach(() => rmSync(...))` makes each test start from an empty directory regardless of how the previous test's traces finished writing. `rmSync({ force: true })` is idempotent on a non-existent path.

### Part 2 — file-based diagnostic for the remaining timeout flakes

The same file also intermittently times out at 360 s on `on-all-retries` and `retain-on-failure`, which looks like a browser session that does not release on teardown. The instrumentation in this PR is the cheapest way to pinpoint the offending state transition without re-running CI N times.

`packages/browser-playwright/src/dbg.ts` (new):

```ts
export function traceDbg(msg: string): void {
  const file = process.env.VITEST_TRACE_DBG_FILE
  if (!file) return
  appendFileSync(file, `${Date.now()} ${msg}\n`)
}
```

No-op when the env var is unset, so unaffected installs see no behaviour change. When set, captures:

- gate evaluation in the runner (`BEFORE / AFTER / STOP`);
- trace command handlers (`PROVIDER start / stop`);
- provider lifecycle (`SIGTERM`, `CLOSE start`, `CLOSE done` with elapsed).

The runner uses fire-and-forget `void triggerCommand(...)` so the diagnostic adds no measurable latency to the test path. The webdriverio commands index registers a no-op `__vitest_logTraceDbg` so the runner's RPC call does not surface as an unknown-command error in webdriverio mode.

`.github/workflows/ci.yml` sets `VITEST_TRACE_DBG_FILE: ${{ runner.temp }}/trace-dbg.log` for the `test-browser` job and uploads the file as `trace-dbg-{os}-node-{ver}` artifact (`if-no-files-found: ignore`).

Earlier revisions of this draft tried `console.log` and `console.error` for the same data; both got captured into stdout / stderr snapshots of unrelated e2e tests (`merge-reports.test.ts`, `list.test.ts`, `runner.test.ts > timeout hooks`) and broke them. File-based logging avoids that entirely.

### Tests

- [x] `cd test/browser && pnpm test:playwright specs/playwright-trace.test.ts` — 4/4 green locally.
- [x] `cd test/e2e && pnpm test list.test merge-reports.test` — 29/29 green; both files snapshot child stdout / stderr and would catch any leak from the diagnostic.
- [x] `pnpm lint` clean.
- [x] With `VITEST_TRACE_DBG_FILE` set locally: file populated as expected; with it unset: no file written.

### Plan

1. Run CI on this branch.
2. If `on-first-retries` snapshot mismatch reproduces: the `beforeEach` did not catch a delayed flush during the next test's execution — fall back to per-test `tracesDir`.
3. If `on-all-retries` / `retain-on-failure` 360s timeout reproduces: download the `trace-dbg-*` artifact and walk the timeline around the relevant `CLOSE start` / `SIGTERM` lines to identify the offending state transition.
4. Open a separate, properly scoped fix PR for whichever flake the artifact reveals.
5. Strip the diagnostic infrastructure from this PR or close it once the root causes are addressed upstream.