### PR TITLE
fix: shell injection safety via github.ref_name in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm i -g npm@^11.5.2 && pnpm run publish-ci ${{ github.ref_name }}
+        run: npm i -g npm@^11.5.2 && pnpm run publish-ci "${{ github.ref_name }}"
 
       - name: Generate Changelog
         run: npx changelogithub


### PR DESCRIPTION
## Security Fix

**Vulnerability:** `${{ github.ref_name }}` is interpolated directly into a `run:` shell command without quoting. Since `github.ref_name` corresponds to the git ref (tag/branch name), an attacker who can influence the ref name (e.g., via a crafted tag) can inject arbitrary shell commands.

**Line:** `.github/workflows/publish.yml:44`
```yaml
- run: npm i -g npm@^11.5.2 && pnpm run publish-ci ${{ github.ref_name }}
```

**Fix:** Wrapped `${{ github.ref_name }}` in double quotes to prevent shell word splitting and injection.

```yaml
- run: npm i -g npm@^11.5.2 && pnpm run publish-ci "${{ github.ref_name }}"
```

This follows GitHub security best practices: treat all context data as untrusted and quote or pass through env: variables when used in shell commands.

Discovered via automated CI/CD security analysis.
