### PR TITLE
fix: don't double-prefix node: built-ins in resolve.external (fix #10630)

### DIFF
--- a/packages/vitest/src/node/plugins/runnerTransform.ts
+++ b/packages/vitest/src/node/plugins/runnerTransform.ts
@@ -115,10 +115,7 @@ export function ModuleRunnerTransform(): VitePlugin {
         }
 
         // remove Vite's externalization logic because we have our own (unfortunately)
-        config.resolve.external = [
-          ...builtinModules,
-          ...builtinModules.map(m => `node:${m}`),
-        ]
+        config.resolve.external = resolveBuiltinExternalModules()
 
         // by setting `noExternal` to `true`, we make sure that
         // Vite will never use its own externalization mechanism
@@ -155,6 +152,19 @@ export function ModuleRunnerTransform(): VitePlugin {
       },
     },
   }
+}
+
+export function resolveBuiltinExternalModules(
+  modules: readonly string[] = builtinModules,
+): string[] {
+  // `builtinModules` can already contain `node:`-prefixed entries on newer Node
+  // versions (e.g. `node:sqlite`, `node:test`, `node:test/reporters`), so only add
+  // the prefix when it is missing to avoid producing invalid `node:node:*` externals.
+  return [
+    ...new Set(
+      modules.flatMap(m => (m.startsWith('node:') ? [m] : [m, `node:${m}`])),
+    ),
+  ]
 }
 
 function resolveViteResolveOptions(

--- a/test/unit/test/runner-transform.test.ts
+++ b/test/unit/test/runner-transform.test.ts
@@ -1,0 +1,37 @@
+import { builtinModules } from 'node:module'
+import { describe, expect, test } from 'vitest'
+import { resolveBuiltinExternalModules } from '../../../packages/vitest/src/node/plugins/runnerTransform'
+
+describe('resolveBuiltinExternalModules', () => {
+  test('adds a node: alias for bare built-ins', () => {
+    const external = resolveBuiltinExternalModules(['fs', 'path'])
+    expect(external).toEqual(['fs', 'node:fs', 'path', 'node:path'])
+  })
+
+  test('does not double-prefix built-ins that are already node: prefixed', () => {
+    // Newer Node versions expose some built-ins only in prefixed form.
+    const external = resolveBuiltinExternalModules([
+      'fs',
+      'node:sea',
+      'node:sqlite',
+      'node:test',
+      'node:test/reporters',
+    ])
+
+    expect(external).not.toContain('node:node:sea')
+    expect(external.some(m => m.startsWith('node:node:'))).toBe(false)
+    expect(external).toEqual([
+      'fs',
+      'node:fs',
+      'node:sea',
+      'node:sqlite',
+      'node:test',
+      'node:test/reporters',
+    ])
+  })
+
+  test('never produces a double node: prefix for the current runtime built-ins', () => {
+    const external = resolveBuiltinExternalModules(builtinModules)
+    expect(external.filter(m => m.startsWith('node:node:'))).toEqual([])
+  })
+})


### PR DESCRIPTION
### Description

On newer Node versions (24+), `builtinModules` already exposes some built-ins only in `node:`-prefixed form (`node:sea`, `node:sqlite`, `node:test`, `node:test/reporters`). `ModuleRunnerTransform` prefixed **every** entry:

```ts
config.resolve.external = [
  ...builtinModules,
  ...builtinModules.map(m => `node:${m}`),
]
```

so those became invalid `node:node:*` values in `resolve.external`, which breaks Vitest startup with `@cloudflare/vite-plugin`.

This extracts the list generation into `resolveBuiltinExternalModules` and only adds the `node:` prefix when it's missing, so already-prefixed built-ins are kept as-is. Normal built-ins are still externalized both bare and prefixed (`fs` and `node:fs`).

Resolves #10630

Verified on Node `v24.18.0`: before the change `resolve.external` contained `node:node:sea`, `node:node:sqlite`, `node:node:test`, `node:node:test/reporters`; after, those are gone while `fs`/`node:fs` and the prefix-only built-ins remain.

I used Claude (AI assistant) to help write this change. I've reviewed it, understand it, and stand behind it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time — Resolves #10630.
- [x] Ideally, include a test that fails without this PR but passes with it — `test/unit/test/runner-transform.test.ts` (fails on the old code with `node:node:sea`, passes with the fix).
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example — no lockfile changes.
- [x] Please check [Allow edits by maintainers].

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Ran locally on Node `v24.18.0`: the new `test/unit/test/runner-transform.test.ts` (red on the old code, green with the fix), the `test/e2e/test/vite-ssr-resolve.test.ts` suite that exercises the changed `configEnvironment` path (32/32 passing), plus `eslint` and the type check on the changed files — all clean. I did not run the full `pnpm test:ci` suite locally.

### Documentation
- [ ] No new user-facing functionality; internal fix only.

### Changesets
- [x] The PR title is prefixed with `fix:` and describes the change for the generated changelog.
