### PR TITLE
docs: add releases page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -88,6 +88,9 @@ export default ({ mode }: { mode: string }) => {
         }),
         llmstxt(),
       ],
+      define: {
+        __VITEST_VERSION__: JSON.stringify(version),
+      },
     },
     markdown: {
       config(md) {
@@ -227,6 +230,10 @@ export default ({ mode }: { mode: string }) => {
                 {
                   text: 'Team',
                   link: '/team',
+                },
+                {
+                  text: 'Releases',
+                  link: '/releases',
                 },
               ],
             },

--- a/docs/.vitepress/theme/SupportedVersions.vue
+++ b/docs/.vitepress/theme/SupportedVersions.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+declare const __VITEST_VERSION__: string
+
+// Constants
+const supportedVersionMessage = {
+  color: 'var(--vp-c-brand-1)',
+  text: 'supported',
+}
+const notSupportedVersionMessage = {
+  color: 'var(--vp-c-danger-1)',
+  text: 'not supported',
+}
+const previousMajorLatestMinors: Record<string, string> = {
+  1: '1.6',
+  2: '2.1',
+  3: '3.2',
+  4: '4.1',
+}
+
+// Current latest Vitest version and support info
+const parsedViteVersion = parseVersion(__VITEST_VERSION__)!
+const supportInfo = computeSupportInfo(parsedViteVersion)
+
+// Check supported version input
+const checkedVersion = ref(`${Math.max(parsedViteVersion.major - 2, 2)}.0.0`)
+const checkedResult = computed(() => {
+  const version = checkedVersion.value
+  if (!isValidVitestVersion(version)) {
+    return notSupportedVersionMessage
+  }
+
+  const parsedVersion = parseVersion(checkedVersion.value)
+  if (!parsedVersion) {
+    return notSupportedVersionMessage
+  }
+
+  const satisfies = (targetVersion: string) => {
+    const compared = parseVersion(targetVersion)!
+    return (
+      parsedVersion.major === compared.major
+      && parsedVersion.minor >= compared.minor
+    )
+  }
+  const satisfiesOneSupportedVersion
+    = parsedVersion.major >= parsedViteVersion.major // Treat future major versions as supported
+      || supportInfo.regularPatches.some(satisfies)
+      || supportInfo.importantFixes.some(satisfies)
+      || supportInfo.securityPatches.some(satisfies)
+
+  return satisfiesOneSupportedVersion
+    ? supportedVersionMessage
+    : notSupportedVersionMessage
+})
+
+function parseVersion(version: string) {
+  let [major, minor, patch] = version.split('.').map((v) => {
+    const num = /^\d+$/.exec(v)?.[0]
+    return num ? Number.parseInt(num) : null
+  })
+  if (!major) {
+    return null
+  }
+  minor ??= 0
+  patch ??= 0
+
+  return { major, minor, patch }
+}
+
+function computeSupportInfo(
+  version: NonNullable<ReturnType<typeof parseVersion>>,
+) {
+  const { major, minor } = version
+  const f = (versions: string[]) => {
+    return versions
+      .map(v => previousMajorLatestMinors[v] ?? v)
+      .filter((version) => {
+        if (!isValidVitestVersion(version)) {
+          return false
+        }
+        // Negative versions are invalid
+        if (/-\d/.test(version)) {
+          return false
+        }
+        return true
+      })
+  }
+
+  return {
+    regularPatches: f([`${major}.${minor}`]),
+    importantFixes: f([`${major - 1}`, `${major}.${minor - 1}`]),
+    // unlike vite, we only support the last major version
+    securityPatches: f([`${major - 1}`, `${major}.${minor - 1}`]),
+  }
+}
+
+function versionsToText(versions: string[]) {
+  versions = versions.map(v => `<code>vitest@${v}</code>`)
+  if (versions.length === 0) {
+    return ''
+  }
+  if (versions.length === 1) {
+    return versions[0]
+  }
+  return (
+    `${versions.slice(0, -1).join(', ')} and ${versions[versions.length - 1]}`
+  )
+}
+
+function isValidVitestVersion(version: string) {
+  if (version.length === 1) {
+    version += '.'
+  }
+  // Vitest 0.x shouldn't be mentioned
+  if (version.startsWith('0.')) {
+    return false
+  }
+  return true
+}
+</script>
+
+<template>
+  <div>
+    <ul>
+      <li v-if="supportInfo.regularPatches.length">
+        Regular patches are released for
+        <span v-html="versionsToText(supportInfo.regularPatches)" />.
+      </li>
+      <li v-if="supportInfo.importantFixes.length">
+        Important fixes and security patches are backported to
+        <span v-html="versionsToText(supportInfo.importantFixes)" />.
+      </li>
+      <li v-if="supportInfo.securityPatches.length">
+        Security patches are also backported to
+        <span v-html="versionsToText(supportInfo.securityPatches)" />.
+      </li>
+      <li>
+        All versions before these are no longer supported. Users should upgrade
+        to receive updates.
+      </li>
+    </ul>
+    <p>
+      If you're using Vitest
+      <input
+        v-model="checkedVersion"
+        class="checked-input"
+        type="text"
+        placeholder="0.0.0"
+      >, it is
+      <strong :style="{ color: checkedResult.color }">{{
+        checkedResult.text
+      }}</strong>.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.checked-input {
+  display: inline-block;
+  padding: 0px 5px;
+  width: 100px;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  font-size: var(--vp-code-font-size);
+  font-family: var(--vp-font-family-mono);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 5px;
+  transition: border-color 0.1s;
+}
+
+.checked-input:focus,
+.checked-input:hover {
+  border-color: var(--vp-c-brand);
+}
+</style>

--- a/docs/.vitepress/theme/SupportedVersions.vue
+++ b/docs/.vitepress/theme/SupportedVersions.vue
@@ -131,10 +131,6 @@ function isValidVitestVersion(version: string) {
         Important fixes and security patches are backported to
         <span v-html="versionsToText(supportInfo.importantFixes)" />.
       </li>
-      <li v-if="supportInfo.securityPatches.length">
-        Security patches are also backported to
-        <span v-html="versionsToText(supportInfo.securityPatches)" />.
-      </li>
       <li>
         All versions before these are no longer supported. Users should upgrade
         to receive updates.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -5,7 +5,7 @@ outline: deep
 
 # Migration Guide
 
-[Migrating to Vitest 3.0](https://v3.vitest.dev/guide/migration) | [Migrating to Vitest 2.0](https://v2.vitest.dev/guide/migration)
+[Migrating to Vitest 4.0](https://v4.vitest.dev/guide/migration) | [Migrating to Vitest 3.0](https://v3.vitest.dev/guide/migration)
 
 ## Migrating to Vitest 5.0 {#vitest-5}
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,57 @@
+<script setup>
+import SupportedVersions from './.vitepress/theme/SupportedVersions.vue';
+</script>
+
+# Releases
+
+Vitest releases follow [Semantic Versioning](https://semver.org/). You can see the latest stable version of Vitest in the [Vitest npm package page](https://www.npmjs.com/package/vite).
+
+A full changelog of past releases is [available on GitHub](https://github.com/vitest-dev/vitest/releases).
+
+## Release Cycle
+
+Vitest does not have a fixed release cycle.
+
+- **Patch** releases are released as needed (usually every week).
+- **Minor** releases always contain new features and are released as needed. Minor releases always have a beta pre-release phase (usually every two months).
+- **Major** releases generally align with [Vite](https://vite.dev/releases) and [Node.js EOL schedule](https://endoflife.date/nodejs), and will be announced ahead of time. These releases will have a long beta pre-release phases (usually every year).
+
+## Supported Versions
+
+In summary, the current supported Vitest versions are:
+
+<SupportedVersions />
+
+<br>
+
+The supported version ranges are automatically determined by:
+
+- **Current Minor** gets regular fixes.
+- **Previous Major** (only for its latest minor) and **Previous Minor** receives important fixes and security patches.
+- All versions before these are no longer supported.
+
+We recommend updating Vitest regularly. Check out the [Migration Guides](/guide/migration) when you update to each Major. We test new Vitest versions before releasing them through the [vitest-ecosystem-ci project](https://github.com/vitest-dev/vitest-ecosystem-ci). Most projects using Vitest should be able to quickly offer support or migrate to new versions as soon as they are released.
+
+## Semantic Versioning Edge Cases
+
+### TypeScript Definitions
+
+We may ship incompatible changes to TypeScript definitions between minor versions. This is because:
+
+- Sometimes TypeScript itself ships incompatible changes between minor versions, and we may have to adjust types to support newer versions of TypeScript.
+- Occasionally we may need to adopt features that are only available in a newer version of TypeScript, raising the minimum required version of TypeScript.
+- If you are using TypeScript, you can use a semver range that locks the current minor and manually upgrade when a new minor version of Vite is released.
+
+## Pre Releases
+
+Minor releases typically go through a non-fixed number of beta releases. Major releases will go through a long beta phase.
+
+Pre-releases allow early adopters and maintainers from the Ecosystem to do integration and stability testing, and provide feedback. Do not use pre-releases in production. All pre-releases are considered unstable and may ship breaking changes in between. Always pin to exact versions when using pre-releases.
+
+## Deprecations
+
+We periodically deprecate features that have been superseded by better alternatives in Minor releases. Deprecated features will continue to work with a type or logged warning. They will be removed in the next major release after entering deprecated status. The [Migration Guide](/guide/migration.html) for each major will list these removals and document an upgrade path for them.
+
+## Experimental Features
+
+Some features are marked as experimental when released in a stable version of Vite. Experimental features allow us to gather real-world experience to influence their final design. The goal is to let users provide feedback by testing them in production. Experimental features themselves are considered unstable, and should only be used in a controlled manner. These features may change between Minors, so users must pin their Vite version when they rely on them. We will create [a GitHub discussion](https://github.com/vitest-dev/vitest/discussions/categories/feedback?discussions_q=is%3Aopen+label%3Aexperimental+category%3AFeedback) for each experimental feature.


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds "Releases" page based on https://vite.dev/releases

Unlike vite, vitest only supports security fixes in the latest major. 

I have removed Node LTS section because they switched to an annual release, and odd numbers don't have the same meaning anymore