### PR TITLE
fix: mock window.print in browser mode (fix #7375)

### DIFF
--- a/packages/browser/src/client/tester/dialog.ts
+++ b/packages/browser/src/client/tester/dialog.ts
@@ -21,5 +21,6 @@ expect(${name}).toHaveBeenCalledWith(${formattedParams})
 export function setupDialogsSpy(): void {
   globalThis.alert = showPopupWarning('alert', undefined)
   globalThis.confirm = showPopupWarning('confirm', false, true)
+  globalThis.print = showPopupWarning('print', undefined)
   globalThis.prompt = showPopupWarning('prompt', null, 'your value')
 }

--- a/test/browser/fixtures/print-logs/test/dialog.test.ts
+++ b/test/browser/fixtures/print-logs/test/dialog.test.ts
@@ -13,3 +13,7 @@ it('prompt', async () => {
 it('confirm', async () => {
   expect(confirm('test')).toBe(false)
 })
+
+it('print', async () => {
+  expect(print()).toBeUndefined()
+})

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -257,6 +257,7 @@ error with a stack
   test('popup apis should log a warning', () => {
     expect(stderr).toContain('Vitest encountered a `alert("test")`')
     expect(stderr).toContain('Vitest encountered a `confirm("test")`')
+    expect(stderr).toContain('Vitest encountered a `print()`')
     expect(stderr).toContain('Vitest encountered a `prompt("test")`')
   })
 })


### PR DESCRIPTION
## Summary

- Add `window.print` to the browser-mode dialog shims
- Cover it in the print-logs browser fixture and warning assertion

## Test plan

- `git diff --check origin/main...HEAD`
- `pnpm exec eslint packages/browser/src/client/tester/dialog.ts test/browser/specs/runner.test.ts`
- `TEST_BROWSER=chromium pnpm -C test/browser run test-logs --run`

I could not run the full browser matrix locally because the Playwright firefox/webkit binaries are not installed in this checkout.

Disclosure: prepared with Codex assistance, then reviewed and tested locally as above.

Fixes #7375