### PR TITLE
chore: improve vitest maintenance path

### DIFF
--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -44,8 +44,9 @@ export function assertTypes(
   const receivedType = typeof value
   const pass = types.includes(receivedType)
   if (!pass) {
+    const received = value === null ? 'null' : receivedType
     throw new TypeError(
-      `${name} value must be ${types.join(' or ')}, received "${receivedType}"`,
+      `${name} value must be ${types.join(' or ')}, received "${received}"`,
     )
   }
 }

--- a/test/unit/test/utils.spec.ts
+++ b/test/unit/test/utils.spec.ts
@@ -21,6 +21,15 @@ describe('assertTypes', () => {
     assertTypes(value_bigint, 'value_bigint', ['number', 'bigint'])
     expect(() => assertTypes(value_string, 'value_string', ['number', 'bigint'])).toThrow()
   })
+
+  test('null reports "null" instead of "object" when it fails the check', () => {
+    // null still passes when 'object' is expected (typeof null === 'object')
+    assertTypes(null, 'null_value', ['object'])
+    // but when it fails, the error message should say "null" not "object"
+    expect(() => assertTypes(null, 'null_value', ['string'])).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: null_value value must be string, received "null"]`,
+    )
+  })
 })
 
 describe('deepMerge', () => {


### PR DESCRIPTION
Summary:
- Improve a narrow TypeScript utility edge case.
- Back the change with focused coverage in the existing test suite.

Notes:
- I kept this scoped to the relevant utility path and tests.