### PR TITLE
test(reporters): increase junit 'many errors' timeout for slow Windows CI runners

### DIFF
--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -170,7 +170,7 @@ test('many errors without warning', async () => {
     resolve(import.meta.dirname, '../fixtures/reporters/many-errors'),
   )
   expect(stderr).not.toContain('MaxListenersExceededWarning')
-})
+}, 120000)
 
 test('CLI reporter option preserves config file options', async () => {
   const { stdout } = await runVitestCli(
@@ -188,7 +188,7 @@ test('CLI reporter option preserves config file options', async () => {
 
   // Verify that addFileAttribute from config is preserved
   expect(xml).toContain('file="')
-})
+}, 120000)
 
 test('suiteNameTemplate string uses {title} (first top-level describe)', async () => {
   const { stdout } = await runVitest({


### PR DESCRIPTION
### Description

Two tests in the JUnit reporter suite call `runVitestCli` and inherit the e2e suite's global `testTimeout: 60_000`. On slow Windows CI runners, 60 s isn't enough. The child process gets killed before it finishes, showing up as a timeout rather than a real assertion failure.

Both now have an explicit `120000` ms timeout. `agent.test.ts`, `html.test.ts`, and `default.test.ts` already use the same value for the same reason.

Caught in CI on PR #10332.

*Developed by Zelys with assistance from Claude.*

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] No new functionality — no docs changes needed.

### Changesets
- [x] No user-facing behavior change — this is a test infrastructure fix only.