### PR TITLE
fix: handle nullish toHaveProperty subjects (fix #10735)

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -469,10 +469,7 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const actual = this._obj as any
       const [propertyName, expected] = args
       const getValue = () => {
-        const hasOwn = Object.hasOwn(
-          actual,
-          propertyName,
-        )
+        const hasOwn = actual != null && Object.hasOwn(actual, propertyName)
         if (hasOwn) {
           return { value: actual[propertyName], exists: true }
         }

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -367,10 +367,20 @@ describe('jest-expect', () => {
     expect(complex).toHaveProperty('bar', expect.any(Object))
     expect(complex).toHaveProperty('bar.arr', expect.any(Array))
     expect(complex).toHaveProperty('bar.arr.0', expect.anything())
+    expect(null).not.toHaveProperty('foo')
+    expect(undefined).not.toHaveProperty('foo')
 
     expect(() => {
       expect(complex).toHaveProperty('some-unknown-property')
     }).toThrow()
+
+    expect(() => {
+      expect(null).toHaveProperty('foo')
+    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected null to have property "foo"]`)
+
+    expect(() => {
+      expect(undefined).toHaveProperty('foo')
+    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected undefined to have property "foo"]`)
 
     expect(() => {
       expect(complex).toHaveProperty('a-b', false)


### PR DESCRIPTION
### What changed

`toHaveProperty` now guards the direct own-property check before calling `Object.hasOwn`. That lets nullish subjects fall through to the existing missing-property path instead of throwing `TypeError: Cannot convert undefined or null to object`.

### Why

Fixes #10735. The positive matcher now fails with a normal assertion error, while the negated matcher passes for `null` and `undefined`.

### Tests

- `pnpm -C test/unit test:threads jest-expect.test.ts`
- `pnpm exec eslint packages/expect/src/jest-expect.ts test/unit/test/jest-expect.test.ts`
- `git diff --check`

### Risk

Low. This only changes the nullish guard before the existing path lookup and keeps existing own-property behavior for objects.