### PR TITLE
fix(mocker): ignore mock calls in comments (fix #10396)

### DIFF
--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -74,6 +74,139 @@ const regexpHoistable
   = /\b(?:vi|vitest)\s*\.\s*(?:mock|unmock|hoisted|doMock|doUnmock)\s*\(/
 const hashbangRE = /^#!.*\n/
 
+function regexpHoistableMatches(code: string, regexp: RegExp): boolean {
+  regexp.lastIndex = 0
+  if (!regexp.test(code)) {
+    return false
+  }
+  regexp.lastIndex = 0
+  const cleanCode = stripCommentsAndStrings(code)
+  const result = regexp.test(cleanCode)
+  regexp.lastIndex = 0
+  return result
+}
+
+function stripCommentsAndStrings(code: string): string {
+  const result = code.split('')
+  const length = code.length
+
+  function mask(start: number, end: number) {
+    for (let i = start; i < end && i < length; i++) {
+      if (code[i] !== '\n' && code[i] !== '\r') {
+        result[i] = ' '
+      }
+    }
+  }
+
+  function skipLineComment(index: number): number {
+    const start = index
+    index += 2
+    while (index < length && code[index] !== '\n' && code[index] !== '\r') {
+      index++
+    }
+    mask(start, index)
+    return index
+  }
+
+  function skipBlockComment(index: number): number {
+    const start = index
+    index += 2
+    while (index < length) {
+      if (code[index - 1] === '*' && code[index] === '/') {
+        index++
+        break
+      }
+      index++
+    }
+    mask(start, index)
+    return index
+  }
+
+  function skipQuotedString(index: number, quote: string): number {
+    const start = index
+    index++
+    while (index < length) {
+      const char = code[index]
+      if (char === '\\') {
+        index = Math.min(index + 2, length)
+        continue
+      }
+      index++
+      if (char === quote) {
+        break
+      }
+    }
+    mask(start, index)
+    return index
+  }
+
+  function skipTemplate(index: number): number {
+    mask(index, index + 1)
+    index++
+    while (index < length) {
+      const char = code[index]
+      if (char === '\\') {
+        mask(index, index + 2)
+        index = Math.min(index + 2, length)
+        continue
+      }
+      if (char === '`') {
+        mask(index, index + 1)
+        return index + 1
+      }
+      if (char === '$' && code[index + 1] === '{') {
+        mask(index, index + 2)
+        index = scanCode(index + 2, true)
+        continue
+      }
+      mask(index, index + 1)
+      index++
+    }
+    return index
+  }
+
+  function scanCode(index: number, stopOnBrace: boolean): number {
+    let braceDepth = 0
+    while (index < length) {
+      const char = code[index]
+      const next = code[index + 1]
+      if (char === '"' || char === '\'') {
+        index = skipQuotedString(index, char)
+        continue
+      }
+      if (char === '`') {
+        index = skipTemplate(index)
+        continue
+      }
+      if (char === '/' && next === '/') {
+        index = skipLineComment(index)
+        continue
+      }
+      if (char === '/' && next === '*') {
+        index = skipBlockComment(index)
+        continue
+      }
+      if (stopOnBrace) {
+        if (char === '{') {
+          braceDepth++
+        }
+        else if (char === '}') {
+          if (braceDepth === 0) {
+            mask(index, index + 1)
+            return index + 1
+          }
+          braceDepth--
+        }
+      }
+      index++
+    }
+    return index
+  }
+
+  scanCode(0, false)
+  return result.join('')
+}
+
 // this is a fork of Vite SSR transform
 export function hoistMocks(
   code: string,
@@ -81,7 +214,10 @@ export function hoistMocks(
   parse: (code: string) => any,
   options: HoistMocksOptions = {},
 ): MagicString | undefined {
-  const needHoisting = (options.regexpHoistable || regexpHoistable).test(code)
+  const needHoisting = regexpHoistableMatches(
+    code,
+    options.regexpHoistable || regexpHoistable,
+  )
 
   if (!needHoisting) {
     return

--- a/test/unit/test/injector-mock.test.ts
+++ b/test/unit/test/injector-mock.test.ts
@@ -40,6 +40,19 @@ test('hoists mock, unmock, hoisted', () => {
   `)
 })
 
+test('does not hoist mock-like calls in comments and strings', () => {
+  expect(hoistSimple(`
+import { value } from './path'
+/**
+ * This documents \`vi.mock('./path')\` without calling it.
+ */
+// vitest.unmock('./path')
+const message = "vi.doMock('./path')"
+const template = \`vi.hoisted(() => {})\`
+console.log(value, message, template)
+  `)).toBeUndefined()
+})
+
 test('always hoists import from vitest', () => {
   expect(hoistSimpleCode(`
 import { vi } from 'vitest'


### PR DESCRIPTION
### Description

Resolves #10396

This updates `@vitest/mocker`'s hoist pre-scan so mock-looking calls inside comments, string literals, and template literal text do not enable mock hoisting. That prevents files with only documented `vi.mock(` snippets from having their static imports rewritten.

AI assistance disclosure: this PR was implemented with OpenAI Codex via Hermes Agent; cyphercodes is submitting it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] `corepack pnpm install --frozen-lockfile`
- [x] `corepack pnpm build`
- [x] `CI=true corepack pnpm test injector-mock.test.ts`
- [x] `corepack pnpm lint:fix`
- [x] `corepack pnpm lint`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm typecheck`
- [x] `git diff --check`

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command. (Not applicable; bug fix only.)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
