### PR TITLE
fix: make `attachmentsDir` root only config

### DIFF
--- a/docs/config/attachmentsdir.md
+++ b/docs/config/attachmentsdir.md
@@ -3,9 +3,11 @@ title: attachmentsDir | Config
 outline: deep
 ---
 
-# attachmentsDir
+# attachmentsDir <CRoot />
 
 - **Type:** `string`
 - **Default:** `'.vitest/attachments'`
 
-Directory path for storing attachments created by [`context.annotate`](/guide/test-context#annotate) relative to the project root.
+Directory path for storing file attachments created by [`context.annotate`](/guide/test-context#annotate).
+
+This option is resolved relative to the root Vitest config. When using [`projects`](/guide/projects), all projects share the same `attachmentsDir`; it cannot be configured per project.

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -289,6 +289,7 @@ Some of the configuration options are not allowed in a project config. Most nota
 - `coverage`: coverage is done for the whole process
 - `reporters`: only root-level reporters can be supported
 - `resolveSnapshotPath`: only root-level resolver is respected
+- `attachmentsDir`: attachments are stored in one root-level directory shared by all projects
 - all other options that don't affect test runners
 
 All configuration options that are not supported inside a project configuration are marked with a <CRoot /> icon next to their name. They can only be defined once in the root config file.

--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -550,9 +550,8 @@ export class TestProject {
       this.vitest,
       {
         ...options,
+        // root-only configs
         coverage: this.vitest.config.coverage,
-        // TODO: doc
-        // root-only attachmentsDir
         attachmentsDir: this.vitest.config.attachmentsDir,
       },
       server.config,

--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -551,6 +551,9 @@ export class TestProject {
       {
         ...options,
         coverage: this.vitest.config.coverage,
+        // TODO: doc
+        // root-only attachmentsDir
+        attachmentsDir: this.vitest.config.attachmentsDir,
       },
       server.config,
     )

--- a/test/e2e/test/annotations.test.ts
+++ b/test/e2e/test/annotations.test.ts
@@ -1,5 +1,7 @@
 import type { TestArtifact } from '@vitest/runner'
 import type { TestAnnotation } from 'vitest'
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
 import { playwright } from '@vitest/browser-playwright'
 import { describe, expect, test } from 'vitest'
 import { runInlineTests } from '../../test-utils'
@@ -664,4 +666,53 @@ describe('reporters', () => {
       `)
     })
   })
+})
+
+test('attachmentsDir is root only', async () => {
+  const result = await runInlineTests(
+    {
+      'packages/client/basic.test.ts': `
+import { test } from 'vitest'
+test("hello", ({ annotate }) => {
+  annotate("hello annotation", { path: "./hello.txt" })
+})
+`,
+      'packages/client/hello.txt': `HELLO`,
+      'packages/server/basic.test.ts': `
+import { test } from 'vitest'
+test("world", ({ annotate }) => {
+  annotate("world annotation", { path: "./world.txt" })
+})
+`,
+      'packages/server/world.txt': `WORLD`,
+    },
+    {
+      projects: ['./packages/*'],
+    },
+  )
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+    {
+      "client": {
+        "basic.test.ts": {
+          "hello": "passed",
+        },
+      },
+      "server": {
+        "basic.test.ts": {
+          "world": "passed",
+        },
+      },
+    }
+  `)
+  const files = readdirSync(path.join(result.root, '.vitest/attachments'))
+  const contents = files.sort().map(file =>
+    result.fs.readFile(path.join('.vitest/attachments', file)),
+  )
+  expect(contents).toMatchInlineSnapshot(`
+    [
+      "HELLO",
+      "WORLD",
+    ]
+  `)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10326

This PR fixes all projects to use the root `attachmentsDir`. Source paths still resolve from the owning project, but all projects now write into the shared root `.vitest/attachments` directory.

This is safe for UI and Browser Mode because attachments are served through the dedicated `/__vitest_attachment__` middleware, not as project-local Vite static files. The default directory change is again breaking-ish change, but v5 already did that by `.vitest-attachments -> .vitest/attachments`, so probably fine without special treatment.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
