### PR TITLE
docs: document the assertion function limitation in in-source testing

### DIFF
--- a/docs/api/assert.md
+++ b/docs/api/assert.md
@@ -2,6 +2,34 @@
 
 Vitest reexports the `assert` method from [`chai`](https://www.chaijs.com/api/assert/) for verifying invariants.
 
+::: warning In-Source Testing {#in-source-testing}
+When using [assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) such as `assert` from `import.meta.vitest` in [in-source tests](/guide/in-source), TypeScript reports error `TS2775` because they must be called via an explicitly annotated name. Annotate the variable with `Chai.Assert` or call it directly:
+
+::: code-group
+```ts [Annotated variable]
+if (import.meta.vitest) {
+  const { test, assert } = import.meta.vitest // [!code --]
+  const { test } = import.meta.vitest // [!code ++]
+  const assert: Chai.Assert = import.meta.vitest.assert // [!code ++]
+
+  test('assert', () => {
+    assert('foo' !== 'bar', 'foo should not be equal to bar')
+  })
+}
+```
+```ts [Direct call]
+if (import.meta.vitest) {
+  const { test, assert } = import.meta.vitest // [!code --]
+  const { test } = import.meta.vitest // [!code ++]
+
+  test('assert', () => {
+    assert('foo' !== 'bar', 'foo should not be equal to bar') // [!code --]
+    import.meta.vitest!.assert('foo' !== 'bar', 'foo should not be equal to bar') // [!code ++]
+  })
+}
+```
+:::
+
 ## assert
 
 - **Type:** `(expression: any, message?: string) => asserts expression`

--- a/docs/guide/in-source.md
+++ b/docs/guide/in-source.md
@@ -152,6 +152,10 @@ To get TypeScript support for `import.meta.vitest`, add `vitest/importMeta` to y
 
 Reference to [`examples/in-source-test`](https://github.com/vitest-dev/vitest/tree/main/examples/in-source-test) for the full example.
 
+::: warning
+There is a limitation when using [assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) such as `assert` in in-source tests. See [`assert`](/api/assert#in-source-testing) for details and workarounds.
+:::
+
 ## Notes
 
 This feature could be useful for:


### PR DESCRIPTION
### Description

Using assertion functions such as `assert` obtained from `import.meta.vitest` in in-source tests results in a TypeScript error (`TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.`). This is a TypeScript language constraint, not a Vitest bug, but it was not documented anywhere.

This PR documents the constraint and its workarounds:

- `docs/api/assert.md`: adds a warning at the top of the page explaining the error, with two workarounds shown as diff-style examples (annotating the variable with
`Chai.Assert`, or calling `import.meta.vitest.assert` directly)
- `docs/guide/in-source.md`: adds a short note in the TypeScript section linking to the warning above

Resolves #10471 

AI assistance: As I am not a fluent English writer, the English text in this PR (both the docs and this description) was written by an AI agent (Claude Code). The decisions on what to document, where to place it, and how to present it were made by me, and I verified the rendered output locally.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

This is a documentation-only change; no test behavior is affected.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->