### PR TITLE
ci(renovate): remove `nodeMaxMemory`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,13 +6,6 @@
   // Align with pnpm's `minimumReleaseAge` default (1440 minutes) so Renovate does
   // not propose versions that pnpm's supply-chain check would reject as too new.
   "minimumReleaseAge": "1 day",
-  // Cap Node memory for package-manager (pnpm) commands to avoid Mend-hosted
-  // `kernel-out-of-memory` job failures. Free plan has a 3GB limit; leave
-  // headroom for Renovate itself.
-  // https://github.com/renovatebot/renovate/discussions/40942#discussioncomment-16011497
-  "toolSettings": {
-    "nodeMaxMemory": 1024
-  },
   "packageRules": [
     {
       "groupName": "Eslint packages",


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- related https://github.com/vitest-dev/vitest/issues/10648

Reverting https://github.com/vitest-dev/vitest/pull/10649 since this cap is still killing jobs though we already got memory increase.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
