### PR TITLE
fix(expect): handle nullish subject in toHaveProperty (#10735)

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -469,10 +469,8 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       const actual = this._obj as any
       const [propertyName, expected] = args
       const getValue = () => {
-        const hasOwn = Object.hasOwn(
-          actual,
-          propertyName,
-        )
+        const hasOwn
+          = actual != null && Object.hasOwn(actual, propertyName)
         if (hasOwn) {
           return { value: actual[propertyName], exists: true }
         }

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -384,6 +384,23 @@ describe('jest-expect', () => {
     }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { a: { b: { c: 1 } } } to deeply equal { a: { b: { c: 2 } } }]`)
   })
 
+  it('toHaveProperty on null/undefined subjects (#10735)', () => {
+    // A nullish subject must fail cleanly instead of throwing a raw
+    // `TypeError: Cannot convert undefined or null to object`.
+    expect(null).not.toHaveProperty('x')
+    expect(undefined).not.toHaveProperty('x')
+    expect(null).not.toHaveProperty('a.b')
+    expect(undefined).not.toHaveProperty(['a', 'b'])
+
+    expect(() => {
+      expect(null).toHaveProperty('x')
+    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected null to have property "x"]`)
+
+    expect(() => {
+      expect(undefined).toHaveProperty('x', 1)
+    }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected undefined to have property "x" with value 1]`)
+  })
+
   it('assertions', () => {
     expect(1).toBe(1)
     expect(1).toBe(1)


### PR DESCRIPTION
### Description

`expect(...).toHaveProperty()` crashes with a raw internal `TypeError: Cannot convert undefined or null to object` when the received value is `null` or `undefined`, instead of failing the assertion cleanly. The negated form `.not.toHaveProperty()` crashes too, when it should pass for a nullish subject.

```ts
expect(null).toHaveProperty('x')        // throws TypeError (should fail cleanly)
expect(null).not.toHaveProperty('x')    // throws TypeError (should pass)
expect(undefined).toHaveProperty('x')   // throws TypeError (should fail cleanly)
```

**Root cause:** in `packages/expect/src/jest-expect.ts`, `toHaveProperty`'s `getValue()` helper calls `Object.hasOwn(actual, propertyName)` before the null-safe `getPathInfo` fallback. `Object.hasOwn(null, …)` throws, and `actual` is never guarded for nullish values.

**Fix:** guard the own-property fast path with `actual != null` so the null-safe `getPathInfo` fallback runs. A nullish subject now fails with a proper matcher error (`expected null to have property "x"`), and the negated form passes — matching Jest's behavior.

Resolves #10735

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Added a regression test in `test/unit/test/jest-expect.test.ts` covering nullish subjects for both `toHaveProperty` and `.not.toHaveProperty`. Verified it fails on `main` and passes with this change. Ran the `jest-expect` suite, `eslint`, and `tsc` typecheck locally — all green.

### Documentation
- [x] No new functionality; bug fix only, no docs changes needed.

### Changesets
- [x] PR title is prefixed with `fix:` and describes the change.

