### PR TITLE
feat(reporters): add fileTemplate option to JUnit reporter

### DIFF
--- a/packages/vitest/src/node/reporters/junit.ts
+++ b/packages/vitest/src/node/reporters/junit.ts
@@ -17,6 +17,11 @@ interface ClassnameTemplateVariables {
   filepath: string
 }
 
+interface FileTemplateVariables {
+  filename: string
+  filepath: string
+}
+
 export interface JUnitOptions {
   outputFile?: string
 
@@ -39,6 +44,10 @@ export interface JUnitOptions {
    * Hostname to use in the report. By default, it uses os.hostname()
    */
   hostname?: string
+  /**
+   * Template for the file attribute and testsuite name. Can be either a string or a function. The string can contain placeholders {filename} and {filepath}.
+   */
+  fileTemplate?: string | ((fileVariables: FileTemplateVariables) => string)
 }
 
 function flattenTasks(task: Task, baseName = ''): Task[] {
@@ -207,9 +216,9 @@ export class JUnitReporter implements Reporter {
     })
   }
 
-  async writeTasks(tasks: Task[], filename: string): Promise<void> {
+  async writeTasks(tasks: Task[], filename: string, defaultClassname: string): Promise<void> {
     for (const task of tasks) {
-      let classname = filename
+      let classname = defaultClassname
 
       const templateVars: ClassnameTemplateVariables = {
         filename: task.file.name,
@@ -371,7 +380,23 @@ export class JUnitReporter implements Reporter {
 
     await this.writeElement('testsuites', { ...stats, time: executionTime(stats.time) }, async () => {
       for (const file of transformed) {
-        const filename = relative(this.ctx.config.root, file.filepath)
+        const relativePath = relative(this.ctx.config.root, file.filepath)
+        let filename = relativePath
+
+        const fileVars: FileTemplateVariables = {
+          filename: file.file.name,
+          filepath: file.filepath,
+        }
+
+        if (typeof this.options.fileTemplate === 'function') {
+          filename = this.options.fileTemplate(fileVars)
+        }
+        else if (typeof this.options.fileTemplate === 'string') {
+          filename = this.options.fileTemplate
+            .replace(/\{filename\}/g, fileVars.filename)
+            .replace(/\{filepath\}/g, fileVars.filepath)
+        }
+
         await this.writeElement(
           'testsuite',
           {
@@ -385,7 +410,7 @@ export class JUnitReporter implements Reporter {
             time: getDuration(file),
           },
           async () => {
-            await this.writeTasks(file.tasks, filename)
+            await this.writeTasks(file.tasks, filename, relativePath)
           },
         )
       }

--- a/test/cli/test/reporters/junit.test.ts
+++ b/test/cli/test/reporters/junit.test.ts
@@ -155,6 +155,48 @@ test.each([true, false])('addFileAttribute %s', async (t) => {
   expect(stabilizeReport(stdout)).matchSnapshot()
 })
 
+test('fileTemplate string replaces testsuite name and file attribute', async () => {
+  const { stdout } = await runVitest({
+    reporters: [['junit', { fileTemplate: 'packages/{filename}/src', addFileAttribute: true }]],
+    root,
+    include: ['ok.test.ts'],
+  })
+
+  const xml = stabilizeReport(stdout)
+
+  expect(xml).toContain('<testsuite name="packages/ok.test.ts/src"')
+  expect(xml).toContain('file="packages/ok.test.ts/src"')
+})
+
+test('fileTemplate function replaces testsuite name and file attribute', async () => {
+  const { stdout } = await runVitest({
+    reporters: [['junit', { fileTemplate: ({ filepath }) => filepath.replace(/.*fixtures\//, ''), addFileAttribute: true }]],
+    root,
+    include: ['ok.test.ts'],
+  })
+
+  const xml = stabilizeReport(stdout)
+
+  expect(xml).toContain('<testsuite name="reporters/ok.test.ts"')
+  expect(xml).toContain('file="reporters/ok.test.ts"')
+})
+
+test('fileTemplate preserves default classname when classnameTemplate is not set', async () => {
+  const { stdout } = await runVitest({
+    reporters: [['junit', { fileTemplate: 'custom-prefix/{filename}', addFileAttribute: true }]],
+    root,
+    include: ['ok.test.ts'],
+  })
+
+  const xml = stabilizeReport(stdout)
+
+  // classname should remain default (relative path) even when fileTemplate changes the file attribute
+  expect(xml).toContain('classname="ok.test.ts"')
+  // but file and testsuite name should use the template
+  expect(xml).toContain('file="custom-prefix/ok.test.ts"')
+  expect(xml).toContain('<testsuite name="custom-prefix/ok.test.ts"')
+})
+
 test('many errors without warning', async () => {
   const { stderr } = await runVitestCli(
     'run',


### PR DESCRIPTION
Fixes #10341

Adds a `fileTemplate` option to the JUnit reporter, analogous to the existing `classnameTemplate`. This lets users control the value of the `file` attribute on `<testcase>` elements and the `name` attribute on `<testsuite>` elements — useful in pnpm monorepos where the default relative path may not include enough prefix for test analytics or CODEOWNERS matching.

### Usage

```ts
// string template with {filename} and {filepath} placeholders
reporters: [['junit', { fileTemplate: 'packages/{filename}/src', addFileAttribute: true }]]

// function template
reporters: [['junit', { fileTemplate: ({ filepath }) => filepath.replace(/.*fixtures\//, ''), addFileAttribute: true }]]
```

Unlike `classnameTemplate`, which only affects the `classname` attribute, `fileTemplate` affects both `file` and `testsuite name` while leaving `classname` unchanged (unless `classnameTemplate` is also set).
