### PR TITLE
fix(browser): escape inline orchestrator scripts

### DIFF
--- a/packages/browser/src/node/serverOrchestrator.ts
+++ b/packages/browser/src/node/serverOrchestrator.ts
@@ -61,7 +61,7 @@ export async function resolveOrchestrator(
       for (const attr in script.attrs || {}) {
         html += `${attr}="${script.attrs![attr]}" `
       }
-      html += `>${script.children}</script>`
+      html += `>${escapeInlineScript(typeof script.children === 'string' ? script.children : '')}</script>`
       return html
     }).join('\n')
   }
@@ -96,8 +96,14 @@ export async function resolveOrchestrator(
     __VITEST_FAVICON__: globalServer.faviconUrl,
     __VITEST_TITLE__: 'Vitest Browser Runner',
     __VITEST_SCRIPTS__: globalServer.orchestratorScripts,
-    __VITEST_INJECTOR__: `<script type="module">${injector}</script>`,
+    __VITEST_INJECTOR__: `<script type="module">${escapeInlineScript(injector)}</script>`,
     __VITEST_ERROR_CATCHER__: `<script type="module" src="${globalServer.errorCatcherUrl}"></script>`,
     __VITEST_SESSION_ID__: JSON.stringify(sessionId),
   })
+}
+
+function escapeInlineScript(content: string): string {
+  return content
+    .replace(/<!--/g, '<\\!--')
+    .replace(/<\/(script)/gi, '</\\$1')
 }

--- a/test/browser/fixtures/inline-script/basic.test.ts
+++ b/test/browser/fixtures/inline-script/basic.test.ts
@@ -1,0 +1,5 @@
+import { expect, inject, test } from 'vitest'
+
+test('provide', () => {
+  expect(inject('someKey' as never)).toBe('</script><h1>inject1</h1><!--')
+})

--- a/test/browser/fixtures/inline-script/vite.config.ts
+++ b/test/browser/fixtures/inline-script/vite.config.ts
@@ -1,0 +1,26 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'node_modules/.vite'
+  ),
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances: [instances[0]],
+      orchestratorScripts: [
+        {
+          content: 'globalThis.__injected = "</script><h1>inject2</h1><!--"',
+        },
+      ],
+    },
+    provide: {
+      someKey: "</script><h1>inject1</h1><!--",
+    },
+  },
+})

--- a/test/browser/specs/inline-script.test.ts
+++ b/test/browser/specs/inline-script.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { runBrowserTests } from './utils'
+
+test('escape inline script', async () => {
+  const result = await runBrowserTests({
+    root: './fixtures/inline-script',
+  })
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "provide": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Minor security gotcha that I noticed when digging https://github.com/vitest-dev/vitest/pull/10283. This isn't vulnerability other than user code attacking itself, but it makes sense to safe guard to avoid any potential future attack surface.

This is also a genuine bug fix for certain string use in provide/inject. Before the fix, the orchestrator page shows up like this with `provide.someKey: "</script><h1>inject1</h1><!--"`:

<img width="917" height="370" alt="image" src="https://github.com/user-attachments/assets/6fc7a26d-7ab8-41d1-85b6-ebbef8bb3d2e" />


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
