### PR TITLE
fix(mocker): refresh stale mocked module across files with isolate:false

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -166,25 +166,50 @@ export class VitestModuleRunner
 
     let mocked: any
     if (mod.meta && 'mockedModule' in mod.meta) {
-      const mockedModule = mod.meta.mockedModule as MockedModule
+      const cachedMockedModule = mod.meta.mockedModule as MockedModule
+      // the cached `mockedModule` in `mod.meta` reflects the mock registered
+      // by the test file whose fetch first populated this node. With
+      // `isolate: false` the module cache is shared between test files, so a
+      // different file may have replaced that mock with another type or
+      // removed it entirely. Always prefer the currently registered mock to
+      // avoid applying a stale factory across files (#10290).
+      const currentMock = this.mocker.getDependencyMock(mod.id)
+      const mockedModule = (currentMock ?? cachedMockedModule)
       const mockId = this.mocker.getMockPath(mod.id)
-      // bypass mock and force "importActual" behavior when:
-      // - mock was removed by doUnmock (stale mockedModule in meta)
-      // - self-import: mock factory/file is importing the module it's mocking
-      const isStale = !this.mocker.getDependencyMock(mod.id)
+      const isStale = !currentMock
       const isSelfImport = callstack.includes(mockId)
         || callstack.includes(url)
         || ('redirect' in mockedModule && callstack.includes(mockedModule.redirect))
       if (isStale || isSelfImport) {
+        // bypass mock and force "importActual" behavior when:
+        // - mock was removed by doUnmock (stale mockedModule in meta)
+        // - self-import: mock factory/file is importing the module it's mocking
         const node = await this.fetchModule(injectQuery(url, '_vitest_original'))
         return this._cachedRequest(node.url, node, callstack, metadata)
       }
-      mocked = await this.mocker.requestWithMockedModule(
-        url,
-        mod,
-        callstack,
-        mockedModule,
-      )
+      // the cached node was populated as a manual/redirect placeholder
+      // (its `code` is empty). When the current mock is an automock/autospy,
+      // it needs the actual source of the original module, so re-fetch it.
+      if (
+        (mockedModule.type === 'automock' || mockedModule.type === 'autospy')
+        && cachedMockedModule.type !== mockedModule.type
+      ) {
+        const node = await this.fetchModule(injectQuery(url, '_vitest_original'))
+        mocked = await this.mocker.requestWithMockedModule(
+          url,
+          node,
+          callstack,
+          mockedModule,
+        )
+      }
+      else {
+        mocked = await this.mocker.requestWithMockedModule(
+          url,
+          mod,
+          callstack,
+          mockedModule,
+        )
+      }
     }
     else {
       mocked = await this.mocker.mockedRequest(url, mod, callstack)

--- a/test/e2e/test/mocking-isolate-false.test.ts
+++ b/test/e2e/test/mocking-isolate-false.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from 'vitest'
+import { runInlineTests } from '../../test-utils'
+
+const configWithoutIsolation = `
+import { defineConfig } from 'vitest/config'
+
+class Sequencer {
+  sort(files) { return files }
+  shard(files) { return files }
+}
+
+export default defineConfig({
+  test: {
+    isolate: false,
+    fileParallelism: false,
+    sequence: { sequencer: Sequencer },
+  },
+})
+`
+
+test('factory mock then bare mock across files with isolate:false (#10290)', async () => {
+  const { stderr, testTree } = await runInlineTests({
+    'vitest.config.js': configWithoutIsolation,
+    './src/repo.js': `
+export function hasThing(name) {
+  return false;
+}
+export function otherThing() {
+  return 'real';
+}
+    `,
+    './test/testA.test.ts': `
+import { vi, test, expect } from 'vitest'
+import * as repo from '../src/repo.js'
+
+vi.mock('../src/repo.js', () => ({
+  otherThing: vi.fn(() => 'mockedA'),
+}))
+
+test('factory mock works', () => {
+  expect(repo.otherThing()).toBe('mockedA')
+})
+    `,
+    './test/testB.test.ts': `
+import { vi, test, expect } from 'vitest'
+import * as repo from '../src/repo.js'
+
+vi.mock('../src/repo.js')
+
+test('bare mock should auto-mock hasThing', () => {
+  vi.mocked(repo.hasThing).mockReturnValue(true)
+  expect(repo.hasThing('anything')).toBe(true)
+})
+    `,
+  })
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "test/testA.test.ts": {
+        "factory mock works": "passed",
+      },
+      "test/testB.test.ts": {
+        "bare mock should auto-mock hasThing": "passed",
+      },
+    }
+  `)
+})
+
+test('bare mock then factory mock across files with isolate:false', async () => {
+  const { stderr, testTree } = await runInlineTests({
+    'vitest.config.js': configWithoutIsolation,
+    './src/repo.js': `
+export function hasThing(name) {
+  return false;
+}
+export function otherThing() {
+  return 'real';
+}
+    `,
+    './test/testA.test.ts': `
+import { vi, test, expect } from 'vitest'
+import * as repo from '../src/repo.js'
+
+vi.mock('../src/repo.js')
+
+test('automock works first', () => {
+  vi.mocked(repo.hasThing).mockReturnValue(true)
+  expect(repo.hasThing('anything')).toBe(true)
+})
+    `,
+    './test/testB.test.ts': `
+import { vi, test, expect } from 'vitest'
+import * as repo from '../src/repo.js'
+
+vi.mock('../src/repo.js', () => ({
+  otherThing: vi.fn(() => 'mockedB'),
+}))
+
+test('factory mock applies after automock', () => {
+  expect(repo.otherThing()).toBe('mockedB')
+})
+    `,
+  })
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "test/testA.test.ts": {
+        "automock works first": "passed",
+      },
+      "test/testB.test.ts": {
+        "factory mock applies after automock": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
<!-- VITEST_AUTOMATED_PR -->

When running with isolate:false, the worker reuses its module-runner cache across test files. The fetch hook stores the resolved mock on a module node's meta as mockedModule the first time the module is requested. Once that meta is cached, subsequent test files that re-import the same module hit the cached meta and end up dispatching through the previous file's mock, not the one they themselves registered. The repro in #10290 shows this clearly: a file that mocks with a factory followed by a file that calls vi.mock without a factory throws "No hasThing export is defined on the ../src/repo.js mock", because the bare vi.mock is being applied through the earlier file's ManualMockedModule proxy.

The fix in cachedRequest looks up the currently registered mock from the mocker registry and uses it in place of the cached meta value. The existing stale handling already bypassed the cached mock when getDependencyMock returned undefined (so doUnmock would fall back to importActual); this extends the same idea to the case where the mock type changed between files. The fallback to the cached value is kept only to keep self-import detection working in narrow cases where the registry has not been populated yet.

There is one extra wrinkle for automock and autospy. When the cached node was originally fetched as a manual or redirect mock, its meta carries an empty code placeholder, so handing that node to requestWithMockedModule for automock produces an empty exports object and downstream calls like vi.mocked(repo.hasThing).mockReturnValue see undefined. When the current mock type differs from the cached one and the new type needs the original source (automock/autospy), the patch refetches the original module via _vitest_original before delegating, matching what mockedRequest sees on a fresh run.

Verified with the existing test/e2e mocking suite (22 tests passing) and test/unit mocking suite (534 tests passing). Added test/e2e/test/mocking-isolate-false.test.ts covering both orderings, factory then bare and bare then factory, under isolate:false with a stable sequencer. Lint and typecheck are clean.

Fixes #10290