### PR TITLE
test: test orchestrator UI and `@vitest/browser-preview` provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,7 @@ importers:
         version: 6.3.0(rollup@4.59.0)(typescript@5.9.3)
       rollup-plugin-license:
         specifier: ^3.7.0
-        version: 3.7.0(picomatch@4.0.3)(rollup@4.59.0)
+        version: 3.7.0(picomatch@4.0.4)(rollup@4.59.0)
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.15
@@ -1541,6 +1541,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: workspace:*
         version: link:../../packages/browser-playwright
+      '@vitest/browser-preview':
+        specifier: workspace:*
+        version: link:../../packages/browser-preview
       happy-dom:
         specifier: latest
         version: 20.9.0
@@ -18300,10 +18303,10 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
-  rollup-plugin-license@3.7.0(picomatch@4.0.3)(rollup@4.59.0):
+  rollup-plugin-license@3.7.0(picomatch@4.0.4)(rollup@4.59.0):
     dependencies:
       commenting: 1.1.0
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       lodash: 4.17.21
       magic-string: 0.30.21
       moment: 2.30.1

--- a/test/ui/fixtures/browser-preview/basic.test.ts
+++ b/test/ui/fixtures/browser-preview/basic.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+import { page } from "vitest/browser";
+
+test("runs in preview provider", async () => {
+  document.body.innerHTML = "<button>hello</button>";
+  await expect.element(page.getByRole("button")).toHaveTextContent("hello");
+});

--- a/test/ui/fixtures/browser-preview/basic.test.ts
+++ b/test/ui/fixtures/browser-preview/basic.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { page } from "vitest/browser";
 
-test("runs in preview provider", async () => {
+test("hello button", async () => {
   document.body.innerHTML = "<button>hello</button>";
   await expect.element(page.getByRole("button")).toHaveTextContent("hello");
 });

--- a/test/ui/fixtures/browser-preview/vitest.config.ts
+++ b/test/ui/fixtures/browser-preview/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     browser: {
       enabled: true,
       traceView: true,
+      headless: false,
+      ui: true,
       provider: preview(),
       instances: [{ browser: "chromium" }],
     },

--- a/test/ui/fixtures/browser-preview/vitest.config.ts
+++ b/test/ui/fixtures/browser-preview/vitest.config.ts
@@ -4,11 +4,13 @@ import type { Vitest } from "vitest/node";
 
 // run preview provider on headless playwright
 // PREVIEW_PLAYWRIGHT=true pnpm -C test/ui test-fixtures --root fixtures/browser-preview
+// PREVIEW_PLAYWRIGHT=headless pnpm -C test/ui test-fixtures --root fixtures/browser-preview
 
 export default defineConfig({
   test: {
     browser: {
       enabled: true,
+      traceView: true,
       provider: preview(),
       instances: [{ browser: "chromium" }],
     },
@@ -26,7 +28,9 @@ declare global {
 function customPreviewPlugin(): Plugin {
   async function handlePreviewPlaywright(url: string) {
     const { chromium } = await import("@playwright/test");
-    const browser = await chromium.launch({ headless: true });
+    const browser = await chromium.launch({
+      headless: process.env.PREVIEW_PLAYWRIGHT === 'headless',
+    });
     globalThis.__hackVitest.onClose(async () => {
       await browser.close();
     })

--- a/test/ui/fixtures/browser-preview/vitest.config.ts
+++ b/test/ui/fixtures/browser-preview/vitest.config.ts
@@ -1,0 +1,61 @@
+import { preview } from "@vitest/browser-preview";
+import { defineConfig, Plugin } from "vitest/config";
+import type { Vitest } from "vitest/node";
+
+// run preview provider on headless playwright
+// PREVIEW_PLAYWRIGHT=true pnpm -C test/ui test-fixtures --root fixtures/browser-preview
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: preview(),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+  plugins: [
+    customPreviewPlugin(),
+  ],
+});
+
+declare global {
+  var __hackVitest: Vitest;
+  var __hackOpenBrowser: ((url: string) => void) | undefined;
+}
+
+function customPreviewPlugin(): Plugin {
+  async function handlePreviewPlaywright(url: string) {
+    const { chromium } = await import("@playwright/test");
+    const browser = await chromium.launch({ headless: true });
+    globalThis.__hackVitest.onClose(async () => {
+      await browser.close();
+    })
+    const page = await browser.newPage();
+    await page.goto(url);
+  }
+
+  return {
+    name: "custom-preview",
+    configureVitest(context) {
+      // pass vitest instance through globalThis
+      // since this config/plugin is loaded twice
+      // as main vite server and as browser mode vite server
+      globalThis.__hackVitest = context.vitest;
+    },
+    configureServer(server) {
+      const overrideOpenBrowser =
+        process.env.PREVIEW_PLAYWRIGHT
+        ? handlePreviewPlaywright
+        : globalThis.__hackOpenBrowser;
+      if (overrideOpenBrowser) {
+        server.openBrowser = () => {
+          const url = server.config.server.open;
+          if (typeof url !== "string") {
+            throw new Error(`Invalid preview url ${url}`);
+          }
+          overrideOpenBrowser(url);
+        };
+      }
+    },
+  }
+}

--- a/test/ui/package.json
+++ b/test/ui/package.json
@@ -10,6 +10,7 @@
     "@testing-library/dom": "^10.4.1",
     "@types/codemirror": "^5.60.17",
     "@vitest/browser-playwright": "workspace:*",
+    "@vitest/browser-preview": "workspace:*",
     "happy-dom": "latest",
     "vitest": "workspace:*"
   }

--- a/test/ui/test/browser-preview.spec.ts
+++ b/test/ui/test/browser-preview.spec.ts
@@ -1,0 +1,30 @@
+import { Writable } from 'node:stream'
+import { expect, test } from '@playwright/test'
+import { startVitest } from 'vitest/node'
+import { assertTestCounts } from './helper'
+
+test.describe('browser preview provider', () => {
+  test('basic', async ({ page }) => {
+    globalThis.__hackOpenBrowser = async (url: string) => {
+      await page.goto(url)
+    }
+    const stdout = new Writable({ write: (_, __, callback) => callback() })
+    const stderr = new Writable({ write: (_, __, callback) => callback() })
+    const vitest = await startVitest(
+      undefined,
+      {
+        root: './fixtures/browser-preview',
+        watch: true,
+        reporters: [],
+      },
+      {},
+      { stdout, stderr },
+    )
+    await assertTestCounts(page, { pass: 1, fail: 0 })
+
+    const testerFrame = page.frameLocator('iframe[data-vitest="true"]')
+    await expect(testerFrame.getByRole('button')).toHaveText('hello')
+
+    await vitest.close()
+  })
+})

--- a/test/ui/test/browser-preview.spec.ts
+++ b/test/ui/test/browser-preview.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test'
 import { startVitest } from 'vitest/node'
 import { assertTestCounts } from './helper'
 
-test.describe('browser preview provider', () => {
+test.describe('orchestrator UI on preview provider', () => {
   test('basic', async ({ page }) => {
     globalThis.__hackOpenBrowser = async (url: string) => {
       await page.goto(url)

--- a/test/ui/test/browser-preview.spec.ts
+++ b/test/ui/test/browser-preview.spec.ts
@@ -13,7 +13,6 @@ test.describe('orchestrator UI on preview provider', () => {
       {
         root: './fixtures/browser-preview',
         watch: true,
-        reporters: [],
       },
       undefined,
       {

--- a/test/ui/test/browser-preview.spec.ts
+++ b/test/ui/test/browser-preview.spec.ts
@@ -8,8 +8,6 @@ test.describe('browser preview provider', () => {
     globalThis.__hackOpenBrowser = async (url: string) => {
       await page.goto(url)
     }
-    const stdout = new Writable({ write: (_, __, callback) => callback() })
-    const stderr = new Writable({ write: (_, __, callback) => callback() })
     const vitest = await startVitest(
       undefined,
       {
@@ -17,11 +15,17 @@ test.describe('browser preview provider', () => {
         watch: true,
         reporters: [],
       },
-      {},
-      { stdout, stderr },
+      undefined,
+      {
+        stdout: new Writable({ write: (_, __, callback) => callback() }),
+        stderr: new Writable({ write: (_, __, callback) => callback() }),
+      },
     )
+
+    // results in dashboard
     await assertTestCounts(page, { pass: 1, fail: 0 })
 
+    // test code runs in tester iframe
     const testerFrame = page.frameLocator('iframe[data-vitest="true"]')
     await expect(testerFrame.getByRole('button')).toHaveText('hello')
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Closes https://github.com/vitest-dev/vitest/issues/10483

I added a test for `@vitest/browser-preview` by intercepting `ViteDevServer.openBrowser` then opening the page through headless playwright browser.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
