### PR TITLE
chore(deps): upgrade rrweb-snapshot to 2.0.1

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -97,7 +97,7 @@
     "ivya": "^1.8.2",
     "mime": "^4.1.0",
     "pathe": "catalog:",
-    "rrweb-snapshot": "2.0.0-alpha.20",
+    "rrweb-snapshot": "2.0.1",
     "vitest": "workspace:*"
   }
 }

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -46,10 +46,15 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
   doc.open()
   doc.close()
   const mirror = createMirror()
+  // rrweb >=2.0 guards rebuild() behind its createSandboxedIframe()/WeakSet
+  // contract (CVE-2025-45806). We already render into our own sandboxed iframe
+  // (see iframeSandbox), so opt out of rrweb owning iframe creation rather than
+  // weakening anything — the sandbox attribute is still enforced by us.
   rebuild(serialized, {
     doc,
     cache: createCache(),
     mirror,
+    UNSAFE_allowUnprotectedRebuild: true,
   })
   for (const [className, ids] of Object.entries(pseudoClassIds)) {
     for (const id of ids) {

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -46,10 +46,7 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
   doc.open()
   doc.close()
   const mirror = createMirror()
-  // rrweb >=2.0 guards rebuild() behind its createSandboxedIframe()/WeakSet
-  // contract (CVE-2025-45806). We already render into our own sandboxed iframe
-  // (see iframeSandbox), so opt out of rrweb owning iframe creation rather than
-  // weakening anything — the sandbox attribute is still enforced by us.
+  // rrweb >=2.0 hardened the API to force sandbox iframe usage https://github.com/rrweb-io/rrweb/issues/1817. We already ensure the same manually so opt-out the guard by UNSAFE_allowUnprotectedRebuild
   rebuild(serialized, {
     doc,
     cache: createCache(),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -84,7 +84,7 @@
     "floating-vue": "^5.2.2",
     "mime": "^4.1.0",
     "rollup": "^4.59.0",
-    "rrweb-snapshot": "2.0.0-alpha.20",
+    "rrweb-snapshot": "2.0.1",
     "splitpanes": "^4.0.4",
     "typescript": "^5.9.3",
     "unocss": "catalog:",

--- a/patches/rrweb-snapshot@2.0.1.patch
+++ b/patches/rrweb-snapshot@2.0.1.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/rrweb-snapshot.js b/dist/rrweb-snapshot.js
-index 3a3b67808308f4b50ad906dccfaaf577b4264742..3cf40a7d3c7d847e34850b32c424e2b0bb9331ac 100644
+index f2694ac8c01dd248a2d659f1ec2628bc9e65729a..ed99e153f33e5235602cf09efc8dab5bd6c98903 100644
 --- a/dist/rrweb-snapshot.js
 +++ b/dist/rrweb-snapshot.js
-@@ -1513,6 +1513,18 @@ const pseudoClassPlugin = {
+@@ -1534,6 +1534,18 @@ const pseudoClassPlugin = {
            if (selector.includes(":hover")) {
              rule2.selector += ",\n" + selector.replace(/:hover/g, ".\\:hover");
            }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ patchedDependencies:
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
   istanbul-lib-source-maps: be977704c4b9838da456619fe2421b5e24df2103a25967bd383b2246c88ddf6e
-  rrweb-snapshot: d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044
+  rrweb-snapshot@2.0.1: 9e976b2c55a5c2ed589c41b8f46cc44b6fe6f528ebb4d3780a44b1ca8cbb17a4
 
 importers:
 
@@ -591,8 +591,8 @@ importers:
         specifier: 'catalog:'
         version: 2.0.3
       rrweb-snapshot:
-        specifier: 2.0.0-alpha.20
-        version: 2.0.0-alpha.20(patch_hash=d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044)
+        specifier: 2.0.1
+        version: 2.0.1(patch_hash=9e976b2c55a5c2ed589c41b8f46cc44b6fe6f528ebb4d3780a44b1ca8cbb17a4)
       vitest:
         specifier: workspace:*
         version: link:../vitest
@@ -959,8 +959,8 @@ importers:
         specifier: ^4.59.0
         version: 4.59.0
       rrweb-snapshot:
-        specifier: 2.0.0-alpha.20
-        version: 2.0.0-alpha.20(patch_hash=d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044)
+        specifier: 2.0.1
+        version: 2.0.1(patch_hash=9e976b2c55a5c2ed589c41b8f46cc44b6fe6f528ebb4d3780a44b1ca8cbb17a4)
       splitpanes:
         specifier: ^4.0.4
         version: 4.0.4(vue@3.5.29(typescript@5.9.3))
@@ -9523,8 +9523,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rrweb-snapshot@2.0.0-alpha.20:
-    resolution: {integrity: sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==}
+  rrweb-snapshot@2.0.1:
+    resolution: {integrity: sha512-H8TA29ct2tpYtr5oaB0N+ksRY9bhEErfAYcKbce4+w8lqEUQChpKZd41HpBJLkp04b5QUfWUg4v6r9Okf8r7vA==}
 
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
@@ -14868,7 +14868,7 @@ snapshots:
       '@vue/shared': 3.5.28
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.29':
@@ -19281,9 +19281,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
-  rrweb-snapshot@2.0.0-alpha.20(patch_hash=d11ec9bd9b66247ba493ab5fd117fbf0b4cb6e5d0a6a7c600d1d844bfa3d3044):
+  rrweb-snapshot@2.0.1(patch_hash=9e976b2c55a5c2ed589c41b8f46cc44b6fe6f528ebb4d3780a44b1ca8cbb17a4):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.14
 
   run-applescript@7.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ patchedDependencies:
   cac@6.7.14: patches/cac@6.7.14.patch
   istanbul-lib-instrument: patches/istanbul-lib-instrument.patch
   istanbul-lib-source-maps: patches/istanbul-lib-source-maps.patch
-  rrweb-snapshot: patches/rrweb-snapshot.patch
+  rrweb-snapshot@2.0.1: patches/rrweb-snapshot@2.0.1.patch
 catalog:
   '@babel/core': ^7.29.0
   '@babel/plugin-proposal-decorators': ^7.29.0


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Extracting from renovate PR https://github.com/vitest-dev/vitest/pull/9958 (that is currently failing with invalid patch). This PR updates rrweb from the long time alpha to stable v2.0.1.

They did some security hardening for https://github.com/rrweb-io/rrweb/issues/1817, but we did already had sandbox ensured manually, so I went with `UNSAFE_allowUnprotectedRebuild`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
