### PR TITLE
perf(ui): html reporter serializes module graph like blob reporter

### DIFF
--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -1,18 +1,19 @@
 import type {
-  ModuleGraphData,
   RunnerTestFile,
   SerializedRootConfig,
 } from 'vitest'
+import type { SerializedProjectEnvironmentModules } from '../../../../vitest/src/utils/module-graph-serialization'
 import type { VitestClient, VitestClientRpc } from './ws'
 import { decompressSync, strFromU8 } from 'fflate'
 import { parse } from 'flatted'
 import { reactive } from 'vue'
+import { deriveModuleGraphData } from '../../../../vitest/src/utils/module-graph-serialization'
 import { StateManager } from './state'
 
 export interface HTMLReportMetadata {
   files: RunnerTestFile[]
   config: SerializedRootConfig
-  moduleGraph: Record<string, Record<string, ModuleGraphData>>
+  environmentModules: Record<string, SerializedProjectEnvironmentModules>
   unhandledErrors: unknown[]
   testModules: {
     projectName: string
@@ -41,8 +42,12 @@ function deserializeReportMetadata(metadata: HTMLReportMetadata) {
     getConfig: async () => {
       return metadata.config
     },
-    getModuleGraph: async (projectName, id) => {
-      return metadata.moduleGraph[projectName]?.[id]
+    getModuleGraph: async (projectName, id, browser) => {
+      return deriveModuleGraphData(
+        metadata.environmentModules[projectName],
+        id,
+        browser,
+      )
     },
     getUnhandledErrors: async () => {
       return metadata.unhandledErrors

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -9,7 +9,7 @@ import { stringify } from 'flatted'
 import { dirname, relative, resolve } from 'pathe'
 import { globSync } from 'tinyglobby'
 import c from 'tinyrainbow'
-import { getModuleGraph } from '../../vitest/src/utils/graph'
+import { serializeProjectModules } from '../../vitest/src/utils/module-graph-serialization'
 
 interface PotentialConfig {
   outputFile?: string | Partial<Record<string, string>>
@@ -142,7 +142,7 @@ async function serializeReportMetadata(
     files: [],
     config: ctx.serializedRootConfig,
     unhandledErrors: [...unhandledErrors],
-    moduleGraph: {},
+    environmentModules: {},
     testModules: [],
     sourceCode: {
       codeTable: [],
@@ -168,8 +168,9 @@ async function serializeReportMetadata(
     result.sourceCode.codeTable.push(code)
     return index
   }
-
-  const promises: Promise<void>[] = []
+  ctx.projects.forEach((project) => {
+    result.environmentModules[project.name] = serializeProjectModules(project)
+  })
 
   for (const testModule of testModules) {
     result.files.push(testModule.task)
@@ -193,20 +194,7 @@ async function serializeReportMetadata(
       }
       catch {}
     }
-
-    // TODO: https://github.com/vitest-dev/vitest/issues/9763
-    promises.push((async () => {
-      result.moduleGraph[projectName] ??= {}
-      result.moduleGraph[projectName][testModule.moduleId] = await getModuleGraph(
-        ctx,
-        projectName,
-        testModule.moduleId,
-        project.config.browser.enabled,
-      )
-    })())
   }
-
-  await Promise.all(promises)
 
   return result
 }

--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -1,6 +1,6 @@
 import type { File } from '@vitest/runner'
 import type { SerializedError } from '@vitest/utils'
-import type { DevEnvironment, EnvironmentModuleNode } from 'vite'
+import type { SerializedProjectEnvironmentModules } from '../../utils/module-graph-serialization'
 import type { Vitest } from '../core'
 import type { TestProject } from '../project'
 import type { Reporter } from '../types/reporter'
@@ -11,6 +11,7 @@ import { sanitizeFilePath } from '@vitest/utils/helpers'
 import { parse, stringify } from 'flatted'
 import { dirname, resolve } from 'pathe'
 import { getOutputFile } from '../../utils/config-helpers'
+import { deserializeEnvironmentModuleGraph, serializeProjectModules } from '../../utils/module-graph-serialization'
 
 export interface BlobOptions {
   outputFile?: string
@@ -50,29 +51,7 @@ export class BlobReporter implements Reporter {
 
     const environmentModules: MergeReportEnvironmentModules = {}
     this.ctx.projects.forEach((project) => {
-      const serializedProject: MergeReportEnvironmentModules[string] = {
-        environments: {},
-        external: [],
-      }
-      Object.entries(project.vite.environments).forEach(([environmentName, environment]) => {
-        serializedProject.environments[environmentName] = serializeEnvironmentModuleGraph(
-          environment,
-        )
-      })
-
-      if (project.browser?.vite.environments.client) {
-        serializedProject.browser = serializeEnvironmentModuleGraph(
-          project.browser.vite.environments.client,
-        )
-      }
-
-      for (const [id, value] of project._resolver.externalizeCache.entries()) {
-        if (typeof value === 'string') {
-          serializedProject.external.push([id, value])
-        }
-      }
-
-      environmentModules[project.name] = serializedProject
+      environmentModules[project.name] = serializeProjectModules(project)
     })
 
     const content = stringify([
@@ -235,107 +214,5 @@ export type MergeReport = [
 ]
 
 interface MergeReportEnvironmentModules {
-  [projectName: string]: {
-    environments: {
-      [environmentName: string]: SerializedEnvironmentModuleGraph
-    }
-    browser?: SerializedEnvironmentModuleGraph
-    external: [id: string, externalized: string][]
-  }
-}
-
-type SerializedEnvironmentModuleNode = [
-  id: number,
-  file: number,
-  url: number,
-  importedIds: number[],
-]
-
-interface SerializedEnvironmentModuleGraph {
-  idTable: string[]
-  modules: SerializedEnvironmentModuleNode[]
-}
-
-function serializeEnvironmentModuleGraph(
-  environment: DevEnvironment,
-): SerializedEnvironmentModuleGraph {
-  const idTable: string[] = []
-  const idMap = new Map<string, number>()
-
-  const getIdIndex = (id: string) => {
-    const existing = idMap.get(id)
-    if (existing != null) {
-      return existing
-    }
-    const next = idTable.length
-    idMap.set(id, next)
-    idTable.push(id)
-    return next
-  }
-
-  const modules: SerializedEnvironmentModuleNode[] = []
-  for (const [id, mod] of environment.moduleGraph.idToModuleMap.entries()) {
-    // Vite can generate module with `file = ""` for module id "#..."
-    // when the actual module doesn't exist (e.g. resolve failure or mocked module)
-    if (mod.file == null) {
-      continue
-    }
-
-    const importedIds: number[] = []
-    for (const importedNode of mod.importedModules) {
-      if (importedNode.id !== null) {
-        importedIds.push(getIdIndex(importedNode.id))
-      }
-    }
-
-    modules.push([
-      getIdIndex(id),
-      getIdIndex(mod.file),
-      getIdIndex(mod.url),
-      importedIds,
-    ])
-  }
-
-  return {
-    idTable,
-    modules,
-  }
-}
-
-function deserializeEnvironmentModuleGraph(
-  environment: DevEnvironment,
-  serialized: SerializedEnvironmentModuleGraph,
-): void {
-  const nodesById = new Map<string, EnvironmentModuleNode>()
-
-  serialized.modules.forEach(([id, file, url]) => {
-    const moduleId = serialized.idTable[id]
-    const filePath = serialized.idTable[file]
-    const urlPath = serialized.idTable[url]
-    // `createFileOnlyEntry('')` normalizes the file to ".". This keeps
-    // the graph usable, but doesn't perfectly round-trip Vite's `file = ""`
-    // nodes for ids like "#...".
-    // We may just do moduleNode.file = filePath in the future.
-    const moduleNode = environment.moduleGraph.createFileOnlyEntry(filePath)
-    moduleNode.url = urlPath
-    moduleNode.id = moduleId
-    moduleNode.transformResult = {
-      // print error checks that transformResult is set
-      code: ' ',
-      map: null,
-    }
-    environment.moduleGraph.idToModuleMap.set(moduleId, moduleNode)
-    nodesById.set(moduleId, moduleNode)
-  })
-
-  serialized.modules.forEach(([id, _file, _url, importedIds]) => {
-    const moduleId = serialized.idTable[id]
-    const moduleNode = nodesById.get(moduleId)!
-    importedIds.forEach((importedIdIndex) => {
-      const importedId = serialized.idTable[importedIdIndex]
-      const importedNode = nodesById.get(importedId)!
-      moduleNode.importedModules.add(importedNode)
-      importedNode.importers.add(moduleNode)
-    })
-  })
+  [projectName: string]: SerializedProjectEnvironmentModules
 }

--- a/packages/vitest/src/utils/module-graph-serialization.ts
+++ b/packages/vitest/src/utils/module-graph-serialization.ts
@@ -1,0 +1,135 @@
+import type { DevEnvironment, EnvironmentModuleNode } from 'vite'
+import type { TestProject } from '../node/project'
+
+export type SerializedEnvironmentModuleNode = [
+  id: number,
+  file: number,
+  url: number,
+  importedIds: number[],
+]
+
+export interface SerializedEnvironmentModuleGraph {
+  idTable: string[]
+  modules: SerializedEnvironmentModuleNode[]
+}
+
+export interface SerializedProjectEnvironmentModules {
+  environments: {
+    [environmentName: string]: SerializedEnvironmentModuleGraph
+  }
+  browser?: SerializedEnvironmentModuleGraph
+  external: [id: string, externalized: string][]
+}
+
+export function serializeEnvironmentModuleGraph(
+  environment: DevEnvironment,
+): SerializedEnvironmentModuleGraph {
+  const idTable: string[] = []
+  const idMap = new Map<string, number>()
+
+  const getIdIndex = (id: string) => {
+    const existing = idMap.get(id)
+    if (existing != null) {
+      return existing
+    }
+    const next = idTable.length
+    idMap.set(id, next)
+    idTable.push(id)
+    return next
+  }
+
+  const modules: SerializedEnvironmentModuleNode[] = []
+  for (const [id, mod] of environment.moduleGraph.idToModuleMap.entries()) {
+    // Vite can generate module with `file = ""` for module id "#..."
+    // when the actual module doesn't exist (e.g. resolve failure or mocked module)
+    if (mod.file == null) {
+      continue
+    }
+
+    const importedIds: number[] = []
+    for (const importedNode of mod.importedModules) {
+      if (importedNode.id !== null) {
+        importedIds.push(getIdIndex(importedNode.id))
+      }
+    }
+
+    modules.push([
+      getIdIndex(id),
+      getIdIndex(mod.file),
+      getIdIndex(mod.url),
+      importedIds,
+    ])
+  }
+
+  return {
+    idTable,
+    modules,
+  }
+}
+
+export function deserializeEnvironmentModuleGraph(
+  environment: DevEnvironment,
+  serialized: SerializedEnvironmentModuleGraph,
+): void {
+  const nodesById = new Map<string, EnvironmentModuleNode>()
+
+  serialized.modules.forEach(([id, file, url]) => {
+    const moduleId = serialized.idTable[id]
+    const filePath = serialized.idTable[file]
+    const urlPath = serialized.idTable[url]
+    // `createFileOnlyEntry('')` normalizes the file to ".". This keeps
+    // the graph usable, but doesn't perfectly round-trip Vite's `file = ""`
+    // nodes for ids like "#...".
+    // We may just do moduleNode.file = filePath in the future.
+    const moduleNode = environment.moduleGraph.createFileOnlyEntry(filePath)
+    moduleNode.url = urlPath
+    moduleNode.id = moduleId
+    moduleNode.transformResult = {
+      // print error checks that transformResult is set
+      code: ' ',
+      map: null,
+    }
+    environment.moduleGraph.idToModuleMap.set(moduleId, moduleNode)
+    nodesById.set(moduleId, moduleNode)
+  })
+
+  serialized.modules.forEach(([id, _file, _url, importedIds]) => {
+    const moduleId = serialized.idTable[id]
+    const moduleNode = nodesById.get(moduleId)!
+    importedIds.forEach((importedIdIndex) => {
+      const importedId = serialized.idTable[importedIdIndex]
+      const importedNode = nodesById.get(importedId)!
+      moduleNode.importedModules.add(importedNode)
+      importedNode.importers.add(moduleNode)
+    })
+  })
+}
+
+export function serializeProjectModules(
+  project: TestProject,
+): SerializedProjectEnvironmentModules {
+  const serialized: SerializedProjectEnvironmentModules = {
+    environments: {},
+    external: [],
+  }
+
+  Object.entries(project.vite.environments).forEach(([environmentName, environment]) => {
+    serialized.environments[environmentName] = serializeEnvironmentModuleGraph(
+      environment,
+    )
+  })
+
+  if (project.browser?.vite.environments.client) {
+    serialized.browser = serializeEnvironmentModuleGraph(
+      project.browser.vite.environments.client,
+    )
+  }
+
+  for (const [id, value] of project._resolver.externalizeCache.entries()) {
+    if (typeof value === 'string') {
+      serialized.external.push([id, value])
+    }
+  }
+
+  return serialized
+}

--- a/packages/vitest/src/utils/module-graph-serialization.ts
+++ b/packages/vitest/src/utils/module-graph-serialization.ts
@@ -1,5 +1,6 @@
 import type { DevEnvironment, EnvironmentModuleNode } from 'vite'
 import type { TestProject } from '../node/project'
+import type { ModuleGraphData } from '../types/general'
 
 export type SerializedEnvironmentModuleNode = [
   id: number,
@@ -18,7 +19,9 @@ export interface SerializedProjectEnvironmentModules {
     [environmentName: string]: SerializedEnvironmentModuleGraph
   }
   browser?: SerializedEnvironmentModuleGraph
+  browserCacheDir?: string
   external: [id: string, externalized: string][]
+  setupFiles: string[]
 }
 
 export function serializeEnvironmentModuleGraph(
@@ -111,6 +114,7 @@ export function serializeProjectModules(
   const serialized: SerializedProjectEnvironmentModules = {
     environments: {},
     external: [],
+    setupFiles: project.config.setupFiles,
   }
 
   Object.entries(project.vite.environments).forEach(([environmentName, environment]) => {
@@ -123,6 +127,7 @@ export function serializeProjectModules(
     serialized.browser = serializeEnvironmentModuleGraph(
       project.browser.vite.environments.client,
     )
+    serialized.browserCacheDir = project.browser.vite.config.cacheDir
   }
 
   for (const [id, value] of project._resolver.externalizeCache.entries()) {
@@ -132,4 +137,126 @@ export function serializeProjectModules(
   }
 
   return serialized
+}
+
+interface DeserializedGraph {
+  adjacency: Map<string, string[]>
+  files: Map<string, string>
+}
+
+function deserializeGraph(serialized: SerializedEnvironmentModuleGraph): DeserializedGraph {
+  const adjacency = new Map<string, string[]>()
+  const files = new Map<string, string>()
+
+  for (const [idIndex, fileIndex, _urlIndex, importedIds] of serialized.modules) {
+    const id = serialized.idTable[idIndex]
+    files.set(id, serialized.idTable[fileIndex])
+    adjacency.set(id, importedIds.map(i => serialized.idTable[i]))
+  }
+
+  return { adjacency, files }
+}
+
+function clearId(id?: string | null) {
+  return id?.replace(/\?v=\w+$/, '') || ''
+}
+
+const emptyModuleGraph: ModuleGraphData = {
+  graph: {},
+  externalized: [],
+  inlined: [],
+}
+
+// Static HTML reports cannot call getModuleGraph because they only have the
+// serialized environment graph. Keep this traversal behavior aligned with
+// packages/vitest/src/utils/graph.ts#getModuleGraph; if the two paths drift
+// further, consider extracting a shared traversal over a small graph adapter.
+export function deriveModuleGraphData(
+  projectModules: SerializedProjectEnvironmentModules | undefined,
+  testFilePath: string,
+  browser = false,
+): ModuleGraphData {
+  if (!projectModules) {
+    return emptyModuleGraph
+  }
+
+  const externalCache = new Map(projectModules.external)
+  let serializedGraph: SerializedEnvironmentModuleGraph | undefined
+
+  if (browser && projectModules.browser) {
+    serializedGraph = projectModules.browser
+  }
+  else {
+    for (const environmentName in projectModules.environments) {
+      const environment = projectModules.environments[environmentName]
+      if (environment.modules.some(([idIndex]) => environment.idTable[idIndex] === testFilePath)) {
+        serializedGraph = environment
+        break
+      }
+    }
+  }
+
+  if (!serializedGraph) {
+    return emptyModuleGraph
+  }
+
+  const graph: Record<string, string[]> = {}
+  const externalized = new Set<string>()
+  const inlined = new Set<string>()
+  const seen = new Map<string, string>()
+  const browserCacheDir = projectModules.browserCacheDir
+  const { adjacency, files } = deserializeGraph(serializedGraph)
+
+  function visit(moduleId?: string | null) {
+    if (!moduleId) {
+      return
+    }
+    if (
+      moduleId === '\0vitest/browser'
+      || moduleId.includes('plugin-vue:export-helper')
+    ) {
+      return
+    }
+    if (seen.has(moduleId)) {
+      return seen.get(moduleId)
+    }
+
+    const id = clearId(moduleId)
+    seen.set(moduleId, id)
+
+    if (id.startsWith('__vite-browser-external:')) {
+      const external = id.slice('__vite-browser-external:'.length)
+      externalized.add(external)
+      return external
+    }
+
+    const external = externalCache.get(id)
+    if (typeof external === 'string') {
+      externalized.add(external)
+      return external
+    }
+
+    const file = files.get(moduleId)
+    if (browser && browserCacheDir && file?.includes(browserCacheDir)) {
+      externalized.add(moduleId)
+      return id
+    }
+
+    inlined.add(id)
+    const importedIds = adjacency.get(moduleId) || []
+    graph[id] = importedIds
+      .filter(i => !i.includes('/vitest/dist/'))
+      .map(i => visit(i))
+      .filter(Boolean) as string[]
+    return id
+  }
+
+  visit(testFilePath)
+  projectModules.setupFiles.forEach(setupFile => visit(setupFile))
+
+  return {
+    graph,
+    externalized: Array.from(externalized),
+    inlined: Array.from(inlined),
+  }
 }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- closes https://github.com/vitest-dev/vitest/issues/9763
- stacked on https://github.com/vitest-dev/vitest/pull/10338

This draft explores aligning the HTML reporter’s module graph metadata with the blob reporter’s environment-level graph serialization. Instead of eagerly storing a derived `ModuleGraphData` subgraph for every test file, the HTML reporter stores the serialized module graph once per project/environment and the static client derives the per-file graph on demand.

A few reasons to hold off this PR are:
- this introduces duplicated traversal logic between the live `getModuleGraph` path and the static `deriveModuleGraphData` path. it appears there's actually some refactoring opportunity on `getModuleGraph` side first.
- In a dogfood `test/unit` report this reduced the graph payload from ~798 KB to ~327 KB uncompressed (~59%), but only reduced total metadata from ~15.57 MB to ~15.10 MB (~3%) and gzip size from 2,046,402 to 2,031,104 bytes (~0.7%) because the report is dominated by serialized `files` task data. See below for comparison table.


### Size summary from the two dogfood artifacts of `test/unit`:

| Field | Before (main) | After (this PR) |
|---|---:|---:|
| `files` | 13.88 MB, 89.1% | 13.87 MB, 91.9% |
| graph payload | `moduleGraph`: 798 KB, 5.1% | `environmentModules`: 327 KB, 2.2% |
| `sourceCode` | 695 KB, 4.5% | 695 KB, 4.6% |
| `testModules` | 189 KB, 1.2% | 186 KB, 1.2% |
| other/config/errors | negligible | negligible |

Overall:

- Full flatted metadata: `15.57 MB -> 15.10 MB`
- Gzipped metadata: `2,046,402 -> 2,031,104` bytes
- Graph payload: `798 KB -> 327 KB`
- Graph reduction: ~59%
- Total uncompressed reduction: ~3%
- Total gzipped reduction: ~0.7%

Interpretation: graph storage improves materially, but this `unit` report is dominated by serialized `files` task data, so the total artifact barely moves.

TODO
- [x] compare html report metadata size before and after
- [ ] test


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
