### PR TITLE
perf: make the Node compile cache opt-in, persist worker caches on teardown

### DIFF
--- a/docs/guide/improving-performance.md
+++ b/docs/guide/improving-performance.md
@@ -91,6 +91,18 @@ Duration  8.75s (transform 4.02s, setup 629ms, import 5.52s, tests 2.52s, enviro
 Duration  5.90s (transform 842ms, setup 543ms, import 2.35s, tests 2.94s, environment 0ms, prepare 3ms)
 ```
 
+## Node Compile Cache
+
+Vitest supports Node's [on-disk compile cache](https://nodejs.org/api/cli.html#node_compile_cachedir): when the `NODE_COMPILE_CACHE` environment variable points at a directory, the V8 bytecode of Vitest's own modules and of your externalized dependencies is written to disk and reused by later runs instead of being recompiled. Vitest propagates the variable to every worker, and workers persist the modules they compiled when they shut down.
+
+```shell
+NODE_COMPILE_CACHE=node_modules/.cache/node-compile-cache vitest
+```
+
+The first run with an empty directory pays for serializing the compiled modules, so this is only worth enabling when the directory survives between runs: local runs, or CI pipelines that cache the directory. `NODE_DISABLE_COMPILE_CACHE=1` disables the cache entirely, taking precedence over `NODE_COMPILE_CACHE`.
+
+Note that Vitest automatically disables the compile cache in workers when the `v8` coverage provider is enabled — V8 serializes cached scripts without the source positions that precise coverage relies on.
+
 ## Pool
 
 By default Vitest runs tests in `pool: 'forks'`. While `'forks'` pool is better for compatibility issues ([hanging process](/guide/common-errors.html#failed-to-terminate-worker) and [segfaults](/guide/common-errors.html#segfaults-and-native-code-errors)), it may be slightly slower than `pool: 'threads'` in larger projects.

--- a/packages/vitest/src/runtime/workers/init.ts
+++ b/packages/vitest/src/runtime/workers/init.ts
@@ -2,6 +2,9 @@ import type { WorkerRequest, WorkerResponse } from '../../node/pools/types'
 import type { MetaEnv, WorkerSetupContext } from '../../types/worker'
 import type { FileSpecification } from '../runner/types'
 import type { VitestWorker } from './types'
+// default import: `flushCompileCache` only exists since Node 22.10, a named
+// import would fail to link on older versions
+import Module from 'node:module'
 import { serializeError } from '@vitest/utils/error'
 import { disableDefaultColors } from 'tinyrainbow'
 import { Traces } from '../../utils/traces'
@@ -241,6 +244,20 @@ export function init(worker: Options): void {
       case 'stop': {
         await runPromise
 
+        // Persist this worker's compile cache before the parent tears the
+        // worker down — forks are SIGTERM'd and never reach Node's exit-time
+        // flush, so without this the cache stays write-only for them. Runs
+        // even when teardown throws (the compiled modules are still worth
+        // persisting). A no-op when the cache is disabled or was fully loaded
+        // from disk, and cheap (~tens of ms) otherwise, so every worker can
+        // afford it.
+        const persistCompileCache = () => {
+          try {
+            Module.flushCompileCache?.()
+          }
+          catch {}
+        }
+
         try {
           const context = traces.getContextFromCarrier(message.otelCarrier)
 
@@ -256,9 +273,13 @@ export function init(worker: Options): void {
 
           await traces.finish()
 
+          persistCompileCache()
+
           send({ type: 'stopped', error, __vitest_worker_response__ })
         }
         catch (error) {
+          persistCompileCache()
+
           send({ type: 'stopped', error: serializeError(error), __vitest_worker_response__ })
         }
 

--- a/packages/vitest/vitest.mjs
+++ b/packages/vitest/vitest.mjs
@@ -1,19 +1,2 @@
 #!/usr/bin/env node
-import * as module from 'node:module'
-
-// Enable Node's on-disk compile cache before importing the CLI so both the CLI
-// graph and (via the inherited env variable) every spawned worker skip V8
-// recompilation of unchanged modules. `enableCompileCache()` only affects the
-// current process — child processes pick the cache up from NODE_COMPILE_CACHE.
-// Respects an explicit NODE_COMPILE_CACHE and NODE_DISABLE_COMPILE_CACHE; the
-// API is not available before Node 22.8.
-try {
-  const result = module.enableCompileCache?.()
-  if (result?.directory && !process.env.NODE_COMPILE_CACHE) {
-    process.env.NODE_COMPILE_CACHE = result.directory
-  }
-}
-catch {}
-
-// eslint-disable-next-line antfu/no-top-level-await -- the import must not be hoisted above `enableCompileCache`
-await import('./dist/cli.js')
+import './dist/cli.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1337,6 +1337,9 @@ importers:
       '@vitest/browser-preview':
         specifier: workspace:*
         version: link:../../packages/browser-preview
+      '@vitest/coverage-v8':
+        specifier: workspace:*
+        version: link:../../packages/coverage-v8
       '@vitest/mocker':
         specifier: workspace:*
         version: link:../../packages/mocker

--- a/test/e2e/fixtures/compile-cache/basic.test.ts
+++ b/test/e2e/fixtures/compile-cache/basic.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+
+test('worker inherits the compile cache dir from NODE_COMPILE_CACHE', () => {
+  // gate on the discriminator between the two compile-cache.test.ts runs, not
+  // on EXPECTED_COMPILE_CACHE_DIR itself — if the spec's env stops
+  // propagating, this fails loudly (toBe(undefined)) instead of passing
+  // vacuously
+  if (!process.env.NODE_DISABLE_COMPILE_CACHE) {
+    expect(process.env.NODE_COMPILE_CACHE).toBe(process.env.EXPECTED_COMPILE_CACHE_DIR)
+  }
+  expect(document).toBeDefined()
+})

--- a/test/e2e/fixtures/compile-cache/basic.test.ts
+++ b/test/e2e/fixtures/compile-cache/basic.test.ts
@@ -1,11 +1,15 @@
 import { expect, test } from 'vitest'
 
-test('worker inherits the compile cache dir from NODE_COMPILE_CACHE', () => {
-  // gate on the discriminator between the two compile-cache.test.ts runs, not
-  // on EXPECTED_COMPILE_CACHE_DIR itself — if the spec's env stops
-  // propagating, this fails loudly (toBe(undefined)) instead of passing
-  // vacuously
-  if (!process.env.NODE_DISABLE_COMPILE_CACHE) {
+test('worker sees the expected compile cache environment', () => {
+  // set when the spec expects the v8 coverage provider to strip the cache
+  if (process.env.EXPECT_COVERAGE_STRIPPED) {
+    expect(process.env.NODE_COMPILE_CACHE).toBeUndefined()
+    expect(process.env.NODE_DISABLE_COMPILE_CACHE).toBe('1')
+  }
+  // gate on the discriminator between the spec's runs, not on
+  // EXPECTED_COMPILE_CACHE_DIR itself — if the spec's env stops propagating,
+  // this fails loudly (toBe(undefined)) instead of passing vacuously
+  else if (!process.env.NODE_DISABLE_COMPILE_CACHE) {
     expect(process.env.NODE_COMPILE_CACHE).toBe(process.env.EXPECTED_COMPILE_CACHE_DIR)
   }
   expect(document).toBeDefined()

--- a/test/e2e/fixtures/compile-cache/vitest.config.ts
+++ b/test/e2e/fixtures/compile-cache/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    watch: false,
+    environment: 'jsdom',
+    pool: 'forks',
+  },
+})

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -11,7 +11,6 @@
     "native": "vitest --root=./fixtures/no-module-runner --watch=false --no-isolate --max-workers=1"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-node": "^0.217.0",
     "@opentelemetry/sdk-trace-web": "^2.6.0",
@@ -25,6 +24,7 @@
     "@vitejs/test-dep-virtual": "file:./deps/test-dep-virtual",
     "@vitest/browser-playwright": "workspace:*",
     "@vitest/browser-preview": "workspace:*",
+    "@vitest/coverage-v8": "workspace:*",
     "@vitest/mocker": "workspace:*",
     "@vitest/test-dep-optimizer-external": "file:./deps/optimizer/external",
     "@vitest/test-dep-optimizer-optimized": "file:./deps/optimizer/optimized",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -11,6 +11,7 @@
     "native": "vitest --root=./fixtures/no-module-runner --watch=false --no-isolate --max-workers=1"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-node": "^0.217.0",
     "@opentelemetry/sdk-trace-web": "^2.6.0",

--- a/test/e2e/test/compile-cache.test.ts
+++ b/test/e2e/test/compile-cache.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { expect, test } from 'vitest'
+import { runVitestCli } from '../../test-utils'
+
+const fixture = resolve(import.meta.dirname, '../fixtures/compile-cache')
+const cacheDir = resolve(fixture, 'node_modules/.cache/compile-cache-test')
+
+function cacheEntries(): string[] {
+  return readdirSync(cacheDir, { recursive: true, encoding: 'utf-8' })
+    .filter(file => statSync(join(cacheDir, file)).isFile())
+}
+
+test('NODE_COMPILE_CACHE redirects the compile cache and the worker persists its graph', async () => {
+  rmSync(cacheDir, { recursive: true, force: true })
+
+  // the fixture test asserts that the worker sees this exact NODE_COMPILE_CACHE
+  const { exitCode } = await runVitestCli(
+    { nodeOptions: { env: {
+      NODE_COMPILE_CACHE: cacheDir,
+      EXPECTED_COMPILE_CACHE_DIR: cacheDir,
+    } } },
+    'run',
+    '--root',
+    fixture,
+  )
+
+  expect(exitCode).toBe(0)
+
+  // jsdom is only loaded inside the worker, so its modules can reach the
+  // cache only through the worker flush — the CLI graph alone is ~150 entries,
+  // the worker graph pushes it past 1000
+  expect(cacheEntries().length).toBeGreaterThan(300)
+})
+
+test('NODE_DISABLE_COMPILE_CACHE wins over NODE_COMPILE_CACHE', async () => {
+  rmSync(cacheDir, { recursive: true, force: true })
+
+  const { exitCode } = await runVitestCli(
+    { nodeOptions: { env: {
+      NODE_COMPILE_CACHE: cacheDir,
+      NODE_DISABLE_COMPILE_CACHE: '1',
+    } } },
+    'run',
+    '--root',
+    fixture,
+  )
+
+  expect(exitCode).toBe(0)
+  expect(existsSync(cacheDir)).toBe(false)
+})

--- a/test/e2e/test/compile-cache.test.ts
+++ b/test/e2e/test/compile-cache.test.ts
@@ -49,3 +49,28 @@ test('NODE_DISABLE_COMPILE_CACHE wins over NODE_COMPILE_CACHE', async () => {
   expect(exitCode).toBe(0)
   expect(existsSync(cacheDir)).toBe(false)
 })
+
+test('the cache is stripped from workers when v8 coverage is enabled', async () => {
+  rmSync(cacheDir, { recursive: true, force: true })
+
+  const { exitCode } = await runVitestCli(
+    { nodeOptions: { env: {
+      NODE_COMPILE_CACHE: cacheDir,
+      EXPECT_COVERAGE_STRIPPED: '1',
+    } } },
+    'run',
+    '--root',
+    fixture,
+    '--coverage.enabled',
+    '--coverage.provider=v8',
+    '--coverage.reporter=text',
+  )
+
+  expect(exitCode).toBe(0)
+
+  // the CLI process itself still persists its own graph (Node enabled its
+  // cache from the env var at startup, before coverage is known), but the
+  // worker's jsdom graph must not reach the cache
+  const entries = existsSync(cacheDir) ? cacheEntries() : []
+  expect(entries.length).toBeLessThan(300)
+})


### PR DESCRIPTION
#10708 enabled Node's compile cache unconditionally. That turned out to be a bad default in two ways:

- On cold environments — CI that doesn't persist the cache directory — it makes runs slower: workers pay the code-cache production cost, and thread workers additionally serialize their whole compiled graph when they are terminated, with zero payoff since the directory is thrown away.
- For the default `forks` pool the cache was write-only anyway: SIGTERM'd workers never reach Node's exit-time flush, so worker entries (runtime, test environment, externalized deps) never reached the disk even when the directory did persist.

This PR makes the cache opt-in and makes opting in actually work:

- The executable no longer calls `module.enableCompileCache()`. Setting `NODE_COMPILE_CACHE=<dir>` enables the cache for the CLI (Node reads it at startup) and Vitest propagates it to every worker.
- Workers persist their compiled modules during graceful teardown (`module.flushCompileCache()` in the `stop` handler, both teardown paths; default import because a named import fails to link before Node 22.10). This is what makes the cache useful for `forks`.
- The `v8` coverage provider still strips the cache from workers (V8 serializes cached scripts without the source positions precise coverage relies on) — now covered by a test.
- Documented in `docs/guide/improving-performance.md` as a tuning knob for environments where the directory survives between runs.

40-file happy-dom `isolate: true` suite, median of 5 interleaved runs (Apple M4 ×10, Node 24):

| pool | scenario | main (always on) | this PR |
|---|---|---:|---:|
| forks | cold, cache not persisted (CI) | 2123 ms | **1924 ms (−9%)** |
| forks | `NODE_COMPILE_CACHE`, first run | — | 2366 ms |
| forks | `NODE_COMPILE_CACHE`, subsequent runs | — | 1812 ms |
| threads | cold, cache not persisted (CI) | 2115 ms | **1709 ms (−19%)** |
| threads | `NODE_COMPILE_CACHE`, first run | — | 2123 ms |
| threads | `NODE_COMPILE_CACHE`, subsequent runs | — | 1618 ms |

Cold runs get faster by default. Opting in pays the first-run serialization once and runs ~23% faster than that first run afterwards; the benefit over not enabling the cache at all grows with the size of the natively-imported graph (heavier environments and dependencies).

The e2e test covers env propagation into workers, `NODE_DISABLE_COMPILE_CACHE` precedence, and the coverage exclusion.
