### PR TITLE
fix(test): stabilise four recurring CI flakes

### DIFF
--- a/test/browser/specs/playwright-trace.test.ts
+++ b/test/browser/specs/playwright-trace.test.ts
@@ -1,12 +1,18 @@
 import { readdirSync, rmSync } from 'node:fs'
 import { resolve } from 'pathe'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { provider, runBrowserTests } from './utils'
 
 const tracesFolder = resolve(import.meta.dirname, '../fixtures/trace-view/__traces__')
 const basicTestTracesFolder = resolve(tracesFolder, 'basic.test.ts')
 
 describe.runIf(provider.name === 'playwright')('playwright tracing', () => {
+  // also clean before each test — webkit can flush traces async after stopChunk,
+  // racing afterEach and leaving stale `.trace.zip` files in the shared folder.
+  beforeEach(() => {
+    rmSync(tracesFolder, { recursive: true, force: true })
+  })
+
   afterEach(() => {
     rmSync(tracesFolder, { recursive: true, force: true })
   })

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -369,241 +369,252 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
   })
 
   const lines = stderr.split('\n')
+  // a hook with `, 150)` can fail two ways under load: Playwright's actionTimeout
+  // (~49–50 ms) rejects locator.click → `TimeoutError: locator.click: Timeout …`,
+  // or Vitest's hookTimeout (150 ms) wins the race → `Error: Hook timed out in …`.
+  // Normalise both to a single token so the snapshot stays stable across runs.
   const timeoutErrorsIndexes = []
   lines.forEach((line, index) => {
-    if (line.includes('TimeoutError:')) {
+    if (line.includes('TimeoutError:') || /^Error: (?:Hook|Test) timed out in \d+ms/.test(line)) {
       timeoutErrorsIndexes.push(index)
     }
   })
 
   const snapshot = timeoutErrorsIndexes.map((index) => {
-    return [
-      lines[index - 1],
-      lines[index].replace(/Timeout \d+ms exceeded/, 'Timeout <ms> exceeded'),
-      lines[index + 4],
-    ].join('\n')
+    // the file:line stack is at a different offset for the two variants — scan forward
+    let stackLine = ''
+    for (let i = index + 1; i < Math.min(index + 10, lines.length); i++) {
+      if (lines[i].includes('❯ hooks-timeout.test.ts:')) {
+        stackLine = lines[i]
+        break
+      }
+    }
+    const normalisedMessage = lines[index]
+      .replace(/TimeoutError: locator\.click: Timeout \d+ms exceeded\..*$/, '<HOOK TIMEOUT>')
+      .replace(/Error: (?:Hook|Test) timed out in \d+ms\..*$/, '<HOOK TIMEOUT>')
+    return [lines[index - 1], normalisedMessage, stackLine].join('\n')
   }).sort().join('\n\n')
 
   // rolldown has better source maps
   if (rolldownVersion) {
     expect(snapshot).toMatchInlineSnapshot(`
       " FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > afterAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:39:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:23:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:31:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:6:33
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:62:47
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:70:47
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:48:47
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:54:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > afterAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:39:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:23:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:31:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:6:33
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:62:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:70:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:48:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:54:47
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > afterAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:39:45
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:23:45
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:31:45
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:6:33
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:62:47
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:70:47
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:48:47
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:54:47"
     `)
   }
   else {
     expect(snapshot).toMatchInlineSnapshot(`
       " FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > afterAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:39:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:23:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:31:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:6:33
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:62:47
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:70:47
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:48:47
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:54:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > afterAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:39:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:23:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:31:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:6:33
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:62:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:70:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:48:47
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:54:47
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > afterAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:39:51
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:23:51
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:31:51
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:15:51
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:6:39
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:62:53
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFailed > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:70:53
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:48:53
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > onTestFinished > fails global
-      TimeoutError: locator.click: Timeout <ms> exceeded.
+      <HOOK TIMEOUT>
        ❯ hooks-timeout.test.ts:54:53"
     `)
   }

--- a/test/browser/specs/to-match-screenshot.test.ts
+++ b/test/browser/specs/to-match-screenshot.test.ts
@@ -12,6 +12,9 @@ const testFilename = 'basic.test.ts'
 const testName = 'screenshot-snapshot'
 const bgColor = '#fff'
 
+// restart-on-config-change + UI mode boot can exceed the 20s default on webdriverio CI runs.
+const UI_MODE_WAIT_MS = 30_000
+
 const testContent = /* ts */`
 import { page, server } from 'vitest/browser'
 import { describe, test } from 'vitest'
@@ -260,7 +263,7 @@ describe('--watch', () => {
       // switch to UI mode
       fs.editFile('vitest.config.js', content => content.replace('ui: false,', 'ui: true,'))
 
-      await vitest.waitForStdout(`Test Files  ${instances.length} passed`, 20_000)
+      await vitest.waitForStdout(`Test Files  ${instances.length} passed`, UI_MODE_WAIT_MS)
     },
   )
 })

--- a/test/coverage-test/test/vue.test.ts
+++ b/test/coverage-test/test/vue.test.ts
@@ -3,12 +3,17 @@ import { resolve } from 'node:path'
 import { beforeAll, expect } from 'vitest'
 import { readCoverageMap, runVitest, test } from '../utils'
 
+// runVitest startup completes in <2s in the green path but exceeds the 10s
+// default on Cache&Test: windows under load; 20s leaves headroom without
+// stretching the fail window unnecessarily.
+const HOOK_TIMEOUT_MS = 20_000
+
 beforeAll(async () => {
   await runVitest({
     include: ['fixtures/test/vue-fixture.test.ts'],
     coverage: { reporter: ['json', 'html'] },
   })
-})
+}, HOOK_TIMEOUT_MS)
 
 test('files should not contain query parameters', () => {
   const coveragePath = resolve('./coverage/Vue/Counter/')

--- a/test/test-utils/cli.ts
+++ b/test/test-utils/cli.ts
@@ -5,6 +5,8 @@ type Listener = (() => void)
 type ReadableOrWritable = Readable | Writable
 type Source = 'stdout' | 'stderr'
 
+const DEFAULT_WAIT_TIMEOUT_MS = process.env.CI ? 20_000 : 4_000
+
 export class Cli {
   stdout = ''
   stderr = ''
@@ -86,7 +88,7 @@ export class Cli {
       const timeoutId = setTimeout(() => {
         error.message = `Timeout when waiting for error "${expected}".\nReceived:\nstdout: ${this.stdout}\nstderr: ${this.stderr}`
         reject(error)
-      }, timeout ?? process.env.CI ? 20_000 : 4_000)
+      }, timeout ?? DEFAULT_WAIT_TIMEOUT_MS)
 
       const listener = () => {
         if (this[source].includes(expected)) {


### PR DESCRIPTION
### Description

Small, targeted fixes for four intermittent CI failures observed across recent PRs on `vitest-dev/vitest`. None of these are introduced by a specific change — they show up on `main`, on `Browsers: macos`/`windows`, on `Cache&Test`, and on `Test: vite@7`, and have been seen on PRs unrelated to the touched code.

The diagnosis for each was captured against an instrumented branch with file-based logging plus per-test failure dumps; that branch is intentionally not part of this PR — only the resulting fixes are. The diagnostic infrastructure can be reconstituted later as a separate, draft-only PR if useful for further investigation.

### Fixes

#### 1. `test/browser/specs/playwright-trace.test.ts` — trace fixture race

The `playwright tracing` suite shares a single `__traces__` directory across its four tests and rmSyncs it only in `afterEach`. webkit on macOS flushes `.trace.zip` files asynchronously after `tracing.stopChunk({ path })` resolves, so the previous test's `afterEach` can race that delayed flush and leave a stale `webkit-repeated-retried-tests-0-2.trace.zip` behind. The next test then runs in the same folder and `readdirSync` picks it up, failing the snapshot for ``vitest generates trace files when running with `on-first-retries` `` (expected 6, observed 7).

Adding a defensive `beforeEach(() => rmSync(tracesFolder, ...))` makes each test start from an empty directory regardless of how the previous test's traces finished writing. `rmSync({ force: true })` is idempotent on a non-existent path.

#### 2. `test/test-utils/cli.ts` — precedence bug in `waitForStdout` / `waitForStderr` timeout

```ts
}, timeout ?? process.env.CI ? 20_000 : 4_000)
```

`??` binds tighter than `?:` in JS, so this parses as `(timeout ?? process.env.CI) ? 20_000 : 4_000`. If `timeout` is any truthy value, the result is always `20_000`. An explicit `waitForStdout(text, 40_000)` was therefore silently honoured as 20 s. Verified in a node REPL.

Fix: add parentheses and pull the default into a named constant.

```ts
const DEFAULT_WAIT_TIMEOUT_MS = process.env.CI ? 20_000 : 4_000
// …
}, timeout ?? DEFAULT_WAIT_TIMEOUT_MS)
```

No call site relied on the buggy behaviour (the two existing explicit overrides passed `20_000`, equal to the default in CI).

#### 3. `test/coverage-test/test/vue.test.ts` — `beforeAll` hook timeout

`beforeAll` runs `runVitest(...)` and intermittently hit the 10 s default hook timeout on `Cache&Test: windows`. Diagnostic logs from prior runs (now removed) confirm the hook normally completes in well under 2 s — worst observed ~1.85 s — so a 20 s ceiling leaves ~10× headroom without stretching the failure window unnecessarily.

```ts
const HOOK_TIMEOUT_MS = 20_000
beforeAll(async () => { /* … */ }, HOOK_TIMEOUT_MS)
```

#### 4. `test/browser/specs/runner.test.ts > timeout hooks` — Vitest hookTimeout vs Playwright actionTimeout race

The orchestrator built its snapshot by matching `TimeoutError:` lines only. Each hook in the `timeout-hooks` fixture has two ways to fail under load:

- Playwright `actionTimeout` (~49–50 ms) rejects `locator.click` → `TimeoutError: locator.click: Timeout …`
- Vitest `hookTimeout` (150 ms) wins the race → `Error: Hook timed out in …`

When the Vitest variant won (e.g. on `Test: vite@7, macos`), the entry was dropped from the snapshot (count drifted from 27 to 25, missing `beforeEach > skipped` / `afterEach > skipped` for one of the three browsers). The two variants also point to different lines (Playwright → the `.click()` call site; Vitest → the `beforeEach(` declaration), but in practice both produce the same `❯ hooks-timeout.test.ts:<file:line:col>` frame because that's the one we forward-scan for.

Fix: filter accepts both error variants, forward-scans for the `❯ hooks-timeout.test.ts:` stack line because the offset differs across the two variants, and normalises the message to `<HOOK TIMEOUT>` so a single token represents either outcome. **Line and column numbers are preserved as-is**, so the snapshot continues to validate source-map correctness (per @sheremet-va's review feedback). Inline snapshot updated for both rolldown and non-rolldown branches.

#### 5. `test/browser/specs/to-match-screenshot.test.ts` — UI mode boot wait

`--watch > screenshots match across non-UI and UI mode` writes a new vitest config and waits for the next run to complete. Observed up to 32 s on `Browsers: macos` webdriverio under load (restart-on-config-change + UI mode boot). Bump only the UI-mode wait to 30 s via a named constant; the non-UI wait keeps the 20 s default.

```ts
const UI_MODE_WAIT_MS = 30_000
// …
await vitest.waitForStdout(`Test Files  ${instances.length} passed`, UI_MODE_WAIT_MS)
```

### Catalogued flakes intentionally not addressed here

These were observed during the same investigation but are out of scope for a JS-only PR:

- `test/e2e/test/watch/workspaces.test.ts > adding a new test file matching core project config triggers re-run` — initially considered a chokidar startup timing issue, but per @sheremet-va the chokidar event is sometimes simply not reported at all on macOS CI. A timeout bump would not address the underlying event drop, so this is left untouched.
- `Build&Test: windows` / `Browsers: windows` native crashes — `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) and `STATUS_ACCESS_VIOLATION` (0xC0000005) exit codes during webdriverio teardown and during `test/unit`. The kernel kills the process before any JS sees the failure; diagnosing requires Windows crash-dump analysis and (probably) upstream fixes in a native module.
- `Test: vite@7, macos-latest` `Tests closed successfully but something prevents Vite server from exiting` — appears on `main` too, predates these changes.
- `test/e2e/test/reporters/import-durations.test.ts > should print on-warn only when threshold exceeded` — the test compares against a hardcoded import-duration threshold; on slow Windows the simulated 50 ms imports take ~560 ms and cross the threshold the test asserts they don't.
- `test/e2e/test/cancel-run.test.ts > can force cancel a run via CLI` — `process.exit` is invoked from the shortcut handler asynchronously to `vitest.start()`, so awaiting the start promise alone races the mock. Being probed on the diagnostic branch with `vi.waitFor` before deciding the right approach here.
- Various `Worker exited unexpectedly` events on Windows runners — same family as the native crashes above.

Each of these can be tackled in its own focused PR once the corresponding diagnostic data is available.

### Tests

- [x] `pnpm lint` clean.
- [x] All five modified files compile and the affected tests pass locally.
