### PR TITLE
fix(browser): check fs access in builtin commands [backport to v4]

### DIFF
--- a/packages/browser-playwright/src/commands/screenshot.ts
+++ b/packages/browser-playwright/src/commands/screenshot.ts
@@ -1,7 +1,7 @@
 import type { ScreenshotOptions } from 'vitest/browser'
 import type { BrowserCommandContext } from 'vitest/node'
 import { mkdir } from 'node:fs/promises'
-import { resolveScreenshotPath } from '@vitest/browser'
+import { assertBrowserApiWrite, assertBrowserFileAccess, resolveScreenshotPath } from '@vitest/browser'
 import { dirname, normalize } from 'pathe'
 import { getDescribedLocator } from './utils'
 
@@ -38,6 +38,9 @@ export async function takeScreenshot(
 
   if (options.save) {
     savePath = normalize(path)
+
+    assertBrowserApiWrite(context.project, savePath)
+    assertBrowserFileAccess(context.project, savePath)
 
     await mkdir(dirname(savePath), { recursive: true })
   }

--- a/packages/browser-playwright/src/commands/trace.ts
+++ b/packages/browser-playwright/src/commands/trace.ts
@@ -2,6 +2,7 @@ import type { ParsedStack } from 'vitest'
 import type { BrowserCommand, BrowserCommandContext, BrowserProvider } from 'vitest/node'
 import type { PlaywrightBrowserProvider } from '../playwright'
 import { unlink } from 'node:fs/promises'
+import { assertBrowserApiWrite, assertBrowserFileAccess } from '@vitest/browser'
 import { basename, dirname, relative, resolve } from 'pathe'
 import { getDescribedLocator } from './utils'
 
@@ -51,6 +52,8 @@ export const stopChunkTrace: BrowserCommand<[{ name: string }]> = async (
 ) => {
   if (isPlaywrightProvider(context.provider)) {
     const path = resolveTracesPath(context, name)
+    assertBrowserApiWrite(context.project, path)
+    assertBrowserFileAccess(context.project, path)
     context.provider.pendingTraces.delete(path)
     await context.context.tracing.stopChunk({ path })
     return { tracePath: path }
@@ -162,6 +165,10 @@ export const deleteTracing: BrowserCommand<[{ traces: string[] }]> = async (
     throw new Error(`stopChunkTrace cannot be called outside of the test file.`)
   }
   if (isPlaywrightProvider(context.provider)) {
+    for (const trace of traces) {
+      assertBrowserApiWrite(context.project, trace)
+      assertBrowserFileAccess(context.project, trace)
+    }
     return Promise.all(
       traces.map(trace => unlink(trace).catch((err) => {
         if (err.code === 'ENOENT') {

--- a/packages/browser-playwright/src/commands/trace.ts
+++ b/packages/browser-playwright/src/commands/trace.ts
@@ -190,6 +190,8 @@ export const annotateTraces: BrowserCommand<[{ traces: string[]; testId: string 
 ) => {
   const vitest = project.vitest
   await Promise.all(traces.map((trace) => {
+    assertBrowserApiWrite(project, trace)
+    assertBrowserFileAccess(project, trace)
     const entity = vitest.state.getReportedEntityById(testId)
     const location = entity?.location
       ? {

--- a/packages/browser-playwright/src/commands/upload.ts
+++ b/packages/browser-playwright/src/commands/upload.ts
@@ -1,5 +1,6 @@
 import type { UserEventUploadOptions } from 'vitest/browser'
 import type { UserEventCommand } from './utils'
+import { assertBrowserFileAccess } from '@vitest/browser'
 import { resolve } from 'pathe'
 import { getDescribedLocator } from './utils'
 
@@ -21,7 +22,9 @@ export const upload: UserEventCommand<(element: string, files: Array<string | {
 
   const playwrightFiles = files.map((file) => {
     if (typeof file === 'string') {
-      return resolve(root, file)
+      const filepath = resolve(root, file)
+      assertBrowserFileAccess(context.project, filepath)
+      return filepath
     }
     return {
       name: file.name,

--- a/packages/browser-webdriverio/src/commands/screenshot.ts
+++ b/packages/browser-webdriverio/src/commands/screenshot.ts
@@ -3,7 +3,7 @@ import type { BrowserCommandContext } from 'vitest/node'
 import crypto from 'node:crypto'
 import { mkdir, rm } from 'node:fs/promises'
 import { normalize as platformNormalize } from 'node:path'
-import { resolveScreenshotPath } from '@vitest/browser'
+import { assertBrowserApiWrite, assertBrowserFileAccess, resolveScreenshotPath } from '@vitest/browser'
 import { dirname, normalize, resolve } from 'pathe'
 
 interface ScreenshotCommandOptions extends Omit<ScreenshotOptions, 'element' | 'mask'> {
@@ -40,6 +40,9 @@ export async function takeScreenshot(
 
   if (options.save) {
     savePath = normalize(path)
+
+    assertBrowserApiWrite(context.project, savePath)
+    assertBrowserFileAccess(context.project, savePath)
 
     await mkdir(dirname(savePath), { recursive: true })
   }

--- a/packages/browser-webdriverio/src/commands/upload.ts
+++ b/packages/browser-webdriverio/src/commands/upload.ts
@@ -1,5 +1,6 @@
 import type { UserEventUploadOptions } from 'vitest/browser'
 import type { UserEventCommand } from './utils'
+import { assertBrowserFileAccess } from '@vitest/browser'
 import { resolve } from 'pathe'
 
 export const upload: UserEventCommand<(element: string, files: Array<string | {
@@ -28,6 +29,7 @@ export const upload: UserEventCommand<(element: string, files: Array<string | {
 
   for (const file of files) {
     const filepath = resolve(root, file as string)
+    assertBrowserFileAccess(context.project, filepath)
     const remoteFilePath = await context.browser.uploadFile(filepath)
     await element.addValue(remoteFilePath)
   }

--- a/packages/browser/src/node/commands/fs.ts
+++ b/packages/browser/src/node/commands/fs.ts
@@ -1,33 +1,15 @@
 import type { BrowserCommands } from 'vitest/browser'
-import type { BrowserCommand, TestProject } from 'vitest/node'
+import type { BrowserCommand } from 'vitest/node'
 import fs, { promises as fsp } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
 import mime from 'mime/lite'
-import { isFileLoadingAllowed } from 'vitest/node'
-import { slash } from '../utils'
-
-function assertFileAccess(path: string, project: TestProject) {
-  if (
-    !isFileLoadingAllowed(project.vite.config, path)
-    && !isFileLoadingAllowed(project.vitest.vite.config, path)
-  ) {
-    throw new Error(
-      `Access denied to "${path}". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.`,
-    )
-  }
-}
-
-function assertWrite(path: string, project: TestProject) {
-  if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
-    throw new Error(`Cannot modify file "${path}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/browser/api.`)
-  }
-}
+import { assertBrowserApiWrite, assertBrowserFileAccess } from '../utils'
 
 export const readFile: BrowserCommand<
   Parameters<BrowserCommands['readFile']>
 > = async ({ project }, path, options = {}) => {
   const filepath = resolve(project.config.root, path)
-  assertFileAccess(slash(filepath), project)
+  assertBrowserFileAccess(project, filepath)
   // never return a Buffer
   if (typeof options === 'object' && !options.encoding) {
     options.encoding = 'utf-8'
@@ -38,9 +20,9 @@ export const readFile: BrowserCommand<
 export const writeFile: BrowserCommand<
   Parameters<BrowserCommands['writeFile']>
 > = async ({ project }, path, data, options) => {
-  assertWrite(path, project)
   const filepath = resolve(project.config.root, path)
-  assertFileAccess(slash(filepath), project)
+  assertBrowserApiWrite(project, filepath)
+  assertBrowserFileAccess(project, filepath)
   const dir = dirname(filepath)
   if (!fs.existsSync(dir)) {
     await fsp.mkdir(dir, { recursive: true })
@@ -51,15 +33,15 @@ export const writeFile: BrowserCommand<
 export const removeFile: BrowserCommand<
   Parameters<BrowserCommands['removeFile']>
 > = async ({ project }, path) => {
-  assertWrite(path, project)
   const filepath = resolve(project.config.root, path)
-  assertFileAccess(slash(filepath), project)
+  assertBrowserApiWrite(project, filepath)
+  assertBrowserFileAccess(project, filepath)
   await fsp.rm(filepath)
 }
 
 export const _fileInfo: BrowserCommand<[path: string, encoding: BufferEncoding]> = async ({ project }, path, encoding) => {
   const filepath = resolve(project.config.root, path)
-  assertFileAccess(slash(filepath), project)
+  assertBrowserFileAccess(project, filepath)
   const content = await fsp.readFile(filepath, encoding || 'base64')
   return {
     content,

--- a/packages/browser/src/node/commands/fs.ts
+++ b/packages/browser/src/node/commands/fs.ts
@@ -20,8 +20,8 @@ export const readFile: BrowserCommand<
 export const writeFile: BrowserCommand<
   Parameters<BrowserCommands['writeFile']>
 > = async ({ project }, path, data, options) => {
+  assertBrowserApiWrite(project, path)
   const filepath = resolve(project.config.root, path)
-  assertBrowserApiWrite(project, filepath)
   assertBrowserFileAccess(project, filepath)
   const dir = dirname(filepath)
   if (!fs.existsSync(dir)) {
@@ -33,8 +33,8 @@ export const writeFile: BrowserCommand<
 export const removeFile: BrowserCommand<
   Parameters<BrowserCommands['removeFile']>
 > = async ({ project }, path) => {
+  assertBrowserApiWrite(project, path)
   const filepath = resolve(project.config.root, path)
-  assertBrowserApiWrite(project, filepath)
   assertBrowserFileAccess(project, filepath)
   await fsp.rm(filepath)
 }

--- a/packages/browser/src/node/commands/screenshotMatcher/index.ts
+++ b/packages/browser/src/node/commands/screenshotMatcher/index.ts
@@ -1,6 +1,6 @@
 import type { SnapshotUpdateState } from 'vitest'
 import type { ScreenshotMatcherOptions } from 'vitest/browser'
-import type { BrowserCommand, BrowserCommandContext } from 'vitest/node'
+import type { BrowserCommand, BrowserCommandContext, TestProject } from 'vitest/node'
 import type { ScreenshotMatcherArguments, ScreenshotMatcherOutput } from '../../../shared/screenshotMatcher/types'
 import type { AnyCodec } from './codecs'
 import type { AnyComparator } from './comparators'
@@ -8,6 +8,7 @@ import type { TypedArray } from './types'
 import type { ResolvedOptions } from './utils'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname } from 'pathe'
+import { assertBrowserApiWrite, assertBrowserFileAccess } from '../../utils'
 import { asyncTimeout, resolveOptions, takeDecodedScreenshot } from './utils'
 
 /** Decoded image data with dimensions metadata. */
@@ -108,7 +109,7 @@ export const screenshotMatcher: BrowserCommand<ScreenshotMatcherArguments> = asy
     comparatorOptions,
   })
 
-  await performSideEffects(outcome, codec)
+  await performSideEffects(outcome, codec, context.project)
 
   return buildOutput(outcome, timeout)
 }
@@ -230,6 +231,7 @@ async function determineOutcome(
 async function performSideEffects(
   outcome: MatchOutcome,
   codec: AnyCodec,
+  project: TestProject,
 ): Promise<void> {
   switch (outcome.type) {
     case 'missing-reference':
@@ -237,6 +239,7 @@ async function performSideEffects(
       await writeScreenshot(
         outcome.reference.path,
         await codec.encode(outcome.reference.image, {}),
+        project,
       )
 
       break
@@ -246,12 +249,14 @@ async function performSideEffects(
       await writeScreenshot(
         outcome.actual.path,
         await codec.encode(outcome.actual.image, {}),
+        project,
       )
 
       if (outcome.diff) {
         await writeScreenshot(
           outcome.diff.path,
           await codec.encode(outcome.diff.image, {}),
+          project,
         )
       }
 
@@ -456,8 +461,10 @@ async function getStableScreenshot({
 }
 
 /** Writes encoded images to disk, creating parent directories as needed. */
-async function writeScreenshot(path: string, image: TypedArray) {
+async function writeScreenshot(path: string, image: TypedArray, project: TestProject) {
   try {
+    assertBrowserApiWrite(project, path)
+    assertBrowserFileAccess(project, path)
     await mkdir(dirname(path), { recursive: true })
     await writeFile(path, image)
   }

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -18,7 +18,7 @@ export function defineBrowserCommand<T extends unknown[]>(
 }
 
 // export type { ProjectBrowser } from './project'
-export { parseKeyDef, resolveScreenshotPath } from './utils'
+export { assertBrowserApiWrite, assertBrowserFileAccess, parseKeyDef, resolveScreenshotPath } from './utils'
 
 export { asLocator } from 'ivya'
 

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -12,7 +12,7 @@ import { ServerMockResolver } from '@vitest/mocker/node'
 import { extractSourcemapFromFile } from '@vitest/utils/source-map/node'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
-import { dirname, join } from 'pathe'
+import { dirname, join, resolve } from 'pathe'
 import { createDebugger, isFileLoadingAllowed, isValidApiRequest } from 'vitest/node'
 import { WebSocketServer } from 'ws'
 
@@ -209,6 +209,19 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
               vitest.logger.error(
                 `[vitest] Cannot record attachments ("${attachments}") because file writing is disabled, removing attachments from artifact "${artifact.type}". See https://vitest.dev/config/browser/api.`,
               )
+            }
+          }
+          else {
+            // attachment files are copied into `attachmentsDir`, so confine
+            // client-supplied paths to Vite's `server.fs` boundary
+            const attachments = artifact.type === 'internal:annotation'
+              ? (artifact.annotation.attachment ? [artifact.annotation.attachment] : [])
+              : (artifact.attachments ?? [])
+            for (const attachment of attachments) {
+              const path = attachment.path
+              if (path && !path.startsWith('http://') && !path.startsWith('https://')) {
+                checkFileAccess(resolve(project.config.root, path))
+              }
             }
           }
 

--- a/packages/browser/src/node/utils.ts
+++ b/packages/browser/src/node/utils.ts
@@ -8,6 +8,7 @@ import type {
 import { defaultKeyMap } from '@testing-library/user-event/dist/esm/keyboard/keyMap.js'
 import { parseKeyDef as tlParse } from '@testing-library/user-event/dist/esm/keyboard/parseKeyDef.js'
 import { basename, dirname, relative, resolve } from 'pathe'
+import { isFileLoadingAllowed } from 'vitest/node'
 
 declare enum DOM_KEY_LOCATION {
   STANDARD = 0,
@@ -94,4 +95,24 @@ export async function getBrowserProvider(
 
 export function slash(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/')
+}
+
+export function assertBrowserFileAccess(project: TestProject, path: string): void {
+  const normalized = slash(path)
+  if (
+    !isFileLoadingAllowed(project.vite.config, normalized)
+    && !isFileLoadingAllowed(project.vitest.vite.config, normalized)
+  ) {
+    throw new Error(
+      `Access denied to "${path}". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.`,
+    )
+  }
+}
+
+export function assertBrowserApiWrite(project: TestProject, path: string): void {
+  if (!project.config.browser.api.allowWrite || !project.vitest.config.api.allowWrite) {
+    throw new Error(
+      `Cannot modify file "${path}". File writing is disabled because the server is exposed to the internet, see https://vitest.dev/config/browser/api.`,
+    )
+  }
 }

--- a/test/browser/fixtures/command-permissions-screenshot-denied/screenshot-denied.test.ts
+++ b/test/browser/fixtures/command-permissions-screenshot-denied/screenshot-denied.test.ts
@@ -1,0 +1,7 @@
+import { test } from 'vitest'
+import { page } from 'vitest/browser'
+
+test('screenshot denied path', async () => {
+  // write is allowed, but the target is denied via `server.fs.deny`
+  await page.screenshot({ path: 'my-secret.png' })
+})

--- a/test/browser/fixtures/command-permissions-screenshot-denied/vitest.config.ts
+++ b/test/browser/fixtures/command-permissions-screenshot-denied/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  server: {
+    fs: {
+      deny: ['my-secret.png'],
+    },
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+      screenshotFailures: false,
+    },
+  },
+})

--- a/test/browser/fixtures/command-permissions-screenshot-no-write/screenshot-write.test.ts
+++ b/test/browser/fixtures/command-permissions-screenshot-no-write/screenshot-write.test.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest'
+import { page } from 'vitest/browser'
+
+test('screenshot blocked', async () => {
+  await page.screenshot({ path: 'out.png' })
+})

--- a/test/browser/fixtures/command-permissions-screenshot-no-write/vitest.config.ts
+++ b/test/browser/fixtures/command-permissions-screenshot-no-write/vitest.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    api: {
+      allowExec: false,
+      allowWrite: false,
+    },
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+      screenshotFailures: false,
+      api: {
+        allowExec: false,
+        allowWrite: false,
+      },
+    },
+  },
+})

--- a/test/browser/fixtures/command-permissions-upload-denied/my-secret.txt
+++ b/test/browser/fixtures/command-permissions-upload-denied/my-secret.txt
@@ -1,0 +1,1 @@
+secret content

--- a/test/browser/fixtures/command-permissions-upload-denied/upload-denied.test.ts
+++ b/test/browser/fixtures/command-permissions-upload-denied/upload-denied.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'vitest'
+import { userEvent } from 'vitest/browser'
+
+test('upload denied path', async () => {
+  const input = document.createElement('input')
+  input.type = 'file'
+  document.body.append(input)
+  // the file exists in the project, but is denied via `server.fs.deny`
+  await userEvent.upload(input, 'my-secret.txt')
+})

--- a/test/browser/fixtures/command-permissions-upload-denied/vitest.config.ts
+++ b/test/browser/fixtures/command-permissions-upload-denied/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  server: {
+    fs: {
+      deny: ['my-secret.txt'],
+    },
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+      screenshotFailures: false,
+    },
+  },
+})

--- a/test/browser/specs/errors.test.ts
+++ b/test/browser/specs/errors.test.ts
@@ -251,3 +251,57 @@ test.runIf(provider.name === 'playwright')('cannot use cdp if write or exec is d
     }
   `)
 })
+
+test('upload is blocked for files denied by server.fs.deny', async () => {
+  const result = await runBrowserTests({
+    root: './fixtures/command-permissions-upload-denied',
+    project: [instances[0].browser],
+  })
+  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+    {
+      "chromium": {
+        "upload-denied.test.ts": {
+          "upload denied path": [
+            "Access denied to "<root>/my-secret.txt". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.",
+          ],
+        },
+      },
+    }
+  `)
+})
+
+test('takeScreenshot is blocked for files denied by server.fs.deny', async () => {
+  const result = await runBrowserTests({
+    root: './fixtures/command-permissions-screenshot-denied',
+    project: [instances[0].browser],
+  })
+  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+    {
+      "chromium": {
+        "screenshot-denied.test.ts": {
+          "screenshot denied path": [
+            "Access denied to "<root>/my-secret.png". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.",
+          ],
+        },
+      },
+    }
+  `)
+})
+
+test('takeScreenshot is blocked when write is disabled', async () => {
+  const result = await runBrowserTests({
+    root: './fixtures/command-permissions-screenshot-no-write',
+    project: [instances[0].browser],
+  })
+  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+    {
+      "chromium": {
+        "screenshot-write.test.ts": {
+          "screenshot blocked": [
+            "Cannot modify file "<root>/out.png". File writing is disabled because the server is exposed to the internet, see https://vitest.dev/config/browser/api.",
+          ],
+        },
+      },
+    }
+  `)
+})

--- a/test/browser/specs/errors.test.ts
+++ b/test/browser/specs/errors.test.ts
@@ -257,14 +257,12 @@ test('upload is blocked for files denied by server.fs.deny', async () => {
     root: './fixtures/command-permissions-upload-denied',
     project: [instances[0].browser],
   })
-  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+  expect(result.errorTree()).toMatchInlineSnapshot(`
     {
-      "chromium": {
-        "upload-denied.test.ts": {
-          "upload denied path": [
-            "Access denied to "<root>/my-secret.txt". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.",
-          ],
-        },
+      "upload-denied.test.ts": {
+        "upload denied path": [
+          "Access denied to "<root>/my-secret.txt". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.",
+        ],
       },
     }
   `)
@@ -275,14 +273,12 @@ test('takeScreenshot is blocked for files denied by server.fs.deny', async () =>
     root: './fixtures/command-permissions-screenshot-denied',
     project: [instances[0].browser],
   })
-  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+  expect(result.errorTree()).toMatchInlineSnapshot(`
     {
-      "chromium": {
-        "screenshot-denied.test.ts": {
-          "screenshot denied path": [
-            "Access denied to "<root>/my-secret.png". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.",
-          ],
-        },
+      "screenshot-denied.test.ts": {
+        "screenshot denied path": [
+          "Access denied to "<root>/my-secret.png". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.",
+        ],
       },
     }
   `)
@@ -293,14 +289,12 @@ test('takeScreenshot is blocked when write is disabled', async () => {
     root: './fixtures/command-permissions-screenshot-no-write',
     project: [instances[0].browser],
   })
-  expect(result.errorTree({ project: true })).toMatchInlineSnapshot(`
+  expect(result.errorTree()).toMatchInlineSnapshot(`
     {
-      "chromium": {
-        "screenshot-write.test.ts": {
-          "screenshot blocked": [
-            "Cannot modify file "<root>/out.png". File writing is disabled because the server is exposed to the internet, see https://vitest.dev/config/browser/api.",
-          ],
-        },
+      "screenshot-write.test.ts": {
+        "screenshot blocked": [
+          "Cannot modify file "<root>/out.png". File writing is disabled because the server is exposed to the internet, see https://vitest.dev/config/browser/api.",
+        ],
       },
     }
   `)

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -577,6 +577,9 @@ export function buildErrorTree(testModules: TestModule[], options?: { stackTrace
 
   function mapError(e: { message: string; diff?: string; stacks?: { file: string; line: number; column: number; method: string }[] }) {
     let message = e.message
+    if (root) {
+      message = replaceRoot(message, root)
+    }
     if (options?.diff && e.diff) {
       message = [message, stripVTControlCharacters(e.diff)].join('\n')
     }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- backport https://github.com/vitest-dev/vitest/pull/10674

This is mostly same diff as original. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
