### PR TITLE
docs(guide): clarify beforeEach state isolation

### DIFF
--- a/docs/guide/learn/setup-teardown.md
+++ b/docs/guide/learn/setup-teardown.md
@@ -33,11 +33,16 @@ test('items starts with 3 fruits', () => {
   expect(items).toHaveLength(3)
 })
 
+test('can remove an item', () => {
+  items.pop()
+  expect(items).toHaveLength(2)
+})
+
 test('can add an item', () => {
   items.push('date')
   expect(items).toHaveLength(4)
-  // afterEach will reset items for the next test,
-  // so this mutation won't leak into other tests
+  // beforeEach reset the array to 3 items before this test ran,
+  // proving that mutations from the previous test do not leak.
 })
 ```
 

--- a/docs/guide/learn/setup-teardown.md
+++ b/docs/guide/learn/setup-teardown.md
@@ -46,7 +46,7 @@ test('can add an item', () => {
 })
 ```
 
-Without these hooks, the second test's `push` would affect any test that runs after it, which is a classic source of flaky tests. The hooks guarantee clean state for every test.
+Without these hooks, mutations like `pop` or `push` from earlier tests would affect subsequent ones, which is a classic source of flaky tests, while the hooks guarantee clean state for every test.
 
 ## One-Time Setup
 


### PR DESCRIPTION
This PR improves the `beforeEach` and `afterEach`
documentation example.

The current example shows an initial check and an
addition test. However, it does not explicitly demonstrate to a learner that mutations in one test are completely wiped clean for the next.

* Added a mid-sequence test that mutates the array via `items.pop()`.
* Updated the final test to show that despite the previous deletion, the array starts fresh with 3 items again, making the length 4 after a push.
* Updated comments to highlight this isolation.

This makes the "known state" and "won't leak" concepts instantly visual
 and clear for readers.

In summary, this PR adds a test mutating state to explicitly prove hooks reset data between tests. The current example lacks a sequential state mutation, which forces learners to assume isolation works rather than seeing it in action. This change makes the teardown and setup cycle visually obvious and easier to understand for beginners.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
