### PR TITLE
fix(expect): allow function parameter in expect().resolves

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -1075,6 +1075,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       utils.flag(this, 'error', error)
       const test: Test = utils.flag(this, 'vitest-test')
       const obj = utils.flag(this, 'object')
+      const wrapper = typeof obj === 'function' ? obj() : obj // for jest compat
 
       if (utils.flag(this, 'poll')) {
         throw new SyntaxError(
@@ -1082,9 +1083,9 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
         )
       }
 
-      if (typeof obj?.then !== 'function') {
+      if (typeof wrapper?.then !== 'function') {
         throw new TypeError(
-          `You must provide a Promise to expect() when using .resolves, not '${typeof obj}'.`,
+          `You must provide a Promise to expect() when using .resolves, not '${typeof wrapper}'.`,
         )
       }
 
@@ -1098,7 +1099,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
           return (...args: any[]) => {
             utils.flag(this, '_name', key)
-            const promise = Promise.resolve(obj).then(
+            const promise = Promise.resolve(wrapper).then(
               (value: any) => {
                 utils.flag(this, 'object', value)
                 return result.call(this, ...args)


### PR DESCRIPTION
## fix(expect): allow function parameter in `expect().resolves`

Fixes #10281

### Problem

When calling `expect(someFn).resolves.toThrow()`, vitest throws:
```
TypeError: You must provide a Promise to expect() when using .resolves, not 'function'.
```

This is because the `.resolves` implementation directly checks if the value has a `.then` method, without first invoking it if it's a function.

### Solution

Added the same function-handling logic that `.rejects` already has:

```ts
const wrapper = typeof obj === 'function' ? obj() : obj // for jest compat
```

This mirrors the existing behavior in `.rejects` (line 1150 of the original file), which already calls the function before checking for `.then`.

Jest has supported this since [jest#15713](https://github.com/jestjs/jest/issues/15713). This change brings vitest in line with Jest's behavior.

### Changes
- `packages/expect/src/jest-expect.ts`: Added function invocation wrapper in `__VITEST_RESOLVES__` handler, matching the pattern already used in `__VITEST_REJECTS__`.
