### PR TITLE
fix: collect cached in-source tests (fix #10577)

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -151,6 +151,7 @@ export function createPool(ctx: Vitest): ProcessPool {
           context: {
             files: specs.map(spec => ({
               filepath: spec.moduleId,
+              isInSourceTest: spec.isInSourceTest,
               fileTags: tags.get(spec),
               testLocations: spec.testLines,
               testNamePattern: spec.testNamePattern,

--- a/packages/vitest/src/node/pools/browser.ts
+++ b/packages/vitest/src/node/pools/browser.ts
@@ -74,6 +74,7 @@ export function createBrowserPool(vitest: Vitest): ProcessPool {
       const files = groupedFiles.get(project) || []
       files.push({
         filepath: moduleId,
+        isInSourceTest: spec.isInSourceTest,
         testLocations: testLines,
         testIds,
         testNamePattern,

--- a/packages/vitest/src/node/project.ts
+++ b/packages/vitest/src/node/project.ts
@@ -74,6 +74,7 @@ export class TestProject {
   /** @internal */ _fetcher!: VitestFetchFunction
   /** @internal */ _serializedDefines?: string
   /** @internal */ testFilesList: string[] | null = null
+  /** @internal */ inSourceTestFiles = new Set<string>()
   /** @internal */ _browserReadySessions = new Set<string>()
 
   private runner!: ModuleRunner
@@ -162,7 +163,9 @@ export class TestProject {
       this,
       moduleId,
       pool || getFilePoolName(this),
-      locationsOrOptions,
+      Array.isArray(locationsOrOptions)
+        ? { testLines: locationsOrOptions, isInSourceTest: this.inSourceTestFiles.has(moduleId) }
+        : { ...locationsOrOptions, isInSourceTest: this.inSourceTestFiles.has(moduleId) },
       taskIdOverride,
     )
   }
@@ -337,6 +340,8 @@ export class TestProject {
       return this.testFilesList
     }
 
+    this.inSourceTestFiles.clear()
+
     const testFiles = await this.globFiles(include, exclude, cwd)
 
     if (includeSource?.length) {
@@ -347,6 +352,7 @@ export class TestProject {
           try {
             const code = await fs.readFile(file, 'utf-8')
             if (this.isInSourceTestCode(code)) {
+              this.inSourceTestFiles.add(file)
               testFiles.push(file)
             }
           }

--- a/packages/vitest/src/node/test-specification.ts
+++ b/packages/vitest/src/node/test-specification.ts
@@ -6,6 +6,7 @@ import { relative } from 'pathe'
 import { generateFileHash } from '../utils/tasks'
 
 export interface TestSpecificationOptions {
+  isInSourceTest?: boolean
   testNamePattern?: RegExp
   testIds?: string[]
   testLines?: number[]
@@ -45,6 +46,10 @@ export class TestSpecification {
    * The tags of tests to run.
    */
   public testTagsFilter: string[] | undefined
+  /**
+   * Whether this specification was discovered via includeSource.
+   */
+  public isInSourceTest = false
 
   /**
    * This class represents a test suite for a test module within a single project.
@@ -71,6 +76,7 @@ export class TestSpecification {
       this.testLines = testLinesOrOptions
     }
     else if (testLinesOrOptions && typeof testLinesOrOptions === 'object') {
+      this.isInSourceTest = testLinesOrOptions.isInSourceTest ?? false
       this.testLines = testLinesOrOptions.testLines
       this.testNamePattern = testLinesOrOptions.testNamePattern
       this.testIds = testLinesOrOptions.testIds
@@ -98,6 +104,7 @@ export class TestSpecification {
       this.moduleId,
       {
         pool: this.pool,
+        isInSourceTest: this.isInSourceTest,
         testLines: this.testLines,
         testIds: this.testIds,
         testNamePattern: this.testNamePattern,

--- a/packages/vitest/src/runtime/runner/types.ts
+++ b/packages/vitest/src/runtime/runner/types.ts
@@ -1572,6 +1572,7 @@ export type TestArtifact
  */
 export interface FileSpecification {
   filepath: string
+  isInSourceTest?: boolean
   // file can be marked via a jsdoc comment to have tags,
   // these are _not_ tags to filter tests by
   fileTags?: string[]

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -8,6 +8,7 @@ import type { SerializedConfig } from '../config'
 import type {
   CancelReason,
   File,
+  FileSpecification,
   ImportDuration,
   Suite,
   Task,
@@ -26,6 +27,7 @@ import { getSnapshotClient } from '../../integrations/snapshot/chai'
 import { vi } from '../../integrations/vi'
 import { createFileTask, getNames, getTestName, getTests } from '../../utils/tasks'
 import { createBench, kFinalize } from '../benchmark'
+import { injectQuery } from '../moduleRunner/utils'
 import { rpc } from '../rpc'
 import { getFn, getHooks } from '../runner/map'
 import { createTaskCollector, getCurrentSuite } from '../runner/suite'
@@ -48,6 +50,7 @@ export class TestRunner implements VitestTestRunner {
    * @internal
    */
   public _otel!: Traces
+  public _currentSpecification?: FileSpecification | undefined
   public viteEnvironment: string
   private viteModuleRunner: boolean
 
@@ -72,8 +75,8 @@ export class TestRunner implements VitestTestRunner {
         },
       },
       () => {
-        if (!this.viteModuleRunner) {
-          filepath = `${filepath}?vitest=${Date.now()}`
+        if (!this.viteModuleRunner || (source === 'collect' && this._currentSpecification?.isInSourceTest)) {
+          filepath = injectQuery(filepath, `vitest=${Date.now()}`)
         }
         return this.moduleRunner.import(filepath)
       },

--- a/packages/vitest/src/runtime/types/utils.ts
+++ b/packages/vitest/src/runtime/types/utils.ts
@@ -3,6 +3,7 @@ export type SerializedTestSpecification = [
   file: string,
   options: {
     pool: string
+    isInSourceTest?: boolean | undefined
     testLines?: number[] | undefined
     testIds?: string[] | undefined
     testNamePattern?: RegExp | undefined

--- a/packages/vitest/src/utils/graph.ts
+++ b/packages/vitest/src/utils/graph.ts
@@ -17,7 +17,7 @@ export async function getModuleGraph(
 
   const environment = project.config.experimental.viteModuleRunner === false
     ? project.vite.environments.__vitest__
-    : getTestFileEnvironment(project, testFilePath, browser)
+    : getTestFileEnvironment(project, testFilePath, browser) ?? project.vite.environments.__vitest__
 
   if (!environment) {
     throw new Error(`Cannot find environment for ${testFilePath}`)

--- a/test/e2e/test/pool.test.ts
+++ b/test/e2e/test/pool.test.ts
@@ -2,7 +2,7 @@ import type { SerializedConfig } from 'vitest'
 import type { TestUserConfig } from 'vitest/node'
 import { normalize } from 'pathe'
 import { assert, describe, expect, test, vi } from 'vitest'
-import { runVitest, StableTestFileOrderSorter } from '../../test-utils'
+import { runInlineTests, runVitest, StableTestFileOrderSorter } from '../../test-utils'
 
 describe.each(['forks', 'threads', 'vmThreads', 'vmForks'])('%s', async (pool) => {
   test('resolves top-level pool', async () => {
@@ -87,6 +87,73 @@ test('non-isolated single worker pool receives all testfiles at once', async () 
       "<process-cwd>/fixtures/pool/c.test.ts",
       "<process-cwd>/fixtures/pool/print-testfiles.test.ts",
     ]
+  `)
+})
+
+test('non-isolated single worker pool collects in-source tests after importing the same files', async () => {
+  const { stderr, testTree } = await runInlineTests(
+    {
+      '0-import-source.test.ts': `
+        import { add } from './source-with-test'
+        import { multiply } from './source-importing-source'
+        import { expect, test } from 'vitest'
+
+        test('imports source files', () => {
+          expect(add(1, 2)).toBe(3)
+          expect(multiply(2, 3)).toBe(6)
+        })
+      `,
+      'source-with-test.ts': `
+        export function add(a: number, b: number) {
+          return a + b
+        }
+
+        if (import.meta.vitest) {
+          const { expect, test } = import.meta.vitest
+
+          test('add in source', () => {
+            expect(add(2, 3)).toBe(5)
+          })
+        }
+      `,
+      'source-importing-source.ts': `
+        import { add } from './source-with-test'
+
+        export function multiply(a: number, b: number) {
+          return Array.from({ length: b }).reduce<number>((total) => add(total, a), 0)
+        }
+
+        if (import.meta.vitest) {
+          const { expect, test } = import.meta.vitest
+
+          test('multiply in source', () => {
+            expect(multiply(2, 4)).toBe(8)
+          })
+        }
+      `,
+    },
+    {
+      include: ['0-import-source.test.ts'],
+      includeSource: ['source-*.ts'],
+      isolate: false,
+      maxWorkers: 1,
+      sequence: { sequencer: StableTestFileOrderSorter },
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "0-import-source.test.ts": {
+        "imports source files": "passed",
+      },
+      "source-importing-source.ts": {
+        "multiply in source": "passed",
+      },
+      "source-with-test.ts": {
+        "add in source": "passed",
+      },
+    }
   `)
 })
 

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -492,6 +492,59 @@ test.for([
   `)
 })
 
+test('html reporter can merge in-source test reports', async () => {
+  const root = resolve(process.cwd(), `vitest-test-${crypto.randomUUID()}`)
+  useFS(root, {
+    'import-source.test.ts': `
+import { value } from './source'
+import { expect, test } from 'vitest'
+
+test('imports source', () => {
+  expect(value).toBe(1)
+})
+`,
+    'source.ts': `
+export const value = 1
+
+if (import.meta.vitest) {
+  const { expect, test } = import.meta.vitest
+
+  test('in-source test', () => {
+    expect(value).toBe(1)
+  })
+}
+`,
+  })
+
+  const result1 = await runVitest({
+    root,
+    include: ['import-source.test.ts'],
+    includeSource: ['source.ts'],
+    isolate: false,
+    maxWorkers: 1,
+    reporters: ['blob'],
+  })
+  expect(result1.stderr).toMatchInlineSnapshot(`""`)
+  expect(result1.errorTree()).toMatchInlineSnapshot(`
+    {
+      "import-source.test.ts": {
+        "imports source": "passed",
+      },
+      "source.ts": {
+        "in-source test": "passed",
+      },
+    }
+  `)
+
+  const result2 = await runVitest({
+    root,
+    mergeReports: resolve(root, '.vitest/blob'),
+    reporters: ['html'],
+  })
+  expect(result2.stderr).toMatchInlineSnapshot(`""`)
+  expect(result2.stdout).toContain('HTML  Report is generated')
+})
+
 async function getSerializedModuleGraph(ctx: Vitest) {
   const files = ctx.state.getFiles().slice().sort((a, b) => a.filepath.localeCompare(b.filepath))
   const moduleGraphs = Object.fromEntries(


### PR DESCRIPTION
### Description

Resolves #10577.

When `isolate: false` and `maxWorkers: 1` are used, several test files can run in the same worker and share the module runner cache. If a regular test file imports a module that also contains in-source tests, that module is cached before it is later collected as an in-source test file. The later collection can then reuse the dependency import and report `No test suite found`.

This PR makes collection imports use Vitest's internal `?vitest=<timestamp>` query for the default module runner as well. The existing `experimental.viteModuleRunner: false` path already did this; this extends the same cache-busting behavior to normal collection imports while preserving setup import behavior.

AI assistance disclosure: I used Codex as a coding assistant while preparing this PR. I reviewed the issue, implementation, tests, and verification output before submitting.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by GitHub organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Targeted verification completed locally:

- `pnpm run build`
- red check before the fix: `pnpm -C test/e2e test test/pool.test.ts -t "collects in-source tests after importing"` failed with `No test suite found`
- `pnpm --filter vitest build`
- `pnpm -C test/e2e test test/pool.test.ts`
- `pnpm exec eslint packages/vitest/src/runtime/runners/test.ts test/e2e/test/pool.test.ts`
- `git diff --check`

`pnpm run typecheck` was attempted, but the current local dependency tree has duplicate Vite/PostCSS versions after install, causing unrelated cross-package type conflicts. `pnpm install --frozen-lockfile` also fails on the current checkout with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` before changing any files. I did not modify `pnpm-lock.yaml`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No user-facing API change.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
