### PR TITLE
docs(ai-prompts): prefer test.for over test.each

### DIFF
--- a/docs/guide/learn/writing-tests-with-ai.md
+++ b/docs/guide/learn/writing-tests-with-ai.md
@@ -45,7 +45,7 @@ This tells the AI exactly which function to focus on, which scenarios matter, an
 ### Tips for Better Prompts
 
 - Ask for edge cases explicitly. "Include tests for empty inputs, boundary values, and error handling" produces more comprehensive coverage than leaving it to the AI's judgment. Without this nudge, most tools will generate a handful of happy-path tests and stop there.
-- Mention specific Vitest features if you want them used. "Use `toMatchInlineSnapshot` for the error messages" or "use `test.each` for the different currency formats" guides the AI toward the right tools instead of letting it fall back to repetitive copy-paste tests.
+- Mention specific Vitest features if you want them used. "Use `toMatchInlineSnapshot` for the error messages" or "use `test.for` for the different currency formats" guides the AI toward the right tools instead of letting it fall back to repetitive copy-paste tests.
 - If you're testing async code, say so. "The function returns a Promise" or "this calls an external API" helps the AI use `async`/`await` and appropriate matchers like `.resolves` and `.rejects`.
 - Tell the AI what *not* to do. "Test against the real implementation, don't mock any modules" or "don't use snapshot tests" prevents common defaults you don't want. AI tools tend to over-mock, and an explicit constraint prevents that.
 - Describe the test structure you want. "Group tests by method using `describe` blocks" or "use `test.extend` fixtures for the database connection instead of `beforeEach`" saves you from restructuring the output afterwards.


### PR DESCRIPTION
Update the AI prompting tips section to recommend test.for instead of test.each. This aligns the guide with Vitest's official stance of using test.for for new code, rather than relying on test.each which exists primarily for Jest compatibility.

In https://vitest.dev/guide/learn/writing-tests.html#parameterized-tests

it was stated that:
'Vitest also provides test.each, which you may recognize from Jest. It works similarly but spreads array arguments instead of passing them as a single value, and doesn't provide access to the Test Context. It exists mainly for Jest compatibility. Prefer test.for in new code.'

However,
In https://vitest.dev/guide/learn/writing-tests-with-ai.html#tips-for-better-prompts

Users were encourged to
'Mention specific Vitest features if you want them used. "Use toMatchInlineSnapshot for the error messages" or "use test.each for the different currency formats" guides the AI toward the right tools instead of letting it fall back to repetitive copy-paste tests.'

Changing it to "test.for" will further reinforce the recommendation to use test.for for new code instead of the test.each which exists only for Jest compatibility.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
