### PR TITLE
docs(guide): document assertion functions in in-source testing

### DIFF
--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -150,6 +150,29 @@ To get TypeScript support for `import.meta.vitest`, add `vitest/importMeta` to y
 }
 ```
 
+### Assertion Functions
+
+Because of a TypeScript limitation, assertion functions (functions typed with `asserts`, such as `assert`) cannot be called when they are destructured from `import.meta.vitest`. TypeScript reports:
+
+```
+TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
+```
+
+To work around this, either call `assert` directly without destructuring, or declare it with an explicit `Chai.Assert` type annotation:
+
+```ts [src/index.ts]
+if (import.meta.vitest) {
+  const { test } = import.meta.vitest
+  const assert: Chai.Assert = import.meta.vitest.assert // [!code ++]
+
+  test('add', () => {
+    const value = add(1, 2)
+    import.meta.vitest.assert(value === 3) // call directly
+    assert(value === 3) // or use the annotated binding
+  })
+}
+```
+
 Reference to [`examples/in-source-test`](https://github.com/vitest-dev/vitest/tree/main/examples/in-source-test) for the full example.
 
 ## Notes


### PR DESCRIPTION
### Description

Closes #10471.

When using [in-source testing](https://vitest.dev/guide/in-source.html), calling an assertion function (e.g. `assert`) that has been destructured from `import.meta.vitest` fails to type-check:

```
TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.
```

As noted by @sheremet-va in the issue, this is a TypeScript limitation (assertion functions must be referenced through an explicitly typed binding), not something Vitest can fix in code — so it deserves a mention in the docs.

This PR adds an **Assertion Functions** subsection to the TypeScript part of the In-Source Testing guide describing the two workarounds:

- call the assertion directly via `import.meta.vitest.assert(...)`, or
- declare an explicitly typed binding: `const assert: Chai.Assert = import.meta.vitest.assert`.

The example uses the exact pattern the maintainer confirmed in the issue.

### Notes

Docs-only change. It uses the same VitePress constructs already present in `docs/guide/in-source.md` (no `twoslash` block). I verified locally that the added section does not introduce any new docs-build errors (the pre-existing twoslash errors that appear without first building the packages are identical with and without this change).