### PR TITLE
feat(coverage): pass previous threshold as second argument to autoUpdate function

### DIFF
--- a/docs/config/coverage.md
+++ b/docs/config/coverage.md
@@ -250,7 +250,7 @@ Check thresholds per file.
 Update all threshold values `lines`, `functions`, `branches` and `statements` to configuration file when current coverage is better than the configured thresholds.
 This option helps to maintain thresholds when coverage is improved.
 
-You can also pass a function for formatting the updated threshold values:
+You can also pass a function for formatting the updated threshold values. The function receives the new threshold as the first argument and the previous threshold as the second:
 
 <!-- eslint-skip -->
 ```ts
@@ -259,6 +259,12 @@ You can also pass a function for formatting the updated threshold values:
     thresholds: {
       // Update thresholds without decimals
       autoUpdate: (newThreshold) => Math.floor(newThreshold),
+
+      // Log the change and update without decimals
+      autoUpdate: (newThreshold, previousThreshold) => {
+        console.log(`Updated threshold from ${previousThreshold} to ${newThreshold}`)
+        return Math.floor(newThreshold)
+      },
 
       // 95.85 -> 95
       functions: 95,

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -595,7 +595,7 @@ export class BaseCoverageProvider {
             )
         : [coverageMap.getCoverageSummary()]
 
-      const thresholdsToUpdate: [Threshold, number][] = []
+      const thresholdsToUpdate: [Threshold, number, number][] = []
 
       for (const key of THRESHOLD_KEYS) {
         const threshold = thresholds[key] ?? 100
@@ -609,7 +609,7 @@ export class BaseCoverageProvider {
           )
 
           if (actual > threshold) {
-            thresholdsToUpdate.push([key, actual])
+            thresholdsToUpdate.push([key, actual, threshold])
           }
         }
         else {
@@ -621,7 +621,7 @@ export class BaseCoverageProvider {
           if (actual < absoluteThreshold) {
             // If everything was covered, set new threshold to 100% (since a threshold of 0 would be considered as 0%)
             const updatedThreshold = actual === 0 ? 100 : actual * -1
-            thresholdsToUpdate.push([key, updatedThreshold])
+            thresholdsToUpdate.push([key, updatedThreshold, threshold])
           }
         }
       }
@@ -634,8 +634,8 @@ export class BaseCoverageProvider {
 
       const thresholdFormatter = typeof this.options.thresholds?.autoUpdate === 'function' ? this.options.thresholds?.autoUpdate : (value: number) => value
 
-      for (const [threshold, newValue] of thresholdsToUpdate) {
-        const formattedValue = thresholdFormatter(newValue)
+      for (const [threshold, newValue, previousValue] of thresholdsToUpdate) {
+        const formattedValue = thresholdFormatter(newValue, previousValue)
         if (name === GLOBAL_THRESHOLDS_KEY) {
           config.test.coverage.thresholds[threshold] = formattedValue
         }

--- a/packages/vitest/src/node/types/coverage.ts
+++ b/packages/vitest/src/node/types/coverage.ts
@@ -340,7 +340,7 @@ interface Thresholds {
    *
    * @default false
    */
-  autoUpdate?: boolean | ((newThreshold: number) => number)
+  autoUpdate?: boolean | ((newThreshold: number, previousThreshold: number) => number)
 
   /** Thresholds for statements */
   statements?: number

--- a/test/coverage-test/test/threshold-auto-update.unit.test.ts
+++ b/test/coverage-test/test/threshold-auto-update.unit.test.ts
@@ -156,6 +156,22 @@ test('formats values with custom formatter', async () => {
   expect(calls.sort()).toEqual([50, 60, 70, 80])
 })
 
+test('passes previous threshold as second argument to custom formatter', async () => {
+  const config = parseModule(`export default ${initialConfig}`)
+
+  const autoUpdate = vi.fn().mockImplementation(value => value)
+  await updateThresholds(config, { thresholds: { autoUpdate } })
+
+  const previousValues = autoUpdate.mock.calls.map(call => [call[0], call[1]])
+
+  expect(previousValues.sort((a, b) => a[0] - b[0])).toEqual([
+    [coveredThresholds.lines, initialThresholds.lines],
+    [coveredThresholds.branches, initialThresholds.branches],
+    [coveredThresholds.functions, initialThresholds.functions],
+    [coveredThresholds.statements, initialThresholds.statements],
+  ].sort((a, b) => a[0] - b[0]))
+})
+
 async function updateThresholds(configurationFile: ReturnType<typeof parseModule>, _coverageOptions: Partial<(InstanceType<typeof BaseCoverageProvider>)['options']> = {}) {
   const summaryData = { total: 0, covered: 0, skipped: 0 }
   const thresholds = [{


### PR DESCRIPTION
### Description

When `coverage.thresholds.autoUpdate` is set to a function, the previous threshold value is now passed as the second argument. This allows users to log or track changes, e.g.:

```ts
autoUpdate: (newThreshold, previousThreshold) => {
  console.log(`Updated threshold from ${previousThreshold} to ${newThreshold}`)
  return Math.floor(newThreshold)
}
```

Resolves #10459

Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to pnpm-lock.yaml unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

Tests

- [x] Run the tests with pnpm test:ci.

Documentation

- [x] If you introduce new functionality, document it. You can run documentation with pnpm run docs command.

Changesets

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with feat:, fix:, perf:, docs:, or chore:.
