### PR TITLE
fix: disable server HMR before plugins read it in their config hook

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -1029,7 +1029,7 @@ export async function resolveConfig(
       mode: options.mode || 'test',
       plugins: [
         CliOverride(cliOptionsCopy),
-        VitestConfigServer(pluginsHarness),
+        ...VitestConfigServer(pluginsHarness),
         ...VitestConfig(pluginsHarness),
         ...VitestCorePlugin(pluginsHarness, options),
         ...BrowserLoaderPlugin(rootBrowserHolder, pluginsHarness),

--- a/packages/vitest/src/node/plugins/server.ts
+++ b/packages/vitest/src/node/plugins/server.ts
@@ -4,47 +4,66 @@ import type { ResolvedApiConfig, ResolvedConfig } from '../types/config'
 import { defaultPort } from '../../constants'
 import { resolveApiServerConfig } from '../config/resolveConfig'
 
-export function VitestConfigServer(harness: PluginHarness, globalConfig?: ResolvedConfig): Plugin {
-  return {
-    name: 'vitest:config:server',
-    enforce: 'post',
-    config: {
-      order: 'post',
-      handler(viteConfig) {
-        // Custom user config, this plugin already received CLI overrides
-        const testConfig = viteConfig.test ?? {}
-        const isBrowserEnabled = !!testConfig.browser?.enabled
-
-        const api = resolveApiServerConfig(
-          testConfig,
-          isBrowserEnabled ? harness._browserLastPort++ : defaultPort,
-          harness.logger,
-        ) as ResolvedApiConfig
-        testConfig.api = api
-        if (globalConfig) {
-          api.token = globalConfig.api.token
-          api.tokenCreated = globalConfig.api.tokenCreated
-        }
-
-        const server: ServerOptions = {
-          ...api,
-          preTransformRequests: false,
-          hmr: false,
-          open: false,
-        }
-
-        // Always disable the websocket server in middlewareMode
-        if (!isBrowserEnabled && api.middlewareMode) {
-          server.ws = false
-        }
-        else if (viteConfig.server && 'ws' in viteConfig.server) {
-          viteConfig.server.ws = undefined
-        }
-
-        return {
-          server,
-        }
+export function VitestConfigServer(harness: PluginHarness, globalConfig?: ResolvedConfig): Plugin[] {
+  return [
+    {
+      name: 'vitest:config:server-defaults',
+      config: {
+        // These static server toggles must be visible to other plugins that
+        // read `server.hmr` in their own `config` hook — e.g.
+        // `@vitejs/plugin-react` turns React Fast Refresh off only when it sees
+        // HMR disabled. A `post` hook (below) runs after such plugins, so set
+        // them here in a `pre` hook instead.
+        order: 'pre',
+        handler() {
+          return {
+            server: {
+              preTransformRequests: false,
+              hmr: false,
+              open: false,
+            },
+          }
+        },
       },
     },
-  }
+    {
+      name: 'vitest:config:server',
+      enforce: 'post',
+      config: {
+        order: 'post',
+        handler(viteConfig) {
+          // Custom user config, this plugin already received CLI overrides
+          const testConfig = viteConfig.test ?? {}
+          const isBrowserEnabled = !!testConfig.browser?.enabled
+
+          const api = resolveApiServerConfig(
+            testConfig,
+            isBrowserEnabled ? harness._browserLastPort++ : defaultPort,
+            harness.logger,
+          ) as ResolvedApiConfig
+          testConfig.api = api
+          if (globalConfig) {
+            api.token = globalConfig.api.token
+            api.tokenCreated = globalConfig.api.tokenCreated
+          }
+
+          const server: ServerOptions = {
+            ...api,
+          }
+
+          // Always disable the websocket server in middlewareMode
+          if (!isBrowserEnabled && api.middlewareMode) {
+            server.ws = false
+          }
+          else if (viteConfig.server && 'ws' in viteConfig.server) {
+            viteConfig.server.ws = undefined
+          }
+
+          return {
+            server,
+          }
+        },
+      },
+    },
+  ]
 }

--- a/packages/vitest/src/node/plugins/workspace.ts
+++ b/packages/vitest/src/node/plugins/workspace.ts
@@ -76,7 +76,7 @@ export function WorkspaceVitestPlugin(
         config.server.watch = null
       },
     },
-    VitestConfigServer(harness, globalConfig),
+    ...VitestConfigServer(harness, globalConfig),
     SsrRunnerFixerPlugin(harness),
     MetaEnvReplacerPlugin(),
     ...CSSEnablerPlugin(),

--- a/test/e2e/test/override.test.ts
+++ b/test/e2e/test/override.test.ts
@@ -123,6 +123,29 @@ describe.each([
   })
 })
 
+it('disables server.hmr before plugins read it in their own config hook', async () => {
+  // `@vitejs/plugin-react` (and others) turn features like React Fast Refresh
+  // off only when they observe `server.hmr === false` inside their `config`
+  // hook. Vitest must disable HMR early enough for such plugins — which often
+  // run as `enforce: 'post'` — to see it, otherwise Fast Refresh stays on and
+  // injects `$RefreshSig$`, which is undefined outside a browser preamble.
+  let observedHmr: unknown = 'unset'
+  await resolveTestConfig({
+    $viteConfig: {
+      plugins: [
+        {
+          name: 'test:observe-hmr',
+          enforce: 'post',
+          config(userConfig) {
+            observedHmr = userConfig.server?.hmr
+          },
+        },
+      ],
+    },
+  })
+  expect(observedHmr).toBe(false)
+})
+
 it('experimental fsModuleCache is inherited in a project', async () => {
   const v = await config({
     experimental: {


### PR DESCRIPTION
## Problem

`main` CI is red on `Test: unit, node-24/26, ubuntu-latest` (the *Test Examples* step). The `examples/projects` client suite crashes on import:

```
FAIL  packages/client/test/basic.test.tsx
ReferenceError: $RefreshSig$ is not defined
 ❯ components/Link.tsx:7
```

## Root cause

Vitest disables Vite HMR for test runs, but `VitestConfigServer` sets `server.hmr = false` from a `config` hook ordered `post`. `@vitejs/plugin-react` decides whether to apply React Fast Refresh inside its *own* `config` hook (`vite:react:config-post`), which runs before the `post` group — so it never observes that HMR is disabled. On rolldown-vite this leaves Fast Refresh enabled and injects the `$RefreshSig$` runtime helper, which is only defined by the browser HMR preamble; under jsdom it is undefined and the module crashes on import.

This is a regression from the config-resolution refactor (#10554), surfaced once #10716 added `@vitejs/plugin-react` to the client example. It affects any `@vitejs/plugin-react` + Vitest (jsdom / happy-dom) setup on rolldown-vite, not just the example.

## Fix

Emit the static server toggles (`hmr`, `preTransformRequests`, `open`) from a separate `order: 'pre'` config hook so other plugins can observe them, keeping the api/port resolution in the existing `post` hook. Adds a regression test asserting a `post`-enforced plugin sees `server.hmr === false` in its `config` hook.
