### PR TITLE
fix: keep per-file isolation in vm pools when maxWorkers is 1

### DIFF
--- a/packages/vitest/src/node/pool.ts
+++ b/packages/vitest/src/node/pool.ts
@@ -431,8 +431,12 @@ function groupSpecs(specs: TestSpecification[], environments: WeakMap<TestSpecif
       throw new Error(`Projects "${last}" and "${spec.project.name}" have different 'maxWorkers' but same 'sequence.groupOrder'.\nProvide unique 'sequence.groupOrder' for them.`)
     }
 
-    // Non-isolated single worker can receive all files at once
-    if (isolate === false && maxWorkers === 1) {
+    // Non-isolated single worker can receive all files at once.
+    // vm pools are excluded: their `isolate: false` comes from config
+    // resolution rather than the user, because their isolation is a fresh VM
+    // context per run request — batching files into a single run request
+    // would share one context across all of them.
+    if (isolate === false && maxWorkers === 1 && spec.pool !== 'vmThreads' && spec.pool !== 'vmForks') {
       const previous = groups[order].specs[0]?.[0]
 
       if (previous && previous.project.name === spec.project.name && isEqualEnvironments(spec, previous)) {

--- a/test/e2e/test/vm-threads.test.ts
+++ b/test/e2e/test/vm-threads.test.ts
@@ -16,6 +16,36 @@ test('importing files in restricted fs works correctly', async () => {
   expect(exitCode).toBe(0)
 })
 
+// vm pools resolve `isolate` to false (isolation comes from a fresh VM
+// context per run request), which used to trigger the "single non-isolated
+// worker receives all files at once" batching with `maxWorkers: 1` — all
+// files then shared one VM context and leaked state into each other
+test.for(['vmThreads', 'vmForks'] as const)(
+  '%s keeps per-file isolation when maxWorkers is 1',
+  async (pool) => {
+    // each file both expects a clean context and pollutes it, so the test
+    // does not depend on the file execution order
+    const pollutingTest = `
+      import { expect, test } from 'vitest'
+
+      test('does not see state from other test files', () => {
+        expect(globalThis.__isolation_leak__).toBeUndefined()
+        globalThis.__isolation_leak__ = import.meta.url
+      })
+    `
+    const { stderr, exitCode } = await runInlineTests({
+      'a.test.js': pollutingTest,
+      'b.test.js': pollutingTest,
+    }, {
+      pool,
+      maxWorkers: 1,
+    })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  },
+)
+
 // The module-sync condition was added in Node 22.12/20.19 when require(esm)
 // was unflagged. The fix uses the _resolveFilename conditions option which
 // is only available on Node 22.12+. Node 20 is unfixable and reaches EOL


### PR DESCRIPTION
### Description

vm pools resolve `isolate` to `false` during config resolution — their isolation comes from a fresh VM context per run request, not from worker lifecycle. The single-worker batching in `groupSpecs` treated that resolved flag as a user opt-in: with `maxWorkers: 1`, all same-environment files were packed into one run request, and `runVmTests` executes a whole run request in a single VM context. Every test file then shared one context — `globalThis`, DOM and module state leaked across files:

```ts
// a.test.ts
test('pollutes', () => {
  globalThis.__leaked = 'from a'
})

// b.test.ts — fails with vmThreads + maxWorkers: 1, passes with maxWorkers >= 2
test('isolated', () => {
  expect(globalThis.__leaked).toBeUndefined()
})
```

`vmThreads`/`vmForks` are now excluded from that batching and fall back to one run request per file on the shared worker, restoring the same per-file context isolation as any other `maxWorkers` value. No opt-in is lost: explicit `isolate` settings are already overwritten for vm pools, so `isolate: false` there never expressed user intent to share state.