### PR TITLE
fix: don't print typecheck warning more than once

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -146,6 +146,10 @@ function resolveInlineWorkerOption(value: string | number): number {
   }
 }
 
+// warn only once, check one PER PROCESS, not per instance,
+// that's why it's on a module-level
+let warnedTypeCheck = false
+
 export function resolveConfig(
   vitest: Vitest,
   options: UserConfig,
@@ -820,7 +824,8 @@ export function resolveConfig(
   resolved.typecheck ??= {} as any
   resolved.typecheck.enabled ??= false
 
-  if (resolved.typecheck.enabled) {
+  if (resolved.typecheck.enabled && !warnedTypeCheck) {
+    warnedTypeCheck = true
     logger.console.warn(
       c.yellow(
         'Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.',

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -100,9 +100,7 @@ TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string,
 `;
 
 exports[`should fail > typechecks empty "include" but with tests 1`] = `
-"Testing types with tsc and vue-tsc is an experimental feature.
-Breaking changes might not follow SemVer, please pin Vitest's version when using it.
-⎯⎯ Unhandled Errors ⎯⎯
+"⎯⎯ Unhandled Errors ⎯⎯
 
 Vitest caught 1 unhandled error during the test run.
 This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

--- a/test/typescript/test/runner.test.ts
+++ b/test/typescript/test/runner.test.ts
@@ -85,7 +85,7 @@ describe('should fail', async () => {
 
     const message = removeLines(stderr.replace(resolve(import.meta.dirname, '..'), '<root>'))
 
-    expect(message).toMatchSnapshot()
+    expect(message.replace('Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.\n', '')).toMatchSnapshot()
   })
 })
 


### PR DESCRIPTION
Related #9823
Closes #10033