### PR TITLE
feat: add --smart-rerun to prioritize or skip previously failed tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test/e2e/fixtures/browser-multiple/basic-*
 .vitest
 explainFiles.txt
 .vitest-dump
+.vitest-failed-cache.json

--- a/docs/config/smartrerun.md
+++ b/docs/config/smartrerun.md
@@ -1,0 +1,14 @@
+---
+title: smartRerun | Config
+outline: deep
+---
+
+# smartRerun
+
+- **Type:** `boolean`
+- **CLI:** `--smartRerun`, `--smart-rerun`
+- **Default:** `false`
+
+Cache the file paths of failed tests in `.vitest-failed-cache.json` in the project root. On the next run, previously failed tests are moved to the front of the test queue so they run first, ahead of the rest of the suite. The cache file is automatically removed once all tests pass.
+
+See [`smartRerunOnlyFailed`](/config/smartrerunonlyfailed) to skip files that passed in the previous run instead of just reordering them.

--- a/docs/config/smartrerunonlyfailed.md
+++ b/docs/config/smartrerunonlyfailed.md
@@ -1,0 +1,16 @@
+---
+title: smartRerunOnlyFailed | Config
+outline: deep
+---
+
+# smartRerunOnlyFailed
+
+- **Type:** `boolean`
+- **CLI:** `--smartRerunOnlyFailed`, `--smart-rerun-only-failed`
+- **Default:** `false`
+
+Requires [`smartRerun`](/config/smartrerun) to be enabled. Instead of just moving previously failed tests to the front, skips files that passed in the previous run entirely and only runs files from the failed tests cache. Falls back to running every file when the cache is empty or none of the cached files still exist.
+
+::: warning
+Skipped files are not part of the run's report, the same way files excluded by `--shard` are not reported. Regressions introduced in skipped files won't be caught until a full run (without this option) happens.
+:::

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -548,6 +548,20 @@ Ignore any unhandled errors that occur
 
 Run tests that are affected by the changed files (default: `false`)
 
+### smartRerun
+
+- **CLI:** `--smartRerun`
+- **Config:** [smartRerun](/config/smartrerun)
+
+Run previously failed tests first, caching failed test files between runs in `.vitest-failed-cache.json` (default: `false`)
+
+### smartRerunOnlyFailed
+
+- **CLI:** `--smartRerunOnlyFailed`
+- **Config:** [smartRerunOnlyFailed](/config/smartrerunonlyfailed)
+
+Requires `--smart-rerun`. Skip files that passed in the previous run and only run files from the failed tests cache (default: `false`)
+
 ### sequence.shuffle.files
 
 - **CLI:** `--sequence.shuffle.files`

--- a/packages/vitest/src/node/cache/smart-rerun.ts
+++ b/packages/vitest/src/node/cache/smart-rerun.ts
@@ -1,0 +1,83 @@
+import type { TestSpecification } from '../test-specification'
+import fs from 'node:fs'
+import { resolve } from 'pathe'
+
+export const smartRerunCacheFilename = '.vitest-failed-cache.json'
+
+interface SmartRerunCacheFile {
+  failedFiles: string[]
+}
+
+export function getSmartRerunCachePath(root: string): string {
+  return resolve(root, smartRerunCacheFilename)
+}
+
+export async function readSmartRerunCache(root: string): Promise<string[]> {
+  const cachePath = getSmartRerunCachePath(root)
+  if (!fs.existsSync(cachePath)) {
+    return []
+  }
+
+  try {
+    const content = await fs.promises.readFile(cachePath, 'utf8')
+    const data = JSON.parse(content) as Partial<SmartRerunCacheFile>
+    return Array.isArray(data.failedFiles) ? data.failedFiles : []
+  }
+  catch {
+    return []
+  }
+}
+
+export async function writeSmartRerunCache(root: string, failedFiles: string[]): Promise<void> {
+  const cachePath = getSmartRerunCachePath(root)
+  const data: SmartRerunCacheFile = { failedFiles }
+  await fs.promises.writeFile(cachePath, JSON.stringify(data, null, 2))
+}
+
+export async function clearSmartRerunCache(root: string): Promise<void> {
+  const cachePath = getSmartRerunCachePath(root)
+  if (fs.existsSync(cachePath)) {
+    await fs.promises.rm(cachePath, { force: true })
+  }
+}
+
+// Moves specs for previously failed files to the front, keeping the relative order otherwise untouched.
+export function prioritizeFailedSpecs(
+  specs: TestSpecification[],
+  failedFiles: string[],
+): TestSpecification[] {
+  if (!failedFiles.length) {
+    return specs
+  }
+
+  const failed = new Set(failedFiles)
+  const previouslyFailed: TestSpecification[] = []
+  const rest: TestSpecification[] = []
+
+  for (const spec of specs) {
+    if (failed.has(spec.moduleId)) {
+      previouslyFailed.push(spec)
+    }
+    else {
+      rest.push(spec)
+    }
+  }
+
+  return [...previouslyFailed, ...rest]
+}
+
+// Keeps only specs for previously failed files, skipping the rest of the suite.
+// Falls back to every spec when the cache is empty or none of the cached files still match a spec.
+export function filterToFailedSpecs(
+  specs: TestSpecification[],
+  failedFiles: string[],
+): TestSpecification[] {
+  if (!failedFiles.length) {
+    return specs
+  }
+
+  const failed = new Set(failedFiles)
+  const matched = specs.filter(spec => failed.has(spec.moduleId))
+
+  return matched.length ? matched : specs
+}

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -517,6 +517,14 @@ export const cliOptionsConfig: VitestCLIOptions = {
       'Run tests that are affected by the changed files (default: `false`)',
     argument: '[since]',
   },
+  smartRerun: {
+    description:
+      'Run previously failed tests first, caching failed test files between runs in `.vitest-failed-cache.json` (default: `false`)',
+  },
+  smartRerunOnlyFailed: {
+    description:
+      'Requires `--smart-rerun`. Skip files that passed in the previous run and only run files from the failed tests cache (default: `false`)',
+  },
   sequence: {
     description: 'Options for how tests should be sorted',
     argument: '<options>',

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -35,6 +35,7 @@ import { astCollectTests, createFailedFileTask } from './ast-collect'
 import { BrowserSessions } from './browser/sessions'
 import { VitestCache } from './cache'
 import { FileSystemModuleCache } from './cache/fsModuleCache'
+import { clearSmartRerunCache, writeSmartRerunCache } from './cache/smart-rerun'
 import { resolveConfig } from './config/resolveConfig'
 import { getCoverageProvider } from './coverage'
 import { createFetchModuleFunction } from './environments/fetchModule'
@@ -1004,6 +1005,19 @@ export class Vitest {
             await this.cache.results.writeToCache()
           }
           catch {}
+
+          if (this.config.smartRerun) {
+            const failedFilepaths = this.state.getFailedFilepaths()
+            try {
+              if (failedFilepaths.length) {
+                await writeSmartRerunCache(this.config.root, failedFilepaths)
+              }
+              else {
+                await clearSmartRerunCache(this.config.root)
+              }
+            }
+            catch {}
+          }
 
           return {
             testModules: this.state.getTestModules(),

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -13,6 +13,7 @@ import { rootDir } from '../paths'
 import { isWindows } from '../utils/env'
 import { getWorkerMemoryLimit, stringToBytes } from '../utils/memory-limit'
 import { getSpecificationsOptions } from '../utils/test-helpers'
+import { filterToFailedSpecs, prioritizeFailedSpecs, readSmartRerunCache } from './cache/smart-rerun'
 import { createBrowserPool } from './pools/browser'
 import { Pool } from './pools/pool'
 
@@ -86,7 +87,13 @@ export function createPool(ctx: Vitest): ProcessPool {
     }[] = []
     let workerId = 1
 
-    const sorted = await sequencer.sort(specs)
+    let sorted = await sequencer.sort(specs)
+    if (ctx.config.smartRerun) {
+      const failedFiles = await readSmartRerunCache(ctx.config.root)
+      sorted = ctx.config.smartRerunOnlyFailed
+        ? filterToFailedSpecs(sorted, failedFiles)
+        : prioritizeFailedSpecs(sorted, failedFiles)
+    }
     const { environments, tags } = await getSpecificationsOptions(specs)
     const groups = groupSpecs(sorted, environments)
 

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -992,6 +992,23 @@ export interface InlineConfig {
    * @default false
    */
   changed?: boolean | string
+
+  /**
+   * Cache the file paths of failed tests in `.vitest-failed-cache.json` in the project root.
+   * On the next run, previously failed tests are moved to the front of the test queue so they run first.
+   * The cache file is automatically removed once all tests pass.
+   * @default false
+   */
+  smartRerun?: boolean
+
+  /**
+   * Requires `smartRerun` to be enabled. Instead of just moving previously failed tests to the front,
+   * skips files that passed in the previous run entirely and only runs files from the failed tests cache.
+   * Skipped files are not part of the run's report, the same way files excluded by `--shard` are not reported.
+   * Falls back to running every file when the cache is empty or none of the cached files still exist.
+   * @default false
+   */
+  smartRerunOnlyFailed?: boolean
 }
 
 export interface TypecheckConfig {

--- a/test/unit/test/cli-test.test.ts
+++ b/test/unit/test/cli-test.test.ts
@@ -347,6 +347,22 @@ test('configure expect', () => {
   })
 })
 
+test('smartRerun is parsed correctly', () => {
+  expect(getCLIOptions('--smartRerun')).toEqual({ smartRerun: true })
+  expect(getCLIOptions('--smart-rerun')).toEqual({ smartRerun: true })
+  expect(getCLIOptions('--no-smart-rerun')).toEqual({ smartRerun: false })
+})
+
+test('smartRerunOnlyFailed is parsed correctly', () => {
+  expect(getCLIOptions('--smartRerunOnlyFailed')).toEqual({ smartRerunOnlyFailed: true })
+  expect(getCLIOptions('--smart-rerun-only-failed')).toEqual({ smartRerunOnlyFailed: true })
+  expect(getCLIOptions('--no-smart-rerun-only-failed')).toEqual({ smartRerunOnlyFailed: false })
+  expect(getCLIOptions('--smart-rerun --smart-rerun-only-failed')).toEqual({
+    smartRerun: true,
+    smartRerunOnlyFailed: true,
+  })
+})
+
 test('silent', () => {
   expect(getCLIOptions('--silent')).toEqual({ silent: true })
   expect(getCLIOptions('--silent=true')).toEqual({ silent: true })

--- a/test/unit/test/smart-rerun.test.ts
+++ b/test/unit/test/smart-rerun.test.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import {
+  clearSmartRerunCache,
+  filterToFailedSpecs,
+  getSmartRerunCachePath,
+  prioritizeFailedSpecs,
+  readSmartRerunCache,
+  smartRerunCacheFilename,
+  writeSmartRerunCache,
+} from '../../../packages/vitest/src/node/cache/smart-rerun'
+import { TestSpecification } from '../../../packages/vitest/src/node/test-specification'
+
+function buildWorkspace() {
+  return {
+    name: 'test',
+    config: {
+      root: import.meta.dirname,
+      sequence: { groupOrder: 0 },
+    },
+  } as any
+}
+
+const workspace = buildWorkspace()
+
+function specs(files: string[]) {
+  return files.map(file => new TestSpecification(workspace, file, 'forks'))
+}
+
+describe('smart rerun cache', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(join(tmpdir(), 'vitest-smart-rerun-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  test('saves the failed file paths to .vitest-failed-cache.json', async () => {
+    await writeSmartRerunCache(root, ['/repo/a.test.ts', '/repo/b.test.ts'])
+
+    const cachePath = getSmartRerunCachePath(root)
+    expect(cachePath.endsWith(smartRerunCacheFilename)).toBe(true)
+    expect(fs.existsSync(cachePath)).toBe(true)
+    expect(JSON.parse(fs.readFileSync(cachePath, 'utf8'))).toEqual({
+      failedFiles: ['/repo/a.test.ts', '/repo/b.test.ts'],
+    })
+  })
+
+  test('loads the failed file paths that were previously saved', async () => {
+    await writeSmartRerunCache(root, ['/repo/a.test.ts'])
+    expect(await readSmartRerunCache(root)).toEqual(['/repo/a.test.ts'])
+  })
+
+  test('loading returns an empty array when no cache file exists yet', async () => {
+    expect(await readSmartRerunCache(root)).toEqual([])
+  })
+
+  test('loading returns an empty array when the cache file is corrupted', async () => {
+    fs.writeFileSync(getSmartRerunCachePath(root), 'not valid json')
+    expect(await readSmartRerunCache(root)).toEqual([])
+  })
+
+  test('clears the cache file once all tests pass', async () => {
+    await writeSmartRerunCache(root, ['/repo/a.test.ts'])
+    await clearSmartRerunCache(root)
+    expect(fs.existsSync(getSmartRerunCachePath(root))).toBe(false)
+  })
+
+  test('clearing a cache file that does not exist is a no-op', async () => {
+    await expect(clearSmartRerunCache(root)).resolves.not.toThrow()
+  })
+})
+
+describe('prioritizeFailedSpecs', () => {
+  test('moves a previously failed file to the front of the queue', () => {
+    const files = specs(['a', 'b', 'c'])
+    const sorted = prioritizeFailedSpecs(files, ['b'])
+    expect(sorted).toStrictEqual(specs(['b', 'a', 'c']))
+  })
+
+  test('moves multiple previously failed files to the front, preserving their relative order', () => {
+    const files = specs(['a', 'b', 'c', 'd'])
+    const sorted = prioritizeFailedSpecs(files, ['c', 'a'])
+    expect(sorted).toStrictEqual(specs(['a', 'c', 'b', 'd']))
+  })
+
+  test('returns the same specs untouched when there are no previously failed files', () => {
+    const files = specs(['a', 'b', 'c'])
+    expect(prioritizeFailedSpecs(files, [])).toBe(files)
+  })
+
+  test('ignores failed paths that no longer match any spec', () => {
+    const files = specs(['a', 'b'])
+    expect(prioritizeFailedSpecs(files, ['/no-longer-exists.test.ts'])).toStrictEqual(files)
+  })
+})
+
+describe('filterToFailedSpecs', () => {
+  test('keeps only the specs that previously failed', () => {
+    const files = specs(['a', 'b', 'c'])
+    expect(filterToFailedSpecs(files, ['b'])).toStrictEqual(specs(['b']))
+  })
+
+  test('keeps multiple previously failed specs, preserving their relative order', () => {
+    const files = specs(['a', 'b', 'c', 'd'])
+    expect(filterToFailedSpecs(files, ['c', 'a'])).toStrictEqual(specs(['a', 'c']))
+  })
+
+  test('returns the same specs untouched when there are no previously failed files', () => {
+    const files = specs(['a', 'b', 'c'])
+    expect(filterToFailedSpecs(files, [])).toBe(files)
+  })
+
+  test('falls back to every spec when none of the failed paths match', () => {
+    const files = specs(['a', 'b'])
+    expect(filterToFailedSpecs(files, ['/no-longer-exists.test.ts'])).toStrictEqual(files)
+  })
+})


### PR DESCRIPTION

## Summary
- Adds `--smart-rerun`: caches failed test file paths to `.vitest-failed-cache.json` and runs them first on the next invocation, ahead of the rest of the suite. Cache clears automatically once everything passes.
- Adds `--smart-rerun-only-failed` (requires `--smart-rerun`): instead of reordering, skips files that passed last run entirely and only executes previously-failed files. Falls back to a full run if the cache is empty or stale.
- Both flags are off by default and do not alter existing behavior.

## Test plan
- [x] Unit tests for cache save/load/clear, corrupted-cache handling, reorder, and filter logic (`test/unit/test/smart-rerun.test.ts`)
- [x] CLI parsing tests for both flags (`test/unit/test/cli-test.test.ts`)
- [x] `pnpm run build` passes with no type errors
- [x] Full `test/unit` suite passes
- [x] Verified pre-existing/environment-specific failures elsewhere in the monorepo are unaffected by this change (reproduced identically on `main` via `git stash`)

Closes #7834
Related to #10247

<!-- VITEST_AUTOMATED_PR -->
