### PR TITLE
fix(reporter): fix non-existing import subpath module blob serialization

### DIFF
--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -276,7 +276,7 @@ function serializeEnvironmentModuleGraph(
   const modules: SerializedEnvironmentModuleNode[] = []
   for (const [id, mod] of environment.moduleGraph.idToModuleMap.entries()) {
     // Vite can generate module with `file = ""` for module id "#..."
-    // when module is non-existing.
+    // when the actual module doesn't exist (e.g. resolve failure or mocked module)
     if (mod.file == null) {
       continue
     }
@@ -312,9 +312,10 @@ function deserializeEnvironmentModuleGraph(
     const moduleId = serialized.idTable[id]
     const filePath = serialized.idTable[file]
     const urlPath = serialized.idTable[url]
-    // TODO: `createFileOnlyEntry('')` normalizes the file to ".". This keeps
+    // `createFileOnlyEntry('')` normalizes the file to ".". This keeps
     // the graph usable, but doesn't perfectly round-trip Vite's `file = ""`
     // nodes for ids like "#...".
+    // We may just do moduleNode.file = filePath in the future.
     const moduleNode = environment.moduleGraph.createFileOnlyEntry(filePath)
     moduleNode.url = urlPath
     moduleNode.id = moduleId

--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -275,13 +275,15 @@ function serializeEnvironmentModuleGraph(
 
   const modules: SerializedEnvironmentModuleNode[] = []
   for (const [id, mod] of environment.moduleGraph.idToModuleMap.entries()) {
-    if (!mod.file) {
+    // Vite can generate module with `file = ""` for module id "#..."
+    // when module is non-existing.
+    if (mod.file == null) {
       continue
     }
 
     const importedIds: number[] = []
     for (const importedNode of mod.importedModules) {
-      if (importedNode.id) {
+      if (importedNode.id !== null) {
         importedIds.push(getIdIndex(importedNode.id))
       }
     }

--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -312,6 +312,9 @@ function deserializeEnvironmentModuleGraph(
     const moduleId = serialized.idTable[id]
     const filePath = serialized.idTable[file]
     const urlPath = serialized.idTable[url]
+    // TODO: `createFileOnlyEntry('')` normalizes the file to ".". This keeps
+    // the graph usable, but doesn't perfectly round-trip Vite's `file = ""`
+    // nodes for ids like "#...".
     const moduleNode = environment.moduleGraph.createFileOnlyEntry(filePath)
     moduleNode.url = urlPath
     moduleNode.id = moduleId

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -281,7 +281,8 @@ test('total and merged execution times are shown', async () => {
 test('merges reports with a file-less imported module graph entry', async () => {
   const root = resolve(process.cwd(), `vitest-test-${crypto.randomUUID()}`)
   useFS(root, {
-    // TODO: vite 8 crashes when resolving non existing `imports` subpath.
+    // TODO: vite 8 crashes when trying to resolve
+    // non existing `imports` subpath in `test/e2e/package.json`.
     'package.json': '{ "type": "module" }',
     'repro1.test.ts': `
 test('repro1', async () => {

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -278,6 +278,65 @@ test('total and merged execution times are shown', async () => {
   expect(stdout).toContain('Per blob  1.50s 3.00s')
 })
 
+test('merges reports with a file-less imported module graph entry', async () => {
+  const root = resolve(process.cwd(), `vitest-test-${crypto.randomUUID()}`)
+  useFS(root, {
+    // TODO: vite 8 crashes when resolving non existing `imports` subpath.
+    'package.json': '{ "type": "module" }',
+    'repro1.test.ts': `
+test('repro1', async () => {
+  await expect(import('#repro1')).rejects.toThrow()
+})
+`,
+    'repro2.test.ts': `
+import * as repro from "#repro2";
+
+vi.mock("#repro2", () => ({
+  someExport: { mocked: true },
+}));
+
+it("repro2", () => {
+  expect(repro.someExport).toEqual({ mocked: true })
+});
+`,
+  })
+
+  const result1 = await runVitest({
+    root,
+    reporters: ['blob'],
+    globals: true,
+  })
+  expect(result1.stderr).toMatchInlineSnapshot(`""`)
+  expect(result1.errorTree()).toMatchInlineSnapshot(`
+    {
+      "repro1.test.ts": {
+        "repro1": "passed",
+      },
+      "repro2.test.ts": {
+        "repro2": "passed",
+      },
+    }
+  `)
+  expect(result1.exitCode).toBe(0)
+
+  const result2 = await runVitest({
+    root,
+    mergeReports: resolve(root, '.vitest/blob'),
+  })
+  expect(result2.stderr).toMatchInlineSnapshot(`""`)
+  expect(result2.errorTree()).toMatchInlineSnapshot(`
+    {
+      "repro1.test.ts": {
+        "repro1": "passed",
+      },
+      "repro2.test.ts": {
+        "repro2": "passed",
+      },
+    }
+  `)
+  expect(result2.exitCode).toBe(0)
+})
+
 test.for([
   'node',
   'browser',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10173

This PR fixes blob report merging when the serialized module graph contains an edge to a module with `file = ""`.

Vite’s `EnvironmentModuleGraph.ensureEntryFromUrl()` can produce `file = ""` shape for unresolved subpath imports module `#...`. The module graph node has `id`/`url` set to the specifier, but `file === ""` because Vite derives `file` via `cleanUrl("#...")`. The blob reporter previously treated falsy `file` as absent and skipped that node, while still serializing importer edges to it. During `--merge-reports`, deserialization then assumed the edge target existed and crashed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
