### PR TITLE
feat!: `toHaveTextContent` is strict, add `toMatchTextContent` as alternative

### DIFF
--- a/docs/api/browser/assertions.md
+++ b/docs/api/browser/assertions.md
@@ -34,7 +34,7 @@ test('error banner is rendered', async () => {
   // It will repeatedly check that the element exists in the DOM and that
   // the content of `element.textContent` is equal to "Error!"
   // until all the conditions are met
-  await expect.element(banner).toHaveTextContent('Error!')
+  await expect.element(banner).toMatchTextContent('Error!')
 })
 ```
 
@@ -56,11 +56,11 @@ interface ExpectPollOptions {
 ::: tip
 Like [`expect.poll`](/api/expect#poll), `expect.element` retries DOM assertions until they pass or the timeout is reached. When it receives a locator, Vitest resolves it with [`locator.findElement()`](/api/browser/locators#findelement) before running the DOM assertion. The `timeout` option applies to the whole retry operation. The `interval` option controls how often failed DOM assertions are retried, but locator resolution uses `findElement`'s own increasing retry intervals.
 
-`toHaveTextContent` and all other assertions are still available on a regular `expect` without a built-in retry-ability mechanism:
+`toMatchTextContent` and all other assertions are still available on a regular `expect` without a built-in retry-ability mechanism:
 
 ```ts
 // will fail immediately if .textContent is not `'Error!'`
-expect(banner).toHaveTextContent('Error!')
+expect(banner).toMatchTextContent('Error!')
 ```
 :::
 
@@ -738,21 +738,15 @@ The usual rules of css precedence apply.
 
 ```ts
 function toHaveTextContent(
-  text: string | RegExp,
+  text: string | number,
   options?: { normalizeWhitespace: boolean }
 ): Promise<void>
 ```
 
-This allows you to check whether the given node has a text content or not. This
+This matcher allows you to validate that an element's text matches provided string exactly. This
 supports elements, but also text nodes and fragments.
 
-When a `string` argument is passed through, it will perform a partial
-case-sensitive match to the node content.
-
-To perform a case-insensitive match, you can use a `RegExp` with the `/i`
-modifier.
-
-If you want to match the whole content, you can use a `RegExp` to do it.
+If you wish to perform a partial check or do a case-sensitive match, use [`toMatchTextContent`](#tomatchtextcontent) instead.
 
 ```html
 <span data-testid="text-content">Text Content</span>
@@ -761,12 +755,43 @@ If you want to match the whole content, you can use a `RegExp` to do it.
 ```ts
 const element = getByTestId('text-content')
 
-await expect.element(element).toHaveTextContent('Content')
+await expect.element(element).toHaveTextContent('Text Content')
+await expect.element(element).not.toHaveTextContent('Content')
+```
+
+## toMatchTextContent
+
+```ts
+function toMatchTextContent(
+  text: string | number | RegExp,
+  options?: { normalizeWhitespace: boolean }
+): Promise<void>
+```
+
+This matcher allows you to check whether the given node has a text content or not. This
+supports elements, but also text nodes and fragments.
+
+When a `string` argument is passed through, it will perform a partial
+case-sensitive match to the node content.
+
+To perform a case-insensitive match, you can use a `RegExp` with the `/i`
+modifier.
+
+If you want to match the whole content, you can use a `RegExp` to do it or [`toHaveTextContent`](#tohavetextcontent) matcher instead.
+
+```html
+<span data-testid="text-content">Text Content</span>
+```
+
+```ts
+const element = getByTestId('text-content')
+
+await expect.element(element).toMatchTextContent('Content')
 // to match the whole content
-await expect.element(element).toHaveTextContent(/^Text Content$/)
+await expect.element(element).toMatchTextContent(/^Text Content$/)
 // to use case-insensitive match
-await expect.element(element).toHaveTextContent(/content$/i)
-await expect.element(element).not.toHaveTextContent('content')
+await expect.element(element).toMatchTextContent(/content$/i)
+await expect.element(element).not.toMatchTextContent('content')
 ```
 
 ## toHaveValue

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -80,6 +80,21 @@ Several entry points were marked as deprecated in Vitest 4.1. This release remov
 - `vitest/mocker` is removed completely, use `@vitest/mocker` package directly (this was published by accident at one point and never removed)
 - `vitest/internal/module-runner` is removed
 
+### `toHaveTextContent` Now Performs Strict Equality
+
+The browser-mode [`toHaveTextContent`](/api/browser/assertions#tohavetextcontent) matcher now validates that an element's text content is exactly equal to the expected string instead of performing a partial, case-sensitive match. Regular expressions are no longer accepted. The previous behaviour, including `RegExp` support, has moved to the new [`toMatchTextContent`](/api/browser/assertions#tomatchtextcontent) matcher.
+
+```ts
+// Partial or regex matches:
+await expect.element(banner).toHaveTextContent('Error') // [!code --]
+await expect.element(banner).toHaveTextContent(/error/i) // [!code --]
+await expect.element(banner).toMatchTextContent('Error') // [!code ++]
+await expect.element(banner).toMatchTextContent(/error/i) // [!code ++]
+
+// Exact matches stay on `toHaveTextContent`:
+await expect.element(banner).toHaveTextContent('Error!')
+```
+
 ## Migrating to Vitest 4.0 {#vitest-4}
 
 ::: warning Prerequisites

--- a/examples/lit/test/basic.test.ts
+++ b/examples/lit/test/basic.test.ts
@@ -14,13 +14,13 @@ describe('Button with increment', async () => {
   it('should increment the count on each click', async () => {
     await page.getByRole('button').click()
 
-    await expect.element(page.getByRole('button')).toHaveTextContent('2')
+    await expect.element(page.getByRole('button')).toMatchTextContent('2')
     if (import.meta.env.VITE_FAIL_TEST) {
-      await expect.element(page.getByRole('button'), { timeout: 3000 }).toHaveTextContent('3')
+      await expect.element(page.getByRole('button'), { timeout: 3000 }).toMatchTextContent('3')
     }
   })
 
   it('should show name props', async () => {
-    await expect.element(page.getByRole('heading')).toHaveTextContent('World')
+    await expect.element(page.getByRole('heading')).toMatchTextContent('World')
   })
 })

--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -379,6 +379,25 @@ export interface TestingLibraryMatchers<E, R> {
   toHaveStyle(css: string | Partial<CSSStyleDeclaration>): R
   /**
    * @description
+   * Validate that the given element's text content matches the provided string exactly.
+   *
+   * Supports elements, but also text nodes and fragments.
+   *
+   * If you wish to perform a partial check or use a RegExp, use `toMatchTextContent` instead.
+   * @example
+   * <span data-testid="text-content">Text Content</span>
+   *
+   * const element = page.getByTestId('text-content')
+   * await expect.element(element).toHaveTextContent('Text Content')
+   * await expect.element(element).not.toHaveTextContent('Content')
+   * @see https://vitest.dev/api/browser/assertions#tohavetextcontent
+   */
+  toHaveTextContent(
+    text: string | number,
+    options?: {normalizeWhitespace: boolean},
+  ): R
+  /**
+   * @description
    * Check whether the given element has a text content or not.
    *
    * When a string argument is passed through, it will perform a partial case-sensitive match to the element
@@ -391,15 +410,15 @@ export interface TestingLibraryMatchers<E, R> {
    * <span data-testid="text-content">Text Content</span>
    *
    * const element = page.getByTestId('text-content')
-   * await expect.element(element).toHaveTextContent('Content')
+   * await expect.element(element).toMatchTextContent('Content')
    * // to match the whole content
-   * await expect.element(element).toHaveTextContent(/^Text Content$/)
+   * await expect.element(element).toMatchTextContent(/^Text Content$/)
    * // to use case-insensitive match
-   * await expect.element(element).toHaveTextContent(/content$/i)
-   * await expect.element(element).not.toHaveTextContent('content')
-   * @see https://vitest.dev/api/browser/assertions#tohavetextcontent
+   * await expect.element(element).toMatchTextContent(/content$/i)
+   * await expect.element(element).not.toMatchTextContent('content')
+   * @see https://vitest.dev/api/browser/assertions#tomatchtextcontent
    */
-  toHaveTextContent(
+  toMatchTextContent(
     text: string | number | RegExp,
     options?: {normalizeWhitespace: boolean},
   ): R

--- a/packages/browser/src/client/tester/expect/index.ts
+++ b/packages/browser/src/client/tester/expect/index.ts
@@ -24,6 +24,7 @@ import toHaveStyle from './toHaveStyle'
 import toHaveTextContent from './toHaveTextContent'
 import toHaveValue from './toHaveValue'
 import toMatchScreenshot from './toMatchScreenshot'
+import toMatchTextContent from './toMatchTextContent'
 
 export const matchers: MatchersObject = {
   toBeDisabled,
@@ -46,6 +47,7 @@ export const matchers: MatchersObject = {
   toHaveFormValues,
   toHaveStyle,
   toHaveTextContent,
+  toMatchTextContent,
   toHaveValue,
   toHaveDisplayValue,
   toBeChecked,

--- a/packages/browser/src/client/tester/expect/toMatchTextContent.ts
+++ b/packages/browser/src/client/tester/expect/toMatchTextContent.ts
@@ -38,13 +38,13 @@ export default function toMatchTextContent(
       return getMessage(
         this,
         this.utils.matcherHint(
-          `${this.isNot ? '.not' : ''}.toHaveTextContent`,
+          `${this.isNot ? '.not' : ''}.toMatchTextContent`,
           'element',
           '',
         ),
         checkingWithEmptyString
           ? `Checking with empty string will always match, use .toBeEmptyDOMElement() instead`
-          : `Expected element ${to} have text content`,
+          : `Expected element ${to} match text content`,
         matcher,
         'Received',
         textContent,

--- a/packages/browser/src/client/tester/expect/toMatchTextContent.ts
+++ b/packages/browser/src/client/tester/expect/toMatchTextContent.ts
@@ -15,24 +15,24 @@
 
 import type { MatcherResult, MatcherState } from 'vitest'
 import type { Locator } from '../locators'
-import { getMessage, getNodeFromUserInput, normalize } from './utils'
+import { getMessage, getNodeFromUserInput, matches, normalize } from './utils'
 
-export default function toHaveTextContent(
+export default function toMatchTextContent(
   this: MatcherState,
   actual: Element | Locator,
-  matcher: string | number,
+  matcher: string | RegExp,
   options: { normalizeWhitespace?: boolean } = { normalizeWhitespace: true },
 ): MatcherResult {
-  const node = getNodeFromUserInput(actual, toHaveTextContent, this)
+  const node = getNodeFromUserInput(actual, toMatchTextContent, this)
 
   const textContent = options.normalizeWhitespace
     ? normalize(node.textContent || '')
     : (node.textContent || '').replace(/\u00A0/g, ' ') // Replace &nbsp; with normal spaces
 
-  const expectedText = String(matcher)
+  const checkingWithEmptyString = textContent !== '' && matcher === ''
 
   return {
-    pass: textContent === expectedText,
+    pass: !checkingWithEmptyString && matches(textContent, matcher),
     message: () => {
       const to = this.isNot ? 'not to' : 'to'
       return getMessage(
@@ -42,8 +42,10 @@ export default function toHaveTextContent(
           'element',
           '',
         ),
-        `Expected element ${to} have text content`,
-        expectedText,
+        checkingWithEmptyString
+          ? `Checking with empty string will always match, use .toBeEmptyDOMElement() instead`
+          : `Expected element ${to} have text content`,
+        matcher,
         'Received',
         textContent,
       )

--- a/test/browser/fixtures/expect-dom/toHaveTextContent.test.ts
+++ b/test/browser/fixtures/expect-dom/toHaveTextContent.test.ts
@@ -3,30 +3,35 @@ import { render } from './utils'
 
 describe('.toHaveTextContent', () => {
   test('handles positive test cases', () => {
-    const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
+    const { queryByTestId } = render(`<span data-testid="count-value">2</span>`)
 
     expect(queryByTestId('count-value')).toHaveTextContent('2')
     expect(queryByTestId('count-value')).toHaveTextContent(2)
-    expect(queryByTestId('count-value')).toHaveTextContent(/2/)
     expect(queryByTestId('count-value')).not.toHaveTextContent('21')
   })
 
-  test('handles text nodes', () => {
-    const {container} = render(`<span>example</span>`)
+  test('performs strict equality, not partial match', () => {
+    const { queryByTestId } = render(`<span data-testid="text">Text Content</span>`)
 
-    expect(container.querySelector('span').firstChild).toHaveTextContent(
-      'example',
-    )
+    expect(queryByTestId('text')).toHaveTextContent('Text Content')
+    expect(queryByTestId('text')).not.toHaveTextContent('Content')
+    expect(queryByTestId('text')).not.toHaveTextContent('Text')
+  })
+
+  test('handles text nodes', () => {
+    const { container } = render(`<span>example</span>`)
+
+    expect(container.querySelector('span')?.firstChild).toHaveTextContent('example')
   })
 
   test('handles fragments', () => {
-    const {asFragment} = render(`<span>example</span>`)
+    const { asFragment } = render(`<span>example</span>`)
 
     expect(asFragment()).toHaveTextContent('example')
   })
 
   test('handles negative test cases', () => {
-    const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
+    const { queryByTestId } = render(`<span data-testid="count-value">2</span>`)
 
     expect(() =>
       expect(queryByTestId('count-value2')).toHaveTextContent('2'),
@@ -41,7 +46,7 @@ describe('.toHaveTextContent', () => {
   })
 
   test('normalizes whitespace by default', () => {
-    const {container} = render(`
+    const { container } = render(`
       <span>
         Step
           1
@@ -54,7 +59,7 @@ describe('.toHaveTextContent', () => {
   })
 
   test('allows whitespace normalization to be turned off', () => {
-    const {container} = render(`<span>&nbsp;&nbsp;Step 1 of 4</span>`)
+    const { container } = render(`<span>&nbsp;&nbsp;Step 1 of 4</span>`)
 
     expect(container.querySelector('span')).toHaveTextContent('  Step 1 of 4', {
       normalizeWhitespace: false,
@@ -62,15 +67,15 @@ describe('.toHaveTextContent', () => {
   })
 
   test('can handle multiple levels', () => {
-    const {container} = render(`<span id="parent"><span>Step 1 
-    
+    const { container } = render(`<span id="parent"><span>Step 1
+
     of 4</span></span>`)
 
     expect(container.querySelector('#parent')).toHaveTextContent('Step 1 of 4')
   })
 
   test('can handle multiple levels with content spread across descendants', () => {
-    const {container} = render(`
+    const { container } = render(`
         <span id="parent">
             <span>Step</span>
             <span>      1</span>
@@ -85,25 +90,24 @@ describe('.toHaveTextContent', () => {
   })
 
   test('does not throw error with empty content', () => {
-    const {container} = render(`<span></span>`)
+    const { container } = render(`<span></span>`)
     expect(container.querySelector('span')).toHaveTextContent('')
   })
 
+  test('throws when element has content but matcher is empty', () => {
+    const { container } = render('<span>not empty</span>')
+
+    expect(() =>
+      expect(container.querySelector('span')).toHaveTextContent(''),
+    ).toThrow()
+  })
+
   test('is case-sensitive', () => {
-    const {container} = render('<span>Sensitive text</span>')
+    const { container } = render('<span>Sensitive text</span>')
 
     expect(container.querySelector('span')).toHaveTextContent('Sensitive text')
     expect(container.querySelector('span')).not.toHaveTextContent(
       'sensitive text',
     )
-  })
-
-  test('when matching with empty string and element with content, suggest using toBeEmptyDOMElement instead', () => {
-    // https://github.com/testing-library/jest-dom/issues/104
-    const {container} = render('<span>not empty</span>')
-
-    expect(() =>
-      expect(container.querySelector('span')).toHaveTextContent(''),
-    ).toThrow(/toBeEmptyDOMElement\(\)/)
   })
 })

--- a/test/browser/fixtures/expect-dom/toMatchTextContent.test.ts
+++ b/test/browser/fixtures/expect-dom/toMatchTextContent.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest'
+import { render } from './utils'
+
+describe('.toMatchTextContent', () => {
+  test('handles positive test cases', () => {
+    const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
+
+    expect(queryByTestId('count-value')).toMatchTextContent('2')
+    expect(queryByTestId('count-value')).toMatchTextContent(2)
+    expect(queryByTestId('count-value')).toMatchTextContent(/2/)
+    expect(queryByTestId('count-value')).not.toMatchTextContent('21')
+  })
+
+  test('handles text nodes', () => {
+    const {container} = render(`<span>example</span>`)
+
+    expect(container.querySelector('span')?.firstChild).toMatchTextContent(
+      'example',
+    )
+  })
+
+  test('handles fragments', () => {
+    const {asFragment} = render(`<span>example</span>`)
+
+    expect(asFragment()).toMatchTextContent('example')
+  })
+
+  test('handles negative test cases', () => {
+    const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
+
+    expect(() =>
+      expect(queryByTestId('count-value2')).toMatchTextContent('2'),
+    ).toThrow()
+
+    expect(() =>
+      expect(queryByTestId('count-value')).toMatchTextContent('3'),
+    ).toThrow()
+    expect(() =>
+      expect(queryByTestId('count-value')).not.toMatchTextContent('2'),
+    ).toThrow()
+  })
+
+  test('normalizes whitespace by default', () => {
+    const {container} = render(`
+      <span>
+        Step
+          1
+            of
+              4
+      </span>
+    `)
+
+    expect(container.querySelector('span')).toMatchTextContent('Step 1 of 4')
+  })
+
+  test('allows whitespace normalization to be turned off', () => {
+    const {container} = render(`<span>&nbsp;&nbsp;Step 1 of 4</span>`)
+
+    expect(container.querySelector('span')).toMatchTextContent('  Step 1 of 4', {
+      normalizeWhitespace: false,
+    })
+  })
+
+  test('can handle multiple levels', () => {
+    const {container} = render(`<span id="parent"><span>Step 1 
+    
+    of 4</span></span>`)
+
+    expect(container.querySelector('#parent')).toMatchTextContent('Step 1 of 4')
+  })
+
+  test('can handle multiple levels with content spread across descendants', () => {
+    const {container} = render(`
+        <span id="parent">
+            <span>Step</span>
+            <span>      1</span>
+            <span><span>of</span></span>
+
+
+            4</span>
+        </span>
+    `)
+
+    expect(container.querySelector('#parent')).toMatchTextContent('Step 1 of 4')
+  })
+
+  test('does not throw error with empty content', () => {
+    const {container} = render(`<span></span>`)
+    expect(container.querySelector('span')).toMatchTextContent('')
+  })
+
+  test('is case-sensitive', () => {
+    const {container} = render('<span>Sensitive text</span>')
+
+    expect(container.querySelector('span')).toMatchTextContent('Sensitive text')
+    expect(container.querySelector('span')).not.toMatchTextContent(
+      'sensitive text',
+    )
+  })
+
+  test('when matching with empty string and element with content, suggest using toBeEmptyDOMElement instead', () => {
+    // https://github.com/testing-library/jest-dom/issues/104
+    const {container} = render('<span>not empty</span>')
+
+    expect(() =>
+      expect(container.querySelector('span')).toMatchTextContent(''),
+    ).toThrow(/toBeEmptyDOMElement\(\)/)
+  })
+})

--- a/test/browser/fixtures/locators/blog.test.tsx
+++ b/test/browser/fixtures/locators/blog.test.tsx
@@ -13,19 +13,19 @@ test('renders blog posts', async () => {
 
   const [firstPost, secondPost] = posts
 
-  expect(firstPost.element()).toHaveTextContent(/molestiae ut ut quas/)
-  expect(firstPost.getByRole('heading').element()).toHaveTextContent(/occaecati excepturi/)
+  expect(firstPost.element()).toMatchTextContent(/molestiae ut ut quas/)
+  expect(firstPost.getByRole('heading').element()).toMatchTextContent(/occaecati excepturi/)
 
-  await expect.element(secondPost.getByRole('heading')).toHaveTextContent('qui est esse')
+  await expect.element(secondPost.getByRole('heading')).toMatchTextContent('qui est esse')
 
   await userEvent.click(secondPost.getByRole('button', { name: 'Delete' }))
 
   expect(screen.getByRole('listitem').all()).toHaveLength(3)
 
-  expect(screen.getByRole('listitem').nth(0).element()).toHaveTextContent(/molestiae ut ut quas/)
+  expect(screen.getByRole('listitem').nth(0).element()).toMatchTextContent(/molestiae ut ut quas/)
   await expect.element(screen.getByRole('listitem').nth(666)).not.toBeInTheDocument()
-  expect(screen.getByRole('listitem').first().element()).toHaveTextContent(/molestiae ut ut quas/)
-  expect(screen.getByRole('listitem').last().element()).toHaveTextContent(/eum et est/)
+  expect(screen.getByRole('listitem').first().element()).toMatchTextContent(/molestiae ut ut quas/)
+  expect(screen.getByRole('listitem').last().element()).toMatchTextContent(/eum et est/)
 
   expect(screen.getByPlaceholder('non-existing').query()).not.toBeInTheDocument()
 })


### PR DESCRIPTION
related https://github.com/vitest-dev/vitest/discussions/9664#discussioncomment-16122733

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
