### PR TITLE
fix(types): allow `changed` in configuration options

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -584,6 +584,10 @@ export default ({ mode }: { mode: string }) => {
                 link: '/config/disableconsoleintercept',
               },
               {
+                text: 'changed',
+                link: '/config/changed',
+              },
+              {
                 text: 'experimental',
                 link: '/config/experimental',
               },

--- a/docs/.vitepress/scripts/cli-generator.ts
+++ b/docs/.vitepress/scripts/cli-generator.ts
@@ -11,7 +11,6 @@ const nonNullable = <T>(value: T): value is NonNullable<T> => value !== null && 
 
 const skipCli = new Set([
   'mergeReports',
-  'changed',
   'shard',
 ])
 

--- a/docs/config/changed.md
+++ b/docs/config/changed.md
@@ -1,0 +1,18 @@
+---
+title: changed | Config
+outline: deep
+---
+
+### changed <CRoot />
+
+- **Type:** `boolean | string`
+- **Default:** `false`
+- **CLI:** `--changed`, `--changed=HEAD~1`
+
+Run tests only against changed files. If no value is provided, it will run tests against uncommitted changes (including staged and unstaged).
+
+To run tests against changes made in the last commit, you can use `--changed HEAD~1`. You can also pass commit hash (e.g. `--changed 09a9920`) or branch name (e.g. `--changed origin/develop`).
+
+When used with code coverage the report will contain only the files that were related to the changes.
+
+If paired with the [`forceRerunTriggers`](/config/forcereruntriggers) config option it will run the whole test suite if at least one of the files listed in the `forceRerunTriggers` list changes. By default, changes to the Vitest config file and `package.json` will always rerun the whole suite.

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -541,6 +541,13 @@ Allow tests and suites that are marked as only (default: `!process.env.CI`)
 
 Ignore any unhandled errors that occur
 
+### changed
+
+- **CLI:** `--changed [since]`
+- **Config:** [changed](/config/changed)
+
+Run tests that are affected by the changed files (default: `false`)
+
 ### sequence.shuffle.files
 
 - **CLI:** `--sequence.shuffle.files`

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -189,19 +189,6 @@ vitest --api=false
 
 <!--@include: ./cli-generated.md-->
 
-### changed
-
-- **Type:** `boolean | string`
-- **Default:** false
-
-Run tests only against changed files. If no value is provided, it will run tests against uncommitted changes (including staged and unstaged).
-
-To run tests against changes made in the last commit, you can use `--changed HEAD~1`. You can also pass commit hash (e.g. `--changed 09a9920`) or branch name (e.g. `--changed origin/develop`).
-
-When used with code coverage the report will contain only the files that were related to the changes.
-
-If paired with the [`forceRerunTriggers`](/config/forcereruntriggers) config option it will run the whole test suite if at least one of the files listed in the `forceRerunTriggers` list changes. By default, changes to the Vitest config file and `package.json` will always rerun the whole suite.
-
 ### shard
 
 - **Type:** `string`

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -985,6 +985,13 @@ export interface InlineConfig {
    * @default true
    */
   strictTags?: boolean
+
+  /**
+   * Runs tests that are affected by the changes in the repository, or between specified branch or commit hash
+   * Requires initialized git repository
+   * @default false
+   */
+  changed?: boolean | string
 }
 
 export interface TypecheckConfig {
@@ -1072,13 +1079,6 @@ export interface UserConfig extends InlineConfig {
    * @default 'test'
    */
   mode?: string
-
-  /**
-   * Runs tests that are affected by the changes in the repository, or between specified branch or commit hash
-   * Requires initialized git repository
-   * @default false
-   */
-  changed?: boolean | string
 
   /**
    * Test suite shard to execute in a format of <index>/<count>.


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves https://github.com/vitest-dev/vitest/issues/10644

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
