### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -36,6 +36,9 @@ pnpm add -D vitest
 ```bash [bun]
 bun add -D vitest
 ```
+```bash [deno]
+deno add -D vitest
+```
 :::
 
 :::tip


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install `code-group` lists npm / yarn / pnpm / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity:

```sh
deno add -D vitest
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._

<!-- VITEST_AUTOMATED_PR -->
