### PR TITLE
docs: add custom browser command example to show how to validate input

### DIFF
--- a/docs/api/browser/commands.md
+++ b/docs/api/browser/commands.md
@@ -127,9 +127,9 @@ Custom functions will override built-in ones if they have the same name.
 ::: warning Security
 Custom commands run in the Vitest Node process and are callable from browser test code through Vitest's browser RPC connection. They can access local files, environment variables, network services, databases, shell commands, and other Node APIs.
 
-Vitest's built-in file commands validate paths against Vite's `server.fs` restrictions and separately check whether writes are allowed. Custom commands do not automatically inherit these protections. If a custom command accepts browser-provided input and uses it to read, write, delete, execute, or expose local resources, validate that input before using it.
+Vitest's built-in file commands validate paths against Vite's [`server.fs`](https://vite.dev/config/server-options#server-fs-allow) restrictions and separately check whether writes are allowed. Custom commands do not automatically inherit these protections. If a custom command accepts browser-provided input and uses it to read, write, delete, execute, or expose local resources, validate that input before using it.
 
-For file reads or fixture loading, use `isFileLoadingAllowed` from `vitest/node` or an explicit allowlist. For writes and deletes, also require an explicit mutation policy, such as `browser.api.allowWrite`, `api.allowWrite`, and a command-specific allowed directory.
+For file reads or fixture loading, use `isFileLoadingAllowed` from `vitest/node` or an explicit allowlist. For writes and deletes, also require an explicit mutation policy, such as [`browser.api.allowWrite`](/config/browser/api#api-allowwrite), [`api.allowWrite`](/config/api#api-allowwrite), and a command-specific allowed directory. For commands that execute code, shell commands, or project scripts, also check [`browser.api.allowExec`](/config/browser/api#api-allowexec) and [`api.allowExec`](/config/api#api-allowexec).
 
 For example, if you create your own file-writing command instead of using Vitest's built-in `writeFile`, apply the same checks:
 

--- a/docs/api/browser/commands.md
+++ b/docs/api/browser/commands.md
@@ -16,9 +16,9 @@ You can use the `readFile`, `writeFile`, and `removeFile` APIs to handle files i
 By default, Vitest uses `utf-8` encoding but you can override it with options.
 
 ::: tip
-This API follows [`server.fs`](https://vitejs.dev/config/server-options.html#server-fs-allow) limitations for security reasons.
+The built-in file commands follow Vite's [`server.fs`](https://vitejs.dev/config/server-options.html#server-fs-allow) restrictions for security reasons.
 
-If [`browser.api.allowWrite`](/config/browser/api) or [`api.allowWrite`](/config/api#api-allowwrite) are disabled, `writeFile` and `removeFile` functions won't do anything.
+`writeFile` and `removeFile` also require write access through [`browser.api.allowWrite`](/config/browser/api) and [`api.allowWrite`](/config/api#api-allowwrite).
 :::
 
 ```ts
@@ -123,6 +123,55 @@ declare module 'vitest/browser' {
 ::: warning
 Custom functions will override built-in ones if they have the same name.
 :::
+
+::: warning Security
+Custom commands run in the Vitest Node process and are callable from browser test code through Vitest's browser RPC connection. They can access local files, environment variables, network services, databases, shell commands, and other Node APIs.
+
+Vitest's built-in file commands validate paths against Vite's `server.fs` restrictions and separately check whether writes are allowed. Custom commands do not automatically inherit these protections. If a custom command accepts browser-provided input and uses it to read, write, delete, execute, or expose local resources, validate that input before using it.
+
+For file reads or fixture loading, use `isFileLoadingAllowed` from `vitest/node` or an explicit allowlist. For writes and deletes, also require an explicit mutation policy, such as `browser.api.allowWrite`, `api.allowWrite`, and a command-specific allowed directory.
+:::
+
+For example, a command that writes a fixture can combine Vitest's write access setting with Vite's `server.fs` check:
+
+```ts
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { normalizePath } from 'vite'
+import { isFileLoadingAllowed } from 'vitest/node'
+import type { BrowserCommand } from 'vitest/node'
+
+function assertFileAccess(path: string, project: any) {
+  if (
+    !isFileLoadingAllowed(project.vite.config, path)
+    && !isFileLoadingAllowed(project.vitest.vite.config, path)
+  ) {
+    throw new Error(`Access denied to "${path}".`)
+  }
+}
+
+function assertWrite(project: any) {
+  if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
+    throw new Error('Writing files is disabled.')
+  }
+}
+
+export const writeFixture: BrowserCommand<[name: string, content: string]> = async (
+  { project },
+  name,
+  content,
+) => {
+  assertWrite(project)
+
+  const file = resolve(project.config.root, name)
+  assertFileAccess(normalizePath(file), project)
+
+  await mkdir(dirname(file), { recursive: true })
+  await writeFile(file, content)
+}
+```
+
+If a command should only touch a narrower area, such as a fixtures directory, add a command-specific allowlist on top of the `server.fs` check.
 
 ### Recording trace markers
 

--- a/docs/api/browser/commands.md
+++ b/docs/api/browser/commands.md
@@ -132,7 +132,7 @@ Vitest's built-in file commands validate paths against Vite's `server.fs` restri
 For file reads or fixture loading, use `isFileLoadingAllowed` from `vitest/node` or an explicit allowlist. For writes and deletes, also require an explicit mutation policy, such as `browser.api.allowWrite`, `api.allowWrite`, and a command-specific allowed directory.
 :::
 
-For example, a command that writes a fixture can combine Vitest's write access setting with Vite's `server.fs` check:
+For example, if you create your own file-writing command instead of using Vitest's built-in `writeFile`, apply the same checks:
 
 ```ts
 import { mkdir, writeFile } from 'node:fs/promises'
@@ -156,14 +156,14 @@ function assertWrite(project: any) {
   }
 }
 
-export const writeFixture: BrowserCommand<[name: string, content: string]> = async (
+export const myWriteFileCommand: BrowserCommand<[path: string, content: string]> = async (
   { project },
-  name,
+  path,
   content,
 ) => {
   assertWrite(project)
 
-  const file = resolve(project.config.root, name)
+  const file = resolve(project.config.root, path)
   assertFileAccess(normalizePath(file), project)
 
   await mkdir(dirname(file), { recursive: true })
@@ -171,7 +171,7 @@ export const writeFixture: BrowserCommand<[name: string, content: string]> = asy
 }
 ```
 
-If a command should only touch a narrower area, such as a fixtures directory, add a command-specific allowlist on top of the `server.fs` check.
+This mirrors the protection used by Vitest's built-in file commands. Prefer the built-in commands when they fit your use case; custom commands that read, write, delete, execute, or expose local resources need equivalent checks. If a command should only touch a narrower area, such as a fixtures directory, add a command-specific allowlist on top of the `server.fs` check.
 
 ### Recording trace markers
 

--- a/docs/api/browser/commands.md
+++ b/docs/api/browser/commands.md
@@ -130,7 +130,6 @@ Custom commands run in the Vitest Node process and are callable from browser tes
 Vitest's built-in file commands validate paths against Vite's `server.fs` restrictions and separately check whether writes are allowed. Custom commands do not automatically inherit these protections. If a custom command accepts browser-provided input and uses it to read, write, delete, execute, or expose local resources, validate that input before using it.
 
 For file reads or fixture loading, use `isFileLoadingAllowed` from `vitest/node` or an explicit allowlist. For writes and deletes, also require an explicit mutation policy, such as `browser.api.allowWrite`, `api.allowWrite`, and a command-specific allowed directory.
-:::
 
 For example, if you create your own file-writing command instead of using Vitest's built-in `writeFile`, apply the same checks:
 
@@ -171,7 +170,7 @@ export const myWriteFileCommand: BrowserCommand<[path: string, content: string]>
 }
 ```
 
-This mirrors the protection used by Vitest's built-in file commands. Prefer the built-in commands when they fit your use case; custom commands that read, write, delete, execute, or expose local resources need equivalent checks. If a command should only touch a narrower area, such as a fixtures directory, add a command-specific allowlist on top of the `server.fs` check.
+:::
 
 ### Recording trace markers
 

--- a/docs/config/browser/commands.md
+++ b/docs/config/browser/commands.md
@@ -9,3 +9,9 @@ outline: deep
 - **Default:** `{ readFile, writeFile, ... }`
 
 Custom [commands](/api/browser/commands) that can be imported during browser tests from `vitest/browser`.
+
+::: warning Security
+Commands run in the Vitest Node process. If a command exposes filesystem, process, network, database, or shell access based on browser-provided input, validate and restrict that input inside the command. Built-in file commands apply Vite `server.fs` checks and write-access checks, but custom commands are responsible for their own protections.
+
+See [Custom Commands security notes](/api/browser/commands#custom-commands).
+:::


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- related https://github.com/vitest-dev/vitest/pull/10433#discussion_r3295747684

This PR updates docs to call out that custom commands handling browser-provided input must validate file access, writes/deletes, execution, and other privileged operations, with an example mirroring the built-in file command guard pattern. 

Probably longer term, we should expose some ergonomic helper for these validations (just like `isFileLoadingAllowed`), but for now, doc examples should be enough.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
