### PR TITLE
perf: serve warm modules to workers in one round-trip, enable the node compile cache

### DIFF
--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -34,7 +34,7 @@ export class FileSystemModuleCache {
   private rootCache: string
   private metadataFilePath: string
 
-  private version = '1.0.0-beta.4'
+  private version = '1.0.0-beta.5'
   private fsCacheRoots = new WeakMap<ResolvedConfig, string>()
   private fsEnvironmentHashMap = new WeakMap<DevEnvironment, string>()
   private fsCacheKeyGenerators = new Set<CacheKeyIdGenerator>()
@@ -214,6 +214,7 @@ export class FileSystemModuleCache {
           mode: config.mode,
           consumer: config.consumer,
           resolve: config.resolve,
+          injectCjsGlobal: vitestConfig.injectCjsGlobals,
           // plugins can have different options, so this is not the best key,
           // but we cannot access the options because there is no standard API for it
           plugins: config.plugins

--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -1,4 +1,5 @@
-import type { DevEnvironment, FetchResult } from 'vite'
+import type { DevEnvironment } from 'vite'
+import type { ModuleType, VitestFetchResult } from '../../types/general'
 import type { Vitest } from '../core'
 import type { ResolvedConfig } from '../types/config'
 import fs, { existsSync, mkdirSync, readFileSync } from 'node:fs'
@@ -110,12 +111,13 @@ export class FileSystemModuleCache {
       code,
       importedUrls: meta.importedUrls,
       mappings: meta.mappings,
+      moduleType: meta.moduleType,
     }
   }
 
-  async saveCachedModule<T extends FetchResult>(
+  async saveCachedModule(
     cachedFilePath: string,
-    fetchResult: T,
+    fetchResult: VitestFetchResult,
     importedUrls: string[] = [],
     mappings: boolean = false,
   ): Promise<void> {
@@ -126,6 +128,7 @@ export class FileSystemModuleCache {
         url: fetchResult.url,
         importedUrls,
         mappings,
+        moduleType: fetchResult.moduleType,
       } satisfies Omit<CachedInlineModuleMeta, 'code'>
       debugFs?.(`${c.yellow('[write]')} ${fetchResult.id} is cached in ${cachedFilePath}`)
       await atomicWriteFile(cachedFilePath, `${fetchResult.code}${cacheComment}${this.toBase64(result)}`)
@@ -366,6 +369,7 @@ export interface CachedInlineModuleMeta {
   code: string
   mappings: boolean
   importedUrls: string[]
+  moduleType?: ModuleType
 }
 
 /**

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -269,11 +269,18 @@ class ModuleFetcher {
     if (!map && cachedModule.mappings) {
       map = { mappings: '' }
     }
+    const moduleType = await this.cachedModuleType(
+      cachedModule.file,
+      cachedModule.code,
+      moduleGraphModule.transformResult,
+      cachedModule.moduleType,
+    )
     moduleGraphModule.transformResult = {
       code: cachedModule.code,
       map,
       ssr: true,
       __vitestTmp: cachePath,
+      __vitestModuleType: moduleType,
     }
 
     // we populate the module graph to make the watch mode work because it relies on importers
@@ -299,12 +306,7 @@ class ModuleFetcher {
       tmp: cachePath,
       url: cachedModule.url,
       invalidate: false,
-      moduleType: await this.cachedModuleType(
-        cachedModule.file,
-        cachedModule.code,
-        moduleGraphModule.transformResult,
-        cachedModule.moduleType,
-      ),
+      moduleType,
     }
   }
 

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -136,7 +136,14 @@ class ModuleFetcher {
     const map = moduleGraphModule.transformResult?.map
     const mappings = map && !('version' in map) && map.mappings === ''
 
-    return this.cacheResult(result, cachePath, importedUrls, !!mappings)
+    const cachedResult = await this.cacheResult(result, cachePath, importedUrls, !!mappings)
+    // remember where the code is stored on disk so that repeat fetches and the
+    // `fetchWarmModules` snapshot can point at it in this session already, not
+    // only after the cache is read back in the next one
+    if ('code' in result && moduleGraphModule.transformResult) {
+      moduleGraphModule.transformResult.__vitestTmp = cachePath
+    }
+    return cachedResult
   }
 
   // we need this for UI to be able to show a module graph

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -1,7 +1,7 @@
 import type { Span } from '@opentelemetry/api'
 import type { DevEnvironment, EnvironmentModuleNode, Rollup, TransformResult } from 'vite'
 import type { FetchFunctionOptions, FetchResult } from 'vite/module-runner'
-import type { FetchCachedFileSystemResult, VitestFetchResult } from '../../types/general'
+import type { FetchCachedFileSystemResult, ModuleType, VitestFetchResult } from '../../types/general'
 import type { OTELCarrier, Traces } from '../../utils/traces'
 import type { FileSystemModuleCache } from '../cache/fsModuleCache'
 import type { VitestResolver } from '../resolver'
@@ -246,13 +246,11 @@ class ModuleFetcher {
         tmp: moduleGraphModule.transformResult.__vitestTmp,
         url: moduleGraphModule.url,
         invalidate: false,
-        moduleType: this.detectModuleType
-          ? await detectModuleType(
-              moduleGraphModule.file,
-              moduleGraphModule.transformResult.code,
-              this.sourceLoader(moduleGraphModule.file),
-            )
-          : undefined,
+        moduleType: await this.cachedModuleType(
+          moduleGraphModule.file,
+          moduleGraphModule.transformResult.code,
+          moduleGraphModule.transformResult,
+        ),
       }
     }
 
@@ -301,9 +299,12 @@ class ModuleFetcher {
       tmp: cachePath,
       url: cachedModule.url,
       invalidate: false,
-      moduleType: this.detectModuleType
-        ? await detectModuleType(cachedModule.file, cachedModule.code, this.sourceLoader(cachedModule.file))
-        : undefined,
+      moduleType: await this.cachedModuleType(
+        cachedModule.file,
+        cachedModule.code,
+        moduleGraphModule.transformResult,
+        cachedModule.moduleType,
+      ),
     }
   }
 
@@ -325,8 +326,8 @@ class ModuleFetcher {
     ).catch(handleRollupError)
 
     const result: VitestFetchResult = processResultSource(environment, moduleRunnerModule)
-    if (this.detectModuleType && 'code' in result) {
-      result.moduleType = await detectModuleType(result.file, result.code, this.sourceLoader(result.file))
+    if ('code' in result) {
+      result.moduleType = await this.cachedModuleType(result.file, result.code, moduleGraphModule.transformResult)
     }
     return result
   }
@@ -336,6 +337,30 @@ class ModuleFetcher {
       return undefined
     }
     return () => this.readFileConcurrently(file)
+  }
+
+  // the module type is a pure function of the module, so detect it at most once
+  // and memoize the verdict on the transform result. repeat fetches, the on-disk
+  // cache (`cached`), and the `fetchWarmModules` snapshot all reuse it instead of
+  // re-detecting. a no-op unless `injectCjsGlobals` is disabled — otherwise every
+  // module receives the CJS globals and the type is irrelevant.
+  private async cachedModuleType(
+    file: string | null,
+    code: string,
+    transformResult: TransformResult | null | undefined,
+    cached?: ModuleType,
+  ): Promise<ModuleType | undefined> {
+    if (!this.detectModuleType) {
+      return undefined
+    }
+    const moduleType
+      = transformResult?.__vitestModuleType
+        ?? cached
+        ?? await detectModuleType(file, code, this.sourceLoader(file))
+    if (transformResult) {
+      transformResult.__vitestModuleType = moduleType
+    }
+    return moduleType
   }
 
   private async cacheResult(
@@ -550,5 +575,6 @@ export function handleRollupError(e: unknown): never {
 declare module 'vite' {
   export interface TransformResult {
     __vitestTmp?: string
+    __vitestModuleType?: ModuleType
   }
 }

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -269,12 +269,7 @@ class ModuleFetcher {
     if (!map && cachedModule.mappings) {
       map = { mappings: '' }
     }
-    const moduleType = await this.cachedModuleType(
-      cachedModule.file,
-      cachedModule.code,
-      moduleGraphModule.transformResult,
-      cachedModule.moduleType,
-    )
+    const moduleType = cachedModule.moduleType
     moduleGraphModule.transformResult = {
       code: cachedModule.code,
       map,
@@ -350,14 +345,12 @@ class ModuleFetcher {
     file: string | null,
     code: string,
     transformResult: TransformResult | null | undefined,
-    cached?: ModuleType,
   ): Promise<ModuleType | undefined> {
     if (!this.detectModuleType) {
       return undefined
     }
     const moduleType
       = transformResult?.__vitestModuleType
-        ?? cached
         ?? await detectModuleType(file, code, this.sourceLoader(file))
     if (transformResult) {
       transformResult.__vitestModuleType = moduleType

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -127,6 +127,14 @@ export function createPool(ctx: Vitest): ProcessPool {
             ...project.config.env,
           }
 
+          // V8 serializes compile-cached scripts without the source positions
+          // that precise coverage relies on — never let workers (or the
+          // processes they spawn) use the compile cache when coverage is on
+          if (ctx.config.coverage.enabled) {
+            delete env.NODE_COMPILE_CACHE
+            env.NODE_DISABLE_COMPILE_CACHE = '1'
+          }
+
           // env are case-insensitive on Windows, but spawned processes don't support it
           if (isWindows) {
             for (const name in env) {

--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -128,9 +128,12 @@ export function createPool(ctx: Vitest): ProcessPool {
           }
 
           // V8 serializes compile-cached scripts without the source positions
-          // that precise coverage relies on — never let workers (or the
-          // processes they spawn) use the compile cache when coverage is on
-          if (ctx.config.coverage.enabled) {
+          // that precise coverage relies on, so the compile cache must stay off
+          // for the v8 provider (and custom providers, whose mechanism we can't
+          // assume) in workers and any process they spawn. istanbul instruments
+          // the source at transform time, so the cache is harmless there and the
+          // boot speedup is kept.
+          if (ctx.config.coverage.enabled && ctx.config.coverage.provider !== 'istanbul') {
             delete env.NODE_COMPILE_CACHE
             env.NODE_DISABLE_COMPILE_CACHE = '1'
           }

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -4,11 +4,13 @@ import type { RuntimeRPC } from '../../types/rpc'
 import type { TestProject } from '../project'
 import type { ResolveSnapshotPathHandlerContext } from '../types/config'
 import { existsSync, mkdirSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { cleanUrl } from '@vitest/utils/helpers'
 import { isBuiltin, toBuiltin } from '../../utils/modules'
 import { handleRollupError } from '../environments/fetchModule'
 import { normalizeResolvedIdToUrl } from '../environments/normalizeUrl'
+import { detectModuleType } from '../resolver'
 
 interface MethodsOptions {
   cacheFs?: boolean
@@ -25,6 +27,16 @@ interface MethodsOptions {
 // Keyed by the Vite server so a server restart drops the accumulated verdicts
 // together with the resolver that produced them.
 const warmExternals = new WeakMap<ViteDevServer, Record<string, FetchResult>>()
+
+// `detectModuleType` only reads the original source in the ambiguous case where
+// the transformed code both looks like ESM and mentions a CommonJS variable;
+// mirror the guard `ModuleFetcher.sourceLoader` uses for virtual modules
+function warmSourceLoader(file: string | null): (() => Promise<string | null>) | undefined {
+  if (!file || file.startsWith('\x00') || file.startsWith('virtual:')) {
+    return undefined
+  }
+  return () => readFile(file, 'utf-8').then(source => source, () => null)
+}
 
 export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOptions = {}): RuntimeRPC {
   const vitest = project.vitest
@@ -84,6 +96,14 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         throw new Error(`The environment ${environmentName} was not defined in the Vite config.`)
       }
 
+      // with `injectCjsGlobals: false` the evaluator injects the CommonJS
+      // variables only into modules the server tagged `moduleType: 'cjs'`. that
+      // tag is produced by the per-module `fetch`, which the warm snapshot
+      // bypasses, so it has to be recomputed here — otherwise a CommonJS module
+      // served from the snapshot evaluates without `require`/`module`/`__dirname`
+      // and throws. the detection is skipped entirely on the default path.
+      const detectType = project.config.injectCjsGlobals === false
+
       const warm: Record<string, FetchResult | FetchCachedFileSystemResult> = Object.create(null)
 
       // walk the import graphs of the requested files instead of dumping the
@@ -126,6 +146,9 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
           tmp,
           url: node.url,
           invalidate: false,
+          moduleType: detectType
+            ? await detectModuleType(node.file, transformResult.code, warmSourceLoader(node.file))
+            : undefined,
         }
         warm[node.url] = entry
         if (node.id !== node.url) {

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -1,3 +1,5 @@
+import type { EnvironmentModuleNode, FetchResult, ViteDevServer } from 'vite'
+import type { FetchCachedFileSystemResult } from '../../types/general'
 import type { RuntimeRPC } from '../../types/rpc'
 import type { TestProject } from '../project'
 import type { ResolveSnapshotPathHandlerContext } from '../types/config'
@@ -13,6 +15,16 @@ interface MethodsOptions {
   // do not report files
   collect?: boolean
 }
+
+// externalize verdicts served during this session, shared with fresh workers
+// via `fetchWarmModules`. Only verdicts for already-resolved urls are stored:
+// an unresolved specifier (a runtime-variable dynamic import of a bare name)
+// resolves through the requesting environment's plugin container, so its
+// verdict is environment- and importer-specific and cannot be shared. Resolved
+// ids always externalize the same way (the resolver memoizes by resolved id).
+// Keyed by the Vite server so a server restart drops the accumulated verdicts
+// together with the resolver that produced them.
+const warmExternals = new WeakMap<ViteDevServer, Record<string, FetchResult>>()
 
 export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOptions = {}): RuntimeRPC {
   const vitest = project.vitest
@@ -47,6 +59,16 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         const metadata = project.vitest.state.metadata[project.name]
         if ('externalize' in result) {
           metadata.externalized[url] = result.externalize
+          // builtins and network urls are already resolved inside the worker
+          // without a round-trip, only module externalizations are worth sharing
+          if (result.type === 'module' && url[0] === '/') {
+            let externals = warmExternals.get(project.vite)
+            if (!externals) {
+              externals = Object.create(null) as Record<string, FetchResult>
+              warmExternals.set(project.vite, externals)
+            }
+            externals[url] = result
+          }
         }
         if ('tmp' in result) {
           metadata.tmps[url] = result.tmp
@@ -55,6 +77,70 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         metadata.duration[url].push(duration)
         return result
       })
+    },
+    async fetchWarmModules(environmentName, files) {
+      const environment = project.vite.environments[environmentName]
+      if (!environment) {
+        throw new Error(`The environment ${environmentName} was not defined in the Vite config.`)
+      }
+
+      const warm: Record<string, FetchResult | FetchCachedFileSystemResult> = Object.create(null)
+
+      // walk the import graphs of the requested files instead of dumping the
+      // whole module graph — in large (watch) sessions the graph accumulates
+      // modules this worker will never load
+      const moduleGraph = environment.moduleGraph
+      const queue: EnvironmentModuleNode[] = []
+      for (const file of [...files, ...project.config.setupFiles]) {
+        const nodes = moduleGraph.getModulesByFile(file)
+        if (nodes) {
+          queue.push(...nodes)
+        }
+      }
+
+      const seen = new Set<EnvironmentModuleNode>()
+      while (queue.length) {
+        const node = queue.pop()!
+        if (seen.has(node)) {
+          continue
+        }
+        seen.add(node)
+        queue.push(...node.importedModules)
+
+        const transformResult = node.transformResult
+        if (!transformResult || node.id == null) {
+          continue
+        }
+        // the transformed code is already stored on disk either by the forks
+        // pool (`cacheFs`) or by `experimental.fsModuleCache` — the worker can
+        // read the file itself instead of fetching each module separately.
+        // invalidated modules lose `transformResult` and drop out automatically
+        const tmp = transformResult.__vitestTmp ?? (transformResult as { _vitest_tmp?: string })._vitest_tmp
+        if (typeof tmp !== 'string') {
+          continue
+        }
+        const entry: FetchCachedFileSystemResult = {
+          cached: true,
+          file: node.file,
+          id: node.id,
+          tmp,
+          url: node.url,
+          invalidate: false,
+        }
+        warm[node.url] = entry
+        if (node.id !== node.url) {
+          warm[node.id] = entry
+        }
+      }
+
+      const externals = warmExternals.get(project.vite)
+      if (externals) {
+        for (const url in externals) {
+          warm[url] ??= externals[url]
+        }
+      }
+
+      return warm
     },
     async resolve(id, importer, environmentName) {
       const environment = project.vite.environments[environmentName]

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentModuleNode, FetchResult, ViteDevServer } from 'vite'
+import type { DevEnvironment, EnvironmentModuleNode, FetchResult } from 'vite'
 import type { FetchCachedFileSystemResult } from '../../types/general'
 import type { RuntimeRPC } from '../../types/rpc'
 import type { TestProject } from '../project'
@@ -22,11 +22,14 @@ interface MethodsOptions {
 // via `fetchWarmModules`. Only verdicts for already-resolved urls are stored:
 // an unresolved specifier (a runtime-variable dynamic import of a bare name)
 // resolves through the requesting environment's plugin container, so its
-// verdict is environment- and importer-specific and cannot be shared. Resolved
-// ids always externalize the same way (the resolver memoizes by resolved id).
-// Keyed by the Vite server so a server restart drops the accumulated verdicts
-// together with the resolver that produced them.
-const warmExternals = new WeakMap<ViteDevServer, Record<string, FetchResult>>()
+// verdict is importer-specific and cannot be shared.
+// Keyed by the DevEnvironment, not the server: a leading-slash url still
+// resolves to its id through that environment's plugin container, so a plugin
+// that resolves conditionally (e.g. on `this.environment`) can externalize the
+// same url in one environment and inline it in another — sharing the verdict
+// across environments would serve the wrong one. Per-environment keying also
+// drops the verdicts on a server restart, since environments are recreated.
+const warmExternals = new WeakMap<DevEnvironment, Record<string, FetchResult>>()
 
 // `detectModuleType` only reads the original source in the ambiguous case where
 // the transformed code both looks like ESM and mentions a CommonJS variable;
@@ -74,10 +77,10 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
           // builtins and network urls are already resolved inside the worker
           // without a round-trip, only module externalizations are worth sharing
           if (result.type === 'module' && url[0] === '/') {
-            let externals = warmExternals.get(project.vite)
+            let externals = warmExternals.get(environment)
             if (!externals) {
               externals = Object.create(null) as Record<string, FetchResult>
-              warmExternals.set(project.vite, externals)
+              warmExternals.set(environment, externals)
             }
             externals[url] = result
           }
@@ -156,7 +159,7 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         }
       }
 
-      const externals = warmExternals.get(project.vite)
+      const externals = warmExternals.get(environment)
       if (externals) {
         for (const url in externals) {
           warm[url] ??= externals[url]

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -4,13 +4,11 @@ import type { RuntimeRPC } from '../../types/rpc'
 import type { TestProject } from '../project'
 import type { ResolveSnapshotPathHandlerContext } from '../types/config'
 import { existsSync, mkdirSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { cleanUrl } from '@vitest/utils/helpers'
 import { isBuiltin, toBuiltin } from '../../utils/modules'
 import { handleRollupError } from '../environments/fetchModule'
 import { normalizeResolvedIdToUrl } from '../environments/normalizeUrl'
-import { detectModuleType } from '../resolver'
 
 interface MethodsOptions {
   cacheFs?: boolean
@@ -30,16 +28,6 @@ interface MethodsOptions {
 // across environments would serve the wrong one. Per-environment keying also
 // drops the verdicts on a server restart, since environments are recreated.
 const warmExternals = new WeakMap<DevEnvironment, Record<string, FetchResult>>()
-
-// `detectModuleType` only reads the original source in the ambiguous case where
-// the transformed code both looks like ESM and mentions a CommonJS variable;
-// mirror the guard `ModuleFetcher.sourceLoader` uses for virtual modules
-function warmSourceLoader(file: string | null): (() => Promise<string | null>) | undefined {
-  if (!file || file.startsWith('\x00') || file.startsWith('virtual:')) {
-    return undefined
-  }
-  return () => readFile(file, 'utf-8').then(source => source, () => null)
-}
 
 export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOptions = {}): RuntimeRPC {
   const vitest = project.vitest
@@ -99,14 +87,6 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         throw new Error(`The environment ${environmentName} was not defined in the Vite config.`)
       }
 
-      // with `injectCjsGlobals: false` the evaluator injects the CommonJS
-      // variables only into modules the server tagged `moduleType: 'cjs'`. that
-      // tag is produced by the per-module `fetch`, which the warm snapshot
-      // bypasses, so it has to be recomputed here — otherwise a CommonJS module
-      // served from the snapshot evaluates without `require`/`module`/`__dirname`
-      // and throws. the detection is skipped entirely on the default path.
-      const detectType = project.config.injectCjsGlobals === false
-
       const warm: Record<string, FetchResult | FetchCachedFileSystemResult> = Object.create(null)
 
       // walk the import graphs of the requested files instead of dumping the
@@ -149,9 +129,11 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
           tmp,
           url: node.url,
           invalidate: false,
-          moduleType: detectType
-            ? await detectModuleType(node.file, transformResult.code, warmSourceLoader(node.file))
-            : undefined,
+          // the fetch that stored this module on disk also memoized its module
+          // type on the transform result (only when `injectCjsGlobals` is
+          // disabled); reuse it so the evaluator injects the CJS globals for the
+          // same modules it would on the direct-fetch path, no re-detection here
+          moduleType: transformResult.__vitestModuleType,
         }
         warm[node.url] = entry
         if (node.id !== node.url) {

--- a/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
@@ -1,5 +1,6 @@
 import type vm from 'node:vm'
-import type { EvaluatedModules } from 'vite/module-runner'
+import type { EvaluatedModules, FetchResult } from 'vite/module-runner'
+import type { FetchCachedFileSystemResult } from '../../types/general'
 import type { WorkerGlobalState } from '../../types/worker'
 import type { Traces } from '../../utils/traces'
 import type { ExternalModulesExecutor } from '../external-executor'
@@ -53,6 +54,29 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
         externalModulesExecutor: options.externalModulesExecutor,
       }
     : undefined
+
+  // A fresh worker pays one strictly sequential `fetch` round-trip per module
+  // in its test files' import graphs, even when the server processed all of
+  // them already. Ask the server ONCE per run request for everything it has on
+  // disk and answer those fetches locally. A file change invalidates the module
+  // server-side, dropping it from the snapshot of every subsequent run request,
+  // which keeps reused (isolate: false) workers in sync; an edit DURING a run
+  // was racy before this fast path existed and stays racy with it — the
+  // scheduled rerun always sees the fresh transform.
+  let warmModules: Promise<Record<string, FetchResult | FetchCachedFileSystemResult> | null> | undefined
+  let warmModulesContext: unknown
+
+  function fetchWarmModules() {
+    const workerState = state()
+    if (warmModulesContext !== workerState.ctx) {
+      warmModulesContext = workerState.ctx
+      warmModules = rpc()
+        .fetchWarmModules(environment(), workerState.ctx.files.map(file => file.filepath))
+        // if the snapshot cannot be fetched, fall back to per-module fetches
+        .catch(() => null)
+    }
+    return warmModules!
+  }
 
   const evaluator = options.evaluator || new VitestModuleEvaluator(
     vm,
@@ -139,6 +163,37 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
           // so cached is always true in a single worker
           if (!isImportActual && options?.cached) {
             return { cache: true }
+          }
+
+          // only dependency fetches consult the snapshot: by the time the
+          // first dependency is requested, the entry file is transformed and
+          // its import graph is connected on the server, so the snapshot
+          // actually covers the file's transitive dependencies
+          if (importer != null) {
+            const warm = await fetchWarmModules()
+            // the null prototype is not preserved by the IPC serialization, so
+            // ids like "constructor" must not fall through to Object.prototype
+            const warmResult = warm && (
+              Object.hasOwn(warm, id)
+                ? warm[id]
+                : Object.hasOwn(warm, rawId)
+                  ? warm[rawId]
+                  : undefined
+            )
+            if (warmResult) {
+              if ('tmp' in warmResult) {
+                try {
+                  const code = readFileSync(warmResult.tmp, 'utf-8')
+                  return { code, ...warmResult }
+                }
+                catch {
+                  // the tmp file is gone — fall back to a live fetch
+                }
+              }
+              else {
+                return warmResult
+              }
+            }
           }
 
           const otelCarrier = traces?.getContextCarrier()

--- a/packages/vitest/src/types/rpc.ts
+++ b/packages/vitest/src/types/rpc.ts
@@ -13,6 +13,12 @@ export interface RuntimeRPC {
     otelCarrier?: OTELCarrier,
   ) => Promise<FetchResult | FetchCachedFileSystemResult>
   resolve: (id: string, importer: string | undefined, environment: string) => Promise<ResolveFunctionResult | null>
+  /**
+   * Returns the modules of the given test files' import graphs that the server
+   * has already processed, so a fresh worker can load them from disk without
+   * paying a `fetch` round-trip per module.
+   */
+  fetchWarmModules: (environment: string, files: string[]) => Promise<Record<string, FetchResult | FetchCachedFileSystemResult>>
   transform: (id: string) => Promise<{ code?: string }>
 
   onUserConsoleLog: (log: UserConsoleLog) => void

--- a/packages/vitest/vitest.mjs
+++ b/packages/vitest/vitest.mjs
@@ -1,2 +1,19 @@
 #!/usr/bin/env node
-import './dist/cli.js'
+import * as module from 'node:module'
+
+// Enable Node's on-disk compile cache before importing the CLI so both the CLI
+// graph and (via the inherited env variable) every spawned worker skip V8
+// recompilation of unchanged modules. `enableCompileCache()` only affects the
+// current process — child processes pick the cache up from NODE_COMPILE_CACHE.
+// Respects an explicit NODE_COMPILE_CACHE and NODE_DISABLE_COMPILE_CACHE; the
+// API is not available before Node 22.8.
+try {
+  const result = module.enableCompileCache?.()
+  if (result?.directory && !process.env.NODE_COMPILE_CACHE) {
+    process.env.NODE_COMPILE_CACHE = result.directory
+  }
+}
+catch {}
+
+// eslint-disable-next-line antfu/no-top-level-await -- the import must not be hoisted above `enableCompileCache`
+await import('./dist/cli.js')

--- a/test/e2e/test/config/injectCjsGlobals.test.ts
+++ b/test/e2e/test/config/injectCjsGlobals.test.ts
@@ -63,6 +63,50 @@ test.for(pools)('inlined ".cjs" modules keep the module scope when injectCjsGlob
   expect(exitCode).toBe(0)
 })
 
+test('cjs dep served from the warm-modules snapshot keeps the module scope when injectCjsGlobals is disabled', async () => {
+  // the `fetchWarmModules` fast path hands a module the server already
+  // transformed to a fresh worker without the per-module `fetch` that tags its
+  // `moduleType`. that tag is what tells the evaluator to inject the CommonJS
+  // scope when `injectCjsGlobals` is disabled, so the snapshot has to carry it.
+  // isolate + sequential files make the ordering deterministic: the first file
+  // transforms and caches the dependency (direct fetch), every later file reads
+  // it back from the snapshot — without the tag those files throw
+  // "require is not defined" while the first one still passes.
+  const structure: Record<string, string> = {
+    'package.json': '{ "type": "module" }',
+    'cjs-dep.cjs': ts`
+      const path = require('node:path')
+      module.exports = {
+        answer: 42,
+        base: path.basename(__filename),
+        dir: typeof __dirname,
+      }
+    `,
+  }
+  for (const name of ['a', 'b', 'c', 'd']) {
+    structure[`${name}.test.js`] = ts`
+      import { expect, test } from 'vitest'
+      import cjs from './cjs-dep.cjs'
+
+      test('cjs module keeps its scope', () => {
+        expect(cjs.answer).toBe(42)
+        expect(cjs.base).toBe('cjs-dep.cjs')
+        expect(cjs.dir).toBe('string')
+        expect(typeof module).toBe('undefined')
+      })
+    `
+  }
+  const { stderr, exitCode } = await runInlineTests(structure, {
+    pool: 'forks',
+    isolate: true,
+    fileParallelism: false,
+    injectCjsGlobals: false,
+    experimental: { fsModuleCache: true },
+  })
+  expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
+})
+
 test('".js" modules without ESM syntax are detected as commonjs in a typeless package', async () => {
   const { stderr, exitCode } = await runInlineTests({
     'package.json': '{}',


### PR DESCRIPTION
Two runtime performance changes.

## What changed

**1. Warm-module snapshot (`fetchWarmModules`).** With `isolate: true`, every fresh worker fetched each module of its test file's import graph through one strictly sequential RPC round-trip — on an app-shaped fixture that is ~122 round-trips per file and ~97 ms of pure serial waiting, *even when the server had already transformed every module*. Most of the per-call latency is queueing on the main process event loop, which serves all workers at once, so the cost compounds with worker count.

Workers now ask the server **once per run request** for every module of their files' import graphs that is already stored on disk (the forks pool tmp files, or `experimental.fsModuleCache`) and read the code directly; only misses go through the per-module `fetch` path. Externalize verdicts for resolved urls ride the same snapshot.

Correctness notes:
- The snapshot is requested at the first *dependency* fetch — by then the entry file's transform has connected its import graph on the server, so the snapshot actually covers the file's transitive dependencies.
- It is re-requested per run request, and the server builds it from the live module graph: a file edit invalidates the module server-side and it simply drops out of the next snapshot, keeping reused (`isolate: false`) workers in sync in watch mode.
- The mock/builtin resolution ladder runs *before* the snapshot lookup, so `vi.mock` semantics are unchanged.
- Only externalize verdicts for already-resolved urls are shared (an unresolved bare specifier resolves through the requesting environment's plugin container, so its verdict is environment/importer-specific), keyed by the Vite server instance so a restart drops them.

**2. Node compile cache.** The `vitest` bin now calls `module.enableCompileCache()` before importing the CLI and propagates `NODE_COMPILE_CACHE` to workers (child processes do not inherit it otherwise). The CLI graph and every worker's bundle skip V8 recompilation across processes and runs. Respects a pre-set `NODE_COMPILE_CACHE` and `NODE_DISABLE_COMPILE_CACHE`; no-op before Node 22.8. Workers get the cache disabled when coverage is enabled, because V8 serializes compile-cached scripts without the source positions precise coverage relies on.

**3.** `experimental.fsModuleCache` now remembers the on-disk location when *saving* a fresh transform (previously only when reading it back), so the snapshot is effective in the first session already, not only in the next one.

## Benchmarks

App fixture = 176 TS source modules + 40 test files with heavily overlapping import graphs (layered utils/services/features, a 60-export barrel, a depth-15 chain, one externalized dep); `tiny`/`huge` bracket the startup-dominated and execution-dominated extremes. min of N interleaved runs, Apple Silicon 10 cores, Node 24. Measured while this PR was stacked on #10685 (the base column is that branch); the PR is now based on `main` directly and the numbers were not re-run — the changes themselves are unchanged.

| benchmark | base | this PR | this PR + `fsModuleCache` |
|---|---:|---:|---:|
| tiny (1 test, 1 file, forks) | 267 ms | 205 ms (−23%) | 152 ms (−43%) |
| huge (10k tests, 1 file, forks) | 921 ms | 864 ms (−6%) | 574 ms (−38%) |
| app node, forks isolate:true (default) | 1266 ms | 1050 ms (−17%) | 751 ms (−41%) |
| app node, forks isolate:false | 629 ms | 613 ms (−3%) | 346 ms (−45%) |
| app node, threads isolate:true | 967 ms | 773 ms (−20%) | 652 ms (−33%) |
| app node, threads isolate:false | 481 ms | 411 ms (−15%) | 283 ms (−41%) |
| app jsdom, forks isolate:true | 3809 ms | 3393 ms (−11%) | 3209 ms (−16%) |
| app jsdom, forks isolate:false | 1184 ms | 1095 ms (−8%) | 880 ms (−26%) |
| app happy-dom, forks isolate:true | 2134 ms | 1969 ms (−8%) | 1787 ms (−16%) |

Why the shape of the numbers: the snapshot removes a cost that scales with modules × test files (biggest on isolated many-file runs and on warm `fsModuleCache` sessions where transform work is already gone), while the compile cache removes a fixed per-process boot cost (biggest on single-file runs and visible in every worker). The jsdom rows dilute in relative terms because jsdom setup (~550 ms per worker) dominates isolated DOM runs — that cost is untouched here and remains the main argument for the environment diagnostic in #10710.


## Decomposition and cold/warm follow-up

The table above is base → PR → PR + `fsModuleCache`. These two blocks break that down: which of the three changes each delta comes from, and the cold-vs-warm behaviour of `fsModuleCache`. Reproduced on the original stack (base = #10685, this PR cherry-picked on top), same fixtures and harness, `min` of N interleaved runs, Apple Silicon 10-core / Node 24. Each block is its own session — compare per-row deltas, not absolute ms across blocks (the two blocks are self-consistent where they overlap: `+ compile cache` below == `fsModuleCache off` further down, and `+ fsModuleCache (warm)` == `warm`).

### Per-lever contribution

Each row turns on one more lever on top of the previous. warm-modules is measured by running `dist/cli.js` directly (the bin is bypassed, so the compile cache is off for that row).

| stacked on #10685 | app forks isolate:true | app threads isolate:true | app forks isolate:false |
|---|---:|---:|---:|
| base | 1167 ms | 880 ms | 673 ms |
| + warm-modules | 1061 ms (−9%) | 850 ms (−3%) | 607 ms (−10%) |
| + compile cache | 1018 ms (−13%) | 799 ms (−9%) | 577 ms (−14%) |
| + `fsModuleCache` (warm) | 789 ms (−32%) | 663 ms (−25%) | 352 ms (−48%) |

- warm-modules carries the isolated-**forks** win on its own (−9…−10%): the forks pool writes tmp copies (`cacheFs: true`), so the snapshot already has on-disk modules to serve without `fsModuleCache`.
- On **threads** warm-modules alone is ~0 (−3%, noise): threads don't write tmp copies, so without `fsModuleCache` the snapshot finds nothing on disk and falls back to per-module fetches — the threads delta in that row is the compile cache. `fsModuleCache` writes on-disk copies for every pool, which is what makes the snapshot pay off on threads as well.
- compile cache is a flat ~−4…−6 pts everywhere, and the dominant lever on single-file runs (`tiny` above).
- `fsModuleCache` is the largest lever (−15…−33 additional pts). It is default-on (separate PR), so the `fsModuleCache` column is the default steady state, not an opt-in.

### `fsModuleCache` cold vs warm

The `fsModuleCache` gain is a warm-cache steady state; the run that *populates* the cache pays for it. App fixture, forks isolate:true, on this PR (compile cache + Vite optimizeDeps kept warm, so cache presence is the only variable; % relative to `fsModuleCache` off):

| `fsModuleCache` | wall (min) | transform phase |
|---|---:|---:|
| off | 1010 ms | 2.06 s |
| cold — first run, writes 217 files / 0.9 MB | 1080 ms (+7%) | 2.20 s |
| warm — cache present | 780 ms (−23%) | 0.52 s |

The cold run is slightly *slower* (full transforms plus the disk writes); the warm run collapses the transform phase (2.06 s → 0.52 s) because a fresh worker reads the transformed modules off disk instead of re-transforming them. Keys are content-hashed, so an edit invalidates only the changed module and leaves the rest warm. With `fsModuleCache` default-on, the warm row is what a repeat run — or a CI shard with a restored cache — actually gets.
