### PR TITLE
docs: clarify typecheck and runtime typo tip

### DIFF
--- a/docs/guide/testing-types.md
+++ b/docs/guide/testing-types.md
@@ -111,9 +111,11 @@ assertType<string>(answer)
 ```
 
 ::: tip
-When using `@ts-expect-error` syntax, you might want to make sure that you didn't make a typo. You can do that by including your type files in [`test.include`](/config/include) config option, so Vitest will also actually *run* these tests and fail with `ReferenceError`.
+When using `@ts-expect-error` syntax, you might want to make sure that you didn't make a typo. You can do that by including your type files in [`test.include`](/config/include) config option, so Vitest will also actually *run* these tests and fail when the typo causes a runtime error such as `ReferenceError`.
 
-This will pass, because it expects an error, but the word “answer” has a typo, so it's a false positive error:
+This is separate from typechecking. Runtime execution can catch typos in values that no longer exist, but it doesn't replace [`--typecheck`](/config/typecheck) for checking type assertions.
+
+This will pass typechecking, because it expects an error, but the word “answer” has a typo. If this file is also included in `test.include`, running it catches the typo as a runtime error:
 
 ```ts
 // @ts-expect-error answer is not a string


### PR DESCRIPTION
### Description

Clarifies the `@ts-expect-error` tip in the Testing Types guide.

Including type files in `test.include` can catch typos that become runtime errors, but that runtime check is separate from `--typecheck` and does not replace type assertion checking.

This should make the tip less ambiguous for users following the docs and expecting one command path to catch both type errors and runtime `ReferenceError`s.

Refs #5604.