### PR TITLE
fix(pool): vm pools to respect cgroupsv2 memory limit

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -6,6 +6,7 @@ import type { TestProject } from './project'
 import type { TestSpecification } from './test-specification'
 import type { BuiltinPool, ResolvedConfig } from './types/config'
 import * as nodeos from 'node:os'
+import process from 'node:process'
 import { isatty } from 'node:tty'
 import { resolve } from 'pathe'
 import { version as viteVersion } from 'vite'
@@ -324,7 +325,7 @@ function getMemoryLimit(config: ResolvedConfig, pool: string) {
     return null
   }
 
-  const memory = nodeos.totalmem()
+  const memory = process.constrainedMemory?.() || nodeos.totalmem()
   const limit = getWorkerMemoryLimit(config)
 
   if (typeof memory === 'number') {


### PR DESCRIPTION
### Description
When determining memory based on a percentage of the total available, use the constrained memory value if present to avoid OOM in scenarios where the process has been restricted to less memory than the host physically has.

For example, if running tests in a Kubernetes pod, the container resource requets/limits are used to configure the cgroupsv2 namespace. Exceeding this will result in being OOM killed.

Vitest might see that it's scheduled on a node with 128GiB of RAM even though the container itself has been limited to 4GiB.

It will then allow each worker to have 1/N * 128Gi instead of 1/N * 4Gi of memory.
This can quickly result in an OOM situation, requiring manually setting the `vmMemoryLimit` and `maxWorkers` in the conf.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
   - ⬆️  Adding tests is unfortunately not straightforward here, requires mocking `process` stuff. I'm happy to give it a shot if given guidance on preferred approach from a maintainer.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.
  - ⬆️ I don't think this warrants a change in the current docs, but I'm happy to clarify that it _does_ respect cgroupsv2 now if desired.
 
### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
  - ⬆️ I marked this as `feat` but feel free to retitle as `fix` if desired!
