### PR TITLE
refactor(ui): minor cleanup

### DIFF
--- a/packages/ui/client/components/artifacts/visual-regression/SmallTabs.spec.ts
+++ b/packages/ui/client/components/artifacts/visual-regression/SmallTabs.spec.ts
@@ -25,7 +25,7 @@ function createSmallTabs(children: number) {
 
 describe('SmallTabs', () => {
   it('has accessible elements', async () => {
-    const result = render(createSmallTabs(2))
+    const result = await render(createSmallTabs(2))
 
     // a tablist with two elements inside
     const tablist = page.getByRole('tablist')
@@ -78,7 +78,7 @@ describe('SmallTabs', () => {
   it('opens one panel at a time', async () => {
     const tabsLimit = 5
 
-    const result = render(createSmallTabs(tabsLimit))
+    const result = await render(createSmallTabs(tabsLimit))
 
     const tabs = page.getByRole('tablist').getByRole('tab')
     const panels = page.getByRole('tabpanel', { includeHidden: true })

--- a/packages/ui/client/components/artifacts/visual-regression/VisualRegression.spec.ts
+++ b/packages/ui/client/components/artifacts/visual-regression/VisualRegression.spec.ts
@@ -30,7 +30,7 @@ describe('VisualRegression', () => {
   it('renders content with no attachments', async () => {
     const messageContent = faker.lorem.words(5)
 
-    const result = render(VisualRegression, {
+    const result = await render(VisualRegression, {
       props: {
         regression: {
           type: 'internal:toMatchScreenshot',
@@ -59,7 +59,7 @@ describe('VisualRegression', () => {
   })
 
   it('renders diff tab', async () => {
-    const result = render(VisualRegression, {
+    const result = await render(VisualRegression, {
       props: {
         regression: {
           type: 'internal:toMatchScreenshot',
@@ -88,7 +88,7 @@ describe('VisualRegression', () => {
   })
 
   it('renders reference tab', async () => {
-    render(VisualRegression, {
+    await render(VisualRegression, {
       props: {
         regression: {
           type: 'internal:toMatchScreenshot',
@@ -106,7 +106,7 @@ describe('VisualRegression', () => {
   })
 
   it('renders actual tab', async () => {
-    render(VisualRegression, {
+    await render(VisualRegression, {
       props: {
         regression: {
           type: 'internal:toMatchScreenshot',
@@ -124,7 +124,7 @@ describe('VisualRegression', () => {
   })
 
   it('renders reference, actual, and slider tabs', async () => {
-    const result = render(VisualRegression, {
+    const result = await render(VisualRegression, {
       props: {
         regression: {
           type: 'internal:toMatchScreenshot',
@@ -176,7 +176,7 @@ describe('VisualRegression', () => {
   })
 
   it('renders diff, reference, actual, and slider tabs', async () => {
-    const result = render(VisualRegression, {
+    const result = await render(VisualRegression, {
       props: {
         regression: {
           type: 'internal:toMatchScreenshot',

--- a/packages/ui/client/components/artifacts/visual-regression/VisualRegressionSlider.spec.ts
+++ b/packages/ui/client/components/artifacts/visual-regression/VisualRegressionSlider.spec.ts
@@ -27,7 +27,7 @@ const inputLabel = 'Adjust slider to compare reference and actual images'
 
 describe('VisualRegressionSlider', () => {
   it('renders both images with correct URLs', async () => {
-    render(VisualRegressionSlider, {
+    await render(VisualRegressionSlider, {
       props: {
         reference,
         actual,
@@ -67,7 +67,7 @@ describe('VisualRegressionSlider', () => {
   })
 
   it('has accessible descriptions', async () => {
-    render(VisualRegressionSlider, {
+    await render(VisualRegressionSlider, {
       props: {
         reference,
         actual,
@@ -101,7 +101,7 @@ describe('VisualRegressionSlider', () => {
   })
 
   it('has slider boundaries', async () => {
-    render(VisualRegressionSlider, {
+    await render(VisualRegressionSlider, {
       props: {
         reference,
         actual,
@@ -116,7 +116,7 @@ describe('VisualRegressionSlider', () => {
   })
 
   it('updates split percentage on slider movement', async () => {
-    render(VisualRegressionSlider, {
+    await render(VisualRegressionSlider, {
       props: {
         reference,
         actual,

--- a/packages/ui/client/components/dashboard/DashboardEntry.spec.ts
+++ b/packages/ui/client/components/dashboard/DashboardEntry.spec.ts
@@ -13,7 +13,7 @@ function div(o: { testId: string; body: string }) {
 
 describe('DashboardEntry', () => {
   it('renders the body and header slots', async () => {
-    render(DashboardEntry, {
+    await render(DashboardEntry, {
       slots: {
         body: div({ testId: bodyTestId, body: faker.lorem.words(2) }),
         header: div({ testId: headerTestId, body: faker.hacker.phrase() }),

--- a/packages/ui/client/components/views/ViewConsoleOutputEntry.spec.ts
+++ b/packages/ui/client/components/views/ViewConsoleOutputEntry.spec.ts
@@ -4,10 +4,10 @@ import { render } from '~/test'
 import ViewConsoleOutputEntry from './ViewConsoleOutputEntry.vue'
 
 describe('ViewConsoleOutputEntry', () => {
-  it('test html entry', () => {
+  it('test html entry', async () => {
     const now = new Date().toISOString()
     const content = new Filter().toHtml(`\x1B[33m${now}\x1B[0m`)
-    const { container } = render(ViewConsoleOutputEntry, {
+    const { container } = await render(ViewConsoleOutputEntry, {
       props: {
         taskName: 'test/html',
         type: 'stderr',

--- a/packages/ui/client/components/views/ViewReport.spec.ts
+++ b/packages/ui/client/components/views/ViewReport.spec.ts
@@ -62,8 +62,8 @@ fileWithTextStacks.file = fileWithTextStacks
 
 describe.todo('ViewReport', () => {
   describe('RunnerTestFile where stacks are in text', () => {
-    beforeEach(() => {
-      render(ViewReport, {
+    beforeEach(async () => {
+      await render(ViewReport, {
         props: {
           file: fileWithTextStacks,
         },
@@ -92,7 +92,7 @@ describe.todo('ViewReport', () => {
     })
   })
 
-  it('test html stack trace without html message', () => {
+  it('test html stack trace without html message', async () => {
     const file: RunnerTestFile = {
       id: 'f-1',
       name: 'test/plain-stack-trace.ts',
@@ -118,7 +118,7 @@ describe.todo('ViewReport', () => {
       file: null!,
     }
     file.file = file
-    const container = render(ViewReport, {
+    const container = await render(ViewReport, {
       props: { file },
     })
     const taskError = container.getByTestId(taskErrorTestId)
@@ -152,7 +152,7 @@ describe.todo('ViewReport', () => {
     ).toBe('color:#A50')
   })
 
-  it('test html stack trace and message', () => {
+  it('test html stack trace and message', async () => {
     const file: RunnerTestFile = {
       id: 'f-1',
       name: 'test/plain-stack-trace.ts',
@@ -178,7 +178,7 @@ describe.todo('ViewReport', () => {
       file: null!,
     }
     file.file = file
-    const container = render(ViewReport, {
+    const container = await render(ViewReport, {
       props: { file },
     })
     const taskError = container.getByTestId(taskErrorTestId)
@@ -220,8 +220,8 @@ describe.todo('ViewReport', () => {
     ).toBe('color:#A50')
   })
 
-  it('test diff display', () => {
-    const component = render(ViewReport, {
+  it('test diff display', async () => {
+    const component = await render(ViewReport, {
       props: {
         file: fileWithTextStacks,
       },

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -85,7 +85,6 @@ export function findById(id: string) {
 
 export const isConnected = computed(() => status.value === 'OPEN')
 export const isConnecting = computed(() => status.value === 'CONNECTING')
-export const isDisconnected = computed(() => status.value === 'CLOSED')
 
 export function runAll() {
   return runFiles(client.state.getFiles())

--- a/packages/ui/client/constants.ts
+++ b/packages/ui/client/constants.ts
@@ -4,4 +4,3 @@ export const ENTRY_URL = `${
   location.protocol === 'https:' ? 'wss:' : 'ws:'
 }//${HOST}/__vitest_api__?token=${(window as any).VITEST_API_TOKEN}`
 export const isReport = !!window.METADATA_PATH
-export const BASE_PATH = isReport ? import.meta.env.BASE_URL : __BASE_PATH__

--- a/packages/ui/client/global-setup.ts
+++ b/packages/ui/client/global-setup.ts
@@ -1,12 +1,10 @@
-/// <reference types="vite-plugin-pages/client" />
-
 import type { Directive } from 'vue'
 import FloatingVue, { vTooltip } from 'floating-vue'
-import routes from 'virtual:generated-pages'
 import {
   createRouter as _createRouter,
   createWebHashHistory,
 } from 'vue-router'
+import IndexPage from './pages/index.vue'
 import 'd3-graph-controller/default.css'
 import 'splitpanes/dist/splitpanes.css'
 import '@unocss/reset/tailwind.css'
@@ -26,7 +24,12 @@ FloatingVue.options.distance = 10
 export function createRouter() {
   return _createRouter({
     history: createWebHashHistory(),
-    routes,
+    routes: [
+      {
+        path: '/',
+        component: IndexPage,
+      },
+    ],
   })
 }
 

--- a/packages/ui/client/shim.d.ts
+++ b/packages/ui/client/shim.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pages/client" />
 
 const __BASE_PATH__: string
 

--- a/packages/ui/client/shim.d.ts
+++ b/packages/ui/client/shim.d.ts
@@ -1,7 +1,5 @@
 /// <reference types="vite/client" />
 
-const __BASE_PATH__: string
-
 declare interface Window {
   METADATA_PATH?: string
 }

--- a/packages/ui/client/test.ts
+++ b/packages/ui/client/test.ts
@@ -1,4 +1,4 @@
-import type { ComponentRenderOptions } from 'vitest-browser-vue'
+import type { ComponentRenderOptions, RenderResult } from 'vitest-browser-vue'
 import { vTooltip } from 'floating-vue'
 import {
   render as _render,
@@ -6,7 +6,10 @@ import {
 
 export { page } from 'vitest/browser'
 
-export function render<C>(component: C, options?: ComponentRenderOptions<C, any>) {
+export function render<C>(
+  component: C,
+  options?: ComponentRenderOptions<C, any>,
+): PromiseLike<RenderResult<any>> {
   return _render(component, {
     ...options,
     global: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -89,7 +89,7 @@
     "splitpanes": "^4.0.4",
     "typescript": "^5.9.3",
     "unocss": "catalog:",
-    "vite": "^5.0.0",
+    "vite": "latest",
     "vite-plugin-pages": "^0.33.3",
     "vitest-browser-vue": "2.0.2",
     "vue": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -75,7 +75,6 @@
     "@vitest/browser-preview": "workspace:*",
     "@vitest/browser-webdriverio": "workspace:*",
     "@vitest/runner": "workspace:*",
-    "@vue/test-utils": "^2.4.6",
     "@vueuse/core": "catalog:",
     "ansi-to-html": "^0.7.2",
     "birpc": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -90,7 +90,7 @@
     "typescript": "^5.9.3",
     "unocss": "catalog:",
     "vite": "latest",
-    "vitest-browser-vue": "2.0.2",
+    "vitest-browser-vue": "2.1.0",
     "vue": "catalog:",
     "vue-router": "^5.0.3",
     "vue-tsc": "^3.2.5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -90,7 +90,6 @@
     "typescript": "^5.9.3",
     "unocss": "catalog:",
     "vite": "latest",
-    "vite-plugin-pages": "^0.33.3",
     "vitest-browser-vue": "2.0.2",
     "vue": "catalog:",
     "vue-router": "^5.0.3",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -20,14 +20,7 @@ export default defineConfig({
     },
   },
   plugins: [
-    Vue({
-      features: {
-        propsDestructure: true,
-      },
-      script: {
-        defineModel: true,
-      },
-    }),
+    Vue(),
     Unocss({
       presets: [presetWind3(), presetAttributify(), presetIcons()],
       shortcuts: {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 import { resolve } from 'pathe'
-import { presetAttributify, presetIcons, presetUno, transformerDirectives } from 'unocss'
+import { presetAttributify, presetIcons, presetWind3, transformerDirectives } from 'unocss'
 import Unocss from 'unocss/vite'
 import { defineConfig } from 'vite'
 import Pages from 'vite-plugin-pages'
@@ -12,16 +12,13 @@ import Pages from 'vite-plugin-pages'
 // const debugLink = 'http://127.0.0.1:4173/__vitest__'
 
 export default defineConfig({
-  root: import.meta.dirname,
   base: './',
   resolve: {
-    dedupe: ['vue'],
+    // TODO: keep manual alias for vite 7 CI
+    // tsconfigPaths: true,
     alias: {
       '~/': `${resolve(import.meta.dirname, 'client')}/`,
     },
-  },
-  define: {
-    __BASE_PATH__: '"/__vitest__/"',
   },
   plugins: [
     Vue({
@@ -33,7 +30,7 @@ export default defineConfig({
       },
     }),
     Unocss({
-      presets: [presetUno(), presetAttributify(), presetIcons()] as any,
+      presets: [presetWind3(), presetAttributify(), presetIcons()],
       shortcuts: {
         'bg-base': 'bg-white dark:bg-[#111]',
         'bg-overlay': 'bg-[#eee]:50 dark:bg-[#222]:50',
@@ -48,7 +45,7 @@ export default defineConfig({
         'tab-button-active': 'op100 bg-gray-500:10',
       },
       transformers: [
-        transformerDirectives() as any,
+        transformerDirectives(),
       ],
       safelist: 'absolute origin-top mt-[8px]'.split(' '),
     }),

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -4,7 +4,6 @@ import { resolve } from 'pathe'
 import { presetAttributify, presetIcons, presetWind3, transformerDirectives } from 'unocss'
 import Unocss from 'unocss/vite'
 import { defineConfig } from 'vite'
-import Pages from 'vite-plugin-pages'
 
 // for debug:
 // open a static file serve to share the report json
@@ -48,9 +47,6 @@ export default defineConfig({
         transformerDirectives(),
       ],
       safelist: 'absolute origin-top mt-[8px]'.split(' '),
-    }),
-    Pages({
-      dirs: ['client/pages'],
     }),
     devUiScriptPlugin(),
     // uncomment to see the HTML reporter preview

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -981,8 +981,8 @@ importers:
         specifier: 8.0.11
         version: 8.0.11(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest-browser-vue:
-        specifier: 2.0.2
-        version: 2.0.2(vitest@packages+vitest)(vue@3.5.29(typescript@5.9.3))
+        specifier: 2.1.0
+        version: 2.1.0(@vue/compiler-dom@3.5.29)(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3)))(vitest@packages+vitest)(vue@3.5.29(typescript@5.9.3))
       vue:
         specifier: 'catalog:'
         version: 3.5.29(typescript@5.9.3)
@@ -5565,6 +5565,16 @@ packages:
 
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  '@vue/test-utils@2.4.10':
+    resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -10205,8 +10215,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  vitest-browser-vue@2.0.2:
-    resolution: {integrity: sha512-/IM/+gOBEPL5Ocu/n28NmAvr1XgqGxzJrgwkPx9O+ioB52iuyg25nDQXlDDPSCm5PJFmwNzA6yycWxFAFTqXYA==}
+  vitest-browser-vue@2.1.0:
+    resolution: {integrity: sha512-K3H/oxIOY4EjXx2bxwrLsPg4jTMvzpRW6Jb6T8XZRoxUvmDVwGkd8mua130F8GZezE7H5QYoXd/S8hYijw7j5g==}
     peerDependencies:
       vitest: workspace:*
       vue: ^3.0.0
@@ -10228,6 +10238,9 @@ packages:
 
   vue-component-type-helpers@2.0.17:
     resolution: {integrity: sha512-2car49m8ciqg/JjgMBkx7o/Fd2A7fHESxNqL/2vJYFLXm4VwYO4yH0rexOi4a35vwNgDyvt17B07Vj126l9rAQ==}
+
+  vue-component-type-helpers@3.2.8:
+    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -14138,6 +14151,15 @@ snapshots:
   '@vue/shared@3.5.28': {}
 
   '@vue/shared@3.5.29': {}
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.29)(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.29
+      js-beautify: 1.15.1
+      vue: 3.5.29(typescript@5.9.3)
+      vue-component-type-helpers: 3.2.8
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.29(vue@3.5.29(typescript@5.9.3))
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -19565,11 +19587,14 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 18.2.14
 
-  vitest-browser-vue@2.0.2(vitest@packages+vitest)(vue@3.5.29(typescript@5.9.3)):
+  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.5.29)(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3)))(vitest@packages+vitest)(vue@3.5.29(typescript@5.9.3)):
     dependencies:
-      '@vue/test-utils': 2.4.6
+      '@vue/test-utils': 2.4.10(@vue/compiler-dom@3.5.29)(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
       vitest: link:packages/vitest
       vue: 3.5.29(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - '@vue/server-renderer'
 
   vitest-environment-custom@file:test/unit/vitest-environment-custom: {}
 
@@ -19585,6 +19610,8 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   vue-component-type-helpers@2.0.17: {}
+
+  vue-component-type-helpers@3.2.8: {}
 
   vue-demi@0.14.10(vue@3.5.29(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,9 +935,6 @@ importers:
       '@vitest/runner':
         specifier: workspace:*
         version: link:../runner
-      '@vue/test-utils':
-        specifier: ^2.4.6
-        version: 2.4.6
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.2.1(vue@3.5.29(typescript@5.9.3))
@@ -1354,7 +1351,7 @@ importers:
         version: link:../../packages/web-worker
       '@vue/test-utils':
         specifier: latest
-        version: 2.4.6
+        version: 2.4.10(@vue/compiler-dom@3.5.29)(@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3)))(vue@3.5.29(typescript@5.9.3))
       happy-dom:
         specifier: latest
         version: 20.8.7
@@ -5575,9 +5572,6 @@ packages:
     peerDependenciesMeta:
       '@vue/server-renderer':
         optional: true
-
-  '@vue/test-utils@2.4.6':
-    resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
 
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
@@ -10236,9 +10230,6 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-component-type-helpers@2.0.17:
-    resolution: {integrity: sha512-2car49m8ciqg/JjgMBkx7o/Fd2A7fHESxNqL/2vJYFLXm4VwYO4yH0rexOi4a35vwNgDyvt17B07Vj126l9rAQ==}
-
   vue-component-type-helpers@3.2.8:
     resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
@@ -14161,11 +14152,6 @@ snapshots:
     optionalDependencies:
       '@vue/server-renderer': 3.5.29(vue@3.5.29(typescript@5.9.3))
 
-  '@vue/test-utils@2.4.6':
-    dependencies:
-      js-beautify: 1.15.1
-      vue-component-type-helpers: 2.0.17
-
   '@vueuse/core@12.8.2(typescript@5.9.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
@@ -15209,7 +15195,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.1
-      semver: 7.7.3
+      semver: 7.7.4
 
   ee-first@1.1.1: {}
 
@@ -19608,8 +19594,6 @@ snapshots:
       vitest: link:packages/vitest
 
   vscode-uri@3.1.0: {}
-
-  vue-component-type-helpers@2.0.17: {}
 
   vue-component-type-helpers@3.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,9 +980,6 @@ importers:
       vite:
         specifier: 8.0.11
         version: 8.0.11(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-pages:
-        specifier: ^0.33.3
-        version: 0.33.3(@vue/compiler-sfc@3.5.29)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(vue-router@5.0.3(@vue/compiler-sfc@3.5.29)(vue@3.5.29(typescript@5.9.3)))
       vitest-browser-vue:
         specifier: 2.0.2
         version: 2.0.2(vitest@packages+vitest)(vue@3.5.29(typescript@5.9.3))
@@ -6885,10 +6882,6 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  esprima-extract-comments@1.1.0:
-    resolution: {integrity: sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==}
-    engines: {node: '>=4'}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -6955,10 +6948,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  extract-comments@1.1.0:
-    resolution: {integrity: sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==}
-    engines: {node: '>=6'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -8630,10 +8619,6 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
-  parse-code-context@1.0.0:
-    resolution: {integrity: sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==}
-    engines: {node: '>=6'}
-
   parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
     engines: {node: '>=14'}
@@ -10118,24 +10103,6 @@ packages:
 
   vfile@6.0.1:
     resolution: {integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==}
-
-  vite-plugin-pages@0.33.3:
-    resolution: {integrity: sha512-k97CAlVN7VUD5CIkRaose8Ty1xjtpuSeJQngFxsinPyM7PCtAIp23QdnkygNRdoo4gjX21TORYdEAAN/lGtCIA==}
-    peerDependencies:
-      '@solidjs/router': '*'
-      '@vue/compiler-sfc': ^2.7.0 || ^3.0.0
-      react-router: '*'
-      vite: 8.0.11
-      vue-router: '*'
-    peerDependenciesMeta:
-      '@solidjs/router':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      react-router:
-        optional: true
-      vue-router:
-        optional: true
 
   vite-plugin-pwa@1.2.0:
     resolution: {integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==}
@@ -15692,10 +15659,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.11.3(patch_hash=62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4))
       eslint-visitor-keys: 5.0.1
 
-  esprima-extract-comments@1.1.0:
-    dependencies:
-      esprima: 4.0.1
-
   esprima@4.0.1: {}
 
   esquery@1.7.0:
@@ -15796,11 +15759,6 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
-
-  extract-comments@1.1.0:
-    dependencies:
-      esprima-extract-comments: 1.1.0
-      parse-code-context: 1.0.0
 
   extract-zip@2.0.1:
     dependencies:
@@ -17387,6 +17345,7 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+    optional: true
 
   millify@6.1.0:
     dependencies:
@@ -17828,8 +17787,6 @@ snapshots:
   package-name-regex@2.0.6: {}
 
   pako@1.0.11: {}
-
-  parse-code-context@1.0.0: {}
 
   parse-gitignore@2.0.0: {}
 
@@ -19485,25 +19442,6 @@ snapshots:
       '@types/unist': 3.0.2
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
-
-  vite-plugin-pages@0.33.3(@vue/compiler-sfc@3.5.29)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(vue-router@5.0.3(@vue/compiler-sfc@3.5.29)(vue@3.5.29(typescript@5.9.3))):
-    dependencies:
-      '@types/debug': 4.1.12
-      debug: 4.4.3
-      dequal: 2.0.3
-      extract-comments: 1.1.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      micromatch: 4.0.8
-      picocolors: 1.1.1
-      tinyglobby: 0.2.15
-      vite: 8.0.11(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      yaml: 2.8.2
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.29
-      vue-router: 5.0.3(@vue/compiler-sfc@3.5.29)(vue@3.5.29(typescript@5.9.3))
-    transitivePeerDependencies:
-      - supports-color
 
   vite-plugin-pwa@1.2.0(@vite-pwa/assets-generator@1.0.2)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(workbox-build@7.1.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR does minor cleanup to reduce churns. Here is a summary:

- remove unused code, config, and deps
- replaced deprecated unocss config, vue plugin config
- updated `vitest-browser-vue` and used `await render` so it gives `vue.render` snapshot.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
