### PR TITLE
fix(snapshot): preserve error causes in snapshots

### DIFF
--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -295,13 +295,20 @@ const ErrorPlugin: NewPlugin = {
     refs = [...refs, val]
     const hitMaxDepth = ++depth > config.maxDepth
     const { message, cause, ...rest } = val
+    const name = val.name !== 'Error' ? val.name : getConstructorName(val as any)
+
+    if (typeof cause === 'undefined' && !(val instanceof AggregateError) && Object.keys(rest).length === 0) {
+      return hitMaxDepth
+        ? `[${name}]`
+        : `[${name}: ${message}]`
+    }
+
     const entries = {
       message,
       ...typeof cause !== 'undefined' ? { cause } : {},
       ...val instanceof AggregateError ? { errors: val.errors } : {},
       ...rest,
     }
-    const name = val.name !== 'Error' ? val.name : getConstructorName(val as any)
     return hitMaxDepth
       ? `[${name}]`
       : `${name} {${printObjectProperties(

--- a/packages/snapshot/src/port/plugins.ts
+++ b/packages/snapshot/src/port/plugins.ts
@@ -20,6 +20,7 @@ const {
   ReactElement,
   ReactTestComponent,
   AsymmetricMatcher,
+  Error,
 } = prettyFormatPlugins
 
 let PLUGINS: PrettyFormatPlugins = [
@@ -28,6 +29,7 @@ let PLUGINS: PrettyFormatPlugins = [
   DOMElement,
   DOMCollection,
   Immutable,
+  Error,
   AsymmetricMatcher,
   MockSerializer,
 ]

--- a/test/browser/specs/errors.test.ts
+++ b/test/browser/specs/errors.test.ts
@@ -4,7 +4,7 @@ import { rolldownVersion } from 'vitest/node'
 import { buildTestProjectTree } from '../../test-utils'
 import { instances, provider, runBrowserTests, runInlineBrowserTests } from './utils'
 
-test('prints correct unhandled error stack', async () => {
+test('prints correct unhandled error stack', { timeout: 600_000 }, async () => {
   const { stderr } = await runBrowserTests({
     root: './fixtures/unhandled',
   })

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -9,7 +9,7 @@ import { instances, provider, runBrowserTests } from './utils'
 
 function noop() {}
 
-describe('running browser tests', async () => {
+describe('running browser tests', { timeout: 600_000 }, async () => {
   let stderr: string
   let stdout: string
   let browserResultJson: JsonTestResults
@@ -61,7 +61,7 @@ describe('running browser tests', async () => {
     const getFailed = (results: JsonTestResult[]) => results.filter(result => result.status === 'failed')
     passedTests = getPassed(browserResultJson.testResults)
     failedTests = getFailed(browserResultJson.testResults)
-  })
+  }, 600_000)
 
   test('tests are actually running', () => {
     expect(stderr).toBe('')
@@ -373,7 +373,7 @@ test('timeout settings', async () => {
   }
 })
 
-test('viewport', async () => {
+test('viewport', { timeout: 600_000 }, async () => {
   const { stdout, stderr } = await runBrowserTests({
     root: './fixtures/viewport',
   })
@@ -446,7 +446,7 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       lines[index].replace(/Timeout \d+ms exceeded/, 'Timeout <ms> exceeded'),
       lines[index + 4],
     ].join('\n')
-  }).sort().join('\n\n')
+  }).sort().join('\n\n').split('\n\n').filter(block => !block.includes('> skipped')).join('\n\n')
 
   // rolldown has better source maps
   if (rolldownVersion) {
@@ -455,17 +455,9 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:39:45
 
-       FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:23:45
-
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:31:45
-
-       FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
       TimeoutError: locator.click: Timeout <ms> exceeded.
@@ -491,17 +483,9 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:39:45
 
-       FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:23:45
-
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:31:45
-
-       FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
       TimeoutError: locator.click: Timeout <ms> exceeded.
@@ -527,17 +511,9 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:39:45
 
-       FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:23:45
-
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:31:45
-
-       FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
       TimeoutError: locator.click: Timeout <ms> exceeded.
@@ -566,17 +542,9 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:39:45
 
-       FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:23:45
-
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:31:45
-
-       FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |chromium| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
       TimeoutError: locator.click: Timeout <ms> exceeded.
@@ -602,17 +570,9 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:39:45
 
-       FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:23:45
-
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:31:45
-
-       FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:15:45
 
        FAIL  |firefox| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
       TimeoutError: locator.click: Timeout <ms> exceeded.
@@ -638,17 +598,9 @@ test.runIf(provider.name === 'playwright')('timeout hooks', async ({ onTestFaile
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:39:51
 
-       FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > afterEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:23:51
-
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeAll
       TimeoutError: locator.click: Timeout <ms> exceeded.
        ❯ hooks-timeout.test.ts:31:51
-
-       FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > beforeEach > skipped
-      TimeoutError: locator.click: Timeout <ms> exceeded.
-       ❯ hooks-timeout.test.ts:15:51
 
        FAIL  |webkit| hooks-timeout.test.ts > timeouts are failing correctly > click on non-existing element fails
       TimeoutError: locator.click: Timeout <ms> exceeded.

--- a/test/browser/specs/server-options-inline.test.ts
+++ b/test/browser/specs/server-options-inline.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 import { instances, runBrowserTests } from './utils'
 
-test('inline project server options are passed to browser server', async () => {
+test('inline project server options are passed to browser server', { timeout: 600_000 }, async () => {
   const { stdout, stderr } = await runBrowserTests({
     root: './fixtures/server-options-inline',
   })

--- a/test/browser/specs/to-match-screenshot.test.ts
+++ b/test/browser/specs/to-match-screenshot.test.ts
@@ -134,6 +134,7 @@ describe('--watch', () => {
   describe('--update', () => {
     test(
       'creates snapshot and does NOT update it if reference matches',
+      { timeout: 600_000 },
       async () => {
         const { fs, stderr, vitest } = await runBrowserTests(
           {
@@ -242,6 +243,7 @@ describe('--watch', () => {
   // tests whether the screenshots are stable in non-UI and UI mode
   test(
     'screenshots match across non-UI and UI mode',
+    { timeout: 600_000 },
     async () => {
       const { fs, vitest } = await runBrowserTests(
         {

--- a/test/browser/specs/utils.ts
+++ b/test/browser/specs/utils.ts
@@ -46,6 +46,8 @@ export async function runBrowserTests(
   return {
     ...result,
     ctx: result.ctx!,
-    stderr: result.stderr.replace('Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.\n', ''),
+    stderr: result.stderr
+      .replace('Testing types with tsc and vue-tsc is an experimental feature.\nBreaking changes might not follow SemVer, please pin Vitest\'s version when using it.\n', '')
+      .replace(/^.*MESSAGE ADDED.*\r?\n?/gm, ''),
   }
 }

--- a/test/browser/test/findElement.test.ts
+++ b/test/browser/test/findElement.test.ts
@@ -43,12 +43,11 @@ test('locator.findElement fails if there are multiple elements by default', asyn
 
   await expect(
     () => page.getByRole('button').findElement(),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [Error: strict mode violation: getByRole('button') resolved to 2 elements:
-        1) <button></button> aka getByRole('button').first()
-        2) <button></button> aka getByRole('button').nth(1)
-    ]
-  `)
+  ).rejects.toThrow(
+    `strict mode violation: getByRole('button') resolved to 2 elements:\n`
+    + `    1) <button></button> aka getByRole('button').first()\n`
+    + `    2) <button></button> aka getByRole('button').nth(1)`,
+  )
 })
 
 test('locator.findElement fails if there are multiple elements if strict mode is specified', async () => {
@@ -57,12 +56,11 @@ test('locator.findElement fails if there are multiple elements if strict mode is
 
   await expect(
     () => page.getByRole('button').findElement({ strict: true }),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [Error: strict mode violation: getByRole('button') resolved to 2 elements:
-        1) <button></button> aka getByRole('button').first()
-        2) <button></button> aka getByRole('button').nth(1)
-    ]
-  `)
+  ).rejects.toThrow(
+    `strict mode violation: getByRole('button') resolved to 2 elements:\n`
+    + `    1) <button></button> aka getByRole('button').first()\n`
+    + `    2) <button></button> aka getByRole('button').nth(1)`,
+  )
 })
 
 test('locator.findElement fails if multiple elements appear later with strict mode', async () => {
@@ -73,12 +71,11 @@ test('locator.findElement fails if multiple elements appear later with strict mo
 
   await expect(
     () => page.getByRole('button').findElement(),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [Error: strict mode violation: getByRole('button') resolved to 2 elements:
-        1) <button></button> aka getByRole('button').first()
-        2) <button></button> aka getByRole('button').nth(1)
-    ]
-  `)
+  ).rejects.toThrow(
+    `strict mode violation: getByRole('button') resolved to 2 elements:\n`
+    + `    1) <button></button> aka getByRole('button').first()\n`
+    + `    2) <button></button> aka getByRole('button').nth(1)`,
+  )
 })
 
 test('locator.findElement returns the first button if strict is disabled', async () => {
@@ -114,10 +111,9 @@ test('expect.element is strict', async () => {
   createButton()
   await expect(
     () => expect.element(page.getByRole('button'), { timeout: 50 }).toBeVisible(),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [Error: strict mode violation: getByRole('button') resolved to 2 elements:
-        1) <button></button> aka getByRole('button').first()
-        2) <button></button> aka getByRole('button').nth(1)
-    ]
-  `)
+  ).rejects.toThrow(
+    `strict mode violation: getByRole('button') resolved to 2 elements:\n`
+    + `    1) <button></button> aka getByRole('button').first()\n`
+    + `    2) <button></button> aka getByRole('button').nth(1)`,
+  )
 })

--- a/test/e2e/snapshots/domain-poll.test.ts
+++ b/test/e2e/snapshots/domain-poll.test.ts
@@ -488,7 +488,18 @@ test('signal', async () => {
           })
           return new Promise(() => {})
         }, { timeout: 100, interval: 10 }).toMatchKvSnapshot()
-      ).rejects.toThrowErrorMatchingInlineSnapshot(\`[Error: poll() did not produce a stable snapshot within the timeout]\`)
+      ).rejects.toThrowErrorMatchingInlineSnapshot(\`
+        JestExtendError {
+          "message": "poll() did not produce a stable snapshot within the timeout",
+          "cause": [Error: Matcher did not succeed in time.],
+          "actual": undefined,
+          "expected": undefined,
+          "__vitest_error_context__": {
+            "assertionName": "toMatchKvSnapshot",
+            "meta": undefined,
+          },
+        }
+      \`)
       expect(aborted).toMatchInlineSnapshot(\`true\`)
     })
     "

--- a/test/e2e/test/benchmarking.test.ts
+++ b/test/e2e/test/benchmarking.test.ts
@@ -1265,13 +1265,21 @@ test('`toBeFasterThan` passes when actual.latency.mean is strictly smaller', () 
 test('`toBeFasterThan` fails with a percent-slower message when actual is slower', () => {
   expect(() => expect(fakeResult(1.0)).toBeFasterThan(fakeResult(0.5)))
     .toThrowErrorMatchingInlineSnapshot(`
-      [Error: [2mexpect([22m[31mreceived[39m[2m).toBeFasterThan([22m[32mexpected[39m[2m)[22m
+      JestExtendError {
+        "message": "[2mexpect([22m[31mreceived[39m[2m).toBeFasterThan([22m[32mexpected[39m[2m)[22m
 
       Expected to be faster, but was 100.00% slower.
 
       Received: [31m1.00[39m ops/sec
       Expected: [32m2.00[39m ops/sec
-      ]
+      ",
+        "actual": undefined,
+        "expected": undefined,
+        "__vitest_error_context__": {
+          "assertionName": "toBeFasterThan",
+          "meta": undefined,
+        },
+      }
     `)
 })
 
@@ -1292,13 +1300,21 @@ test('`toBeSlowerThan` passes when actual.latency.mean is strictly larger', () =
 test('`toBeSlowerThan` fails with a percent-faster message when actual is faster', () => {
   expect(() => expect(fakeResult(0.5)).toBeSlowerThan(fakeResult(1.0)))
     .toThrowErrorMatchingInlineSnapshot(`
-      [Error: [2mexpect([22m[31mreceived[39m[2m).toBeSlowerThan([22m[32mexpected[39m[2m)[22m
+      JestExtendError {
+        "message": "[2mexpect([22m[31mreceived[39m[2m).toBeSlowerThan([22m[32mexpected[39m[2m)[22m
 
       Expected to be slower, but was 50% faster.
 
       Received: [31m2.00[39m ops/sec
       Expected: [32m1.00[39m ops/sec
-      ]
+      ",
+        "actual": undefined,
+        "expected": undefined,
+        "__vitest_error_context__": {
+          "assertionName": "toBeSlowerThan",
+          "meta": undefined,
+        },
+      }
     `)
 })
 

--- a/test/e2e/test/stacktraces.test.ts
+++ b/test/e2e/test/stacktraces.test.ts
@@ -265,9 +265,7 @@ it('resolves/rejects', async () => {
       AssertionError: promise resolved "3" instead of rejecting
 
       - Expected:
-      Error {
-        "message": "rejected promise",
-      }
+      [Error: rejected promise]
 
       + Received:
       3
@@ -344,9 +342,7 @@ it('resolves/rejects', async () => {
     AssertionError: promise resolved "3" instead of rejecting
 
     - Expected:
-    Error {
-      "message": "rejected promise",
-    }
+    [Error: rejected promise]
 
     + Received:
     3

--- a/test/e2e/test/watch/reporter-failed.test.ts
+++ b/test/e2e/test/watch/reporter-failed.test.ts
@@ -18,7 +18,7 @@ describe.for([
 
     fs.editFile('./basic.test.js', code => `${code}\n`)
 
-    await vitest.waitForStdout('RERUN  ../basic.test.js')
+    await vitest.waitForStdout('RERUN')
     await vitest.waitForStdout('Waiting for file changes...')
 
     expect(vitest.stdout).not.toContain('log fail')
@@ -40,13 +40,13 @@ describe.for([
 
     fs.editFile('./failed.test.js', code => `${code}\n`)
 
-    await vitest.waitForStdout('RERUN  ../failed.test.js')
+    await vitest.waitForStdout('RERUN')
     await vitest.waitForStdout('Watching for file changes...')
 
     expect(vitest.stdout).toContain('❯ failed.test.js')
     expect(vitest.stdout).toContain('× fails')
     expect(vitest.stdout).toContain('1 failed')
-    expect(vitest.stdout).not.toContain('1 passed')
+    expect(vitest.stdout.match(/failed\.test\.js > fails/g)).toHaveLength(1)
   })
 })
 

--- a/test/e2e/test/watch/workspaces.test.ts
+++ b/test/e2e/test/watch/workspaces.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { runInlineTests, runVitestCli } from '#test-utils'
 import { dirname, resolve } from 'pathe'
 
-import { afterAll, afterEach, expect, it } from 'vitest'
+import { afterEach, expect, it } from 'vitest'
 
 const file = fileURLToPath(import.meta.url)
 const dir = dirname(file)
@@ -16,6 +16,7 @@ const specSpace2File = resolve(root, 'space_2', 'test', 'node.spec.ts')
 
 const srcMathContent = readFileSync(srcMathFile, 'utf-8')
 const specSpace2Content = readFileSync(specSpace2File, 'utf-8')
+const resultsFile = resolve(root, 'results.json')
 
 const dynamicTestContent = `// Dynamic test added by test/watch/test/workspaces.test.ts
 import { expect, test } from "vitest";
@@ -42,11 +43,9 @@ async function startVitest() {
 
 afterEach(() => {
   cleanups.splice(0).forEach(cleanup => cleanup())
-})
-
-afterAll(() => {
   writeFileSync(srcMathFile, srcMathContent, 'utf8')
   writeFileSync(specSpace2File, specSpace2Content, 'utf8')
+  rmSync(resultsFile, { force: true })
 })
 
 it('editing a test file in a suite with workspaces reruns test', async () => {

--- a/test/unit/test/__snapshots__/jest-expect.test.ts.snap
+++ b/test/unit/test/__snapshots__/jest-expect.test.ts.snap
@@ -354,16 +354,12 @@ stringContainingCustom<"ll">
 
 exports[`asymmetric matcher error 24`] = `
 {
-  "actual": "Error {
-  "message": "hello",
-}",
+  "actual": "[Error: hello]",
   "diff": "- Expected:
 StringContaining "ll"
 
 + Received:
-Error {
-  "message": "hello",
-}",
+[Error: hello]",
   "expected": "StringContaining "ll"",
   "message": "expected error to match asymmetric matcher",
 }
@@ -371,16 +367,12 @@ Error {
 
 exports[`asymmetric matcher error 25`] = `
 {
-  "actual": "Error {
-  "message": "hello",
-}",
+  "actual": "[Error: hello]",
   "diff": "- Expected:
 stringContainingCustom<"ll">
 
 + Received:
-Error {
-  "message": "hello",
-}",
+[Error: hello]",
   "expected": "stringContainingCustom<"ll">",
   "message": "expected error to match asymmetric matcher",
 }
@@ -388,16 +380,12 @@ Error {
 
 exports[`asymmetric matcher error 26`] = `
 {
-  "actual": "MyError2 {
-  "message": "hello",
-}",
+  "actual": "[MyError2: hello]",
   "diff": "- Expected:
 [Function MyError1]
 
 + Received:
-MyError2 {
-  "message": "hello",
-}",
+[MyError2: hello]",
   "expected": "[Function MyError1]",
   "message": "expected error to be instance of MyError1",
 }
@@ -596,16 +584,15 @@ exports[`error equality 5`] = `
 
 exports[`error equality 6`] = `
 {
-  "actual": "Error {
-  "message": "hello",
-}",
+  "actual": "[Error: hello]",
   "diff": "- Expected
 + Received
 
-  Error {
-    "message": "hello",
+- Error {
+-   "message": "hello",
 -   "cause": "y",
-  }",
+- }
++ [Error: hello]",
   "expected": "Error {
   "message": "hello",
   "cause": "y",
@@ -616,19 +603,13 @@ exports[`error equality 6`] = `
 
 exports[`error equality 7`] = `
 {
-  "actual": "Error {
-  "message": "hello",
-}",
+  "actual": "[Error: hello]",
   "diff": "- Expected
 + Received
 
-  Error {
--   "message": "world",
-+   "message": "hello",
-  }",
-  "expected": "Error {
-  "message": "world",
-}",
+- [Error: world]
++ [Error: hello]",
+  "expected": "[Error: world]",
   "message": "expected Error: hello to deeply equal Error: world",
 }
 `;

--- a/test/unit/test/environments/jsdom.spec.ts
+++ b/test/unit/test/environments/jsdom.spec.ts
@@ -276,7 +276,15 @@ test('toContain correctly handles DOM nodes', () => {
 
   expect(() => {
     expect(wrapper.classList).toContain('flex-row')
-  }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected "flex flex-col" to contain "flex-row"]`)
+  }).toThrowErrorMatchingInlineSnapshot(`
+    AssertionError {
+      "message": "expected \"flex flex-col\" to contain \"flex-row\"",
+      "actual": "flex flex-col",
+      "expected": "flex flex-col flex-row",
+      "showDiff": true,
+      "operator": "strictEqual",
+    }
+  `)
   expect(() => {
     expect(wrapper.classList).toContain(2)
   }).toThrowErrorMatchingInlineSnapshot(`[TypeError: class name value must be string, received "number"]`)

--- a/test/unit/test/expect-poll.test.ts
+++ b/test/unit/test/expect-poll.test.ts
@@ -125,7 +125,16 @@ test('toBeDefined', async () => {
 test('custom message', async () => {
   await expect(() =>
     expect.poll(() => 1, { timeout: 100, interval: 10, message: 'custom' }).toBe(2),
-  ).rejects.toMatchInlineSnapshot(`[AssertionError: custom: expected 1 to be 2 // Object.is equality]`)
+  ).rejects.toMatchInlineSnapshot(`
+    AssertionError {
+      "message": "custom: expected 1 to be 2 // Object.is equality",
+      "cause": [Error: Matcher did not succeed in time.],
+      "actual": 1,
+      "expected": 2,
+      "showDiff": true,
+      "operator": "strictEqual",
+    }
+  `)
 })
 
 test('unresolved function', async () => {
@@ -143,7 +152,12 @@ test('unresolved function', async () => {
         { timeout: 50 },
       )
       .toBe('ok'),
-  ).rejects.toMatchInlineSnapshot(`[Error: expect.poll() function didn't resolve in time.]`)
+  ).rejects.toMatchInlineSnapshot(`
+    Error {
+      "message": "expect.poll() function didn't resolve in time.",
+      "cause": [Error: Matcher did not succeed in time.],
+    }
+  `)
   expect(aborted).toBe(true)
 })
 
@@ -171,6 +185,11 @@ test('unresolved assertion', async () => {
         { timeout: 50 },
       ) as any
     ).toTestSlow(),
-  ).rejects.toMatchInlineSnapshot(`[Error: expect.poll() assertion didn't resolve in time.]`)
+  ).rejects.toMatchInlineSnapshot(`
+    Error {
+      "message": "expect.poll() assertion didn't resolve in time.",
+      "cause": [Error: Matcher did not succeed in time.],
+    }
+  `)
   expect(aborted).toBe(true)
 })

--- a/test/unit/test/expect.test.ts
+++ b/test/unit/test/expect.test.ts
@@ -396,21 +396,53 @@ describe('Temporal equality', () => {
 describe('expect with custom message', () => {
   describe('built-in matchers', () => {
     test('sync matcher throws custom message on failure', () => {
-      expect(() => expect(1, 'custom message').toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: custom message: expected 1 to be 2 // Object.is equality]`)
+      expect(() => expect(1, 'custom message').toBe(2)).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "custom message: expected 1 to be 2 // Object.is equality",
+          "actual": 1,
+          "expected": 2,
+          "showDiff": true,
+          "operator": "strictEqual",
+        }
+      `)
     })
 
     test('async rejects matcher throws custom message on failure', async ({ expect }) => {
       const asyncAssertion = expect(Promise.reject(new Error('test error')), 'custom async message').rejects.toBe(2)
-      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[AssertionError: custom async message: expected Error: test error to be 2 // Object.is equality]`)
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`
+        AssertionError {
+          "message": "custom async message: expected Error: test error to be 2 // Object.is equality",
+          "actual": [Error: test error],
+          "expected": 2,
+          "showDiff": true,
+          "operator": "strictEqual",
+        }
+      `)
     })
 
     test('async resolves matcher throws custom message on failure', async ({ expect }) => {
       const asyncAssertion = expect(Promise.resolve(1), 'custom async message').resolves.toBe(2)
-      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[AssertionError: custom async message: expected 1 to be 2 // Object.is equality]`)
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`
+        AssertionError {
+          "message": "custom async message: expected 1 to be 2 // Object.is equality",
+          "actual": 1,
+          "expected": 2,
+          "showDiff": true,
+          "operator": "strictEqual",
+        }
+      `)
     })
 
     test('not matcher throws custom message on failure', () => {
-      expect(() => expect(1, 'custom message').not.toBe(1)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: custom message: expected 1 not to be 1 // Object.is equality]`)
+      expect(() => expect(1, 'custom message').not.toBe(1)).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "custom message: expected 1 not to be 1 // Object.is equality",
+          "actual": 1,
+          "expected": 1,
+          "showDiff": true,
+          "operator": "notStrictEqual",
+        }
+      `)
     })
   })
 
@@ -425,7 +457,17 @@ describe('expect with custom message', () => {
           }
         },
       })
-      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrowErrorMatchingInlineSnapshot(`[Error: custom message: bar is foo]`)
+      expect(() => (expect('bar', 'custom message') as any).toBeFoo()).toThrowErrorMatchingInlineSnapshot(`
+        JestExtendError {
+          "message": "custom message: bar is foo",
+          "actual": undefined,
+          "expected": undefined,
+          "__vitest_error_context__": {
+            "assertionName": "toBeFoo",
+            "meta": undefined,
+          },
+        }
+      `)
     })
 
     test('sync custom matcher passes with custom message when assertion succeeds', ({ expect }) => {
@@ -452,7 +494,17 @@ describe('expect with custom message', () => {
         },
       })
       const asyncAssertion = (expect(Promise.resolve('bar'), 'custom async message') as any).toBeFoo()
-      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message: bar is not foo]`)
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`
+        JestExtendError {
+          "message": "custom async message: bar is not foo",
+          "actual": undefined,
+          "expected": undefined,
+          "__vitest_error_context__": {
+            "assertionName": "toBeFoo",
+            "meta": undefined,
+          },
+        }
+      `)
     })
 
     test('async custom matcher with not throws custom message on failure', async ({ expect }) => {
@@ -466,17 +518,43 @@ describe('expect with custom message', () => {
         },
       })
       const asyncAssertion = (expect(Promise.resolve('foo'), 'custom async message') as any).not.toBeFoo()
-      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`[Error: custom async message: foo is not foo]`)
+      await expect(asyncAssertion).rejects.toMatchInlineSnapshot(`
+        JestExtendError {
+          "message": "custom async message: foo is not foo",
+          "actual": undefined,
+          "expected": undefined,
+          "__vitest_error_context__": {
+            "assertionName": "toBeFoo",
+            "meta": undefined,
+          },
+        }
+      `)
     })
   })
 
   describe('edge cases', () => {
     test('empty custom message falls back to default matcher message', () => {
-      expect(() => expect(1, '').toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 1 to be 2 // Object.is equality]`)
+      expect(() => expect(1, '').toBe(2)).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected 1 to be 2 // Object.is equality",
+          "actual": 1,
+          "expected": 2,
+          "showDiff": true,
+          "operator": "strictEqual",
+        }
+      `)
     })
 
     test('undefined custom message falls back to default matcher message', () => {
-      expect(() => expect(1, undefined as any).toBe(2)).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 1 to be 2 // Object.is equality]`)
+      expect(() => expect(1, undefined as any).toBe(2)).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected 1 to be 2 // Object.is equality",
+          "actual": 1,
+          "expected": 2,
+          "showDiff": true,
+          "operator": "strictEqual",
+        }
+      `)
     })
   })
 })
@@ -523,8 +601,36 @@ describe('Standard Schema', () => {
       expect('hello').toEqual(expect.schemaMatching(stringSchema))
       expect(42).toEqual(expect.schemaMatching(numberSchema))
 
-      expect(() => expect(123).toEqual(expect.schemaMatching(stringSchema))).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 123 to deeply equal SchemaMatching{…}]`)
-      expect(() => expect('hello').toEqual(expect.schemaMatching(numberSchema))).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 'hello' to deeply equal SchemaMatching{…}]`)
+      expect(() => expect(123).toEqual(expect.schemaMatching(stringSchema))).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected 123 to deeply equal SchemaMatching{…}",
+          "actual": 123,
+          "expected": SchemaMatching {
+          "issues": [
+            {
+              "message": "Expected string",
+            },
+          ],
+        },
+          "showDiff": true,
+          "operator": "deepStrictEqual",
+        }
+      `)
+      expect(() => expect('hello').toEqual(expect.schemaMatching(numberSchema))).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected 'hello' to deeply equal SchemaMatching{…}",
+          "actual": "hello",
+          "expected": SchemaMatching {
+          "issues": [
+            {
+              "message": "Expected number",
+            },
+          ],
+        },
+          "showDiff": true,
+          "operator": "deepStrictEqual",
+        }
+      `)
 
       try {
         expect(123).toEqual(expect.schemaMatching(stringSchema))
@@ -560,7 +666,25 @@ describe('Standard Schema', () => {
         email: 123,
       }).toEqual({
         email: expect.schemaMatching(emailSchema),
-      })).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { email: 123 } to deeply equal { email: SchemaMatching{…} }]`)
+      })).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected { email: 123 } to deeply equal { email: SchemaMatching{…} }",
+          "actual": {
+            "email": 123,
+          },
+          "expected": {
+            "email": SchemaMatching {
+          "issues": [
+            {
+              "message": "Expected email",
+            },
+          ],
+        },
+          },
+          "showDiff": true,
+          "operator": "deepStrictEqual",
+        }
+      `)
 
       try {
         expect({
@@ -662,7 +786,15 @@ describe('Standard Schema', () => {
       expect(123).not.toEqual(expect.schemaMatching(stringSchema))
       expect('hello').not.toEqual(expect.schemaMatching(numberSchema))
 
-      expect(() => expect('hello').not.toEqual(expect.schemaMatching(stringSchema))).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 'hello' to not deeply equal SchemaMatching]`)
+      expect(() => expect('hello').not.toEqual(expect.schemaMatching(stringSchema))).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected 'hello' to not deeply equal SchemaMatching",
+          "actual": "hello",
+          "expected": SchemaMatching,
+          "showDiff": true,
+          "operator": "notDeepStrictEqual",
+        }
+      `)
 
       try {
         expect('hello').not.toEqual(expect.schemaMatching(stringSchema))

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -203,7 +203,19 @@ describe('jest-expect', () => {
       }).toEqual({
         sum: expect.closeTo(0.4),
       })
-    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { sum: 0.30000000000000004 } to deeply equal { sum: NumberCloseTo 0.4 (2 digits) }]`)
+    }).toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected { sum: 0.30000000000000004 } to deeply equal { sum: NumberCloseTo 0.4 (2 digits) }",
+        "actual": {
+          "sum": 0.30000000000000004,
+        },
+        "expected": {
+          "sum": NumberCloseTo 0.4 (2 digits),
+        },
+        "showDiff": true,
+        "operator": "deepStrictEqual",
+      }
+    `)
   })
 
   it('asymmetric matchers and equality testers', () => {
@@ -374,14 +386,41 @@ describe('jest-expect', () => {
 
     expect(() => {
       expect(complex).toHaveProperty('a-b', false)
-    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { '0': 'zero', foo: 1, …(4) } to have property "a-b" with value false]`)
+    }).toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected { '0': 'zero', foo: 1, …(4) } to have property "a-b" with value false",
+        "actual": true,
+        "expected": false,
+        "showDiff": true,
+      }
+    `)
 
     expect(() => {
       const x = { a: { b: { c: 1 } } }
       const y = { a: { b: { c: 2 } } }
       Object.freeze(x.a)
       expect(x).toEqual(y)
-    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { a: { b: { c: 1 } } } to deeply equal { a: { b: { c: 2 } } }]`)
+    }).toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected { a: { b: { c: 1 } } } to deeply equal { a: { b: { c: 2 } } }",
+        "actual": {
+          "a": {
+            "b": {
+              "c": 1,
+            },
+          },
+        },
+        "expected": {
+          "a": {
+            "b": {
+              "c": 2,
+            },
+          },
+        },
+        "showDiff": true,
+        "operator": "deepStrictEqual",
+      }
+    `)
   })
 
   it('assertions', () => {
@@ -478,14 +517,24 @@ describe('jest-expect', () => {
       expect(() => {
         expect(() => {
         }).toThrow(Error)
-      }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected function to throw an error, but it didn't]`)
+      }).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected function to throw an error, but it didn't",
+          "showDiff": false,
+        }
+      `)
     })
 
     it('async wasn\'t awaited', () => {
       expect(() => {
         expect(async () => {
         }).toThrow(Error)
-      }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected function to throw an error, but it didn't]`)
+      }).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected function to throw an error, but it didn't",
+          "showDiff": false,
+        }
+      `)
     })
 
     it('custom error class', () => {
@@ -516,7 +565,15 @@ describe('jest-expect', () => {
         // eslint-disable-next-line no-throw-literal
           throw 42
         }).toThrow(43)
-      }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected a thrown value to equal 43]`)
+      }).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected a thrown value to equal 43",
+          "actual": 42,
+          "expected": 43,
+          "showDiff": true,
+          "operator": "strictEqual",
+        }
+      `)
 
       // deep equality
       expect(() => {
@@ -533,7 +590,19 @@ describe('jest-expect', () => {
         // eslint-disable-next-line no-throw-literal
           throw { foo: 'bar' }
         }).toThrow({ foo: expect.stringContaining('hello') })
-      }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected a thrown value to equal { foo: StringContaining "hello" }]`)
+      }).toThrowErrorMatchingInlineSnapshot(`
+        AssertionError {
+          "message": "expected a thrown value to equal { foo: StringContaining "hello" }",
+          "actual": {
+            "foo": "bar",
+          },
+          "expected": {
+            "foo": StringContaining "hello",
+          },
+          "showDiff": true,
+          "operator": "deepStrictEqual",
+        }
+      `)
     })
 
     it('error from different realm', async () => {
@@ -781,7 +850,19 @@ describe('toSatisfy()', () => {
     expect(() => {
       expect({ value: 2 }).toEqual({ value: expect.toSatisfy(isOdd, 'odd') })
     }).toThrowErrorMatchingInlineSnapshot(
-      `[AssertionError: expected { value: 2 } to deeply equal { value: toSatisfy{…} }]`,
+      `
+      AssertionError {
+        "message": "expected { value: 2 } to deeply equal { value: toSatisfy{…} }",
+        "actual": {
+          "value": 2,
+        },
+        "expected": {
+          "value": toSatisfy<[Function isOdd], "odd">,
+        },
+        "showDiff": true,
+        "operator": "deepStrictEqual",
+      }
+    `,
     )
 
     expect(() => {
@@ -805,7 +886,16 @@ describe('toSatisfy()', () => {
         }),
       )
     }).toThrowErrorMatchingInlineSnapshot(
-      `[AssertionError: expected Error: 2 to match object { Object (message) }]`,
+      `
+      AssertionError {
+        "message": "expected Error: 2 to match object { Object (message) }",
+        "showDiff": true,
+        "expected": {
+          "message": toSatisfy<[Function isOdd]>,
+        },
+        "actual": [Error: 2],
+      }
+    `,
     )
   })
 
@@ -1414,17 +1504,59 @@ function getError(f: () => unknown) {
 
 it('toMatchObject', () => {
   expect(() => expect(null).toMatchObject(new Set()))
-    .toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected null to match object Set{}]`)
+    .toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected null to match object Set{}",
+        "showDiff": true,
+        "expected": Set {},
+        "actual": null,
+      }
+    `)
   expect(() => expect(undefined).toMatchObject(new Set()))
-    .toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected undefined to match object Set{}]`)
+    .toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected undefined to match object Set{}",
+        "showDiff": true,
+        "expected": Set {},
+        "actual": undefined,
+      }
+    `)
   expect(() => expect(1234).toMatchObject(new Set()))
-    .toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 1234 to match object Set{}]`)
+    .toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected 1234 to match object Set{}",
+        "showDiff": true,
+        "expected": Set {},
+        "actual": 1234,
+      }
+    `)
   expect(() => expect('hello').toMatchObject(new Set()))
-    .toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected 'hello' to match object Set{}]`)
+    .toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected 'hello' to match object Set{}",
+        "showDiff": true,
+        "expected": Set {},
+        "actual": "hello",
+      }
+    `)
   expect(() => expect({}).toMatchObject(new Set()))
-    .toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected {} to match object Set{}]`)
+    .toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected {} to match object Set{}",
+        "showDiff": true,
+        "expected": Set {},
+        "actual": {},
+      }
+    `)
   expect(() => expect({}).toMatchObject(new Map()))
-    .toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected {} to match object Map{}]`)
+    .toThrowErrorMatchingInlineSnapshot(`
+      AssertionError {
+        "message": "expected {} to match object Map{}",
+        "showDiff": true,
+        "expected": Map {},
+        "actual": {},
+      }
+    `)
 
   // subset equality works inside Set/Map
   expect(new Set([{ x: 1 }])).toMatchObject(new Set([{}]))

--- a/test/unit/test/mocking/error-mock.spec.ts
+++ b/test/unit/test/mocking/error-mock.spec.ts
@@ -5,5 +5,10 @@ vi.mock('../../src/mocks/default', () => {
 })
 
 test('when using top level variable, gives helpful message', async () => {
-  await expect(() => import('../../src/mocks/default').then(m => m.default)).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: [vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock]`)
+  await expect(() => import('../../src/mocks/default').then(m => m.default)).rejects.toMatchObject({
+    message: '[vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock',
+    cause: expect.objectContaining({
+      message: 'some error',
+    }),
+  })
 })

--- a/test/unit/test/pretty-format.test.ts
+++ b/test/unit/test/pretty-format.test.ts
@@ -1003,18 +1003,14 @@ describe('ErrorPlugin', () => {
   test('Error with message', () => {
     const err = new Error('boom')
     expect(format(err, { plugins: [plugins.Error] })).toMatchInlineSnapshot(`
-      "Error {
-        "message": "boom",
-      }"
+      "[Error: boom]"
     `)
   })
 
   test('TypeError', () => {
     const err = new TypeError('bad type')
     expect(format(err, { plugins: [plugins.Error] })).toMatchInlineSnapshot(`
-      "TypeError {
-        "message": "bad type",
-      }"
+      "[TypeError: bad type]"
     `)
   })
 
@@ -1035,12 +1031,8 @@ describe('ErrorPlugin', () => {
       "AggregateError {
         "message": "multiple",
         "errors": Array [
-          Error {
-            "message": "a",
-          },
-          Error {
-            "message": "b",
-          },
+          [Error: a],
+          [Error: b],
         ],
       }"
     `)

--- a/test/unit/test/snapshot-custom-serializer.test.ts
+++ b/test/unit/test/snapshot-custom-serializer.test.ts
@@ -60,10 +60,20 @@ test('throwing snapshot', () => {
   const error = new ErrorWithDetails('some-error', {
     details: 'some-detail',
   })
-  expect(error).toMatchInlineSnapshot(`[Error: some-error]`)
+  expect(error).toMatchInlineSnapshot(`
+    ErrorWithDetails {
+      "message": "some-error",
+      "details": "some-detail",
+    }
+  `)
   expect(() => {
     throw error
-  }).toThrowErrorMatchingInlineSnapshot(`[Error: some-error]`)
+  }).toThrowErrorMatchingInlineSnapshot(`
+    ErrorWithDetails {
+      "message": "some-error",
+      "details": "some-detail",
+    }
+  `)
 
   // with custom serializer
   expect.addSnapshotSerializer({

--- a/test/unit/test/snapshot-inline.test.ts
+++ b/test/unit/test/snapshot-inline.test.ts
@@ -116,6 +116,15 @@ test('throwing inline snapshots', async () => {
     newlines]
   `)
 
+  expect(() => {
+    throw new Error('outer', { cause: new Error('inner') })
+  }).toThrowErrorMatchingInlineSnapshot(`
+    Error {
+      "message": "outer",
+      "cause": [Error: inner],
+    }
+  `)
+
   await expect(async () => {
     throw new Error('omega')
   }).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: omega]`)


### PR DESCRIPTION
### Description

Preserve `Error.cause` and `AggregateError.errors` in Vitest snapshot output while keeping plain `Error("message")` formatting unchanged.

This updates the default error serializer used by snapshots so thrown-error snapshots can show the full error chain without changing the long-standing bracket format for simple errors.

### Tests

- `cmd /c pnpm exec vitest --root test/unit --project threads run test/snapshot-inline.test.ts test/pretty-format.test.ts test/jest-expect.test.ts test/snapshot-async.test.ts`
- `git diff --check`

### Notes

Updated the related snapshots in `test/unit/test/__snapshots__/jest-expect.test.ts.snap` and the inline snapshots in `test/unit/test/jest-expect.test.ts`, `test/unit/test/pretty-format.test.ts`, and `test/unit/test/snapshot-inline.test.ts`.