### PR TITLE
docs: (browser) re-word browser mode development status

### DIFF
--- a/docs/guide/browser/why.md
+++ b/docs/guide/browser/why.md
@@ -23,9 +23,9 @@ To achieve the highest level of confidence in our tests, it's crucial to test in
 
 When using Vitest browser, it is important to consider the following drawbacks:
 
-### Early Development
+### Not a Drop-In Replacement
 
-The browser mode feature of Vitest is still in its early stages of development. As such, it may not yet be fully optimized, and there may be some bugs or issues that have not yet been ironed out. It is recommended that users augment their Vitest browser experience with a standalone browser-side test runner like WebdriverIO, Cypress or Playwright.
+The browser mode feature of Vitest does not completely replace standalone end-to-end test runners. It is recommended that users augment their Vitest browser experience with a standalone browser-side test runner like WebdriverIO, Cypress or Playwright.
 
 ### Longer Initialization
 


### PR DESCRIPTION
### Description

- Re-word the "development status" of **Browser Mode** to clarify that it _is stable_ but not a replacement for standalone browser test runners
- Go to [Why Browser Mode](https://vitest.dev/guide/browser/why.html) -> [Early Development](https://vitest.dev/guide/browser/why.html#early-development) -> reads like an experimental feature: 

  > Early Development
  > The browser mode feature of Vitest is still in its early stages of development...

- However, when digging deeper into the docs and issues/pull requests, it appears to be mature enough and widely used?
- Small adjustments to the wording would help avoid future confusion

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
