### PR TITLE
docs: clarify userEvent keyboard special keys

### DIFF
--- a/docs/api/browser/interactivity.md
+++ b/docs/api/browser/interactivity.md
@@ -282,6 +282,19 @@ function keyboard(text: string): Promise<void>
 The `userEvent.keyboard` allows you to trigger keyboard strokes. If any input has a focus, it will type characters into that input. Otherwise, it will trigger keyboard events on the currently focused element (`document.body` if there are no focused elements).
 
 This API supports [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard).
+For cross-provider tests, prefer printable characters and logical key names in
+braces, such as `{Shift}`, `{Control}`, `{Alt}`, `{Meta}`, `{Enter}`, `{Tab}`,
+`{Escape}`, `{Backspace}`, or `{ArrowLeft}`. These descriptors are parsed before
+Vitest delegates to the browser provider.
+
+Physical key code descriptors in square brackets, such as `[ShiftLeft]`, and
+left/right-specific modifier descriptors, such as `{ShiftLeft}` and
+`{ShiftRight}`, are provider-dependent. Playwright can distinguish left and
+right modifier keys, WebdriverIO support depends on the driver, and the
+`preview` provider follows `@testing-library/user-event` in the page instead of
+using browser automation APIs. Avoid asserting on `KeyboardEvent.code` or
+`KeyboardEvent.location` for these descriptors unless your test targets a
+specific provider.
 
 ```ts
 import { userEvent } from 'vitest/browser'

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -279,6 +279,10 @@ export interface UserEvent {
    * Type text on the keyboard. If any input is focused, it will receive the text,
    * otherwise it will be typed on the document. Uses provider's API under the hood.
    * **Supports** [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard) (e.g., `{Shift}`) even with `playwright` and `webdriverio` providers.
+   * For cross-provider tests, prefer printable characters and logical key names
+   * in braces, like `{Shift}`, `{Enter}`, or `{ArrowLeft}`. Physical key code
+   * descriptors in square brackets and left/right-specific modifier descriptors
+   * can produce provider-specific `code` and `location` values.
    * @example
    * await userEvent.keyboard('foo') // translates to: f, o, o
    * await userEvent.keyboard('{{a[[') // translates to: {, a, [

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -69,7 +69,8 @@ test('click with modifier', async () => {
   await expect.poll(() => el.textContent).toContain("[ok]")
 })
 
-// TODO: https://github.com/vitest-dev/vitest/issues/7118
+// Documents the provider-specific behavior described in
+// https://github.com/vitest-dev/vitest/issues/7118
 // https://testing-library.com/docs/user-event/keyboard
 // https://github.com/testing-library/user-event/blob/main/src/keyboard/keyMap.ts
 // https://playwright.dev/docs/api/class-keyboard


### PR DESCRIPTION
### Description

Clarifies which `userEvent.keyboard` descriptors are safe to use across browser providers and which ones have provider-specific `code` / `location` behavior.

Also updates the public type comment and replaces the issue TODO in the existing provider behavior fixture with a descriptive comment.

Fixes #7118

### Verification

- `pnpm exec eslint --no-warn-ignored docs/api/browser/interactivity.md packages/browser/context.d.ts test/browser/fixtures/user-event/keyboard.test.ts`
- `git diff --check`
- `pnpm -C docs run build` was attempted, but failed on unrelated Twoslash examples that cannot resolve local `vitest` package imports before package build artifacts are present in this fresh checkout.