### PR TITLE
test: fix e2e fixture path

### DIFF
--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -163,13 +163,14 @@ test.each([true, false])('addFileAttribute %s', async (t) => {
 })
 
 test('many errors without warning', async () => {
-  const { stderr } = await runVitestCli(
+  const result = await runVitestCli(
     'run',
     '--reporter=junit',
     '--root',
-    resolve(import.meta.dirname, '../fixtures/reporters/many-errors'),
+    resolve(import.meta.dirname, '../../fixtures/reporters/many-errors'),
   )
-  expect(stderr).not.toContain('MaxListenersExceededWarning')
+  expect(result.stderr).not.toContain('MaxListenersExceededWarning')
+  expect(result.exitCode).not.toBe(0)
 })
 
 test('CLI reporter option preserves config file options', async () => {

--- a/test/e2e/test/reporters/junit.test.ts
+++ b/test/e2e/test/reporters/junit.test.ts
@@ -169,6 +169,9 @@ test('many errors without warning', async () => {
     '--root',
     resolve(import.meta.dirname, '../../fixtures/reporters/many-errors'),
   )
+  expect(stabilizeReport(result.stdout).split('\n')[1]).toMatchInlineSnapshot(
+    `"<testsuites name="vitest tests" tests="20" failures="20" errors="0" time="...">"`,
+  )
   expect(result.stderr).not.toContain('MaxListenersExceededWarning')
   expect(result.exitCode).not.toBe(0)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The fixture path was wrong and it's effectively (for some reason) running entire `test/e2e/snapshots` project:

```sh
$ pnpm -C test/e2e exec vitest --root test/fixtures/reporters/many-errors
...
 ✓  snapshots  snapshots.test.ts > non default snapshot format 9ms
 ✓  snapshots  snapshots.test.ts > --update works for workspace project 203ms
```

This is why `test/reporters/junit.test.ts:165:1 > many errors without warning` kept timing out.

The correct path is one directory up:

```sh
 $ pnpm -C test/e2e exec vitest --root fixtures/reporters/many-errors

 DEV  v5.0.0-beta.2 /home/hiroshi/code/others/vitest/test/e2e/fixtures/reporters/many-errors

 ❯ basic.test.ts (20 tests | 20 failed) 11ms
...
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
