### PR TITLE
fix(browser): disable client `cdp` API when `allowWrite/allowExec: false` [backport to v3]

### DIFF
--- a/docs/guide/browser/commands.md
+++ b/docs/guide/browser/commands.md
@@ -59,6 +59,8 @@ expect(input).toHaveValue('a')
 
 ::: warning
 CDP session works only with `playwright` provider and only when using `chromium` browser. You can read more about it in playwright's [`CDPSession`](https://playwright.dev/docs/api/class-cdpsession) documentation.
+
+CDP is a privileged debugging API. It is available only when browser API write and exec operations are enabled through [`browser.api.allowWrite`](/guide/browser/config#browser-api-allowwrite), [`browser.api.allowExec`](/guide/browser/config#browser-api-allowexec), [`api.allowWrite`](/config/#api-allowwrite), and [`api.allowExec`](/config/#api-allowexec).
 :::
 
 ## Custom Commands

--- a/docs/guide/browser/config.md
+++ b/docs/guide/browser/config.md
@@ -155,14 +155,14 @@ Configure options for Vite server that serves code in the browser. Does not affe
 - **Type:** `boolean`
 - **Default:** inherited from [`api.allowWrite`](/config/#api-allowwrite)
 
-Allows browser API clients to write files, including snapshots and browser command writes. If `browser.api.host` is set to anything other than `localhost` or `127.0.0.1`, Vitest disables write operations by default unless this option or [`api.allowWrite`](/config/#api-allowwrite) is explicitly enabled.
+Allows browser API clients to write files, including snapshots and browser command writes. If `browser.api.host` is set to anything other than `localhost` or `127.0.0.1`, Vitest disables write operations by default unless this option or [`api.allowWrite`](/config/#api-allowwrite) is explicitly enabled. This option also gates privileged browser APIs that can write files indirectly, such as raw Chrome DevTools Protocol access through [`cdp()`](/guide/browser/context#cdp).
 
 ### browser.api.allowExec {#browser-api-allowexec}
 
 - **Type:** `boolean`
 - **Default:** inherited from [`api.allowExec`](/config/#api-allowexec)
 
-Allows browser API clients to run tests from the UI. If `browser.api.host` is exposed to the network and write/exec operations are enabled, anyone who can reach the browser API server can run arbitrary code on your machine.
+Allows browser API clients to run tests from the UI. If `browser.api.host` is exposed to the network and write/exec operations are enabled, anyone who can reach the browser API server can run arbitrary code on your machine. This option also gates privileged browser APIs that can execute code indirectly, such as raw Chrome DevTools Protocol access through [`cdp()`](/guide/browser/context#cdp).
 
 ## browser.provider {#browser-provider}
 

--- a/docs/guide/browser/context.md
+++ b/docs/guide/browser/context.md
@@ -116,6 +116,8 @@ The `cdp` export returns the current Chrome DevTools Protocol session. It is mos
 
 ::: warning
 CDP session works only with `playwright` provider and only when using `chromium` browser. You can read more about it in playwright's [`CDPSession`](https://playwright.dev/docs/api/class-cdpsession) documentation.
+
+CDP is a privileged debugging API. It is available only when browser API write and exec operations are enabled through [`browser.api.allowWrite`](/guide/browser/config#browser-api-allowwrite), [`browser.api.allowExec`](/guide/browser/config#browser-api-allowexec), [`api.allowWrite`](/config/#api-allowwrite), and [`api.allowExec`](/config/#api-allowexec).
 :::
 
 ```ts

--- a/packages/browser/src/node/commands/coverage.ts
+++ b/packages/browser/src/node/commands/coverage.ts
@@ -1,0 +1,16 @@
+import type { BrowserCommand } from 'vitest/node'
+import type { BrowserServerCDPHandler } from '../cdp'
+
+export const _startV8Coverage: BrowserCommand<[]> = async (context) => {
+  const session: BrowserServerCDPHandler = await context.__ensureCDPHandler()
+  await session.send('Profiler.enable')
+  await session.send('Profiler.startPreciseCoverage', {
+    callCount: true,
+    detailed: true,
+  })
+}
+
+export const _takeV8Coverage: BrowserCommand<[]> = async (context) => {
+  const session: BrowserServerCDPHandler = await context.__ensureCDPHandler()
+  return session.send('Profiler.takePreciseCoverage')
+}

--- a/packages/browser/src/node/commands/index.ts
+++ b/packages/browser/src/node/commands/index.ts
@@ -1,3 +1,4 @@
+import { _startV8Coverage, _takeV8Coverage } from './coverage'
 import { clear } from './clear'
 import { click, dblClick, tripleClick } from './click'
 import { dragAndDrop } from './dragAndDrop'
@@ -22,6 +23,8 @@ export default {
   removeFile: removeFile as typeof removeFile,
   writeFile: writeFile as typeof writeFile,
   __vitest_fileInfo: _fileInfo as typeof _fileInfo,
+  __vitest_startV8Coverage: _startV8Coverage as typeof _startV8Coverage,
+  __vitest_takeV8Coverage: _takeV8Coverage as typeof _takeV8Coverage,
   __vitest_upload: upload as typeof upload,
   __vitest_click: click as typeof click,
   __vitest_dblClick: dblClick as typeof dblClick,

--- a/packages/browser/src/node/commands/index.ts
+++ b/packages/browser/src/node/commands/index.ts
@@ -1,6 +1,6 @@
-import { _startV8Coverage, _takeV8Coverage } from './coverage'
 import { clear } from './clear'
 import { click, dblClick, tripleClick } from './click'
+import { _startV8Coverage, _takeV8Coverage } from './coverage'
 import { dragAndDrop } from './dragAndDrop'
 import { fill } from './fill'
 import {

--- a/packages/browser/src/node/providers/playwright.ts
+++ b/packages/browser/src/node/providers/playwright.ts
@@ -404,19 +404,10 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     const page = this.getPage(sessionid)
     const cdp = await page.context().newCDPSession(page)
     return {
-      async send(method: string, params: any) {
-        const result = await cdp.send(method as 'DOM.querySelector', params)
-        return result as unknown
-      },
-      on(event: string, listener: (...args: any[]) => void) {
-        cdp.on(event as 'Accessibility.loadComplete', listener)
-      },
-      off(event: string, listener: (...args: any[]) => void) {
-        cdp.off(event as 'Accessibility.loadComplete', listener)
-      },
-      once(event: string, listener: (...args: any[]) => void) {
-        cdp.once(event as 'Accessibility.loadComplete', listener)
-      },
+      send: cdp.send.bind(cdp) as CDPSession['send'],
+      on: cdp.on.bind(cdp) as CDPSession['on'],
+      off: cdp.off.bind(cdp) as CDPSession['off'],
+      once: cdp.once.bind(cdp) as CDPSession['once'],
     }
   }
 

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -128,6 +128,27 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
     )
   }
 
+  function isCdpAllowed(project: TestProject) {
+    return (
+      project.config.api.allowExec
+      && project.config.browser.api.allowExec
+      && project.vitest.config.api.allowExec
+      && project.vitest.config.browser.api.allowExec
+      && project.config.api.allowWrite
+      && project.config.browser.api.allowWrite
+      && project.vitest.config.api.allowWrite
+      && project.vitest.config.browser.api.allowWrite
+    )
+  }
+
+  function assertCdpAllowed(project: TestProject) {
+    if (!isCdpAllowed(project)) {
+      throw new Error(
+        `Cannot use CDP because browser API write or exec operations are disabled. See https://vitest.dev/config/browser/api.`,
+      )
+    }
+  }
+
   function setupClient(project: TestProject, rpcId: string, ws: WebSocket) {
     const mockResolver = new ServerMockResolver(globalServer.vite, {
       moduleDirectories: project.config.server?.deps?.moduleDirectories,
@@ -271,6 +292,7 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
               provider,
               contextId: sessionId,
               sessionId,
+              __ensureCDPHandler: () => globalServer.ensureCDPHandler(sessionId, rpcId),
             },
             provider.getCommandsContext(sessionId),
           ) as any as BrowserCommandContext
@@ -344,10 +366,12 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
 
         // CDP
         async sendCdpEvent(sessionId: string, event: string, payload?: Record<string, unknown>) {
+          assertCdpAllowed(project)
           const cdp = await globalServer.ensureCDPHandler(sessionId, rpcId)
           return cdp.send(event, payload)
         },
         async trackCdpEvent(sessionId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) {
+          assertCdpAllowed(project)
           const cdp = await globalServer.ensureCDPHandler(sessionId, rpcId)
           cdp[type](event, listenerId)
         },

--- a/packages/coverage-v8/src/browser.ts
+++ b/packages/coverage-v8/src/browser.ts
@@ -1,12 +1,15 @@
+import type { Profiler } from 'node:inspector'
 import type { CoverageProviderModule } from 'vitest/node'
 import type { V8CoverageProvider } from './provider'
-import { cdp } from '@vitest/browser/context'
 import { loadProvider } from './load-provider'
 
-const session = cdp()
 let enabled = false
 
-type ScriptCoverage = Awaited<ReturnType<typeof session.send<'Profiler.takePreciseCoverage'>>>
+type ScriptCoverage = Profiler.TakePreciseCoverageReturnType
+
+function triggerCommand(command: string, args: any[] = []): Promise<any> {
+  return (globalThis as any).__vitest_browser_runner__.commands.triggerCommand(command, args)
+}
 
 const mod: CoverageProviderModule = {
   async startCoverage() {
@@ -16,15 +19,11 @@ const mod: CoverageProviderModule = {
 
     enabled = true
 
-    await session.send('Profiler.enable')
-    await session.send('Profiler.startPreciseCoverage', {
-      callCount: true,
-      detailed: true,
-    })
+    await triggerCommand('__vitest_startV8Coverage')
   },
 
   async takeCoverage(): Promise<{ result: any[] }> {
-    const coverage = await session.send('Profiler.takePreciseCoverage')
+    const coverage: ScriptCoverage = await triggerCommand('__vitest_takeV8Coverage')
     const result: typeof coverage.result = []
 
     // Reduce amount of data sent over rpc by doing some early result filtering

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -245,6 +245,12 @@ export interface BrowserCommandContext {
   /** @deprecated use `sessionId` instead */
   contextId: string
   sessionId: string
+  /**
+   * Returns Vitest's cached CDP handler for the current tester RPC connection.
+   *
+   * @internal
+   */
+  __ensureCDPHandler: () => Promise<any>
 }
 
 export interface BrowserServerStateSession {

--- a/test/browser/fixtures/errors-cdp/cdp.test.ts
+++ b/test/browser/fixtures/errors-cdp/cdp.test.ts
@@ -1,0 +1,6 @@
+import { cdp } from '@vitest/browser/context'
+import { test } from 'vitest'
+
+test('cdp throws an error', async () => {
+  await cdp().send('Runtime.evaluate', { expression: '1 + 1' })
+})

--- a/test/browser/fixtures/errors-cdp/vitest.config.ts
+++ b/test/browser/fixtures/errors-cdp/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances: [{ browser: 'chromium' }],
+      headless: true,
+      screenshotFailures: false,
+      api: {
+        allowExec: false,
+        allowWrite: false,
+      },
+    },
+  },
+})

--- a/test/browser/specs/errors-cdp.test.ts
+++ b/test/browser/specs/errors-cdp.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+import { provider, runBrowserTests } from './utils'
+
+// v3 backport of
+// https://github.com/vitest-dev/vitest/blob/a88ab04c710d7703b3d48c74bec4cd6382077acc/test/browser/specs/errors.test.ts#L222
+test.runIf(provider === 'playwright')('cannot use cdp if write or exec is disabled', async () => {
+  const { stderr } = await runBrowserTests({
+    root: './fixtures/errors-cdp',
+  })
+
+  expect(stderr).toContain(
+    'Cannot use CDP because browser API write or exec operations are disabled. See https://vitest.dev/config/browser/api.',
+  )
+})

--- a/test/coverage-test/test/browser-api-permissions.browser.test.ts
+++ b/test/coverage-test/test/browser-api-permissions.browser.test.ts
@@ -1,0 +1,36 @@
+import { expect } from 'vitest'
+import { readCoverageMap, runVitest, test } from '../utils'
+
+test('browser coverage works when browser api write and exec are disabled', async () => {
+  await runVitest({
+    api: {
+      allowExec: false,
+      allowWrite: false,
+    },
+    browser: {
+      api: {
+        allowExec: false,
+        allowWrite: false,
+      },
+    },
+    include: ['fixtures/test/math.test.ts'],
+    coverage: {
+      reporter: 'json',
+      include: ['fixtures/src/math.ts'],
+    },
+  })
+
+  const coverageMap = await readCoverageMap()
+  const fileCoverages = coverageMap.files().map(file => coverageMap.fileCoverageFor(file))
+
+  expect(fileCoverages).toMatchInlineSnapshot(`
+    {
+      "<process-cwd>/fixtures/src/math.ts": {
+        "branches": "0/0 (100%)",
+        "functions": "1/4 (25%)",
+        "lines": "1/4 (25%)",
+        "statements": "1/4 (25%)",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- backport of https://github.com/vitest-dev/vitest/pull/10444
- stacked on https://github.com/vitest-dev/vitest/pull/10445
  - diff https://github.com/hi-ogawa/vitest/compare/backport-v3-allow-write-exec-hardening...backport-v3-browser-cdp-api-permissions

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
