### PR TITLE
fix(mocker): skip hoist transform without ast mock calls

### DIFF
--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -248,6 +248,7 @@ export function hoistMocks(
 
   const usedUtilityExports = new Set<string>()
   let hasImportMetaVitest = false
+  let hasMockApiCall = false
 
   esmWalker(ast, {
     onImportMeta(node) {
@@ -310,6 +311,7 @@ export function hoistMocks(
         usedUtilityExports.add(node.callee.object.name)
 
         if (hoistableMockMethodNames.includes(methodName)) {
+          hasMockApiCall = true
           const method = `${node.callee.object.name}.${methodName}`
           assertNotDefaultExport(
             node,
@@ -356,6 +358,7 @@ export function hoistMocks(
         // vi.doMock(import('./path')) -> vi.doMock('./path')
         // vi.doMock(await import('./path')) -> vi.doMock('./path')
         else if (dynamicImportMockMethodNames.includes(methodName)) {
+          hasMockApiCall = true
           const moduleInfo = node.arguments[0] as Positioned<Expression>
           let source: Positioned<Expression> | null = null
           if (moduleInfo.type === 'ImportExpression') {
@@ -377,6 +380,7 @@ export function hoistMocks(
         }
 
         if (hoistedMethodNames.includes(methodName)) {
+          hasMockApiCall = true
           assertNotDefaultExport(
             node,
             'Cannot export hoisted variable. You can control hoisting behavior by placing the import from this file first.',
@@ -405,6 +409,10 @@ export function hoistMocks(
       }
     },
   })
+
+  if (!hasMockApiCall) {
+    return
+  }
 
   function getNodeName(node: CallExpression) {
     const callee = node.callee || {}

--- a/test/unit/test/injector-mock.test.ts
+++ b/test/unit/test/injector-mock.test.ts
@@ -774,7 +774,7 @@ add(4);
         del = () => __vi_import_0__.del()
         call = __vi_import_0__.call(4)
       }
-      
+
       __vi_import_0__.remove(2);
       __vi_import_0__.add(4);"
     `)
@@ -1741,4 +1741,19 @@ if (import.meta.vitest) {
     `)
     expect(warn).not.toHaveBeenCalled()
   })
+})
+
+test('does not transform when hoistable API only appears in comments', () => {
+  expect(hoistSimpleCode(`
+import { lib } from 'lib'
+// vi.mock('lib')
+console.log(lib)
+  `)).toMatchInlineSnapshot(`undefined`)
+})
+
+test('does not transform when hoistable API only appears in strings', () => {
+  expect(hoistSimpleCode(`
+import { lib } from 'lib'
+console.log("vi.mock('lib')", lib)
+  `)).toMatchInlineSnapshot(`undefined`)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10396

This fixes a false-positive path in the mock hoist transform due to the initial regex overmatching mock API usage in comments or string literals. Although the later full parse has enough information to know that no real mock API call exists, the transform still proceeded and rewrote static imports into dynamic imports. Like in https://github.com/vitest-dev/vitest/issues/10396, such rewrite can affect module semantics, especially in cases like cyclic imports.

We could add an extra pre-regex `stripLiteral` pass like in other transform, but I didn't because we'll have full AST parse anyways and can decide fully during ast traverse.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
