### PR TITLE
test: use `vi.defineHelper` for vue render wrapper

### DIFF
--- a/packages/ui/client/test.ts
+++ b/packages/ui/client/test.ts
@@ -1,13 +1,17 @@
+import type { ComponentRenderOptions, RenderResult } from 'vitest-browser-vue'
 import { vTooltip } from 'floating-vue'
 import { vi } from 'vitest'
 import {
-  render as renderOriginal,
+  render as _render,
 } from 'vitest-browser-vue'
 
 export { page } from 'vitest/browser'
 
-export const render: typeof renderOriginal = vi.defineHelper((component, options) => {
-  return renderOriginal(component, {
+export const render = vi.defineHelper(<C>(
+  component: C,
+  options?: ComponentRenderOptions<C, any>,
+): PromiseLike<RenderResult<any>> => {
+  return _render(component, {
     ...options,
     global: {
       directives: {

--- a/packages/ui/client/test.ts
+++ b/packages/ui/client/test.ts
@@ -1,16 +1,13 @@
-import type { ComponentRenderOptions, RenderResult } from 'vitest-browser-vue'
 import { vTooltip } from 'floating-vue'
+import { vi } from 'vitest'
 import {
-  render as _render,
+  render as renderOriginal,
 } from 'vitest-browser-vue'
 
 export { page } from 'vitest/browser'
 
-export function render<C>(
-  component: C,
-  options?: ComponentRenderOptions<C, any>,
-): PromiseLike<RenderResult<any>> {
-  return _render(component, {
+export const render: typeof renderOriginal = vi.defineHelper((component, options) => {
+  return renderOriginal(component, {
     ...options,
     global: {
       directives: {
@@ -18,4 +15,4 @@ export function render<C>(
       },
     },
   })
-}
+})

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -29,6 +29,7 @@ const testConfig = defineConfig({
     browser: {
       enabled: true,
       traceView: true,
+      headless: true,
       provider:
         providerName === 'preview'
           ? preview()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is needed to make `vue.render` trace step to point to the callsite in tests:

<img width="1293" height="755" alt="image" src="https://github.com/user-attachments/assets/57a01558-58b6-4f58-9131-780c8d40a559" />

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
