### PR TITLE
docs: note TypeScript assertion-function limitation in in-source testing

### DIFF
--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -152,6 +152,41 @@ To get TypeScript support for `import.meta.vitest`, add `vitest/importMeta` to y
 
 Reference to [`examples/in-source-test`](https://github.com/vitest-dev/vitest/tree/main/examples/in-source-test) for the full example.
 
+### Assertion Functions
+
+Vitest exposes its whole API through `import.meta.vitest`, including [`assert`](/api/assert). Because `assert` is a TypeScript [assertion function](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions), calling it through a destructured variable triggers a compiler error:
+
+```ts
+if (import.meta.vitest) {
+  const { assert, test } = import.meta.vitest
+
+  test('add', () => {
+    // TS2775: Assertions require every name in the call target
+    // to be declared with an explicit type annotation.
+    assert(add(1, 2) === 3) // [!code error]
+  })
+}
+```
+
+This is a constraint of the TypeScript language: an assertion function can only be called through a name that carries an explicit type annotation, which a destructured variable does not have. To work around it, either annotate the variable with `Chai.Assert`, or call `import.meta.vitest.assert` directly without destructuring it:
+
+```ts
+if (import.meta.vitest) {
+  const { test } = import.meta.vitest
+  // either annotate the variable explicitly...
+  const assert: Chai.Assert = import.meta.vitest.assert
+
+  test('add', () => {
+    const value = add(1, 2)
+    assert(value === 3)
+    // ...or call it without destructuring
+    import.meta.vitest!.assert(value === 3)
+  })
+}
+```
+
+The same applies to any other function whose type is an `asserts` predicate.
+
 ## Notes
 
 This feature could be useful for:


### PR DESCRIPTION
### Description

In-source testing exposes the whole Vitest API through `import.meta.vitest`, including `assert`. However, calling `assert` (or any `asserts` predicate function) through a **destructured** variable fails to type-check:

```
TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
```

As clarified by @sheremet-va in #10471, this is a constraint of the TypeScript language itself (assertion functions can only be called through a name carrying an explicit type annotation), not a Vitest bug — so it deserves a place in the documentation.

This PR adds an **"Assertion Functions"** subsection to the *TypeScript* part of the in-source testing guide. It shows the error and documents the two recommended workarounds:

1. annotate the variable with `Chai.Assert`, or
2. call `import.meta.vitest.assert` directly without destructuring.

Resolves #10471

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. This references #10471, where the change was requested by a maintainer ("PR welcome").
- [ ] Ideally, include a test that fails without this PR but passes with it. _Not applicable — this is a documentation-only change._
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example. _No lockfile changes._
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [ ] Run the tests with `pnpm test:ci`. _Documentation-only change; ran `pnpm exec eslint docs/guide/in-source.md` (passes) instead._

### Documentation
- [x] If you introduce new functionality, document it. This PR *is* the documentation change.

### Changesets
- [x] Changes in changelog are generated from PR name. The PR title is prefixed with `docs:`.

<!-- VITEST_AUTOMATED_PR -->
