### PR TITLE
fix: fix typos in comments and error messages

### DIFF
--- a/packages/browser/src/client/tester/tester-utils.ts
+++ b/packages/browser/src/client/tester/tester-utils.ts
@@ -175,7 +175,7 @@ export class CommandsManager {
         if (hasActiveTraceView) {
           // Covers provider-backed actionability/waiting after command dispatch.
           // Local pre-command resolution, such as serializeElement/findElement paths
-          // is not coverd within by this action trace range.
+          // is not covered within by this action trace range.
           await recordBrowserTraceEntry(currentTest, {
             name: actionTraceGroupName,
             kind: 'action',

--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -326,7 +326,7 @@ export class SnapshotClient {
     }
 
     // TODO: should `all` mode ignore parse error?
-    // Sielently hiding the error and creating snaphsot full scratch isn't good either.
+    // Silently hiding the error and creating snapshot full scratch isn't good either.
     // Users can fix or purge the broken snapshot manually and that decision affects how domain snapshot gets updated.
     const matchResult = expectedSnapshot.data !== undefined
       ? adapter.match(stableResult.captured, adapter.parseExpected(expectedSnapshot.data))

--- a/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
@@ -2,7 +2,7 @@ import type { Writable } from 'node:stream'
 import type { Vitest } from '../../core'
 import { stripVTControlCharacters } from 'node:util'
 
-/** Minimum time between two renders, no matter how many scheduled renderes were called */
+/** Minimum time between two renders, no matter how many scheduled renders were called */
 const DEFAULT_RENDER_THRESHOLD_MS = 100
 
 /** Interval between automatic renders. If no test state changes happened, this will increase just duration field */

--- a/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
@@ -126,7 +126,7 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
         }
 
         // strip _vitest_original query added by importActual so that
-        // the plugin pipeline sees the original import id (e.g. virtual modules's load hook)
+        // the plugin pipeline sees the original import id (e.g. virtual module's load hook)
         const isImportActual = id.includes('_vitest_original')
         if (isImportActual) {
           id = removeQuery(id, '_vitest_original')

--- a/packages/vitest/src/runtime/runner/utils/tags.ts
+++ b/packages/vitest/src/runtime/runner/utils/tags.ts
@@ -36,7 +36,7 @@ export function validateTags(config: SerializedConfig, tags: string[]): void {
 
 export function createNoTagsError(availableTags: TestTagDefinition[], tag: string, prefix = 'tag'): never {
   if (!availableTags.length) {
-    throw new Error(`The Vitest config does't define any "tags", cannot apply "${tag}" ${prefix} for this test. See: https://vitest.dev/guide/test-tags`)
+    throw new Error(`The Vitest config doesn't define any "tags", cannot apply "${tag}" ${prefix} for this test. See: https://vitest.dev/guide/test-tags`)
   }
   throw new Error(`The ${prefix} "${tag}" is not defined in the configuration. Available tags are:\n${availableTags
     .map(t => `- ${t.name}${t.description ? `: ${t.description}` : ''}`)

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -302,7 +302,7 @@ export class TestRunner implements VitestTestRunner {
   /**
    * @experimental
    * A function that runs tinybench tasks.
-   * Can be overriden to run tasks in a special environment.
+   * Can be overridden to run tasks in a special environment.
    */
   static async runBenchmarks(tinybench: Tinybench): Promise<TinybenchTask[]> {
     return await tinybench.run()


### PR DESCRIPTION
Fix several typos found in source code comments and one error message string:

- `snaphsot` -> `snapshot` and `Sielently` -> `Silently` in `packages/snapshot/src/client.ts`
- `does't` -> `doesn't` in `packages/vitest/src/runtime/runner/utils/tags.ts`
- `overriden` -> `overridden` in `packages/vitest/src/runtime/runners/test.ts`
- `renderes` -> `renders` in `packages/vitest/src/node/reporters/renderers/windowedRenderer.ts`
- `modules's` -> `module's` in `packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts`
- `coverd` -> `covered` in `packages/browser/src/client/tester/tester-utils.ts`

<!-- VITEST_AUTOMATED_PR -->