### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -89,7 +89,7 @@ export class TestRunner implements VitestTestRunner {
   }
 
   async onAfterRunSuite(suite: Suite): Promise<void> {
-    if (this.config.logHeapUsage && typeof process !== 'undefined') {
+    if (this.config.logHeapUsage && typeof process !== 'undefined' && typeof process.memoryUsage === 'function') {
       suite.result!.heap = process.memoryUsage().heapUsed
     }
 
@@ -122,7 +122,7 @@ export class TestRunner implements VitestTestRunner {
   }
 
   onAfterRunTask(test: Task): void {
-    if (this.config.logHeapUsage && typeof process !== 'undefined') {
+    if (this.config.logHeapUsage && typeof process !== 'undefined' && typeof process.memoryUsage === 'function') {
       test.result!.heap = process.memoryUsage().heapUsed
     }
 

--- a/packages/vitest/src/runtime/workers/init.ts
+++ b/packages/vitest/src/runtime/workers/init.ts
@@ -14,7 +14,9 @@ interface Options extends VitestWorker {
 }
 
 const __vitest_worker_response__ = true
-const memoryUsage = process.memoryUsage.bind(process)
+const memoryUsage = typeof process !== 'undefined' && typeof process.memoryUsage === 'function'
+  ? process.memoryUsage.bind(process)
+  : () => ({ heapUsed: 0 })
 let reportMemory = false
 
 let traces!: Traces


### PR DESCRIPTION
### Description

When `logHeapUsage` is enabled in browser mode, Vitest crashes with
`UnhandledRejection` because `process.memoryUsage` does not exist in
browser environments.

The root cause has two parts:
1. `packages/vitest/src/runtime/workers/init.ts` — top-level
   `process.memoryUsage.bind(process)` executes unconditionally at
   module load, crashing immediately in browsers.
2. `packages/vitest/src/runtime/runners/test.ts` — the existing guard
   only checks `typeof process !== 'undefined'`, but in browsers
   `process` can be polyfilled without `memoryUsage`.

This PR adds `typeof` guards to all three call sites so the code
degrades gracefully instead of crashing.

Resolves #6500

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- N/A (no new functionality introduced)