### PR TITLE
fix: vi.stubEnv(key, undefined) removes the variable after process.env is reassigned

### DIFF
--- a/packages/vitest/src/runtime/worker.ts
+++ b/packages/vitest/src/runtime/worker.ts
@@ -110,5 +110,14 @@ function createImportMetaEnvProxy(): WorkerGlobalState['metaEnv'] {
 
       return true
     },
+    deleteProperty(_, key) {
+      if (typeof key !== 'string') {
+        return true
+      }
+
+      delete process.env[key]
+
+      return true
+    },
   }) as WorkerGlobalState['metaEnv']
 }

--- a/test/unit/test/stubs.test.ts
+++ b/test/unit/test/stubs.test.ts
@@ -82,6 +82,30 @@ describe('stubbing envs', () => {
     expect(process.env.VITE_TEST_UPDATE_ENV).toBe('development')
   })
 
+  it('stubs to undefined to remove the env var', () => {
+    vi.stubEnv('VITE_TEST_UPDATE_ENV', undefined)
+    expect('VITE_TEST_UPDATE_ENV' in process.env).toBe(false)
+    expect(process.env.VITE_TEST_UPDATE_ENV).toBeUndefined()
+    expect(import.meta.env.VITE_TEST_UPDATE_ENV).toBeUndefined()
+  })
+
+  it('stubs to undefined to remove the env var after process.env is reassigned', () => {
+    const original = process.env
+    // Code under test may reassign process.env to a fresh object. The metaEnv proxy
+    // must keep targeting the live process.env for deletes too, not the object it
+    // captured at init.
+    process.env = { ...original, VITE_TEST_UPDATE_ENV: 'development' }
+    try {
+      vi.stubEnv('VITE_TEST_UPDATE_ENV', undefined)
+      expect('VITE_TEST_UPDATE_ENV' in process.env).toBe(false)
+      expect(process.env.VITE_TEST_UPDATE_ENV).toBeUndefined()
+    }
+    finally {
+      process.env = original
+      vi.unstubAllEnvs()
+    }
+  })
+
   it('stubs and restores previously not defined env', () => {
     delete process.env.VITE_TEST_UPDATE_ENV
     vi.stubEnv('VITE_TEST_UPDATE_ENV', 'production')


### PR DESCRIPTION
### Description

`vi.stubEnv(key, undefined)` is documented to delete the variable, and it does in the common case. But when test code reassigns `process.env` to a new object (for example `process.env = {}` in a `beforeEach`), the variable is not removed and `process.env[key]` keeps its value.

The `import.meta.env` proxy created in the worker reads and writes the live `process.env` in its `get` and `set` traps, but it has no `deleteProperty` trap. So `delete` falls back to the default behaviour, which removes the key from the object the proxy was constructed with at worker init. Once `process.env` is reassigned, that captured target is stale, so the delete misses the current `process.env` and the variable survives.

This adds a `deleteProperty` trap that deletes from the live `process.env`, matching `get` and `set`.

Resolves #10525

### Tests

Added two cases to `test/unit/test/stubs.test.ts`: `stubEnv(key, undefined)` removes the var, and removes it even after `process.env` is reassigned. The second fails on `main` and passes with this change. Verified red to green across the threads, forks, and vmThreads pools.