### PR TITLE
fix(browser): apply LocatorByRoleOptions filter properties in getByRole

### DIFF
--- a/packages/browser-playwright/src/locators.ts
+++ b/packages/browser-playwright/src/locators.ts
@@ -89,7 +89,12 @@ page.extend({
     return new PlaywrightLocator(getByLabelSelector(text, options))
   },
   getByRole(role, options) {
-    return new PlaywrightLocator(getByRoleSelector(role, options))
+    const { hasText, hasNotText, has, hasNot, ...ariaOptions } = options ?? {}
+    const locator = new PlaywrightLocator(getByRoleSelector(role, ariaOptions))
+    if (hasText !== undefined || hasNotText !== undefined || has !== undefined || hasNot !== undefined) {
+      return locator.filter({ hasText, hasNotText, has, hasNot })
+    }
+    return locator
   },
   getByTestId(testId) {
     return new PlaywrightLocator(getByTestIdSelector(server.config.browser.locators.testIdAttribute, testId))

--- a/packages/browser-preview/src/locators.ts
+++ b/packages/browser-preview/src/locators.ts
@@ -105,7 +105,12 @@ page.extend({
     return new PreviewLocator(getByLabelSelector(text, options))
   },
   getByRole(role, options) {
-    return new PreviewLocator(getByRoleSelector(role, options))
+    const { hasText, hasNotText, has, hasNot, ...ariaOptions } = options ?? {}
+    const locator = new PreviewLocator(getByRoleSelector(role, ariaOptions))
+    if (hasText !== undefined || hasNotText !== undefined || has !== undefined || hasNot !== undefined) {
+      return locator.filter({ hasText, hasNotText, has, hasNot })
+    }
+    return locator
   },
   getByTestId(testId) {
     return new PreviewLocator(getByTestIdSelector(server.config.browser.locators.testIdAttribute, testId))

--- a/packages/browser/src/client/tester/locators.ts
+++ b/packages/browser/src/client/tester/locators.ts
@@ -246,7 +246,12 @@ export abstract class Locator {
   protected abstract elementLocator(element: Element): Locator
 
   public getByRole(role: string, options?: LocatorByRoleOptions): Locator {
-    return this.locator(getByRoleSelector(role, options))
+    const { hasText, hasNotText, has, hasNot, ...ariaOptions } = options ?? {}
+    const locator = this.locator(getByRoleSelector(role, ariaOptions))
+    if (hasText !== undefined || hasNotText !== undefined || has !== undefined || hasNot !== undefined) {
+      return locator.filter({ hasText, hasNotText, has, hasNot })
+    }
+    return locator
   }
 
   public getByAltText(text: string | RegExp, options?: LocatorOptions): Locator {

--- a/test/browser/fixtures/locators/query.test.ts
+++ b/test/browser/fixtures/locators/query.test.ts
@@ -157,3 +157,50 @@ describe('locator.filter', () => {
     )
   })
 })
+
+describe('getByRole inline filter options', () => {
+  test('hasText filters by text content', () => {
+    document.body.innerHTML = `
+    <button>A</button>
+    <button>B</button>
+    `
+    const locator = page.getByRole('button', { hasText: 'A' })
+    expect(locator.element()).toBe(document.querySelectorAll('button')[0])
+  })
+
+  test('hasNotText filters out matching text', () => {
+    document.body.innerHTML = `
+    <button>A</button>
+    <button>B</button>
+    `
+    const locator = page.getByRole('button', { hasNotText: 'B' })
+    expect(locator.element()).toBe(document.querySelectorAll('button')[0])
+  })
+
+  test('name and hasText can be combined', () => {
+    document.body.innerHTML = `
+    <button aria-label="submit">Save</button>
+    <button aria-label="submit">Cancel</button>
+    `
+    const locator = page.getByRole('button', { name: 'submit', hasText: 'Save' })
+    expect(locator.element()).toBe(document.querySelectorAll('button')[0])
+  })
+
+  test('has filters by nested locator', () => {
+    document.body.innerHTML = `
+    <article><span>Vitest</span></article>
+    <article><span>Playwright</span></article>
+    `
+    const locator = page.getByRole('article', { has: page.getByText('Vitest') })
+    expect(locator.element()).toBe(document.querySelectorAll('article')[0])
+  })
+
+  test('ARIA-only options still work without filter properties', () => {
+    document.body.innerHTML = `
+    <button>A</button>
+    <button disabled>B</button>
+    `
+    const locator = page.getByRole('button', { disabled: false })
+    expect(locator.element()).toBe(document.querySelectorAll('button')[0])
+  })
+})


### PR DESCRIPTION
`getByRole` accepts `LocatorByRoleOptions`, which extends `LocatorOptions` with filter properties (`hasText`, `hasNotText`, `has`, `hasNot`). When these are passed inline — e.g. `page.getByRole('button', { hasText: 'Save' })` — they're silently dropped. The `getByRoleSelector` function from `ivya` only handles ARIA attributes; it doesn't know about filter options.

The fix splits the options before calling `getByRoleSelector`: ARIA-only properties go to it, then any filter properties chain through `.filter()`. `Locator.filter()` already handles them correctly by building `internal:has-text`, `internal:has-not-text`, `internal:has`, and `internal:has-not` selectors. The fix applies in three places — the abstract `Locator.getByRole()` base method and both provider-specific overrides in `@vitest/browser-playwright` and `@vitest/browser-preview`.

Resolves #10295. Thanks @hi-ogawa for the clear minimal reproduction.

I used Claude to assist with this contribution.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Five regression tests added to `test/browser/fixtures/locators/query.test.ts`: `hasText` inline, `hasNotText` inline, ARIA `name` combined with `hasText`, `has` inline, and ARIA-only options pass through unchanged. Ran the browser locator suite locally on Chromium — all 19 tests pass. Full `pnpm test:ci` will run in CI.

### Documentation
- [x] If you introduce new functionality, document it.

Bug fix only — the filter options were already documented in the type definitions; they just weren't working.

### Changesets
- [x] Changes in changelog are generated from PR name. Prefix: `fix(browser):`.

<!-- VITEST_AUTOMATED_PR -->