### PR TITLE
feat(mocker): hoist vi.mock() for vite-plus/test imports

### DIFF
--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -83,6 +83,12 @@ const regexpHoistable
   = /\b(?:vi|vitest)\s*\.\s*(?:mock|unmock|hoisted|doMock|doUnmock)\s*\(/
 const hashbangRE = /^#!.*\n/
 
+// Public redistributions of Vitest that re-export its mocking API (`vi`)
+// verbatim under their own specifier. Imports from these are treated as the
+// hoisted module so `vi.mock()` is hoisted for e.g.
+// `import { vi } from 'vite-plus/test'`, exactly as it is for `vitest`.
+const REDISTRIBUTED_HOISTED_MODULES = ['vite-plus/test']
+
 // this is a fork of Vite SSR transform
 export function hoistMocks(
   code: string,
@@ -141,8 +147,9 @@ export function hoistMocks(
   ) {
     const source = importNode.source.value as string
     // always hoist vitest import to top of the file, so
-    // "vi" helpers can access it
-    if (hoistedModule === source) {
+    // "vi" helpers can access it. Vitest redistributions that re-export the
+    // mocking API under their own specifier are recognized the same way.
+    if (hoistedModule === source || REDISTRIBUTED_HOISTED_MODULES.includes(source)) {
       hoistedModuleImported = true
       return
     }

--- a/test/unit/test/injector-mock.test.ts
+++ b/test/unit/test/injector-mock.test.ts
@@ -60,6 +60,21 @@ import { test } from 'vitest'
   `)
 })
 
+test('recognizes the vite-plus/test redistribution as the hoisted module', () => {
+  expect(hoistSimpleCode(`
+import { vi } from 'vite-plus/test'
+vi.mock('path', () => {})
+vi.unmock('path')
+vi.hoisted(() => {})
+  `)).toMatchInlineSnapshot(`
+    "vi.mock('path', () => {})
+    vi.unmock('path')
+    vi.hoisted(() => {})
+
+    import { vi } from 'vite-plus/test'"
+  `)
+})
+
 test('always hoists all imports but they are under mocks', () => {
   expect(hoistSimpleCode(`
   import { vi } from 'vitest'


### PR DESCRIPTION
### Description

[Vite+](https://github.com/voidzero-dev/vite-plus) re-exports Vitest's mocking API as `vite-plus/test`, so established users write:

```ts
import { vi } from 'vite-plus/test'
vi.mock('./foo')
```

The static `vi.mock()` hoister only recognizes `vitest` as the module that provides the mocking API, so for the specifier above the `vi.mock()` call is **not hoisted** — it runs after the import binding instead of before it, causing silent breakage / a TDZ error at runtime.

This recognizes `vite-plus/test` as a hoisted-module specifier alongside `vitest`, so `vi.mock()` is hoisted for it exactly as it is for `vitest`. It's **recognition-only** (the injected import for files that use the API without importing it is unchanged) and requires **no configuration**.

This upstreams the small pnpm patch vite-plus currently ships (which hardcodes the same `vite-plus/test` check); landing it lets that patch be dropped.

> Note: an earlier revision of this PR added a `hoistedModule: string[]` option instead. As @sheremet-va pointed out, `hoistMocksPlugin` is wired internally (`MocksPlugins()` in `packages/vitest/src/node/plugins/index.ts`) with no public config path, so the option wasn't reachable by a downstream without forking the plugin pipeline. Recognizing the specifier directly avoids new public surface. If you'd prefer a generic, config-driven mechanism (or a different list shape) over a named entry, happy to switch.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. <!-- discussed with @sheremet-va on this PR -->
- [x] Ideally, include a test that fails without this PR but passes with it. <!-- added to test/unit/test/injector-mock.test.ts -->
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example. <!-- lockfile untouched -->
- [x] Please check [Allow edits by maintainers].

### Tests
- [x] Run the tests with `pnpm test:ci`. <!-- ran the affected suite: `pnpm -C test/unit exec vitest run test/injector-mock` → 83 passed -->

### Documentation
- [x] If you introduce new functionality, document it. <!-- internal hoister behavior; documented via code comment on the recognized-redistributions list -->

### Changesets
- [x] Changes in changelog are generated from PR name.

---

**AI disclosure:** prepared with assistance from Claude (Claude Code); reviewed and validated locally (build + `injector-mock` suite + eslint) before submitting.