### PR TITLE
fix(ui): preserve about:blank URL in trace iframe

### DIFF
--- a/packages/ui/client/components/trace/TraceView.spec.ts
+++ b/packages/ui/client/components/trace/TraceView.spec.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createCache, createMirror, rebuild, snapshot } from 'rrweb-snapshot'
+
+// Verifies that rebuilding an rrweb snapshot into a sandboxed iframe does not
+// change the iframe document's URL. The bug: document.open() — called either
+// from TraceView.vue directly or from inside rrweb-snapshot's buildNodeWithSN —
+// makes Chrome update the iframe document URL to the parent page's URL, which
+// produces confusing "Blocked script execution in '/__vitest__/'" sandbox warnings.
+
+describe('TraceView iframe sandbox', () => {
+  let targetIframe: HTMLIFrameElement
+  let sourceIframe: HTMLIFrameElement
+
+  beforeEach(() => {
+    // Use a standards-mode document so rrweb does not serialize
+    // compatMode: 'BackCompat', which intentionally still uses doc.open().
+    sourceIframe = document.createElement('iframe')
+    document.body.appendChild(sourceIframe)
+    const srcDoc = sourceIframe.contentDocument!
+    srcDoc.open()
+    srcDoc.write('<!DOCTYPE html><html><head></head><body></body></html>')
+    srcDoc.close()
+
+    // Target: a sandboxed iframe that mirrors TraceView's setup (allow-same-origin, no allow-scripts).
+    targetIframe = document.createElement('iframe')
+    targetIframe.setAttribute('sandbox', 'allow-same-origin')
+    document.body.appendChild(targetIframe)
+  })
+
+  afterEach(() => {
+    sourceIframe.remove()
+    targetIframe.remove()
+  })
+
+  it('does not change contentDocument.URL after rebuild', () => {
+    const serialized = snapshot(sourceIframe.contentDocument!)
+    expect(serialized, 'snapshot() must succeed on a blank document').not.toBeNull()
+
+    const doc = targetIframe.contentDocument!
+    expect(doc.URL).toBe('about:blank')
+
+    rebuild(serialized!, {
+      doc,
+      cache: createCache(),
+      mirror: createMirror(),
+    })
+
+    // If doc.open() was called (either locally or inside rrweb-snapshot),
+    // Chrome changes the iframe document URL to the parent page URL.
+    // The correct value after rebuild is still 'about:blank'.
+    expect(targetIframe.contentDocument!.URL).toBe('about:blank')
+  })
+})

--- a/packages/ui/client/components/trace/TraceView.spec.ts
+++ b/packages/ui/client/components/trace/TraceView.spec.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createCache, createMirror, rebuild, snapshot } from 'rrweb-snapshot'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 // Verifies that rebuilding an rrweb snapshot into a sandboxed iframe does not
 // change the iframe document's URL. The bug: document.open() — called either

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -38,14 +38,11 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
   const { serialized, selectorId, viewport, scroll, pseudoClassIds } = step.snapshot
   iframe.style.width = `${viewport.width}px`
   iframe.style.height = `${viewport.height}px`
-  // Rebuild snapshot into iframe contentDocument — pattern from rrweb replayer:
-  // https://github.com/rrweb-io/rrweb/blob/master/packages/rrweb/src/replay/index.ts
-  // doc.open/close resets the iframe document to a blank state before rebuild.
+  // Rebuild snapshot into iframe contentDocument.
   // Unlike Playwright which serves snapshots via HTTP, this is fully client-side
   // but external resources (images, stylesheets) won't load without a server.
+  // rrweb-snapshot's rebuild() resets the document internally; no local doc.open/close needed.
   const doc = iframe.contentDocument!
-  doc.open()
-  doc.close()
   const mirror = createMirror()
   rebuild(serialized, {
     doc,

--- a/patches/rrweb-snapshot.patch
+++ b/patches/rrweb-snapshot.patch
@@ -1,11 +1,12 @@
 diff --git a/dist/rrweb-snapshot.js b/dist/rrweb-snapshot.js
-index 3a3b67808308f4b50ad906dccfaaf577b4264742..3cf40a7d3c7d847e34850b32c424e2b0bb9331ac 100644
+index 3a3b67808308f4b50ad906dccfaaf577b4264742..8338aede2a2d3362aa241d7a260d60bbc6a14907 100644
 --- a/dist/rrweb-snapshot.js
 +++ b/dist/rrweb-snapshot.js
-@@ -1513,6 +1513,18 @@ const pseudoClassPlugin = {
+@@ -1512,6 +1512,18 @@ const pseudoClassPlugin = {
+         rule2.selectors.forEach(function(selector) {
            if (selector.includes(":hover")) {
              rule2.selector += ",\n" + selector.replace(/:hover/g, ".\\:hover");
-           }
++          }
 +          if (selector.includes(":active")) {
 +            rule2.selector += ",\n" + selector.replace(/:active/g, ".\\:active");
 +          }
@@ -17,7 +18,27 @@ index 3a3b67808308f4b50ad906dccfaaf577b4264742..3cf40a7d3c7d847e34850b32c424e2b0
 +          }
 +          if (/:focus(?![-\w])/.test(selector)) {
 +            rule2.selector += ",\n" + selector.replace(/:focus(?![-\w])/g, ".\\:focus");
-+          }
+           }
          });
        }
-     };
+@@ -5375,9 +5387,9 @@ function buildNodeWithSN(n, options) {
+     mirror.replace(n.rootId, doc);
+   }
+   if (n.type === NodeType.Document) {
+-    doc.close();
+-    doc.open();
+     if (n.compatMode === "BackCompat" && n.childNodes && n.childNodes[0].type !== NodeType.DocumentType) {
++      doc.close();
++      doc.open();
+       if (n.childNodes[0].type === NodeType.Element && "xmlns" in n.childNodes[0].attributes && n.childNodes[0].attributes.xmlns === "http://www.w3.org/1999/xhtml") {
+         doc.write(
+           '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "">'
+@@ -5387,6 +5399,8 @@ function buildNodeWithSN(n, options) {
+           '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "">'
+         );
+       }
++    } else {
++      doc.replaceChildren();
+     }
+     node2 = doc;
+   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ patchedDependencies:
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
   istanbul-lib-source-maps: be977704c4b9838da456619fe2421b5e24df2103a25967bd383b2246c88ddf6e
-  rrweb-snapshot: d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044
+  rrweb-snapshot: ae1d96093d17baefaafcf4afd23f5cf34303afd6c1685efd35143eddabbd1db0
 
 importers:
 
@@ -577,7 +577,7 @@ importers:
         version: 2.0.3
       rrweb-snapshot:
         specifier: 2.0.0-alpha.20
-        version: 2.0.0-alpha.20(patch_hash=d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044)
+        version: 2.0.0-alpha.20(patch_hash=ae1d96093d17baefaafcf4afd23f5cf34303afd6c1685efd35143eddabbd1db0)
       vitest:
         specifier: workspace:*
         version: link:../vitest
@@ -955,7 +955,7 @@ importers:
         version: 4.59.0
       rrweb-snapshot:
         specifier: 2.0.0-alpha.20
-        version: 2.0.0-alpha.20(patch_hash=d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044)
+        version: 2.0.0-alpha.20(patch_hash=ae1d96093d17baefaafcf4afd23f5cf34303afd6c1685efd35143eddabbd1db0)
       splitpanes:
         specifier: ^4.0.4
         version: 4.0.4(vue@3.5.29(typescript@5.9.3))
@@ -18335,7 +18335,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
-  rrweb-snapshot@2.0.0-alpha.20(patch_hash=d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044):
+  rrweb-snapshot@2.0.0-alpha.20(patch_hash=ae1d96093d17baefaafcf4afd23f5cf34303afd6c1685efd35143eddabbd1db0):
     dependencies:
       postcss: 8.5.6
 


### PR DESCRIPTION
### Description

Fixes #10248.

The trace iframe is supposed to stay on about:blank, but rebuilding the rrweb document was causing the iframe URL to switch to the parent /__vitest__/ URL instead.

This removes the extra doc.open() / doc.close() call in TraceView.vue and updates the rrweb snapshot patch to avoid using doc.open() for standards-mode documents, while keeping the existing BackCompat behavior the same.

Also adds a regression test for the iframe behavior.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to pnpm-lock.yaml unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Relevant trace tests were run locally
- [ ] Run the tests with pnpm test:ci.

### Documentation
- [x] No documentation changes needed

### Changesets
- [x] PR title uses fix: