### PR TITLE
fix: preserve failed log replay when reporter hook is shadowed (fix #10383)

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -123,8 +123,12 @@ export abstract class BaseReporter implements Reporter {
 
   protected logFailedTask(task: Task): void {
     if (this.silent === 'passed-only') {
+      const onUserConsoleLog = typeof this.onUserConsoleLog === 'function'
+        ? this.onUserConsoleLog
+        : BaseReporter.prototype.onUserConsoleLog
+
       for (const log of task.logs || []) {
-        this.onUserConsoleLog(log, 'failed')
+        onUserConsoleLog.call(this, log, 'failed')
       }
     }
   }

--- a/test/e2e/test/reporters/silent.test.ts
+++ b/test/e2e/test/reporters/silent.test.ts
@@ -77,6 +77,41 @@ Log from failed file`,
   expect(stdout.match(/stdout/g)).toHaveLength(4)
 })
 
+test('{ silent: "passed-only" } replays failed logs when onUserConsoleLog is shadowed', async () => {
+  const { stderr, stdout } = await runVitest({
+    config: false,
+    include: ['./fixtures/reporters/console-some-failing.test.ts'],
+    silent: 'passed-only',
+    reporters: [new ShadowedLogReporter()],
+  })
+
+  const logs = stdout
+    .split('\n')
+    .filter(line => line.startsWith('stdout |') || line.startsWith('Log from'))
+    .join('\n')
+
+  expect({
+    hasPassedLogs: stdout.includes('Log from passed'),
+    hasReporterError: stderr.includes('Unhandled Reporter Error'),
+    logs,
+    stdoutCount: stdout.match(/stdout/g)?.length,
+  }).toMatchInlineSnapshot(`
+    {
+      "hasPassedLogs": false,
+      "hasReporterError": false,
+      "logs": "stdout | fixtures/reporters/console-some-failing.test.ts > failed test #1
+    Log from failed test
+    stdout | fixtures/reporters/console-some-failing.test.ts > failed suite #1 > failed test #2
+    Log from failed test
+    stdout | fixtures/reporters/console-some-failing.test.ts > failed suite #1
+    Log from failed suite
+    stdout | fixtures/reporters/console-some-failing.test.ts
+    Log from failed file",
+      "stdoutCount": 4,
+    }
+  `)
+})
+
 test('{ silent: "passed-only" } logs are filtered by custom onConsoleLog', async () => {
   const { stdout } = await runVitest({
     config: false,
@@ -105,4 +140,11 @@ Log from failed suite`,
 
 class LogReporter extends DefaultReporter {
   isTTY = true
+}
+
+class ShadowedLogReporter extends LogReporter {
+  constructor() {
+    super()
+    Object.defineProperty(this, 'onUserConsoleLog', { value: undefined })
+  }
 }


### PR DESCRIPTION
### Description

Resolves #10383

`BaseReporter.logFailedTask` now falls back to the base console-log replay implementation when `onUserConsoleLog` has been shadowed or removed on the reporter instance. This avoids the reporter crash while still replaying failed-task logs for `silent: 'passed-only'`.

AI assistance disclosure: implemented with OpenAI Codex via Hermes Agent; cyphercodes owns this contribution.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] `corepack pnpm build`
- [x] `corepack pnpm lint:fix`
- [x] `CI=true corepack pnpm -C test/e2e test reporters/silent.test.ts --watch=false`

Full `pnpm test:ci` was not run locally due cron scope; targeted reporter coverage and the workspace build passed.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No documentation changes are needed for this bug fix.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
