### PR TITLE
ci: fix don't close issues that was recently updated

### DIFF
--- a/.github/actions/issues-helper/action.yml
+++ b/.github/actions/issues-helper/action.yml
@@ -90,7 +90,7 @@ runs:
               .filter(e => e.event === 'labeled' && labelSet.has(e.label?.name))
               .at(-1)?.created_at
 
-            if (!labeledAt || new Date(labeledAt) > cutoff) continue
+            if (!labeledAt || new Date(labeledAt) > cutoff || new Date(issue.updated_at) > cutoff) continue
 
             console.log(`Closing #${issue.number}, labeled at ${labeledAt}`)
             await github.rest.issues.update({


### PR DESCRIPTION
### Description

The `issue-close-require` workflow was closing issues that was updated after the `needs reproduction` label was added. But previously it didn't and this PR restores that the previous behavior.

I found this in https://github.com/vitejs/vite/pull/22584. This probably won't matter in most cases, but thought to send it anyways.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
