### PR TITLE
docs(browser): remove stale TODO in trace-view

### DIFF
--- a/docs/guide/browser/trace-view.md
+++ b/docs/guide/browser/trace-view.md
@@ -59,17 +59,6 @@ Selecting a step also opens its source location in the Editor tab when that loca
 
 ## Common Setups
 
-<!--
-TODO: The browser UI / Vitest UI / browser driver combinations are not specific to trace view and might be better documented in the Browser Mode guide.  Something like:
-
-  | top-level --ui | browser.ui | browser.headless | Result |
-  | --- | --- | --- | --- |
-  | off | true | false | browser UI/live iframe in headed browser |
-  | on | false | true | pure Vitest UI, tests in headless browser |
-  | on | false | false | pure Vitest UI, tests in separate headed browser window |
-
--->
-
 `browser.traceView` records traces. The browser mode, UI, and reporter options determine where you inspect them.
 
 | Goal | Configuration | Result |


### PR DESCRIPTION
The HTML comment in `docs/guide/browser/trace-view.md` (lines 62-71) suggests adding a `browser.ui` / `browser.headless` configuration table, but [the table directly below](https://github.com/vitest-dev/vitest/blob/main/docs/guide/browser/trace-view.md#L75-L80) (the "Common Setups" section) already covers those mode combinations using the actual CLI flags.

The note is invisible in the rendered page, so removing it.