### PR TITLE
fix(expect): allow readonly arrays and sets in toBeOneOf (fix #10264)

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -152,7 +152,7 @@ interface CustomMatcher {
    * expect('foo').toBeOneOf([expect.any(String)])
    * expect({ a: 1 }).toEqual({ a: expect.toBeOneOf(['1', '2', '3']) })
    */
-  toBeOneOf: <T>(sample: Array<T> | Set<T>) => any
+  toBeOneOf: <T>(sample: ReadonlyArray<T> | ReadonlySet<T>) => any
 }
 
 export interface AsymmetricMatchersContaining extends CustomMatcher {

--- a/test/unit/test/expect.test-d.ts
+++ b/test/unit/test/expect.test-d.ts
@@ -119,4 +119,24 @@ test('expect.* allows asymmetrict mattchers with different types', () => {
     expect(value).toMatchObject(value)
   }
   expectMany({ enabled: true, data: 'ok' })
+
+  // toBeOneOf accepts readonly arrays and sets
+  // https://github.com/vitest-dev/vitest/issues/10264
+  {
+    const allowed = ['A', 'B'] as const
+    expect('A').toBeOneOf(allowed)
+    expect('A').toEqual(expect.toBeOneOf(allowed))
+
+    const readonlyArray: ReadonlyArray<string> = ['A', 'B']
+    expect('A').toBeOneOf(readonlyArray)
+    expect('A').toEqual(expect.toBeOneOf(readonlyArray))
+
+    const readonlySet: ReadonlySet<string> = new Set(['A', 'B'])
+    expect('A').toBeOneOf(readonlySet)
+    expect('A').toEqual(expect.toBeOneOf(readonlySet))
+
+    // mutable arrays and sets still work
+    expect('A').toBeOneOf(['A', 'B'])
+    expect('A').toBeOneOf(new Set(['A', 'B']))
+  }
 })


### PR DESCRIPTION
### Description

`expect.toBeOneOf` typed its `sample` argument as `Array<T> | Set<T>`. Since mutable `Array`/`Set` are not assignable from their `readonly` counterparts, passing a `ReadonlyArray<T>`, a `ReadonlySet<T>`, or an `as const` array produced a type error — even though the runtime implementation only reads the argument and never mutates it.

This widens the public type of `toBeOneOf` (used by both `expect(value).toBeOneOf(...)` and the asymmetric `expect.toBeOneOf(...)`) to `ReadonlyArray<T> | ReadonlySet<T>`. Mutable arrays and sets are still accepted, and the runtime behaviour is unchanged.

Resolves #10264

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

A type test was added to `test/unit/test/expect.test-d.ts` covering `as const` arrays, `ReadonlyArray`, and `ReadonlySet`. It fails the typecheck without this change and passes with it. The existing runtime `toBeOneOf()` tests in `jest-expect.test.ts` still pass.

### Documentation
- [ ] If you introduce new functionality, document it.

No documentation change needed — this only relaxes a type and adds no new functionality. The docs already describe `toBeOneOf` as accepting an array or set.

### Changesets
- [x] Changes in changelog are generated from PR name.

---

AI disclosure: this PR was prepared with the assistance of Claude (Claude Code).