### PR TITLE
docs: note TypeScript assertion-function limitation in in-source testing

### DIFF
--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -150,6 +150,31 @@ To get TypeScript support for `import.meta.vitest`, add `vitest/importMeta` to y
 }
 ```
 
+::: warning
+Assertion functions such as `assert` cannot be called from a binding destructured off `import.meta.vitest`. TypeScript requires the call target of an assertion function to be declared with an explicit type annotation (error `TS2775`), and a plain destructured binding does not carry one:
+
+```ts
+if (import.meta.vitest) {
+  const { assert, test } = import.meta.vitest
+  test('add', () => {
+    assert(add(1, 2) === 3) // TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
+  })
+}
+```
+
+To work around this, give the binding an explicit `Chai.Assert` type annotation:
+
+```ts
+if (import.meta.vitest) {
+  const assert: Chai.Assert = import.meta.vitest.assert // [!code ++]
+  const { test } = import.meta.vitest
+  test('add', () => {
+    assert(add(1, 2) === 3)
+  })
+}
+```
+:::
+
 Reference to [`examples/in-source-test`](https://github.com/vitest-dev/vitest/tree/main/examples/in-source-test) for the full example.
 
 ## Notes


### PR DESCRIPTION
### Description

Closes #10471.

In [in-source tests](https://vitest.dev/guide/in-source), assertion functions
such as `assert` cannot be called from a binding destructured off
`import.meta.vitest`:

```ts
if (import.meta.vitest) {
  const { assert, test } = import.meta.vitest
  test('add', () => {
    assert(add(1, 2) === 3)
    // TS2775: Assertions require every name in the call target to be
    // declared with an explicit type annotation.
  })
}
```

TypeScript requires the call target of an assertion function to carry an
explicit type annotation, and a plain destructured binding does not. The
same code works in a normal `.test.ts` file only because the `assert`
global is declared with a type there.

This PR adds a note to the **TypeScript** section of the In-Source Testing
guide documenting the limitation and the working `Chai.Assert` annotation
workaround:

```ts
if (import.meta.vitest) {
  const assert: Chai.Assert = import.meta.vitest.assert
  const { test } = import.meta.vitest
  test('add', () => {
    assert(add(1, 2) === 3)
  })
}
```

`assert` is exported as `Chai.Assert`
(`packages/vitest/src/integrations/chai/index.ts`), so this annotation
matches its real type.

> Note: I verified that the direct-access form `import.meta.vitest!.assert(value)`
> suggested in the issue does **not** compile — it fails with `TS2776`
> ("Assertions require the call target to be an identifier or qualified
> name") because `import.meta.vitest` is an optional, non-identifier
> expression. So the doc recommends only the annotated-binding form.

Verified with `tsc` 5.8.3 (the version from the issue): the destructured
form reports `TS2775`; the annotated form compiles cleanly.

Docs-only change.

AI disclosure: drafted with the assistance of Claude (Claude Code). I have
read, verified, and own every line.

<!-- VITEST_AUTOMATED_PR -->
