### PR TITLE
fix(mocker): ignore vi.mock-like text in comments and strings

### DIFF
--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -74,6 +74,139 @@ const regexpHoistable
   = /\b(?:vi|vitest)\s*\.\s*(?:mock|unmock|hoisted|doMock|doUnmock)\s*\(/
 const hashbangRE = /^#!.*\n/
 
+function regexpHoistableMatches(code: string, regexp: RegExp): boolean {
+  regexp.lastIndex = 0
+  if (!regexp.test(code)) {
+    return false
+  }
+  regexp.lastIndex = 0
+  const cleanCode = stripCommentsAndStrings(code)
+  const result = regexp.test(cleanCode)
+  regexp.lastIndex = 0
+  return result
+}
+
+function stripCommentsAndStrings(code: string): string {
+  const result = code.split('')
+  const length = code.length
+
+  function mask(start: number, end: number) {
+    for (let i = start; i < end && i < length; i++) {
+      if (code[i] !== '\n' && code[i] !== '\r') {
+        result[i] = ' '
+      }
+    }
+  }
+
+  function skipLineComment(index: number): number {
+    const start = index
+    index += 2
+    while (index < length && code[index] !== '\n' && code[index] !== '\r') {
+      index++
+    }
+    mask(start, index)
+    return index
+  }
+
+  function skipBlockComment(index: number): number {
+    const start = index
+    index += 2
+    while (index < length) {
+      if (code[index - 1] === '*' && code[index] === '/') {
+        index++
+        break
+      }
+      index++
+    }
+    mask(start, index)
+    return index
+  }
+
+  function skipQuotedString(index: number, quote: string): number {
+    const start = index
+    index++
+    while (index < length) {
+      const char = code[index]
+      if (char === '\\') {
+        index = Math.min(index + 2, length)
+        continue
+      }
+      index++
+      if (char === quote) {
+        break
+      }
+    }
+    mask(start, index)
+    return index
+  }
+
+  function skipTemplate(index: number): number {
+    mask(index, index + 1)
+    index++
+    while (index < length) {
+      const char = code[index]
+      if (char === '\\') {
+        mask(index, index + 2)
+        index = Math.min(index + 2, length)
+        continue
+      }
+      if (char === '`') {
+        mask(index, index + 1)
+        return index + 1
+      }
+      if (char === '$' && code[index + 1] === '{') {
+        mask(index, index + 2)
+        index = scanCode(index + 2, true)
+        continue
+      }
+      mask(index, index + 1)
+      index++
+    }
+    return index
+  }
+
+  function scanCode(index: number, stopOnBrace: boolean): number {
+    let braceDepth = 0
+    while (index < length) {
+      const char = code[index]
+      const next = code[index + 1]
+      if (char === '"' || char === '\'') {
+        index = skipQuotedString(index, char)
+        continue
+      }
+      if (char === '`') {
+        index = skipTemplate(index)
+        continue
+      }
+      if (char === '/' && next === '/') {
+        index = skipLineComment(index)
+        continue
+      }
+      if (char === '/' && next === '*') {
+        index = skipBlockComment(index)
+        continue
+      }
+      if (stopOnBrace) {
+        if (char === '{') {
+          braceDepth++
+        }
+        else if (char === '}') {
+          if (braceDepth === 0) {
+            mask(index, index + 1)
+            return index + 1
+          }
+          braceDepth--
+        }
+      }
+      index++
+    }
+    return index
+  }
+
+  scanCode(0, false)
+  return result.join('')
+}
+
 // this is a fork of Vite SSR transform
 export function hoistMocks(
   code: string,
@@ -81,7 +214,10 @@ export function hoistMocks(
   parse: (code: string) => any,
   options: HoistMocksOptions = {},
 ): MagicString | undefined {
-  const needHoisting = (options.regexpHoistable || regexpHoistable).test(code)
+  const needHoisting = regexpHoistableMatches(
+    code,
+    options.regexpHoistable || regexpHoistable,
+  )
 
   if (!needHoisting) {
     return

--- a/test/unit/test/injector-mock.test.ts
+++ b/test/unit/test/injector-mock.test.ts
@@ -27,6 +27,19 @@ function hoistSimpleCode(code: string) {
   return hoistMockAndResolve(code, '/test.js', parse, hoistMocksOptions)?.code.trim()
 }
 
+test('does not hoist mock-like calls in comments and strings', () => {
+  expect(hoistSimple(`
+import { value } from './path'
+/**
+ * This documents \`vi.mock('./path')\` without calling it.
+ */
+// vitest.unmock('./path')
+const message = "vi.doMock('./path')"
+const template = \`vi.hoisted(() => {})\`
+console.log(value, message, template)
+  `)).toBeUndefined()
+})
+
 test('hoists mock, unmock, hoisted', () => {
   expect(hoistSimpleCode(`
   vi.mock('path', () => {})


### PR DESCRIPTION
## Summary

- Fix false-positive mock hoisting when `vi.mock(` / `vitest.unmock(` / similar text appears only in comments, string literals, or template literals (fixes #10396).
- The hoist pre-scan now strips comments and string/template content before running the hoistable regex, so static imports are not rewritten unless there is a real mock call in source code.
- Add a regression test in `injector-mock.test.ts`.

## Context

`@vitest/mocker`'s `hoistMocksPlugin` used a raw-source regex to decide whether to hoist. A `vi.mock(` substring inside a JSDoc comment was enough to enable hoisting and rewrite all static imports as top-level `await`, which can deadlock browser mode with benign import cycles.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build`
- [x] `CI=true pnpm exec vitest run test/unit/test/injector-mock.test.ts` (81 tests passed)
- [x] `pnpm lint`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm typecheck`


Made with [Cursor](https://cursor.com)