### PR TITLE
fix(browser): wait for orchestrator readiness before resolving browser sessions [backport to v4]

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -37,6 +37,13 @@ export class IframeOrchestrator {
       'message',
       e => this.onGlobalChannelEvent(e),
     )
+
+    // Notify the server once the websocket is ready without blocking orchestrator creation.
+    void client.waitForConnection()
+      .then(() => client.rpc.onOrchestratorReady())
+      .catch((error) => {
+        debug('failed to notify orchestrator readiness', error)
+      })
   }
 
   public async createTesters(options: BrowserTesterOptions): Promise<void> {

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -69,7 +69,8 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
 
     if (type === 'orchestrator') {
       const session = sessions.getSession(sessionId)
-      // it's possible the session was already resolved by the preview provider
+      // it's possible the session was already resolved by the preview provider,
+      // but we still mark the websocket connection when the page reconnects
       session?.connected()
     }
 
@@ -84,7 +85,7 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
     wss.handleUpgrade(request, socket, head, (ws) => {
       wss.emit('connection', ws, request)
 
-      const { rpc, offCancel } = setupClient(project, rpcId, ws)
+      const { rpc, offCancel } = setupClient(project, rpcId, ws, { sessionId })
       const state = project.browser!.state as BrowserServerState
       const clients = type === 'tester' ? state.testers : state.orchestrators
       clients.set(rpcId, rpc)
@@ -151,7 +152,14 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
     }
   }
 
-  function setupClient(project: TestProject, rpcId: string, ws: WebSocket) {
+  function setupClient(
+    project: TestProject,
+    rpcId: string,
+    ws: WebSocket,
+    options: {
+      sessionId: string
+    },
+  ) {
     const mockResolver = new ServerMockResolver(globalServer.vite, {
       moduleDirectories: project.config?.deps?.moduleDirectories,
     })
@@ -159,6 +167,10 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
 
     const rpc = createBirpc<WebSocketBrowserEvents, WebSocketBrowserHandlers>(
       {
+        onOrchestratorReady() {
+          const sessions = vitest._browserSessions
+          sessions.getSession(options.sessionId)?.ready()
+        },
         async onUnhandledError(error, type) {
           if (error && typeof error === 'object') {
             const _error = error as TestError

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -21,6 +21,7 @@ export interface WebSocketBrowserHandlers {
   onTaskArtifactRecord: <Artifact extends TestArtifact>(testId: string, artifact: Artifact) => Promise<Artifact>
   onTaskUpdate: (method: TestExecutionMethod, packs: TaskResultPack[], events: TaskEventPack[]) => void
   onAfterSuiteRun: (meta: AfterSuiteRunMeta) => void
+  onOrchestratorReady: () => void
   cancelCurrentRun: (reason: CancelReason) => void
   getCountOfFailedTests: () => number
   readSnapshotFile: (id: string) => Promise<string | null>

--- a/packages/vitest/src/node/browser/sessions.ts
+++ b/packages/vitest/src/node/browser/sessions.ts
@@ -22,19 +22,32 @@ export class BrowserSessions {
     pool: { reject: (error: Error) => void },
     options?: { otelCarrier?: OTELCarrier },
   ): Promise<void> {
-    // this promise only waits for the WS connection with the orchestrator to be established
+    // this promise waits until the orchestrator is ready to accept RPC calls
     const defer = createDefer<void>()
-
+    let isConnected = false
+    let isReady = false
     const timeout = setTimeout(() => {
       defer.reject(new Error(`Failed to connect to the browser session "${sessionId}" [${project.name}] within the timeout.`))
     }, project.vitest.config.browser.connectTimeout ?? 60_000).unref()
+
+    const resolveIfReady = () => {
+      if (!isConnected || !isReady) {
+        return
+      }
+      defer.resolve()
+      clearTimeout(timeout)
+    }
 
     this.sessions.set(sessionId, {
       project,
       otelCarrier: options?.otelCarrier,
       connected: () => {
-        defer.resolve()
-        clearTimeout(timeout)
+        isConnected = true
+        resolveIfReady()
+      },
+      ready: () => {
+        isReady = true
+        resolveIfReady()
       },
       // this fails the whole test run and cancels the pool
       fail: (error: Error) => {

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -324,6 +324,7 @@ export interface BrowserServerStateSession {
   project: TestProject
   otelCarrier?: OTELCarrier
   connected: () => void
+  ready: () => void
   fail: (v: Error) => void
 }
 

--- a/test/core/test/browser-sessions.test.ts
+++ b/test/core/test/browser-sessions.test.ts
@@ -1,0 +1,73 @@
+import type { TestProject } from 'vitest/node'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { BrowserSessions } from '../../../packages/vitest/src/node/browser/sessions'
+
+function createProject(connectTimeout = 100) {
+  return { name: 'browser', vitest: { config: { browser: { connectTimeout } } } } as TestProject
+}
+
+describe('BrowserSessions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('resolves only after the session is connected and ready', async () => {
+    const sessions = new BrowserSessions()
+    const promise = sessions.createSession('session-id', createProject(), { reject() {} })
+    const session = sessions.getSession('session-id')
+    expect(session).toBeDefined()
+
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    session!.ready()
+    expect(resolved).toBe(false)
+
+    session!.connected()
+    await promise
+    expect(resolved).toBe(true)
+  })
+
+  describe('timeouts and failures', () => {
+    test('times out if the session connects but never becomes ready', async () => {
+      const sessions = new BrowserSessions()
+      const promise = sessions.createSession('session-id', createProject(), { reject() {} })
+
+      const session = sessions.getSession('session-id')
+      expect(session).toBeDefined()
+
+      const timeoutError = expect(promise).rejects.toThrowError(
+        'Failed to connect to the browser session "session-id" [browser] within the timeout.',
+      )
+
+      session!.connected()
+      await vi.advanceTimersByTimeAsync(101)
+
+      await timeoutError
+    })
+
+    test('fails the pool without waiting for the connect timeout', async () => {
+      const sessions = new BrowserSessions()
+      const poolReject = vi.fn()
+      const promise = sessions.createSession('session-id', createProject(), { reject: poolReject })
+
+      const session = sessions.getSession('session-id')
+      expect(session).toBeDefined()
+
+      const error = new Error('browser failed')
+      session!.fail(error)
+
+      await expect(promise).resolves.toBeUndefined()
+      expect(poolReject).toHaveBeenCalledExactlyOnceWith(error)
+
+      await vi.advanceTimersByTimeAsync(101)
+      expect(poolReject).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
Backport of https://github.com/vitest-dev/vitest/pull/10397