### PR TITLE
fix: fix `setImmediate` await in detect-async-leak 

### DIFF
--- a/packages/vitest/src/runtime/detect-async-leaks.ts
+++ b/packages/vitest/src/runtime/detect-async-leaks.ts
@@ -76,7 +76,7 @@ export function detectAsyncLeaks(testFile: string, projectName: string): () => P
   hook.enable()
 
   return async function collect() {
-    await Promise.resolve(setImmediate)
+    await new Promise<void>(resolve => setImmediate(resolve))
 
     hook.disable()
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Just spotted `await Promise.resolve(setImmediate)` which appeared to be the typo.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
