### PR TITLE
fix(reporters): print parent suites for slow tests and benchmarks

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -55,6 +55,7 @@ export abstract class BaseReporter implements Reporter {
   private _filesInWatchMode = new Map<string, number>()
   private _timeStart = formatTimeString(new Date())
   private _perProjectBenchmarks = new Map<string, Map<string, TestBenchmarkTask>>()
+  private _printedSuites = new Set<string>()
 
   constructor(options: BaseOptions = {}) {
     this.isTTY = options.isTTY ?? isTTY
@@ -154,6 +155,8 @@ export abstract class BaseReporter implements Reporter {
       return
     }
 
+    this._printedSuites.clear()
+
     let testsCount = 0
     let failedCount = 0
     let skippedCount = 0
@@ -231,11 +234,13 @@ export abstract class BaseReporter implements Reporter {
     const inlineBenchmarks: TestBenchmark[] = benchmarks.filter(b => b.tasks.length > 0)
 
     if (testResult.state === 'failed') {
+      this.printTestCaseAncestors(test)
       this.log(c.red(` ${padding}${taskFail} ${this.getTestName(test.task, separator)}`) + suffix)
     }
 
     // also print slow tests
     else if (duration > this.ctx.config.slowTestThreshold) {
+      this.printTestCaseAncestors(test)
       this.log(` ${padding}${c.yellow(c.dim(F_CHECK))} ${this.getTestName(test.task, separator)}${suffix}`)
     }
 
@@ -244,6 +249,7 @@ export abstract class BaseReporter implements Reporter {
     }
 
     else if (this.renderSucceed || moduleState === 'failed' || inlineBenchmarks.length) {
+      this.printTestCaseAncestors(test)
       this.log(` ${padding}${this.getStateSymbol(test)} ${this.getTestName(test.task, separator)}${suffix}`)
     }
 
@@ -289,11 +295,43 @@ export abstract class BaseReporter implements Reporter {
       return
     }
 
+    this.printSuiteEntry(testSuite)
+  }
+
+  private printSuiteEntry(testSuite: TestSuite): void {
+    if (this._printedSuites.has(testSuite.id)) {
+      return
+    }
+    this._printedSuites.add(testSuite.id)
+
     const indentation = '  '.repeat(getIndentation(testSuite.task))
     const tests = Array.from(testSuite.children.allTests())
     const state = this.getStateSymbol(testSuite)
 
     this.log(` ${indentation}${state} ${testSuite.name} ${c.dim(`(${tests.length})`)}`)
+  }
+
+  // When a test case is printed even though its parent suites were not rendered
+  // (e.g. slow tests or inline benchmarks in CI), print the missing parent
+  // suites first so the nesting is displayed correctly.
+  private printTestCaseAncestors(test: TestCase): void {
+    if (this.renderSucceed) {
+      return
+    }
+
+    const ancestors: TestSuite[] = []
+    let parent = test.parent
+    while (parent.type === 'suite') {
+      if (this._printedSuites.has(parent.id)) {
+        break
+      }
+      ancestors.push(parent)
+      parent = parent.parent
+    }
+
+    for (let i = ancestors.length - 1; i >= 0; i--) {
+      this.printSuiteEntry(ancestors[i])
+    }
   }
 
   protected getTestName(test: Task, _separator?: string): string {

--- a/test/e2e/test/reporters/agent.test.ts
+++ b/test/e2e/test/reporters/agent.test.ts
@@ -18,8 +18,10 @@ describe('agent reporter', async () => {
     const output = trimReporterOutput(stdout)
     expect(output).toMatchInlineSnapshot(`
       "❯ b1.test.ts (13 tests | 1 failed) [...]ms
+         ❯ b1 failed (7)
            × b failed test [...]ms
        ❯ b2.test.ts (13 tests | 1 failed) [...]ms
+         ❯ b2 failed (7)
            × b failed test [...]ms"
     `)
 

--- a/test/e2e/test/reporters/default.test.ts
+++ b/test/e2e/test/reporters/default.test.ts
@@ -18,30 +18,38 @@ describe('default reporter', async () => {
 
     expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
       "❯ b1.test.ts (13 tests | 1 failed) [...]ms
+         ✓ b1 passed (6)
            ✓ b1 test [...]ms
            ✓ b2 test [...]ms
            ✓ b3 test [...]ms
+           ✓ nested b (3)
              ✓ nested b1 test [...]ms
              ✓ nested b2 test [...]ms
              ✓ nested b3 test [...]ms
+         ❯ b1 failed (7)
            ✓ b1 test [...]ms
            ✓ b2 test [...]ms
            ✓ b3 test [...]ms
            × b failed test [...]ms
+           ✓ nested b (3)
              ✓ nested b1 test [...]ms
              ✓ nested b2 test [...]ms
              ✓ nested b3 test [...]ms
        ❯ b2.test.ts (13 tests | 1 failed) [...]ms
+         ✓ b2 passed (6)
            ✓ b1 test [...]ms
            ✓ b2 test [...]ms
            ✓ b3 test [...]ms
+           ✓ nested b (3)
              ✓ nested b1 test [...]ms
              ✓ nested b2 test [...]ms
              ✓ nested b3 test [...]ms
+         ❯ b2 failed (7)
            ✓ b1 test [...]ms
            ✓ b2 test [...]ms
            ✓ b3 test [...]ms
            × b failed test [...]ms
+           ✓ nested b (3)
              ✓ nested b1 test [...]ms
              ✓ nested b2 test [...]ms
              ✓ nested b3 test [...]ms"

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -108,6 +108,7 @@ test('merge reports', async () => {
 
      ❯ second.test.ts (3 tests | 1 failed) <time>
        × test 2-1 <time>
+       ✓ group (2)
          ✓ test 2-2 <time>
          ✓ test 2-3 <time>
 

--- a/test/e2e/test/reporters/nested-suites-ci.test.ts
+++ b/test/e2e/test/reporters/nested-suites-ci.test.ts
@@ -1,0 +1,80 @@
+import { runInlineTests } from '#test-utils'
+import { expect, test } from 'vitest'
+import { trimReporterOutput } from './utils'
+
+const fastBenchOptions = { time: 0, iterations: 2, warmupTime: 0, warmupIterations: 0 }
+
+// https://github.com/vitest-dev/vitest/issues/10606
+// When `renderSucceed` is disabled (e.g. in CI), a slow test or a test with
+// inline benchmarks is still printed, so its parent suites must be printed too
+// to keep the nesting correct instead of leaving the test orphaned.
+
+test('prints parent suites for slow tests when renderSucceed is disabled', async () => {
+  const { stdout, stderr } = await runInlineTests(
+    {
+      'slow.test.ts': /* ts */`
+        import { describe, test } from 'vitest'
+        describe('outer suite', () => {
+          describe('inner suite', () => {
+            test('slow nested test', async () => {
+              await new Promise(resolve => setTimeout(resolve, 500))
+            })
+          })
+        })
+      `,
+    },
+    {
+      reporters: [['default', { isTTY: false, summary: false }]],
+      slowTestThreshold: 100,
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    "✓ slow.test.ts (1 test) [...]ms
+       ✓ outer suite (1)
+         ✓ inner suite (1)
+           ✓ slow nested test [...]ms"
+  `)
+})
+
+test('prints parent suites for inline benchmarks when renderSucceed is disabled', async () => {
+  const { stdout, stderr } = await runInlineTests(
+    {
+      'suite.bench.ts': /* ts */`
+        import { describe, test, inject } from 'vitest'
+        describe('my first suite', () => {
+          test('foo', async ({ bench }) => {
+            await bench('foo', () => { let x = 0; for (let i = 0; i < 10; i++) x += i }).run(inject('options'))
+          })
+        })
+        describe('my second suite', () => {
+          test('foo', async ({ bench }) => {
+            await bench('foo', () => { let x = 0; for (let i = 0; i < 10; i++) x += i }).run(inject('options'))
+          })
+        })
+      `,
+    },
+    {
+      benchmark: { enabled: true },
+      reporters: [['default', { isTTY: false, summary: false }]],
+      provide: { options: fastBenchOptions },
+    },
+  )
+
+  expect(stderr).toBe('')
+
+  // benchmark table rows carry measurement noise, so keep only the tree lines
+  // to assert each suite label is printed with its bench nested underneath
+  const tree = trimReporterOutput(stdout)
+    .split('\n')
+    .filter(line => /[✓❯×↓]/.test(line))
+    .join('\n')
+  expect(tree).toMatchInlineSnapshot(`
+    "✓ |bench| suite.bench.ts (2 tests) [...]ms
+       ✓ my first suite (1)
+         ✓ foo [...]ms
+       ✓ my second suite (1)
+         ✓ foo [...]ms"
+  `)
+})


### PR DESCRIPTION
### Description

In CI (or any multi-file run) `renderSucceed` is disabled so `describe` suite labels are not printed. Slow tests and tests with inline benchmarks are still printed though which leaves them indented with no parent suite shown above them. This prints the missing parent suites before such a test so the nesting matches the local/TTY output.

Fixes #10606

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->