### PR TITLE
fix(runner): propagate describe.for chainable context

### DIFF
--- a/packages/runner/src/suite.ts
+++ b/packages/runner/src/suite.ts
@@ -706,13 +706,13 @@ function createSuite() {
   }
 
   suiteFn.for = function <T>(
-    this: {
-      withContext: () => SuiteAPI
-      setContext: (key: string, value: boolean | undefined) => SuiteAPI
-    },
+    this: SuiteAPI,
     cases: ReadonlyArray<T>,
     ...args: any[]
   ) {
+    const context = getChainableContext(this)
+    const suite = context.withContext()
+
     if (Array.isArray(cases) && args.length) {
       cases = formatTemplateString(cases, args)
     }

--- a/test/core/test/test-for-suite.test.ts
+++ b/test/core/test/test-for-suite.test.ts
@@ -33,3 +33,15 @@ describe.for([
     expect(a + b).matchSnapshot()
   })
 })
+
+describe.skipIf(true).for(['skipped'])('%s describe.for suite', () => {
+  test('does not run skipped describe.for cases', () => {
+    throw new Error('skipped describe.for case should not run')
+  })
+})
+
+describe.runIf(false).for(['skipped'])('%s runIf describe.for suite', () => {
+  test('does not run false runIf describe.for cases', () => {
+    throw new Error('runIf(false) describe.for case should not run')
+  })
+})


### PR DESCRIPTION
## Summary
- Backports the chainable context propagation used on main for `describe.for` to the `v4.1` branch
- Preserves `skipIf` / `runIf` flags when `describe` is chained with `.for(cases)`
- Adds regression coverage for skipped `describe.for` and false `runIf(...).for` suites

Fixes #10407.
Backport of the runner-side behavior from #10187 for `v4.1`.

## Tests
- `pnpm exec eslint packages/runner/src/suite.ts test/core/test/test-for-suite.test.ts`
- from `test/core`: `pnpm vitest --project threads test/test-for-suite.test.ts`