### PR TITLE
fix(snapshot): make inline comment-skip regex non-greedy

### DIFF
--- a/packages/snapshot/src/port/inlineSnapshot.ts
+++ b/packages/snapshot/src/port/inlineSnapshot.ts
@@ -50,7 +50,7 @@ export async function saveInlineSnapshots(
 }
 
 const defaultStartObjectRegex
-  = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*(?:\/\*[\s\S]*\*\/\s*|\/\/.*(?:[\n\r\u2028\u2029]\s*|[\t\v\f \xA0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]))*\{/
+  = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*|\/\/.*(?:[\n\r\u2028\u2029]\s*|[\t\v\f \xA0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]))*\{/
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -160,7 +160,7 @@ function getCodeStartingAtIndex(code: string, index: number, methodNames: string
 }
 
 const defaultStartRegex
-  = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*(?:\/\*[\s\S]*\*\/\s*|\/\/.*(?:[\n\r\u2028\u2029]\s*|[\t\v\f \xA0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]))*[\w$]*(['"`)])/
+  = /(?:toMatchInlineSnapshot|toThrowErrorMatchingInlineSnapshot)\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*|\/\/.*(?:[\n\r\u2028\u2029]\s*|[\t\v\f \xA0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]))*[\w$]*(['"`)])/
 
 const buildStartRegex = memo((assertionName: string) => {
   const replaced = defaultStartRegex.source.replace(

--- a/test/e2e/snapshots/fixtures/inline-multiple-calls/comment-directive.test.ts
+++ b/test/e2e/snapshots/fixtures/inline-multiple-calls/comment-directive.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+
+test('block-comment directives, multiple calls', () => {
+  expect('alpha').toMatchInlineSnapshot(/* HTML */`"alpha"`)
+  expect('beta').toMatchInlineSnapshot(/* HTML */`"beta"`)
+  expect('gamma').toMatchInlineSnapshot(/* HTML */`"gamma"`)
+})

--- a/test/e2e/snapshots/inline-comment-directive.test.ts
+++ b/test/e2e/snapshots/inline-comment-directive.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs'
+import { join } from 'pathe'
+import { expect, test } from 'vitest'
+import { editFile, runVitest } from '../../test-utils'
+
+// Regression for the greedy comment-skip in the inline-snapshot updater
+// regexes (packages/snapshot/src/port/inlineSnapshot.ts). With multiple
+// `toMatchInlineSnapshot(/* … */)` calls carrying block-comment directives
+// in one file, the greedy `\/\*[\s\S]*\*\/` matched from the FIRST `/*` to
+// the LAST `*/`, so every earlier call's write coalesced onto the last
+// call's location. On update only the last snapshot was written, mangled
+// (`/* HTML */`"alpha"``"beta"``"gamma"`), and the earlier calls were left
+// empty — silently. The fix makes the comment-skip lazy (`[\s\S]*?`).
+
+test('multiple block-comment directives each get written on update', async () => {
+  const root = join(import.meta.dirname, 'fixtures/inline-multiple-calls')
+  const testFile = join(root, 'comment-directive.test.ts')
+
+  // reset: clear each snapshot to the empty `(/* HTML */)` form that triggers
+  // the bug, keeping its directive
+  editFile(testFile, s =>
+    s.replace(/toMatchInlineSnapshot\(\/\* HTML \*\/`[^`]*`\)/g, 'toMatchInlineSnapshot(/* HTML */)'))
+
+  const vitest = await runVitest({ root, include: [testFile], update: true })
+  expect(vitest.stderr).toBe('')
+
+  // Each call gets its own snapshot, on its own line. Pre-fix, only the last
+  // (`gamma`) landed — and mangled — while `alpha`/`beta` stayed empty.
+  const content = fs.readFileSync(testFile, 'utf-8')
+  expect(content).toContain('toMatchInlineSnapshot(/* HTML */`"alpha"`)')
+  expect(content).toContain('toMatchInlineSnapshot(/* HTML */`"beta"`)')
+  expect(content).toContain('toMatchInlineSnapshot(/* HTML */`"gamma"`)')
+})


### PR DESCRIPTION
### Description

Multiple `toMatchInlineSnapshot` / `toThrowErrorMatchingInlineSnapshot` calls in a single file that carry block-comment directives (e.g. `/* HTML */`) corrupt each other on `--update`: only the last snapshot is written — mangled — and the earlier ones are silently left empty.

**Root cause.** The comment-skip alternative in `defaultStartObjectRegex` and `defaultStartRegex` (`packages/snapshot/src/port/inlineSnapshot.ts`) uses a greedy `\/\*[\s\S]*\*\/`. When several such calls share a file, the per-call match runs from that call's `/*` to the **last** call's `*/`, so each earlier call's computed start index lands inside the last call. `MagicString` then coalesces the overlapping `overwrite()`s onto that one location. The run still reports success, so the corruption is silent.

**Repro** (`vitest --update`):

```ts
test('x', () => {
  expect('a').toMatchInlineSnapshot(/* HTML */)
  expect('b').toMatchInlineSnapshot(/* HTML */)
  expect('c').toMatchInlineSnapshot(/* HTML */)
})
```

Before — only the last call writes, mangled; `a`/`b` are left empty:

```ts
  expect('a').toMatchInlineSnapshot(/* HTML */)
  expect('b').toMatchInlineSnapshot(/* HTML */)
  expect('c').toMatchInlineSnapshot(/* HTML */`"a"``"b"``"c"`)
```

After — each call writes on its own line:

```ts
  expect('a').toMatchInlineSnapshot(/* HTML */`"a"`)
  expect('b').toMatchInlineSnapshot(/* HTML */`"b"`)
  expect('c').toMatchInlineSnapshot(/* HTML */`"c"`)
```

**Fix.** Make the comment-skip lazy (`[\s\S]*` → `[\s\S]*?`) in both regexes. A block comment cannot legally contain `*/`, so the lazy form is equivalent for valid input — it simply stops at each call's own comment close.

Related: #8632 is a different comment-position case (a comment between the method name and `()`, single call); it is **not** addressed by this change.

### Tests

Adds an e2e regression — `test/e2e/snapshots/inline-comment-directive.test.ts` with fixture `test/e2e/snapshots/fixtures/inline-multiple-calls/comment-directive.test.ts`. It fails before this change (only `gamma` written, mangled) and passes after.

Verified locally:
- New regression: fails on `main`, passes with the fix.
- Existing `inline-multiple-calls`, `soft-inline`, `domain-inline` e2e suites: pass.
- Unit `snapshot-inline` suite: pass.
- No `pnpm-lock.yaml` changes.
