### PR TITLE
fix: don't print column in test names when `includeTaskLocation` is enabled

### DIFF
--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -248,10 +248,10 @@ Example output:
 An example with `--includeTaskLocation`:
 
 ```bash
-✓ __tests__/file1.test.ts:2:1 > first test file > 2 + 2 should equal 4 1ms
-✓ __tests__/file1.test.ts:3:1 > first test file > 4 - 2 should equal 2 1ms
-✓ __tests__/file2.test.ts:2:1 > second test file > 1 + 1 should equal 2 1ms
-✓ __tests__/file2.test.ts:3:1 > second test file > 2 - 1 should equal 1 1ms
+✓ __tests__/file1.test.ts:2 > first test file > 2 + 2 should equal 4 1ms
+✓ __tests__/file1.test.ts:3 > first test file > 4 - 2 should equal 2 1ms
+✓ __tests__/file2.test.ts:2 > second test file > 1 + 1 should equal 2 1ms
+✓ __tests__/file2.test.ts:3 > second test file > 2 - 1 should equal 1 1ms
 
  Test Files  2 passed (2)
       Tests  4 passed (4)

--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -307,7 +307,7 @@ export abstract class BaseReporter implements Reporter {
 
     let name = test.file.name
     if (test.location) {
-      name += c.dim(`:${test.location.line}:${test.location.column}`)
+      name += c.dim(`:${test.location.line}`)
     }
     name += separator
     name += getTestName(test, separator)

--- a/packages/vitest/src/node/reporters/verbose.ts
+++ b/packages/vitest/src/node/reporters/verbose.ts
@@ -26,7 +26,7 @@ export class VerboseReporter extends DefaultReporter {
 
     title += test.module.task.name
     if (test.location) {
-      title += c.dim(`:${test.location.line}:${test.location.column}`)
+      title += c.dim(`:${test.location.line}`)
     }
     title += separator
 

--- a/test/e2e/test/no-module-runner.test.ts
+++ b/test/e2e/test/no-module-runner.test.ts
@@ -517,7 +517,7 @@ if (import.meta.vitest) {
       "
       ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 
-       FAIL  in-source.ts:12:3 > works
+       FAIL  in-source.ts:12 > works
       Error: test throws correctly
        ❯ <anonymous> in-source.ts:13:11
            11|

--- a/test/e2e/test/public-api.test.ts
+++ b/test/e2e/test/public-api.test.ts
@@ -46,7 +46,7 @@ it.each([
 
   expect(stderr).toBe('')
 
-  expect(stdout).toContain('custom.spec.ts:14:1 > custom')
+  expect(stdout).toContain('custom.spec.ts:14 > custom')
 
   const suiteMeta = { done: true }
   const testMeta = { custom: 'some-custom-handler' }

--- a/test/e2e/test/reporters/verbose.test.ts
+++ b/test/e2e/test/reporters/verbose.test.ts
@@ -135,20 +135,20 @@ test('renders locations if enabled', async () => {
   })
 
   expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
-    "✓ fixtures/reporters/verbose/example-1.test.ts:3:1 > test pass in root [...]ms
-     ↓ fixtures/reporters/verbose/example-1.test.ts:5:6 > test skip in root
-     ✓ fixtures/reporters/verbose/example-1.test.ts:8:3 > suite in root > test pass in 1. suite #1 [...]ms
-     ✓ fixtures/reporters/verbose/example-1.test.ts:10:3 > suite in root > test pass in 1. suite #2 [...]ms
-     ✓ fixtures/reporters/verbose/example-1.test.ts:13:5 > suite in root > suite in suite > test pass in nested suite #1 [...]ms
-     ✓ fixtures/reporters/verbose/example-1.test.ts:15:5 > suite in root > suite in suite > test pass in nested suite #2 [...]ms
-     × fixtures/reporters/verbose/example-1.test.ts:18:7 > suite in root > suite in suite > suite in nested suite > test failure in 2x nested suite [...]ms
+    "✓ fixtures/reporters/verbose/example-1.test.ts:3 > test pass in root [...]ms
+     ↓ fixtures/reporters/verbose/example-1.test.ts:5 > test skip in root
+     ✓ fixtures/reporters/verbose/example-1.test.ts:8 > suite in root > test pass in 1. suite #1 [...]ms
+     ✓ fixtures/reporters/verbose/example-1.test.ts:10 > suite in root > test pass in 1. suite #2 [...]ms
+     ✓ fixtures/reporters/verbose/example-1.test.ts:13 > suite in root > suite in suite > test pass in nested suite #1 [...]ms
+     ✓ fixtures/reporters/verbose/example-1.test.ts:15 > suite in root > suite in suite > test pass in nested suite #2 [...]ms
+     × fixtures/reporters/verbose/example-1.test.ts:18 > suite in root > suite in suite > suite in nested suite > test failure in 2x nested suite [...]ms
        → expected 'should fail' to be 'as expected' // Object.is equality
-     ↓ fixtures/reporters/verbose/example-1.test.ts:26:3 > suite skip in root > test 1.3
-     ↓ fixtures/reporters/verbose/example-1.test.ts:29:5 > suite skip in root > suite in suite > test in nested suite
-     ↓ fixtures/reporters/verbose/example-1.test.ts:31:5 > suite skip in root > suite in suite > test failure in nested suite of skipped suite
-     ✓ fixtures/reporters/verbose/example-2.test.ts:3:1 > test 0.1 [...]ms
-     ↓ fixtures/reporters/verbose/example-2.test.ts:5:6 > test 0.2
-     ✓ fixtures/reporters/verbose/example-2.test.ts:8:3 > suite 1.1 > test 1.1 [...]ms"
+     ↓ fixtures/reporters/verbose/example-1.test.ts:26 > suite skip in root > test 1.3
+     ↓ fixtures/reporters/verbose/example-1.test.ts:29 > suite skip in root > suite in suite > test in nested suite
+     ↓ fixtures/reporters/verbose/example-1.test.ts:31 > suite skip in root > suite in suite > test failure in nested suite of skipped suite
+     ✓ fixtures/reporters/verbose/example-2.test.ts:3 > test 0.1 [...]ms
+     ↓ fixtures/reporters/verbose/example-2.test.ts:5 > test 0.2
+     ✓ fixtures/reporters/verbose/example-2.test.ts:8 > suite 1.1 > test 1.1 [...]ms"
   `)
 })
 

--- a/test/typescript/test/__snapshots__/runner.test.ts.snap
+++ b/test/typescript/test/__snapshots__/runner.test.ts.snap
@@ -12,7 +12,7 @@ TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has n
 `;
 
 exports[`should fail > typecheck files 2`] = `
-" FAIL  fail.test-d.ts:7:1 > nested suite
+" FAIL  fail.test-d.ts:7 > nested suite
 TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has no call signatures.
  ❯ fail.test-d.ts:15:19
      13|   })
@@ -23,7 +23,7 @@ TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has n
 `;
 
 exports[`should fail > typecheck files 3`] = `
-" FAIL  expect-error.test-d.ts:4:1 > failing test with expect-error
+" FAIL  expect-error.test-d.ts:4 > failing test with expect-error
 TypeCheckError: Unused '@ts-expect-error' directive.
  ❯ expect-error.test-d.ts:5:3
       3| //
@@ -34,7 +34,7 @@ TypeCheckError: Unused '@ts-expect-error' directive.
 `;
 
 exports[`should fail > typecheck files 4`] = `
-" FAIL  fail.test-d.ts:3:1 > failing test
+" FAIL  fail.test-d.ts:3 > failing test
 TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string, Actual number"'.
  ❯ fail.test-d.ts:4:33
       2|
@@ -45,7 +45,7 @@ TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string,
 `;
 
 exports[`should fail > typecheck files 5`] = `
-" FAIL  fail.test-d.ts:9:5 > nested suite > nested 2 > failing test 2
+" FAIL  fail.test-d.ts:9 > nested suite > nested 2 > failing test 2
 TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has no call signatures.
  ❯ fail.test-d.ts:10:23
       8|   describe('nested 2', () => {
@@ -56,7 +56,7 @@ TypeCheckError: This expression is not callable. Type 'ExpectVoid<number>' has n
 `;
 
 exports[`should fail > typecheck files 6`] = `
-" FAIL  fail.test-d.ts:9:5 > nested suite > nested 2 > failing test 2
+" FAIL  fail.test-d.ts:9 > nested suite > nested 2 > failing test 2
 TypeCheckError: This expression is not callable. Type 'ExpectUndefined<number>' has no call signatures.
  ❯ fail.test-d.ts:11:23
       9|     test('failing test 2', () => {
@@ -67,7 +67,7 @@ TypeCheckError: This expression is not callable. Type 'ExpectUndefined<number>' 
 `;
 
 exports[`should fail > typecheck files 7`] = `
-" FAIL  js-fail.test-d.js:5:1 > js test fails
+" FAIL  js-fail.test-d.js:5 > js test fails
 TypeCheckError: This expression is not callable. Type 'ExpectArray<number>' has no call signatures.
  ❯ js-fail.test-d.js:6:19
       4|
@@ -78,7 +78,7 @@ TypeCheckError: This expression is not callable. Type 'ExpectArray<number>' has 
 `;
 
 exports[`should fail > typecheck files 8`] = `
-" FAIL  node-types.test-d.ts:3:1 > buffer is not available
+" FAIL  node-types.test-d.ts:3 > buffer is not available
 TypeCheckError: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try \`npm i --save-dev @types/node\` and then add 'node' to the types field in your tsconfig.
  ❯ node-types.test-d.ts:4:3
       2|
@@ -89,7 +89,7 @@ TypeCheckError: Cannot find name 'Buffer'. Do you need to install type definitio
 `;
 
 exports[`should fail > typecheck files 9`] = `
-" FAIL  only.test-d.ts:3:1 > failing test
+" FAIL  only.test-d.ts:3 > failing test
 TypeCheckError: Type 'string' does not satisfy the constraint '"Expected string, Actual number"'.
  ❯ only.test-d.ts:4:33
       2|


### PR DESCRIPTION
Vitest doesn't support `file:line:column` format when running tests, so one always has to manually remove the column when copying the path. Instead, let's just only print the line. Column is usually irrelevant anyway