### PR TITLE
fix: avoid double-prefixing node-only builtins (fix #10630)

### DIFF
--- a/packages/vitest/src/node/plugins/runnerTransform.ts
+++ b/packages/vitest/src/node/plugins/runnerTransform.ts
@@ -4,6 +4,13 @@ import { normalize } from 'pathe'
 import { escapeRegExp } from '../../utils/base'
 import { resolveOptimizerConfig } from './utils'
 
+export function resolveBuiltinExternalModules(modules: readonly string[]): string[] {
+  return [
+    ...modules,
+    ...modules.map(m => m.startsWith('node:') ? m : `node:${m}`),
+  ]
+}
+
 export function ModuleRunnerTransform(): VitePlugin {
   let testConfig: NonNullable<UserConfig['test']>
   const noExternal: (string | RegExp)[] = []
@@ -97,10 +104,7 @@ export function ModuleRunnerTransform(): VitePlugin {
         }
 
         // remove Vite's externalization logic because we have our own (unfortunately)
-        config.resolve.external = [
-          ...builtinModules,
-          ...builtinModules.map(m => `node:${m}`),
-        ]
+        config.resolve.external = resolveBuiltinExternalModules(builtinModules)
 
         // by setting `noExternal` to `true`, we make sure that
         // Vite will never use its own externalization mechanism

--- a/test/unit/test/builtin-external.test.ts
+++ b/test/unit/test/builtin-external.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { resolveBuiltinExternalModules } from '../../../packages/vitest/src/node/plugins/runnerTransform'
+
+test('does not double-prefix node-only builtin modules', () => {
+  const external = resolveBuiltinExternalModules([
+    'fs',
+    'node:sea',
+    'node:sqlite',
+    'node:test',
+    'node:test/reporters',
+  ])
+
+  expect(external).toContain('fs')
+  expect(external).toContain('node:fs')
+  expect(external).toContain('node:sea')
+  expect(external).toContain('node:sqlite')
+  expect(external).toContain('node:test')
+  expect(external).toContain('node:test/reporters')
+  expect(external).not.toContain('node:node:sea')
+  expect(external).not.toContain('node:node:sqlite')
+  expect(external).not.toContain('node:node:test')
+  expect(external).not.toContain('node:node:test/reporters')
+})


### PR DESCRIPTION
## Problem

Node can expose some builtins only in `node:` form, for example `node:sea`, `node:sqlite`, `node:test`, and `node:test/reporters`. Vitest currently prefixes every entry from `builtinModules`, so those entries become invalid `node:node:*` values in `resolve.external`.

## Fix

Make the builtin external list generation idempotent for entries that already start with `node:` while preserving the existing unprefixed + prefixed coverage for normal builtins.

Closes #10630.

## Test

- `./node_modules/.bin/vitest run test/builtin-external.test.ts --project threads`
- `./node_modules/.bin/eslint packages/vitest/src/node/plugins/runnerTransform.ts test/unit/test/builtin-external.test.ts`
- `git diff --check`

## Risk

Low. The change only avoids adding a second `node:` prefix; it keeps existing builtin entries and their `node:` aliases in the external list.

Disclosure: assisted by Codex.
