### PR TITLE
fix(reporters): fix blob file name with label

### DIFF
--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -103,8 +103,8 @@ export class BlobReporter implements Reporter {
       outputFile = [
         'blob',
         this.ctx.config.mergeReportsLabel,
-        shard ? `-${shard.index}-${shard.count}` : '',
-      ].join('')
+        shard ? `${shard.index}-${shard.count}` : '',
+      ].filter(Boolean).join('-')
 
       outputFile = `${sanitizeFilePath(outputFile)}.json`
 

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -2,7 +2,7 @@ import type { RunVitestConfig } from '#test-utils'
 import type { File, Test } from '@vitest/runner/types'
 import type { TestUserConfig, Vitest } from 'vitest/node'
 import type { MergeReport } from 'vitest/src/node/reporters/blob.js'
-import { existsSync, rmSync } from 'node:fs'
+import { existsSync, readdirSync, rmSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { buildTestTree, runVitest, useFS } from '#test-utils'
 import { playwright } from '@vitest/browser-playwright'
@@ -652,10 +652,17 @@ test("macos only", () => {})
       },
     }
   `)
+  const blobDir = resolve(root, '.vitest/blob')
   const result = await runVitest({
     root,
-    mergeReports: resolve(root, '.vitest/blob'),
+    mergeReports: blobDir,
   })
+  expect(readdirSync(blobDir)).toMatchInlineSnapshot(`
+    [
+      "blob-linux.json",
+      "blob-macos.json",
+    ]
+  `)
   expect(trimReporterOutput(result.stdout)).toMatchInlineSnapshot(`
     "✓  linux  first.test.ts > always good <time>
      ✓  linux  first.test.ts > works on linux <time>


### PR DESCRIPTION
### Description

The hyphen was missing for blob label and the file like `bloblinux.json` was generated.

*Before*

```sh
$ VITEST_BLOB_LABEL=linux pnpm -C examples/basic test --run --r
eporter=blob

> @vitest/example-test@ test /home/hiroshi/code/others/vitest-wt2/examples/basic
> vitest --run --reporter=blob

blob report written to /home/hiroshi/code/others/vitest-wt2/examples/basic/.vitest/blob/bloblinux.json
```

*After*

```sh
$ VITEST_BLOB_LABEL=linux pnpm -C examples/basic test --run --reporter=blob

> @vitest/example-test@ test /home/hiroshi/code/others/vitest-wt2/examples/basic
> vitest --run --reporter=blob

blob report written to /home/hiroshi/code/others/vitest-wt2/examples/basic/.vitest/blob/blob-linux.json
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
