### PR TITLE
chore: document release branch and backporting branch convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,14 +122,6 @@ These measures help reduce maintenance burden and keep the team's work efficient
 
 Public support ranges are documented in [Releases](./docs/releases.md). This section describes how maintainers map those ranges to Git branches for releases and backports. These names refer to branches, not release tags; release tags always include the full version, for example `v4.1.8`.
 
-<!--
-Current branch alignment notes for maintainers:
-- Create `v4` from the current `v4.1` branch. Under this convention, `v4` is the latest maintained v4 minor line, currently `4.1.x`.
-- Create `v4.0` from the current `v4.0.x` branch. Under this convention, older maintained minor lines use `vN.M`, not `vN.M.x`.
-- The existing `v3` branch already fits the convention if it is the latest maintained v3 minor line, currently `3.2.x`.
-- The existing `v3.1` branch already fits the convention as an older v3 minor line.
--->
-
 - `main` is the active development branch for the next release line.
 - `vN` is the latest maintained minor line for non-main major version `N`.
 - `vN.M` is an older minor line for major version `N`, kept when that exact minor still needs releases or backports.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,14 @@ No backport is made to `v3` unless the support policy changes or maintainers dec
 
 Backport PR titles should include the target branch in a `[backport to x]` marker, for example `fix: [backport to v5.0] ...` or `fix: [backport to v4] ...`. Branch names never include patch versions.
 
+#### Documentation Branches
+
+The release branches are also linked with the documentation site releases:
+
+- `main` is the source for unreleased documentation at <https://main.vitest.dev/>.
+- `release` points to the latest stable release line used for <https://vitest.dev/>. It is updated only for non-beta releases from `main`, not for older-line backports.
+- `vN` branches are used for old major documentation sites. For example, <https://v3.vitest.dev/> uses `v3`.
+
 ### Issue Triaging Workflow
 
 ```mermaid

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Current branch alignment notes for maintainers:
 - `vN` is the latest maintained minor line for non-main major version `N`.
 - `vN.M` is an older minor line for major version `N`, kept when that exact minor still needs releases or backports.
 
-For example, if `v5.1.2` is the latest Vitest release, and the latest releases for older majors are `v4.1.7` and `v3.2.4`, the branch shape can be:
+As a hypothetical example, if `v5.1.2` is the latest Vitest release, and the latest releases for older majors are `v4.1.7` and `v3.2.4`, the branch shape can be:
 
 - `main` is the active development branch for `5.1.x`.
 - `v5.0` is an older minor line for Vitest 5.
@@ -143,15 +143,15 @@ For example, if `v5.1.2` is the latest Vitest release, and the latest releases f
 - `v3` is the latest maintained minor line for Vitest 3, so it is the `3.2.x` line.
 - `v3.1` and `v3.0` are older minor lines for Vitest 3.
 
-`v5` branch doesn't exist yet and it will be created from the latest v5 minor only after `main` moves on to a newer release line `6.0.0` (or often as `6.0.0-beta.x`).
+The `v5` branch does not exist yet. It will be created from the latest v5 minor only after `main` moves on to a newer release line, such as `6.0.0` or often `6.0.0-beta.x`.
 
 For backports, first use the public support policy to decide which version ranges are supported, then map them to branches:
 
-- first the changes can land as usual on `main` branch.
+- Changes can land as usual on the `main` branch first.
 - If the fix targets the latest maintained minor of major version `N`, target `vN`. This is the default backport target for a supported non-main major.
 - If the fix also needs an older maintained minor `N.M`, target `vN.M`.
 
-For example, with `v5.1.2` as the latest release, the public support policy covers regular fixes for `5.1.x` and important fixes or security patches for `5.0.x` and `4.1.x`:
+For example, using the hypothetical `v5.1.2` release above, the public support policy covers regular fixes for `5.1.x` and important fixes or security patches for `5.0.x` and `4.1.x`:
 
 - fixes for `5.1.x` target `main`
 - backports to `5.0.x` target `v5.0`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ These measures help reduce maintenance burden and keep the team's work efficient
 
 ### Release Branches
 
-Vitest follows Vite's maintenance branch convention. Public support ranges are documented in [Releases](./docs/releases.md); this section describes how maintainers map those ranges to Git branches.
+Public support ranges are documented in [Releases](./docs/releases.md). This section describes how maintainers map those ranges to Git branches for releases and backports. These names refer to branches, not release tags; release tags always include the full version, for example `v4.1.8`.
 
 <!--
 Current branch alignment notes for maintainers:
@@ -131,25 +131,23 @@ Current branch alignment notes for maintainers:
 -->
 
 - `main` is the active development branch for the next release line.
-- `vN` is the latest maintained minor line for major version `N`.
+- `vN` is the latest maintained minor line for non-main major version `N`.
 - `vN.M` is an older minor line for major version `N`, kept when that exact minor still needs releases or backports.
 
 For example, if `v5.1.2` is the latest Vitest release, and the latest releases for older majors are `v4.1.7` and `v3.2.4`, the branch shape can be:
 
-- `main` is the active development branch after `v5.1.2`.
-- `v5` is the latest maintained minor line for Vitest 5, so it is the `5.1.x` line.
+- `main` is the active development branch for `5.1.x`.
 - `v5.0` is an older minor line for Vitest 5.
 - `v4` is the latest maintained minor line for Vitest 4, so it is the `4.1.x` line.
 - `v4.0` is an older minor line for Vitest 4.
 - `v3` is the latest maintained minor line for Vitest 3, so it is the `3.2.x` line.
 - `v3.1` and `v3.0` are older minor lines for Vitest 3.
 
-The existence of an older branch does not mean that version is supported. Always use the public support policy to decide which branches should receive backports.
-
-When releasing a new major, create `vN` from the commit that produces the first stable `vN.0.0` tag. When releasing a new minor on an existing major, create `vN.M` from the previous minor line before moving `vN` to the new latest minor.
+`v5` branch doesn't exist yet and it will be created from the latest v5 minor only after `main` moves on to a newer release line `6.0.0` (or often as `6.0.0-beta.x`).
 
 For backports, first use the public support policy to decide which version ranges are supported, then map them to branches:
 
+- first the changes can land as usual on `main` branch.
 - If the fix targets the latest maintained minor of major version `N`, target `vN`. This is the default backport target for a supported non-main major.
 - If the fix also needs an older maintained minor `N.M`, target `vN.M`.
 
@@ -159,11 +157,9 @@ For example, with `v5.1.2` as the latest release, the public support policy cove
 - backports to `5.0.x` target `v5.0`
 - backports to `4.1.x` target `v4`
 
-The `v5` branch is used for the latest maintained v5 minor after `main` moves on to a newer release line.
-
 No backport is made to `v3` unless the support policy changes or maintainers decide on an explicit exception.
 
-Backport PR titles should include the target branch in a `[backport to x]` marker, for example `fix: [backport to v5.0] ...` or `fix: [backport to v4] ...`. Release tags remain full semver tags such as `v4.1.8`; branch names never include patch versions.
+Backport PR titles should include the target branch in a `[backport to x]` marker, for example `fix: [backport to v5.0] ...` or `fix: [backport to v4] ...`. Branch names never include patch versions.
 
 ### Issue Triaging Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Backport PR titles should include the target branch in a `[backport to x]` marke
 The release branches are also linked with the documentation site releases:
 
 - `main` is the source for unreleased documentation at <https://main.vitest.dev/>.
-- `release` points to the latest stable release line used for <https://vitest.dev/>. It is updated only for non-beta releases from `main`, not for older-line backports.
+- `release` points to the latest stable release line used for <https://vitest.dev/>. Release managers update it manually for non-beta releases from `main`; it is not moved for older-line backports.
 - `vN` branches are used for old major documentation sites. For example, <https://v3.vitest.dev/> uses `v3`.
 
 ### Issue Triaging Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,53 @@ These measures help reduce maintenance burden and keep the team's work efficient
 
 > The following section is mostly for maintainers who have commit access, but it's helpful to go through if you intend to make non-trivial contributions to the codebase.
 
+### Release Branches
+
+Vitest follows Vite's maintenance branch convention. Public support ranges are documented in [Releases](./docs/releases.md); this section describes how maintainers map those ranges to Git branches.
+
+<!--
+Current branch alignment notes for maintainers:
+- Create `v4` from the current `v4.1` branch. Under this convention, `v4` is the latest maintained v4 minor line, currently `4.1.x`.
+- Create `v4.0` from the current `v4.0.x` branch. Under this convention, older maintained minor lines use `vN.M`, not `vN.M.x`.
+- The existing `v3` branch already fits the convention if it is the latest maintained v3 minor line, currently `3.2.x`.
+- The existing `v3.1` branch already fits the convention as an older v3 minor line.
+-->
+
+- `main` is the active development branch for the next release line.
+- `vN` is the latest maintained minor line for major version `N`.
+- `vN.M` is an older minor line for major version `N`, kept when that exact minor still needs releases or backports.
+
+For example, if `v5.1.2` is the latest Vitest release, and the latest releases for older majors are `v4.1.7` and `v3.2.4`, the branch shape can be:
+
+- `main` is the active development branch after `v5.1.2`.
+- `v5` is the latest maintained minor line for Vitest 5, so it is the `5.1.x` line.
+- `v5.0` is an older minor line for Vitest 5.
+- `v4` is the latest maintained minor line for Vitest 4, so it is the `4.1.x` line.
+- `v4.0` is an older minor line for Vitest 4.
+- `v3` is the latest maintained minor line for Vitest 3, so it is the `3.2.x` line.
+- `v3.1` and `v3.0` are older minor lines for Vitest 3.
+
+The existence of an older branch does not mean that version is supported. Always use the public support policy to decide which branches should receive backports.
+
+When releasing a new major, create `vN` from the commit that produces the first stable `vN.0.0` tag. When releasing a new minor on an existing major, create `vN.M` from the previous minor line before moving `vN` to the new latest minor.
+
+For backports, first use the public support policy to decide which version ranges are supported, then map them to branches:
+
+- If the fix targets the latest maintained minor of major version `N`, target `vN`. This is the default backport target for a supported non-main major.
+- If the fix also needs an older maintained minor `N.M`, target `vN.M`.
+
+For example, with `v5.1.2` as the latest release, the public support policy covers regular fixes for `5.1.x` and important fixes or security patches for `5.0.x` and `4.1.x`:
+
+- fixes for `5.1.x` target `main`
+- backports to `5.0.x` target `v5.0`
+- backports to `4.1.x` target `v4`
+
+The `v5` branch is used for the latest maintained v5 minor after `main` moves on to a newer release line.
+
+No backport is made to `v3` unless the support policy changes or maintainers decide on an explicit exception.
+
+Backport PR titles should include the target branch in a `[backport to x]` marker, for example `fix: [backport to v5.0] ...` or `fix: [backport to v4] ...`. Release tags remain full semver tags such as `v4.1.8`; branch names never include patch versions.
+
 ### Issue Triaging Workflow
 
 ```mermaid

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -16,7 +16,8 @@ try {
     tag: true,
   })
 
-  if (!result.newVersion.includes('beta')) {
+  const currentBranch = (await $`git branch --show-current`).stdout.trim()
+  if (!result.newVersion.includes('beta') && currentBranch === 'main') {
     console.log('Pushing to release branch')
     await $`git update-ref refs/heads/release refs/heads/main`
     await $`git push origin release`

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -16,8 +16,7 @@ try {
     tag: true,
   })
 
-  const currentBranch = (await $`git branch --show-current`).stdout.trim()
-  if (!result.newVersion.includes('beta') && currentBranch === 'main') {
+  if (!result.newVersion.includes('beta')) {
     console.log('Pushing to release branch')
     await $`git update-ref refs/heads/release refs/heads/main`
     await $`git push origin release`


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Related https://github.com/vitest-dev/vitest/pull/10432

This documents the release branch naming convention for releases and backports in `CONTRIBUTING.md`, as part of the broader effort to codify Vitest’s security and maintenance processes. The convention looks mildly complicated for me human but should be at least clear for agents so they can drive some mechanical backport process.

The rule is extracted by probing Vite's existing branches though they don't seem to have this explicitly written anywhere. I'll check with Sapphi if this matches with what he's doing.
(EDIT: Sapphi confirmed it)

Vitest's exiting branches don't actually match this yet (v3 line matches but v4 doesn't), so this rule is basically a proposal to do it this way. If agreed, we can create new branches as follows:

- create `v4` from the current `v4.1` branch
- create `v4.0` from the current `v4.0.x` branch
- (keep `v3` as-is if it represents the latest maintained v3 minor line)
- (keep `v3.1` as-is as an older maintained v3 minor line)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
