### PR TITLE
fix(spy): preserve class mock prototype methods

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -500,6 +500,21 @@ function createMock(
       try {
         if (new.target) {
           returnValue = Reflect.construct(implementation, args, new.target)
+          const implementationPrototype = (implementation as any).prototype
+          if (
+            prototypeMembers.length === 0
+            && new.target?.prototype
+            && implementationPrototype
+            && Object.getPrototypeOf(returnValue) === new.target.prototype
+          ) {
+            const { properties, descriptors } = getAllProperties(implementationPrototype)
+            for (const property of properties) {
+              if (property === 'constructor' || property in returnValue) {
+                continue
+              }
+              Object.defineProperty(returnValue, property, descriptors[property]!)
+            }
+          }
 
           // jest calls this before the implementation, but we have to resolve this _after_
           // because we cannot do it before the `Reflect.construct` called the custom implementation.

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -504,9 +504,9 @@ function createMock(
           if (
             // prototypeMembers is used by automocking case and we want to skip that case.
             prototypeMembers.length === 0
-            // TODO: no idea what
-            && new.target?.prototype
+            && new.target.prototype
             && implementationPrototype
+            // skip when constructor returns value
             && Object.getPrototypeOf(returnValue) === new.target.prototype
           ) {
             const { properties, descriptors } = getAllProperties(implementationPrototype)

--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -502,7 +502,9 @@ function createMock(
           returnValue = Reflect.construct(implementation, args, new.target)
           const implementationPrototype = (implementation as any).prototype
           if (
+            // prototypeMembers is used by automocking case and we want to skip that case.
             prototypeMembers.length === 0
+            // TODO: no idea what
             && new.target?.prototype
             && implementationPrototype
             && Object.getPrototypeOf(returnValue) === new.target.prototype

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -809,6 +809,24 @@ describe('vi.fn() implementations', () => {
     expect(new Mock().method()).toBe('mocked')
   })
 
+  test('vi.fn(class) does not copy prototype methods when constructor returns an object', () => {
+    const returned = { custom: true }
+    const Mock = vi.fn(class {
+      constructor() {
+        return returned as any
+      }
+
+      method() {
+        return 'mocked'
+      }
+    })
+
+    const instance = new Mock()
+
+    expect(instance).toBe(returned)
+    expect(instance.method).toBeUndefined()
+  })
+
   test('vi.fn(class) does not leak prototype methods from once implementations', () => {
     const Mock = vi.fn()
       .mockImplementationOnce(class {

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -799,6 +799,38 @@ describe('vi.fn() implementations', () => {
     expect(Mock.mock.calls).toEqual([['test', 42]])
   })
 
+  test('vi.fn(class) exposes prototype methods on constructed instances', () => {
+    const Mock = vi.fn(class {
+      method() {
+        return 'mocked'
+      }
+    })
+
+    expect(new Mock().method()).toBe('mocked')
+  })
+
+  test('vi.fn(class) does not leak prototype methods from once implementations', () => {
+    const Mock = vi.fn()
+      .mockImplementationOnce(class {
+        first() {
+          return 'first'
+        }
+      })
+      .mockImplementation(class {
+        second() {
+          return 'second'
+        }
+      })
+
+    const first = new Mock()
+    const second = new Mock()
+
+    expect(first.first()).toBe('first')
+    expect(first.second).toBeUndefined()
+    expect(second.second()).toBe('second')
+    expect(second.first).toBeUndefined()
+  })
+
   test('vi.fn() with mockReturnValue throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockReturnValue(42)

--- a/test/unit/test/mocking/vi-spyOn.test.ts
+++ b/test/unit/test/mocking/vi-spyOn.test.ts
@@ -262,6 +262,23 @@ describe('vi.spyOn() state', () => {
     assertStateEmpty(state)
   })
 
+  test('vi.spyOn() exposes mockImplementation class prototype methods', () => {
+    class OriginalClass {
+      method() {
+        return 'original'
+      }
+    }
+    const object = { Class: OriginalClass }
+
+    vi.spyOn(object, 'Class').mockImplementation(class MockClass extends OriginalClass {
+      method() {
+        return 'mocked'
+      }
+    })
+
+    expect(new object.Class().method()).toBe('mocked')
+  })
+
   test('vi.spyOn() spies and tracks overridden async calls', async () => {
     const object = createObject()
     const mock = vi.spyOn(object, 'async')


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

 - closes https://github.com/vitest-dev/vitest/issues/10553

#### Root cause

Vitest constructs class mocks by running the original/mock implementation constructor, but it uses the mock wrapper as `newTarget`. That means the constructor body and class fields run, but the allocated object inherits from `MockClass.prototype` instead of `ActualClass.prototype`. The gap is easiest to see by splitting construction into two conceptual phases: object allocation with a prototype, then constructor/class-field initialization.

```js
class ActualClass {
  constructor(...ctorArgs) {
    // In normal construction, `this` already inherits from ActualClass.prototype.
    // So `this.method1` is visible here.
  }

  method1() {} // lives on ActualClass.prototype
  method2 = () => {} // assigned as an own property during construction
}

const actualInstance = new ActualClass(...ctorArgs)
//
// This is equivalent to:
//
//   Reflect.construct(ActualClass, ctorArgs, ActualClass)
//
// which then semantically almost same as:
//
//   const actualInstance = Object.create(ActualClass.prototype)
//   // Creates this prototype chain:
//   //   actualInstance -> ActualClass.prototype -> Object.prototype
//   // This is why:
//   //   actualInstance.method1                 // found via ActualClass.prototype
//   //   actualInstance instanceof ActualClass  // true
//
//   ActualClass[[constructorBody]].apply(actualInstance, ctorArgs)
//   // Runs constructor/class-field initialization on `actualInstance`.
//   // This is why:
//   //   actualInstance.method2                 // own property assigned during construction

const MockClass = vi.fn(ActualClass)
const mockInstance = new MockClass(...ctorArgs)
//
// Vitest currently implements this as:
//
//   Reflect.construct(ActualClass, ctorArgs, MockClass)
//
// which mostly means:
//
//   const mockInstance = Object.create(MockClass.prototype)
//   // Creates this prototype chain:
//   //   mockInstance -> MockClass.prototype -> Object.prototype
//   //
//   // This is why:
//   //   mockInstance.method1                 // missing: ActualClass.prototype is not in the chain
//   //   mockInstance instanceof MockClass    // true
//   //   mockInstance instanceof ActualClass  // false
//
//   ActualClass[[constructorBody]].apply(mockInstance, ctorArgs)
//   // Runs constructor/class-field initialization on `mockInstance`.
//   // This is why:
//   //   mockInstance.method2                 // own property assigned during construction
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
