### PR TITLE
Fix current test filepath matching on Windows

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -20,6 +20,7 @@ import {
   ssrModuleExportsKey,
 } from 'vite/module-runner'
 import { Traces } from '../../utils/traces'
+import { isSameFilePath } from '../utils/paths'
 import { ModuleDebug } from './moduleDebug'
 
 const isWindows = process.platform === 'win32'
@@ -278,7 +279,7 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
     meta.env = this.env
 
     const testFilepath = this.options.getCurrentTestFilepath?.()
-    if (testFilepath === module.file) {
+    if (isSameFilePath(testFilepath, module.file)) {
       const globalNamespace = this.vm?.context || globalThis
       Object.defineProperty(meta, 'vitest', {
         // @ts-expect-error injected untyped global

--- a/packages/vitest/src/runtime/utils/paths.ts
+++ b/packages/vitest/src/runtime/utils/paths.ts
@@ -1,0 +1,24 @@
+const windowsDrivePathRE = /^[a-z]:[\\/]/i
+
+export function normalizeWindowsDriveLetter(
+  filepath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== 'win32' || !windowsDrivePathRE.test(filepath)) {
+    return filepath
+  }
+
+  return filepath[0].toLowerCase() + filepath.slice(1)
+}
+
+export function isSameFilePath(
+  left: string | undefined,
+  right: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!left || !right) {
+    return false
+  }
+
+  return left === right || normalizeWindowsDriveLetter(left, platform) === normalizeWindowsDriveLetter(right, platform)
+}

--- a/packages/vitest/src/runtime/workers/native.ts
+++ b/packages/vitest/src/runtime/workers/native.ts
@@ -12,10 +12,12 @@ import { resolve } from 'pathe'
 import c from 'tinyrainbow'
 import { distDir } from '../../paths'
 import { toBuiltin } from '../../utils/modules'
+import { normalizeWindowsDriveLetter } from '../utils/paths'
 
 const NOW_LENGTH = Date.now().toString().length
 const REGEXP_VITEST = new RegExp(`%3Fvitest=\\d{${NOW_LENGTH}}`)
 const REGEXP_MOCK_ACTUAL = /\?mock=actual/
+const isWindows = process.platform === 'win32'
 
 export async function setupNodeLoaderHooks(worker: WorkerSetupContext): Promise<void> {
   if (module.setSourceMapsSupport) {
@@ -138,8 +140,13 @@ function replaceInSourceMarker(url: string, source: string, ms: () => MagicStrin
   }
   if (overridden) {
     const filename = resolve(fileURLToPath(url))
+    const escapedFilename = filename.replace(/"/g, '\\"')
+    const normalizedFilename = normalizeWindowsDriveLetter(filename).replace(/"/g, '\\"')
+    const filenameMatches = isWindows
+      ? `filepath === "${escapedFilename}" || (filepath[1] === ':' && filepath[0].toLowerCase() + filepath.slice(1) === "${normalizedFilename}")`
+      : `filepath === "${escapedFilename}"`
     // appending instead of prepending because functions are hoisted and we don't change the offset
-    ms().append(`;\nfunction IMPORT_META_TEST() { return typeof __vitest_worker__ !== 'undefined' && __vitest_worker__.filepath === "${filename.replace(/"/g, '\\"')}" ? __vitest_index__ : undefined; }`)
+    ms().append(`;\nfunction IMPORT_META_TEST() { const filepath = typeof __vitest_worker__ !== 'undefined' ? __vitest_worker__.filepath : undefined; return typeof filepath === 'string' && (${filenameMatches}) ? __vitest_index__ : undefined; }`)
   }
 }
 

--- a/test/unit/test/file-path.test.ts
+++ b/test/unit/test/file-path.test.ts
@@ -1,9 +1,37 @@
 import { describe, expect, it, vi } from 'vitest'
+import { isSameFilePath, normalizeWindowsDriveLetter } from '../../../packages/vitest/src/runtime/utils/paths'
 
 vi.mock('fs', () => {
   return {
     existsSync: vi.fn(),
   }
+})
+
+describe('isSameFilePath', () => {
+  it('matches windows paths that only differ by drive letter casing', () => {
+    expect(isSameFilePath('c:/project/test.ts', 'C:/project/test.ts', 'win32')).toBe(true)
+    expect(isSameFilePath('C:\\project\\test.ts', 'c:\\project\\test.ts', 'win32')).toBe(true)
+  })
+
+  it('does not normalize non-drive-letter casing', () => {
+    expect(isSameFilePath('C:/project/Test.ts', 'C:/project/test.ts', 'win32')).toBe(false)
+  })
+
+  it('preserves case-sensitive comparisons on non-windows platforms', () => {
+    expect(isSameFilePath('c:/project/test.ts', 'C:/project/test.ts', 'linux')).toBe(false)
+  })
+})
+
+describe('normalizeWindowsDriveLetter', () => {
+  it('normalizes only the drive letter on windows', () => {
+    expect(normalizeWindowsDriveLetter('C:/project/Test.ts', 'win32')).toBe('c:/project/Test.ts')
+    expect(normalizeWindowsDriveLetter('D:\\project\\Test.ts', 'win32')).toBe('d:\\project\\Test.ts')
+  })
+
+  it('does not change non-windows paths', () => {
+    expect(normalizeWindowsDriveLetter('C:/project/Test.ts', 'linux')).toBe('C:/project/Test.ts')
+    expect(normalizeWindowsDriveLetter('/project/Test.ts', 'win32')).toBe('/project/Test.ts')
+  })
 })
 
 const isWindows = process.platform === 'win32'


### PR DESCRIPTION
﻿## Summary
- Compare current test file paths with Windows drive-letter normalization
- Apply the same matching to `import.meta.vitest` injection in the module runner and native loader
- Add unit coverage for drive-letter-only case differences

Fixes #10692

## Tests
- pnpm.cmd --filter vitest... build
- pnpm.cmd exec eslint packages/vitest/src/runtime/utils/paths.ts packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts packages/vitest/src/runtime/workers/native.ts test/unit/test/file-path.test.ts
- pnpm.cmd --filter @vitest/test-unit test:threads file-path.test.ts

`pnpm.cmd typecheck` currently fails on an unrelated existing error: `test/unit/test/web-worker-node.test.ts(3,15): Module '"@vitest/web-worker/pure"' has no exported member 'defineWebWorkers'.`
