### PR TITLE
fix: close the pool before the Vite servers, stabilize flaky tests

### DIFF
--- a/packages/browser/src/client/tester/tester-utils.ts
+++ b/packages/browser/src/client/tester/tester-utils.ts
@@ -247,8 +247,10 @@ export function processTimeoutOptions<T extends { timeout?: number }>(options_: 
   const remainingTime = Math.floor(endTime - currentTime)
   // keep some buffer to process the timeout, but always hand the provider a
   // positive value so it surfaces a descriptive, source-mapped locator error
-  // instead of letting the task timer win the race with a generic timeout
-  options_.timeout = Math.max(remainingTime - 100, 1)
+  // instead of letting the task timer win the race with a generic timeout;
+  // the buffer covers the provider->server->client round-trip of the rejection,
+  // which can exceed 100ms on loaded CI machines running several browsers
+  options_.timeout = Math.max(remainingTime - 250, 1)
   return options_
 }
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1519,8 +1519,7 @@ export class Vitest {
         // close the pool (and the browser pages with it) BEFORE the Vite
         // servers: closing a server releases its port while automated pages may
         // still be alive — a page's websocket client would auto-reconnect onto
-        // the next server that binds the same port and fail with
-        // "Unknown session id" (#9800)
+        // the next server that binds the same port and fail with "Unknown session id"
         if (this.pool) {
           try {
             await this.pool.close?.()

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -168,6 +168,7 @@ export class Vitest {
   /** @internal */ _tmpDir = join(tmpdir(), nanoid())
   /** @internal */ _traces!: Traces
   /** @internal */ _harness: PluginHarness
+  /** @internal */ _exitTimeout: ReturnType<typeof setTimeout> | undefined
 
   private isFirstRun = true
   private restartsCount = 0
@@ -1515,19 +1516,27 @@ export class Vitest {
           })
         }
 
+        // close the pool (and the browser pages with it) BEFORE the Vite
+        // servers: closing a server releases its port while automated pages may
+        // still be alive — a page's websocket client would auto-reconnect onto
+        // the next server that binds the same port and fail with
+        // "Unknown session id" (#9800)
+        if (this.pool) {
+          try {
+            await this.pool.close?.()
+          }
+          catch (error) {
+            teardownErrors.push(error)
+          }
+
+          this.pool = undefined
+        }
+
         const closePromises: unknown[] = this.projects.map(w => w.close())
         // close the core workspace server only once
         // it's possible that it's not initialized at all because it's not running any tests
         if (this.coreWorkspaceProject && !this.projects.includes(this.coreWorkspaceProject)) {
           closePromises.push(this.coreWorkspaceProject.close().then(() => this.vite = undefined as any))
-        }
-
-        if (this.pool) {
-          closePromises.push((async () => {
-            await this.pool?.close?.()
-
-            this.pool = undefined
-          })())
         }
 
         closePromises.push(...this._onClose.map(fn => fn()))
@@ -1550,7 +1559,8 @@ export class Vitest {
    * @param force If true, the process will exit immediately after closing the projects.
    */
   public async exit(force = false): Promise<void> {
-    setTimeout(() => {
+    clearTimeout(this._exitTimeout)
+    this._exitTimeout = setTimeout(() => {
       this.report('onProcessTimeout').then(() => {
         console.warn(`close timed out after ${this.config.teardownTimeout}ms`)
 
@@ -1574,7 +1584,8 @@ export class Vitest {
 
         process.exit()
       })
-    }, this.config.teardownTimeout).unref()
+    }, this.config.teardownTimeout)
+    this._exitTimeout.unref()
 
     await this.close()
     if (force) {

--- a/test/browser/fixtures/user-event/wheel.test.ts
+++ b/test/browser/fixtures/user-event/wheel.test.ts
@@ -55,7 +55,8 @@ describe.for([
 
     await (testType === 'userEvent' ? userEvent.wheel(selector, options) : selector.wheel(options))
 
-    expect(wheel).toHaveBeenCalledOnce()
+    // the browser dispatches the event asynchronously, poll like the tests above
+    await expect.poll(() => wheel).toHaveBeenCalledOnce()
     expect(wheel.mock.calls[0][0].deltaX).toBe(deltaX)
     expect(wheel.mock.calls[0][0].deltaY).toBe(deltaY)
   })

--- a/test/browser/test/commands.test.ts
+++ b/test/browser/test/commands.test.ts
@@ -4,7 +4,9 @@ import { server } from 'vitest/browser'
 const { readFile, writeFile, removeFile, myCustomCommand } = server.commands
 
 it('can manipulate files', async () => {
-  const file = './test.txt'
+  // all browser instances run this file against the same cwd in parallel,
+  // so the file name must be unique per instance to avoid races
+  const file = `./test-${server.browser}.txt`
 
   try {
     await readFile(file)
@@ -13,10 +15,10 @@ it('can manipulate files', async () => {
   catch (err) {
     expect(err.message).toMatch(`ENOENT: no such file or directory, open`)
     if (server.platform === 'win32') {
-      expect(err.message).toMatch('test\\browser\\test.txt')
+      expect(err.message).toMatch(`test\\browser\\test-${server.browser}.txt`)
     }
     else {
-      expect(err.message).toMatch('test/browser/test.txt')
+      expect(err.message).toMatch(`test/browser/test-${server.browser}.txt`)
     }
   }
 
@@ -34,10 +36,10 @@ it('can manipulate files', async () => {
   catch (err) {
     expect(err.message).toMatch(`ENOENT: no such file or directory, open`)
     if (server.platform === 'win32') {
-      expect(err.message).toMatch('test\\browser\\test.txt')
+      expect(err.message).toMatch(`test\\browser\\test-${server.browser}.txt`)
     }
     else {
-      expect(err.message).toMatch('test/browser/test.txt')
+      expect(err.message).toMatch(`test/browser/test-${server.browser}.txt`)
     }
   }
 })

--- a/test/e2e/test/cancel-run.test.ts
+++ b/test/e2e/test/cancel-run.test.ts
@@ -21,7 +21,13 @@ test('can force cancel a run via CLI', async () => {
     include: ['blocked-thread.test.ts'],
     reporters: [{ onTestModuleStart: () => onTestModuleStart.resolve() }],
   })
-  onTestFinished(() => vitest.close())
+  onTestFinished(async () => {
+    await vitest.close()
+    // this test stubs `process.exit` to survive `vitest.exit()`, so it also has
+    // to disarm the force-exit watchdog that `exit()` armed — otherwise the
+    // timer would `process.exit()` this worker `teardownTimeout` later
+    clearTimeout(vitest._exitTimeout)
+  })
 
   const stdin = new Readable({ read: () => '' }) as NodeJS.ReadStream
   stdin.isTTY = true
@@ -46,7 +52,9 @@ test('can force cancel a run via CLI', async () => {
   stdin.emit('data', CTRL_C)
   await promise
 
-  expect(onExit).toHaveBeenCalled()
+  // `exit()` calls `process.exit` only after `close()` finishes — poll instead
+  // of racing the teardown
+  await expect.poll(() => onExit).toHaveBeenCalled()
 })
 
 test('cancelling test run stops test execution immediately', async () => {

--- a/test/test-utils/index.ts
+++ b/test/test-utils/index.ts
@@ -265,14 +265,20 @@ export async function runVitest(
     exitCode = process.exitCode
     process.exitCode = 0
 
+    // tests emulating CLI shortcuts (`q`, double CTRL+C) trigger `vitest.exit()`,
+    // which arms an unref'd force-exit watchdog; it must be disarmed before the
+    // real `process.exit` is restored, or it would kill this worker
+    // `teardownTimeout` later, in the middle of a subsequent test file
     if (TestRunner.getCurrentTest()) {
       onTestFinished(async () => {
+        clearTimeout(ctx?._exitTimeout)
         await ctx?.close()
         process.exit = exit
       })
     }
     else {
       afterEach(async () => {
+        clearTimeout(ctx?._exitTimeout)
         await ctx?.close()
         process.exit = exit
       })


### PR DESCRIPTION
Standalone stability fixes that previously rode along in #10685, extracted so they can land independently.

## `Vitest.close()` closes the pool before the Vite servers

Closing a Vite server releases its port while automated browser pages may still be alive: a page's websocket client would auto-reconnect onto the next server that binds the same port and fail with `Unknown session id` (the reconnect race behind #9800). The pool (and the browser pages with it) is now closed first, and only then the per-project Vite servers.

## The force-exit watchdog is kept disarmable

`Vitest.exit()` arms an unref'd watchdog that force-exits the process after `teardownTimeout` if teardown hangs. In-process tests that stub `process.exit` to survive `exit()` (the `q` / double-CTRL+C shortcuts) left that watchdog armed, and it killed the shared e2e test worker ~10s later, in the middle of an unrelated test file. The timeout handle is now stored on the instance (`_exitTimeout`) so tests can disarm it; the watchdog itself still fires in real runs.

## Browser test stability

- `processTimeoutOptions` keeps a 250ms buffer (was 100ms) so the provider's descriptive, source-mapped locator error wins the race against the generic task timeout on loaded CI machines running several browsers.
- `commands.test.ts` uses a per-browser file name — all browser instances run the file against the same cwd in parallel.
- `wheel.test.ts` polls for the wheel event, which the browser dispatches asynchronously.
- `cancel-run.test.ts` polls for the `process.exit` call instead of racing the teardown.
