### PR TITLE
fix(browser): encode iframeId in tester iframe URL (fix #10520)

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -317,7 +317,7 @@ export class IframeOrchestrator {
 
   private createTestIframe(iframeId: string) {
     const iframe = document.createElement('iframe')
-    const src = `/?sessionId=${getBrowserState().sessionId}&iframeId=${iframeId}`
+    const src = `/?sessionId=${getBrowserState().sessionId}&iframeId=${encodeURIComponent(iframeId)}`
     const config = getConfig()
 
     iframe.setAttribute('loading', 'eager')

--- a/test/browser/fixtures/file-path-encoding/a+b.test.ts
+++ b/test/browser/fixtures/file-path-encoding/a+b.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+
+// The file name contains a "+" on purpose: the orchestrator passes the test
+// file path as the `iframeId` query parameter of the tester iframe URL. If it
+// is not encoded, the "+" is decoded back as a space, the tester never matches
+// the orchestrator events, and the run hangs at "0 passed".
+test('runs a test from a file whose path contains a plus sign', () => {
+  expect(true).toBe(true)
+})

--- a/test/browser/fixtures/file-path-encoding/a+b.test.ts
+++ b/test/browser/fixtures/file-path-encoding/a+b.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from 'vitest'
 
-// The file name contains a "+" on purpose: the orchestrator passes the test
-// file path as the `iframeId` query parameter of the tester iframe URL. If it
-// is not encoded, the "+" is decoded back as a space, the tester never matches
-// the orchestrator events, and the run hangs at "0 passed".
 test('runs a test from a file whose path contains a plus sign', () => {
   expect(true).toBe(true)
 })

--- a/test/browser/fixtures/file-path-encoding/vitest.config.ts
+++ b/test/browser/fixtures/file-path-encoding/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+    },
+  },
+})

--- a/test/browser/specs/file-path-encoding.test.ts
+++ b/test/browser/specs/file-path-encoding.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { instances, provider, runBrowserTests } from './utils'
+
+test('runs tests from files whose path contains a plus sign', async () => {
+  const { stderr, stdout, exitCode } = await runBrowserTests({
+    root: './fixtures/file-path-encoding',
+    reporters: ['verbose'],
+    browser: {
+      provider,
+      instances,
+    },
+  })
+
+  expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
+
+  instances.forEach(({ browser }) => {
+    expect(stdout).toReportPassedTest('a+b.test.ts', browser)
+  })
+})


### PR DESCRIPTION
createTestIframe interpolates the test-file path (iframeId) into the iframe URL query string without encoding. A '+' in the path is decoded back as a space, so the spec no longer matches a real file, the iframe never runs the test, and browser mode hangs at '0 passed' with no error. Encode the value with encodeURIComponent; it is read back with standard URL decoding.

Add a regression test: a fixture whose test file path contains a '+', which hangs (times out) without this fix and passes with it.
### Description

`createTestIframe` (`packages/browser/src/client/orchestrator.ts`) builds the tester iframe URL by interpolating the test-file path (`iframeId`) into the query string without encoding. A `+` in the path is decoded back as a space, so the spec no longer matches a real file, the iframe never runs the test, and browser mode hangs forever at `0 passed` with no error.

This affects any project whose path contains a `+` — e.g. a git worktree named `feat+210-…`. Present on `main` and `v4.1.8`.

Fix: wrap the value in `encodeURIComponent`. It is read back with standard URL decoding (`URLSearchParams.get`), so `+` and `/` round-trip correctly.

Resolves #10520

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [X] Ideally, include a test that fails without this PR but passes with it.
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [X] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [X] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [X] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

---

A regression test is included (`test/browser/specs/file-path-encoding.test.ts` + a fixture whose test file path contains a `+`): without this fix the run hangs and the spec times out; with it, the test passes on chromium, firefox and webkit. Reproduction: https://github.com/Pduhard/vitest-browser-hang-plus-path

_Disclosure: this PR was drafted with the help of Claude (Claude Code). A real person reviewed it and is submitting and owning it._

<!-- VITEST_AUTOMATED_PR -->

---