### PR TITLE
fix(reporters): print suite labels for CI-only reporter rows

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -1,5 +1,5 @@
 import type { ParsedStack, SerializedError } from '@vitest/utils'
-import type { File, Task, TestAnnotation, TestBenchmark, TestBenchmarkTask } from '../../runtime/runner/types'
+import type { File, Suite, Task, TestAnnotation, TestBenchmark, TestBenchmarkTask } from '../../runtime/runner/types'
 import type { AsyncLeak, TestError, UserConsoleLog } from '../../types/general'
 import type { Vitest } from '../core'
 import type { TestSpecification } from '../test-specification'
@@ -55,6 +55,7 @@ export abstract class BaseReporter implements Reporter {
   private _filesInWatchMode = new Map<string, number>()
   private _timeStart = formatTimeString(new Date())
   private _perProjectBenchmarks = new Map<string, Map<string, TestBenchmarkTask>>()
+  private _printedSuites = new Set<string>()
 
   constructor(options: BaseOptions = {}) {
     this.isTTY = options.isTTY ?? isTTY
@@ -154,6 +155,8 @@ export abstract class BaseReporter implements Reporter {
       return
     }
 
+    this._printedSuites.clear()
+
     let testsCount = 0
     let failedCount = 0
     let skippedCount = 0
@@ -236,6 +239,7 @@ export abstract class BaseReporter implements Reporter {
 
     // also print slow tests
     else if (duration > this.ctx.config.slowTestThreshold) {
+      this.printTestCaseParents(test)
       this.log(` ${padding}${c.yellow(c.dim(F_CHECK))} ${this.getTestName(test.task, separator)}${suffix}`)
     }
 
@@ -244,10 +248,15 @@ export abstract class BaseReporter implements Reporter {
     }
 
     else if (this.renderSucceed || moduleState === 'failed' || inlineBenchmarks.length) {
+      if (inlineBenchmarks.length) {
+        this.printTestCaseParents(test)
+      }
+
       this.log(` ${padding}${this.getStateSymbol(test)} ${this.getTestName(test.task, separator)}${suffix}`)
     }
 
     if (inlineBenchmarks.length > 0) {
+      this.printTestCaseParents(test)
       this.printBenchmarkTable(inlineBenchmarks, padding)
     }
   }
@@ -289,11 +298,41 @@ export abstract class BaseReporter implements Reporter {
       return
     }
 
-    const indentation = '  '.repeat(getIndentation(testSuite.task))
-    const tests = Array.from(testSuite.children.allTests())
-    const state = this.getStateSymbol(testSuite)
+    this.printTestSuiteEntry(testSuite)
+  }
 
-    this.log(` ${indentation}${state} ${testSuite.name} ${c.dim(`(${tests.length})`)}`)
+  private printTestSuiteEntry(testSuite: TestSuite): void {
+    this.printSuiteTaskEntry(testSuite.task)
+  }
+
+  private printTestCaseParents(test: TestCase): void {
+    if (this.renderSucceed) {
+      return
+    }
+
+    const parents: Suite[] = []
+    let parent = test.task.suite
+
+    while (parent && !('filepath' in parent) && !this._printedSuites.has(parent.id)) {
+      parents.push(parent)
+      parent = parent.suite
+    }
+
+    parents.reverse().forEach(parent => this.printSuiteTaskEntry(parent))
+  }
+
+  private printSuiteTaskEntry(suite: Suite): void {
+    if (this._printedSuites.has(suite.id)) {
+      return
+    }
+
+    this._printedSuites.add(suite.id)
+
+    const indentation = '  '.repeat(getIndentation(suite))
+    const tests = getTests(suite)
+    const state = getStateSymbol(suite)
+
+    this.log(` ${indentation}${state} ${suite.name} ${c.dim(`(${tests.length})`)}`)
   }
 
   protected getTestName(test: Task, _separator?: string): string {

--- a/test/e2e/test/reporters/default.test.ts
+++ b/test/e2e/test/reporters/default.test.ts
@@ -1,8 +1,10 @@
 import type { RunnerTask } from 'vitest/node'
-import { runVitest, runVitestCli, StableTestFileOrderSorter } from '#test-utils'
+import { runInlineTests, runVitest, runVitestCli, StableTestFileOrderSorter } from '#test-utils'
 import { describe, expect, test } from 'vitest'
 import { DefaultReporter } from 'vitest/node'
 import { trimReporterOutput } from './utils'
+
+const fastBenchOptions = { time: 0, iterations: 2, warmupTime: 0, warmupIterations: 0 }
 
 describe('default reporter', async () => {
   test('normal', async () => {
@@ -63,6 +65,67 @@ describe('default reporter', async () => {
     expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
       "✓ b1.test.ts (13 tests | 7 skipped) [...]ms
        ✓ b2.test.ts (13 tests | 7 skipped) [...]ms"
+    `)
+  })
+
+  test('prints parent suites for slow tests without rendering all passed tests', async () => {
+    const { stdout, stderr } = await runInlineTests(
+      {
+        'slow.test.ts': `
+          import { describe, test } from 'vitest'
+
+          describe('outer suite', () => {
+            describe('inner suite', () => {
+              test('slow nested test', async () => {
+                await new Promise(resolve => setTimeout(resolve, 50))
+              })
+            })
+          })
+        `,
+      },
+      {
+        reporters: [['default', { isTTY: false, summary: false }]],
+        slowTestThreshold: 1,
+      },
+    )
+
+    expect(stderr).toBe('')
+    expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+      "✓ slow.test.ts (1 test) [...]ms
+         ✓ outer suite (1)
+           ✓ inner suite (1)
+             ✓ slow nested test [...]ms"
+    `)
+  })
+
+  test('prints parent suites for inline benchmarks without rendering all passed tests', async () => {
+    const { stdout, stderr } = await runInlineTests(
+      {
+        'suite.bench.ts': `
+          import { describe, inject, test } from 'vitest'
+
+          describe('first suite', () => {
+            test('bench test', async ({ bench }) => {
+              await bench('bench', () => {}).run(inject('options'))
+            })
+          })
+        `,
+      },
+      {
+        benchmark: { enabled: true },
+        reporters: [['default', { isTTY: false, summary: false }]],
+        provide: { options: fastBenchOptions },
+      },
+    )
+
+    expect(stderr).toBe('')
+    expect(trimReporterOutput(stdout)
+      .split('\n')
+      .filter(line => /[✓❯×↓]/.test(line))
+      .join('\n')).toMatchInlineSnapshot(`
+      "✓ |bench| suite.bench.ts (1 test) [...]ms
+         ✓ first suite (1)
+           ✓ bench test [...]ms"
     `)
   })
 


### PR DESCRIPTION
Fixes #10606.

## Summary

- print missing parent suite labels before slow tests in non-TTY default reporter output
- print missing parent suite labels before inline benchmark rows in the same compact-output path
- add focused e2e coverage for nested slow tests and inline benchmarks

## Verification

- `CI=true corepack pnpm install -y`
- `CI=true corepack pnpm run build`
- `CI=true corepack pnpm --filter vitest run build`
- `CI=true corepack pnpm exec vitest run test/e2e/test/reporters/default.test.ts -t "prints parent suites"`
- `CI=true corepack pnpm exec eslint packages/vitest/src/node/reporters/base.ts test/e2e/test/reporters/default.test.ts`
- `git diff --check`

I also tried the full `test/e2e/test/reporters/default.test.ts` file locally, but the pre-existing fixture-root tests in this shallow checkout fail resolving `fixtures/reporters/default` from the workspace root. The new inline regression tests pass.

## Notes

AI-assisted implementation, manually reviewed before submission.
