### PR TITLE
chore!: remove vitest/import-meta reexport

### DIFF
--- a/packages/vitest/import-meta.d.ts
+++ b/packages/vitest/import-meta.d.ts
@@ -1,5 +1,0 @@
-/// <reference path="./importMeta.d.ts" />
-
-// https://github.com/microsoft/TypeScript/issues/45096
-// TypeScript has a bug that makes <reference types="vite/types/importMeta" />
-// not possible in userland. This file provides a workaround for now.

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -61,9 +61,6 @@
     "./importMeta": {
       "types": "./importMeta.d.ts"
     },
-    "./import-meta": {
-      "types": "./import-meta.d.ts"
-    },
     "./node": {
       "types": "./dist/node.d.ts",
       "default": "./dist/node.js"

--- a/test/browser/tsconfig.json
+++ b/test/browser/tsconfig.json
@@ -10,7 +10,7 @@
     "types": [
       "vite/client",
       "vitest-browser-react",
-      "vitest/import-meta"
+      "vitest/importMeta"
     ],
     "noEmit": true,
     "esModuleInterop": true


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Deletes vitest/import-meta, as proposed in https://github.com/vitest-dev/vitest/discussions/10330.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
