### PR TITLE
fix(node): match forceRerunTriggers under hidden directories

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -134,7 +134,12 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    // `dot: true` so `**/...` patterns also match paths under hidden
+    // directories (e.g. `.git/`, `.claude/worktrees/<branch>/...`).
+    // Without it the trigger silently no-ops when the project lives
+    // under a hidden ancestor, since `findChangedFiles` returns
+    // absolute paths.
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,11 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    // `dot: true` so `**/...` patterns also match paths under hidden
+    // directories (e.g. `.git/`, `.claude/worktrees/<branch>/...`).
+    // Without it the trigger silently no-ops when the project lives
+    // under a hidden ancestor, since chokidar emits absolute paths.
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }


### PR DESCRIPTION
## Description

`forceRerunTriggers` is matched against absolute file paths (returned by `findChangedFiles` for `--changed` runs, and chokidar events in watch mode). The default `picomatch` behavior excludes paths whose ancestors are hidden (start with `.`), so a project located under a hidden directory — for example a git worktree at `.git/worktrees/<branch>/...` or any tool-managed worktree such as `.claude/worktrees/<branch>/...` — never matches any `**/...` trigger glob.

This silently breaks the default config triggers
(`['**/package.json/**', '**/{vitest,vite}.config.*/**']`) as well as anything users register: changes to `vitest.config.ts`, `package.json`, or a custom trigger fail to force-rerun the suite when invoked from a hidden-dir checkout. The failure mode is invisible — no warning, no error, just "0 tests affected" — so it's especially easy to miss in CI.

## Reproduction

Pure picomatch, no vitest needed:

```js
const pm = require('picomatch')
const pattern = '**/{vitest,vite}.config.*'
const path = '/Users/x/.claude/worktrees/foo/frontend/vite.config.ts'

pm(pattern)(path)                 // false  (bug)
pm(pattern, { dot: true })(path)  // true   (fixed)
```

End-to-end repro is the same — run `vitest --changed <ref>` from a checkout whose path contains a hidden segment (e.g. `git worktree add .git/worktrees/branch` or any path under `~/.claude/`, `~/.cache/`, etc.), modify `vitest.config.ts`, observe vitest reports "No test files found" instead of running the whole suite.

## Fix

Pass `{ dot: true }` at both call sites that match `forceRerunTriggers` so the matcher walks into hidden ancestors:

- `packages/vitest/src/node/specifications.ts` — `--changed` filtering
- `packages/vitest/src/node/watcher.ts` — watch-mode file change handling

Two lines + comments. Behavior change is strictly *more* paths can match — users who registered a trigger expecting it to fire across all locations get the documented behavior; users with an existing trigger that *intentionally* skipped hidden paths would need to add an explicit exclusion, but I'd argue that's a vanishingly rare intent for a "force rerun" trigger.

## Notes

- Verified the repro locally; did not run vitest's own test suite (relying on CI). Happy to add a regression test if you'd like — wasn't sure whether you'd prefer an e2e mirror of `test/e2e/test/git-changed.test.ts` (would need a fixture under a hidden dir, which is awkward to commit) or a unit test against the matcher directly.
- I hit this in a downstream project where tests live under `.claude/worktrees/<branch>/frontend/` and `forceRerunTriggers` silently didn't fire; root-caused by reading the source. Happy to provide more context if useful.
