### PR TITLE
fix(spy): keep prototype methods on instances created from mocked classes

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -499,6 +499,24 @@ function createMock(
 
       try {
         if (new.target) {
+          // The created instance inherits from `new.target.prototype`, which
+          // is the mock's own prototype when the mock is constructed directly,
+          // so prototype methods of the implementation would be lost. Link the
+          // implementation's prototype into the chain instead; methods
+          // assigned directly on `mock.prototype` keep priority.
+          const implementationPrototype = (implementation as Constructable).prototype
+          if (
+            implementationPrototype
+            && typeof implementationPrototype === 'object'
+            // eslint-disable-next-line ts/no-use-before-define
+            && implementationPrototype !== mock.prototype
+            // eslint-disable-next-line ts/no-use-before-define
+            && Object.getPrototypeOf(mock.prototype) !== implementationPrototype
+          ) {
+            // eslint-disable-next-line ts/no-use-before-define
+            Object.setPrototypeOf(mock.prototype, implementationPrototype)
+          }
+
           returnValue = Reflect.construct(implementation, args, new.target)
 
           // jest calls this before the implementation, but we have to resolve this _after_

--- a/test/unit/test/jest-mock.test.ts
+++ b/test/unit/test/jest-mock.test.ts
@@ -617,10 +617,110 @@ describe('jest mock compat layer', () => {
     Spy.mockImplementation(MockExample)
 
     expect(new Spy()).toBeInstanceOf(Spy)
-    expect(new Spy()).not.toBeInstanceOf(MockExample)
+    // the implementation's prototype is linked into the chain so that
+    // instances keep its prototype methods (#10553)
+    expect(new Spy()).toBeInstanceOf(MockExample)
+    expect(typeof new Spy().test).toBe('function')
 
     const instance = new Spy()
     expectTypeOf(instance).toEqualTypeOf<Example>()
+  })
+
+  it('instances created from a spied class keep prototype methods', () => {
+    class Example {
+      test() {
+        return 'original'
+      }
+    }
+
+    const obj = { Example }
+    const Spy = vi.spyOn(obj, 'Example')
+
+    const instance = new obj.Example()
+
+    expect(instance).toBeInstanceOf(Spy)
+    expect(instance.test()).toBe('original')
+    expect(Spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('mockImplementation with a class keeps prototype methods (#10553)', () => {
+    class OriginalClass {
+      method() {
+        return 'original'
+      }
+    }
+
+    const myObj = { TestClass: OriginalClass }
+
+    vi.spyOn(myObj, 'TestClass').mockImplementation(
+      class MockClass extends OriginalClass {
+        method() {
+          return 'mocked'
+        }
+      },
+    )
+
+    const instance = new myObj.TestClass()
+
+    expect(typeof instance.method).toBe('function')
+    expect(instance.method()).toBe('mocked')
+    expect(instance).toBeInstanceOf(myObj.TestClass)
+    expect(instance).toBeInstanceOf(OriginalClass)
+  })
+
+  it('vi.fn with a class keeps prototype methods', () => {
+    const MockedClass = vi.fn(class {
+      method() {
+        return 'fn-mocked'
+      }
+    })
+
+    const instance = new MockedClass()
+
+    expect(instance.method()).toBe('fn-mocked')
+    expect(instance).toBeInstanceOf(MockedClass)
+  })
+
+  it('methods assigned on the mock prototype take priority over the implementation', () => {
+    class Example {
+      test() {
+        return 'class method'
+      }
+    }
+
+    const obj = { Example }
+    const Spy = vi.spyOn(obj, 'Example')
+    ;(Spy.prototype as any).test = vi.fn(() => 'assigned method')
+
+    const instance = new obj.Example() as any
+
+    expect(instance.test()).toBe('assigned method')
+  })
+
+  it('mockImplementationOnce with different classes resolves each prototype', () => {
+    class Example {
+      which() {
+        return 'original'
+      }
+    }
+
+    const obj = { Example }
+    const Spy = vi.spyOn(obj, 'Example')
+
+    Spy.mockImplementationOnce(class {
+      which() {
+        return 'A'
+      }
+    } as typeof Example)
+    Spy.mockImplementationOnce(class {
+      which() {
+        return 'B'
+      }
+    } as typeof Example)
+
+    expect(new obj.Example().which()).toBe('A')
+    expect(new obj.Example().which()).toBe('B')
+    expect(new obj.Example().which()).toBe('original')
   })
 
   it('returns temporary implementations from getMockImplementation()', () => {


### PR DESCRIPTION
### Description

Resolves #10553

When a mock is constructed, the instance is created with `Reflect.construct(implementation, args, new.target)`, where `new.target` is the mock itself — so the instance's prototype is `mock.prototype`, and any methods defined on the implementation's prototype are lost. This breaks the documented `mockImplementation(class { ... })` pattern:

```ts
vi.spyOn(myObj, "TestClass").mockImplementation(
  class MockClass extends OriginalClass {
    method() { return "mocked" }
  },
)

const instance = new myObj.TestClass()
typeof instance.method // "undefined" ❌
```

The same root cause also affects:
- plain `vi.spyOn(obj, 'Class')` with **no** mock implementation — constructed instances lose the original class's methods,
- `vi.fn(class { ... })` — instances lose the class's prototype methods.

(Class *fields* work because the constructor installs them as own properties; only prototype members are lost.)

### Fix

Before constructing, link the resolved implementation's prototype into the chain: `Object.setPrototypeOf(mock.prototype, implementation.prototype)`. The instance's chain becomes `instance → mock.prototype → implementation.prototype → ...`, which preserves the existing pinned semantics:

- `instance instanceof mock` stays `true` ([docs promise](https://vitest.dev/api/mock#class-support), `mocks constructors` test),
- methods assigned directly on `mock.prototype` (e.g. `Dog.prototype.speak = vi.fn()`) keep priority,
- the automocker path is unaffected — its member mocks live as own properties of `mock.prototype`,
- `mockImplementationOnce` with different classes resolves each class's prototype per construction.

⚠️ **One deliberate semantic change** that maintainers should weigh in on: the existing `spies on classes` test asserted `expect(new Spy()).not.toBeInstanceOf(MockExample)`. Prototype methods can only resolve through the prototype chain, so making `instance.method` work necessarily puts `MockExample.prototype` in the chain, and `instanceof MockExample` becomes `true`. I updated that assertion — it also matches how a real `class MockClass extends Original` instance would behave. If hiding the implementation class is intentional, an alternative is copying prototype descriptors instead of linking, but that breaks `mockImplementationOnce` sequencing and user-assigned method priority in subtle ways.

### Tests

- New tests covering: the issue repro (`extends` + override), plain `vi.spyOn` on a class, `vi.fn(class)`, `mock.prototype`-assigned method priority, and `mockImplementationOnce` with different classes.
- `test/unit` full suite: 2425 passed, type checks clean. (Browser-dependent e2e specs were skipped locally — no Playwright browsers installed.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. (#10553)
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`. (`test/unit` projects run locally; browser e2e requires Playwright binaries not available in my environment)

### Documentation
- [ ] No new functionality — existing documented behavior is fixed.

### Changesets
- [x] Changes in changelog are generated from PR name.