### PR TITLE
fix(spy): point ESM namespace spy error to module mocking docs

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -410,7 +410,7 @@ export function spyOn<T extends object, K extends keyof any>(
         || error.message.includes('can\'t redefine non-configurable property'))
     ) {
       throw new TypeError(
-        `Cannot spy on export "${String(key)}". Module namespace is not configurable in ESM. See: https://vitest.dev/guide/browser/#limitations`,
+        `Cannot spy on export "${String(key)}". Module namespace is not configurable in ESM. See: https://vitest.dev/guide/mocking/modules#mocking-a-module`,
         { cause: error },
       )
     }

--- a/test/browser/test/mocking.test.ts
+++ b/test/browser/test/mocking.test.ts
@@ -12,7 +12,7 @@ it('spying on an esm module prints an error', () => {
     }
   })()
   expect(error.name).toBe('TypeError')
-  expect(error.message).toMatchInlineSnapshot(`"Cannot spy on export "calculator". Module namespace is not configurable in ESM. See: https://vitest.dev/guide/browser/#limitations"`)
+  expect(error.message).toMatchInlineSnapshot(`"Cannot spy on export "calculator". Module namespace is not configurable in ESM. See: https://vitest.dev/guide/mocking/modules#mocking-a-module"`)
 
   expect(error.cause).toBeInstanceOf(TypeError)
 })

--- a/test/unit/test/mocking/vi-spyOn.test.ts
+++ b/test/unit/test/mocking/vi-spyOn.test.ts
@@ -19,6 +19,39 @@ describe('vi.spyOn() edge cases', () => {
     expect(fn3.length).toBe(3)
   })
 
+  test('spying on a non-configurable ESM namespace export points to the module mocking docs, not browser mode', () => {
+    // Fake an ES module namespace: `Symbol.toStringTag` is 'Module' and the
+    // export is non-configurable, so `Object.defineProperty` throws
+    // "Cannot redefine property" — the same guard the real ESM path hits.
+    const namespace: Record<string, unknown> = {}
+    Object.defineProperty(namespace, Symbol.toStringTag, { value: 'Module' })
+    Object.defineProperty(namespace, 'answer', {
+      value: () => 42,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    })
+    Object.preventExtensions(namespace)
+
+    const error = (() => {
+      try {
+        vi.spyOn(namespace as any, 'answer')
+        expect.unreachable()
+      }
+      catch (err) {
+        return err as Error
+      }
+    })()
+
+    expect(error).toBeInstanceOf(TypeError)
+    expect(error.message).toContain('Cannot spy on export "answer"')
+    // This error fires in Node too, so it must not send users to the
+    // browser-mode-only docs (issue #9467). It should point at the
+    // environment-agnostic module mocking guide instead.
+    expect(error.message).toContain('https://vitest.dev/guide/mocking/modules#mocking-a-module')
+    expect(error.message).not.toContain('/guide/browser')
+  })
+
   test('can spy on a proxy with undefined descriptor\'s value', () => {
     const obj = new Proxy<{ fn: () => number }>({} as any, {
       get(_, prop) {


### PR DESCRIPTION
### Description

The `Cannot spy on export "…". Module namespace is not configurable in ESM` error links users to a **browser-mode-only** docs anchor (`/guide/browser/#limitations`). But this error fires in Node too — the reproduction in the issue (`vi.spyOn(lodash, 'after')`) has nothing to do with browser mode, so the link sends Node users somewhere irrelevant.

This points the message at the environment-agnostic module mocking guide (`/guide/mocking/modules#mocking-a-module`) instead — the standard `vi.mock(path, { spy: true })` solution — following @sheremet-va's steer in the issue to "lean into the standard" rather than suggest a mode-specific config. The message body and the guard are unchanged; only the link moves. No environment branching is added.

I used the `#mocking-a-module` section anchor (not the bare page) to match the deep-linking convention already used for the sibling module-mocking error in `packages/mocker/src/node/hoistMocks.ts`.

Resolves #9467

### Tests

Verified locally (`fix` reverted → test fails, `fix` applied → passes):

- **Node** (`test/unit`): added a regression test in `vi.spyOn() edge cases` that fakes a non-configurable ESM namespace and asserts the message points at the mocking guide and **not** at `/guide/browser`. This is the path the browser snapshot test didn't cover.
- **Browser** (`test/browser`): updated the existing inline snapshot to the new link.

### Open questions for maintainers

- The `{ spy: true }` remedy on the target page currently sits inside a "Browser Mode Support" danger callout — a Node reader landing there might still hesitate. Happy to open a small follow-up to make that section's framing environment-agnostic if you'd like, but kept it out of this PR to keep the change minimal.
- I left the error message body as-is (link only). If you'd prefer it to inline the `vi.mock(path, { spy: true })` hint directly, I can do that too — just wanted to avoid over-reaching (the earlier #9505 went that route).
- The issue also notes the v3→v4 behavior change isn't in the migration guide. That felt separable from this message fix, so I left it out — happy to follow up if useful.

### 🤖 AI assistance

Developed with Claude Code. I diagnosed the throw site, verified the docs anchor lands on the right content, and confirmed the fix with a local red→green test run. I've reviewed every line of this diff.
