### PR TITLE
fix: apply cjs interop for truthy `__esModule`

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -531,7 +531,7 @@ function interopModule(mod: any) {
 
   let defaultExport = 'default' in mod ? mod.default : mod
 
-  if (!isPrimitive(defaultExport) && '__esModule' in defaultExport) {
+  if (!isPrimitive(defaultExport) && defaultExport.__esModule) {
     mod = defaultExport
     if ('default' in defaultExport) {
       defaultExport = defaultExport.default

--- a/test/unit/deps/dep-cjs/esmodule-false.js
+++ b/test/unit/deps/dep-cjs/esmodule-false.js
@@ -1,0 +1,2 @@
+exports.__esModule = false
+exports.test = "hello"

--- a/test/unit/deps/dep-cjs/esmodule-false.js
+++ b/test/unit/deps/dep-cjs/esmodule-false.js
@@ -1,2 +1,2 @@
 exports.__esModule = false
-exports.test = "hello"
+exports.test = 'hello'

--- a/test/unit/deps/dep-cjs/esmodule.js
+++ b/test/unit/deps/dep-cjs/esmodule.js
@@ -1,2 +1,2 @@
 exports.__esModule = true
-exports.test = "hello"
+exports.test = 'hello'

--- a/test/unit/deps/dep-cjs/esmodule.js
+++ b/test/unit/deps/dep-cjs/esmodule.js
@@ -1,0 +1,2 @@
+exports.__esModule = true
+exports.test = "hello"

--- a/test/unit/deps/dep-cjs/package.json
+++ b/test/unit/deps/dep-cjs/package.json
@@ -2,6 +2,8 @@
   "name": "@vitest/test-dep-cjs",
   "type": "commonjs",
   "exports": {
+    "./esmodule": "./esmodule.js",
+    "./esmodule-false": "./esmodule-false.js",
     "./esm-comment": "./esm-comment.js",
     "./esm-string": "./esm-string.js"
   }

--- a/test/unit/test/interop.test.ts
+++ b/test/unit/test/interop.test.ts
@@ -4,6 +4,8 @@ import * as esModule from '@vitest/test-dep-cjs/esmodule'
 import * as esModuleFalse from '@vitest/test-dep-cjs/esmodule-false'
 import { expect, test } from 'vitest'
 
+const nodeMajor = Number(process.versions.node.split('.')[0])
+
 test('interop', async ({ task }) => {
   expect(esModule).toMatchInlineSnapshot(`
     {
@@ -11,8 +13,7 @@ test('interop', async ({ task }) => {
       "test": "hello",
     }
   `)
-  if (task.file.projectName === 'vmThreads') {
-    // TODO: vitest vm should align with newer node for "module.exports"?
+  if (task.file.projectName === 'vmThreads' || nodeMajor < 23) {
     expect(esModuleFalse).toMatchInlineSnapshot(`
       {
         "__esModule": false,

--- a/test/unit/test/interop.test.ts
+++ b/test/unit/test/interop.test.ts
@@ -1,0 +1,28 @@
+import { expect,  test } from "vitest"
+// @ts-expect-error no type
+import * as esModule from "@vitest/test-dep-cjs/esmodule"
+// @ts-expect-error no type
+import * as esModuleFalse from "@vitest/test-dep-cjs/esmodule-false"
+
+test('interop', async () => {
+  expect(esModule). toMatchInlineSnapshot(`
+    {
+      "__esModule": true,
+      "test": "hello",
+    }
+  `)
+  expect(esModuleFalse). toMatchInlineSnapshot(`
+    {
+      "__esModule": false,
+      "default": {
+        "__esModule": false,
+        "test": "hello",
+      },
+      "module.exports": {
+        "__esModule": false,
+        "test": "hello",
+      },
+      "test": "hello",
+    }
+  `)
+})

--- a/test/unit/test/interop.test.ts
+++ b/test/unit/test/interop.test.ts
@@ -1,28 +1,43 @@
-import { expect,  test } from "vitest"
 // @ts-expect-error no type
-import * as esModule from "@vitest/test-dep-cjs/esmodule"
+import * as esModule from '@vitest/test-dep-cjs/esmodule'
 // @ts-expect-error no type
-import * as esModuleFalse from "@vitest/test-dep-cjs/esmodule-false"
+import * as esModuleFalse from '@vitest/test-dep-cjs/esmodule-false'
+import { expect, test } from 'vitest'
 
-test('interop', async () => {
-  expect(esModule). toMatchInlineSnapshot(`
+test('interop', async ({ task }) => {
+  expect(esModule).toMatchInlineSnapshot(`
     {
       "__esModule": true,
       "test": "hello",
     }
   `)
-  expect(esModuleFalse). toMatchInlineSnapshot(`
-    {
-      "__esModule": false,
-      "default": {
+  if (task.file.projectName === 'vmThreads') {
+    // TODO: vitest vm should align with newer node for "module.exports"?
+    expect(esModuleFalse).toMatchInlineSnapshot(`
+      {
         "__esModule": false,
+        "default": {
+          "__esModule": false,
+          "test": "hello",
+        },
         "test": "hello",
-      },
-      "module.exports": {
+      }
+    `)
+  }
+  else {
+    expect(esModuleFalse).toMatchInlineSnapshot(`
+      {
         "__esModule": false,
+        "default": {
+          "__esModule": false,
+          "test": "hello",
+        },
+        "module.exports": {
+          "__esModule": false,
+          "test": "hello",
+        },
         "test": "hello",
-      },
-      "test": "hello",
-    }
-  `)
+      }
+    `)
+  }
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10359

As written in https://github.com/vitest-dev/vitest/issues/10359#issuecomment-4465834973, Bun defines `__esModule` export for genuine esm in a way `'__esModule' in mod === true` but `mod.__esModule === undefined`. This behavior is Bun specific quirk, but Vitest applying interop based on `__esModule` property existence seems less conventional and can be naturally mitigated on Vitest side by detecting truthy `__esModule`. That's what PR changes.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
