### PR TITLE
perf(browser): cut per-file round trips

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -576,6 +576,8 @@ function generateFileId(file: string) {
   )
 }
 
+let currentViewport: { width: number; height: number } | undefined
+
 async function setIframeViewport(
   width: number,
   height: number,
@@ -589,12 +591,26 @@ async function setIframeViewport(
     document.body.style.setProperty('--viewport-width', `${width}px`)
     document.body.style.setProperty('--viewport-height', `${height}px`)
 
+    // playwright emulates the viewport per page, so it keeps its size
+    // between test files and the command round trip is only needed when
+    // the size actually changes; other providers resize the window, which
+    // outside code can move under us, so they always re-pin
+    const cacheable = getBrowserState().provider === 'playwright'
+    if (
+      cacheable
+      && currentViewport?.width === width
+      && currentViewport?.height === height
+    ) {
+      return
+    }
+
     await client.rpc.triggerCommand(
       getBrowserState().sessionId,
       '__vitest_viewport',
       undefined,
       [{ width, height }],
     )
+    currentViewport = cacheable ? { width, height } : undefined
   }
 }
 

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -58,6 +58,7 @@ export function createBrowserRunner(
     public config: SerializedConfig
     public hashMap = browserHashMap
     public sourceMapCache = new Map<string, any>()
+    private sourceMapPrefetches = new Map<string, Promise<any>>()
     public method = 'run' as TestExecutionMethod
     private commands: CommandsManager
 
@@ -218,7 +219,13 @@ export function createBrowserRunner(
           if (!('filepath' in suite)) {
             return
           }
-          const map = await rpc().getBrowserFileSourceMap(suite.filepath)
+          // usually resolved already: the request is fired as soon as the
+          // file finishes importing, while collection is still running
+          const map = await (
+            this.sourceMapPrefetches.get(suite.filepath)
+            ?? rpc().getBrowserFileSourceMap(suite.filepath)
+          )
+          this.sourceMapPrefetches.delete(suite.filepath)
           this.sourceMapCache.set(suite.filepath, map)
           const snapshotEnvironment = this.config.snapshotOptions.snapshotEnvironment
           if (snapshotEnvironment instanceof VitestBrowserSnapshotEnvironment) {
@@ -333,6 +340,15 @@ export function createBrowserRunner(
       }
       catch (err) {
         throw new Error(`Failed to import test file ${filepath}`, { cause: err })
+      }
+
+      if (mode === 'collect' && !this.sourceMapPrefetches.has(filepath)) {
+        // the file is transformed now, so the server can hand out its map;
+        // request it early so onBeforeRunSuite doesn't have to wait
+        this.sourceMapPrefetches.set(
+          filepath,
+          rpc().getBrowserFileSourceMap(filepath).catch(() => undefined),
+        )
       }
     }
 

--- a/packages/browser/src/node/project.ts
+++ b/packages/browser/src/node/project.ts
@@ -22,6 +22,10 @@ import { getBrowserProvider } from './utils'
 export class ProjectBrowser implements IProjectBrowser {
   public testerHtml: Promise<string> | string
   public testerFilepath: string
+  // the tester template is read once per server, so the transformed HTML
+  // is stable too — computing it for every iframe request pays the whole
+  // transformIndexHtml plugin pipeline each time
+  public testerHtmlTransformed: Promise<string> | undefined
 
   public provider!: BrowserProvider
   public vitest: Vitest

--- a/packages/browser/src/node/serverTester.ts
+++ b/packages/browser/src/node/serverTester.ts
@@ -59,13 +59,15 @@ export async function resolveTester(
     __VITEST_API_TOKEN__: JSON.stringify(globalServer.vitest.config.api.token),
   })
 
-  const testerHtml = typeof browserProject.testerHtml === 'string'
-    ? browserProject.testerHtml
-    : await browserProject.testerHtml
-
   try {
-    const url = join('/@fs/', browserProject.testerFilepath)
-    const indexhtml = await browserProject.vite.transformIndexHtml(url, testerHtml)
+    browserProject.testerHtmlTransformed ??= (async () => {
+      const testerHtml = typeof browserProject.testerHtml === 'string'
+        ? browserProject.testerHtml
+        : await browserProject.testerHtml
+      const url = join('/@fs/', browserProject.testerFilepath)
+      return await browserProject.vite.transformIndexHtml(url, testerHtml)
+    })()
+    const indexhtml = await browserProject.testerHtmlTransformed
     const html = replacer(indexhtml, {
       __VITEST_FAVICON__: globalServer.faviconUrl,
       __VITEST_INJECTOR__: injector,
@@ -73,6 +75,8 @@ export async function resolveTester(
     return html
   }
   catch (err: any) {
+    // don't cache a rejection — the next request should retry the transform
+    browserProject.testerHtmlTransformed = undefined
     session.fail(err)
     next(err)
   }


### PR DESCRIPTION
Removes redundant per-file / per-iframe server round trips from browser runs.

- **Tester HTML transformed once.** The tester HTML is passed through `transformIndexHtml` once per server and cached on the project, instead of running the whole index-html plugin pipeline on every iframe request. A rejected transform is not cached, so the next request retries.
- **Test-file sourcemap prefetched.** The sourcemap is requested as soon as the file finishes importing (while collection is still running), so `onBeforeRunSuite` doesn't have to wait for it after collection.
- **Viewport round trip skipped when unchanged.** The `__vitest_viewport` command round trip is skipped when the viewport size didn't change between test files. Playwright only — its per-page viewport can't drift under us; window-resizing providers re-pin every file.
