### PR TITLE
fix: mock Temporal.Now with mocked system time

### DIFF
--- a/packages/vitest/src/integrations/mock/date.ts
+++ b/packages/vitest/src/integrations/mock/date.ts
@@ -26,6 +26,115 @@ SOFTWARE.
 export const RealDate: DateConstructor = Date
 
 let now: null | number = null
+type TemporalNowMethod = 'instant' | 'plainDateTimeISO' | 'plainDateISO' | 'plainTimeISO' | 'plainYearMonthISO' | 'plainMonthDayISO' | 'zonedDateTimeISO'
+
+const temporalNowMethods: TemporalNowMethod[] = [
+  'instant',
+  'plainDateTimeISO',
+  'plainDateISO',
+  'plainTimeISO',
+  'plainYearMonthISO',
+  'plainMonthDayISO',
+  'zonedDateTimeISO',
+]
+
+let originalTemporalNowDescriptors: Partial<Record<TemporalNowMethod, PropertyDescriptor | undefined>> | null = null
+let originalTemporalTimeZoneIdDescriptor: PropertyDescriptor | undefined
+
+function getTemporal(): any {
+  return (globalThis as any).Temporal as any
+}
+
+function getTemporalNowInstant(): any {
+  const Temporal = getTemporal()
+  return Temporal.Instant.fromEpochMilliseconds(Date.now())
+}
+
+function getTemporalNowZonedDateTimeISO(timeZone = getTemporal().Now.timeZoneId()): any {
+  return getTemporalNowInstant().toZonedDateTimeISO(timeZone)
+}
+
+function patchTemporalNow(): void {
+  const Temporal = getTemporal()
+  if (!Temporal?.Now) {
+    return
+  }
+
+  if (!originalTemporalNowDescriptors) {
+    originalTemporalNowDescriptors = {}
+    for (const method of temporalNowMethods) {
+      originalTemporalNowDescriptors[method] = Object.getOwnPropertyDescriptor(Temporal.Now, method)
+    }
+    originalTemporalTimeZoneIdDescriptor = Object.getOwnPropertyDescriptor(Temporal.Now, 'timeZoneId')
+  }
+
+  Object.defineProperty(Temporal.Now, 'instant', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: () => getTemporalNowInstant(),
+  })
+  Object.defineProperty(Temporal.Now, 'plainDateTimeISO', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: (timeZone?: string) => getTemporalNowZonedDateTimeISO(timeZone).toPlainDateTime(),
+  })
+  Object.defineProperty(Temporal.Now, 'plainDateISO', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: (timeZone?: string) => getTemporalNowZonedDateTimeISO(timeZone).toPlainDate(),
+  })
+  Object.defineProperty(Temporal.Now, 'plainTimeISO', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: (timeZone?: string) => getTemporalNowZonedDateTimeISO(timeZone).toPlainTime(),
+  })
+  Object.defineProperty(Temporal.Now, 'plainYearMonthISO', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: (timeZone?: string) => getTemporalNowZonedDateTimeISO(timeZone).toPlainYearMonth(),
+  })
+  Object.defineProperty(Temporal.Now, 'plainMonthDayISO', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: (timeZone?: string) => getTemporalNowZonedDateTimeISO(timeZone).toPlainMonthDay(),
+  })
+  Object.defineProperty(Temporal.Now, 'zonedDateTimeISO', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: (timeZone?: string) => getTemporalNowZonedDateTimeISO(timeZone),
+  })
+}
+
+function restoreTemporalNow(): void {
+  const Temporal = getTemporal()
+  if (!Temporal?.Now || !originalTemporalNowDescriptors) {
+    return
+  }
+
+  for (const method of temporalNowMethods) {
+    const descriptor = originalTemporalNowDescriptors[method]
+    if (descriptor) {
+      Object.defineProperty(Temporal.Now, method, descriptor)
+    }
+    else {
+      Reflect.deleteProperty(Temporal.Now, method)
+    }
+  }
+
+  if (originalTemporalTimeZoneIdDescriptor) {
+    Object.defineProperty(Temporal.Now, 'timeZoneId', originalTemporalTimeZoneIdDescriptor)
+  }
+
+  originalTemporalNowDescriptors = null
+  originalTemporalTimeZoneIdDescriptor = undefined
+}
 
 class MockDate extends RealDate {
   constructor()
@@ -101,10 +210,20 @@ export function mockDate(date: string | number | Date): void {
 
   // @ts-expect-error global
   globalThis.Date = MockDate
+  patchTemporalNow()
 
   now = dateObj.valueOf()
 }
 
 export function resetDate(): void {
   globalThis.Date = RealDate
+  restoreTemporalNow()
+}
+
+export function mockTemporalNow(): void {
+  patchTemporalNow()
+}
+
+export function resetTemporalNow(): void {
+  restoreTemporalNow()
 }

--- a/packages/vitest/src/integrations/mock/timers.ts
+++ b/packages/vitest/src/integrations/mock/timers.ts
@@ -13,7 +13,7 @@ import type {
 } from '@sinonjs/fake-timers'
 import { withGlobal } from '@sinonjs/fake-timers'
 import { isChildProcess } from '../../runtime/utils'
-import { mockDate, RealDate, resetDate } from './date'
+import { mockDate, mockTemporalNow, RealDate, resetDate, resetTemporalNow } from './date'
 
 export class FakeTimers {
   private _global: typeof globalThis
@@ -137,6 +137,9 @@ export class FakeTimers {
       resetDate()
       this._fakingDate = null
     }
+    else {
+      resetTemporalNow()
+    }
 
     if (this._fakingTime) {
       this._clock.uninstall()
@@ -180,6 +183,7 @@ export class FakeTimers {
       ignoreMissingTimers: true,
     })
 
+    mockTemporalNow()
     this._fakingTime = true
   }
 
@@ -200,6 +204,8 @@ export class FakeTimers {
       this._fakingDate = date ?? new Date(this.getRealSystemTime())
       mockDate(this._fakingDate)
     }
+
+    mockTemporalNow()
   }
 
   getMockedSystemTime(): Date | null {

--- a/test/unit/test/date-mock.test.ts
+++ b/test/unit/test/date-mock.test.ts
@@ -39,4 +39,47 @@ describe('testing date mock functionality', () => {
 
     expect(new Date()).toBeInstanceOf(Date)
   })
+
+  test('mocked system time also updates Temporal.Now', () => {
+    const originalTemporal = (globalThis as any).Temporal
+    const realNow = Date.now.bind(Date)
+
+    ;(globalThis as any).Temporal = {
+      Instant: {
+        fromEpochMilliseconds: (epochMilliseconds: number) => ({
+          epochMilliseconds,
+          toZonedDateTimeISO: () => ({
+            epochMilliseconds,
+            toPlainDateTime: () => ({ epochMilliseconds }),
+            toPlainDate: () => ({ epochMilliseconds }),
+            toPlainTime: () => ({ epochMilliseconds }),
+            toPlainYearMonth: () => ({ epochMilliseconds }),
+            toPlainMonthDay: () => ({ epochMilliseconds }),
+          }),
+        }),
+      },
+      Now: {
+        instant: () => ({ epochMilliseconds: realNow() }),
+        plainDateTimeISO: () => ({ epochMilliseconds: realNow() }),
+        plainDateISO: () => ({ epochMilliseconds: realNow() }),
+        plainTimeISO: () => ({ epochMilliseconds: realNow() }),
+        plainYearMonthISO: () => ({ epochMilliseconds: realNow() }),
+        plainMonthDayISO: () => ({ epochMilliseconds: realNow() }),
+        zonedDateTimeISO: () => ({ epochMilliseconds: realNow() }),
+        timeZoneId: () => 'UTC',
+      },
+    }
+
+    try {
+      const date = new Date(2000, 1, 1)
+
+      vi.setSystemTime(date)
+
+      expect((globalThis as any).Temporal.Now.instant().epochMilliseconds).toBe(date.valueOf())
+      expect((globalThis as any).Temporal.Now.plainDateTimeISO().epochMilliseconds).toBe(date.valueOf())
+    }
+    finally {
+      ;(globalThis as any).Temporal = originalTemporal
+    }
+  })
 })


### PR DESCRIPTION
This updates Vitest's timer mocking so `Temporal.Now` follows `vi.setSystemTime()` and fake timers, matching the mocked `Date` clock.

- patches `Temporal.Now` methods when timers are mocked
- restores the original `Temporal.Now` methods when timers are reset
- adds a regression test covering `Temporal.Now.instant()` and `Temporal.Now.plainDateTimeISO()`

Verified with:
- `corepack pnpm build`
- `corepack pnpm test date-mock.test.ts --run`

<!-- VITEST_AUTOMATED_PR -->
