### PR TITLE
chore: use catalog protocol in pnpm overrides

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ packages:
   - test/e2e/dts/*
   - test/e2e/fixtures/conditions-pkg
 overrides:
-  '@types/node': $@types/node
+  '@types/node': 'catalog:'
   '@vitest/browser': workspace:*
   '@vitest/browser-playwright': workspace:*
   '@vitest/browser-preview': workspace:*
@@ -35,8 +35,8 @@ overrides:
   '@vitest/ui': workspace:*
   acorn: 8.11.3
   mlly: ^1.8.0
-  rollup: $rollup
-  vite: $vite
+  rollup: 'catalog:'
+  vite: 'catalog:'
   vitest: workspace:*
 patchedDependencies:
   '@sinonjs/fake-timers@15.3.2': patches/@sinonjs__fake-timers@15.3.2.patch
@@ -85,6 +85,7 @@ catalog:
   obug: ^2.1.1
   pathe: ^2.0.3
   playwright: ^1.60.0
+  rollup: ^4.59.0
   semver: ^7.8.3
   sinon: ^21.0.3
   sinon-chai: ^4.0.1
@@ -99,6 +100,7 @@ catalog:
   tinyspy: ^4.0.4
   typescript: ^5.9.3
   unocss: ^66.6.6
+  vite: 8.0.11
   vitest-sonar-reporter: 3.0.0
   vue: ^3.5.29
   ws: ^8.19.0


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Since we bumped pnpm to 11.6 https://github.com/vitest-dev/vitest/pull/10550, it's making this warning:

```
[WARN] The "$" version reference syntax in overrides is deprecated (used by: @types/node, rollup, vite). Define the version in a catalog and reference it with the "catalog:" protocol instead. See https://pnpm.io/catalogs
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
