### PR TITLE
fix(vitest): normalize cached imports on lowercase Windows drives (fix #10692)

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
+++ b/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
@@ -6,8 +6,22 @@ import { distDir } from '../../paths'
 
 const bareVitestRegexp = /^@?vitest(?:\/|$)/
 const normalizedDistDir = normalize(distDir)
+const isWindows = process.platform === 'win32'
+const distDirMatcher = isWindows ? distDir.toLowerCase() : distDir
+const normalizedDistDirMatcher = isWindows ? normalizedDistDir.toLowerCase() : normalizedDistDir
 const relativeIds: Record<string, string> = {}
 const externalizeMap = new Map<string, string>()
+
+function getMatcher(id: string): string {
+  return isWindows ? id.toLowerCase() : id
+}
+
+function normalizeDriveLetter(id: string, root: string): string {
+  if (id[1] === ':' && root[1] === ':' && id[0].toLowerCase() === root[0].toLowerCase()) {
+    return root[0] + id.slice(1)
+  }
+  return id
+}
 
 // all Vitest imports always need to be externalized
 export function getCachedVitestImport(
@@ -18,14 +32,21 @@ export function getCachedVitestImport(
     id = id.slice(process.platform === 'win32' ? 5 : 4)
   }
 
+  let root: string | undefined
+  if (isWindows && id[1] === ':') {
+    root = state().config.root
+    id = normalizeDriveLetter(id, root)
+  }
+
   if (externalizeMap.has(id)) {
     return { externalize: externalizeMap.get(id)!, type: 'module' }
   }
   // always externalize Vitest because we import from there before running tests
   // so we already have it cached by Node.js
-  const root = state().config.root
+  root ??= state().config.root
   const relativeRoot = relativeIds[root] ?? (relativeIds[root] = normalizedDistDir.slice(root.length))
-  if (id.includes(distDir) || id.includes(normalizedDistDir)) {
+  const idMatcher = getMatcher(id)
+  if (idMatcher.includes(distDirMatcher) || idMatcher.includes(normalizedDistDirMatcher)) {
     const { file, postfix } = splitFileAndPostfix(id)
     const externalize = id.startsWith('file://')
       ? id
@@ -36,7 +57,7 @@ export function getCachedVitestImport(
   if (
     // "relative" to root path:
     // /node_modules/.pnpm/vitest/dist
-    (relativeRoot && relativeRoot !== '/' && id.startsWith(relativeRoot))
+    (relativeRoot && relativeRoot !== '/' && idMatcher.startsWith(getMatcher(relativeRoot)))
   ) {
     const { file, postfix } = splitFileAndPostfix(id)
     const path = join(root, file)

--- a/test/core/test/cached-resolver.test.ts
+++ b/test/core/test/cached-resolver.test.ts
@@ -1,0 +1,46 @@
+import type { WorkerGlobalState } from '../../../packages/vitest/src/types/worker'
+import { pathToFileURL } from 'node:url'
+import { expect, test } from 'vitest'
+import { distDir } from '../../../packages/vitest/src/paths'
+import { getCachedVitestImport } from '../../../packages/vitest/src/runtime/moduleRunner/cachedResolver'
+
+const DRIVE_LETTER_START_RE = /^[A-Z]:/i
+
+function withLowercaseDrive(path: string): string {
+  return path.replace(DRIVE_LETTER_START_RE, drive => drive.toLowerCase())
+}
+
+function withUppercaseDrive(path: string): string {
+  return path.replace(DRIVE_LETTER_START_RE, drive => drive.toUpperCase())
+}
+
+test.runIf(process.platform === 'win32')('externalizes Vitest imports with a lowercase drive letter', () => {
+  const id = `${withLowercaseDrive(distDir)}/index.js`
+
+  const result = getCachedVitestImport(id, () => ({
+    config: {
+      root: distDir,
+    },
+  } as WorkerGlobalState))
+
+  expect(result).toEqual({
+    externalize: pathToFileURL(`${distDir}/index.js`).toString(),
+    type: 'module',
+  })
+})
+
+test.runIf(process.platform === 'win32')('normalizes /@fs/ Vitest imports to the project root drive letter', () => {
+  const id = `${withUppercaseDrive(distDir)}/index.js`
+  const root = withLowercaseDrive(distDir)
+
+  const result = getCachedVitestImport(`/@fs/${id}`, () => ({
+    config: {
+      root,
+    },
+  } as WorkerGlobalState))
+
+  expect(result).toEqual({
+    externalize: pathToFileURL(`${withLowercaseDrive(distDir)}/index.js`).toString(),
+    type: 'module',
+  })
+})


### PR DESCRIPTION
# fix(vitest): normalize cached imports on lowercase Windows drives (fix #10692)

<!-- VITEST_AUTOMATED_PR -->

## Summary

This PR fixes Vitest's cached self-import resolution on Windows when the process is started from a lowercase drive-letter path.

- Match Vitest dist paths case-insensitively on Windows.
- Normalize absolute Windows module ids to the configured project root drive-letter casing before externalizing them.
- Add regression coverage for lowercase drive letters and `/@fs/` Vitest import ids.

## Related Issue

Fixes https://github.com/vitest-dev/vitest/issues/10692

## Context

The issue reproduces with `worker-f` on Windows:

- `d:\...\worker-f && npm test` fails during collection with `Vitest failed to find the current suite`.
- `D:\...\worker-f && npm test` collects tests and reaches the project's own assertion failure.

The failing path is a duplicated Vitest module instance: `/@fs/D:/.../node_modules/vitest/dist/index.js` is externalized as `file:///D:/...`, while the CLI process was started from `d:/...`.

## Changes

- `packages/vitest/src/runtime/moduleRunner/cachedResolver.ts`: normalize Windows drive-letter casing for absolute ids before cache lookup and externalization.
- `test/core/test/cached-resolver.test.ts`: add Windows-only regression tests for lowercase dist ids and `/@fs/` ids.

## Validation

Commands run:

```bash
corepack pnpm -C test/core test cached-resolver.test.ts
corepack pnpm -C test/cli test windows-drive-case.test.ts
corepack pnpm exec eslint packages/vitest/src/runtime/moduleRunner/cachedResolver.ts test/core/test/cached-resolver.test.ts
corepack pnpm --filter vitest run build
cmd /c "cd /d d:\GitHubTemp\worker-f && npm test"
```

Results:

- `cached-resolver.test.ts`: 3 projects passed, 6 tests passed.
- `windows-drive-case.test.ts`: passed.
- ESLint: passed.
- `vitest` package build: passed.
- `worker-f` with the local rebuilt Vitest dist no longer fails with `Vitest failed to find the current suite`; it reaches the same project assertion failure as the uppercase-drive run.

## Scope And Risk

- Scope intentionally kept to Vitest self-import caching in the module runner.
- This does not change general user module resolution.
- Maintainers may want to confirm whether aligning to `config.root` is preferred over `process.cwd()` for drive-letter casing.

## Assistance Disclosure

I used Codex as a development assistant for reading code, drafting candidate tests, and organizing validation notes. I reviewed the code, ran the listed checks, and take responsibility for the final content of this PR.
