### PR TITLE
fix(browser): remove filter options from locator query types

### DIFF
--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -515,7 +515,7 @@ page.getByRole('button')
 ## filter
 
 ```ts
-function filter(options: LocatorOptions): Locator
+function filter(options: LocatorFilterOptions): Locator
 ```
 
 This methods narrows down the locator according to the options, such as filtering by text. It can be chained to apply multiple filters.

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -447,6 +447,9 @@ export interface LocatorOptions {
    * regular expression. Note that exact match still trims whitespace.
    */
   exact?: boolean
+}
+
+export interface LocatorFilterOptions {
   hasText?: string | RegExp
   hasNotText?: string | RegExp
   has?: Locator
@@ -766,7 +769,7 @@ export interface Locator extends LocatorSelectors {
    * Narrows existing locator according to the options.
    * @see {@link https://vitest.dev/api/browser/locators#filter}
    */
-  filter(options: LocatorOptions): Locator
+  filter(options: LocatorFilterOptions): Locator
   /**
    * This method returns an element matching the locator.
    * Unlike [`.element()`](https://vitest.dev/api/browser/locators#element),

--- a/packages/browser/src/client/tester/locators.ts
+++ b/packages/browser/src/client/tester/locators.ts
@@ -1,6 +1,7 @@
 import type { ParsedSelector } from 'ivya'
 import type {
   LocatorByRoleOptions,
+  LocatorFilterOptions,
   LocatorOptions,
   LocatorScreenshotOptions,
   MarkOptions,
@@ -273,7 +274,7 @@ export abstract class Locator {
     return this.locator(getByTitleSelector(title, options))
   }
 
-  public filter(filter: LocatorOptions): Locator {
+  public filter(filter: LocatorFilterOptions): Locator {
     const selectors = []
 
     if (filter?.hasText) {

--- a/packages/ui/client/components/artifacts/visual-regression/VisualRegressionSlider.spec.ts
+++ b/packages/ui/client/components/artifacts/visual-regression/VisualRegressionSlider.spec.ts
@@ -76,10 +76,8 @@ describe('VisualRegressionSlider', () => {
 
     const container = page.getByLabelText(containerLabel)
     const input = page.getByLabelText(inputLabel)
-    const status = page.getByRole(
-      'status',
-      { hasText: 'Showing 50% reference, 50% actual' },
-    )
+    const status = page.getByRole('status')
+      .filter({ hasText: 'Showing 50% reference, 50% actual' })
 
     // container with accessible label should exist and contain input and status
     await expect.element(container).toBeInTheDocument()

--- a/test/browser/test/locators.test-d.ts
+++ b/test/browser/test/locators.test-d.ts
@@ -1,0 +1,41 @@
+import { test } from 'vitest'
+import { page } from 'vitest/browser'
+
+test('locators accept only their own query options', () => {
+  page.getByRole('button', { name: 'Submit', exact: true })
+  page.getByText('Submit', { exact: true })
+  page.getByLabelText('Submit', { exact: true })
+  page.getByPlaceholder('Submit', { exact: true })
+  page.getByAltText('Submit', { exact: true })
+  page.getByTitle('Submit', { exact: true })
+
+  // @ts-expect-error use the `name` option or chain .filter() instead
+  page.getByRole('button', { hasText: 'Submit' })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByRole('button', { hasNotText: 'Submit' })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByRole('button', { has: page.getByText('Submit') })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByRole('button', { hasNot: page.getByText('Submit') })
+
+  // @ts-expect-error filter options belong to .filter()
+  page.getByText('Submit', { hasText: 'Submit' })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByLabelText('Submit', { hasText: 'Submit' })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByPlaceholder('Submit', { hasText: 'Submit' })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByAltText('Submit', { hasText: 'Submit' })
+  // @ts-expect-error filter options belong to .filter()
+  page.getByTitle('Submit', { hasText: 'Submit' })
+})
+
+test('filter accepts only filter options', () => {
+  page.getByRole('button').filter({ hasText: 'Submit' })
+  page.getByRole('button').filter({ hasNotText: /Submit/ })
+  page.getByRole('button').filter({ has: page.getByText('Submit') })
+  page.getByRole('button').filter({ hasNot: page.getByText('Submit') })
+
+  // @ts-expect-error `exact` is a query option, not a filter
+  page.getByRole('button').filter({ exact: true })
+})


### PR DESCRIPTION
### Description

Fixes #10295

`getByRole('button', { hasText: 'A' })` typechecks but the filter is silently ignored — the role selector never applies `hasText`/`hasNotText`/`has`/`hasNot`, so the locator matches every button and interactions fail with a strict mode violation.

As the maintainer stated in the issue:

> the expected fix is in the types, not implementation. The implementation is correct, it doesn't expect options for a different function.

and in the review of a previous attempt (#10297):

> I think options in all locators are typed incorrectly, they accept only `exact` (see ivya types). The filter functions should have its own type

This PR follows that instruction exactly — it is a **types-only change with no runtime behavior change**:

- `LocatorOptions` now only contains `exact`, matching what the ivya selector builders actually support. `LocatorByRoleOptions` keeps the role-specific options (`name`, `checked`, `level`, …) plus `exact`.
- The filter fields (`hasText`, `hasNotText`, `has`, `hasNot`) moved to a new `LocatorFilterOptions` type, which is what `locator.filter()` accepts.
- Updated an internal UI spec that relied on the old (broken) typing to use `.filter()` instead.
- Added `test/browser/test/locators.test-d.ts` asserting that the filter options are rejected on all `getBy*` query methods and that `filter()` rejects `exact`.
- Updated the `filter()` signature in the locators docs.

**Effect for users:** code like `page.getByRole('button', { hasText: 'A' })` now fails to compile with a clear type error instead of silently matching everything, pointing users toward `getByRole('button', { name: 'A' })` or `.filter({ hasText: 'A' })`.

AI disclosure (per CONTRIBUTING.md): This PR was prepared with AI assistance (Claude Code); every change was reviewed and verified by typecheck/tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. (`test/browser/test/locators.test-d.ts` — the `@ts-expect-error` directives are reported as unused without this change)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] `pnpm build`
- [x] `pnpm -C packages/browser typecheck`
- [x] `pnpm -C packages/ui typecheck:client`
- [x] `tsc -p test/browser --noEmit` — no errors in the new type test; identical pre-existing error count as `main`
- [x] `eslint` on all changed files

### Documentation
- [x] Updated the `filter()` type signature in `docs/api/browser/locators.md` (the filter options were already documented under `.filter()`, not the query methods).

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- VITEST_AUTOMATED_PR -->
