### PR TITLE
docs: fix the file extension glob pattern

### DIFF
--- a/docs/config/include.md
+++ b/docs/config/include.md
@@ -25,7 +25,7 @@ export default defineConfig({
   test: {
     include: [
       './test',
-      './**/*.{test,spec}.tsx?',
+      './**/*.{test,spec}.ts(x)?',
     ],
   },
 })
@@ -67,7 +67,7 @@ export default defineConfig({
     include: [
       ...configDefaults.include,
       './test',
-      './**/*.{test,spec}.tsx?',
+      './**/*.{test,spec}.ts(x)?',
     ],
   },
 })


### PR DESCRIPTION
Changed the invalid glob pattern `tsx?` to a valid one `ts(x)?`
