### PR TITLE
fix(vitest): strip non-serializable functions from inline diff config

### DIFF
--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -1,3 +1,4 @@
+import type { SerializedDiffOptions } from '@vitest/utils/diff'
 import type { SerializedConfig } from '../../runtime/config'
 import type { TestProject } from '../project'
 import type { ApiConfig } from '../types/config'
@@ -42,8 +43,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
         allowWrite: api?.allowWrite,
       }
     })(project.isBrowserEnabled() ? config.browser.api : config.api),
-    // TODO: non serializable function?
-    diff: config.diff,
+    diff: serializeDiffOptions(config.diff),
     retry: config.retry,
     repeats: config.repeats,
     disableConsoleIntercept: config.disableConsoleIntercept,
@@ -160,5 +160,35 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       ?? globalConfig.slowTestThreshold
       ?? configDefaults.slowTestThreshold,
     disableColors: isAgent && !isForceColor(),
+  }
+}
+
+// `diff` can be an inline object containing color/compareKeys functions
+// (`DiffOptions`). Those functions are not structured-cloneable (threads pool)
+// and are silently dropped over `child_process` IPC (forks pool), so passing
+// the raw object to workers throws `DataCloneError`. Forward only the
+// serializable fields declared by `SerializedDiffOptions`; the function-based
+// options still require the file-path form, which workers import locally.
+function serializeDiffOptions(
+  diff: string | SerializedDiffOptions | undefined,
+): string | SerializedDiffOptions | undefined {
+  if (diff == null || typeof diff === 'string') {
+    return diff
+  }
+  return {
+    aAnnotation: diff.aAnnotation,
+    aIndicator: diff.aIndicator,
+    bAnnotation: diff.bAnnotation,
+    bIndicator: diff.bIndicator,
+    commonIndicator: diff.commonIndicator,
+    contextLines: diff.contextLines,
+    emptyFirstOrLastLinePlaceholder: diff.emptyFirstOrLastLinePlaceholder,
+    expand: diff.expand,
+    includeChangeCounts: diff.includeChangeCounts,
+    omitAnnotationLines: diff.omitAnnotationLines,
+    printBasicPrototype: diff.printBasicPrototype,
+    maxDepth: diff.maxDepth,
+    truncateThreshold: diff.truncateThreshold,
+    truncateAnnotation: diff.truncateAnnotation,
   }
 }

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -163,32 +163,42 @@ export function serializeConfig(project: TestProject): SerializedConfig {
   }
 }
 
+const serializableDiffKeys = [
+  'aAnnotation',
+  'aIndicator',
+  'bAnnotation',
+  'bIndicator',
+  'commonIndicator',
+  'contextLines',
+  'emptyFirstOrLastLinePlaceholder',
+  'expand',
+  'includeChangeCounts',
+  'omitAnnotationLines',
+  'printBasicPrototype',
+  'maxDepth',
+  'truncateThreshold',
+  'truncateAnnotation',
+] satisfies (keyof SerializedDiffOptions)[]
+
 // `diff` can be an inline object containing color/compareKeys functions
 // (`DiffOptions`). Those functions are not structured-cloneable (threads pool)
 // and are silently dropped over `child_process` IPC (forks pool), so passing
 // the raw object to workers throws `DataCloneError`. Forward only the
-// serializable fields declared by `SerializedDiffOptions`; the function-based
-// options still require the file-path form, which workers import locally.
+// serializable fields declared by `SerializedDiffOptions`, and only the ones
+// actually set — explicit `undefined` values would override the diff defaults
+// when the worker merges the options. The function-based options still
+// require the file-path form, which workers import locally.
 function serializeDiffOptions(
   diff: string | SerializedDiffOptions | undefined,
 ): string | SerializedDiffOptions | undefined {
   if (diff == null || typeof diff === 'string') {
     return diff
   }
-  return {
-    aAnnotation: diff.aAnnotation,
-    aIndicator: diff.aIndicator,
-    bAnnotation: diff.bAnnotation,
-    bIndicator: diff.bIndicator,
-    commonIndicator: diff.commonIndicator,
-    contextLines: diff.contextLines,
-    emptyFirstOrLastLinePlaceholder: diff.emptyFirstOrLastLinePlaceholder,
-    expand: diff.expand,
-    includeChangeCounts: diff.includeChangeCounts,
-    omitAnnotationLines: diff.omitAnnotationLines,
-    printBasicPrototype: diff.printBasicPrototype,
-    maxDepth: diff.maxDepth,
-    truncateThreshold: diff.truncateThreshold,
-    truncateAnnotation: diff.truncateAnnotation,
+  const result: SerializedDiffOptions = {}
+  for (const key of serializableDiffKeys) {
+    if (diff[key] !== undefined) {
+      (result as Record<string, unknown>)[key] = diff[key]
+    }
   }
+  return result
 }

--- a/test/e2e/test/reporters/custom-diff-config.test.ts
+++ b/test/e2e/test/reporters/custom-diff-config.test.ts
@@ -21,3 +21,31 @@ test('invalid diff config file', async () => {
   expect(stderr).toContain('invalid diff config file')
   expect(stderr).toContain('Must have a default export with config object')
 })
+
+// https://github.com/vitest-dev/vitest/issues/8663
+// An inline `diff` object may carry non-serializable color functions. They must
+// be stripped before the config is sent to workers, otherwise the `threads`
+// pool throws a `DataCloneError` (structured clone) and the `forks` pool drops
+// them over IPC. The serializable annotations must still be applied.
+test.each(['forks', 'threads'] as const)(
+  'inline diff config object with color functions works in %s pool',
+  async (pool) => {
+    const filename = resolve('./fixtures/reporters/custom-diff-config.test.ts')
+    const { stderr } = await runVitest({
+      root: './fixtures/reporters',
+      pool,
+      diff: {
+        aAnnotation: 'Expected to be',
+        bAnnotation: 'But got',
+        // @ts-expect-error color functions are not part of the public diff type,
+        // but users pass them at runtime — this is what used to crash the worker.
+        aColor: (s: string) => s,
+      },
+    }, [filename])
+
+    expect(stderr).not.toContain('could not be cloned')
+    expect(stderr).not.toContain('DataCloneError')
+    expect(stderr).toContain('Expected to be')
+    expect(stderr).toContain('But got')
+  },
+)


### PR DESCRIPTION
### Description

Fixes #8663.

When `test.diff` is given as an **inline object**, it may contain color/`compareKeys` functions (the public `DiffOptions` type). `serializeConfig` forwarded that object to the worker pool verbatim:

```ts
// TODO: non serializable function?
diff: config.diff,
```

Because functions are not serializable across the worker boundary, every run with an inline diff object that includes a function crashed the worker before any test ran:

- **`threads` / `vmThreads`** → `DataCloneError` on `postMessage` structured clone
- **`forks` / `vmForks`** → `(s) => s could not be cloned` on `child_process` IPC

The string (file-path) form was unaffected because only a string is serialized and the worker imports the module locally in `loadDiffConfig`.

### Fix

Strip the object down to the serializable fields already declared by `SerializedDiffOptions` before sending it to workers. This honors the existing contract — `SerializedDiffOptions` deliberately omits every `*Color`/`compareKeys` function field — and `loadDiffConfig` already accepts an object `diff` and uses it as-is. The function-based options continue to work via the file-path form, which the worker imports locally.

### Tests

Added a regression test in `test/e2e/test/reporters/custom-diff-config.test.ts` that runs with an inline diff object containing both serializable annotations and a color function, across the `forks` and `threads` pools. It asserts the run no longer crashes with `could not be cloned` and that the serializable annotations are still applied.

Verified the test fails without the fix (both pools throw `could not be cloned`) and passes with it.
