### PR TITLE
feat(browser): include `originalReferencePath` on visual regression artifacts

### DIFF
--- a/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
+++ b/packages/browser/src/client/tester/expect/toMatchScreenshot.ts
@@ -97,6 +97,7 @@ export default async function toMatchScreenshot(
         kind: 'visual-regression',
         message: result.message,
         attachments,
+        originalReferencePath: result.reference?.path,
       })
     }
   }

--- a/packages/runner/src/types/tasks.ts
+++ b/packages/runner/src/types/tasks.ts
@@ -1365,6 +1365,12 @@ export interface VisualRegressionArtifact extends TestArtifactBase {
   kind: 'visual-regression'
   message: string
   attachments: VisualRegressionArtifactAttachment[]
+  /**
+   * Original file system path to the reference screenshot, before attachment resolution.
+   * Absent when the matcher could not determine a reference (e.g. an `unstable-screenshot`
+   * outcome without a stored reference).
+   */
+  originalReferencePath?: string
 }
 
 /**

--- a/test/browser/specs/to-match-screenshot.test.ts
+++ b/test/browser/specs/to-match-screenshot.test.ts
@@ -264,3 +264,60 @@ describe('--watch', () => {
     },
   )
 })
+
+describe('artifact', () => {
+  test(
+    'exposes the original `__screenshots__` reference path on the visual-regression artifact',
+    async () => {
+      const artifacts: Array<{
+        type: string
+        originalReferencePath?: string
+      }> = []
+
+      await runInlineTests(
+        {
+          [testFilename]: testContent,
+          'utils.ts': utilsContent,
+        },
+        {
+          $cliOptions: {
+            watch: false,
+          },
+          browser: {
+            enabled: true,
+            screenshotFailures: false,
+            provider,
+            headless: true,
+            instances,
+            viewport: {
+              width: 400,
+              height: 200,
+            },
+          },
+          update: 'new',
+          reporters: [
+            'verbose',
+            {
+              onTestCaseArtifactRecord(_testCase, artifact) {
+                if (artifact.type === 'internal:toMatchScreenshot') {
+                  artifacts.push({
+                    type: artifact.type,
+                    originalReferencePath: artifact.originalReferencePath,
+                  })
+                }
+              },
+            },
+          ],
+        },
+      )
+
+      // One artifact per browser instance, all from the missing-reference outcome.
+      expect(artifacts).toHaveLength(instances.length)
+      for (const artifact of artifacts) {
+        expect(artifact.originalReferencePath).toMatch(
+          new RegExp(`__screenshots__[\\\\/]${testFilename.replace(/\./g, '\\\\.')}[\\\\/]${testName}-[\\w-]+\\.png$`),
+        )
+      }
+    },
+  )
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adds an `originalReferencePath` field to `VisualRegressionArtifact` (`internal:toMatchScreenshot`) that preserves the on-disk `__screenshots__` path of the reference screenshot before it gets rewritten by `resolveTestAttachment`.

Today, when a `toMatchScreenshot` assertion fails, the artifact's reference attachment carries a `path` that's the resolved location (`<attachmentsDir>/<sha1>.png`). The original `__screenshots__/<spec>/<test>/<name>-<browser>-<platform>.png` path is no longer recoverable from the artifact — reporter authors have to either re-derive it (mirroring vitest's internal `sanitize` + `resolveScreenshotPath` logic, which is private) or hash-walk the screenshot directory to match it up.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed. *This is so small that I didn't file an issue, but can do if necessary!*
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
