### PR TITLE
fix(browser): skip `wrapDynamicImport` transform on ssr environment

### DIFF
--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -344,7 +344,10 @@ export default (parentServer: ParentBrowserProject, base = '/'): Plugin[] => {
     BrowserContext(parentServer),
     dynamicImportPlugin({
       globalThisAccessor: '"__vitest_browser_runner__"',
-      filter(id) {
+      filter(id, environment) {
+        if (environment.name !== 'client') {
+          return false
+        }
         if (id.includes(distRoot)) {
           return false
         }

--- a/packages/mocker/src/node/dynamicImportPlugin.ts
+++ b/packages/mocker/src/node/dynamicImportPlugin.ts
@@ -1,5 +1,5 @@
 import type { SourceMap } from 'magic-string'
-import type { Plugin, Rollup } from 'vite'
+import type { Environment, Plugin, Rollup } from 'vite'
 import type { Expression, Positioned } from './esmWalker'
 import MagicString from 'magic-string'
 import { esmWalker } from './esmWalker'
@@ -11,7 +11,7 @@ export interface DynamicImportPluginOptions {
    * @default `"__vitest_mocker__"`
    */
   globalThisAccessor?: string
-  filter?: (id: string) => boolean
+  filter?: (id: string, environment: Environment) => boolean
 }
 
 export function dynamicImportPlugin(options: DynamicImportPluginOptions = {}): Plugin {
@@ -23,7 +23,7 @@ export function dynamicImportPlugin(options: DynamicImportPluginOptions = {}): P
       if (!regexDynamicImport.test(source)) {
         return
       }
-      if (options.filter && !options.filter(id)) {
+      if (options.filter && !options.filter(id, this.environment)) {
         return
       }
       return injectDynamicImport(source, id, this.parse, options)

--- a/test/browser/test/server/entry.ts
+++ b/test/browser/test/server/entry.ts
@@ -1,0 +1,7 @@
+export default async (url: URL) => {
+  if (url.pathname === '/api/ssr-dep') {
+    const lib = await import('./ssr-dep')
+    return lib.default
+  }
+  return 'not-found'
+}

--- a/test/browser/test/server/ssr-dep.ts
+++ b/test/browser/test/server/ssr-dep.ts
@@ -1,0 +1,1 @@
+export default 'ssr-dep'

--- a/test/browser/test/ssr.test.ts
+++ b/test/browser/test/ssr.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+
+test('ssr dynamic import', async () => {
+  const res = await fetch('/api/ssr-dep')
+  const text = await res.json()
+  expect(text).toBe('ssr-dep')
+})

--- a/test/browser/vitest.config.mts
+++ b/test/browser/vitest.config.mts
@@ -106,5 +106,26 @@ export default defineConfig({
         await server.ssrLoadModule('/package.json')
       },
     },
+    {
+      name: 'my-ssr',
+      configureServer(server) {
+        server.middlewares.use(async (req, res, next) => {
+          const url = new URL(req.url || '', 'http://localhost')
+          if (url.pathname.startsWith('/api/')) {
+            try {
+              const mod = await server.ssrLoadModule('./test/server/entry.ts')
+              const result = await mod.default(url)
+              res.end(JSON.stringify(result))
+              return
+            }
+            catch (e) {
+              next(e)
+              return
+            }
+          }
+          next()
+        })
+      },
+    },
   ],
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- closes https://github.com/vitest-dev/vitest/issues/10319

This PR extends `wrapDynamicImport` transform plugin to allow `filter(id, environment)` so browser mode can limit the transform to client environment.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
