### PR TITLE
fix(coverage): non-awaited module imports cause wrong offsets

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -330,6 +330,15 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
 
     // this will always be 1 element because it's cached after load
     const importer = module.importers.values().next().value
+
+    // Initialize execution info in case worker exited before module evaluation finished
+    this.options.moduleExecutionInfo?.set(options.filename, {
+      duration: 0,
+      selfTime: 0,
+      startOffset: codeDefinition.length,
+      importer,
+    })
+
     const finishModuleExecutionInfo = this.debug.startCalculateModuleExecutionInfo(options.filename, {
       startOffset: codeDefinition.length,
       importer,

--- a/test/coverage-test/fixtures/src/slow-module-imported.ts
+++ b/test/coverage-test/fixtures/src/slow-module-imported.ts
@@ -1,0 +1,17 @@
+import { response } from "./slow-module";
+
+export function uncovered() {
+  throw new Error("uncovered");
+}
+
+export function uncovered2() {
+  throw new Error("uncovered");
+}
+
+export function covered(value: number) {
+  if(!response.ok) {
+    throw new Error("response not ok");
+  }
+
+  return value + 100;
+}

--- a/test/coverage-test/fixtures/src/slow-module.ts
+++ b/test/coverage-test/fixtures/src/slow-module.ts
@@ -1,0 +1,9 @@
+import { setTimeout } from "node:timers/promises";
+
+const delay = parseInt(process.env.DELAY ?? "100", 10);
+
+if (delay > 0) {
+  await setTimeout(delay);
+}
+
+export const response = { ok: true };

--- a/test/coverage-test/fixtures/test/slow-module-import-awaited.test.ts
+++ b/test/coverage-test/fixtures/test/slow-module-import-awaited.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+import { covered } from "../src/slow-module-imported";
+
+test("covers covered()", () => {
+  expect(covered(2)).toBe(102);
+});

--- a/test/coverage-test/fixtures/test/slow-module-import-pending.test.ts
+++ b/test/coverage-test/fixtures/test/slow-module-import-pending.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+
+process.env.DELAY = "10000";
+
+test("module import pending", async () => {
+  const promise = import("../src/slow-module-imported");
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  expect(promise).toBeTruthy();
+});

--- a/test/coverage-test/test/module-import-pending.v8.test.ts
+++ b/test/coverage-test/test/module-import-pending.v8.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'vitest'
+import { StableTestFileOrderSorter } from '../../test-utils'
+import { readCoverageMap, runVitest, test } from '../utils'
+
+test('module offset is set correctly when module import is pending (#10581)', async () => {
+  await runVitest({
+    include: [
+      'fixtures/test/slow-module-import-awaited.test.ts',
+      'fixtures/test/slow-module-import-pending.test.ts',
+    ],
+    fileParallelism: false,
+    sequence: { sequencer: StableTestFileOrderSorter },
+    coverage: { reporter: 'json' },
+  })
+
+  const coverageMap = await readCoverageMap()
+  expect(coverageMap.files()).toMatchInlineSnapshot(`
+    [
+      "<process-cwd>/fixtures/src/slow-module-imported.ts",
+      "<process-cwd>/fixtures/src/slow-module.ts",
+    ]
+  `)
+
+  const fileCoverage = coverageMap.fileCoverageFor('<process-cwd>/fixtures/src/slow-module-imported.ts')
+
+  /** {@link file://./../fixtures/src/slow-module-imported.ts} */
+  const lineCoverage = fileCoverage.getLineCoverage()
+
+  expect.soft(lineCoverage['4']).toBe(0)
+  expect.soft(lineCoverage['8']).toBe(0)
+
+  expect.soft(lineCoverage['12']).toBe(1)
+  expect.soft(lineCoverage['13']).toBe(0)
+  expect.soft(lineCoverage['16']).toBe(1)
+})


### PR DESCRIPTION
### Description

Resolves https://github.com/vitest-dev/vitest/issues/10581

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
