### PR TITLE
fix: combine negated project filters (fix #10491)

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1675,10 +1675,26 @@ export class Vitest {
     if (!projects || !projects.length) {
       return true
     }
-    return toArray(projects).some((project) => {
-      const regexp = wildcardPatternToRegExp(project)
-      return regexp.test(name)
-    })
+
+    let hasPositiveFilter = false
+    let matchesPositiveFilter = false
+
+    for (const project of toArray(projects)) {
+      if (project.startsWith('!')) {
+        const positivePattern = project.slice(1)
+        if (wildcardPatternToRegExp(positivePattern).test(name)) {
+          return false
+        }
+      }
+      else {
+        hasPositiveFilter = true
+        if (wildcardPatternToRegExp(project).test(name)) {
+          matchesPositiveFilter = true
+        }
+      }
+    }
+
+    return hasPositiveFilter ? matchesPositiveFilter : true
   }
 
   /** @internal */

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -237,6 +237,7 @@ describe('project filtering', () => {
     { pattern: '!project_1', expected: ['project_2', 'space_1'] },
     { pattern: '!project*', expected: ['space_1'] },
     { pattern: '!project', expected: allProjects },
+    { pattern: ['!project_1', '!project_2'], expected: ['space_1'] },
   ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
     const { ctx, stderr, stdout } = await runVitest({
       root: 'fixtures/project',


### PR DESCRIPTION
### Description

Resolves #10491

Multiple negated `--project=!name` filters were previously OR-combined, so each excluded project matched another negated pattern and was kept. This separates positive and negated project filters: positive filters opt projects in, negated filters always remove matches, and an all-negated filter list includes everything else.

I used Codex while preparing this change, reviewed the final diff, and ran the checks listed below locally.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Commands run:

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run build`
- `CI=true corepack pnpm -C test/e2e test projects.test.ts -t 'project filtering'` (failed before the production fix after adding the regression test)
- `corepack pnpm exec eslint --fix packages/vitest/src/node/core.ts test/e2e/test/projects.test.ts`
- `corepack pnpm exec tsc -p tsconfig.check.json --noEmit`
- `corepack pnpm --filter vitest run build`
- `CI=true corepack pnpm -C test/e2e test projects.test.ts -t 'project filtering'`

I did not run the full `pnpm test:ci` suite locally.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No documentation change: this fixes documented repeated `--project` negation behavior.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
