### PR TITLE
refactor: use a single field for the on-disk transform location

### DIFF
--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -96,7 +96,7 @@ class ModuleFetcher {
       }
 
       const transformResult = moduleGraphModule.transformResult
-      const tmpPath = transformResult && Reflect.get(transformResult, '_vitest_tmp')
+      const tmpPath = transformResult?.__vitestTmp
       if (typeof tmpPath === 'string') {
         return getCachedResult(result, tmpPath)
       }
@@ -112,7 +112,7 @@ class ModuleFetcher {
       const tmpFile = join(tmpDir, hash('sha1', result.id, 'hex'))
       return this.cacheResult(result, tmpFile).then((result) => {
         if (transformResult) {
-          Reflect.set(transformResult, '_vitest_tmp', tmpFile)
+          transformResult.__vitestTmp = tmpFile
         }
         return result
       })
@@ -514,6 +514,8 @@ export function handleRollupError(e: unknown): never {
 
 declare module 'vite' {
   export interface TransformResult {
+    // on-disk location of the transformed code, written by either the
+    // `experimental.fsModuleCache` store or the forks pool's tmp copies
     __vitestTmp?: string
   }
 }


### PR DESCRIPTION
The path to a module's transformed code on disk is stored in two different fields on Vite's `TransformResult`:

- **`__vitestTmp`** — a typed field, written by the `experimental.fsModuleCache` store (both on a fresh transform and when re-hydrating a cached module from disk).
- **`_vitest_tmp`** — an untyped property read/written via `Reflect`, written by the forks pool's tmp copies (the `makeTmpCopies` path that avoids `process.send`-ing large buffers).

Both hold the same thing (a path to transformed code on disk) and every reader treats them identically. They also never coexist on the same module: the forks tmp path only runs when `fsModuleCache` produced no cache path (`cachePath == null`), while `__vitestTmp` is otherwise only ever the cache path. So this collapses them onto the single typed `__vitestTmp` field and drops the `Reflect` access.

No behaviour change.