### PR TITLE
fix(ui): fix module graph in browser mode with --ui

### DIFF
--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -113,7 +113,6 @@ async function loadModuleGraph(force = false) {
       let moduleGraph = await client.rpc.getModuleGraph(
         gd.projectName,
         gd.filepath,
-        !!browserState,
       )
       // remove node_modules from the graph when enabled
       if (hideNodeModules.value) {

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -6,7 +6,7 @@ import { asyncComputed, onKeyStroke } from '@vueuse/core'
 import { Tooltip as VueTooltip } from 'floating-vue'
 import { join, relative } from 'pathe'
 import { computed } from 'vue'
-import { browserState, client, config } from '~/composables/client'
+import { client, config } from '~/composables/client'
 import { currentModule } from '~/composables/navigation'
 import { formatPreciseTime, formatTime, getDurationClass, getImportDurationType } from '~/utils/task'
 import Badge from './Badge.vue'
@@ -31,7 +31,7 @@ const result = asyncComputed<TransformResultWithSource | ExternalResult | undefi
     return undefined
   }
   if (props.type === 'inline') {
-    return client.rpc.getTransformResult(props.projectName, props.id, currentModule.value.id, !!browserState)
+    return client.rpc.getTransformResult(props.projectName, props.id, currentModule.value.id)
   }
   if (props.type === 'external') {
     return client.rpc.getExternalResult(props.id, currentModule.value.id)

--- a/packages/ui/node/reporter.ts
+++ b/packages/ui/node/reporter.ts
@@ -201,7 +201,6 @@ async function serializeReportMetadata(
         ctx,
         projectName,
         testModule.moduleId,
-        project.config.browser.enabled,
       )
     })())
   }

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -122,13 +122,14 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
 
           return result
         },
-        async getTransformResult(projectName: string, moduleId, testFileTaskId, browser = false) {
+        async getTransformResult(projectName: string, moduleId, testFileTaskId) {
           const project = ctx.getProjectByName(projectName)
           const testModule = ctx.state.getReportedEntityById(testFileTaskId) as TestModule | undefined
           if (!testModule || !isFileServingAllowed(project.vite.config, moduleId)) {
             return
           }
 
+          const browser = !!project.config.browser.enabled
           const environment = getTestFileEnvironment(project, testModule.moduleId, browser)
 
           const moduleNode = environment?.moduleGraph.getModuleById(moduleId)

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -155,8 +155,8 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
           catch {}
           return result
         },
-        async getModuleGraph(project, id, browser): Promise<ModuleGraphData> {
-          return getModuleGraph(ctx, project, id, browser)
+        async getModuleGraph(project, id): Promise<ModuleGraphData> {
+          return getModuleGraph(ctx, project, id)
         },
         async updateSnapshot(file?: File) {
           // silently ignore exec/write attempts if not allowed

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -47,7 +47,6 @@ export interface WebSocketHandlers {
   getModuleGraph: (
     projectName: string,
     id: string,
-    browser?: boolean,
   ) => Promise<ModuleGraphData>
   getTransformResult: (
     projectName: string,

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -52,7 +52,6 @@ export interface WebSocketHandlers {
     projectName: string,
     id: string,
     testFileId: string,
-    browser?: boolean,
   ) => Promise<TransformResultWithSource | undefined>
   getExternalResult: (
     id: string,

--- a/packages/vitest/src/utils/graph.ts
+++ b/packages/vitest/src/utils/graph.ts
@@ -7,13 +7,13 @@ export async function getModuleGraph(
   ctx: Vitest,
   projectName: string,
   testFilePath: string,
-  browser = false,
 ): Promise<ModuleGraphData> {
   const graph: Record<string, string[]> = {}
   const externalized = new Set<string>()
   const inlined = new Set<string>()
 
   const project = ctx.getProjectByName(projectName)
+  const browser = project.config.browser.enabled
 
   const environment = project.config.experimental.viteModuleRunner === false
     ? project.vite.environments.__vitest__

--- a/test/ui/fixtures/main/browser/sample-browser.test.ts
+++ b/test/ui/fixtures/main/browser/sample-browser.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('window', () => {
+  expect(typeof window).toBe('object')
+})

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       name: 'chromium',
       // increase viewport height so virtual scroller renders all explorer items
-      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 900 } },
+      use: { ...devices['Desktop Chrome'], viewport: { width: 900, height: 1300 } },
     },
   ],
   use: {

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       name: 'chromium',
       // increase viewport height so virtual scroller renders all explorer items
-      use: { ...devices['Desktop Chrome'], viewport: { width: 900, height: 1300 } },
+      use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 1300 } },
     },
   ],
   use: {

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -53,6 +53,12 @@ test.describe('ui', () => {
     await testFilter(page, { mode: 'ui' })
   })
 
+  test('filter reveals initially invisible explorer item', async ({ page }) => {
+    await page.setViewportSize({ width: 1000, height: 500 })
+    await page.goto(pageUrl)
+    await testFilterInitiallyInvisibleItem(page)
+  })
+
   test('tags filter', async ({ page }) => {
     await page.goto(pageUrl)
     await testTagsFilter(page)
@@ -494,6 +500,12 @@ async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
     await testItem.getByLabel('Run current test').click()
     await expect(page.getByText('The test has passed without any errors')).toBeVisible()
   }
+}
+
+async function testFilterInitiallyInvisibleItem(page: Page) {
+  await expect(getExplorerItem(page, 'sample.test.ts')).not.toBeVisible()
+  await page.getByPlaceholder('Search...').fill('sample.test.ts')
+  await expect(getExplorerItem(page, 'sample.test.ts')).toBeVisible()
 }
 
 async function testCrossOriginAccess(page: Page, pageUrl: string) {

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -87,6 +87,11 @@ test.describe('ui', () => {
     await page.goto(pageUrl)
     await testExecute(page, { mode: 'ui' })
   })
+
+  test('module graph', async ({ page }) => {
+    await page.goto(pageUrl)
+    await testModuleGraph(page)
+  })
 })
 
 test.describe('html report', () => {
@@ -175,7 +180,20 @@ test.describe('html report', () => {
     await page.goto(pageUrl)
     await testExecute(page, { mode: 'static' })
   })
+
+  test('module graph', async ({ page }) => {
+    await page.goto(pageUrl)
+    await testModuleGraph(page)
+  })
 })
+
+const TEST_COUNTS = {
+  pass: 18,
+  fail: 3,
+  files: {
+    pass: 7,
+  },
+}
 
 async function testBasic(page: Page, pageUrl: string) {
   const pageErrors: unknown[] = []
@@ -184,7 +202,7 @@ async function testBasic(page: Page, pageUrl: string) {
   await page.goto(pageUrl)
 
   // dashboard
-  await assertTestCounts(page, { pass: 17, fail: 3 })
+  await assertTestCounts(page, { pass: TEST_COUNTS.pass, fail: TEST_COUNTS.fail })
 
   // unhandled errors
   await expect(page.getByTestId('unhandled-errors')).toContainText(
@@ -208,6 +226,18 @@ async function testBasic(page: Page, pageUrl: string) {
   await expect(page.getByTestId('console')).toContainText('log test')
 
   expect(pageErrors).toEqual([])
+}
+
+async function testModuleGraph(page: Page) {
+  await openExplorerFileItem(page, 'sample.test.ts')
+  await page.getByTestId('btn-graph').click()
+  await expect(page.locator('[data-testid=graph] text')).toBeVisible()
+  await expect(page.locator('[data-testid=graph] text')).toHaveText('sample.test.ts')
+
+  await openExplorerFileItem(page, 'sample-browser.test.ts')
+  await page.getByTestId('btn-graph').click()
+  await expect(page.locator('[data-testid=graph] text')).toBeVisible()
+  await expect(page.locator('[data-testid=graph] text')).toHaveText('sample-browser.test.ts')
 }
 
 async function testCoverage(page: Page) {
@@ -414,7 +444,7 @@ async function testDashboardFilter(page: Page) {
 async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
   // match all files when no filter
   await page.getByPlaceholder('Search...').fill('')
-  await page.getByText('PASS (6)').click()
+  await page.getByText(`PASS (${TEST_COUNTS.files.pass})`).click()
   await expect(page.getByTestId('results-panel').getByText('sample.test.ts', { exact: true })).toBeVisible()
 
   // match nothing
@@ -527,7 +557,6 @@ async function testExecute(page: Page, options: { mode: 'ui' | 'ui-disallow' | '
     await item.hover()
     await expect(item.getByTestId('btn-run-test')).toBeEnabled()
 
-    await page.getByPlaceholder('Search...').fill('snapshot')
     const snapshotItem = getExplorerItem(page, 'snapshot.test.ts')
     await snapshotItem.hover()
     await expect(snapshotItem.getByTestId('btn-fix-snapshot')).toBeVisible()
@@ -539,7 +568,6 @@ async function testExecute(page: Page, options: { mode: 'ui' | 'ui-disallow' | '
     await item.hover()
     await expect(item.getByTestId('btn-run-test')).toBeDisabled()
 
-    await page.getByPlaceholder('Search...').fill('snapshot')
     const snapshotItem = getExplorerItem(page, 'snapshot.test.ts')
     await snapshotItem.hover()
     await expect(snapshotItem.getByTestId('btn-fix-snapshot')).not.toBeVisible()
@@ -551,7 +579,6 @@ async function testExecute(page: Page, options: { mode: 'ui' | 'ui-disallow' | '
     await item.hover()
     await expect(item.getByTestId('btn-run-test')).not.toBeVisible()
 
-    await page.getByPlaceholder('Search...').fill('snapshot')
     const snapshotItem = getExplorerItem(page, 'snapshot.test.ts')
     await snapshotItem.hover()
     await expect(snapshotItem.getByTestId('btn-fix-snapshot')).not.toBeVisible()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently we rely on caller to pass `browser: boolean` to indicate which module graph to pick, but this is redundant since `project.config.browser.enabled` is already available on server side. 

Additionally UI uses `browserState` global (i.e. browser orchestrator mode) for `browser: boolean` flag switch but that's not correct and causes missing module graph on browser mode with pure `--ui` mode such as:

```sh
pnpm -C packages/ui test:ui --ui
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
