### PR TITLE
fix: remove listeners in the typecheck worker's `off`

### DIFF
--- a/packages/vitest/src/node/pools/workers/typecheckWorker.ts
+++ b/packages/vitest/src/node/pools/workers/typecheckWorker.ts
@@ -46,7 +46,7 @@ export class TypecheckPoolWorker implements PoolWorker {
   }
 
   off(event: string, callback: (arg: any) => any): void {
-    this._eventEmitter.on(event, callback)
+    this._eventEmitter.off(event, callback)
   }
 
   deserialize(data: unknown): unknown {


### PR DESCRIPTION
`TypecheckPoolWorker.off()` called `emitter.on()`, so `PoolRunner.stop()`'s `worker.off('exit', ...)` added a listener instead of removing one, accumulating stale listeners across start/stop cycles in watch mode.