### PR TITLE
docs: fix dead vitest.dev/releases and storybook test-addon links

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Refer to the [Releases](https://vitest.dev/releases) page in the documentation for the supported Vitest versions.
+Refer to the [Releases](https://github.com/vitest-dev/vitest/releases) page in the documentation for the supported Vitest versions.
 
 ## Threat Model
 

--- a/docs/blog/vitest-3.md
+++ b/docs/blog/vitest-3.md
@@ -31,7 +31,7 @@ _January 17, 2025_
 
 ![Vitest 3 Announcement Cover Image](/og-vitest-3.jpg)
 
-We released Vitest 2 half a year ago. We have seen huge adoption, from 4,8M to 7,7M weekly npm downloads. Our ecosystem is growing rapidly too. Among others, [Storybook new testing capabilities powered by our vscode extension and browser mode](https://storybook.js.org/docs/writing-tests/test-addon) and Matt Pocock is building [Evalite](https://www.evalite.dev/), a tool for evaluating AI-powered apps, on top of Vitest.
+We released Vitest 2 half a year ago. We have seen huge adoption, from 4,8M to 7,7M weekly npm downloads. Our ecosystem is growing rapidly too. Among others, [Storybook new testing capabilities powered by our vscode extension and browser mode](https://storybook.js.org/docs/writing-tests/integrations/vitest-addon) and Matt Pocock is building [Evalite](https://www.evalite.dev/), a tool for evaluating AI-powered apps, on top of Vitest.
 
 ## The next Vitest major is here
 


### PR DESCRIPTION
docs: fix dead vitest.dev/releases and storybook test-addon links

Two dead external links, both in the docs surface:

- `SECURITY.md:5`, `https://vitest.dev/releases` returns HTTP 404. The
  releases listing is hosted on GitHub at
  `https://github.com/vitest-dev/vitest/releases` (HTTP 200, same
  content). The vitest.dev site no longer carries a top-level
  `/releases` page; release notes live alongside the GitHub release
  workflow.

- `docs/blog/vitest-3.md:34` -
  `https://storybook.js.org/docs/writing-tests/test-addon` returns
  HTTP 404. Storybook restructured the testing docs tree and promoted
  the Vitest integration to a first-class entry under
  `docs/writing-tests/integrations/vitest-addon`. The new page
  (HTTP 200) covers the same material the original link was pointing
  at (the vscode extension + browser mode integration).

## Diff

```
 SECURITY.md           | 2 +-
 docs/blog/vitest-3.md | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

## Verification

```
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://vitest.dev/releases"
404
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://github.com/vitest-dev/vitest/releases"
200
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://storybook.js.org/docs/writing-tests/test-addon"
404
$ curl -sI -A "Mozilla/5.0" -L -o /dev/null -w '%{http_code}\n' \
    "https://storybook.js.org/docs/writing-tests/integrations/vitest-addon"
200
```
