### PR TITLE
docs: clarify assert usage in in-source tests

### DIFF
--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -152,6 +152,22 @@ To get TypeScript support for `import.meta.vitest`, add `vitest/importMeta` to y
 
 Reference to [`examples/in-source-test`](https://github.com/vitest-dev/vitest/tree/main/examples/in-source-test) for the full example.
 
+When using assertion functions like `assert`, TypeScript requires the call target to have an explicit type annotation. If you destructure `assert` from `import.meta.vitest`, annotate it before use:
+
+```ts [src/index.ts]
+if (import.meta.vitest) {
+  const { test } = import.meta.vitest
+  const assert: Chai.Assert = import.meta.vitest.assert
+
+  test('add', () => {
+    const value = add(1, 2)
+
+    import.meta.vitest!.assert(value === 3)
+    assert(value === 3)
+  })
+}
+```
+
 ## Notes
 
 This feature could be useful for:


### PR DESCRIPTION
### Description

Documents the TypeScript assertion-function limitation for `assert` in in-source tests.

The issue is that destructuring `assert` from `import.meta.vitest` can trigger TS2775 unless the assertion function has an explicit type annotation. This adds the maintainer-suggested workaround to the in-source testing guide:

- use `import.meta.vitest!.assert(...)` directly, or
- annotate the destructured assertion as `Chai.Assert`.

Closes #10471

### Validation

- `pnpm exec eslint docs/guide/in-source.md`
- `pnpm run docs:build` attempted, but failed in existing Twoslash examples before this changed page because the local docs build could not resolve existing `vitest` / `vitest/node` imports without built package artifacts.