### PR TITLE
fix(mocker): preserve same-path doMock order

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
+++ b/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
@@ -152,11 +152,23 @@ export class BareModuleMocker implements TestModuleMocker {
       return
     }
 
+    const pendingIds = BareModuleMocker.pendingIds
+    BareModuleMocker.pendingIds = []
+
     const resolveMock = async (mock: PendingSuiteMock) => {
-      const { id, url, external } = await this.resolveId(
+      const resolved = await this.resolveId(
         mock.id,
         mock.importer,
       )
+      return { mock, ...resolved }
+    }
+
+    const applyMock = ({
+      mock,
+      id,
+      url,
+      external,
+    }: Awaited<ReturnType<typeof resolveMock>>) => {
       if (mock.action === 'unmock') {
         this.unmockPath(id)
       }
@@ -172,15 +184,16 @@ export class BareModuleMocker implements TestModuleMocker {
       }
     }
 
-    // group consecutive mocks of the same action type together,
-    // resolve in parallel inside each group, but run groups sequentially
-    // to preserve mock/unmock ordering
-    const groups = groupByConsecutiveAction(BareModuleMocker.pendingIds)
+    // group consecutive mocks of the same action type together, resolve in
+    // parallel inside each group, but apply the results in queue order and run
+    // groups sequentially to preserve mock/unmock ordering.
+    const groups = groupByConsecutiveAction(pendingIds)
     for (const group of groups) {
-      await Promise.all(group.map(resolveMock))
+      const mocks = await Promise.all(group.map(resolveMock))
+      for (const mock of mocks) {
+        applyMock(mock)
+      }
     }
-
-    BareModuleMocker.pendingIds = []
   }
 
   // public method to avoid circular dependency

--- a/test/unit/test/bare-module-mocker.test.ts
+++ b/test/unit/test/bare-module-mocker.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, expect, test } from 'vitest'
+import { BareModuleMocker } from '../../../packages/vitest/src/runtime/moduleRunner/bareModuleMocker'
+import { Traces } from '../../../packages/vitest/src/utils/traces'
+
+const traces = new Traces({ enabled: false })
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+beforeEach(() => {
+  BareModuleMocker.pendingIds = []
+})
+
+afterEach(() => {
+  BareModuleMocker.pendingIds = []
+})
+
+test('resolveMocks preserves same-path doMock registration order when resolution finishes out of order', async () => {
+  let resolveCount = 0
+  const mocker = new BareModuleMocker({
+    traces,
+    root: '/root',
+    moduleDirectories: [],
+    getCurrentTestFilepath: () => '/root/basic.test.ts',
+    async resolveId() {
+      resolveCount += 1
+      if (resolveCount === 1) {
+        await delay(10)
+      }
+      return {
+        id: '/target.ts',
+        file: '/root/target.ts',
+        url: '/target.ts',
+      }
+    },
+  })
+
+  const firstFactory = () => ({ value: 'first' })
+  const secondFactory = () => ({ value: 'second' })
+
+  mocker.queueMock('./target', '/root/basic.test.ts', firstFactory)
+  mocker.queueMock('./target', '/root/basic.test.ts', secondFactory)
+
+  await mocker.resolveMocks()
+
+  const mock = mocker.getDependencyMock('/target.ts')
+  expect(mock?.type).toBe('manual')
+  expect(mock).toHaveProperty('factory', secondFactory)
+})


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #10706.


`BareModuleMocker.resolveMocks()` grouped consecutive mock/unmock actions and resolved each group in parallel. That preserved ordering between mock/unmock groups, but not within a same-action group.

When two `vi.doMock()` calls for the same path were flushed by the same dynamic import, the later mock could resolve first and register first, then be overwritten by the earlier mock when its slower resolution completed. This made the final mock implementation depend on async resolution timing instead of call order.

This PR keeps parallel resolution inside each same-action group, but applies the resolved mock operations in the original queue order. It also clears the pending queue before resolving so mocks queued during resolution are not dropped by the final cleanup.

Added a regression test that forces the first same-path mock resolution to finish after the second one and asserts the later `doMock` remains registered.


<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] `pnpm --filter vitest build`
- [x] `pnpm exec eslint packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts test/unit/test/bare-module-mocker.test.ts`
- [x] `pnpm -C test/unit test:threads bare-module-mocker.test.ts`
- [x] `pnpm -C test/unit test:threads bare-module-mocker.test.ts do-mock.test.ts do-mock-reset-modules.test.ts`

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
