### PR TITLE
feat(cli): add `--repeats` CLI option

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -508,6 +508,10 @@ export default ({ mode }: { mode: string }) => {
                 link: '/config/retry',
               },
               {
+                text: 'repeats',
+                link: '/config/repeats',
+              },
+              {
                 text: 'onConsoleLog',
                 link: '/config/onconsolelog',
               },

--- a/docs/config/repeats.md
+++ b/docs/config/repeats.md
@@ -1,0 +1,14 @@
+---
+title: repeats | Config
+outline: deep
+---
+
+# repeats
+
+- **Type:** `number`
+- **Default:** `0`
+- **CLI:** `--repeats=<number>`
+
+Repeat every test a specific number of times regardless of the result. A test that uses the [`repeats`](/api/test#repeats) test option takes precedence over this value.
+
+This is useful for verifying that tests are stable across multiple runs. If a test fails on any repetition, the whole test is reported as failed.

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -637,6 +637,13 @@ Delay in milliseconds between retry attempts (default: `0`)
 
 Regex pattern to match error messages that should trigger a retry. Only errors matching this pattern will cause a retry (default: retry on all errors)
 
+### repeats
+
+- **CLI:** `--repeats <number>`
+- **Config:** [repeats](/config/repeats)
+
+Repeat every test a specific number of times regardless of the result (default: `0`)
+
 ### diff.aAnnotation
 
 - **CLI:** `--diff.aAnnotation <annotation>`

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -630,6 +630,11 @@ export const cliOptionsConfig: VitestCLIOptions = {
       },
     },
   },
+  repeats: {
+    description:
+      'Repeat every test a specific number of times regardless of the result (default: `0`)',
+    argument: '<number>',
+  },
   diff: {
     description:
       'DiffOptions object or a path to a module which exports DiffOptions object',

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -45,6 +45,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
     // TODO: non serializable function?
     diff: config.diff,
     retry: config.retry,
+    repeats: config.repeats,
     disableConsoleIntercept: config.disableConsoleIntercept,
     root: config.root,
     name: config.name,

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -52,6 +52,7 @@ export async function resolveProjects(
     'expandSnapshotDiff',
     'disableConsoleIntercept',
     'retry',
+    'repeats',
     'testNamePattern',
     'passWithNoTests',
     'bail',

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -831,6 +831,13 @@ export interface InlineConfig {
   retry?: SerializableRetry
 
   /**
+   * Repeat every test a specific number of times regardless of the result.
+   *
+   * @default 0 // Don't repeat
+   */
+  repeats?: number
+
+  /**
    * Show full diff when snapshot fails instead of a patch.
    */
   expandSnapshotDiff?: boolean

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -31,6 +31,7 @@ export interface SerializedConfig {
   testTimeout: number
   hookTimeout: number
   retry: SerializableRetry
+  repeats?: number
   includeTaskLocation: boolean | undefined
   tags: TestTagDefinition[]
   tagsFilter: string[] | undefined

--- a/packages/vitest/src/runtime/runner/suite.ts
+++ b/packages/vitest/src/runtime/runner/suite.ts
@@ -387,7 +387,7 @@ function createSuiteCollector(
       file: (currentSuite?.file ?? collectorContext.currentSuite?.file)!,
       timeout,
       retry: options.retry ?? runner.config.retry,
-      repeats: options.repeats,
+      repeats: options.repeats ?? runner.config.repeats,
       mode: options.only
         ? 'only'
         : options.skip

--- a/test/e2e/fixtures/repeats/repeats-config.test.ts
+++ b/test/e2e/fixtures/repeats/repeats-config.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+
+test('uses repeats from config', () => {
+  expect(1 + 1).toBe(2)
+})
+
+test('test option overrides config', { repeats: 1 }, () => {
+  expect(1 + 1).toBe(2)
+})

--- a/test/e2e/test/cli-config.test.ts
+++ b/test/e2e/test/cli-config.test.ts
@@ -27,6 +27,7 @@ it('correctly inherit from the cli', async () => {
       globals: true,
       expandSnapshotDiff: true,
       retry: 6,
+      repeats: 3,
       testNamePattern: 'math',
       passWithNoTests: true,
       bail: 100,
@@ -50,6 +51,7 @@ it('correctly inherit from the cli', async () => {
     globals: true,
     expandSnapshotDiff: true,
     retry: 6,
+    repeats: 3,
     passWithNoTests: true,
     bail: 100,
     experimental: {

--- a/test/e2e/test/repeats.test.ts
+++ b/test/e2e/test/repeats.test.ts
@@ -1,0 +1,26 @@
+import type { TestModule } from 'vitest/node'
+import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+const root = resolve(__dirname, '..', 'fixtures', 'repeats')
+
+test('repeats config option is exposed to tests and repeats execution', async () => {
+  const { ctx } = await runVitest({
+    root,
+    include: ['repeats-config.test.ts'],
+    repeats: 3,
+  })
+
+  const file = ctx!.state.getFiles()[0]
+  const testModule = ctx!.state.getReportedEntity(file)! as TestModule
+  const tests = [...testModule.children.allTests()]
+
+  const fromConfig = tests.find(t => t.name === 'uses repeats from config')!
+  expect(fromConfig.options.repeats).toBe(3)
+  expect(fromConfig.diagnostic()!.repeatCount).toBe(3)
+
+  const overridden = tests.find(t => t.name === 'test option overrides config')!
+  expect(overridden.options.repeats).toBe(1)
+  expect(overridden.diagnostic()!.repeatCount).toBe(1)
+})


### PR DESCRIPTION
### Description

Exposes the test `repeats` option as a CLI argument (`--repeats <number>`) and config option, mirroring `retry`. Resolves #7352.

Builds on the stale #9250 and addresses its review feedback:

- Applies the config default during collection (`packages/runner/src/suite.ts`: `options.repeats ?? runner.config.repeats`) so `testCase.options.repeats` reflects the config value instead of being forced to `0`. A per-test `repeats` option still takes precedence. (`run.ts` is left unchanged, per the maintainer's note.)
- Uses the maintainer-suggested wording for the CLI/docs descriptions.
- Adds `repeats` to the project-config override allowlist in `resolveProjects.ts`, which #9250 missed — without it `--repeats` did not reach workspace/project configs (covered by a new test).

### Tests

- `test/e2e/test/repeats.test.ts` — config `repeats` propagates to `testCase.options.repeats` and the test actually repeats; per-test option overrides config.
- `test/e2e/test/cli-config.test.ts` — `--repeats` inherited from the CLI into the resolved (project) config.

---

This PR was prepared with AI assistance.

---

<!-- VITEST_AUTOMATED_PR -->