### PR TITLE
test: add coverage for source module diagnostic

### DIFF
--- a/test/unit/test/module-diagnostic.test.ts
+++ b/test/unit/test/module-diagnostic.test.ts
@@ -3,24 +3,146 @@ import type { TestModule } from 'vitest/node'
 import { expect, test } from 'vitest'
 import { runInlineTests } from '../../test-utils'
 
-// TODO: write comprehensive tests
-test.skip('123', async () => {
-  const source = `
-import {} from './hello-world'
-import { test } from 'vitest'
-// import 'side-effect'
-// import * as m from 'module-import'
-// import * as m2 from "module-import-2"
-test('hello world')
-    `
-  const { fs, ctx } = await runInlineTests({
-    'source.test.js': source,
-    'hello-world': '',
-  })
-  const file = fs.resolveFile('./source.test.js')
+// `experimental_getSourceModuleDiagnostic` only attaches timings when the
+// `importDurations` experimental feature is collecting them, so it is enabled by default here.
+async function getDiagnostic(
+  structure: Record<string, string>,
+  moduleFile: string,
+  options?: { withTestModule?: boolean; importDurations?: boolean },
+) {
+  const importDurations = options?.importDurations ?? true
+  const { fs, ctx } = await runInlineTests(
+    structure,
+    importDurations ? { experimental: { importDurations: { limit: 100 } } } : {},
+  )
 
-  const testFile = ctx!.state.filesMap.get(file) as RunnerTestFile[] | undefined
-  const testModule = testFile?.length ? ctx!.state.getReportedEntity(testFile[0]) as TestModule : undefined
-  const diagnostic = await ctx!.experimental_getSourceModuleDiagnostic(file, testModule)
-  expect(diagnostic).toBeDefined()
+  const moduleId = fs.resolveFile(moduleFile)
+
+  let testModule: TestModule | undefined
+  if (options?.withTestModule) {
+    const testFile = ctx!.state.filesMap.get(moduleId) as RunnerTestFile[] | undefined
+    testModule = testFile?.length
+      ? ctx!.state.getReportedEntity(testFile[0]) as TestModule
+      : undefined
+  }
+
+  const diagnostic = await ctx!.experimental_getSourceModuleDiagnostic(moduleId, testModule)
+  return { diagnostic, moduleId }
+}
+
+type SourceModuleDiagnostic = Awaited<ReturnType<typeof getDiagnostic>>['diagnostic']
+
+function findByRawUrl(diagnostic: SourceModuleDiagnostic, rawUrl: string) {
+  return diagnostic.modules.filter(m => m.rawUrl === rawUrl)
+}
+
+test('collects imported modules with their source locations and durations', async ({ skip, task }) => {
+  skip(task.file.pool !== 'threads', 'run only once inside threads')
+
+  const source = `\nimport { foo } from './dep'\nimport { test } from 'vitest'\ntest('t', () => { foo() })\n`
+  const { diagnostic, moduleId } = await getDiagnostic(
+    {
+      'source.test.js': source,
+      'dep.js': `export const foo = () => 1`,
+    },
+    './source.test.js',
+    { withTestModule: true },
+  )
+
+  expect(diagnostic.untrackedModules).toEqual([])
+
+  const [dep] = findByRawUrl(diagnostic, './dep')
+  expect(dep).toBeDefined()
+
+  // the location maps back to the original import in the source, which verifies the
+  // SSR-transform -> source sourcemap resolution
+  expect(dep.start).toEqual({ line: 2, column: 20 })
+  expect(source.slice(dep.startIndex, dep.endIndex)).toBe(`'./dep'`)
+  expect(dep.resolvedId).toMatch(/dep\.js$/)
+  expect(dep.resolvedUrl).toBe('/dep.js')
+  expect(dep.importer).toBe(moduleId)
+  expect(dep.external).toBeFalsy()
+  expect(dep.selfTime).toBeGreaterThanOrEqual(0)
+  expect(dep.totalTime).toBeGreaterThanOrEqual(0)
+  expect(typeof dep.transformTime).toBe('number')
+
+  // bare specifiers resolved outside the project are flagged as external
+  const [vitestImport] = findByRawUrl(diagnostic, 'vitest')
+  expect(vitestImport).toBeDefined()
+  expect(vitestImport.external).toBe(true)
+})
+
+test('reports a module imported twice in the same file only once with a duration', async ({ skip, task }) => {
+  skip(task.file.pool !== 'threads', 'run only once inside threads')
+
+  const source = `\nimport { foo } from './dep'\nimport { foo as foo2 } from './dep'\nimport { test } from 'vitest'\ntest('t', () => { foo(); foo2() })\n`
+  const { diagnostic } = await getDiagnostic(
+    {
+      'source.test.js': source,
+      'dep.js': `export const foo = () => 1`,
+    },
+    './source.test.js',
+    { withTestModule: true },
+  )
+
+  const deps = findByRawUrl(diagnostic, './dep')
+  expect(deps).toHaveLength(2)
+
+  const [first, second] = deps
+  expect(first.resolvedId).toBe(second.resolvedId)
+  expect(first.start).not.toEqual(second.start)
+
+  // the duplicate import is zeroed out so the same cost is not counted twice
+  expect(second.selfTime).toBe(0)
+  expect(second.totalTime).toBe(0)
+  expect(second.transformTime).toBe(0)
+  expect(first.totalTime).toBeGreaterThanOrEqual(second.totalTime)
+})
+
+test('aggregates across all test modules when no test module is provided', async ({ skip, task }) => {
+  skip(task.file.pool !== 'threads', 'run only once inside threads')
+
+  const source = `\nimport { foo } from './dep'\nimport { test } from 'vitest'\ntest('t', () => { foo() })\n`
+  const { diagnostic } = await getDiagnostic(
+    {
+      'source.test.js': source,
+      'dep.js': `export const foo = () => 1`,
+    },
+    './source.test.js',
+    { withTestModule: false },
+  )
+
+  const [dep] = findByRawUrl(diagnostic, './dep')
+  expect(dep).toBeDefined()
+  expect(dep.resolvedId).toMatch(/dep\.js$/)
+  expect(dep.selfTime).toBeGreaterThanOrEqual(0)
+})
+
+test('returns an empty diagnostic for a module without imports', async ({ skip, task }) => {
+  skip(task.file.pool !== 'threads', 'run only once inside threads')
+
+  const { diagnostic } = await getDiagnostic(
+    {
+      'source.test.js': `import { test } from 'vitest'\ntest('t', () => {})\n`,
+      'lonely.js': `export const x = 1`,
+    },
+    './lonely.js',
+  )
+
+  expect(diagnostic).toEqual({ modules: [], untrackedModules: [] })
+})
+
+test('returns an empty diagnostic when import durations are disabled', async ({ skip, task }) => {
+  skip(task.file.pool !== 'threads', 'run only once inside threads')
+
+  const { diagnostic } = await getDiagnostic(
+    {
+      'source.test.js': `import { foo } from './dep'\nimport { test } from 'vitest'\ntest('t', () => { foo() })\n`,
+      'dep.js': `export const foo = () => 1`,
+    },
+    './source.test.js',
+    { withTestModule: true, importDurations: false },
+  )
+
+  expect(diagnostic).toEqual({ modules: [], untrackedModules: [] })
 })


### PR DESCRIPTION
### Description

`test/unit/test/module-diagnostic.test.ts` only contained a skipped placeholder (`test.skip('123', ...)` with a `// TODO: write comprehensive tests`). This PR replaces it with real coverage for `experimental_getSourceModuleDiagnostic` / the `module-diagnostic` collectors.

The tests drive the public API through `runInlineTests` (with `experimental.importDurations` enabled, since the diagnostic only attaches timings when durations are being collected) and assert on the deterministic structure of the result:

- imported modules are reported with their source locations mapped back through the SSR transform, along with `selfTime`/`totalTime`/`transformTime`, the resolving `importer`, and the `external` flag for bare specifiers;
- a module imported twice in the same file is reported once with a duration and the duplicate occurrence is zeroed out, so the same cost isn't counted twice;
- aggregation works when no `testModule` is provided (the `state.filesMap` branch);
- an empty diagnostic is returned for a module without imports and when `importDurations` is disabled.

Following the existing convention for nested-`runInlineTests` suites, the tests run only once in the `threads` pool.

Resolves #10510

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
