### PR TITLE
fix(snapshot): support no-unsafe-eval CSP by evaluating snapshot files server-side

### DIFF
--- a/packages/browser/src/client/tester/snapshot.ts
+++ b/packages/browser/src/client/tester/snapshot.ts
@@ -23,6 +23,10 @@ export class VitestBrowserSnapshotEnvironment implements SnapshotEnvironment {
     return rpc().readSnapshotFile(filepath)
   }
 
+  readSnapshotFileData(filepath: string): Promise<Record<string, string> | null> {
+    return rpc().readSnapshotFileData(filepath)
+  }
+
   saveSnapshotFile(filepath: string, snapshot: string): Promise<void> {
     return rpc().saveSnapshotFile(filepath, snapshot)
   }

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -268,6 +268,28 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
           }
           return fs.readFile(snapshotPath, 'utf-8')
         },
+        async readSnapshotFileData(snapshotPath) {
+          checkFileAccess(snapshotPath)
+          if (!existsSync(snapshotPath)) {
+            return null
+          }
+          const content = await fs.readFile(snapshotPath, 'utf-8')
+          const data = Object.create(null)
+          try {
+            // eslint-disable-next-line no-new-func
+            const populate = new Function('exports', content)
+            populate(data)
+          }
+          catch (cause) {
+            // surface corrupted snapshot files as a hard error instead of
+            // silently ignoring them
+            throw new Error(
+              `Invalid snapshot file, please manually fix or delete it: ${snapshotPath}`,
+              { cause },
+            )
+          }
+          return data
+        },
         async saveSnapshotFile(id, content) {
           checkFileAccess(id)
           if (!canWrite(project)) {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -33,6 +33,7 @@ export interface WebSocketBrowserHandlers {
   cancelCurrentRun: (reason: CancelReason) => void
   getCountOfFailedTests: () => number
   readSnapshotFile: (id: string) => Promise<string | null>
+  readSnapshotFileData: (id: string) => Promise<Record<string, string> | null>
   saveSnapshotFile: (id: string, content: string) => Promise<void>
   removeSnapshotFile: (id: string) => Promise<void>
   sendLog: (method: TestExecutionMethod, log: UserConsoleLog) => void

--- a/packages/snapshot/src/env/node.ts
+++ b/packages/snapshot/src/env/node.ts
@@ -1,6 +1,7 @@
 import type { SnapshotEnvironment, SnapshotEnvironmentOptions } from '../types'
 import { existsSync, promises as fs } from 'node:fs'
 import { basename, dirname, isAbsolute, join, resolve } from 'pathe'
+import { evaluateSnapshotFile } from '../port/utils'
 
 export class NodeSnapshotEnvironment implements SnapshotEnvironment {
   constructor(private options: SnapshotEnvironmentOptions = {}) {}
@@ -38,6 +39,14 @@ export class NodeSnapshotEnvironment implements SnapshotEnvironment {
       return null
     }
     return fs.readFile(filepath, 'utf-8')
+  }
+
+  async readSnapshotFileData(filepath: string): Promise<Record<string, string> | null> {
+    const content = await this.readSnapshotFile(filepath)
+    if (content == null) {
+      return null
+    }
+    return evaluateSnapshotFile(filepath, content)
   }
 
   async removeSnapshotFile(filepath: string): Promise<void> {

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -97,9 +97,20 @@ export default class SnapshotState {
     public snapshotPath: string,
     snapshotContent: string | null,
     options: SnapshotStateOptions,
+    preEvaluatedData?: Record<string, string> | null,
   ) {
-    const { data, dirty } = getSnapshotData(snapshotContent, options)
-    this._fileExists = snapshotContent != null // TODO: update on watch?
+    let data: SnapshotData
+    let dirty: boolean
+    if (preEvaluatedData !== undefined) {
+      data = preEvaluatedData ?? Object.create(null)
+      this._fileExists = preEvaluatedData !== null
+      const update = options.updateSnapshot
+      dirty = (update === 'all' || update === 'new') && preEvaluatedData !== null
+    }
+    else {
+      ;({ data, dirty } = getSnapshotData(snapshotContent, options))
+      this._fileExists = snapshotContent != null // TODO: update on watch?
+    }
     this._initialData = { ...data }
     this._snapshotData = { ...data }
     this._dirty = dirty
@@ -125,6 +136,10 @@ export default class SnapshotState {
     const snapshotPath = await options.snapshotEnvironment.resolvePath(
       testFilePath,
     )
+    if (options.snapshotEnvironment.readSnapshotFileData) {
+      const fileData = await options.snapshotEnvironment.readSnapshotFileData(snapshotPath)
+      return new SnapshotState(testFilePath, snapshotPath, null, options, fileData)
+    }
     const content = await options.snapshotEnvironment.readSnapshotFile(
       snapshotPath,
     )

--- a/packages/snapshot/src/port/utils.ts
+++ b/packages/snapshot/src/port/utils.ts
@@ -62,6 +62,28 @@ export function getSnapshotData(
   return { data, dirty }
 }
 
+// Evaluate a snapshot file's content into its snapshot data.
+// Throws a hard error when the content cannot be evaluated so corrupted
+// snapshot files surface immediately instead of being silently ignored.
+export function evaluateSnapshotFile(
+  filepath: string,
+  content: string,
+): SnapshotData {
+  const data = Object.create(null)
+  try {
+    // eslint-disable-next-line no-new-func
+    const populate = new Function('exports', content)
+    populate(data)
+  }
+  catch (cause) {
+    throw new Error(
+      `Invalid snapshot file, please manually fix or delete it: ${filepath}`,
+      { cause },
+    )
+  }
+  return data
+}
+
 // Add extra line breaks at beginning and end of multiline snapshot
 // to make the content easier to read.
 export function addExtraLineBreaks(string: string): string {

--- a/packages/snapshot/src/types/environment.ts
+++ b/packages/snapshot/src/types/environment.ts
@@ -7,6 +7,7 @@ export interface SnapshotEnvironment {
   resolveRawPath: (testPath: string, rawPath: string) => Promise<string>
   saveSnapshotFile: (filepath: string, snapshot: string) => Promise<void>
   readSnapshotFile: (filepath: string) => Promise<string | null>
+  readSnapshotFileData?: (filepath: string) => Promise<Record<string, string> | null>
   removeSnapshotFile: (filepath: string) => Promise<void>
   processStackTrace?: (stack: ParsedStack) => ParsedStack
 }

--- a/test/browser/fixtures/snapshot-csp/__snapshots__/basic.test.ts.snap
+++ b/test/browser/fixtures/snapshot-csp/__snapshots__/basic.test.ts.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`file snapshot under CSP 1`] = `
+{
+  "hello": "world",
+}
+`;

--- a/test/browser/fixtures/snapshot-csp/basic.test.ts
+++ b/test/browser/fixtures/snapshot-csp/basic.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+
+test('inline snapshot under CSP', () => {
+  expect(1).toMatchInlineSnapshot(`1`)
+})
+
+test('file snapshot under CSP', () => {
+  expect({ hello: 'world' }).toMatchSnapshot()
+})

--- a/test/browser/fixtures/snapshot-csp/vite.config.ts
+++ b/test/browser/fixtures/snapshot-csp/vite.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'node_modules/.vite'
+  ),
+  server: {
+    headers: {
+      // CSP without `'unsafe-eval'`: forbids `eval`/`new Function`. Reading an
+      // existing snapshot file used to evaluate its content in the browser via
+      // `new Function`, which this header blocks. Snapshots must now be
+      // evaluated server-side. `'unsafe-inline'` (and no `default-src`) keeps
+      // the rest of the browser runtime working, so only the eval path is
+      // exercised here.
+      'content-security-policy': 'script-src \'self\' \'unsafe-inline\'',
+    },
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances: [instances[0]],
+    },
+  },
+})

--- a/test/browser/specs/snapshot-csp.test.ts
+++ b/test/browser/specs/snapshot-csp.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+import { runBrowserTests } from './utils'
+
+// Regression test for the `no-unsafe-eval` CSP fix: reading an existing
+// snapshot file used to evaluate its content in the browser via `new Function`,
+// which a `script-src 'self'` Content-Security-Policy blocks. Snapshot files are
+// now evaluated server-side, so the matchers below pass even under the CSP.
+test('snapshots pass under a no-unsafe-eval CSP', async () => {
+  const result = await runBrowserTests({
+    root: './fixtures/snapshot-csp',
+  })
+
+  expect(result.stderr).toMatchInlineSnapshot(`""`)
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "file snapshot under CSP": "passed",
+        "inline snapshot under CSP": "passed",
+      },
+    }
+  `)
+})

--- a/test/e2e/snapshots/custom-environment-data-reader.test.ts
+++ b/test/e2e/snapshots/custom-environment-data-reader.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'pathe'
+import { afterEach, expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+const customRoot = resolve(import.meta.dirname, './fixtures/custom-snapshot-environment-data-reader')
+const customSnapshotFile = resolve(customRoot, 'test/__snapshots__/snapshots.test.ts.snap')
+
+const defaultRoot = resolve(import.meta.dirname, './fixtures/default-snapshot-environment-data-reader')
+const defaultSnapshotFile = resolve(defaultRoot, 'test/__snapshots__/snapshots.test.ts.snap')
+
+const corruptedRoot = resolve(import.meta.dirname, './fixtures/corrupted-snapshot-environment-data-reader')
+const corruptedSnapshotFile = resolve(corruptedRoot, 'test/__snapshots__/snapshots.test.ts.snap')
+
+afterEach(() => {
+  rmSync(customSnapshotFile, { force: true })
+  rmSync(defaultSnapshotFile, { force: true })
+  rmSync(corruptedSnapshotFile, { force: true })
+})
+
+test('readSnapshotFileData is used instead of readSnapshotFile', async () => {
+  // First run: create the snapshot file
+  await runVitest({ root: customRoot, update: true })
+
+  // Second run: file exists — readSnapshotFileData must parse it correctly
+  const { stdout, stderr } = await runVitest({ root: customRoot })
+
+  const logs = stdout.split('\n').filter(i => i.startsWith('## ')).map(i => `${i.split(' ')[0]} ${i.split(' ')[1]}`).join('\n')
+  // No stderr means the existing snapshot was read and matched correctly
+  expect(stderr).toBe('')
+  expect(logs).toMatchInlineSnapshot(`"## readSnapshotFileData"`)
+})
+
+test('default readSnapshotFileData reads existing snapshots without overriding it', async () => {
+  // First run: create the snapshot file with the default environment
+  await runVitest({ root: defaultRoot, update: true })
+
+  // Second run: file exists — the default readSnapshotFileData implementation
+  // must parse it correctly so integrators that don't override it keep working
+  const { stderr, exitCode } = await runVitest({ root: defaultRoot })
+
+  expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
+})
+
+test('a corrupted snapshot file produces a hard error', async () => {
+  mkdirSync(dirname(corruptedSnapshotFile), { recursive: true })
+  // not a valid snapshot file — evaluating it throws
+  writeFileSync(corruptedSnapshotFile, 'this is not valid javascript {{{', 'utf-8')
+
+  const { stderr } = await runVitest({ root: corruptedRoot })
+
+  expect(stderr).toContain('Invalid snapshot file, please manually fix or delete it')
+  expect(stderr).toContain(corruptedSnapshotFile)
+})

--- a/test/e2e/snapshots/fixtures/corrupted-snapshot-environment-data-reader/test/snapshots.test.ts
+++ b/test/e2e/snapshots/fixtures/corrupted-snapshot-environment-data-reader/test/snapshots.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('regular snapshot', () => {
+  expect({ a: 1 }).toMatchSnapshot()
+})

--- a/test/e2e/snapshots/fixtures/corrupted-snapshot-environment-data-reader/vitest.config.ts
+++ b/test/e2e/snapshots/fixtures/corrupted-snapshot-environment-data-reader/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {},
+})

--- a/test/e2e/snapshots/fixtures/custom-snapshot-environment-data-reader/snapshot-environment.ts
+++ b/test/e2e/snapshots/fixtures/custom-snapshot-environment-data-reader/snapshot-environment.ts
@@ -1,0 +1,24 @@
+import { VitestSnapshotEnvironment } from 'vitest/runtime'
+
+class DataReaderSnapshotEnvironment extends VitestSnapshotEnvironment {
+  readSnapshotFile(filepath: string) {
+    console.log('## readSnapshotFile', filepath)
+    return super.readSnapshotFile(filepath)
+  }
+
+  async readSnapshotFileData(filepath: string) {
+    console.log('## readSnapshotFileData', filepath)
+    return super.readSnapshotFile(filepath).then((content) => {
+      if (content == null) {
+        return null
+      }
+      const data = Object.create(null)
+      // eslint-disable-next-line no-new-func
+      const populate = new Function('exports', content)
+      populate(data)
+      return data
+    })
+  }
+}
+
+export default new DataReaderSnapshotEnvironment()

--- a/test/e2e/snapshots/fixtures/custom-snapshot-environment-data-reader/test/snapshots.test.ts
+++ b/test/e2e/snapshots/fixtures/custom-snapshot-environment-data-reader/test/snapshots.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('regular snapshot', () => {
+  expect({ a: 1 }).toMatchSnapshot()
+})

--- a/test/e2e/snapshots/fixtures/custom-snapshot-environment-data-reader/vitest.config.ts
+++ b/test/e2e/snapshots/fixtures/custom-snapshot-environment-data-reader/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    snapshotEnvironment: './snapshot-environment.ts',
+  },
+})

--- a/test/e2e/snapshots/fixtures/default-snapshot-environment-data-reader/test/snapshots.test.ts
+++ b/test/e2e/snapshots/fixtures/default-snapshot-environment-data-reader/test/snapshots.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('regular snapshot', () => {
+  expect({ a: 1 }).toMatchSnapshot()
+})

--- a/test/e2e/snapshots/fixtures/default-snapshot-environment-data-reader/vitest.config.ts
+++ b/test/e2e/snapshots/fixtures/default-snapshot-environment-data-reader/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {},
+})


### PR DESCRIPTION
### Description

In browser mode, when the page is served with a `no-unsafe-eval` CSP policy, `getSnapshotData` silently fails to parse `.snap` files because `new Function()` is blocked. The empty `catch {}` discards the error, leaving snapshot data empty and producing confusing mismatch failures with no hint about the real cause.

This PR introduces an optional `readSnapshotFileData` method on `SnapshotEnvironment` that returns already-evaluated snapshot data. When the environment provides it, `SnapshotState.create()` uses it instead of `readSnapshotFile + new Function`, so the browser tester runtime never has to eval. The browser's `VitestBrowserSnapshotEnvironment` implements the method by delegating to the server via RPC, where the file is read and evaluated safely in Node.js context.

Resolves #10615