### PR TITLE
fix(browser): resize the browser ui only if it's not headless

### DIFF
--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -434,7 +434,11 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
       ...contextOptions,
       ignoreHTTPSErrors: true,
     } satisfies BrowserContextOptions
-    if (this.project.config.browser.ui) {
+    // A `null` viewport lets the page adopt the real window size, which is only
+    // meaningful for a headed UI. In headless mode there is no real window, so it
+    // would inherit the host's device scale factor and produce screenshots that
+    // differ from non-UI runs on the same machine.
+    if (this.project.config.browser.ui && !this.project.config.browser.headless) {
       options.viewport = null
     }
     return options


### PR DESCRIPTION
I found that this test always fails locally on Mac with Webkit reporting a different resolution:

https://github.com/vitest-dev/vitest/blob/a60ded0fb1a15a5bc2eb6c26681d9e934d3e17eb/test/browser/specs/to-match-screenshot.test.ts#L284