### PR TITLE
fix(browser-webdriverio): allow gpu in headless chrome

### DIFF
--- a/packages/browser-webdriverio/src/webdriverio.ts
+++ b/packages/browser-webdriverio/src/webdriverio.ts
@@ -192,7 +192,19 @@ export class WebdriverBrowserProvider implements BrowserProvider {
     if (browser !== 'safari' && options.headless) {
       const [key, args] = headlessMap[browser]
       const currentValues = (this.options?.capabilities as any)?.[key] || {}
-      const newArgs = [...(currentValues.args || []), ...args]
+      const currentArgs = currentValues.args || []
+
+      const hasEnableGpu = browser === 'chrome' && currentArgs.some((arg: string) =>
+        arg === '--enable-gpu' || arg === 'enable-gpu',
+      )
+
+      const newArgs = [
+        ...currentArgs,
+        ...args.filter(
+          arg => !(browser === 'chrome' && hasEnableGpu && arg === 'disable-gpu'),
+        ),
+      ]
+
       capabilities[key] = { ...currentValues, args: newArgs as any }
     }
 

--- a/packages/browser-webdriverio/src/webdriverio.ts
+++ b/packages/browser-webdriverio/src/webdriverio.ts
@@ -194,14 +194,11 @@ export class WebdriverBrowserProvider implements BrowserProvider {
       const currentValues = (this.options?.capabilities as any)?.[key] || {}
       const currentArgs: string[] = currentValues.args || []
 
-      let argsToAdd = [...defaultArgs]
+      const hasEnableGpu = browser === 'chrome' && (currentArgs.includes('--enable-gpu') || currentArgs.includes('enable-gpu'))
 
-      if (browser === 'chrome') {
-        const hasEnableGpu = currentArgs.includes('--enable-gpu') || currentArgs.includes('enable-gpu')
-        if (hasEnableGpu) {
-          argsToAdd = argsToAdd.filter(arg => arg !== 'disable-gpu')
-        }
-      }
+      const argsToAdd = hasEnableGpu
+        ? defaultArgs.filter(arg => arg !== 'disable-gpu')
+        : defaultArgs
 
       const newArgs = [...currentArgs, ...argsToAdd]
 

--- a/packages/browser-webdriverio/src/webdriverio.ts
+++ b/packages/browser-webdriverio/src/webdriverio.ts
@@ -190,20 +190,20 @@ export class WebdriverBrowserProvider implements BrowserProvider {
     const options = this.project.config.browser
     const browser = this.browserName
     if (browser !== 'safari' && options.headless) {
-      const [key, args] = headlessMap[browser]
+      const [key, defaultArgs] = headlessMap[browser]
       const currentValues = (this.options?.capabilities as any)?.[key] || {}
-      const currentArgs = currentValues.args || []
+      const currentArgs: string[] = currentValues.args || []
 
-      const hasEnableGpu = browser === 'chrome' && currentArgs.some((arg: string) =>
-        arg === '--enable-gpu' || arg === 'enable-gpu',
-      )
+      let argsToAdd = [...defaultArgs]
 
-      const newArgs = [
-        ...currentArgs,
-        ...args.filter(
-          arg => !(browser === 'chrome' && hasEnableGpu && arg === 'disable-gpu'),
-        ),
-      ]
+      if (browser === 'chrome') {
+        const hasEnableGpu = currentArgs.includes('--enable-gpu') || currentArgs.includes('enable-gpu')
+        if (hasEnableGpu) {
+          argsToAdd = argsToAdd.filter(arg => arg !== 'disable-gpu')
+        }
+      }
+
+      const newArgs = [...currentArgs, ...argsToAdd]
 
       capabilities[key] = { ...currentValues, args: newArgs as any }
     }


### PR DESCRIPTION
Resolves #10351

### Description

This PR allows users to explicitly enable GPU rendering for headless Chrome when using `@vitest/browser-webdriverio`.

By default, Vitest still adds `disable-gpu` for headless Chrome to preserve the existing behavior.

However, when the user explicitly provides `--enable-gpu` or `enable-gpu` in `goog:chromeOptions.args`, Vitest no longer adds `disable-gpu` on top of it.

### Tests

No test was added because the direct `buildCapabilities` unit test was considered too low-level during review.

The change is intentionally conservative: `disable-gpu` remains part of the default headless Chrome arguments, but it is skipped when the user explicitly provides `--enable-gpu`.