### PR TITLE
fix: do not wrap import.meta.env when it is an assignment target

### DIFF
--- a/packages/vitest/src/node/plugins/metaEnvReplacer.ts
+++ b/packages/vitest/src/node/plugins/metaEnvReplacer.ts
@@ -19,11 +19,19 @@ export function MetaEnvReplacerPlugin(): Plugin {
       const envs = cleanCode.matchAll(/\bimport\.meta\.env\b/g)
 
       for (const env of envs) {
-        s ||= new MagicString(code)
-
         const startIndex = env.index!
         const endIndex = startIndex + env[0].length
 
+        // Skip when `import.meta.env` itself is the target of an assignment
+        // (e.g. `import.meta.env = {}` or `import.meta.env ||= {}`). Wrapping it
+        // in `Object.assign(...)` would produce an invalid assignment target and
+        // a parse error. Property assignments like `import.meta.env.FOO = 1` are
+        // not affected because `import.meta.env` is followed by `.FOO` there.
+        if (isAssignmentTarget(cleanCode, endIndex)) {
+          continue
+        }
+
+        s ||= new MagicString(code)
         s.overwrite(
           startIndex,
           endIndex,
@@ -44,4 +52,12 @@ export function MetaEnvReplacerPlugin(): Plugin {
       }
     },
   }
+}
+
+// Matches an assignment operator (`=`, `+=`, `||=`, `??=`, etc.) right after the
+// given index, while ignoring comparisons (`==`, `===`) and arrow functions (`=>`).
+function isAssignmentTarget(code: string, index: number): boolean {
+  return /^\s*(?:\?\?=|\|\|=|&&=|\*\*=|>>>=|<<=|>>=|[-+*/%&|^]=|=(?![=>]))/.test(
+    code.slice(index),
+  )
 }

--- a/test/unit/test/env.test.ts
+++ b/test/unit/test/env.test.ts
@@ -22,6 +22,20 @@ test('can reassign env locally', () => {
   expect(import.meta.env.VITEST_ENV).toBe('TEST')
 })
 
+// https://github.com/vitest-dev/vitest/issues/10091
+test('can reassign import.meta.env itself', () => {
+  import.meta.env = import.meta.env || ({} as any)
+  import.meta.env.VITEST_ENV_REASSIGN = 'reassigned'
+  expect(import.meta.env.VITEST_ENV_REASSIGN).toBe('reassigned')
+})
+
+// https://github.com/vitest-dev/vitest/issues/10091
+test('can use logical assignment on import.meta.env', () => {
+  import.meta.env ||= {} as any
+  import.meta.env.VITEST_ENV_LOGICAL = 'logical'
+  expect(import.meta.env.VITEST_ENV_LOGICAL).toBe('logical')
+})
+
 test('can reassign env everywhere', () => {
   import.meta.env.AUTH_TOKEN = '123'
   expect(getAuthToken()).toBe('123')


### PR DESCRIPTION
### Description

Closes #10091

Assigning to `import.meta.env` **itself** (not one of its properties) throws a transform parse error:

```ts
import.meta.env = import.meta.env || {}
import.meta.env.__config__ = 'true'
```

```
[PARSE_ERROR] Cannot assign to this expression
 2 │ Object.assign(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env) = ...
```

#### Cause

`MetaEnvReplacerPlugin` rewrites **every** occurrence of `import.meta.env` to
`Object.assign(/* istanbul ignore next */ globalThis.__vitest_worker__?.metaEnv ?? import.meta.env)`
so that reads and property writes (`import.meta.env.FOO = 1`) are redirected to the worker's env proxy.

When `import.meta.env` is the **left-hand side of an assignment**, that rewrite produces `Object.assign(...) = ...`, which is not a valid assignment target — hence the parse error. The same happens with logical/compound assignment (`import.meta.env ||= {}`).

#### Fix

Skip the rewrite when `import.meta.env` is immediately followed by an assignment operator (`=`, `+=`, `||=`, `??=`, …), while still rewriting comparisons (`==`, `===`), arrow functions (`=>`), reads, and property assignments (`import.meta.env.FOO = 1`, where `import.meta.env` is followed by `.FOO`, not `=`).

### Tests

Added two cases to `test/unit/test/env.test.ts` (whole-object assignment and logical assignment) that fail with a parse error on `main` and pass with this change.

- [x] The PR references an issue (#10091).
- [x] Includes a test that fails without this PR but passes with it.

### Changesets
- [x] Prefixed with `fix:`.