### PR TITLE
fix: support import.meta.env assignment (fix #10091)

### DIFF
--- a/packages/vitest/src/node/plugins/metaEnvReplacer.ts
+++ b/packages/vitest/src/node/plugins/metaEnvReplacer.ts
@@ -3,6 +3,39 @@ import { cleanUrl } from '@vitest/utils/helpers'
 import MagicString from 'magic-string'
 import { stripLiteral } from 'strip-literal'
 
+const metaEnvAccessor = `Object.assign(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env)`
+
+const ASSIGNMENT_OPERATORS = [
+  '>>>=',
+  '<<=',
+  '>>=',
+  '**=',
+  '&&=',
+  '||=',
+  '??=',
+  '+=',
+  '-=',
+  '*=',
+  '/=',
+  '%=',
+  '&=',
+  '^=',
+  '|=',
+]
+
+function isAssignmentTarget(code: string, endIndex: number): boolean {
+  let index = endIndex
+  while (/\s/.test(code[index])) {
+    index += 1
+  }
+
+  if (code[index] === '=') {
+    return code[index + 1] !== '=' && code[index + 1] !== '>'
+  }
+
+  return ASSIGNMENT_OPERATORS.some(operator => code.startsWith(operator, index))
+}
+
 // so people can reassign envs at runtime
 // import.meta.env.VITE_NAME = 'app' -> process.env.VITE_NAME = 'app'
 export function MetaEnvReplacerPlugin(): Plugin {
@@ -19,15 +52,18 @@ export function MetaEnvReplacerPlugin(): Plugin {
       const envs = cleanCode.matchAll(/\bimport\.meta\.env\b/g)
 
       for (const env of envs) {
-        s ||= new MagicString(code)
-
         const startIndex = env.index!
         const endIndex = startIndex + env[0].length
 
+        if (isAssignmentTarget(cleanCode, endIndex)) {
+          continue
+        }
+
+        s ||= new MagicString(code)
         s.overwrite(
           startIndex,
           endIndex,
-          `Object.assign(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env)`,
+          metaEnvAccessor,
         )
       }
 

--- a/test/unit/test/env-jsdom.test.ts
+++ b/test/unit/test/env-jsdom.test.ts
@@ -24,6 +24,21 @@ test('can reassign env locally', () => {
   expect(import.meta.env.VITEST_ENV).toBe('TEST')
 })
 
+test('can reassign import.meta.env directly', () => {
+  const key = 'VITEST_IMPORT_META_ENV_ASSIGNMENT'
+
+  delete process.env[key]
+
+  // @ts-expect-error -- Vitest rewrites import.meta.env at runtime
+  import.meta.env = import.meta.env || {}
+  import.meta.env[key] = 'true'
+
+  expect(import.meta.env[key]).toBe('true')
+  expect(process.env[key]).toBe('true')
+
+  delete process.env[key]
+})
+
 test('can reassign env everywhere', () => {
   import.meta.env.AUTH_TOKEN = '123'
   expect(getAuthToken()).toBe('123')

--- a/test/unit/test/env.test.ts
+++ b/test/unit/test/env.test.ts
@@ -22,6 +22,21 @@ test('can reassign env locally', () => {
   expect(import.meta.env.VITEST_ENV).toBe('TEST')
 })
 
+test('can reassign import.meta.env directly', () => {
+  const key = 'VITEST_IMPORT_META_ENV_ASSIGNMENT'
+
+  delete process.env[key]
+
+  // @ts-expect-error -- Vitest rewrites import.meta.env at runtime
+  import.meta.env = import.meta.env || {}
+  import.meta.env[key] = 'true'
+
+  expect(import.meta.env[key]).toBe('true')
+  expect(process.env[key]).toBe('true')
+
+  delete process.env[key]
+})
+
 test('can reassign env everywhere', () => {
   import.meta.env.AUTH_TOKEN = '123'
   expect(getAuthToken()).toBe('123')


### PR DESCRIPTION
### Description

Fixes #10091

`import.meta.env = import.meta.env || {}` was being transformed into an assignment to `Object.assign(...)`, which is not a valid assignment target and fails before the test file can run.

This keeps direct `import.meta.env` assignment targets intact while preserving the existing proxy rewrite for reads and property writes, so subsequent `import.meta.env[key] = ...` mutations still update the worker env proxy.

AI assistance disclosure: OpenAI Codex helped prepare this patch and PR description.

### Tests

- [x] `pnpm -C packages/vitest run build`
- [x] `CI=true pnpm test:threads test/env.test.ts test/env-jsdom.test.ts -t "can reassign import.meta.env directly"`
- [x] `CI=true pnpm test:threads test/env.test.ts test/env-jsdom.test.ts`
- [x] `pnpm exec eslint packages/vitest/src/node/plugins/metaEnvReplacer.ts test/unit/test/env.test.ts test/unit/test/env-jsdom.test.ts`

### Documentation

No documentation change; this fixes a transform bug.

### Changesets

PR title uses the `fix:` prefix.

<!-- VITEST_AUTOMATED_PR -->
