### PR TITLE
perf(browser): stop serving framework sourcemaps in headless runs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -651,6 +651,10 @@ export default ({ mode }: { mode: string }) => {
                 link: '/config/browser/screenshotfailures',
               },
               {
+                text: 'browser.dependencySourcemaps',
+                link: '/config/browser/dependencysourcemaps',
+              },
+              {
                 text: 'browser.orchestratorScripts',
                 link: '/config/browser/orchestratorscripts',
               },

--- a/docs/config/browser/dependencysourcemaps.md
+++ b/docs/config/browser/dependencysourcemaps.md
@@ -1,0 +1,21 @@
+---
+title: browser.dependencySourcemaps | Config
+outline: deep
+---
+
+# browser.dependencySourcemaps
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Serve sourcemaps of your dependencies (files in `node_modules`) to the browser during headless test runs.
+
+These sourcemaps are used by browser devtools: with `dependencySourcemaps: false`, pausing inside dependency code shows the compiled code the browser actually runs instead of the dependency's original sources. If you don't debug into your dependencies this way, disabling them makes test runs faster: the server doesn't generate and inline the maps, and every browser tab downloads several times fewer bytes.
+
+Reported test errors are not affected: when an error is thrown inside a pre-bundled dependency, Vitest maps its stack frames using the sourcemaps stored on disk even when this option is disabled. Frames from dependencies that are served without pre-bundling (for example, [linked packages](https://vite.dev/guide/dep-pre-bundling#monorepos-and-linked-dependencies)) that don't ship their own sourcemaps fall back to the position in the served code, which usually matches the original file.
+
+Vitest never serves sourcemaps of its own pre-built modules in headless runs (unless [`--inspect`](/guide/cli#inspect) is used) — their frames are hidden from stack traces anyway. Sourcemaps of your own source files are always served.
+
+::: tip
+If some of your workspace code resolves to a `node_modules` path (for example, with `resolve.preserveSymlinks`), set [`server.sourcemapIgnoreList`](https://vite.dev/config/server-options#server-sourcemapignorelist) to keep its sourcemaps even when this option is disabled.
+:::

--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -374,6 +374,13 @@ Default position for the details panel in browser mode. Either `right` (horizont
 
 If connection to the browser takes longer, the test suite will fail (default: `60_000`)
 
+### browser.dependencySourcemaps
+
+- **CLI:** `--browser.dependencySourcemaps`
+- **Config:** [browser.dependencySourcemaps](/config/browser/dependencysourcemaps)
+
+Serve sourcemaps of dependencies to the browser in headless runs, used by devtools when debugging into `node_modules`. Reported test errors are source-mapped either way. Use `--browser.dependencySourcemaps=false` to speed up test runs if you don't step into dependency code (default: `true`)
+
 ### browser.trackUnhandledErrors
 
 - **CLI:** `--browser.trackUnhandledErrors`

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -9,7 +9,7 @@ import { toArray } from '@vitest/utils/helpers'
 import { join, resolve } from 'pathe'
 import sirv from 'sirv'
 import c from 'tinyrainbow'
-import { isFileServingAllowed, isValidApiRequest, rolldownVersion, distDir as vitestDist } from 'vitest/node'
+import { isCSSRequest, isFileServingAllowed, isValidApiRequest, rolldownVersion, distDir as vitestDist } from 'vitest/node'
 import { version } from '../../package.json'
 import { distRoot } from './constants'
 import { createOrchestratorMiddleware } from './middlewares/orchestratorMiddleware'
@@ -347,9 +347,66 @@ body {
     ...BrowserPlugin(contribution),
     // this plugin's `configureServer` is ignored since it's added through `applyToEnvironment`
     interceptorPlugin({ registry: mockerRegistry }),
+    {
+      name: 'vitest:browser:framework-sourcemaps',
+      enforce: 'post',
+      transform(code, id) {
+        const parentServer = contribution.parent as ParentBrowserProject | undefined
+        // In a headless run nothing can open devtools, so sourcemaps of
+        // Vitest's own pre-built modules are never consumed: their stack
+        // frames are filtered by stackIgnorePatterns. Generating and
+        // inlining these maps costs server CPU and multiplies the bytes
+        // the browser downloads by ~5 for every fresh browser context.
+        // Sourcemaps of user files and (by default) their dependencies are
+        // kept — they point error stacks and devtools at original sources.
+        if (
+          !parentServer
+          || !isHeadlessServer(parentServer)
+          || parentServer.vitest.config.inspector.enabled
+        ) {
+          return null
+        }
+        if (isCSSRequest(id)) {
+          return null
+        }
+        const path = cleanQueryUrl(id)
+        if (path.startsWith(distRoot) || path.startsWith(vitestDist)) {
+          return { code, map: { mappings: '' } as any }
+        }
+        // users that never debug into node_modules can drop dependency
+        // sourcemaps entirely; `server.sourcemapIgnoreList` (default:
+        // node_modules) can opt paths back in even then, e.g. with
+        // `preserveSymlinks` where workspace code keeps its node_modules
+        // path and would be wrongly treated as a dependency
+        if (
+          parentServer.config.browser.dependencySourcemaps === false
+          && path.includes('/node_modules/')
+          && (parentServer.vite?.config.server.sourcemapIgnoreList(path, path) ?? true)
+        ) {
+          return { code, map: { mappings: '' } as any }
+        }
+        return null
+      },
+    },
   ]
 
   return contribution
+}
+
+function isHeadlessServer(parentServer: ParentBrowserProject): boolean {
+  if (!parentServer.config.browser.headless) {
+    return false
+  }
+  // sibling instances share this server (and its module graph cache, so a
+  // late-spawned instance would receive already-cached transforms) and can
+  // override `headless` — check the static instance options instead of the
+  // lazily populated `children` to stay deterministic across runs
+  const instances = parentServer.config.browser.instances ?? []
+  return instances.every(instance => instance.headless !== false)
+}
+
+function cleanQueryUrl(url: string): string {
+  return url.replace(/[?#].*$/, '')
 }
 
 function resolveBrowserOptimizeDeps(

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -5,7 +5,7 @@ import { createRequire } from 'node:module'
 import { MockerRegistry } from '@vitest/mocker'
 import { interceptorPlugin } from '@vitest/mocker/node'
 import { distClientRoot as uiClientRoot } from '@vitest/ui'
-import { toArray } from '@vitest/utils/helpers'
+import { cleanUrl, toArray } from '@vitest/utils/helpers'
 import { join, resolve } from 'pathe'
 import sirv from 'sirv'
 import c from 'tinyrainbow'
@@ -369,7 +369,7 @@ body {
         if (isCSSRequest(id)) {
           return null
         }
-        const path = cleanQueryUrl(id)
+        const path = cleanUrl(id)
         if (path.startsWith(distRoot) || path.startsWith(vitestDist)) {
           return { code, map: { mappings: '' } as any }
         }
@@ -381,7 +381,7 @@ body {
         if (
           parentServer.config.browser.dependencySourcemaps === false
           && path.includes('/node_modules/')
-          && (parentServer.vite?.config.server.sourcemapIgnoreList(path, path) ?? true)
+          && (parentServer.vite.config.server.sourcemapIgnoreList(path, path) ?? true)
         ) {
           return { code, map: { mappings: '' } as any }
         }
@@ -403,10 +403,6 @@ function isHeadlessServer(parentServer: ParentBrowserProject): boolean {
   // lazily populated `children` to stay deterministic across runs
   const instances = parentServer.config.browser.instances ?? []
   return instances.every(instance => instance.headless !== false)
-}
-
-function cleanQueryUrl(url: string): string {
-  return url.replace(/[?#].*$/, '')
 }
 
 function resolveBrowserOptimizeDeps(

--- a/packages/browser/src/node/projectParent.ts
+++ b/packages/browser/src/node/projectParent.ts
@@ -64,9 +64,22 @@ export class ParentBrowserProject {
         }
 
         const result = this.vite.moduleGraph.getModuleById(id)?.transformResult
-        // handle non-inline source map such as pre-bundled deps in node_modules/.vite
-        if (result && !result.map) {
-          const filePath = id.split('?')[0]
+        const filePath = id.split('?')[0]
+        // prefer the map stored on disk when the transform pipeline can't
+        // provide a usable one:
+        // - pre-bundled deps: the pipeline map resolves back into the
+        //   optimizer cache, while the map esbuild wrote next to the file
+        //   points at the real package sources
+        // - an empty `mappings` means the map was intentionally not served
+        //   to the browser (`vitest:browser:framework-sourcemaps`), but disk
+        //   is still the source of truth for error stack traces
+        if (
+          result && (
+            !result.map
+            || result.map.mappings === ''
+            || filePath.startsWith(this.vite.config.cacheDir)
+          )
+        ) {
           const extracted = extractSourcemapFromFile(result.code, filePath)
           this.sourceMapCache.set(id, extracted?.map)
           return extracted?.map

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -394,6 +394,9 @@ export const cliOptionsConfig: VitestCLIOptions = {
         description: 'If connection to the browser takes longer, the test suite will fail (default: `60_000`)',
         argument: '<timeout>',
       },
+      dependencySourcemaps: {
+        description: 'Serve sourcemaps of dependencies to the browser in headless runs, used by devtools when debugging into `node_modules`. Reported test errors are source-mapped either way. Use `--browser.dependencySourcemaps=false` to speed up test runs if you don\'t step into dependency code (default: `true`)',
+      },
       trackUnhandledErrors: {
         description: 'Control if Vitest catches uncaught exceptions so they can be reported (default: `true`)',
       },

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -271,6 +271,28 @@ export interface BrowserConfigOptions {
   screenshotFailures?: boolean
 
   /**
+   * Serve sourcemaps of your dependencies (files in `node_modules`) to the
+   * browser during headless test runs.
+   *
+   * These sourcemaps are used by browser devtools: when disabled, pausing
+   * inside dependency code shows the compiled code the browser actually
+   * runs instead of the dependency's original sources. If you don't debug
+   * into your dependencies this way, disabling them makes test runs faster:
+   * the server doesn't generate and inline the maps, and every browser tab
+   * downloads several times fewer bytes.
+   *
+   * Reported test errors are not affected: stack frames pointing into a
+   * pre-bundled dependency are mapped using the sourcemaps stored on disk
+   * even when this option is disabled.
+   *
+   * Vitest never serves sourcemaps of its own pre-built modules in headless
+   * runs (unless `--inspect` is used) — their frames are hidden from stack
+   * traces anyway. Sourcemaps of your own source files are always served.
+   * @default true
+   */
+  dependencySourcemaps?: boolean
+
+  /**
    * Path to the index.html file that will be used to run tests.
    */
   testerHtmlPath?: string


### PR DESCRIPTION
Stops serving sourcemaps that nothing consumes during headless runs, while keeping reported error stacks readable.

**Framework sourcemaps.** In headless runs (with the inspector off), Vitest no longer generates and inlines sourcemaps for its own pre-built modules — their stack frames are hidden from stack traces anyway. Serving them multiplied the bytes each browser context downloads by ~5 and burned server CPU regenerating maps for minified code on every run.

**`browser.dependencySourcemaps: false`** (also `--browser.dependencySourcemaps=false`) extends this to all of `node_modules` for projects that don't step into dependency code in devtools. It respects `server.sourcemapIgnoreList`, so workspace code that resolves to a `node_modules` path (e.g. with `resolve.preserveSymlinks`) can be opted back in. Sourcemaps of user source files are always served.

**Readable error stacks either way.** Error stack frames pointing into a pre-bundled dependency (or a module whose map was stripped above) are mapped using the sourcemaps stored on disk in the optimizer cache. Previously the transform-pipeline map resolved back into the optimizer cache, so these frames were reported at positions in the optimized chunk (e.g. `deps/react.js?v=…:468:41`) instead of the dependency's real sources. This works regardless of the `dependencySourcemaps` setting.
