### PR TITLE
chore(examples): use modern JSX transform in `examples/projects` to fix warning

### DIFF
--- a/examples/projects/packages/client/test/basic.test.tsx
+++ b/examples/projects/packages/client/test/basic.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 import { expect, test } from 'vitest'
 import Link from '../components/Link.js'
 

--- a/examples/projects/packages/client/tsconfig.json
+++ b/examples/projects/packages/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["esnext", "dom"],
     "module": "node16",
     "moduleResolution": "node16",

--- a/examples/projects/packages/client/vitest.config.ts
+++ b/examples/projects/packages/client/vitest.config.ts
@@ -1,6 +1,8 @@
+import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',


### PR DESCRIPTION
### Description

Just noticed this react project still uses old transform. Switching it to fix the following warning:

```sh
$ pnpm -C examples/projects test
$ vitest

 DEV  v5.0.0-beta.5 /Users/hogawa/code/others/vitest-pr-10554/examples/projects

 ✓  server  test/app.test.ts (3 tests) 32ms
stderr | test/basic.test.tsx > Link changes the state when hovered
Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform

 ✓  client  test/basic.test.tsx (1 test) 54ms

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  09:58:03
   Duration  418ms (transform 23ms, setup 21ms, import 122ms, tests 87ms, environment 236ms)

 PASS  Waiting for file changes...
       press h to show help, press q to quit
```

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
