### PR TITLE
fix mock type isolation between test files

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -167,14 +167,14 @@ export class VitestModuleRunner
     if (mod.meta && 'mockedModule' in mod.meta) {
       const mockedModule = mod.meta.mockedModule as MockedModule
       const mockId = this.mocker.getMockPath(mod.id)
+      const activeMock = this.mocker.getDependencyMock(mod.id)
       // bypass mock and force "importActual" behavior when:
       // - mock was removed by doUnmock (stale mockedModule in meta)
       // - self-import: mock factory/file is importing the module it's mocking
-      const isStale = !this.mocker.getDependencyMock(mod.id)
       const isSelfImport = callstack.includes(mockId)
         || callstack.includes(url)
         || ('redirect' in mockedModule && callstack.includes(mockedModule.redirect))
-      if (isStale || isSelfImport) {
+      if (!activeMock || isSelfImport) {
         const node = await this.fetchModule(injectQuery(url, '_vitest_original'))
         return this._cachedRequest(node.url, node, callstack, metadata)
       }
@@ -182,7 +182,7 @@ export class VitestModuleRunner
         url,
         mod,
         callstack,
-        mockedModule,
+        activeMock,
       )
     }
     else {

--- a/test/e2e/test/mock-isolation.test.ts
+++ b/test/e2e/test/mock-isolation.test.ts
@@ -1,0 +1,51 @@
+import { runInlineTests } from '#test-utils'
+import { expect, test } from 'vitest'
+
+test('mock type does not leak between non-isolated test files', async () => {
+  const result = await runInlineTests(
+    {
+      'a.test.ts': `
+        import { expect, test, vi } from 'vitest'
+        import * as repo from './repo'
+
+        vi.mock('./repo', () => ({ value: 'manual' }))
+
+        test('uses the manual mock', () => {
+          expect(repo.value).toBe('manual')
+        })
+      `,
+      'b.test.ts': `
+        import { expect, test, vi } from 'vitest'
+        import * as repo from './repo'
+
+        vi.mock('./repo')
+
+        test('uses an automock', () => {
+          expect(vi.isMockFunction(repo.value)).toBe(true)
+          expect(repo.value()).toBeUndefined()
+        })
+      `,
+      'repo.ts': `
+        export function value() {
+          return 'actual'
+        }
+      `,
+    },
+    {
+      isolate: false,
+      maxWorkers: 1,
+      sequence: { shuffle: false },
+    },
+  )
+
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "a.test.ts": {
+        "uses the manual mock": "passed",
+      },
+      "b.test.ts": {
+        "uses an automock": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
Fixes #10290.

When `isolate: false` reuses a module runner, an evaluated module can retain the `mockedModule` stored in its metadata from an earlier test file. A later file may register a different mock type for the same module, but the runner previously used the cached metadata as long as any active mock existed. This allowed the earlier manual factory to leak into a later automock.

This change resolves the active mock from the current test file's registry before dispatching. Cached metadata is still used to detect redirect self-imports, while removed mocks continue to fall back to the original module.

The regression test runs two ordered files in one non-isolated worker: the first registers a manual factory and the second registers an automock for the same module.

Checks:

- `CI=true pnpm test test/mock-isolation.test.ts --run` in `test/e2e`
- related mocking tests in both `threads` and `forks` projects (26 tests)
- `pnpm lint:fix`
- `pnpm typecheck`

<!-- VITEST_AUTOMATED_PR -->
