### PR TITLE
docs: fix JavaScript capitalization

### DIFF
--- a/docs/guide/coverage.md
+++ b/docs/guide/coverage.md
@@ -47,7 +47,7 @@ This allows users to have the speed of V8 coverage with accuracy of Istanbul cov
 :::
 
 By default Vitest uses `'v8'` coverage provider.
-This provider requires Javascript runtime that's implemented on top of [V8 engine](https://v8.dev/), such as NodeJS, Deno or any Chromium based browsers such as Google Chrome.
+This provider requires JavaScript runtime that's implemented on top of [V8 engine](https://v8.dev/), such as NodeJS, Deno or any Chromium based browsers such as Google Chrome.
 
 Coverage collection is performed during runtime by instructing V8 using [`node:inspector`](https://nodejs.org/api/inspector.html) and [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/tot/Profiler/) in browsers. User's source files can be executed as-is without any pre-instrumentation steps.
 
@@ -82,9 +82,9 @@ import Box from '../.vitepress/components/Box.vue'
 ## Istanbul Provider
 
 [Istanbul code coverage tooling](https://istanbul.js.org/) has existed since 2012 and is very well battle-tested.
-This provider works on any Javascript runtime as coverage tracking is done by instrumenting user's source files.
+This provider works on any JavaScript runtime as coverage tracking is done by instrumenting user's source files.
 
-In practice, instrumenting source files means adding additional Javascript in user's files:
+In practice, instrumenting source files means adding additional JavaScript in user's files:
 
 ```js
 // Simplified example of branch and function coverage counters
@@ -113,7 +113,7 @@ globalThis.__VITEST_COVERAGE__ ||= {} // [!code ++]
 globalThis.__VITEST_COVERAGE__[filename] = coverage // [!code ++]
 ```
 
-- ✅ Works on any Javascript runtime
+- ✅ Works on any JavaScript runtime
 - ✅ Widely used and battle-tested for over 13 years.
 - ✅ In some cases faster than V8. Coverage instrumentation can be limited to specific files, as opposed to V8 where all modules are instrumented.
 - ❌ Requires pre-instrumentation step
@@ -128,7 +128,7 @@ globalThis.__VITEST_COVERAGE__[filename] = coverage // [!code ++]
   <ArrowDown />
   <Box>Run file</Box>
   <ArrowDown />
-  <Box>Collect coverage results from Javascript scope</Box>
+  <Box>Collect coverage results from JavaScript scope</Box>
   <ArrowDown />
   <Box>Remap coverage results to source files</Box>
   <ArrowDown />

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -195,7 +195,7 @@ In previous versions Vitest included all uncovered files in coverage report by d
 This was due to `coverage.all` defaulting to `true`, and `coverage.include` defaulting to `**`.
 These default values were chosen for a good reason - it is impossible for testing tools to guess where users are storing their source files.
 
-This ended up having Vitest's coverage providers processing unexpected files, like minified Javascript, leading to slow/stuck coverage report generations.
+This ended up having Vitest's coverage providers processing unexpected files, like minified JavaScript, leading to slow/stuck coverage report generations.
 In Vitest v4 we have removed `coverage.all` completely and <ins>**defaulted to include only covered files in the report**</ins>.
 
 When upgrading to v4 it is recommended to define `coverage.include` in your configuration, and then start applying simple `coverage.exclude` patterns if needed.

--- a/docs/guide/profiling-test-performance.md
+++ b/docs/guide/profiling-test-performance.md
@@ -230,7 +230,7 @@ $ DEBUG=vitest:coverage vitest --run --coverage
 ```
 
 This profiling approach is great for detecting large files that are accidentally picked by coverage providers.
-For example if your configuration is accidentally including large built minified Javascript files in code coverage, they should appear in logs.
+For example if your configuration is accidentally including large built minified JavaScript files in code coverage, they should appear in logs.
 In these cases you might want to adjust your [`coverage.include`](/config/coverage#coverage-include) and [`coverage.exclude`](/config/coverage#coverage-exclude) options.
 
 ## Inspecting Profiling Records


### PR DESCRIPTION
Fixes the casing of "Javascript" -> "JavaScript" (the canonical spelling, already used ~38x across the docs) in 7 spots:

- `docs/guide/coverage.md` (5)
- `docs/guide/migration.md` (1)
- `docs/guide/profiling-test-performance.md` (1)

Docs-only. Whole-word replacements only; `NodeJS` and other identifiers are untouched.