### PR TITLE
feat(api): add `allowWrite` and `allowExec` options to `api` [backport to v3]

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1806,11 +1806,25 @@ Open Vitest UI (WIP)
 
 ### api
 
-- **Type:** `boolean | number`
+- **Type:** `boolean | number | { port?, strictPort?, host?, allowWrite?, allowExec? }`
 - **Default:** `false`
-- **CLI:** `--api`, `--api.port`, `--api.host`, `--api.strictPort`
+- **CLI:** `--api`, `--api.port`, `--api.host`, `--api.strictPort`, `--api.allowWrite`, `--api.allowExec`
 
 Listen to port and serve API. When set to true, the default port is 51204
+
+#### api.allowWrite {#api-allowwrite}
+
+- **Type:** `boolean`
+- **Default:** `true` if API is not exposed to the network, `false` otherwise
+
+Allows API clients to write files, including updating test files from the UI. If `api.host` is set to anything other than `localhost` or `127.0.0.1`, Vitest disables write operations by default.
+
+#### api.allowExec {#api-allowexec}
+
+- **Type:** `boolean`
+- **Default:** `true` if API is not exposed to the network, `false` otherwise
+
+Allows API clients to run tests. If `api.host` is exposed to the network and write/exec operations are enabled, anyone who can reach the API server can run arbitrary code on your machine.
 
 ### browser <Badge type="warning">experimental</Badge> {#browser}
 

--- a/docs/guide/browser/commands.md
+++ b/docs/guide/browser/commands.md
@@ -17,6 +17,8 @@ By default, Vitest uses `utf-8` encoding but you can override it with options.
 
 ::: tip
 This API follows [`server.fs`](https://vitejs.dev/config/server-options.html#server-fs-allow) limitations for security reasons.
+
+`writeFile` and `removeFile` also require write access through [`browser.api.allowWrite`](/guide/browser/config#browser-api-allowwrite) and [`api.allowWrite`](/config/#api-allowwrite).
 :::
 
 ```ts

--- a/docs/guide/browser/config.md
+++ b/docs/guide/browser/config.md
@@ -144,11 +144,25 @@ A path to the HTML entry point. Can be relative to the root of the project. This
 
 ## browser.api
 
-- **Type:** `number | { port?, strictPort?, host? }`
+- **Type:** `number | { port?, strictPort?, host?, allowWrite?, allowExec? }`
 - **Default:** `63315`
-- **CLI:** `--browser.api=63315`, `--browser.api.port=1234, --browser.api.host=example.com`
+- **CLI:** `--browser.api=63315`, `--browser.api.port=1234, --browser.api.host=example.com`, `--browser.api.allowWrite`, `--browser.api.allowExec`
 
 Configure options for Vite server that serves code in the browser. Does not affect [`test.api`](#api) option. By default, Vitest assigns port `63315` to avoid conflicts with the development server, allowing you to run both in parallel.
+
+### browser.api.allowWrite {#browser-api-allowwrite}
+
+- **Type:** `boolean`
+- **Default:** inherited from [`api.allowWrite`](/config/#api-allowwrite)
+
+Allows browser API clients to write files, including snapshots and browser command writes. If `browser.api.host` is set to anything other than `localhost` or `127.0.0.1`, Vitest disables write operations by default unless this option or [`api.allowWrite`](/config/#api-allowwrite) is explicitly enabled.
+
+### browser.api.allowExec {#browser-api-allowexec}
+
+- **Type:** `boolean`
+- **Default:** inherited from [`api.allowExec`](/config/#api-allowexec)
+
+Allows browser API clients to run tests from the UI. If `browser.api.host` is exposed to the network and write/exec operations are enabled, anyone who can reach the browser API server can run arbitrary code on your machine.
 
 ## browser.provider {#browser-provider}
 

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -71,6 +71,20 @@ Specify which IP addresses the server should listen on. Set this to `0.0.0.0` or
 
 Set to true to exit if port is already in use, instead of automatically trying the next available port
 
+### api.allowExec
+
+- **CLI:** `--api.allowExec`
+- **Config:** [api.allowExec](/config/#api-allowexec)
+
+Allow API to execute code. (Be careful when enabling this option in untrusted environments)
+
+### api.allowWrite
+
+- **CLI:** `--api.allowWrite`
+- **Config:** [api.allowWrite](/config/#api-allowwrite)
+
+Allow API to edit files. (Be careful when enabling this option in untrusted environments)
+
 ### silent
 
 - **CLI:** `--silent [value]`
@@ -354,6 +368,20 @@ Specify which IP addresses the server should listen on. Set this to `0.0.0.0` or
 - **Config:** [browser.api.strictPort](/guide/browser/config#browser-api-strictport)
 
 Set to true to exit if port is already in use, instead of automatically trying the next available port
+
+### browser.api.allowExec
+
+- **CLI:** `--browser.api.allowExec`
+- **Config:** [browser.api.allowExec](/guide/browser/config#browser-api-allowexec)
+
+Allow API to execute code. (Be careful when enabling this option in untrusted environments)
+
+### browser.api.allowWrite
+
+- **CLI:** `--browser.api.allowWrite`
+- **Config:** [browser.api.allowWrite](/guide/browser/config#browser-api-allowwrite)
+
+Allow API to edit files. (Be careful when enabling this option in untrusted environments)
 
 ### browser.provider
 

--- a/packages/browser/src/node/commands/fs.ts
+++ b/packages/browser/src/node/commands/fs.ts
@@ -5,6 +5,12 @@ import { basename, dirname, resolve } from 'node:path'
 import mime from 'mime/lite'
 import { isFileServingAllowed } from 'vitest/node'
 
+function assertWrite(path: string, project: TestProject) {
+  if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
+    throw new Error(`Cannot modify file "${path}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/browser/api.`)
+  }
+}
+
 function assertFileAccess(path: string, project: TestProject) {
   if (
     !isFileServingAllowed(path, project.vite)
@@ -34,6 +40,7 @@ export const writeFile: BrowserCommand<
   const filepath = resolve(project.config.root, path)
   assertFileAccess(filepath, project)
   const dir = dirname(filepath)
+  assertWrite(path, project)
   if (!fs.existsSync(dir)) {
     await fsp.mkdir(dir, { recursive: true })
   }
@@ -45,6 +52,7 @@ export const removeFile: BrowserCommand<
 > = async ({ project }, path) => {
   const filepath = resolve(project.config.root, path)
   assertFileAccess(filepath, project)
+  assertWrite(path, project)
   await fsp.rm(filepath)
 }
 

--- a/packages/browser/src/node/commands/fs.ts
+++ b/packages/browser/src/node/commands/fs.ts
@@ -6,12 +6,6 @@ import mime from 'mime/lite'
 import { isFileServingAllowed } from 'vitest/node'
 import { slash } from '../utils'
 
-function assertWrite(path: string, project: TestProject) {
-  if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
-    throw new Error(`Cannot modify file "${path}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/browser/api.`)
-  }
-}
-
 function assertFileAccess(path: string, project: TestProject) {
   if (
     !isFileServingAllowed(path, project.vite)
@@ -20,6 +14,12 @@ function assertFileAccess(path: string, project: TestProject) {
     throw new Error(
       `Access denied to "${path}". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.`,
     )
+  }
+}
+
+function assertWrite(path: string, project: TestProject) {
+  if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
+    throw new Error(`Cannot modify file "${path}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/browser/api.`)
   }
 }
 

--- a/packages/browser/src/node/commands/fs.ts
+++ b/packages/browser/src/node/commands/fs.ts
@@ -4,6 +4,7 @@ import fs, { promises as fsp } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import mime from 'mime/lite'
 import { isFileServingAllowed } from 'vitest/node'
+import { slash } from '../utils'
 
 function assertWrite(path: string, project: TestProject) {
   if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
@@ -26,7 +27,7 @@ export const readFile: BrowserCommand<
   Parameters<BrowserCommands['readFile']>
 > = async ({ project }, path, options = {}) => {
   const filepath = resolve(project.config.root, path)
-  assertFileAccess(filepath, project)
+  assertFileAccess(slash(filepath), project)
   // never return a Buffer
   if (typeof options === 'object' && !options.encoding) {
     options.encoding = 'utf-8'
@@ -37,10 +38,10 @@ export const readFile: BrowserCommand<
 export const writeFile: BrowserCommand<
   Parameters<BrowserCommands['writeFile']>
 > = async ({ project }, path, data, options) => {
-  const filepath = resolve(project.config.root, path)
-  assertFileAccess(filepath, project)
-  const dir = dirname(filepath)
   assertWrite(path, project)
+  const filepath = resolve(project.config.root, path)
+  assertFileAccess(slash(filepath), project)
+  const dir = dirname(filepath)
   if (!fs.existsSync(dir)) {
     await fsp.mkdir(dir, { recursive: true })
   }
@@ -50,15 +51,15 @@ export const writeFile: BrowserCommand<
 export const removeFile: BrowserCommand<
   Parameters<BrowserCommands['removeFile']>
 > = async ({ project }, path) => {
-  const filepath = resolve(project.config.root, path)
-  assertFileAccess(filepath, project)
   assertWrite(path, project)
+  const filepath = resolve(project.config.root, path)
+  assertFileAccess(slash(filepath), project)
   await fsp.rm(filepath)
 }
 
 export const _fileInfo: BrowserCommand<[path: string, encoding: BufferEncoding]> = async ({ project }, path, encoding) => {
   const filepath = resolve(project.config.root, path)
-  assertFileAccess(filepath, project)
+  assertFileAccess(slash(filepath), project)
   const content = await fsp.readFile(filepath, encoding || 'base64')
   return {
     content,

--- a/packages/browser/src/node/plugin.ts
+++ b/packages/browser/src/node/plugin.ts
@@ -354,6 +354,8 @@ export default (parentServer: ParentBrowserProject, base = '/'): Plugin[] => {
         const api = resolveApiServerConfig(
           viteConfig.test?.browser || {},
           defaultPort,
+          parentServer.vitest.config.api,
+          parentServer.vitest.logger,
         )
 
         viteConfig.server = {

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -15,6 +15,7 @@ import { parse, stringify } from 'flatted'
 import { dirname, join } from 'pathe'
 import { createDebugger, isFileServingAllowed, isValidApiRequest } from 'vitest/node'
 import { WebSocketServer } from 'ws'
+import { slash } from './utils'
 
 const debug = createDebugger('vitest:browser:api')
 

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -111,7 +111,7 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
   }
 
   function checkFileAccess(path: string) {
-    if (!isFileServingAllowed(path, vite)) {
+    if (!isFileServingAllowed(slash(path), vite)) {
       throw new Error(
         `Access denied to "${path}". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.`,
       )

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -118,6 +118,15 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
     }
   }
 
+  function canWrite(project: TestProject) {
+    return (
+      project.config.browser.api.allowWrite
+      && project.vitest.config.browser.api.allowWrite
+      && project.config.api.allowWrite
+      && project.vitest.config.api.allowWrite
+    )
+  }
+
   function setupClient(project: TestProject, rpcId: string, ws: WebSocket) {
     const mockResolver = new ServerMockResolver(globalServer.vite, {
       moduleDirectories: project.config.server?.deps?.moduleDirectories,
@@ -191,11 +200,23 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
         },
         async saveSnapshotFile(id, content) {
           checkFileAccess(id)
+          if (!canWrite(project)) {
+            vitest.logger.error(
+              `[vitest] Cannot save snapshot file "${id}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/browser/api.`,
+            )
+            return
+          }
           await fs.mkdir(dirname(id), { recursive: true })
           return fs.writeFile(id, content, 'utf-8')
         },
         async removeSnapshotFile(id) {
           checkFileAccess(id)
+          if (!canWrite(project)) {
+            vitest.logger.error(
+              `[vitest] Cannot remove snapshot file "${id}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/browser/api.`,
+            )
+            return
+          }
           if (!existsSync(id)) {
             throw new Error(`Snapshot file "${id}" does not exist.`)
           }

--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -2,7 +2,7 @@
 import type { File } from 'vitest'
 import { Tooltip as VueTooltip } from 'floating-vue'
 import { isDark, toggleDark } from '~/composables'
-import { client, isReport, runAll, runFiles } from '~/composables/client'
+import { client, config, isReport, runAll, runFiles } from '~/composables/client'
 import { explorerTree } from '~/composables/explorer'
 import { initialized, shouldShowExpandAll } from '~/composables/explorer/state'
 import {
@@ -23,6 +23,10 @@ function updateSnapshot() {
 const toggleMode = computed(() => isDark.value ? 'light' : 'dark')
 
 async function onRunAll(files?: File[]) {
+  if (config.value.api?.allowExec === false) {
+    return
+  }
+
   if (coverageEnabled.value) {
     disableCoverage.value = true
     await nextTick()
@@ -45,6 +49,13 @@ function collapseTests() {
 
 function expandTests() {
   explorerTree.expandAllNodes()
+}
+
+function getRerunTooltip(filteredFiles: File[] | undefined) {
+  if (config.value.api?.allowExec === false) {
+    return 'Cannot run tests when `api.allowExec` is `false`. Did you expose UI to the internet?'
+  }
+  return filteredFiles ? (filteredFiles.length === 0 ? 'No test to run (clear filter)' : 'Rerun filtered') : 'Rerun all'
 }
 </script>
 
@@ -110,7 +121,7 @@ function expandTests() {
           @click="showCoverage()"
         />
         <IconButton
-          v-if="(explorerTree.summary.failedSnapshot && !isReport)"
+          v-if="(explorerTree.summary.failedSnapshot && !isReport && config.api?.allowExec && config.api?.allowWrite)"
           v-tooltip.bottom="'Update all failed snapshot(s)'"
           icon="i-carbon:result-old"
           :disabled="!explorerTree.summary.failedSnapshotEnabled"
@@ -118,9 +129,10 @@ function expandTests() {
         />
         <IconButton
           v-if="!isReport"
-          v-tooltip.bottom="filteredFiles ? (filteredFiles.length === 0 ? 'No test to run (clear filter)' : 'Rerun filtered') : 'Rerun all'"
-          :disabled="filteredFiles?.length === 0"
+          v-tooltip.bottom="getRerunTooltip(filteredFiles)"
+          :disabled="filteredFiles?.length === 0 || !config.api?.allowExec"
           icon="i-carbon:play"
+          data-testid="btn-run-all"
           @click="onRunAll(filteredFiles)"
         />
         <IconButton

--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -3,7 +3,7 @@ import type { Task, TaskState } from '@vitest/runner'
 import type { TaskTreeNodeType } from '~/composables/explorer/types'
 import { Tooltip as VueTooltip } from 'floating-vue'
 import { nextTick } from 'vue'
-import { client, isReport, runFiles, runTask } from '~/composables/client'
+import { client, config, isReport, runFiles, runTask } from '~/composables/client'
 import { showTaskSource } from '~/composables/codemirror'
 import { explorerTree } from '~/composables/explorer'
 import { hasFailedSnapshot } from '~/composables/explorer/collector'
@@ -118,6 +118,9 @@ const gridStyles = computed(() => {
 })
 
 const runButtonTitle = computed(() => {
+  if (config.value.api?.allowExec === false) {
+    return 'Cannot run tests when `api.allowExec` is `false`. Did you expose UI to the internet?'
+  }
   return type === 'file'
     ? 'Run current file'
     : type === 'suite'
@@ -195,7 +198,7 @@ const projectNameTextColor = computed(() => getProjectTextColor(projectNameColor
     </div>
     <div gap-1 justify-end flex-grow-1 pl-1 class="test-actions">
       <IconAction
-        v-if="!isReport && failedSnapshot"
+        v-if="!isReport && failedSnapshot && config.api?.allowExec && config.api?.allowWrite"
         v-tooltip.bottom="'Fix failed snapshot(s)'"
         data-testid="btn-fix-snapshot"
         title="Fix failed snapshot(s)"
@@ -232,6 +235,7 @@ const projectNameTextColor = computed(() => getProjectTextColor(projectNameColor
         :title="runButtonTitle"
         icon="i-carbon:play-filled-alt"
         text-green5
+        :disabled="config.api?.allowExec === false"
         @click.prevent.stop="onRun(task)"
       />
     </div>

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -4,7 +4,7 @@ import type CodeMirror from 'codemirror'
 import type { ErrorWithDiff, File, TestAnnotation, TestError } from 'vitest'
 import { createTooltip, destroyTooltip } from 'floating-vue'
 import { getAttachmentUrl, sanitizeFilePath } from '~/composables/attachments'
-import { client, isReport } from '~/composables/client'
+import { client, config, isReport } from '~/composables/client'
 import { finished } from '~/composables/client/state'
 import { codemirrorRef } from '~/composables/codemirror'
 import { openInEditor } from '~/composables/error'
@@ -382,7 +382,7 @@ onBeforeUnmount(clearListeners)
     ref="editor"
     v-model="code"
     h-full
-    v-bind="{ lineNumbers: true, readOnly: isReport, saving }"
+    v-bind="{ lineNumbers: true, readOnly: isReport || !config.api?.allowWrite, saving }"
     :mode="ext"
     data-testid="code-mirror"
     @save="onSave"

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -77,12 +77,21 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
               `Test file "${id}" was not registered, so it cannot be updated using the API.`,
             )
           }
+          if (!ctx.config.api.allowWrite) {
+            return
+          }
           return fs.writeFile(id, content, 'utf-8')
         },
         async rerun(files, resetTestNamePattern) {
+          if (!ctx.config.api.allowExec) {
+            return
+          }
           await ctx.rerunFiles(files, undefined, true, resetTestNamePattern)
         },
         async rerunTask(id) {
+          if (!ctx.config.api.allowExec) {
+            return
+          }
           await ctx.rerunTask(id)
         },
         getConfig() {
@@ -111,6 +120,9 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
           return getModuleGraph(ctx, project, id, browser)
         },
         async updateSnapshot(file?: File) {
+          if (!ctx.config.api.allowExec || !ctx.config.api.allowWrite) {
+            return
+          }
           if (!file) {
             await ctx.updateSnapshot()
           }

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -52,6 +52,12 @@ const apiConfig: (port: number) => CLIOptions<ApiConfig> = (port: number) => ({
     description:
       'Set to true to exit if port is already in use, instead of automatically trying the next available port',
   },
+  allowExec: {
+    description: 'Allow API to execute code. (Be careful when enabling this option in untrusted environments)',
+  },
+  allowWrite: {
+    description: 'Allow API to edit files. (Be careful when enabling this option in untrusted environments)',
+  },
   middlewareMode: null,
 })
 

--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -1,5 +1,6 @@
 import type { ResolvedConfig as ResolvedViteConfig } from 'vite'
 import type { Vitest } from '../core'
+import type { Logger } from '../logger'
 import type { BenchmarkBuiltinReporters } from '../reporters'
 import type { ResolvedBrowserOptions } from '../types/browser'
 import type {
@@ -59,6 +60,8 @@ function parseInspector(inspect: string | undefined | boolean | number) {
 export function resolveApiServerConfig<Options extends ApiConfig & UserConfig>(
   options: Options,
   defaultPort: number,
+  parentApi?: ApiConfig,
+  logger?: Logger,
 ): ApiConfig | undefined {
   let api: ApiConfig | undefined
 
@@ -96,6 +99,22 @@ export function resolveApiServerConfig<Options extends ApiConfig & UserConfig>(
   }
   else {
     api = { middlewareMode: true }
+  }
+
+  if (!api.middlewareMode && api.host && api.host !== 'localhost' && api.host !== '127.0.0.1') {
+    if (parentApi && api.allowWrite == null && api.allowExec == null) {
+      logger?.error(
+        c.yellow(
+          `${c.yellowBright(' WARNING ')} API server is exposed to network, disabling write and exec operations by default for security reasons. This can cause some APIs to not work as expected. Set \`browser.api.allowExec\` manually to hide this warning. See https://vitest.dev/config/browser/api for more details.`,
+        ),
+      )
+    }
+    api.allowWrite ??= parentApi?.allowWrite ?? false
+    api.allowExec ??= parentApi?.allowExec ?? false
+  }
+  else {
+    api.allowWrite ??= parentApi?.allowWrite ?? true
+    api.allowExec ??= parentApi?.allowExec ?? true
   }
 
   return api
@@ -838,6 +857,8 @@ export function resolveConfig(
   resolved.browser.api = resolveApiServerConfig(
     resolved.browser,
     defaultBrowserPort,
+    resolved.api,
+    logger,
   ) || {
     port: defaultBrowserPort,
   }

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -1,5 +1,5 @@
 import type { ResolvedConfig as ViteConfig } from 'vite'
-import type { ResolvedConfig, SerializedConfig } from '../types/config'
+import type { ApiConfig, ResolvedConfig, SerializedConfig } from '../types/config'
 
 export function serializeConfig(
   config: ResolvedConfig,
@@ -37,6 +37,12 @@ export function serializeConfig(
     pool: config.pool,
     expect: config.expect,
     snapshotSerializers: config.snapshotSerializers,
+    api: ((api: ApiConfig | undefined) => {
+      return {
+        allowExec: api?.allowExec,
+        allowWrite: api?.allowWrite,
+      }
+    })(config.browser.enabled ? config.browser.api : config.api),
     // TODO: non serializable function?
     diff: config.diff,
     retry: config.retry,

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -45,7 +45,20 @@ export type CSSModuleScopeStrategy = 'stable' | 'scoped' | 'non-scoped'
 export type ApiConfig = Pick<
   ServerOptions,
   'port' | 'strictPort' | 'host' | 'middlewareMode'
->
+> & {
+  /**
+   * Allow any write operations from the API server.
+   *
+   * @default true if API is not exposed to the network, false otherwise
+   */
+  allowWrite?: boolean
+  /**
+   * Allow running test files via the API.
+   *
+   * @default true if API is not exposed to the network, false otherwise
+   */
+  allowExec?: boolean
+}
 
 export type { EnvironmentOptions, HappyDOMOptions, JSDOMOptions }
 

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -99,6 +99,10 @@ export interface SerializedConfig {
     showDiff?: boolean
     truncateThreshold?: number
   } | undefined
+  api: {
+    allowExec: boolean | undefined
+    allowWrite: boolean | undefined
+  }
   diff: string | SerializedDiffOptions | undefined
   retry: number
   includeTaskLocation: boolean | undefined

--- a/test/browser/fixtures/errors-fs/__snapshots__/basic.test.js.snap
+++ b/test/browser/fixtures/errors-fs/__snapshots__/basic.test.js.snap
@@ -1,0 +1,1 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html

--- a/test/browser/fixtures/errors-fs/basic.test.js
+++ b/test/browser/fixtures/errors-fs/basic.test.js
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('basic test', () => {
+  expect(1 + 1).toBe(2)
+})

--- a/test/browser/fixtures/errors-fs/fs-commands.test.ts
+++ b/test/browser/fixtures/errors-fs/fs-commands.test.ts
@@ -1,0 +1,18 @@
+import { server } from '@vitest/browser/context'
+import { describe, expect, test } from 'vitest'
+
+const { removeFile, writeFile } = server.commands
+
+describe('fs security', () => {
+  test('fs writeFile throws an error', async () => {
+    await writeFile('/test-file.txt', 'Hello World')
+  })
+
+  test('fs removeFile throws an error', async () => {
+    await removeFile('/test-file.txt')
+  })
+
+  test('snapshot saves are not saved', () => {
+    expect('snapshot content').toMatchSnapshot()
+  })
+})

--- a/test/browser/fixtures/errors-fs/vitest.config.ts
+++ b/test/browser/fixtures/errors-fs/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+      api: {
+        allowExec: false,
+        allowWrite: false,
+      },
+    },
+  },
+})

--- a/test/browser/specs/errors-fs.test.ts
+++ b/test/browser/specs/errors-fs.test.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
+import { instances, runBrowserTests } from './utils'
+
+// v3 backport of
+// https://github.com/vitest-dev/vitest/blob/af993b66b4e5ba9498cb658a86a74a2c0416b75e/test/browser/specs/errors.test.ts#L73
+test('cannot use fs commands if write is disabled', async () => {
+  const root = './fixtures/errors-fs'
+  const { stderr } = await runBrowserTests({
+    root,
+    update: true,
+  })
+
+  const errors = stderr.split('\n').filter(line => line.includes('Cannot modify file "/test-file.txt".'))
+  expect(errors).toHaveLength(2 * instances.length)
+
+  expect(stderr).toContain(
+    `Cannot save snapshot file "${resolve(process.cwd(), root, './__snapshots__/fs-commands.test.ts.snap')}". File writing is disabled because server is exposed to the internet`,
+  )
+  expect(stderr).toContain(
+    `Cannot remove snapshot file "${resolve(process.cwd(), root, './__snapshots__/basic.test.js.snap')}". File writing is disabled because server is exposed to the internet`,
+  )
+})

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -319,9 +319,12 @@ test('show a warning if host is exposed', async () => {
         },
       },
     ],
-    browser: {
-      api: {
-        host: 'custom-host',
+  }, [], 'test', {
+    test: {
+      browser: {
+        api: {
+          host: 'custom-host',
+        },
       },
     },
   })

--- a/test/config/test/browser-configs.test.ts
+++ b/test/config/test/browser-configs.test.ts
@@ -5,7 +5,7 @@ import crypto from 'node:crypto'
 import { resolve } from 'pathe'
 import { describe, expect, onTestFinished, test } from 'vitest'
 import { createVitest } from 'vitest/node'
-import { runVitestCli, useFS } from '../../test-utils'
+import { runVitest, runVitestCli, useFS } from '../../test-utils'
 
 async function vitest(cliOptions: UserConfig, configValue: UserConfig = {}, viteConfig: ViteUserConfig = {}, vitestOptions: VitestOptions = {}) {
   const vitest = await createVitest('test', { ...cliOptions, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
@@ -306,6 +306,28 @@ test('can enable browser-cli options for multi-project workspace', async () => {
   // browser config
   expect(projects[1].config.browser.enabled).toBe(true)
   expect(projects[1].config.browser.headless).toBe(true)
+})
+
+test('show a warning if host is exposed', async () => {
+  const { stderr } = await runVitest({
+    config: false,
+    root: './fixtures/fixture-no-async',
+    reporters: [
+      {
+        onInit() {
+          throw new Error('stop')
+        },
+      },
+    ],
+    browser: {
+      api: {
+        host: 'custom-host',
+      },
+    },
+  })
+  expect(stderr).toContain(
+    'API server is exposed to network, disabling write and exec operations by default for security reasons. This can cause some APIs to not work as expected. Set `browser.api.allowExec` manually to hide this warning. See https://vitest.dev/config/browser/api for more details.',
+  )
 })
 
 function getCliConfig(options: UserConfig, cli: string[], fs: TestFsStructure = {}) {

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -249,6 +249,8 @@ describe('correctly defines api flag', () => {
     })
     expect(c.server.config.server.middlewareMode).toBe(true)
     expect(c.config.api).toEqual({
+      allowExec: true,
+      allowWrite: true,
       middlewareMode: true,
       token: expect.any(String),
     })
@@ -263,6 +265,8 @@ describe('correctly defines api flag', () => {
     })
     expect(c.server.config.server.port).toBe(4321)
     expect(c.config.api).toEqual({
+      allowExec: true,
+      allowWrite: true,
       port: 4321,
       token: expect.any(String),
     })

--- a/test/config/test/override.test.ts
+++ b/test/config/test/override.test.ts
@@ -271,6 +271,61 @@ describe('correctly defines api flag', () => {
       token: expect.any(String),
     })
   })
+
+  it('allowWrite and allowExec default to true when not exposed to network', async () => {
+    const c = await config({ api: { port: 5555 } }, {})
+    expect(c.api.allowWrite).toBe(true)
+    expect(c.api.allowExec).toBe(true)
+  })
+
+  it('allowWrite and allowExec default to true for localhost', async () => {
+    const c = await config({ api: { port: 5555, host: 'localhost' } }, {})
+    expect(c.api.allowWrite).toBe(true)
+    expect(c.api.allowExec).toBe(true)
+  })
+
+  it('allowWrite and allowExec default to true for 127.0.0.1', async () => {
+    const c = await config({ api: { port: 5555, host: '127.0.0.1' } }, {})
+    expect(c.api.allowWrite).toBe(true)
+    expect(c.api.allowExec).toBe(true)
+  })
+
+  it('allowWrite and allowExec default to false when exposed to network', async () => {
+    const c = await config({ api: { port: 5555, host: '0.0.0.0' } }, {})
+    expect(c.api.allowWrite).toBe(false)
+    expect(c.api.allowExec).toBe(false)
+  })
+
+  it('allowWrite and allowExec can be explicitly overridden when exposed to network', async () => {
+    const c = await config({ api: { port: 5555, host: '0.0.0.0', allowWrite: true, allowExec: true } }, {})
+    expect(c.api.allowWrite).toBe(true)
+    expect(c.api.allowExec).toBe(true)
+  })
+
+  it('allowWrite and allowExec can be explicitly disabled', async () => {
+    const c = await config({ api: { port: 5555, allowWrite: false, allowExec: false } }, {})
+    expect(c.api.allowWrite).toBe(false)
+    expect(c.api.allowExec).toBe(false)
+  })
+
+  it('browser.api inherits allowWrite and allowExec from api', async () => {
+    const c = await config({ api: { port: 5555, allowWrite: false, allowExec: false } }, {})
+    expect(c.browser.api.allowWrite).toBe(false)
+    expect(c.browser.api.allowExec).toBe(false)
+  })
+
+  it('browser.api can override inherited allowWrite and allowExec', async () => {
+    const c = await config({
+      api: { port: 5555, allowWrite: false, allowExec: false },
+      browser: { api: { allowWrite: true, allowExec: true } },
+    }, {
+      browser: {},
+    })
+    expect(c.api.allowWrite).toBe(false)
+    expect(c.api.allowExec).toBe(false)
+    expect(c.browser.api.allowWrite).toBe(true)
+    expect(c.browser.api.allowExec).toBe(true)
+  })
 })
 
 describe.each([

--- a/test/core/vite.config.ts
+++ b/test/core/vite.config.ts
@@ -55,6 +55,8 @@ export default defineConfig({
   test: {
     api: {
       port: 3023,
+      allowExec: false,
+      allowWrite: false,
     },
     name: 'core',
     includeSource: [


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR backports the `allowWrite` / `allowExec` hardening from https://github.com/vitest-dev/vitest/pull/9350 to the v3 branch for https://github.com/vitest-dev/vitest/security/advisories/GHSA-5xrq-8626-4rwp. Since v3 and v4 have diverged code, this was ported manually rather than as a direct cherry-pick.

Notable divergences:

- Left out artifact/annotation attachment hardening because the v4 artifact RPC/API path is not present in v3.
- Did not port Vite’s newer `isFileLoadingAllowed` usage; v3 keeps `isFileServingAllowed` and only normalizes concrete file paths with `slash(...)`. For the concrete file paths Vitest checks here, that should preserve the relevant protection.
- Manually adjusted tests for v3’s older test utilities and fixture shape, while keeping the same coverage intent.

TODO
- [ ] update affected/patch range in advisory after the release v3.2.5
  (but release should wait for another v3 backport https://github.com/vitest-dev/vitest/pull/10456)

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
