### PR TITLE
fix(browser): wait for iframe tester readiness before preparing

### DIFF
--- a/packages/browser/src/client/channel.ts
+++ b/packages/browser/src/client/channel.ts
@@ -21,6 +21,11 @@ export interface IframeViewportDoneEvent {
   iframeId: string
 }
 
+export interface IframeReadyEvent {
+  event: 'ready'
+  iframeId: string
+}
+
 export interface GlobalChannelTestRunCanceledEvent {
   type: 'cancel'
   reason: CancelReason
@@ -50,6 +55,7 @@ export type GlobalChannelIncomingEvent = GlobalChannelTestRunCanceledEvent
 
 export type IframeChannelIncomingEvent
   = | IframeViewportEvent
+    | IframeReadyEvent
 
 export type IframeChannelOutgoingEvent
   = | IframeExecuteEvent

--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -1,5 +1,5 @@
 import type { Context as OTELContext } from '@opentelemetry/api'
-import type { GlobalChannelIncomingEvent, IframeChannelIncomingEvent, IframeChannelOutgoingEvent, IframeViewportDoneEvent, IframeViewportFailEvent } from '@vitest/browser/client'
+import type { GlobalChannelIncomingEvent, IframeChannelEvent, IframeChannelOutgoingEvent, IframeViewportDoneEvent, IframeViewportFailEvent } from '@vitest/browser/client'
 import type { BrowserTesterOptions, SerializedConfig } from 'vitest'
 import type { FileSpecification } from 'vitest/internal/browser'
 import { channel, client, globalChannel } from '@vitest/browser/client'
@@ -16,6 +16,8 @@ export class IframeOrchestrator {
   private cancelled = false
   private recreateNonIsolatedIframe = false
   private iframes = new Map<string, HTMLIFrameElement>()
+  private readyIframes = new Set<string>()
+  private readyWaiters = new Map<string, () => void>()
 
   public eventTarget: EventTarget = new EventTarget()
 
@@ -91,6 +93,8 @@ export class IframeOrchestrator {
 
     this.iframes.forEach(iframe => iframe.remove())
     this.iframes.clear()
+    this.readyIframes.clear()
+    this.readyWaiters.clear()
 
     for (let i = 0; i < options.files.length; i++) {
       if (this.cancelled) {
@@ -149,8 +153,7 @@ export class IframeOrchestrator {
       // because we called "cleanup" in the previous run
       // the iframe is not removed immediately to let the user see the last test
       this.recreateNonIsolatedIframe = false
-      this.iframes.get(ID_ALL)!.remove()
-      this.iframes.delete(ID_ALL)
+      this.removeIframe(ID_ALL)
       debug('recreate non-isolated iframe')
     }
 
@@ -189,8 +192,7 @@ export class IframeOrchestrator {
     const file = spec.filepath
 
     if (this.iframes.has(file)) {
-      this.iframes.get(file)!.remove()
-      this.iframes.delete(file)
+      this.removeIframe(file)
     }
 
     await this.prepareIframe(
@@ -253,12 +255,14 @@ export class IframeOrchestrator {
         }
         else {
           this.iframes.set(iframeId, iframe)
-          this.sendEventToIframe({
-            event: 'prepare',
-            iframeId,
-            startTime,
-            otelCarrier: this.traces.getContextCarrier(otelContext),
-          }).then(resolve, error => reject(this.dispatchIframeError(error)))
+          this.waitForReady(iframeId)
+            .then(() => this.sendEventToIframe({
+              event: 'prepare',
+              iframeId,
+              startTime,
+              otelCarrier: this.traces.getContextCarrier(otelContext),
+            }))
+            .then(resolve, error => reject(this.dispatchIframeError(error)))
         }
       }
       iframe.onerror = (e) => {
@@ -274,6 +278,34 @@ export class IframeOrchestrator {
       }
     })
     return iframe
+  }
+
+  private markReady(iframeId: string) {
+    this.readyIframes.add(iframeId)
+
+    const waiter = this.readyWaiters.get(iframeId)
+    if (waiter) {
+      this.readyWaiters.delete(iframeId)
+      waiter()
+    }
+  }
+
+  private waitForReady(iframeId: string): Promise<void> {
+    if (this.readyIframes.has(iframeId)) {
+      return Promise.resolve()
+    }
+
+    return new Promise((resolve) => {
+      this.readyWaiters.set(iframeId, resolve)
+    })
+  }
+
+  private removeIframe(iframeId: string) {
+    const iframe = this.iframes.get(iframeId)
+    this.iframes.delete(iframeId)
+    this.readyIframes.delete(iframeId)
+    this.readyWaiters.delete(iframeId)
+    iframe?.remove()
   }
 
   private loggedIframe = new WeakSet<HTMLIFrameElement>()
@@ -365,9 +397,13 @@ export class IframeOrchestrator {
     }
   }
 
-  private async onIframeEvent(e: MessageEvent<IframeChannelIncomingEvent>) {
+  private async onIframeEvent(e: MessageEvent<IframeChannelEvent>) {
     debug('iframe event', JSON.stringify(e.data))
     switch (e.data.event) {
+      case 'ready': {
+        this.markReady(e.data.iframeId)
+        break
+      }
       case 'viewport': {
         const { width, height, iframeId: id } = e.data
         const iframe = this.iframes.get(id)

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -114,6 +114,11 @@ getBrowserState().iframeId = iframeId
 
 registerPageMarkHandler((name, options) => page.mark(name, options))
 
+channel.postMessage({
+  event: 'ready',
+  iframeId,
+})
+
 let contextSwitched = false
 
 async function prepareTestEnvironment(options: PrepareOptions) {

--- a/test/browser/specs/readiness.test.ts
+++ b/test/browser/specs/readiness.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest'
+import { instances, runInlineBrowserTests } from './utils'
+
+test('prepare waits until the tester can receive browser channel events', { timeout: 5000 }, async () => {
+  const { stderr, testTree } = await runInlineBrowserTests(
+    {
+      'basic.test.ts': `
+        import { expect, test } from 'vitest'
+
+        test('runs in the browser', () => {
+          expect(1).toBe(1)
+        })
+      `,
+      'delayed-tester.html': `
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title>Delayed Tester</title>
+            <script>
+              const addEventListener = BroadcastChannel.prototype.addEventListener
+              const postMessage = BroadcastChannel.prototype.postMessage
+              BroadcastChannel.prototype.addEventListener = function(type, listener, options) {
+                if (type === 'message') {
+                  setTimeout(() => addEventListener.call(this, type, listener, options), 100)
+                  return
+                }
+                return addEventListener.call(this, type, listener, options)
+              }
+              BroadcastChannel.prototype.postMessage = function(message) {
+                if (message && message.event === 'ready') {
+                  setTimeout(() => postMessage.call(this, message), 150)
+                  return
+                }
+                return postMessage.call(this, message)
+              }
+            </script>
+          </head>
+          <body></body>
+        </html>
+      `,
+    },
+    {
+      browser: {
+        instances: [instances[0]],
+        testerHtmlPath: './delayed-tester.html',
+      },
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "runs in the browser": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

During the investigation for `vitest`-randomly-hanging-in-CI I (with the help of Codex) initially [diagnosed a race condition that was ultimately fixed](https://github.com/vitest-dev/vitest/pull/10397) but I still was getting CI failures / hangs (even after that first fix) — exposing another race condition.

It's a browser-runner readiness race where the orchestrator could send the initial `prepare` event before the tester `<iframe>` was actually ready to receive channel messages.

Resolves (do you need an issue for a bug fix?)

This PR adds an explicit tester-ready handshake between the browser tester and orchestrator.

#### Changes

- Add a new `<iframe>` channel event: `ready`
- Have the tester post `ready` only after its channel listener is registered
- Make the orchestrator wait for the current `<iframe>` to report `ready` before sending `prepare`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

AI assisted: Codex