### PR TITLE
fix: resolve tsconfig paths from referenced configs (fix #10425)

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -16,6 +16,7 @@ import { MocksPlugins } from './mocks'
 import { NormalizeURLPlugin } from './normalizeURL'
 import { VitestOptimizer } from './optimizer'
 import { ModuleRunnerTransform } from './runnerTransform'
+import { TsconfigPathsReferencesPlugin } from './tsconfigPathsReferences'
 import {
   deleteDefineConfig,
   getDefaultResolveOptions,
@@ -283,6 +284,7 @@ export async function VitestPlugin(
     ...CSSEnablerPlugin(vitest),
     CoverageTransform(vitest),
     VitestCoreResolver(vitest),
+    TsconfigPathsReferencesPlugin(),
     ...MocksPlugins(),
     VitestOptimizer(),
     NormalizeURLPlugin(),

--- a/packages/vitest/src/node/plugins/tsconfigPathsReferences.ts
+++ b/packages/vitest/src/node/plugins/tsconfigPathsReferences.ts
@@ -1,0 +1,216 @@
+import type { Plugin } from 'vite'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'pathe'
+
+interface PathMapping {
+  pattern: RegExp
+  paths: string[]
+}
+
+interface TsConfig {
+  extends?: string
+  references?: Array<{ path: string }>
+  compilerOptions?: {
+    baseUrl?: string
+    paths?: Record<string, string[]>
+  }
+}
+
+const relativeImportRE = /^\.\.?(?:\/|$)/
+
+export function TsconfigPathsReferencesPlugin(): Plugin {
+  let mappings: PathMapping[] = []
+
+  return {
+    name: 'vitest:tsconfig-paths-references',
+    enforce: 'pre',
+    config(config) {
+      if (!config.resolve?.tsconfigPaths) {
+        mappings = []
+        return
+      }
+
+      const root = config.root ?? process.cwd()
+      const tsconfigPath = join(root, 'tsconfig.json')
+      if (!existsSync(tsconfigPath)) {
+        mappings = []
+        return
+      }
+
+      const rootConfig = readTsConfig(tsconfigPath)
+      if (!rootConfig?.references?.length && !rootConfig?.extends) {
+        mappings = []
+        return
+      }
+
+      mappings = collectReferencedPathMappings(tsconfigPath)
+    },
+    async resolveId(source, importer, options) {
+      if (!mappings.length || !importer) {
+        return null
+      }
+
+      if (source.startsWith('\0') || source.includes('\0')) {
+        return null
+      }
+
+      if (relativeImportRE.test(source)) {
+        return null
+      }
+
+      if (source.startsWith('/') || source.startsWith('node:')) {
+        return null
+      }
+
+      for (const mapping of mappings) {
+        const match = source.match(mapping.pattern)
+        if (!match) {
+          continue
+        }
+
+        for (const pathTemplate of mapping.paths) {
+          const mappedId = applyPathTemplate(pathTemplate, match)
+          const resolved = await this.resolve(mappedId, importer, {
+            skipSelf: true,
+            ...options,
+          })
+          if (resolved) {
+            return resolved
+          }
+        }
+      }
+
+      return null
+    },
+  }
+}
+
+export function collectReferencedPathMappings(tsconfigPath: string): PathMapping[] {
+  const config = readTsConfig(tsconfigPath)
+  if (!config) {
+    return []
+  }
+
+  const configDir = dirname(tsconfigPath)
+  const mappings: PathMapping[] = []
+  const visited = new Set<string>([resolve(tsconfigPath)])
+
+  if (config.references?.length) {
+    for (const ref of config.references) {
+      const refPath = resolveConfigPath(configDir, ref.path)
+      if (existsSync(refPath)) {
+        mappings.push(...collectPathMappingsFromConfig(refPath, visited))
+      }
+    }
+  }
+
+  if (config.extends) {
+    const extendsPath = resolveConfigPath(configDir, config.extends)
+    if (existsSync(extendsPath)) {
+      mappings.push(...collectPathMappingsFromConfig(extendsPath, visited))
+    }
+  }
+
+  return mappings
+}
+
+function collectPathMappingsFromConfig(
+  configPath: string,
+  visited: Set<string>,
+): PathMapping[] {
+  const normalized = resolve(configPath)
+  if (visited.has(normalized)) {
+    return []
+  }
+  visited.add(normalized)
+
+  const config = readTsConfig(normalized)
+  if (!config) {
+    return []
+  }
+
+  const configDir = dirname(normalized)
+  const mappings: PathMapping[] = []
+
+  if (config.references?.length) {
+    for (const ref of config.references) {
+      const refPath = resolveConfigPath(configDir, ref.path)
+      if (existsSync(refPath)) {
+        mappings.push(...collectPathMappingsFromConfig(refPath, visited))
+      }
+    }
+  }
+
+  if (config.extends) {
+    const extendsPath = resolveConfigPath(configDir, config.extends)
+    if (existsSync(extendsPath)) {
+      mappings.push(...collectPathMappingsFromConfig(extendsPath, visited))
+    }
+  }
+
+  const paths = config.compilerOptions?.paths
+  if (paths) {
+    const baseUrl = config.compilerOptions?.baseUrl
+    const pathsRoot = baseUrl ? resolve(configDir, baseUrl) : configDir
+    mappings.push(...resolvePathMappings(paths, pathsRoot))
+  }
+
+  return mappings
+}
+
+function resolvePathMappings(
+  paths: Record<string, string[]>,
+  base: string,
+): PathMapping[] {
+  const sortedPatterns = Object.keys(paths).sort(
+    (a, b) => getPrefixLength(b) - getPrefixLength(a),
+  )
+
+  return sortedPatterns.map((pattern) => {
+    const relativePaths = paths[pattern]!
+    const escaped = escapeStringRegexp(pattern).replace(/\*/g, '(.+)')
+    return {
+      pattern: new RegExp(`^${escaped}$`),
+      paths: relativePaths.map(relativePath => resolve(base, relativePath)),
+    }
+  })
+}
+
+function readTsConfig(path: string): TsConfig | null {
+  try {
+    const text = readFileSync(path, 'utf-8')
+    return JSON.parse(stripJsonComments(text)) as TsConfig
+  }
+  catch {
+    return null
+  }
+}
+
+function stripJsonComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '')
+}
+
+function resolveConfigPath(baseDir: string, configPath: string): string {
+  const resolved = resolve(baseDir, configPath)
+  if (resolved.endsWith('.json')) {
+    return resolved
+  }
+  return join(resolved, 'tsconfig.json')
+}
+
+function applyPathTemplate(template: string, match: RegExpMatchArray): string {
+  let starCount = 0
+  return template.replace(/\*/g, () => {
+    starCount++
+    return match[Math.min(starCount, match.length - 1)] ?? ''
+  })
+}
+
+function getPrefixLength(pattern: string): number {
+  const index = pattern.indexOf('*')
+  return index === -1 ? pattern.length : index
+}
+
+function escapeStringRegexp(string: string): string {
+  return string.replace(/[|\\{}()[\]^$+?.]/g, '\\$&').replace(/-/g, '\\x2d')
+}

--- a/test/e2e/fixtures/tsconfig-paths-split/src/lib/helper.js
+++ b/test/e2e/fixtures/tsconfig-paths-split/src/lib/helper.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 42
+}

--- a/test/e2e/fixtures/tsconfig-paths-split/src/main.js
+++ b/test/e2e/fixtures/tsconfig-paths-split/src/main.js
@@ -1,0 +1,5 @@
+import { helper } from 'lib/helper'
+
+export function main() {
+  return helper()
+}

--- a/test/e2e/fixtures/tsconfig-paths-split/src/main.test.js
+++ b/test/e2e/fixtures/tsconfig-paths-split/src/main.test.js
@@ -1,0 +1,8 @@
+import { vi, expect, test } from 'vitest'
+import { main } from './main.js'
+
+vi.mock('lib/helper', { spy: true })
+
+test('autospy resolves tsconfig paths from referenced config', () => {
+  expect(main()).toBe(42)
+})

--- a/test/e2e/fixtures/tsconfig-paths-split/tsconfig.app.json
+++ b/test/e2e/fixtures/tsconfig-paths-split/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "baseUrl": ".",
+    "paths": {
+      "lib/*": ["./src/lib/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/test/e2e/fixtures/tsconfig-paths-split/tsconfig.json
+++ b/test/e2e/fixtures/tsconfig-paths-split/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/test/e2e/fixtures/tsconfig-paths-split/vitest.config.ts
+++ b/test/e2e/fixtures/tsconfig-paths-split/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+})

--- a/test/e2e/test/tsconfig-paths-split.test.ts
+++ b/test/e2e/test/tsconfig-paths-split.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+test('resolve.tsconfigPaths follows paths in referenced tsconfig files', async () => {
+  const { stderr, ctx } = await runVitest({
+    root: './fixtures/tsconfig-paths-split',
+    resolve: {
+      tsconfigPaths: true,
+    },
+  })
+
+  expect(stderr).toBe('')
+  expect(ctx!.state.getFiles()[0]?.result?.state).toBe('pass')
+})

--- a/test/unit/test/tsconfig-paths-references.test.ts
+++ b/test/unit/test/tsconfig-paths-references.test.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { collectReferencedPathMappings } from '../../../packages/vitest/src/node/plugins/tsconfigPathsReferences'
+
+describe('collectReferencedPathMappings', () => {
+  it('collects paths from referenced tsconfig files', () => {
+    const fixtureRoot = resolve(import.meta.dirname, '../../e2e/fixtures/tsconfig-paths-split')
+    const mappings = collectReferencedPathMappings(resolve(fixtureRoot, 'tsconfig.json'))
+
+    expect(mappings).toHaveLength(1)
+    expect('lib/helper'.match(mappings[0]!.pattern)).toBeTruthy()
+    expect(mappings[0]!.paths[0]).toBe(resolve(fixtureRoot, 'src/lib/*'))
+  })
+})


### PR DESCRIPTION
### Description

When the root `tsconfig.json` uses `references` and `paths` live in referenced configs (e.g. `tsconfig.app.json`), Vitest did not merge those path mappings into `resolve.tsconfigPaths`. This change loads path mappings from referenced tsconfig files so aliases resolve correctly in split-config setups.

Resolves #10425

**AI disclosure:** This PR was prepared with assistance from Cursor (AI coding agent). The changes were reviewed and validated locally with lint, typecheck, unit, and e2e tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

**Test plan**
- `pnpm run lint` and `pnpm run typecheck`
- Unit: `cd test/unit && node ../../packages/vitest/vitest.mjs run --project threads test/tsconfig-paths-references.test.ts`
- E2E: `cd test/e2e && node ../../packages/vitest/vitest.mjs run test/tsconfig-paths-split.test.ts`

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.


Made with [Cursor](https://cursor.com)