### PR TITLE
fix(reporters): `summary` to intercept logger's streams even when they are not `process.std*` streams

### DIFF
--- a/packages/vitest/src/node/reporters/default.ts
+++ b/packages/vitest/src/node/reporters/default.ts
@@ -9,6 +9,9 @@ import { SummaryReporter } from './summary'
 
 export interface DefaultReporterOptions extends BaseOptions {
   summary?: boolean
+
+  /** @internal */
+  summaryOptions?: SummaryReporter['options']
 }
 
 export class DefaultReporter extends BaseReporter {
@@ -87,6 +90,6 @@ export class DefaultReporter extends BaseReporter {
 
   onInit(ctx: Vitest): void {
     super.onInit(ctx)
-    this.summary?.onInit(ctx, { verbose: this.verbose })
+    this.summary?.onInit(ctx, { verbose: this.verbose, ...this.options.summaryOptions })
   }
 }

--- a/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
@@ -14,7 +14,7 @@ const MOVE_CURSOR_ONE_ROW_UP = `${ESC}1A`
 const SYNC_START = `${ESC}?2026h`
 const SYNC_END = `${ESC}?2026l`
 
-interface Options {
+export interface Options {
   logger: Vitest['logger']
   interval?: number
   threshold?: number

--- a/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
@@ -2,6 +2,10 @@ import type { Writable } from 'node:stream'
 import type { Vitest } from '../../core'
 import { stripVTControlCharacters } from 'node:util'
 
+/** Minimum time between two renders, no matter how many scheduled renderes were called */
+const DEFAULT_RENDER_THRESHOLD_MS = 100
+
+/** Interval between automatic renders. If no test state changes happened, this will increase just duration field */
 const DEFAULT_RENDER_INTERVAL_MS = 1_000
 
 const ESC = '\x1B['
@@ -13,6 +17,7 @@ const SYNC_END = `${ESC}?2026l`
 interface Options {
   logger: Vitest['logger']
   interval?: number
+  threshold?: number
   getWindow: () => string[]
 }
 
@@ -36,10 +41,12 @@ export class WindowRenderer {
 
   constructor(options: Options) {
     this.options = {
-      interval: DEFAULT_RENDER_INTERVAL_MS,
       ...options,
+      threshold: options.threshold ?? DEFAULT_RENDER_THRESHOLD_MS,
+      interval: options.interval ?? DEFAULT_RENDER_INTERVAL_MS,
     }
 
+    // Capture the original write methods early, before intercepting these
     this.streams = {
       output: options.logger.outputStream.write.bind(options.logger.outputStream),
       error: options.logger.errorStream.write.bind(options.logger.errorStream),
@@ -49,6 +56,14 @@ export class WindowRenderer {
       this.interceptStream(process.stdout, 'output'),
       this.interceptStream(process.stderr, 'error'),
     )
+
+    // Intercept calls to custom VitestOptions.stdout and stderr streams
+    if (options.logger.outputStream !== process.stdout) {
+      this.cleanups.push(this.interceptStream(options.logger.outputStream, 'output'))
+    }
+    if (options.logger.errorStream !== process.stderr) {
+      this.cleanups.push(this.interceptStream(options.logger.errorStream, 'error'))
+    }
 
     // Write buffered content on unexpected exits, e.g. direct `process.exit()` calls
     this.options.logger.onTerminalCleanup(() => {
@@ -86,9 +101,14 @@ export class WindowRenderer {
       this.renderScheduled = true
       this.flushBuffer()
 
-      setTimeout(() => {
+      if (this.options.threshold) {
+        setTimeout(() => {
+          this.renderScheduled = false
+        }, this.options.threshold).unref()
+      }
+      else {
         this.renderScheduled = false
-      }, 100).unref()
+      }
     }
   }
 
@@ -121,9 +141,12 @@ export class WindowRenderer {
   }
 
   private render(message?: string, type: StreamType = 'output') {
+    this.write(SYNC_START)
+
     if (this.finished) {
       this.clearWindow()
-      return this.write(message || '', type)
+      this.write(message || '', type)
+      return this.write(SYNC_END)
     }
 
     const windowContent = this.options.getWindow()
@@ -134,7 +157,6 @@ export class WindowRenderer {
       padding -= getRenderedRowCount([message], this.options.logger.getColumns())
     }
 
-    this.write(SYNC_START)
     this.clearWindow()
 
     if (message) {
@@ -165,7 +187,7 @@ export class WindowRenderer {
     this.windowHeight = 0
   }
 
-  private interceptStream(stream: NodeJS.WriteStream, type: StreamType) {
+  private interceptStream(stream: NodeJS.WriteStream | Writable, type: StreamType) {
     const original = stream.write
 
     // @ts-expect-error -- not sure how 2 overloads should be typed

--- a/packages/vitest/src/node/reporters/summary.ts
+++ b/packages/vitest/src/node/reporters/summary.ts
@@ -12,6 +12,12 @@ const FINISHED_TEST_CLEANUP_TIME_MS = 1_000
 
 interface Options {
   verbose?: boolean
+
+  /** @internal */
+  interval?: ConstructorParameters<typeof WindowRenderer>[0]['interval']
+
+  /** @internal */
+  threshold?: ConstructorParameters<typeof WindowRenderer>[0]['threshold']
 }
 
 interface Counter {
@@ -76,6 +82,8 @@ export class SummaryReporter implements Reporter {
     this.renderer = new WindowRenderer({
       logger: ctx.logger,
       getWindow: () => this.createSummary(),
+      interval: this.options.interval,
+      threshold: this.options.threshold,
     })
 
     this.ctx.onClose(() => {

--- a/packages/vitest/src/node/reporters/summary.ts
+++ b/packages/vitest/src/node/reporters/summary.ts
@@ -1,6 +1,7 @@
 import type { Vitest } from '../core'
 import type { TestSpecification } from '../test-specification'
 import type { Reporter } from '../types/reporter'
+import type { Options as WindowRendererOptions } from './renderers/windowedRenderer'
 import type { ReportedHookContext, TestCase, TestModule } from './reported-tasks'
 import c from 'tinyrainbow'
 import { F_POINTER, F_TREE_NODE_END, F_TREE_NODE_MIDDLE } from './renderers/figures'
@@ -14,10 +15,10 @@ interface Options {
   verbose?: boolean
 
   /** @internal */
-  interval?: ConstructorParameters<typeof WindowRenderer>[0]['interval']
+  interval?: WindowRendererOptions['interval']
 
   /** @internal */
-  threshold?: ConstructorParameters<typeof WindowRenderer>[0]['threshold']
+  threshold?: WindowRendererOptions['threshold']
 }
 
 interface Counter {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     acorn-walk:
       specifier: ^8.3.5
       version: 8.3.5
+    ansivision:
+      specifier: ^0.2.7
+      version: 0.2.7
     birpc:
       specifier: ^4.0.0
       version: 4.0.0
@@ -1430,6 +1433,9 @@ importers:
       '@vitest/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      ansivision:
+        specifier: 'catalog:'
+        version: 0.2.7
       flatted:
         specifier: 'catalog:'
         version: 3.4.2
@@ -1712,6 +1718,9 @@ packages:
 
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
+
+  '@ansi-tools/parser@1.0.15':
+    resolution: {integrity: sha512-Y+PIdkMVu8I27z344G65nni8c7TlPtVv/7Kw/ncS6lbpJKBRT00bTtyAlPL/aVjkCrLoYlUwsgvoGJ/iWhH52w==}
 
   '@antfu/eslint-config@7.6.1':
     resolution: {integrity: sha512-MRiskHFHYPF0R3eWDUkPPiHUM3fWXwAviVv9O8iMH5hVJkgp60oJYBMzbImKdqSGMuuyOMY3GXxWbH60t9rK0g==}
@@ -5799,6 +5808,9 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  ansivision@0.2.7:
+    resolution: {integrity: sha512-D2y8fZ2G+S0Ni/Uw2ki9bGpsBu0WkNRSAARJK/on+xb4AzEkNSM2oUNfiJXqjN2wkjHGklWzol8qYDWy0EMyYg==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -10560,6 +10572,8 @@ snapshots:
 
   '@adobe/css-tools@4.4.0': {}
 
+  '@ansi-tools/parser@1.0.15': {}
+
   '@antfu/eslint-config@7.6.1(@typescript-eslint/rule-tester@8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3))(@typescript-eslint/utils@8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.29)(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@packages+vitest)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
@@ -14328,6 +14342,10 @@ snapshots:
       entities: 2.2.0
 
   ansis@4.2.0: {}
+
+  ansivision@0.2.7:
+    dependencies:
+      '@ansi-tools/parser': 1.0.15
 
   anymatch@3.1.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ catalog:
   '@vitejs/plugin-vue': ^6.0.4
   '@vueuse/core': ^14.2.1
   acorn-walk: ^8.3.5
+  ansivision: ^0.2.7
   birpc: ^4.0.0
   cac: ^6.7.14
   chai: ^6.2.2

--- a/test/e2e/fixtures/reporters/summary/first.test.ts
+++ b/test/e2e/fixtures/reporters/summary/first.test.ts
@@ -1,0 +1,21 @@
+import { setTimeout } from 'node:timers/promises'
+import { describe, test } from 'vitest'
+
+const TIMEOUT = 100;
+
+// Test queue time
+await setTimeout(TIMEOUT);
+
+describe("suite", () => {
+  test("one",async () => {
+    await setTimeout(TIMEOUT);
+  })
+
+  test("two", async () => {
+    await setTimeout(TIMEOUT);
+  })
+
+  test("three", async () => {
+    await setTimeout(TIMEOUT);
+  })
+})

--- a/test/e2e/fixtures/reporters/summary/second.test.ts
+++ b/test/e2e/fixtures/reporters/summary/second.test.ts
@@ -1,0 +1,21 @@
+import { setTimeout } from 'node:timers/promises'
+import { describe, test } from 'vitest'
+
+const TIMEOUT = 100;
+
+// Test queue time
+await setTimeout(TIMEOUT);
+
+describe("suite", () => {
+  test("one",async () => {
+    await setTimeout(TIMEOUT);
+  })
+
+  test("two", async () => {
+    await setTimeout(TIMEOUT);
+  })
+
+  test("three", async () => {
+    await setTimeout(TIMEOUT);
+  })
+})

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -26,6 +26,7 @@
     "@vitest/mocker": "workspace:*",
     "@vitest/runner": "workspace:*",
     "@vitest/utils": "workspace:*",
+    "ansivision": "catalog:",
     "flatted": "catalog:",
     "jest-image-snapshot": "^6.5.1",
     "obug": "^2.1.1",

--- a/test/e2e/test/reporters/summary.test.ts
+++ b/test/e2e/test/reporters/summary.test.ts
@@ -1,0 +1,205 @@
+import type { Renderer } from 'ansivision'
+import { runVitest, StableTestFileOrderSorter } from '#test-utils'
+import { renderString } from 'ansivision'
+import { normalize } from 'pathe'
+import { expect, test } from 'vitest'
+
+test('states of running tests are reported', async () => {
+  const { stdout } = await runVitest({
+    root: 'fixtures/reporters/summary',
+    reporters: [['default', { summary: true, summaryOptions: { threshold: 0 }, isTTY: true }]],
+    config: false,
+    fileParallelism: false,
+    sequence: { sequencer: StableTestFileOrderSorter },
+  }, undefined, { preserveAnsi: true, tty: true })
+
+  const frames = await renderString(stdout).then(trimFrames)
+
+  expect(frames).toMatchInlineSnapshot(`
+    "
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+
+     ❯ first.test.ts [queued]
+
+     Test Files 0 passed (2)
+          Tests 0 passed (0)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+
+     ❯ first.test.ts 0/3
+
+     Test Files 0 passed (2)
+          Tests 0 passed (3)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+
+     ❯ first.test.ts 1/3
+
+     Test Files 0 passed (2)
+          Tests 1 passed (3)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+
+     ❯ first.test.ts 2/3
+
+     Test Files 0 passed (2)
+          Tests 2 passed (3)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+
+     ❯ first.test.ts 3/3
+
+     Test Files 0 passed (2)
+          Tests 3 passed (3)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+
+
+     Test Files 1 passed (2)
+          Tests 3 passed (3)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+
+     ❯ second.test.ts [queued]
+
+     Test Files 1 passed (2)
+          Tests 3 passed (3)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+
+     ❯ second.test.ts 0/3
+
+     Test Files 1 passed (2)
+          Tests 3 passed (6)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+
+     ❯ second.test.ts 1/3
+
+     Test Files 1 passed (2)
+          Tests 4 passed (6)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+
+     ❯ second.test.ts 2/3
+
+     Test Files 1 passed (2)
+          Tests 5 passed (6)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+
+     ❯ second.test.ts 3/3
+
+     Test Files 1 passed (2)
+          Tests 6 passed (6)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+     ✓ second.test.ts (3 tests) <time>
+
+
+     Test Files 2 passed (2)
+          Tests 6 passed (6)
+       Start at <time>
+       Duration <time>
+
+    -------------------------------------------------------
+
+     RUN  v[...] <process-cwd>/fixtures/reporters/summary
+
+     ✓ first.test.ts (3 tests) <time>
+     ✓ second.test.ts (3 tests) <time>
+
+     Test Files  2 passed (2)
+          Tests  6 passed (6)
+       Start at  <time>
+       Duration  <time> (transform <time>, setup <time>, import <time>, tests <time>, environment <time>)
+
+    "
+  `)
+})
+
+function trimFrames(frames: Renderer) {
+  return Array.from(frames)
+  // Make each frame stable
+    .map(trimReporterOutput)
+
+  // Filter possible duplicate frames. Maybe just duration changed (that we stabilized to <time>, so frame is duplicate)
+    .filter((item, index, all) => all.indexOf(item) === index)
+
+  // Separate frames with divider
+    .join(`\n${'-'.repeat(55)}\n`)
+}
+
+function trimReporterOutput(report: string) {
+  return report
+    .replace(/\d+ms/g, '<time>')
+    .replace(/\d+\.\d+s/g, '<time>')
+    .replace(normalize(process.cwd()), '<process-cwd>')
+    .replace(/RUN {2}v([\w\-.]+) /, 'RUN  v[...] ')
+    .replace(/(Start at {1,2})\d+:\d+:\d+/, '$1<time>')
+    .split('\n')
+    .join('\n')
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

While adding test cases for summary reporter, I noticed bug around window rendered. It's really edge-case bug that happens only when using Node API and passing custom `stdout`/`stderr` while using summary reporter.

So this is more of a `test(reporter): summary reporter tests` than a `fix:`, but fix has more priority.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
