### PR TITLE
ci: `pkg-pr-new` comments with commit SHAs instead of PR number

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -45,4 +45,4 @@ jobs:
           VITE_TEST_WATCHER_DEBUG: 'false'
 
       - name: Publish to StackBlitz
-        run: pnpx pkg-pr-new publish --compact --no-template --pnpm './packages/*'
+        run: pnpx pkg-pr-new publish --compact --commentWithSha --no-template --pnpm './packages/*'


### PR DESCRIPTION
### Description

Installing `pkg-pr-new` release that references PR number can hit cache when trying to install it again. Using commit SHAs guarantees it's always fresh unique installation.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
