### PR TITLE
fix(cache): persist source map in fs module cache for coverage v8

### DIFF
--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -1,4 +1,4 @@
-import type { DevEnvironment, FetchResult } from 'vite'
+import type { DevEnvironment, FetchResult, Rollup } from 'vite'
 import type { Vitest } from '../core'
 import type { ResolvedConfig } from '../types/config'
 import fs, { existsSync, mkdirSync, readFileSync } from 'node:fs'
@@ -110,6 +110,7 @@ export class FileSystemModuleCache {
       code,
       importedUrls: meta.importedUrls,
       mappings: meta.mappings,
+      map: meta.map,
     }
   }
 
@@ -120,12 +121,19 @@ export class FileSystemModuleCache {
     mappings: boolean = false,
   ): Promise<void> {
     if ('code' in fetchResult) {
+      // Persist the source map explicitly. `inlineSourceMap` (in fetchModule.ts)
+      // only inlines maps that have a `version` field, so transforms whose map
+      // is the rollup sentinel `{ mappings: '' }` or otherwise non-standard
+      // would lose their map on cache hit — which silently breaks coverage v8
+      // (ast-v8-to-istanbul drops files with no source map).
+      const fetchMap = ('map' in fetchResult ? fetchResult.map : undefined) as Rollup.SourceMap | null | undefined
       const result = {
         file: fetchResult.file,
         id: fetchResult.id,
         url: fetchResult.url,
         importedUrls,
         mappings,
+        map: fetchMap ?? null,
       } satisfies Omit<CachedInlineModuleMeta, 'code'>
       debugFs?.(`${c.yellow('[write]')} ${fetchResult.id} is cached in ${cachedFilePath}`)
       await atomicWriteFile(cachedFilePath, `${fetchResult.code}${cacheComment}${this.toBase64(result)}`)
@@ -366,6 +374,7 @@ export interface CachedInlineModuleMeta {
   code: string
   mappings: boolean
   importedUrls: string[]
+  map?: Rollup.SourceMap | null
 }
 
 /**

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -242,8 +242,11 @@ class ModuleFetcher {
       return
     }
 
-    // keep the module graph in sync
-    let map: Rollup.SourceMap | null | { mappings: '' } = extractSourceMap(cachedModule.code)
+    // Prefer the explicitly persisted source map (added in saveCachedModule)
+    // because `inlineSourceMap` only inlines maps with a `version` field, so
+    // some transforms' maps wouldn't be recoverable via `extractSourceMap`
+    // alone — that breaks coverage v8 which silently drops files with no map.
+    let map: Rollup.SourceMap | null | { mappings: '' } = cachedModule.map ?? extractSourceMap(cachedModule.code)
     if (map && cachedModule.file) {
       map.file = cachedModule.file
     }

--- a/test/unit/test/fs-module-cache.test.ts
+++ b/test/unit/test/fs-module-cache.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Regression: when `experimental.fsModuleCache` is enabled, the v8 coverage
+ * provider used to silently drop files from the istanbul output on cache
+ * hits, because the cache read path recovered the source map only by
+ * re-parsing the inlined `//# sourceMappingURL` comment — which is missing
+ * for any transform whose map lacks a `version` field (e.g. the rollup
+ * `{ mappings: '' }` sentinel).
+ *
+ * The fix stores the map explicitly in the cache meta and prefers it on
+ * read. This test locks the contract at the cache-class level so future
+ * refactors do not silently regress coverage again.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from 'vitest'
+import { FileSystemModuleCache } from '../../../packages/vitest/src/node/cache/fsModuleCache'
+
+function makeCache() {
+  // Minimal Vitest stub — FileSystemModuleCache only reads `vite.config.root`
+  // and `config.experimental.fsModuleCachePath` during construction.
+  const vitest = {
+    vite: { config: { root: process.cwd() } },
+    config: { experimental: {}, coverage: { enabled: false } },
+    projects: [],
+    coverageProvider: undefined,
+  } as any
+  return new FileSystemModuleCache(vitest)
+}
+
+async function withTmp<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'vitest-fs-cache-'))
+  try {
+    return await fn(dir)
+  }
+  finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+test('saveCachedModule preserves the source map across a round trip', async () => {
+  const sampleMap = {
+    version: 3 as const,
+    sources: ['src/even.ts'],
+    sourcesContent: ['export const even = (n: number) => n % 2 === 0'],
+    names: [],
+    mappings: 'AAAA,OAAO,MAAM,CAAC',
+  }
+
+  await withTmp(async (dir) => {
+    const cache = makeCache()
+    const cachedFilePath = join(dir, 'entry.js')
+
+    await cache.saveCachedModule(cachedFilePath, {
+      file: '/repo/src/even.ts',
+      id: '/repo/src/even.ts',
+      url: '/repo/src/even.ts',
+      code: 'export const even = n => n % 2 === 0\n',
+      map: sampleMap as any,
+      invalidate: false,
+    } as any)
+
+    const round = await cache.getCachedModule(cachedFilePath)
+    expect(round).toBeDefined()
+    expect(round!.map).toEqual(sampleMap)
+  })
+})
+
+test('cache round-trip keeps a `{ mappings: "" }` rollup sentinel map intact', async () => {
+  // This is the case the original bug hit: the sentinel has no `version`, so
+  // `inlineSourceMap` refused to embed it into the cached code, and on read
+  // `extractSourceMap` (which only parses inlined data URIs) returned `null`.
+  // With the explicit meta field, the sentinel survives unchanged.
+  const sentinel = { mappings: '' } as const
+
+  await withTmp(async (dir) => {
+    const cache = makeCache()
+    const cachedFilePath = join(dir, 'entry.js')
+
+    await cache.saveCachedModule(cachedFilePath, {
+      file: '/repo/src/even.ts',
+      id: '/repo/src/even.ts',
+      url: '/repo/src/even.ts',
+      code: 'export const even = n => n % 2 === 0\n',
+      map: sentinel as any,
+      invalidate: false,
+    } as any)
+
+    const round = await cache.getCachedModule(cachedFilePath)
+    expect(round).toBeDefined()
+    expect(round!.map).toEqual(sentinel)
+  })
+})
+
+test('cache round-trip keeps a missing map as null', async () => {
+  // For results without a map (some plugin paths) we should still round-trip
+  // cleanly. Restoring `null` is fine — the consumer (fetchModule.ts) falls
+  // back to `extractSourceMap` and finally `{ mappings: '' }`.
+  await withTmp(async (dir) => {
+    const cache = makeCache()
+    const cachedFilePath = join(dir, 'entry.js')
+
+    await cache.saveCachedModule(cachedFilePath, {
+      file: '/repo/src/even.ts',
+      id: '/repo/src/even.ts',
+      url: '/repo/src/even.ts',
+      code: 'export const even = n => n % 2 === 0\n',
+      map: null,
+      invalidate: false,
+    } as any)
+
+    const round = await cache.getCachedModule(cachedFilePath)
+    expect(round).toBeDefined()
+    expect(round!.map ?? null).toBeNull()
+  })
+})


### PR DESCRIPTION
### Description

When `experimental.fsModuleCache` is enabled, the v8 coverage provider silently drops files from istanbul output on cache hits.

**Root cause.** `inlineSourceMap` (in `packages/vitest/src/node/environments/fetchModule.ts`) only inlines source maps that have a `version` field. Any transform whose map lacks `version` — the rollup `{ mappings: '' }` sentinel is the common case — is written to cache without an inline `//# sourceMappingURL`. On read, `getCachedModule` recovered the map *only* by re-parsing that inline comment via `extractSourceMap`, so for those files the cached `transformResult.map` was `null`.

Coverage v8 then calls `project.vite.environments[env].transformRequest(filepath)` during `convertCoverage`, gets `result.map === undefined`, hands `sourceMap: undefined` to `ast-v8-to-istanbul`, and the byte-offset → source-position translation silently returns an empty istanbul object for the file. Net effect: cached files show 0% (or strictly less than non-cache runs) coverage even though they executed.

**Fix.** Persist `fetchResult.map` explicitly in the cache meta and prefer it on read. `extractSourceMap(cachedModule.code)` is kept as a fallback so the contract for already-cached files is backwards-compatible.

### Reproduction context

Discovered on a real-world ~3000-file codebase: enabling `fsModuleCache` dropped ~135 files to 0% and reduced another ~100 to roughly half their non-cache coverage. Disabling the cache restored full coverage. The per-file regression is consistent across runs, matching the cache-key behavior (same source = same cache hit = same lost map).

### Tests

Added `test/unit/test/fs-module-cache.test.ts` covering the `FileSystemModuleCache.saveCachedModule` → `getCachedModule` round-trip for three cases:
- Standard rollup source map with `version`
- The `{ mappings: '' }` sentinel (the original failing case)
- Missing map (`null`) — to confirm we don't accidentally fabricate one

All three pass with the fix; the sentinel case fails on `main` because the cache round-trip returns `undefined` for `map`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.  
  Verified `pnpm vitest run test/unit/test/fs-module-cache.test.ts` (3 passed, vmThreads/threads/forks pools).

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.  
  No public API change; behavior fix only.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner.

### AI disclosure

This PR was prepared with Claude (Anthropic) as a coding assistant. A human reviewed the diagnosis, the fix, and the test against a real codebase that surfaced the bug.