### PR TITLE
fix(browser): preserve pre-transform request defaults

### DIFF
--- a/packages/vitest/src/node/plugins/runnerTransform.ts
+++ b/packages/vitest/src/node/plugins/runnerTransform.ts
@@ -80,7 +80,9 @@ export function ModuleRunnerTransform(): VitePlugin {
           else {
             environment.dev.moduleRunnerTransform = true
           }
-          environment.dev.preTransformRequests = false
+          if (name !== 'client' || !browserEnabled) {
+            environment.dev.preTransformRequests = false
+          }
           environment.keepProcessEnv = true
         }
       },

--- a/packages/vitest/src/node/plugins/server.ts
+++ b/packages/vitest/src/node/plugins/server.ts
@@ -18,7 +18,6 @@ export function VitestConfigServer(harness: PluginHarness, globalConfig?: Resolv
         handler() {
           return {
             server: {
-              preTransformRequests: false,
               hmr: false,
               open: false,
             },
@@ -49,6 +48,9 @@ export function VitestConfigServer(harness: PluginHarness, globalConfig?: Resolv
 
           const server: ServerOptions = {
             ...api,
+          }
+          if (!isBrowserEnabled) {
+            server.preTransformRequests = false
           }
 
           // Always disable the websocket server in middlewareMode

--- a/test/e2e/test/config/browser-configs.test.ts
+++ b/test/e2e/test/config/browser-configs.test.ts
@@ -56,6 +56,62 @@ async function config(options?: TestUserConfig & { $viteConfig?: ViteUserConfig;
   return resolvedProjects.filter(p => !p.hidden)
 }
 
+async function observePreTransformRequests(options: TestUserConfig = {}) {
+  let serverPreTransformRequests: unknown = 'unresolved'
+  let clientPreTransformRequests: unknown = 'unresolved'
+  const browserEnabled = !!options.browser?.enabled
+
+  await config({
+    ...options,
+    $viteConfig: {
+      plugins: [
+        {
+          name: 'observe-pre-transform-requests',
+          enforce: 'post',
+          config: {
+            order: 'post',
+            handler(config) {
+              if (!!config.test?.browser?.enabled === browserEnabled) {
+                serverPreTransformRequests = config.server?.preTransformRequests
+                clientPreTransformRequests = config.environments?.client?.dev?.preTransformRequests
+              }
+            },
+          },
+        },
+      ],
+    },
+  })
+
+  return {
+    client: clientPreTransformRequests,
+    server: serverPreTransformRequests,
+  }
+}
+
+test('does not disable pre-transform requests in browser mode', async () => {
+  const result = await observePreTransformRequests({
+    browser: {
+      enabled: true,
+      provider: preview(),
+      instances: [
+        { browser: 'chromium' },
+      ],
+    },
+  })
+
+  expect(result).toEqual({
+    client: undefined,
+    server: undefined,
+  })
+})
+
+test('disables pre-transform requests in node mode', async () => {
+  expect(await observePreTransformRequests()).toEqual({
+    client: false,
+    server: false,
+  })
+})
+
 test('assigns names as browsers', async () => {
   const projects = await config({
     browser: {


### PR DESCRIPTION
## Summary

- omit `server.preTransformRequests` for browser projects
- leave `client.dev.preTransformRequests` unset in browser mode while preserving Node defaults
- cover browser and Node configuration behavior

Fixes #10745
