### PR TITLE
fix(browser): use resolve instead of join for screenshotDirectory path resolution

### DIFF
--- a/packages/browser/src/node/commands/screenshotMatcher/utils.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/utils.ts
@@ -137,7 +137,7 @@ export function resolveOptions(
     root,
     screenshotDirectory: relative(
       root,
-      join(root, context.project.config.browser.screenshotDirectory ?? '__screenshots__'),
+      resolve(root, context.project.config.browser.screenshotDirectory ?? '__screenshots__'),
     ),
     attachmentsDir: relative(root, context.project.config.attachmentsDir),
     testFileDirectory: relative(root, dirname(context.testPath)),


### PR DESCRIPTION
#### What

When `browser.screenshotDirectory` is set to an absolute path, `resolveConfig` pre-resolves it to an absolute path before it reaches `utils.ts`. The call to `join(root, absolutePath)` then concatenates root and the absolute path as literal segments, producing broken paths like `/home/user/project/home/user/project/__shots__/...`.

The fix is one character: swap `join` for `resolve`. When the second argument is already absolute, `pathe.resolve` returns it as-is rather than appending it.

#### Why `join` vs `resolve` matters here

```ts
// resolveConfig pre-resolves screenshotDirectory when set:
resolved.browser.screenshotDirectory = resolve(resolved.root, resolved.browser.screenshotDirectory)

// So by the time utils.ts runs, it's already absolute.
join('/project', '/home/user/__shots__')    // → '/project/home/user/__shots__'  ✗
resolve('/project', '/home/user/__shots__') // → '/home/user/__shots__'           ✓
```

#### Why not PR #9656?

There's an existing PR (#9656) for the same issue. It uses `resolve('/', relative(root, path))` as the fix, but that approach breaks on Windows because `resolve('/')` anchors to the drive root (`C:\`) rather than a meaningful cross-platform root. That PR has a failing `Build&Test: node-24, windows-latest` CI job and has been stale since February. This PR uses the simpler, cross-platform approach.

#### Testing

This is exactly the scenario covered by the existing `to-match-screenshot` test suite. The default `__screenshots__` fallback is a relative path, so the `join`/`resolve` difference doesn't matter there — the change only affects users who set `screenshotDirectory` explicitly to an absolute path, which is the reported bug.

Fixes #9636.