### PR TITLE
ci: use release app token for tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,16 +101,23 @@ jobs:
           PUBLISH_BRANCH: ${{ github.ref_name }}
         run: pnpm run publish-ci "$VERSION"
 
+      - id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Push release tag
         env:
           VERSION: ${{ needs.detect.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           TAG="v$VERSION"
           git config user.name "vitest-release-bot"
           git config user.email "actions@github.com"
           git tag "$TAG" "$GITHUB_SHA"
-          git push "https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" "$TAG"
+          git push "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git" "$TAG"
 
       - name: Generate Changelog
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,8 +114,8 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           TAG="v$VERSION"
-          git config user.name "vitest-release-bot"
-          git config user.email "actions@github.com"
+          git config user.name "vitest-release-bot[bot]"
+          git config user.email "292707936+vitest-release-bot[bot]@users.noreply.github.com"
           git tag "$TAG" "$GITHUB_SHA"
           git push "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git" "$TAG"
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- follow up to https://github.com/vitest-dev/vitest/pull/10550

Currently git tag push is failing due to tag creation rulesets https://github.com/vitest-dev/vitest/actions/runs/27529444689/job/81363776363#step:11:17

We've added vitest-release-bot in bypass list, so git pushing through `create-github-app-token` would make it pass. This is verified in test workflow in https://github.com/vitest-dev/vitest/pull/10600

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
