### PR TITLE
fix(ui): remove file nodes when a test file is deleted or renamed

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -44,6 +44,11 @@ export const client: VitestClient = (function createVitestClient() {
           explorerTree.resumeRun(packs, events)
           testRunState.value = 'running'
         },
+        onTestRemoved(id) {
+          if (id) {
+            explorerTree.removeFiles([id])
+          }
+        },
         onSpecsCollected(_specs, startTime) {
           explorerTree.startTime = startTime || performance.now()
         },

--- a/packages/ui/client/composables/client/state.ts
+++ b/packages/ui/client/composables/client/state.ts
@@ -70,6 +70,26 @@ export class StateManager {
     })
   }
 
+  // drop every file collected under the given paths, e.g. when a test file is
+  // deleted or renamed on disk, so it is not resurrected on the next collect
+  removeFiles(paths: string[]): void {
+    paths.forEach((path) => {
+      const files = this.filesMap.get(path)
+      if (!files) {
+        return
+      }
+      files.forEach(file => this.removeId(file))
+      this.filesMap.delete(path)
+    })
+  }
+
+  private removeId(task: RunnerTask): void {
+    this.idMap.delete(task.id)
+    if (task.type === 'suite') {
+      task.tasks.forEach(child => this.removeId(child))
+    }
+  }
+
   // this file is reused by ws-client, and should not rely on heavy dependencies like workspace
   clearFiles(
     _project: { config: { name: string | undefined; root: string } },

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -74,6 +74,12 @@ export function createWsClient(url: string, options: VitestClientOptions = {}): 
       ctx.state.updateTasks(packs)
       handlers.onTaskUpdate?.(packs, events)
     },
+    onTestRemoved(id) {
+      if (id) {
+        ctx.state.removeFiles([id])
+      }
+      handlers.onTestRemoved?.(id)
+    },
     onUserConsoleLog(log) {
       ctx.state.updateUserLog(log)
       handlers.onUserConsoleLog?.(log)

--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -1,6 +1,6 @@
 import type { Arrayable } from '@vitest/utils'
 import type { RunnerTestFile as File, RunnerTask as Task, RunnerTaskResultPack as TaskResultPack, RunnerTestCase as Test, TestArtifact } from 'vitest'
-import type { CollectFilteredTests, CollectorInfo, Filter, FilteredTests, SearchMatcher } from '~/composables/explorer/types'
+import type { CollectFilteredTests, CollectorInfo, FileTreeNode, Filter, FilteredTests, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
 import { toArray } from '@vitest/utils/helpers'
 import { client, findById } from '~/composables/client'
 import { testRunState } from '~/composables/client/state'
@@ -18,6 +18,7 @@ import {
   createOrUpdateFileNode,
   createOrUpdateNodeTask,
   createOrUpdateSuiteTask,
+  isParentNode,
   isRunningTestNode,
   isSlowTestTask,
 } from '~/composables/explorer/utils'
@@ -44,6 +45,49 @@ export function runLoadFiles(
     slow: filter.slow,
     onlyTests: filter.onlyTests,
   })
+}
+
+function dropNode(node: UITaskTreeNode) {
+  if (isParentNode(node)) {
+    for (let i = 0; i < node.tasks.length; i++) {
+      dropNode(node.tasks[i])
+    }
+  }
+  explorerTree.nodes.delete(node.id)
+}
+
+/**
+ * Drop the file nodes for test files that no longer exist.
+ *
+ * When a test file is deleted or renamed on disk, the watcher removes it from
+ * the run state and reports `onTestRemoved`, but the sidebar tree keeps file
+ * nodes at the root and never dropped them. A deleted file lingered and a
+ * rename left a stale duplicate until Vitest was fully restarted.
+ */
+export function runRemoveFiles(paths: string[]) {
+  const removed = new Set(paths)
+  const root = explorerTree.root
+  const kept: FileTreeNode[] = []
+  let changed = false
+
+  for (let i = 0; i < root.tasks.length; i++) {
+    const fileNode = root.tasks[i]
+    if (removed.has(fileNode.filepath)) {
+      dropNode(fileNode)
+      explorerTree.pendingTasks.delete(fileNode.id)
+      changed = true
+    }
+    else {
+      kept.push(fileNode)
+    }
+  }
+
+  if (!changed) {
+    return
+  }
+
+  root.tasks = kept
+  uiFiles.value = [...root.tasks]
 }
 
 export function preparePendingTasks(packs: TaskResultPack[]) {

--- a/packages/ui/client/composables/explorer/tree-remove.spec.ts
+++ b/packages/ui/client/composables/explorer/tree-remove.spec.ts
@@ -1,0 +1,147 @@
+import type { RunnerTask, RunnerTestFile } from 'vitest'
+import type { FileTreeNode } from '~/composables/explorer/types'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { explorerTree } from '~/composables/explorer'
+import { createOrUpdateFileNode } from '~/composables/explorer/utils'
+// relative on purpose: importing the client state before `~/composables/explorer`
+// trips the client module's circular init (config/testRunState TDZ)
+import { StateManager } from '../client/state'
+
+interface TestSpec {
+  id: string
+  name: string
+  state?: 'pass' | 'fail'
+}
+
+interface SuiteSpec {
+  id: string
+  name: string
+  children: TestSpec[]
+}
+
+function buildTest(spec: TestSpec, file: RunnerTestFile): RunnerTask {
+  // a test task must not own a `tasks` property, otherwise it is treated as a suite
+  return {
+    id: spec.id,
+    name: spec.name,
+    type: 'test',
+    mode: 'run',
+    file,
+    result: spec.state ? { state: spec.state } : undefined,
+  } as unknown as RunnerTask
+}
+
+function buildSuite(spec: SuiteSpec, file: RunnerTestFile): RunnerTask {
+  return {
+    id: spec.id,
+    name: spec.name,
+    type: 'suite',
+    mode: 'run',
+    file,
+    tasks: spec.children.map(child => buildTest(child, file)),
+  } as unknown as RunnerTask
+}
+
+function buildFile(id: string, filepath: string, tasks: Array<TestSpec | SuiteSpec>): RunnerTestFile {
+  const file = {
+    id,
+    name: filepath.slice(1),
+    type: 'suite',
+    mode: 'run',
+    meta: {},
+    filepath,
+    projectName: '',
+    result: { state: 'pass' },
+    tasks: [],
+  } as unknown as RunnerTestFile
+
+  file.tasks = tasks.map(task =>
+    'children' in task ? buildSuite(task, file) : buildTest(task, file),
+  )
+
+  return file
+}
+
+describe('explorer tree file removal', () => {
+  beforeEach(() => {
+    explorerTree.nodes.clear()
+    explorerTree.root.tasks.length = 0
+  })
+
+  it('drops a deleted file node with its descendants and keeps the others', () => {
+    createOrUpdateFileNode(
+      buildFile('file-a', '/a.test.ts', [
+        { id: 'a-t1', name: 'top', state: 'pass' },
+        {
+          id: 'a-s1',
+          name: 'suite',
+          children: [{ id: 'a-t2', name: 'nested', state: 'pass' }],
+        },
+      ]),
+      true,
+    )
+    createOrUpdateFileNode(
+      buildFile('file-b', '/b.test.ts', [{ id: 'b-t1', name: 'kept', state: 'pass' }]),
+      true,
+    )
+
+    expect(explorerTree.root.tasks.map(f => f.id)).toEqual(['file-a', 'file-b'])
+    expect(['file-a', 'a-t1', 'a-s1', 'a-t2'].every(id => explorerTree.nodes.has(id))).toBe(true)
+
+    // the source file /a.test.ts was deleted (or renamed) on disk
+    explorerTree.removeFiles(['/a.test.ts'])
+
+    // the file node and every descendant are gone
+    expect(explorerTree.nodes.has('file-a')).toBe(false)
+    expect(explorerTree.nodes.has('a-t1')).toBe(false)
+    expect(explorerTree.nodes.has('a-s1')).toBe(false)
+    expect(explorerTree.nodes.has('a-t2')).toBe(false)
+    expect(explorerTree.root.tasks.map(f => f.id)).toEqual(['file-b'])
+
+    // the untouched file is preserved
+    expect(explorerTree.nodes.has('file-b')).toBe(true)
+    expect(explorerTree.nodes.has('b-t1')).toBe(true)
+  })
+
+  it('is a no-op when no tracked file matches the removed path', () => {
+    createOrUpdateFileNode(
+      buildFile('file-b', '/b.test.ts', [{ id: 'b-t1', name: 'kept', state: 'pass' }]),
+      true,
+    )
+    const before = explorerTree.root.tasks as FileTreeNode[]
+
+    explorerTree.removeFiles(['/gone.test.ts'])
+
+    expect(explorerTree.root.tasks).toBe(before)
+    expect(explorerTree.root.tasks.map(f => f.id)).toEqual(['file-b'])
+    expect(explorerTree.nodes.has('file-b')).toBe(true)
+  })
+})
+
+describe('state manager file removal', () => {
+  it('removes the file and its task ids so it is not resurrected on the next collect', () => {
+    const state = new StateManager()
+    state.collectFiles([
+      buildFile('file-a', '/a.test.ts', [
+        { id: 'a-t1', name: 'top', state: 'pass' },
+        {
+          id: 'a-s1',
+          name: 'suite',
+          children: [{ id: 'a-t2', name: 'nested', state: 'pass' }],
+        },
+      ]),
+    ])
+
+    expect(state.filesMap.has('/a.test.ts')).toBe(true)
+    expect(['file-a', 'a-t1', 'a-s1', 'a-t2'].every(id => state.idMap.has(id))).toBe(true)
+
+    state.removeFiles(['/a.test.ts'])
+
+    expect(state.filesMap.has('/a.test.ts')).toBe(false)
+    expect(state.getFiles()).toHaveLength(0)
+    expect(state.idMap.has('file-a')).toBe(false)
+    expect(state.idMap.has('a-t1')).toBe(false)
+    expect(state.idMap.has('a-s1')).toBe(false)
+    expect(state.idMap.has('a-t2')).toBe(false)
+  })
+})

--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -8,7 +8,7 @@ import type {
 import { useRafFn } from '@vueuse/core'
 import { reactive } from 'vue'
 import { runCollapseAllTask, runCollapseNode } from '~/composables/explorer/collapse'
-import { collectTestsTotalData, preparePendingTasks, recordTestArtifact, runCollect, runLoadFiles } from '~/composables/explorer/collector'
+import { collectTestsTotalData, preparePendingTasks, recordTestArtifact, runCollect, runLoadFiles, runRemoveFiles } from '~/composables/explorer/collector'
 import { runExpandAll, runExpandNode } from '~/composables/explorer/expand'
 import { runFilter } from '~/composables/explorer/filter'
 import {
@@ -77,6 +77,11 @@ export class ExplorerTree {
         onlyTests: filter.onlyTests,
       },
     )
+  }
+
+  removeFiles(paths: string[]) {
+    runRemoveFiles(paths)
+    this.filterNodes()
   }
 
   startRun() {

--- a/packages/vitest/src/api/setup.ts
+++ b/packages/vitest/src/api/setup.ts
@@ -196,6 +196,7 @@ export function setup(ctx: Vitest, _server?: ViteDevServer): void {
           'onFinishedReportCoverage',
           'onCollected',
           'onTaskUpdate',
+          'onTestRemoved',
         ],
         serialize: (data: any) => stringify(data, stringifyReplace),
         deserialize: parse,
@@ -272,6 +273,16 @@ export class WebSocketReporter implements Reporter {
 
     this.clients.forEach((client) => {
       client.onTaskUpdate?.(packs, events)?.catch?.(noop)
+    })
+  }
+
+  onTestRemoved(trigger?: string): void {
+    if (this.clients.size === 0) {
+      return
+    }
+
+    this.clients.forEach((client) => {
+      client.onTestRemoved?.(trigger)?.catch?.(noop)
     })
   }
 

--- a/packages/vitest/src/api/types.ts
+++ b/packages/vitest/src/api/types.ts
@@ -76,6 +76,7 @@ export interface WebSocketEvents {
   onTestAnnotate?: (testId: string, annotation: TestAnnotation) => Awaitable<void>
   onTestArtifactRecord?: (testId: string, artifact: TestArtifact) => Awaitable<void>
   onTaskUpdate?: (packs: TaskResultPack[], events: TaskEventPack[]) => Awaitable<void>
+  onTestRemoved?: (id?: string) => Awaitable<void>
   onUserConsoleLog?: (log: UserConsoleLog) => Awaitable<void>
   onPathsCollected?: (paths?: string[]) => Awaitable<void>
   onSpecsCollected?: (specs?: SerializedTestSpecification[], startTime?: number) => Awaitable<void>


### PR DESCRIPTION
### Description

Deleting a test file leaves its entry in the UI sidebar until Vitest is fully restarted, and renaming a file leaves a stale duplicate next to the new one. This was reported by @SimonEast in #10670 (and on #10677).

The watcher already handles the deletion server-side: `onFileDelete` drops the file from `state.filesMap` and reports `onTestRemoved`. But `onTestRemoved` was only a terminal-reporter hook and was never part of `WebSocketEvents`, so the browser never learned the file was gone. The explorer tree keeps file nodes directly under its root and only ever adds/updates them while collecting, so a removed file lingered (and a rename left a duplicate) because nothing removed the root node.

This forwards `onTestRemoved` over the websocket and handles it on the client:

- `WebSocketReporter.onTestRemoved` broadcasts the removed file path to every connected client (and `onTestRemoved` is added to `WebSocketEvents` / the birpc `eventNames`).
- On the client, `StateManager.removeFiles` drops the file and its task ids from `filesMap`/`idMap`, so it is not resurrected on the next collect.
- `ExplorerTree.removeFiles` drops the matching file node and its descendants from the tree, refreshes `uiFiles`, and re-runs the filter.

Rename is covered by the same change: the old path is removed via `onTestRemoved` while the new path is added through the normal collect, so no duplicate remains.

This is a follow-up to #10677, which only reconciled tasks *within* a file that is re-collected (a test removed or commented out), not the file node itself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Added `packages/ui/client/composables/explorer/tree-remove.spec.ts`: it collects two files, removes one, and checks that the removed file node and every descendant are dropped while the untouched file stays; a no-op case where no tracked file matches; and that `StateManager.removeFiles` clears the file and its task ids from the run state.

I went with a unit test rather than a browser e2e because reproducing the watcher delete/rename through the UI is timing-dependent, while the tree/state reconciliation is deterministic.

### Documentation
- [ ] No user-facing API changes, so no documentation update is needed.

### Changesets
- [x] Changes in changelog are generated from PR name.
