### PR TITLE
docs: clarify browser keyboard special keys

### DIFF
--- a/docs/api/browser/interactivity.md
+++ b/docs/api/browser/interactivity.md
@@ -282,6 +282,8 @@ function keyboard(text: string): Promise<void>
 The `userEvent.keyboard` allows you to trigger keyboard strokes. If any input has a focus, it will type characters into that input. Otherwise, it will trigger keyboard events on the currently focused element (`document.body` if there are no focused elements).
 
 This API supports [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard).
+Use `{key}` for common named keys, modifiers, and built-in user-event helpers such as
+`{selectall}`. Use printable text for characters that should be typed.
 
 ```ts
 import { userEvent } from 'vitest/browser'
@@ -290,10 +292,25 @@ test('trigger keystrokes', async () => {
   await userEvent.keyboard('foo') // translates to: f, o, o
   await userEvent.keyboard('{{a[[') // translates to: {, a, [
   await userEvent.keyboard('{Shift}{f}{o}{o}') // translates to: Shift, f, o, o
+  await userEvent.keyboard('{Control>}{a}{/Control}') // hold Control while pressing a
+  await userEvent.keyboard('{selectall}{Backspace}') // select all text, then delete it
   await userEvent.keyboard('{a>5}') // press a without releasing it and trigger 5 keydown
   await userEvent.keyboard('{a>5/}') // press a for 5 keydown and then release it
 })
 ```
+
+::: warning Provider differences
+
+Vitest parses the user-event keyboard syntax before forwarding actions to the configured
+browser provider. Common key names such as `{Shift}`, `{Control}`, `{Alt}`, `{Meta}`,
+`{Enter}`, `{Tab}`, `{Escape}`, and arrow keys are the most portable across providers.
+
+Provider support can differ for physical-code syntax such as `[ShiftLeft]` or
+provider-specific key names such as `{ShiftRight}`. Prefer the common `{key}` names
+when your test does not need to distinguish physical left/right keys, and verify provider
+behavior before asserting on `KeyboardEvent.code` or `KeyboardEvent.location`.
+
+:::
 
 References:
 

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -279,10 +279,15 @@ export interface UserEvent {
    * Type text on the keyboard. If any input is focused, it will receive the text,
    * otherwise it will be typed on the document. Uses provider's API under the hood.
    * **Supports** [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard) (e.g., `{Shift}`) even with `playwright` and `webdriverio` providers.
+   * Common key names such as `{Shift}`, `{Control}`, `{Alt}`, `{Meta}`, `{Enter}`,
+   * `{Tab}`, `{Escape}`, and arrow keys are the most portable across providers.
+   * Provider support can differ for physical-code syntax such as `[ShiftLeft]` or
+   * provider-specific key names such as `{ShiftRight}`.
    * @example
    * await userEvent.keyboard('foo') // translates to: f, o, o
    * await userEvent.keyboard('{{a[[') // translates to: {, a, [
    * await userEvent.keyboard('{Shift}{f}{o}{o}') // translates to: Shift, f, o, o
+   * await userEvent.keyboard('{selectall}{Backspace}') // select all text, then delete it
    * @see {@link https://playwright.dev/docs/api/class-keyboard} Playwright API
    * @see {@link https://webdriver.io/docs/api/browser/keys} WebdriverIO API
    * @see {@link https://testing-library.com/docs/user-event/keyboard} testing-library API

--- a/test/browser/fixtures/user-event/keyboard.test.ts
+++ b/test/browser/fixtures/user-event/keyboard.test.ts
@@ -69,7 +69,6 @@ test('click with modifier', async () => {
   await expect.poll(() => el.textContent).toContain("[ok]")
 })
 
-// TODO: https://github.com/vitest-dev/vitest/issues/7118
 // https://testing-library.com/docs/user-event/keyboard
 // https://github.com/testing-library/user-event/blob/main/src/keyboard/keyMap.ts
 // https://playwright.dev/docs/api/class-keyboard


### PR DESCRIPTION
## Summary
- clarify which `userEvent.keyboard` key syntax is most portable across browser providers
- add examples for held modifiers and `{selectall}`
- remove the stale TODO now that the provider-difference tests document the current behavior

Fixes #7118.

## Checks
- `git diff --check`

Note: full repo lint/docs checks were not run locally because this checkout does not have project dependencies installed.
