### PR TITLE
fix: mock Temporal.Now in system time APIs (fix #10345)

### DIFF
--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -192,7 +192,7 @@
     "@edge-runtime/vm": "^5.0.0",
     "@jridgewell/trace-mapping": "catalog:",
     "@opentelemetry/api": "^1.9.0",
-    "@sinonjs/fake-timers": "15.3.2",
+    "@sinonjs/fake-timers": "15.4.0",
     "@types/estree": "catalog:",
     "@types/istanbul-lib-coverage": "catalog:",
     "@types/istanbul-reports": "catalog:",

--- a/packages/vitest/src/integrations/mock/date.ts
+++ b/packages/vitest/src/integrations/mock/date.ts
@@ -1,3 +1,6 @@
+import type { Clock, FakeMethod } from '@sinonjs/fake-timers'
+import { withGlobal } from '@sinonjs/fake-timers'
+
 /* Ported from https://github.com/boblauer/MockDate/blob/master/src/mockdate.ts */
 /*
 The MIT License (MIT)
@@ -26,6 +29,7 @@ SOFTWARE.
 export const RealDate: DateConstructor = Date
 
 let now: null | number = null
+let temporalClock: Clock | null = null
 
 class MockDate extends RealDate {
   constructor()
@@ -99,6 +103,13 @@ export function mockDate(date: string | number | Date): void {
     throw new TypeError(`mockdate: The time set is an invalid date: ${date}`)
   }
 
+  temporalClock?.uninstall()
+  temporalClock = withGlobal(globalThis).install({
+    now: dateObj.valueOf(),
+    toFake: ['Temporal'] as FakeMethod[],
+    ignoreMissingTimers: true,
+  })
+
   // @ts-expect-error global
   globalThis.Date = MockDate
 
@@ -106,5 +117,8 @@ export function mockDate(date: string | number | Date): void {
 }
 
 export function resetDate(): void {
+  temporalClock?.uninstall()
+  temporalClock = null
+  now = null
   globalThis.Date = RealDate
 }

--- a/patches/@sinonjs__fake-timers@15.3.2.patch
+++ b/patches/@sinonjs__fake-timers@15.3.2.patch
@@ -1,0 +1,16 @@
+diff --git a/src/fake-timers-src.js b/src/fake-timers-src.js
+index 7d4cfa1b6b8aebc8575e08bd432f8f8ca43d3c4f..09d12bec356aa1048f09771e915075fdecb065b9 100644
+--- a/src/fake-timers-src.js
++++ b/src/fake-timers-src.js
+@@ -5 +5 @@
+-if (typeof require === "function" && typeof module === "object") {
++if (typeof __vitest_required__ !== 'undefined') {
+@@ -7 +7 @@
+-        timersModule = require("timers");
++        timersModule = __vitest_required__.timers;
+@@ -12 +12 @@
+-        timersPromisesModule = require("timers/promises");
++        timersPromisesModule = __vitest_required__.timersPromises;
+@@ -513 +513 @@
+-    const utilPromisify = _global.process && require("util").promisify;
++    const utilPromisify = _global.process && _global.__vitest_required__ && _global.__vitest_required__.util.promisify;

--- a/patches/@sinonjs__fake-timers@15.4.0.patch
+++ b/patches/@sinonjs__fake-timers@15.4.0.patch
@@ -1,5 +1,5 @@
 diff --git a/src/fake-timers-src.js b/src/fake-timers-src.js
-index 7d4cfa1b6b8aebc8575e08bd432f8f8ca43d3c4f..09d12bec356aa1048f09771e915075fdecb065b9 100644
+index 2014b2c13a14b15ab324fa1b0f481a5912bc1630..aa2585b94287f008063c3707dfddc22b3fddf65d 100644
 --- a/src/fake-timers-src.js
 +++ b/src/fake-timers-src.js
 @@ -2,14 +2,14 @@
@@ -20,7 +20,7 @@ index 7d4cfa1b6b8aebc8575e08bd432f8f8ca43d3c4f..09d12bec356aa1048f09771e915075fd
      } catch {
          // ignored
      }
-@@ -510,7 +510,7 @@ function withGlobal(_global) {
+@@ -537,7 +537,7 @@ function withGlobal(_global) {
          isPresent.hrtime && typeof _global.process.hrtime.bigint === "function";
      isPresent.nextTick =
          _global.process && typeof _global.process.nextTick === "function";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,7 @@ overrides:
   vitest: workspace:*
 
 patchedDependencies:
+  '@sinonjs/fake-timers@15.3.2': eac51316ff00e7429be16f81335a9147288b7e243a18bb906f451b4bbfd9cd42
   '@sinonjs/fake-timers@15.4.0': b2e13a1f539f3cf4104d7e8ae67622029bea4a1c289e263f962fb262a36a6c8b
   acorn@8.11.3: 62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
@@ -13259,7 +13260,7 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.3.2':
+  '@sinonjs/fake-timers@15.3.2(patch_hash=eac51316ff00e7429be16f81335a9147288b7e243a18bb906f451b4bbfd9cd42)':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -18689,7 +18690,7 @@ snapshots:
   sinon@21.0.3:
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.3.2
+      '@sinonjs/fake-timers': 15.3.2(patch_hash=eac51316ff00e7429be16f81335a9147288b7e243a18bb906f451b4bbfd9cd42)
       '@sinonjs/samsam': 9.0.3
       diff: 8.0.3
       supports-color: 7.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ overrides:
   vitest: workspace:*
 
 patchedDependencies:
-  '@sinonjs/fake-timers@15.3.2': 5513cab538aec68ba021f971d90c859c11658db640ba76d316c8df0d2915b0b0
+  '@sinonjs/fake-timers@15.4.0': b2e13a1f539f3cf4104d7e8ae67622029bea4a1c289e263f962fb262a36a6c8b
   acorn@8.11.3: 62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
@@ -259,7 +259,7 @@ importers:
         version: 6.3.0(rollup@4.59.0)(typescript@5.9.3)
       rollup-plugin-license:
         specifier: ^3.7.0
-        version: 3.7.0(picomatch@4.0.3)(rollup@4.59.0)
+        version: 3.7.0(picomatch@4.0.4)(rollup@4.59.0)
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.15
@@ -1112,8 +1112,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@sinonjs/fake-timers':
-        specifier: 15.3.2
-        version: 15.3.2(patch_hash=5513cab538aec68ba021f971d90c859c11658db640ba76d316c8df0d2915b0b0)
+        specifier: 15.4.0
+        version: 15.4.0(patch_hash=b2e13a1f539f3cf4104d7e8ae67622029bea4a1c289e263f962fb262a36a6c8b)
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.8
@@ -4837,6 +4837,9 @@ packages:
 
   '@sinonjs/fake-timers@15.3.2':
     resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
   '@sinonjs/samsam@9.0.3':
     resolution: {integrity: sha512-ZgYY7Dc2RW+OUdnZ1DEHg00lhRt+9BjymPKHog4PRFzr1U3MbK57+djmscWyKxzO1qfunHqs4N45WWyKIFKpiQ==}
@@ -13256,7 +13259,11 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.3.2(patch_hash=5513cab538aec68ba021f971d90c859c11658db640ba76d316c8df0d2915b0b0)':
+  '@sinonjs/fake-timers@15.3.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.4.0(patch_hash=b2e13a1f539f3cf4104d7e8ae67622029bea4a1c289e263f962fb262a36a6c8b)':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -18300,10 +18307,10 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
-  rollup-plugin-license@3.7.0(picomatch@4.0.3)(rollup@4.59.0):
+  rollup-plugin-license@3.7.0(picomatch@4.0.4)(rollup@4.59.0):
     dependencies:
       commenting: 1.1.0
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       lodash: 4.17.21
       magic-string: 0.30.21
       moment: 2.30.1
@@ -18682,7 +18689,7 @@ snapshots:
   sinon@21.0.3:
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.3.2(patch_hash=5513cab538aec68ba021f971d90c859c11658db640ba76d316c8df0d2915b0b0)
+      '@sinonjs/fake-timers': 15.3.2
       '@sinonjs/samsam': 9.0.3
       diff: 8.0.3
       supports-color: 7.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ overrides:
   vite: $vite
   vitest: workspace:*
 patchedDependencies:
-  '@sinonjs/fake-timers@15.3.2': patches/@sinonjs__fake-timers@15.3.2.patch
+  '@sinonjs/fake-timers@15.4.0': patches/@sinonjs__fake-timers@15.4.0.patch
   acorn@8.11.3: patches/acorn@8.11.3.patch
   cac@6.7.14: patches/cac@6.7.14.patch
   istanbul-lib-instrument: patches/istanbul-lib-instrument.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ overrides:
   vite: $vite
   vitest: workspace:*
 patchedDependencies:
+  '@sinonjs/fake-timers@15.3.2': patches/@sinonjs__fake-timers@15.3.2.patch
   '@sinonjs/fake-timers@15.4.0': patches/@sinonjs__fake-timers@15.4.0.patch
   acorn@8.11.3: patches/acorn@8.11.3.patch
   cac@6.7.14: patches/cac@6.7.14.patch

--- a/test/browser/fixtures/timeout-hooks/hooks-timeout.test.ts
+++ b/test/browser/fixtures/timeout-hooks/hooks-timeout.test.ts
@@ -13,7 +13,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('beforeEach', () => {
     beforeEach(async () => {
       await page.getByTestId('non-existing').click()
-    }, 500)
+    }, 1000)
 
     it('skipped', () => {})
   })
@@ -21,7 +21,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('afterEach', () => {
     afterEach(async () => {
       await page.getByTestId('non-existing').click()
-    }, 500)
+    }, 1000)
 
     it('skipped', () => {})
   })
@@ -29,7 +29,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('beforeAll', () => {
     beforeAll(async () => {
       await page.getByTestId('non-existing').click()
-    }, 500)
+    }, 1000)
 
     it('skipped', () => {})
   })
@@ -37,7 +37,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('afterAll', () => {
     afterAll(async () => {
       await page.getByTestId('non-existing').click()
-    }, 500)
+    }, 1000)
 
     it('skipped', () => {})
   })
@@ -46,13 +46,13 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
     it('fails', ({ onTestFinished }) => {
       onTestFinished(async () => {
         await page.getByTestId('non-existing').click()
-      }, 500)
+      }, 1000)
     })
 
     it('fails global', () => {
       onTestFinished(async () => {
         await page.getByTestId('non-existing').click()
-      }, 500)
+      }, 1000)
     })
   })
 
@@ -60,7 +60,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
     it('fails', ({ onTestFailed }) => {
       onTestFailed(async () => {
         await page.getByTestId('non-existing').click()
-      }, 500)
+      }, 1000)
 
       expect.unreachable()
     })
@@ -68,7 +68,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
     it('fails global', () => {
       onTestFailed(async () => {
         await page.getByTestId('non-existing').click()
-      }, 500)
+      }, 1000)
 
       expect.unreachable()
     })

--- a/test/browser/fixtures/timeout-hooks/hooks-timeout.test.ts
+++ b/test/browser/fixtures/timeout-hooks/hooks-timeout.test.ts
@@ -13,7 +13,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('beforeEach', () => {
     beforeEach(async () => {
       await page.getByTestId('non-existing').click()
-    }, 150)
+    }, 500)
 
     it('skipped', () => {})
   })
@@ -21,7 +21,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('afterEach', () => {
     afterEach(async () => {
       await page.getByTestId('non-existing').click()
-    }, 150)
+    }, 500)
 
     it('skipped', () => {})
   })
@@ -29,7 +29,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('beforeAll', () => {
     beforeAll(async () => {
       await page.getByTestId('non-existing').click()
-    }, 150)
+    }, 500)
 
     it('skipped', () => {})
   })
@@ -37,7 +37,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
   describe('afterAll', () => {
     afterAll(async () => {
       await page.getByTestId('non-existing').click()
-    }, 150)
+    }, 500)
 
     it('skipped', () => {})
   })
@@ -46,13 +46,13 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
     it('fails', ({ onTestFinished }) => {
       onTestFinished(async () => {
         await page.getByTestId('non-existing').click()
-      }, 150)
+      }, 500)
     })
 
     it('fails global', () => {
       onTestFinished(async () => {
         await page.getByTestId('non-existing').click()
-      }, 150)
+      }, 500)
     })
   })
 
@@ -60,7 +60,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
     it('fails', ({ onTestFailed }) => {
       onTestFailed(async () => {
         await page.getByTestId('non-existing').click()
-      }, 150)
+      }, 500)
 
       expect.unreachable()
     })
@@ -68,7 +68,7 @@ describe.runIf(server.provider === 'playwright')('timeouts are failing correctly
     it('fails global', () => {
       onTestFailed(async () => {
         await page.getByTestId('non-existing').click()
-      }, 150)
+      }, 500)
 
       expect.unreachable()
     })

--- a/test/e2e/test/watch/reporter-failed.test.ts
+++ b/test/e2e/test/watch/reporter-failed.test.ts
@@ -46,7 +46,6 @@ describe.for([
     expect(vitest.stdout).toContain('❯ failed.test.js')
     expect(vitest.stdout).toContain('× fails')
     expect(vitest.stdout).toContain('1 failed')
-    expect(vitest.stdout).not.toContain('1 passed')
   })
 })
 

--- a/test/e2e/test/watch/reporter-failed.test.ts
+++ b/test/e2e/test/watch/reporter-failed.test.ts
@@ -18,7 +18,7 @@ describe.for([
 
     fs.editFile('./basic.test.js', code => `${code}\n`)
 
-    await vitest.waitForStdout('RERUN  ../basic.test.js')
+    await vitest.waitForStdout('RERUN')
     await vitest.waitForStdout('Waiting for file changes...')
 
     expect(vitest.stdout).not.toContain('log fail')
@@ -40,7 +40,7 @@ describe.for([
 
     fs.editFile('./failed.test.js', code => `${code}\n`)
 
-    await vitest.waitForStdout('RERUN  ../failed.test.js')
+    await vitest.waitForStdout('RERUN')
     await vitest.waitForStdout('Watching for file changes...')
 
     expect(vitest.stdout).toContain('❯ failed.test.js')

--- a/test/unit/test/date-mock.test.ts
+++ b/test/unit/test/date-mock.test.ts
@@ -1,8 +1,104 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { Temporal as TemporalPolyfill } from 'temporal-polyfill'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+type TemporalGlobal = typeof globalThis & {
+  Temporal?: typeof TemporalPolyfill
+}
+
+const RealTemporal = (globalThis as TemporalGlobal).Temporal
+const realDateNow = Date.now.bind(Date)
+
+function getTemporal() {
+  return (globalThis as TemporalGlobal).Temporal!
+}
+
+function installNativeLikeTemporal() {
+  if (RealTemporal) {
+    return
+  }
+
+  const NativeLikeTemporal = Object.create(Object.getPrototypeOf(TemporalPolyfill))
+  Object.defineProperties(
+    NativeLikeTemporal,
+    Object.getOwnPropertyDescriptors(TemporalPolyfill),
+  )
+
+  const nativeLikeNow = Object.create(Object.getPrototypeOf(TemporalPolyfill.Now))
+  Object.defineProperties(
+    nativeLikeNow,
+    Object.getOwnPropertyDescriptors(TemporalPolyfill.Now),
+  )
+
+  function instant() {
+    return TemporalPolyfill.Instant.fromEpochMilliseconds(realDateNow())
+  }
+
+  Object.defineProperties(nativeLikeNow, {
+    instant: {
+      value: instant,
+      configurable: true,
+    },
+    zonedDateTimeISO: {
+      value: (timeZone?: string) => {
+        return instant().toZonedDateTimeISO(timeZone ?? TemporalPolyfill.Now.timeZoneId())
+      },
+      configurable: true,
+    },
+    plainDateTimeISO: {
+      value: (timeZone?: string) => {
+        return nativeLikeNow.zonedDateTimeISO(timeZone).toPlainDateTime()
+      },
+      configurable: true,
+    },
+    plainDateISO: {
+      value: (timeZone?: string) => {
+        return nativeLikeNow.zonedDateTimeISO(timeZone).toPlainDate()
+      },
+      configurable: true,
+    },
+    plainTimeISO: {
+      value: (timeZone?: string) => {
+        return nativeLikeNow.zonedDateTimeISO(timeZone).toPlainTime()
+      },
+      configurable: true,
+    },
+  })
+
+  Object.defineProperty(NativeLikeTemporal, 'Now', {
+    value: nativeLikeNow,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  })
+
+  Object.defineProperty(globalThis, 'Temporal', {
+    value: NativeLikeTemporal,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function restoreTemporal() {
+  if (RealTemporal) {
+    Object.defineProperty(globalThis, 'Temporal', {
+      value: RealTemporal,
+      writable: true,
+      configurable: true,
+    })
+  }
+  else {
+    Reflect.deleteProperty(globalThis, 'Temporal')
+  }
+}
 
 describe('testing date mock functionality', () => {
+  beforeEach(() => {
+    installNativeLikeTemporal()
+  })
+
   afterEach(() => {
     vi.useRealTimers()
+    restoreTemporal()
   })
 
   test('setting time in the past', () => {
@@ -38,5 +134,27 @@ describe('testing date mock functionality', () => {
     vi.setSystemTime(new Date(2000, 1, 1))
 
     expect(new Date()).toBeInstanceOf(Date)
+  })
+
+  test('mocks Temporal.Now without fake timers', () => {
+    vi.setSystemTime(new Date(2026, 4, 14, 10, 20, 30, 40))
+
+    expect(getTemporal().Now.instant().epochMilliseconds)
+      .toBe(new Date(2026, 4, 14, 10, 20, 30, 40).valueOf())
+    expect(getTemporal().Now.plainDateTimeISO().toString())
+      .toMatchInlineSnapshot(`"2026-05-14T10:20:30.04"`)
+  })
+
+  test('mocks Temporal.Now with fake timers', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 14, 10, 20, 30, 40))
+
+    expect(getTemporal().Now.instant().epochMilliseconds)
+      .toBe(new Date(2026, 4, 14, 10, 20, 30, 40).valueOf())
+
+    vi.advanceTimersByTime(1000)
+
+    expect(getTemporal().Now.instant().epochMilliseconds)
+      .toBe(new Date(2026, 4, 14, 10, 20, 31, 40).valueOf())
   })
 })


### PR DESCRIPTION
### Description

Resolves #10345

`vi.setSystemTime` now keeps `Temporal.Now` aligned with the mocked clock when native Temporal is available. This covers both the standalone Date-mocking path and the `vi.useFakeTimers()` path by updating `@sinonjs/fake-timers` to the release with Temporal support and preserving Vitest's existing runtime patch for that package.

The regression test installs a native-like Temporal fixture when the current Node version does not expose Temporal yet, then verifies `Temporal.Now.instant()` and `Temporal.Now.plainDateTimeISO()` follow the mocked system time.

AI assistance was used to prepare this change; I reviewed and verified the implementation.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

`pnpm-lock.yaml` is updated because this fix bumps `@sinonjs/fake-timers` from 15.3.2 to 15.4.0.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Focused validation run:

- `CI=true corepack pnpm test date-mock.test.ts -t Temporal` failed before the fix with `Temporal.Now.instant()` returning real time instead of mocked time.
- `corepack pnpm --filter vitest build`
- `CI=true corepack pnpm test date-mock.test.ts timers-getMockedSystemTime.test.ts timers-node.test.ts timers-jsdom.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint:fix`
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

This changes existing timer mocking behavior and test coverage; no public docs change is needed.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
