### PR TITLE
fix: collect in-source tests when the module is cached (fix #10577)

### DIFF
--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -72,7 +72,11 @@ export class TestRunner implements VitestTestRunner {
         },
       },
       () => {
-        if (!this.viteModuleRunner) {
+        const shouldInvalidate = !this.viteModuleRunner
+        // this is require for in-source tests to be invalidated if
+        // one of the files already imported it in --maxWorkers=1 --no-isolate
+          || (source === 'collect' && this.workerState.evaluatedModules.getModuleById(filepath)?.evaluated)
+        if (shouldInvalidate) {
           filepath = `${filepath}?vitest=${Date.now()}`
         }
         return this.moduleRunner.import(filepath)

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -58,11 +58,9 @@ export class TestRunner implements VitestTestRunner {
   }
 
   importFile(filepath: string, source: VitestRunnerImportSource): unknown {
-    if (source === 'setup') {
-      const moduleNode = this.workerState.evaluatedModules.getModuleById(filepath)
-      if (moduleNode) {
-        this.workerState.evaluatedModules.invalidateModule(moduleNode)
-      }
+    const moduleNode = this.workerState.evaluatedModules.getModuleById(filepath)
+    if (moduleNode && (source === 'setup' || moduleNode.evaluated)) {
+      this.workerState.evaluatedModules.invalidateModule(moduleNode)
     }
     return this._otel.$(
       `vitest.module.import_${source === 'setup' ? 'setup' : 'spec'}`,
@@ -72,11 +70,7 @@ export class TestRunner implements VitestTestRunner {
         },
       },
       () => {
-        const shouldInvalidate = !this.viteModuleRunner
-        // this is require for in-source tests to be invalidated if
-        // one of the files already imported it in --maxWorkers=1 --no-isolate
-          || (source === 'collect' && this.workerState.evaluatedModules.getModuleById(filepath)?.evaluated)
-        if (shouldInvalidate) {
+        if (!this.viteModuleRunner) {
           filepath = `${filepath}?vitest=${Date.now()}`
         }
         return this.moduleRunner.import(filepath)

--- a/test/e2e/test/in-source-collect.test.ts
+++ b/test/e2e/test/in-source-collect.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest'
+import { runInlineTests, StableTestFileOrderSorter, ts } from '../../test-utils'
+
+// https://github.com/vitest-dev/vitest/issues/10577
+test('in-source tests are collected when another test file has already put the source file in the module cache', async () => {
+  const { stderr, testTree } = await runInlineTests({
+    '1-math.test.ts': ts`
+      import { expect, test } from 'vitest'
+      import { add } from './2-math.js'
+
+      test('add', () => {
+        expect(add(1, 2)).toBe(3)
+      })
+    `,
+    '2-math.ts': ts`
+      export function add(a: number, b: number): number {
+        return a + b
+      }
+
+      if (import.meta.vitest) {
+        const { test, expect } = import.meta.vitest
+        test('add in-source', () => {
+          expect(add(1, 2)).toBe(3)
+        })
+      }
+    `,
+    'vitest.config.ts': {
+      test: {
+        includeSource: ['**/*.ts'],
+        // keep all files in a single worker so `2-math.ts` stays in the module cache
+        isolate: false,
+        maxWorkers: 1,
+      },
+    },
+  }, {
+    sequence: { sequencer: StableTestFileOrderSorter },
+  })
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "1-math.test.ts": {
+        "add": "passed",
+      },
+      "2-math.ts": {
+        "add in-source": "passed",
+      },
+    }
+  `)
+})

--- a/test/e2e/test/in-source-collect.test.ts
+++ b/test/e2e/test/in-source-collect.test.ts
@@ -48,3 +48,65 @@ test('in-source tests are collected when another test file has already put the s
     }
   `)
 })
+
+test('in-source tests in non-js files are transformed by extension-checking plugins when the module is cached', async () => {
+  const { stderr, testTree } = await runInlineTests({
+    '1-math.test.ts': ts`
+      import { expect, test } from 'vitest'
+      import { add } from './2-math.custom'
+
+      test('add', () => {
+        expect(add(1, 2)).toBe(3)
+      })
+    `,
+    '2-math.custom': ts`
+      lang custom
+      export function add(a, b) {
+        return a + b
+      }
+
+      if (import.meta.vitest) {
+        const { test, expect } = import.meta.vitest
+        test('add in-source', () => {
+          expect(add(1, 2)).toBe(3)
+        })
+      }
+    `,
+    'vitest.config.ts': `
+      import { defineConfig } from 'vitest/config'
+
+      export default defineConfig({
+        plugins: [
+          {
+            name: 'custom-lang',
+            transform(code, id) {
+              if (!id.endsWith('.custom')) {
+                return
+              }
+              return { code: code.replace('lang custom', ''), map: null }
+            },
+          },
+        ],
+        test: {
+          includeSource: ['**/*.custom'],
+          isolate: false,
+          maxWorkers: 1,
+        },
+      })
+    `,
+  }, {
+    sequence: { sequencer: StableTestFileOrderSorter },
+  })
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "1-math.test.ts": {
+        "add": "passed",
+      },
+      "2-math.custom": {
+        "add in-source": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

When in-source testing is used with both `isolate: false` and `maxWorkers: 1`, files that were already imported by another test file fail with `"No test suite found"`.
  
This happens because tests are registered as a side effect of importing the file. With this configuration, all test files share the same worker's module cache, so files that are already imported are not re-evaluated during collection and no tests are registered.

This was a known problem in the mode that runs tests with Node.js's native loader (`viteModuleRunner: false`), where a workaround is implemented in native.ts and nodejsWorkerLoader.ts in #9210, but it was not covered when running with the default Vite module runner.

This PR applies the same workaround to the default Vite module runner.

Resolves #10577

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
