### PR TITLE
fix: encode browser iframe query params

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -8,7 +8,7 @@ import { Traces } from 'vitest/internal/traces'
 // This needs to be tree shaken properly to not include the whole runner by accident
 import { generateFileHash } from '../../../vitest/src/utils/tasks.js'
 import { getUiAPI } from './ui'
-import { getBrowserState, getConfig } from './utils'
+import { createTestIframeSrc, getBrowserState, getConfig } from './utils'
 
 const ID_ALL = '__vitest_all__'
 
@@ -353,7 +353,7 @@ export class IframeOrchestrator {
 
   private createTestIframe(iframeId: string) {
     const iframe = document.createElement('iframe')
-    const src = `/?sessionId=${getBrowserState().sessionId}&iframeId=${iframeId}`
+    const src = createTestIframeSrc(getBrowserState().sessionId, iframeId, location.href)
     const config = getConfig()
 
     iframe.setAttribute('loading', 'eager')

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -34,6 +34,13 @@ export function getConfig(): SerializedConfig {
   return getBrowserState().config
 }
 
+export function createTestIframeSrc(sessionId: string, iframeId: string, locationHref: string) {
+  const src = new URL('/', locationHref)
+  src.searchParams.set('sessionId', sessionId)
+  src.searchParams.set('iframeId', iframeId)
+  return src.toString()
+}
+
 export function ensureAwaited<T>(promise: (error?: Error) => Promise<T>): Promise<T> {
   const test = getWorkerState().current
   if (!test || test.type !== 'test') {

--- a/test/browser/specs/iframe-path-encoding.test.ts
+++ b/test/browser/specs/iframe-path-encoding.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { createTestIframeSrc } from '../../../packages/browser/src/client/utils'
+
+test('iframe src encodes plus signs in file paths', () => {
+  const src = createTestIframeSrc(
+    'session-123',
+    'plus+/basic.test.ts',
+    'http://localhost/__vitest_test__/',
+  )
+
+  const url = new URL(src)
+
+  expect(url.searchParams.get('sessionId')).toBe('session-123')
+  expect(url.searchParams.get('iframeId')).toBe('plus+/basic.test.ts')
+  expect(src).toContain('iframeId=plus%2B%2Fbasic.test.ts')
+})


### PR DESCRIPTION
## Summary
- build the browser tester iframe URL with `URLSearchParams` instead of string interpolation
- extract the URL construction into a small helper so it can be tested directly
- add a regression test for `+` in the iframe path/query value encoding

## Verification
- `corepack pnpm exec vitest run --config vitest.config.unit.mts specs/iframe-path-encoding.test.ts --reporter=default`
- `corepack pnpm typecheck` in `packages/browser`

## Notes
- I reviewed the implementation and test coverage before pushing this branch.