### PR TITLE
fix(expect): print correct diff for objectContaining

### DIFF
--- a/packages/expect/src/jest-asymmetric-matchers.ts
+++ b/packages/expect/src/jest-asymmetric-matchers.ts
@@ -174,6 +174,16 @@ export class ObjectContaining extends AsymmetricMatcher<
         otherValue,
         customTesters,
       )) {
+        // When match fails, copy properties from  that are not in 
+        // into  so the diff only shows actual differences, not the
+        // entire object. Matches Jest behavior (jestjs/jest#15038).
+        // Mutation only affects diff output since result is already false.
+        const otherProps = other ? this.getProperties(other) : []
+        for (const prop of otherProps) {
+          if (!this.hasProperty(this.sample, prop)) {
+            this.sample[prop] = other[prop]
+          }
+        }
         result = false
         break
       }


### PR DESCRIPTION
## Problem

When expect.objectContaining fails, the diff shows all properties of the received object as additions instead of only the differing ones.

## Fix

Port of jestjs/jest#15038. When the match fails, copy unmatched properties from the received object into the sample so the diff only shows actual differences.

Fixes #5714