### PR TITLE
fix(ui): remove stale task nodes when a file is re-collected

### DIFF
--- a/packages/ui/client/composables/explorer/tree.spec.ts
+++ b/packages/ui/client/composables/explorer/tree.spec.ts
@@ -1,0 +1,162 @@
+import type { RunnerTask, RunnerTestFile } from 'vitest'
+import type { FileTreeNode, SuiteTreeNode } from '~/composables/explorer/types'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { explorerTree } from '~/composables/explorer'
+import { createOrUpdateFileNode } from '~/composables/explorer/utils'
+
+interface TestSpec {
+  id: string
+  name: string
+  state?: 'pass' | 'fail'
+}
+
+interface SuiteSpec {
+  id: string
+  name: string
+  children: TestSpec[]
+}
+
+function buildTest(spec: TestSpec, file: RunnerTestFile): RunnerTask {
+  // a test task must not own a `tasks` property, otherwise it is treated as a suite
+  return {
+    id: spec.id,
+    name: spec.name,
+    type: 'test',
+    mode: 'run',
+    file,
+    result: spec.state ? { state: spec.state } : undefined,
+  } as unknown as RunnerTask
+}
+
+function buildSuite(spec: SuiteSpec, file: RunnerTestFile): RunnerTask {
+  return {
+    id: spec.id,
+    name: spec.name,
+    type: 'suite',
+    mode: 'run',
+    file,
+    tasks: spec.children.map(child => buildTest(child, file)),
+  } as unknown as RunnerTask
+}
+
+function buildFile(tasks: Array<TestSpec | SuiteSpec>): RunnerTestFile {
+  const file = {
+    id: 'file-1',
+    name: 'sample.test.ts',
+    type: 'suite',
+    mode: 'run',
+    meta: {},
+    filepath: '/sample.test.ts',
+    projectName: '',
+    result: { state: 'fail' },
+    tasks: [],
+  } as unknown as RunnerTestFile
+
+  file.tasks = tasks.map(task =>
+    'children' in task ? buildSuite(task, file) : buildTest(task, file),
+  )
+
+  return file
+}
+
+function fileNode() {
+  return explorerTree.nodes.get('file-1') as FileTreeNode
+}
+
+function childIds(node: FileTreeNode | SuiteTreeNode) {
+  return node.tasks.map(task => task.id)
+}
+
+describe('explorer tree re-collect', () => {
+  beforeEach(() => {
+    explorerTree.nodes.clear()
+    explorerTree.root.tasks.length = 0
+  })
+
+  it('removes a test that no longer exists when the file is re-collected', () => {
+    createOrUpdateFileNode(
+      buildFile([
+        { id: 't1', name: 'kept', state: 'pass' },
+        {
+          id: 's1',
+          name: 'suite',
+          children: [
+            { id: 't2', name: 'removed', state: 'fail' },
+            { id: 't3', name: 'sibling', state: 'pass' },
+          ],
+        },
+      ]),
+      true,
+    )
+
+    const suite = explorerTree.nodes.get('s1') as SuiteTreeNode
+    expect(childIds(suite)).toEqual(['t2', 't3'])
+    expect(explorerTree.nodes.has('t2')).toBe(true)
+
+    // re-collect after the failing test was deleted from the source file
+    createOrUpdateFileNode(
+      buildFile([
+        { id: 't1', name: 'kept', state: 'pass' },
+        {
+          id: 's1',
+          name: 'suite',
+          children: [{ id: 't3', name: 'sibling', state: 'pass' }],
+        },
+      ]),
+      true,
+    )
+
+    expect(explorerTree.nodes.has('t2')).toBe(false)
+    expect(suite.children.has('t2')).toBe(false)
+    expect(childIds(suite)).toEqual(['t3'])
+    // untouched tasks are preserved
+    expect(explorerTree.nodes.has('t3')).toBe(true)
+    expect(childIds(fileNode())).toEqual(['t1', 's1'])
+  })
+
+  it('removes an entire suite and its descendants when it is gone', () => {
+    createOrUpdateFileNode(
+      buildFile([
+        { id: 't1', name: 'kept', state: 'pass' },
+        {
+          id: 's1',
+          name: 'suite',
+          children: [{ id: 't3', name: 'nested', state: 'pass' }],
+        },
+      ]),
+      true,
+    )
+
+    expect(childIds(fileNode())).toEqual(['t1', 's1'])
+
+    createOrUpdateFileNode(
+      buildFile([{ id: 't1', name: 'kept', state: 'pass' }]),
+      true,
+    )
+
+    expect(childIds(fileNode())).toEqual(['t1'])
+    expect(fileNode().children.has('s1')).toBe(false)
+    expect(explorerTree.nodes.has('s1')).toBe(false)
+    // the suite's child must be removed too
+    expect(explorerTree.nodes.has('t3')).toBe(false)
+  })
+
+  it('keeps existing tasks and registers new ones on re-collect', () => {
+    createOrUpdateFileNode(
+      buildFile([{ id: 't1', name: 'a', state: 'pass' }]),
+      true,
+    )
+
+    createOrUpdateFileNode(
+      buildFile([
+        { id: 't1', name: 'a', state: 'pass' },
+        { id: 't2', name: 'b', state: 'pass' },
+      ]),
+      true,
+    )
+
+    expect(childIds(fileNode())).toEqual(['t1', 't2'])
+    expect(explorerTree.nodes.has('t1')).toBe(true)
+    expect(explorerTree.nodes.has('t2')).toBe(true)
+  })
+})

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -75,6 +75,52 @@ export function getSortedRootTasks(sort: SortUIType, tasks = explorerTree.root.t
   return sorted
 }
 
+function removeTreeNode(node: UITaskTreeNode) {
+  if (isParentNode(node)) {
+    for (let i = 0; i < node.tasks.length; i++) {
+      removeTreeNode(node.tasks[i])
+    }
+  }
+  explorerTree.nodes.delete(node.id)
+}
+
+// remove tracked children that are gone from the re-collected tasks, so a
+// removed or commented-out test does not linger in the sidebar until a reload
+function removeStaleChildNodes(node: FileTreeNode | SuiteTreeNode, tasks: Task[]) {
+  if (!node.children.size) {
+    return
+  }
+
+  const collected = new Set<string>()
+  for (let i = 0; i < tasks.length; i++) {
+    collected.add(tasks[i].id)
+  }
+
+  let stale = false
+  for (const id of node.children) {
+    if (!collected.has(id)) {
+      stale = true
+      break
+    }
+  }
+  if (!stale) {
+    return
+  }
+
+  const remaining: UITaskTreeNode[] = []
+  for (let i = 0; i < node.tasks.length; i++) {
+    const child = node.tasks[i]
+    if (collected.has(child.id)) {
+      remaining.push(child)
+    }
+    else {
+      node.children.delete(child.id)
+      removeTreeNode(child)
+    }
+  }
+  node.tasks = remaining
+}
+
 export function createOrUpdateFileNode(
   file: File,
   collect = false,
@@ -126,6 +172,7 @@ export function createOrUpdateFileNode(
     for (let i = 0; i < file.tasks.length; i++) {
       createOrUpdateNode(file.id, file.tasks[i], true)
     }
+    removeStaleChildNodes(fileNode, file.tasks)
   }
 }
 
@@ -234,6 +281,7 @@ export function createOrUpdateNode(
       for (let i = 0; i < task.tasks.length; i++) {
         createOrUpdateNode(taskNode.id, task.tasks[i], createAll)
       }
+      removeStaleChildNodes(taskNode as SuiteTreeNode, task.tasks)
     }
   }
 }


### PR DESCRIPTION
### Description

When a test is removed or commented out, the file is re-collected with fewer tasks. The sidebar tree only ever added or updated nodes while collecting; it never dropped the ones that were gone, so the orphaned entry stayed in the explorer (often still showing red) until a full page reload. Re-running all tests does not help, because the rerun goes through the same collect path. This matches the report in #10670.

`createOrUpdateFileNode` (when `collect` is set) and `createOrUpdateNode` (when `createAll` is set) rebuild a file or suite subtree from the collected tasks, but they only walked the incoming list, so any tracked child missing from it was left behind. This change reconciles the tracked children against the collected tasks after each subtree rebuild and removes any node, along with its descendants, that no longer exists.

The summary counts were already correct because they come from the live task tree rather than the UI nodes, which is why the console showed the right totals while the sidebar did not.

Resolves #10670

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Added `packages/ui/client/composables/explorer/tree.spec.ts`. It collects a file containing a suite, re-collects it after a test is deleted, and checks that the orphaned node is dropped, that a removed suite takes its children with it, and that untouched and newly added tasks stay. The two removal cases fail on `main` and pass with this change.

I went with a unit test rather than a browser e2e because the report is intermittent ("sometimes remains"), so an e2e around the watch rerun would be timing-dependent, while the reconciliation itself is deterministic.

### Documentation
- [ ] No user-facing API changes, so no documentation update is needed.

### Changesets
- [x] Changes in changelog are generated from PR name.
