### PR TITLE
fix(browser): remove orphaned Playwright route when same module is mocked via multiple ids [backport to v4]

### DIFF
--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -261,9 +261,9 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
   private createMocker(): BrowserModuleMocker {
     const idPredicates = new Map<string, (url: URL) => boolean>()
-    const sessionIds = new Map<string, string[]>()
+    const sessionIds = new Map<string, Set<string>>()
 
-    function createPredicate(sessionId: string, url: string) {
+    function createPredicate(url: string) {
       const moduleUrl = new URL(url, 'http://localhost')
       const predicate = (url: URL) => {
         if (url.searchParams.has('_vitest_original')) {
@@ -293,11 +293,7 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
         return true
       }
-      const ids = sessionIds.get(sessionId) || []
-      ids.push(moduleUrl.href)
-      sessionIds.set(sessionId, ids)
-      idPredicates.set(predicateKey(sessionId, moduleUrl.href), predicate)
-      return predicate
+      return { url: moduleUrl.href, predicate }
     }
 
     function predicateKey(sessionId: string, url: string) {
@@ -307,7 +303,17 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     return {
       register: async (sessionId: string, module: MockedModule): Promise<void> => {
         const page = this.getPage(sessionId)
-        await page.context().route(createPredicate(sessionId, module.url), async (route) => {
+        const { url: moduleUrl, predicate } = createPredicate(module.url)
+        const key = predicateKey(sessionId, moduleUrl)
+        const existingPredicate = idPredicates.get(key)
+        if (existingPredicate) {
+          await page.context().unroute(existingPredicate)
+        }
+        const ids = sessionIds.get(sessionId) ?? new Set<string>()
+        ids.add(moduleUrl)
+        sessionIds.set(sessionId, ids)
+        idPredicates.set(key, predicate)
+        await page.context().route(predicate, async (route) => {
           if (module.type === 'manual') {
             const exports = Object.keys(await module.resolve())
             const body = createManualModuleSource(module.url, exports)
@@ -381,8 +387,8 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
       },
       clear: async (sessionId: string): Promise<void> => {
         const page = this.getPage(sessionId)
-        const ids = sessionIds.get(sessionId) || []
-        const promises = ids.map((id) => {
+        const ids = sessionIds.get(sessionId) ?? new Set<string>()
+        const promises = [...ids].map((id) => {
           const key = predicateKey(sessionId, id)
           const predicate = idPredicates.get(key)
           if (predicate) {

--- a/test/browser/fixtures/mocking/src/aaa-dual-id-probe.test.ts
+++ b/test/browser/fixtures/mocking/src/aaa-dual-id-probe.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest'
+import { loadModalSource } from './dual-id/consumer'
+
+vi.mock('~/dual-id/modal', () => ({
+  readModalSource: () => 'mocked modal',
+}))
+
+vi.mock('./dual-id/modal', () => ({
+  readModalSource: () => 'mocked modal',
+}))
+
+test('dual-id mock is active in the file that registered it', () => {
+  expect(loadModalSource()).not.toBe('actual modal')
+})

--- a/test/browser/fixtures/mocking/src/dual-id/consumer.ts
+++ b/test/browser/fixtures/mocking/src/dual-id/consumer.ts
@@ -1,0 +1,5 @@
+import { readModalSource } from '~/dual-id/modal'
+
+export function loadModalSource() {
+  return readModalSource()
+}

--- a/test/browser/fixtures/mocking/src/dual-id/modal.ts
+++ b/test/browser/fixtures/mocking/src/dual-id/modal.ts
@@ -1,0 +1,3 @@
+export function readModalSource() {
+  return 'actual modal'
+}

--- a/test/browser/fixtures/mocking/src/zzz-dual-id-target.test.ts
+++ b/test/browser/fixtures/mocking/src/zzz-dual-id-target.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { loadModalSource } from './dual-id/consumer'
+
+test('dual-id mock from the previous file does not leak into this one', () => {
+  expect(loadModalSource()).toBe('actual modal')
+})

--- a/test/browser/fixtures/mocking/vitest.config.ts
+++ b/test/browser/fixtures/mocking/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config'
 import { instances, provider } from '../../settings'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   optimizeDeps: {
     include: ['@vitest/cjs-lib'],
     needsInterop: ['@vitest/cjs-lib'],

--- a/test/browser/specs/mocking.test.ts
+++ b/test/browser/specs/mocking.test.ts
@@ -28,12 +28,34 @@ test.each([true/* , false */])('mocking works correctly - isolated %s', async (i
     expect(result.stdout).toReportPassedTest('import-actual-in-mock.test.ts', browser)
     expect(result.stdout).toReportPassedTest('import-actual-query.test.ts', browser)
     expect(result.stdout).toReportPassedTest('import-mock.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/aaa-dual-id-probe.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/zzz-dual-id-target.test.ts', browser)
     expect(result.stdout).toReportPassedTest('mocked-do-mock-factory.test.ts', browser)
     expect(result.stdout).toReportPassedTest('import-actual-dep.test.ts', browser)
   })
 
   expect(result.exitCode).toBe(0)
 })
+
+test('manual mocks do not leak across browser files when alias and relative ids resolve to the same module', async () => {
+  const result = await runVitest({
+    root: 'fixtures/mocking',
+  }, ['src/aaa-dual-id-probe.test.ts', 'src/zzz-dual-id-target.test.ts'])
+
+  onTestFailed(() => {
+    console.error(result.stdout)
+    console.error(result.stderr)
+  })
+
+  expect(result.stderr).toReportNoErrors()
+
+  instances.forEach(({ browser }) => {
+    expect(result.stdout).toReportPassedTest('src/aaa-dual-id-probe.test.ts', browser)
+    expect(result.stdout).toReportPassedTest('src/zzz-dual-id-target.test.ts', browser)
+  })
+
+  expect(result.exitCode).toBe(0)
+}, 60_000)
 
 test('mocking dependency correctly invalidates it on rerun', async () => {
   const { vitest, ctx } = await runVitest({


### PR DESCRIPTION
### Description

Backport of #10267 (closes #9957) to the `v4` release line — currently shipped only on `main` / `v5.0.0-beta.3`. Cherry-picked clean from `41db6ce` (no conflicts).

Downstream symptom: in `vitest --ui` / watch mode against a project with `vi.mock(...)` and the Playwright browser provider, editing any spec triggers a cascade of unrelated specs failing with `[vitest] There was an error when mocking a module` / `[birpc] rpc is closed, cannot call "resolveManualMock"`. Root cause is the orphaned-route bug fixed in #10267.

### Tests

Tests from the original PR were cherry-picked along with the source change:
- `test/browser/fixtures/mocking/src/aaa-dual-id-probe.test.ts`
- `test/browser/fixtures/mocking/src/zzz-dual-id-target.test.ts`
- `test/browser/fixtures/mocking/src/dual-id/*`
- New assertions in `test/browser/specs/mocking.test.ts`

### Checklist
- [x] References original PR (#10267) and issue (#9957)
- [x] Includes upstream tests
- [x] No `pnpm-lock.yaml` changes
- [x] Allow edits from maintainers