### PR TITLE
ci: wire setup-chrome into webdriverio

### DIFF
--- a/.github/actions/setup-webdriverio/action.yml
+++ b/.github/actions/setup-webdriverio/action.yml
@@ -1,0 +1,65 @@
+name: Setup WebDriverIO Browsers
+description: Setup Chrome, ChromeDriver, and optional Firefox for WebDriverIO tests
+
+inputs:
+  chrome-version:
+    description: Chrome for Testing version to install, or false to skip
+    # Pin to Chrome 148 while Chrome for Testing 149 Linux downloads/install are broken.
+    default: '148'
+  firefox-version:
+    description: Firefox version to install, or false to skip
+    default: latest
+
+runs:
+  using: composite
+  steps:
+    - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
+      if: inputs.chrome-version != 'false'
+      id: setup-chrome
+      with:
+        chrome-version: ${{ inputs.chrome-version }}
+        install-chromedriver: true
+
+    - name: Export Chrome binaries
+      if: inputs.chrome-version != 'false'
+      shell: bash
+      env:
+        CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+        CHROMEDRIVER_PATH_VALUE: ${{ steps.setup-chrome.outputs.chromedriver-path }}
+      run: | # zizmor: ignore[github-env] values come from pinned browser-actions/setup-chrome outputs.
+        echo "CHROME_BIN=$CHROME_PATH" >> "$GITHUB_ENV"
+        echo "CHROMEDRIVER_PATH=$CHROMEDRIVER_PATH_VALUE" >> "$GITHUB_ENV"
+
+    - name: Allow setup-chrome sandbox
+      if: inputs.chrome-version != 'false' && runner.os == 'Linux'
+      shell: bash
+      env:
+        CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+      run: |
+        # Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
+        # https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
+        # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+        # https://github.com/browser-actions/setup-chrome/issues/639
+        cat <<EOF | sudo tee /etc/apparmor.d/chrome-for-testing
+        abi <abi/4.0>,
+        include <tunables/global>
+
+        profile chrome-for-testing "$CHROME_PATH" flags=(unconfined) {
+          userns,
+          include if exists <local/chrome>
+        }
+        EOF
+        sudo apparmor_parser -r /etc/apparmor.d/chrome-for-testing
+
+    - uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
+      if: inputs.firefox-version != 'false'
+      id: setup-firefox
+      with:
+        firefox-version: ${{ inputs.firefox-version }}
+
+    - name: Export Firefox binary
+      if: inputs.firefox-version != 'false'
+      shell: bash
+      env:
+        FIREFOX_PATH: ${{ steps.setup-firefox.outputs.firefox-path }}
+      run: echo "FIREFOX_BIN=$FIREFOX_PATH" >> "$GITHUB_ENV" # zizmor: ignore[github-env] value comes from pinned browser-actions/setup-firefox output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 147.0.7727.117
-          install-dependencies: true
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -190,8 +189,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 147.0.7727.117
-          install-dependencies: true
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -239,8 +237,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 147.0.7727.117
-          install-dependencies: true
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -291,8 +288,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 147.0.7727.117
-          install-dependencies: true
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
+          chrome-version: 148.0.7778.216
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -188,6 +189,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
+          chrome-version: 148.0.7778.216
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -235,6 +237,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
+          chrome-version: 148.0.7778.216
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -285,6 +288,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
+          chrome-version: 148.0.7778.216
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,22 @@ jobs:
           echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
 
+      - name: Diagnose setup-chrome binaries
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -x
+          "$CHROME_BIN" --version
+          "$CHROMEDRIVER_PATH" --version
+          ls -la "$CHROME_BIN" "$CHROMEDRIVER_PATH"
+          ldd "$CHROME_BIN" | grep 'not found' || true
+
+          set +e
+          timeout 20s "$CHROME_BIN" --headless --disable-gpu --dump-dom about:blank
+          echo "chrome_headless_exit=$?"
+          timeout 20s "$CHROME_BIN" --headless --disable-gpu --no-sandbox --disable-dev-shm-usage --dump-dom about:blank
+          echo "chrome_headless_no_sandbox_exit=$?"
+
       - name: Install
         run: pnpm i
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
+        id: setup-chrome
+        with:
+          install-chromedriver: true
+
+      - name: Use setup-chrome binaries for WebDriverIO
+        shell: bash
+        run: |
+          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
+            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
+            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Install
         run: pnpm i
@@ -177,6 +190,19 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
+        id: setup-chrome
+        with:
+          install-chromedriver: true
+
+      - name: Use setup-chrome binaries for WebDriverIO
+        shell: bash
+        run: |
+          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
+            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
+            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Install
         run: pnpm i
@@ -215,6 +241,20 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
+        id: setup-chrome
+        with:
+          install-chromedriver: true
+
+      - name: Use setup-chrome binaries for WebDriverIO
+        shell: bash
+        run: |
+          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
+            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
+            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
+          fi
+
       - uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
 
       - name: Install
@@ -250,6 +290,19 @@ jobs:
           node-version: 24
 
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
+        id: setup-chrome
+        with:
+          install-chromedriver: true
+
+      - name: Use setup-chrome binaries for WebDriverIO
+        shell: bash
+        run: |
+          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
+            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
+            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.178
+          chrome-version: 147.0.7727.117
           install-dependencies: true
           install-chromedriver: true
 
@@ -190,7 +190,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.178
+          chrome-version: 147.0.7727.117
           install-dependencies: true
           install-chromedriver: true
 
@@ -239,7 +239,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.178
+          chrome-version: 147.0.7727.117
           install-dependencies: true
           install-chromedriver: true
 
@@ -291,7 +291,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.178
+          chrome-version: 147.0.7727.117
           install-dependencies: true
           install-chromedriver: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,11 @@ jobs:
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
 
       - uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
+        id: setup-firefox
+
+      - name: Use setup-firefox binary for WebDriverIO
+        shell: bash
+        run: echo "FIREFOX_BIN=${{ steps.setup-firefox.outputs.firefox-path }}" >> "$GITHUB_ENV"
 
       - name: Install
         run: pnpm i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,52 +109,10 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
-        id: setup-chrome
+      - uses: ./.github/actions/setup-webdriverio
+        id: setup-webdriverio
         with:
-          chrome-version: 148.0.7778.178
-          install-chromedriver: true
-
-      - name: Use setup-chrome binaries for WebDriverIO
-        shell: bash
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
-
-      - name: Allow setup-chrome sandbox
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          # Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
-          # https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
-          # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-          # https://github.com/browser-actions/setup-chrome/issues/639
-          cat <<EOF | sudo tee /etc/apparmor.d/chrome-for-testing
-          abi <abi/4.0>,
-          include <tunables/global>
-
-          profile chrome-for-testing "$CHROME_BIN" flags=(unconfined) {
-            userns,
-            include if exists <local/chrome>
-          }
-          EOF
-          sudo apparmor_parser -r /etc/apparmor.d/chrome-for-testing
-
-      - name: Diagnose setup-chrome binaries
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -x
-          "$CHROME_BIN" --version
-          "$CHROMEDRIVER_PATH" --version
-          ls -la "$CHROME_BIN" "$CHROMEDRIVER_PATH"
-          ldd "$CHROME_BIN" | grep 'not found' || true
-
-          set +e
-          timeout 20s "$CHROME_BIN" --headless --disable-gpu --dump-dom about:blank
-          echo "chrome_headless_exit=$?"
-          timeout 20s "$CHROME_BIN" --headless --disable-gpu --no-sandbox --disable-dev-shm-usage --dump-dom about:blank
-          echo "chrome_headless_no_sandbox_exit=$?"
+          firefox-version: false
 
       - name: Install
         run: pnpm i
@@ -221,17 +179,10 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
-        id: setup-chrome
+      - uses: ./.github/actions/setup-webdriverio
+        id: setup-webdriverio
         with:
-          chrome-version: 148.0.7778.178
-          install-chromedriver: true
-
-      - name: Use setup-chrome binaries for WebDriverIO
-        shell: bash
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
+          firefox-version: false
 
       - name: Install
         run: pnpm i
@@ -269,24 +220,8 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
-        id: setup-chrome
-        with:
-          chrome-version: 148.0.7778.178
-          install-chromedriver: true
-
-      - name: Use setup-chrome binaries for WebDriverIO
-        shell: bash
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
-
-      - uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
-        id: setup-firefox
-
-      - name: Use setup-firefox binary for WebDriverIO
-        shell: bash
-        run: echo "FIREFOX_BIN=${{ steps.setup-firefox.outputs.firefox-path }}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-webdriverio
+        id: setup-webdriverio
 
       - name: Install
         run: pnpm i
@@ -320,17 +255,10 @@ jobs:
         with:
           node-version: 24
 
-      - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
-        id: setup-chrome
+      - uses: ./.github/actions/setup-webdriverio
+        id: setup-webdriverio
         with:
-          chrome-version: 148.0.7778.178
-          install-chromedriver: true
-
-      - name: Use setup-chrome binaries for WebDriverIO
-        shell: bash
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-          echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
+          firefox-version: false
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: 148.0.7778.178
+          install-dependencies: true
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -190,6 +191,7 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: 148.0.7778.178
+          install-dependencies: true
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -238,6 +240,7 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: 148.0.7778.178
+          install-dependencies: true
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -289,6 +292,7 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: 148.0.7778.178
+          install-dependencies: true
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,25 @@ jobs:
           echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
 
+      - name: Allow setup-chrome sandbox
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          # Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
+          # https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
+          # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+          # https://github.com/browser-actions/setup-chrome/issues/639
+          cat <<EOF | sudo tee /etc/apparmor.d/chrome-for-testing
+          abi <abi/4.0>,
+          include <tunables/global>
+
+          profile chrome-for-testing "$CHROME_BIN" flags=(unconfined) {
+            userns,
+            include if exists <local/chrome>
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/chrome-for-testing
+
       - name: Diagnose setup-chrome binaries
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,8 @@ jobs:
       - name: Use setup-chrome binaries for WebDriverIO
         shell: bash
         run: |
+          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
-            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
-            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
-          fi
 
       - name: Install
         run: pnpm i
@@ -197,12 +193,8 @@ jobs:
       - name: Use setup-chrome binaries for WebDriverIO
         shell: bash
         run: |
+          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
-            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
-            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
-          fi
 
       - name: Install
         run: pnpm i
@@ -248,12 +240,8 @@ jobs:
       - name: Use setup-chrome binaries for WebDriverIO
         shell: bash
         run: |
+          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
-            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
-            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
-          fi
 
       - uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
 
@@ -297,12 +285,8 @@ jobs:
       - name: Use setup-chrome binaries for WebDriverIO
         shell: bash
         run: |
+          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
           echo "CHROMEDRIVER_PATH=${{ steps.setup-chrome.outputs.chromedriver-path }}" >> "$GITHUB_ENV"
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            mkdir -p "$RUNNER_TEMP/setup-chrome-bin"
-            ln -sf "${{ steps.setup-chrome.outputs.chrome-path }}" "$RUNNER_TEMP/setup-chrome-bin/google-chrome"
-            echo "$RUNNER_TEMP/setup-chrome-bin" >> "$GITHUB_PATH"
-          fi
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.216
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -189,7 +189,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.216
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -237,7 +237,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.216
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO
@@ -288,7 +288,7 @@ jobs:
       - uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
         id: setup-chrome
         with:
-          chrome-version: 148.0.7778.216
+          chrome-version: 148.0.7778.178
           install-chromedriver: true
 
       - name: Use setup-chrome binaries for WebDriverIO

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -58,6 +58,13 @@ const testConfig = defineConfig({
                       'capabilities': {
                         'goog:chromeOptions': {
                           binary: process.env.CHROME_BIN,
+                          // Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
+                          // https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
+                          // https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+                          // https://github.com/browser-actions/setup-chrome/issues/639
+                          ...(process.env.CI && process.platform === 'linux'
+                            ? { args: ['no-sandbox', 'disable-dev-shm-usage'] }
+                            : {}),
                         },
                       },
                     }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -58,13 +58,6 @@ const testConfig = defineConfig({
                       'capabilities': {
                         'goog:chromeOptions': {
                           binary: process.env.CHROME_BIN,
-                          // Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
-                          // https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
-                          // https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-                          // https://github.com/browser-actions/setup-chrome/issues/639
-                          ...(process.env.CI && process.platform === 'linux'
-                            ? { args: ['no-sandbox', 'disable-dev-shm-usage'] }
-                            : {}),
                         },
                       },
                     }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -49,7 +49,20 @@ const testConfig = defineConfig({
         providerName === 'preview'
           ? preview()
           : providerName === 'webdriverio'
-            ? webdriverio()
+            ? webdriverio({
+                ...(process.env.CHROMEDRIVER_PATH && process.env.CHROME_BIN
+                  ? {
+                      'wdio:chromedriverOptions': {
+                        binary: process.env.CHROMEDRIVER_PATH,
+                      },
+                      capabilities: {
+                        'goog:chromeOptions': {
+                          binary: process.env.CHROME_BIN,
+                        },
+                      },
+                    }
+                  : {}),
+              })
             : playwright({
                 actionTimeout: 5000,
               }),

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -55,7 +55,7 @@ const testConfig = defineConfig({
                       'wdio:chromedriverOptions': {
                         binary: process.env.CHROMEDRIVER_PATH,
                       },
-                      capabilities: {
+                      'capabilities': {
                         'goog:chromeOptions': {
                           binary: process.env.CHROME_BIN,
                         },

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -32,7 +32,23 @@ const playwrightInstances: BrowserInstanceOption[] = [
 ]
 
 const webdriverioInstances: BrowserInstanceOption[] = [
-  { browser: 'chrome' },
+  {
+    browser: 'chrome',
+    provider: webdriverio({
+      ...(process.env.CHROMEDRIVER_PATH && process.env.CHROME_BIN
+        ? {
+            'wdio:chromedriverOptions': {
+              binary: process.env.CHROMEDRIVER_PATH,
+            },
+            capabilities: {
+              'goog:chromeOptions': {
+                binary: process.env.CHROME_BIN,
+              },
+            },
+          }
+        : {}),
+    }),
+  },
   { browser: 'firefox' },
 ]
 
@@ -43,6 +59,9 @@ export const instances: BrowserInstanceOption[] = testBrowser
   ? [
       {
         browser: testBrowser as any,
+        provider: provider.name === 'webdriverio' && testBrowser === 'chrome'
+          ? webdriverioInstances[0].provider
+          : undefined,
         headless:
           wsEndpoint
             ? true

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -49,7 +49,20 @@ const webdriverioInstances: BrowserInstanceOption[] = [
         : {}),
     }),
   },
-  { browser: 'firefox' },
+  {
+    browser: 'firefox',
+    provider: webdriverio({
+      ...(process.env.FIREFOX_BIN
+        ? {
+            capabilities: {
+              'moz:firefoxOptions': {
+                binary: process.env.FIREFOX_BIN,
+              },
+            },
+          }
+        : {}),
+    }),
+  },
 ]
 
 // use TEST_BROWSER to avoid BROWSER being selected for UI --open
@@ -59,9 +72,6 @@ export const instances: BrowserInstanceOption[] = testBrowser
   ? [
       {
         browser: testBrowser as any,
-        provider: provider.name === 'webdriverio' && testBrowser === 'chrome'
-          ? webdriverioInstances[0].provider
-          : undefined,
         headless:
           wsEndpoint
             ? true

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -40,7 +40,7 @@ const webdriverioInstances: BrowserInstanceOption[] = [
             'wdio:chromedriverOptions': {
               binary: process.env.CHROMEDRIVER_PATH,
             },
-            capabilities: {
+            'capabilities': {
               'goog:chromeOptions': {
                 binary: process.env.CHROME_BIN,
               },

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -43,6 +43,13 @@ const webdriverioInstances: BrowserInstanceOption[] = [
             'capabilities': {
               'goog:chromeOptions': {
                 binary: process.env.CHROME_BIN,
+                // Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
+                // https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
+                // https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+                // https://github.com/browser-actions/setup-chrome/issues/639
+                ...(process.env.CI && process.platform === 'linux'
+                  ? { args: ['no-sandbox', 'disable-dev-shm-usage'] }
+                  : {}),
               },
             },
           }

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -25,12 +25,16 @@ export const providers = {
       ...options,
       capabilities: {
         ...capabilities,
+        // Explicit browser/driver binaries keep WebDriverIO from auto-downloading mismatched versions.
+        // https://webdriver.io/docs/driverbinaries
+        // https://webdriver.io/docs/capabilities#webdriverio-capabilities-to-manage-browser-driver-options
         ...(process.env.CHROMEDRIVER_PATH && process.env.CHROME_BIN
           ? {
               'wdio:chromedriverOptions': {
                 ...(capabilities as any)['wdio:chromedriverOptions'],
                 binary: process.env.CHROMEDRIVER_PATH,
               },
+              // https://developer.chrome.com/docs/chromedriver/capabilities#chromeoptions-object
               'goog:chromeOptions': {
                 ...(capabilities as any)['goog:chromeOptions'],
                 binary: process.env.CHROME_BIN,
@@ -39,6 +43,7 @@ export const providers = {
           : {}),
         ...(process.env.FIREFOX_BIN
           ? {
+              // https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/Capabilities/firefoxOptions
               'moz:firefoxOptions': {
                 ...(capabilities as any)['moz:firefoxOptions'],
                 binary: process.env.FIREFOX_BIN,

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -43,13 +43,6 @@ const webdriverioInstances: BrowserInstanceOption[] = [
             'capabilities': {
               'goog:chromeOptions': {
                 binary: process.env.CHROME_BIN,
-                // Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
-                // https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
-                // https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-                // https://github.com/browser-actions/setup-chrome/issues/639
-                ...(process.env.CI && process.platform === 'linux'
-                  ? { args: ['no-sandbox', 'disable-dev-shm-usage'] }
-                  : {}),
               },
             },
           }

--- a/test/browser/settings.ts
+++ b/test/browser/settings.ts
@@ -18,7 +18,36 @@ export const providers = {
       }
     : options),
   preview,
-  webdriverio,
+  webdriverio: (options?: Parameters<typeof webdriverio>[0]) => {
+    const capabilities = options?.capabilities || {}
+
+    return webdriverio({
+      ...options,
+      capabilities: {
+        ...capabilities,
+        ...(process.env.CHROMEDRIVER_PATH && process.env.CHROME_BIN
+          ? {
+              'wdio:chromedriverOptions': {
+                ...(capabilities as any)['wdio:chromedriverOptions'],
+                binary: process.env.CHROMEDRIVER_PATH,
+              },
+              'goog:chromeOptions': {
+                ...(capabilities as any)['goog:chromeOptions'],
+                binary: process.env.CHROME_BIN,
+              },
+            }
+          : {}),
+        ...(process.env.FIREFOX_BIN
+          ? {
+              'moz:firefoxOptions': {
+                ...(capabilities as any)['moz:firefoxOptions'],
+                binary: process.env.FIREFOX_BIN,
+              },
+            }
+          : {}),
+      },
+    })
+  },
 }
 
 export const provider = providers[providerName]()
@@ -32,37 +61,8 @@ const playwrightInstances: BrowserInstanceOption[] = [
 ]
 
 const webdriverioInstances: BrowserInstanceOption[] = [
-  {
-    browser: 'chrome',
-    provider: webdriverio({
-      ...(process.env.CHROMEDRIVER_PATH && process.env.CHROME_BIN
-        ? {
-            'wdio:chromedriverOptions': {
-              binary: process.env.CHROMEDRIVER_PATH,
-            },
-            'capabilities': {
-              'goog:chromeOptions': {
-                binary: process.env.CHROME_BIN,
-              },
-            },
-          }
-        : {}),
-    }),
-  },
-  {
-    browser: 'firefox',
-    provider: webdriverio({
-      ...(process.env.FIREFOX_BIN
-        ? {
-            capabilities: {
-              'moz:firefoxOptions': {
-                binary: process.env.FIREFOX_BIN,
-              },
-            },
-          }
-        : {}),
-    }),
-  },
+  { browser: 'chrome' },
+  { browser: 'firefox' },
 ]
 
 // use TEST_BROWSER to avoid BROWSER being selected for UI --open

--- a/test/browser/specs/failure-screenshot.test.ts
+++ b/test/browser/specs/failure-screenshot.test.ts
@@ -2,7 +2,6 @@ import type { TestFsStructure } from '../../test-utils'
 import { describe, expect, test } from 'vitest'
 import { runInlineTests } from '../../test-utils'
 import utilsContent from '../fixtures/expect-dom/utils?raw'
-import { instances, provider } from '../settings'
 
 const testFilename = 'basic.test.ts'
 
@@ -12,16 +11,17 @@ async function runBrowserTests(
   return runInlineTests({
     ...structure,
     'vitest.config.js': `
-      import { ${provider.name} } from '@vitest/browser-${provider.name}'
+      import { instances, provider } from '../settings.ts'
+
       export default {
         test: {
           browser: {
             enabled: true,
             screenshotFailures: true,
-            provider: ${provider.name}(),
+            provider,
             ui: false,
             headless: true,
-            instances: ${JSON.stringify(instances.slice(0, 1) /* logic not bound to browser instance */)},
+            instances: instances.slice(0, 1), // logic not bound to browser instance
           },
           reporters: ['verbose'],
           update: 'new',

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -170,7 +170,20 @@ function modeToConfig(mode: string): RunVitestConfig {
     return {
       browser: {
         enabled: true,
-        provider: webdriverio(),
+        provider: webdriverio({
+          ...(process.env.CHROMEDRIVER_PATH && process.env.CHROME_BIN
+            ? {
+                'wdio:chromedriverOptions': {
+                  binary: process.env.CHROMEDRIVER_PATH,
+                },
+                capabilities: {
+                  'goog:chromeOptions': {
+                    binary: process.env.CHROME_BIN,
+                  },
+                },
+              }
+            : {}),
+        }),
         instances: [{ browser: 'chrome' }],
         headless: true,
       },

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -179,6 +179,13 @@ function modeToConfig(mode: string): RunVitestConfig {
                 'capabilities': {
                   'goog:chromeOptions': {
                     binary: process.env.CHROME_BIN,
+                    // Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
+                    // https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
+                    // https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+                    // https://github.com/browser-actions/setup-chrome/issues/639
+                    ...(process.env.CI && process.platform === 'linux'
+                      ? { args: ['no-sandbox', 'disable-dev-shm-usage'] }
+                      : {}),
                   },
                 },
               }

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -176,7 +176,7 @@ function modeToConfig(mode: string): RunVitestConfig {
                 'wdio:chromedriverOptions': {
                   binary: process.env.CHROMEDRIVER_PATH,
                 },
-                capabilities: {
+                'capabilities': {
                   'goog:chromeOptions': {
                     binary: process.env.CHROME_BIN,
                   },

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -179,13 +179,6 @@ function modeToConfig(mode: string): RunVitestConfig {
                 'capabilities': {
                   'goog:chromeOptions': {
                     binary: process.env.CHROME_BIN,
-                    // Chrome for Testing is not covered by Ubuntu's AppArmor sandbox policy on CI.
-                    // https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
-                    // https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-                    // https://github.com/browser-actions/setup-chrome/issues/639
-                    ...(process.env.CI && process.platform === 'linux'
-                      ? { args: ['no-sandbox', 'disable-dev-shm-usage'] }
-                      : {}),
                   },
                 },
               }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

wdio and setup-chrome doesn't seem to be working together at all (i.e. setup-chrome is unused at all). and now wdio auto download has some glitches and that's breaking CI.

I extracted webdriverio browser installation in `.github/actions/setup-webdriverio/action.yml` and sprinkled some relevant comment for rational.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
