### PR TITLE
fix(mocker): hoist vi.mock() for vite-plus/test imports [backport to v4]

### DIFF
--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -74,6 +74,12 @@ const regexpHoistable
   = /\b(?:vi|vitest)\s*\.\s*(?:mock|unmock|hoisted|doMock|doUnmock)\s*\(/
 const hashbangRE = /^#!.*\n/
 
+// Public redistributions of Vitest that re-export its mocking API (`vi`)
+// verbatim under their own specifier. Imports from these are treated as the
+// hoisted module so `vi.mock()` is hoisted for e.g.
+// `import { vi } from 'vite-plus/test'`, exactly as it is for `vitest`.
+const REDISTRIBUTED_HOISTED_MODULES = ['vite-plus/test']
+
 // this is a fork of Vite SSR transform
 export function hoistMocks(
   code: string,
@@ -132,8 +138,9 @@ export function hoistMocks(
   ) {
     const source = importNode.source.value as string
     // always hoist vitest import to top of the file, so
-    // "vi" helpers can access it
-    if (hoistedModule === source) {
+    // "vi" helpers can access it. Vitest redistributions that re-export the
+    // mocking API under their own specifier are recognized the same way.
+    if (hoistedModule === source || REDISTRIBUTED_HOISTED_MODULES.includes(source)) {
       hoistedModuleImported = true
       return
     }

--- a/test/core/test/injector-mock.test.ts
+++ b/test/core/test/injector-mock.test.ts
@@ -57,6 +57,21 @@ import { test } from 'vitest'
   `)
 })
 
+test('recognizes the vite-plus/test redistribution as the hoisted module', () => {
+  expect(hoistSimpleCode(`
+import { vi } from 'vite-plus/test'
+vi.mock('path', () => {})
+vi.unmock('path')
+vi.hoisted(() => {})
+  `)).toMatchInlineSnapshot(`
+    "vi.mock('path', () => {})
+    vi.unmock('path')
+    vi.hoisted(() => {})
+
+    import { vi } from 'vite-plus/test'"
+  `)
+})
+
 test('always hoists all imports but they are under mocks', () => {
   expect(hoistSimpleCode(`
   import { vi } from 'vitest'


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- backport https://github.com/vitest-dev/vitest/pull/10489
<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
