### PR TITLE
fix(browser): wait for orchestrator readiness before resolving browser sessions

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -36,6 +36,13 @@ export class IframeOrchestrator {
       'message',
       e => this.onGlobalChannelEvent(e),
     )
+
+    // Notify the server once the websocket is ready without blocking orchestrator creation.
+    void client.waitForConnection()
+      .then(() => client.rpc.onOrchestratorReady())
+      .catch((error) => {
+        debug('failed to notify orchestrator readiness', error)
+      })
   }
 
   public async createTesters(options: BrowserTesterOptions): Promise<void> {

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -69,7 +69,8 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
 
     if (type === 'orchestrator') {
       const session = sessions.getSession(sessionId)
-      // it's possible the session was already resolved by the preview provider
+      // it's possible the session was already resolved by the preview provider,
+      // but we still mark the websocket connection when the page reconnects
       session?.connected()
     }
 
@@ -84,7 +85,7 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
     wss.handleUpgrade(request, socket, head, (ws) => {
       wss.emit('connection', ws, request)
 
-      const { rpc, offCancel } = setupClient(project, rpcId, ws)
+      const { rpc, offCancel } = setupClient(project, rpcId, ws, { sessionId })
       const state = project.browser!.state as BrowserServerState
       const clients = type === 'tester' ? state.testers : state.orchestrators
       clients.set(rpcId, rpc)
@@ -151,7 +152,14 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
     }
   }
 
-  function setupClient(project: TestProject, rpcId: string, ws: WebSocket) {
+  function setupClient(
+    project: TestProject,
+    rpcId: string,
+    ws: WebSocket,
+    options: {
+      sessionId: string
+    },
+  ) {
     const mockResolver = new ServerMockResolver(globalServer.vite, {
       moduleDirectories: project.config?.deps?.moduleDirectories,
     })
@@ -159,6 +167,10 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
 
     const rpc = createBirpc<WebSocketBrowserEvents, WebSocketBrowserHandlers>(
       {
+        onOrchestratorReady() {
+          const sessions = vitest._browserSessions
+          sessions.getSession(options.sessionId)?.ready()
+        },
         async onUnhandledError(error, type) {
           if (error && typeof error === 'object') {
             const _error = error as TestError

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -22,6 +22,7 @@ export interface WebSocketBrowserHandlers {
   onTaskArtifactRecord: <Artifact extends TestArtifact>(testId: string, artifact: Artifact) => Promise<Artifact>
   onTaskUpdate: (method: TestExecutionMethod, packs: TaskResultPack[], events: TaskEventPack[]) => void
   onAfterSuiteRun: (meta: AfterSuiteRunMeta) => void
+  onOrchestratorReady: () => void
   cancelCurrentRun: (reason: CancelReason) => void
   getCountOfFailedTests: () => number
   readSnapshotFile: (id: string) => Promise<string | null>

--- a/packages/vitest/src/node/browser/sessions.ts
+++ b/packages/vitest/src/node/browser/sessions.ts
@@ -22,19 +22,32 @@ export class BrowserSessions {
     pool: { reject: (error: Error) => void },
     options?: { otelCarrier?: OTELCarrier },
   ): Promise<void> {
-    // this promise only waits for the WS connection with the orchestrator to be established
+    // this promise waits until the orchestrator is ready to accept RPC calls
     const defer = createDefer<void>()
-
+    let isConnected = false
+    let isReady = false
     const timeout = setTimeout(() => {
       defer.reject(new Error(`Failed to connect to the browser session "${sessionId}" [${project.name}] within the timeout.`))
     }, project.vitest.config.browser.connectTimeout ?? 60_000).unref()
+
+    const resolveIfReady = () => {
+      if (!isConnected || !isReady) {
+        return
+      }
+      defer.resolve()
+      clearTimeout(timeout)
+    }
 
     this.sessions.set(sessionId, {
       project,
       otelCarrier: options?.otelCarrier,
       connected: () => {
-        defer.resolve()
-        clearTimeout(timeout)
+        isConnected = true
+        resolveIfReady()
+      },
+      ready: () => {
+        isReady = true
+        resolveIfReady()
       },
       // this fails the whole test run and cancels the pool
       fail: (error: Error) => {

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -376,6 +376,7 @@ export interface BrowserServerStateSession {
   project: TestProject
   otelCarrier?: OTELCarrier
   connected: () => void
+  ready: () => void
   fail: (v: Error) => void
 }
 

--- a/test/unit/test/browser-sessions.test.ts
+++ b/test/unit/test/browser-sessions.test.ts
@@ -1,0 +1,73 @@
+import type { TestProject } from 'vitest/node'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { BrowserSessions } from '../../../packages/vitest/src/node/browser/sessions'
+
+function createProject(connectTimeout = 100) {
+  return { name: 'browser', vitest: { config: { browser: { connectTimeout } } } } as TestProject
+}
+
+describe('BrowserSessions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('resolves only after the session is connected and ready', async () => {
+    const sessions = new BrowserSessions()
+    const promise = sessions.createSession('session-id', createProject(), { reject() {} })
+    const session = sessions.getSession('session-id')
+    expect(session).toBeDefined()
+
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    session!.ready()
+    expect(resolved).toBe(false)
+
+    session!.connected()
+    await promise
+    expect(resolved).toBe(true)
+  })
+
+  describe('timeouts and failures', () => {
+    test('times out if the session connects but never becomes ready', async () => {
+      const sessions = new BrowserSessions()
+      const promise = sessions.createSession('session-id', createProject(), { reject() {} })
+
+      const session = sessions.getSession('session-id')
+      expect(session).toBeDefined()
+
+      const timeoutError = expect(promise).rejects.toThrowError(
+        'Failed to connect to the browser session "session-id" [browser] within the timeout.',
+      )
+
+      session!.connected()
+      await vi.advanceTimersByTimeAsync(101)
+
+      await timeoutError
+    })
+
+    test('fails the pool without waiting for the connect timeout', async () => {
+      const sessions = new BrowserSessions()
+      const poolReject = vi.fn()
+      const promise = sessions.createSession('session-id', createProject(), { reject: poolReject })
+
+      const session = sessions.getSession('session-id')
+      expect(session).toBeDefined()
+
+      const error = new Error('browser failed')
+      session!.fail(error)
+
+      await expect(promise).resolves.toBeUndefined()
+      expect(poolReject).toHaveBeenCalledExactlyOnceWith(error)
+
+      await vi.advanceTimersByTimeAsync(101)
+      expect(poolReject).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
### Description

I diagnosed an intermittent failure in our CI runs (about one in five) to a timing issue in vitest. The tests would not fail — vitest would hang until the CI job was killed after a while.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves (do you need an issue for a bug fix?)

 I figured out (with the help of Codex) hanging behaviour was caused when the WS upgrade happened (so the `connected()` event was triggered on the session), but the `orchestrator` wasn't created and assigned to `getBrowserState().orchestrator` yet.

The fix was to introduce a "ready" event in the `IframeOrchestrator`'s `constructor` to signal that the websocket connection is ready. In the session only after both the ready + connected events are seen does the promise returned from `createSession` resolve.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

AI assisted: Codex

<!-- VITEST_AUTOMATED_PR -->