### PR TITLE
test: relax api token file 403 assertion on windows

### DIFF
--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -66,7 +66,17 @@ test.describe('ui', () => {
 
     const fsUrl = new URL(join('/@fs/', tokenPath), pageUrl)
     const res = await request.get(fsUrl.toString())
-    expect(res.status()).toBe(403)
+    if (process.platform === 'win32') {
+      // On Windows the token may live on a different drive than the project
+      // (e.g. LOCALAPPDATA on C: vs repo on D: in CI). Vite strips the drive
+      // letter from `/@fs/` paths and re-roots at the cwd drive, so the file is
+      // unreachable and Vite responds 404 instead of 403. Both mean it is not
+      // served. See https://github.com/vitejs/vite/issues/10802
+      expect([403, 404]).toContain(res.status())
+    }
+    else {
+      expect(res.status()).toBe(403)
+    }
   })
 
   test('allows direct ui access after opening authenticated url', async ({ page }) => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- related https://github.com/vitest-dev/vitest/pull/10583

The main CI is failing due to windows specific behavior. I overlooked the CI in the above PR because it failed before reaching this.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
