### PR TITLE
feat: allow merging test reports via a glob pattern

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -176,7 +176,7 @@ This method can be slow because it needs to filter `--changed` flags. Do not use
 function mergeReports(directory?: string): Promise<TestRunResult>
 ```
 
-Merge reports from multiple runs located in the specified directory (value from `--merge-reports` if not specified). This value can also be set on `config.mergeReports` (by default, it will read `.vitest/blob/` folder).
+Merge reports from multiple runs located in the specified directory or matching the specified glob pattern (value from `--merge-reports` if not specified). This value can also be set on `config.mergeReports` (by default, it will read `.vitest/blob/` folder).
 
 Note that the `directory` will always be resolved relative to the working directory.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -219,7 +219,7 @@ If `--reporter=blob` is used without an output file, the default path will inclu
 
 - **Type:** `boolean | string`
 
-Merges every blob report located in the specified folder (`.vitest/blob/` by default). You can use any reporters with this command (except [`blob`](/guide/reporters#blob-reporter)):
+Merges every blob report located in the specified folder (`.vitest/blob/` by default) or matching the specified glob pattern. You can use any reporters with this command (except [`blob`](/guide/reporters#blob-reporter)):
 
 ```sh
 vitest --merge-reports --reporter=junit

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -862,7 +862,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
   },
   mergeReports: {
     description:
-      'Path to a blob reports directory. If this options is used, Vitest won\'t run any tests, it will only report previously recorded tests',
+      'Path to a blob reports directory or glob pattern. If this options is used, Vitest won\'t run any tests, it will only report previously recorded tests',
     argument: '[path]',
     transform(value) {
       if (!value || typeof value === 'boolean') {

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -635,7 +635,7 @@ export class Vitest {
   }
 
   /**
-   * Merge reports from multiple runs located in the specified directory (value from `--merge-reports` if not specified).
+   * Merge reports from multiple runs located in the specified directory or matching the specified glob pattern (value from `--merge-reports` if not specified).
    */
   public async mergeReports(directory?: string): Promise<TestRunResult> {
     return this._traces.$('vitest.merge_reports', async () => {

--- a/packages/vitest/src/node/reporters/blob.ts
+++ b/packages/vitest/src/node/reporters/blob.ts
@@ -9,7 +9,8 @@ import { existsSync } from 'node:fs'
 import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { sanitizeFilePath } from '@vitest/utils/helpers'
 import { parse, stringify } from 'flatted'
-import { dirname, resolve } from 'pathe'
+import { dirname, relative, resolve } from 'pathe'
+import { glob, isDynamicPattern } from 'tinyglobby'
 import { getOutputFile } from '../../utils/config-helpers'
 
 export interface BlobOptions {
@@ -123,10 +124,24 @@ export async function readBlobs(
   projectsArray: TestProject[],
 ): Promise<MergedBlobs> {
   // using process.cwd() because --merge-reports can only be used in CLI
-  const resolvedDir = resolve(process.cwd(), blobsDirectory)
-  const blobsFiles = await readdir(resolvedDir)
-  const promises = blobsFiles.map(async (filename) => {
-    const fullPath = resolve(resolvedDir, filename)
+  const cwd = process.cwd()
+  const resolvedDir = resolve(cwd, blobsDirectory)
+  const blobsFiles = isDynamicPattern(blobsDirectory)
+    ? (await glob(blobsDirectory, {
+        absolute: true,
+        cwd,
+        dot: true,
+        expandDirectories: false,
+        onlyFiles: true,
+      })).map(fullPath => ({
+        fullPath,
+        filename: relative(cwd, fullPath),
+      }))
+    : (await readdir(resolvedDir)).map(filename => ({
+        fullPath: resolve(resolvedDir, filename),
+        filename,
+      }))
+  const promises = blobsFiles.map(async ({ fullPath, filename }) => {
     const stats = await stat(fullPath)
     if (!stats.isFile()) {
       throw new TypeError(
@@ -148,7 +163,7 @@ export async function readBlobs(
 
   if (!blobs.length) {
     throw new Error(
-      `vitest.mergeReports() requires at least one blob file in "${blobsDirectory}" directory, but none were found`,
+      `vitest.mergeReports() requires at least one blob file in "${blobsDirectory}", but none were found`,
     )
   }
 

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -267,9 +267,11 @@ test('merge reports from glob pattern', async () => {
     reporters: [['blob', { outputFile: './.vitest/blob/second-run.json' }]],
   })
 
+  await writeFile(resolve(reportsDir, 'ignored.json'), '{"not":"a blob report"}')
+
   const { stdout, exitCode } = await runVitest({
     root: './fixtures/reporters/merge-reports',
-    mergeReports: `${reportsDir}/*.json`,
+    mergeReports: `${reportsDir}/*-run.json`,
     reporters: [['default', { isTTY: false }]],
   })
 

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -254,6 +254,30 @@ test('merge reports', async () => {
   `)
 })
 
+test('merge reports from glob pattern', async () => {
+  await runVitest({
+    root: './fixtures/reporters/merge-reports',
+    include: ['first.test.ts'],
+    reporters: [['blob', { outputFile: './.vitest/blob/first-run.json' }]],
+  })
+
+  await runVitest({
+    root: './fixtures/reporters/merge-reports',
+    include: ['second.test.ts'],
+    reporters: [['blob', { outputFile: './.vitest/blob/second-run.json' }]],
+  })
+
+  const { stdout, exitCode } = await runVitest({
+    root: './fixtures/reporters/merge-reports',
+    mergeReports: `${reportsDir}/*.json`,
+    reporters: [['default', { isTTY: false }]],
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stdout).toContain('first.test.ts')
+  expect(stdout).toContain('second.test.ts')
+})
+
 test('total and merged execution times are shown', async () => {
   for (const [_index, name] of ['first.test.ts', 'second.test.ts'].entries()) {
     const index = 1 + _index

--- a/test/unit/test/cli-test.test.ts
+++ b/test/unit/test/cli-test.test.ts
@@ -327,6 +327,7 @@ test('merge-reports', () => {
   expect(getCLIOptions('--merge-reports')).toEqual({ mergeReports: '.vitest/blob' })
   expect(getCLIOptions('--merge-reports=different-folder')).toEqual({ mergeReports: 'different-folder' })
   expect(getCLIOptions('--merge-reports different-folder')).toEqual({ mergeReports: 'different-folder' })
+  expect(getCLIOptions('--merge-reports .vitest/blob/**/*.json')).toEqual({ mergeReports: '.vitest/blob/**/*.json' })
 })
 
 test('configure expect', () => {


### PR DESCRIPTION
### Description

Resolves #10699. This adds the functionality to use a glob pattern instead for `--merge-reports` CLI option. This is useful for merging coverage reports across multiple subdirectories in say, a monorepo that's not using vitest's projects option.

Note that I'm not sure this is the correct architectural boundary; ideally, collection of files happens at the interface level _before_ it's passed to `readBlobs`, but I didn't want to do a massive refactor. So this is a bit hairy. I also wasn't sure whether to add a new command line argument like `--glob` to make the usage explicit instead of overriding the string, but given both `--include` and `--exclude` use `isDynamicPattern` to runtime swap between them, I figured this was the idiomatic choice.

Updates docs/docstrings and adds a single e2e test.