### PR TITLE
fix(expect): correct inverted failIfNoFirstInvocation logic in toHaveBeenCalledBefore/After

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -683,11 +683,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const afterInvocationCallOrder = afterSpy.mock.invocationCallOrder
 
     if (beforeInvocationCallOrder.length === 0) {
-      return !failIfNoFirstInvocation
+      return false
     }
 
     if (afterInvocationCallOrder.length === 0) {
-      return false
+      return !failIfNoFirstInvocation
     }
 
     return beforeInvocationCallOrder[0] < afterInvocationCallOrder[0]

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -990,12 +990,14 @@ describe('toHaveBeenCalledBefore', () => {
     }).toThrow(/^expected "vi\.fn\(\)" to have been called before "resultMock"/)
   })
 
-  it('not fails if expect mock is not called with option `failIfNoFirstInvocation` set to false', () => {
-    const resultMock = vi.fn()
+  it('fails if expect mock is not called even with option `failIfNoFirstInvocation` set to false', () => {
+    const resultMock = vi.fn().mockName('resultMock')
 
     resultMock()
 
-    expect(vi.fn()).toHaveBeenCalledBefore(resultMock, false)
+    expect(() => {
+      expect(vi.fn()).toHaveBeenCalledBefore(resultMock, false)
+    }).toThrow(/^expected "vi\.fn\(\)" to have been called before "resultMock"/)
   })
 
   it('fails if result mock is not called', () => {
@@ -1006,6 +1008,14 @@ describe('toHaveBeenCalledBefore', () => {
     expect(() => {
       expect(expectMock).toHaveBeenCalledBefore(vi.fn())
     }).toThrow(/^expected "expectMock" to have been called before "vi\.fn\(\)"/)
+  })
+
+  it('not fails if result mock is not called with option `failIfNoFirstInvocation` set to false', () => {
+    const expectMock = vi.fn().mockName('expectMock')
+
+    expectMock()
+
+    expect(expectMock).toHaveBeenCalledBefore(vi.fn(), false)
   })
 })
 
@@ -1066,12 +1076,14 @@ describe('toHaveBeenCalledAfter', () => {
     }).toThrow(/^expected "expectMock" to have been called after "vi\.fn\(\)"/)
   })
 
-  it('not fails if result mock is not called with option `failIfNoFirstInvocation` set to false', () => {
-    const expectMock = vi.fn()
+  it('fails if result mock is not called even with option `failIfNoFirstInvocation` set to false', () => {
+    const expectMock = vi.fn().mockName('expectMock')
 
     expectMock()
 
-    expect(expectMock).toHaveBeenCalledAfter(vi.fn(), false)
+    expect(() => {
+      expect(expectMock).toHaveBeenCalledAfter(vi.fn(), false)
+    }).toThrow(/^expected "expectMock" to have been called after "vi\.fn\(\)"/)
   })
 
   it('fails if expect mock is not called', () => {
@@ -1082,6 +1094,14 @@ describe('toHaveBeenCalledAfter', () => {
     expect(() => {
       expect(vi.fn()).toHaveBeenCalledAfter(resultMock)
     }).toThrow(/^expected "vi\.fn\(\)" to have been called after "resultMock"/)
+  })
+
+  it('not fails if expect mock is not called with option `failIfNoFirstInvocation` set to false', () => {
+    const resultMock = vi.fn().mockName('resultMock')
+
+    resultMock()
+
+    expect(vi.fn()).toHaveBeenCalledAfter(resultMock, false)
   })
 })
 


### PR DESCRIPTION
isSpyCalledBeforeAnotherSpy has its two empty-invocation checks backwards. The spy under test never being called is gated by `failIfNoFirstInvocation`, while the other spy never being called always returns `false` regardless of the flag. It should be the opposite, per jest-extended's reference implementation.

Concretely: `expect(neverCalledSpy).toHaveBeenCalledBefore(otherSpy, false)` currently passes silently when it should throw, and `expect(calledSpy).toHaveBeenCalledBefore(neverCalledSpy, false)` throws when it shouldn't. Same inversion for `toHaveBeenCalledAfter`. For a matcher, letting a wrong assertion pass quietly is the worse failure mode.

Swapped the two branches and fixed the two existing tests that were locking in the wrong behavior, plus added one test per matcher for the previously-unreachable correct case.