### PR TITLE
fix: Node.js 20 deprecation warning for `ci.yml`

### DIFF
--- a/.github/actions/setup-and-cache/action.yml
+++ b/.github/actions/setup-and-cache/action.yml
@@ -11,7 +11,7 @@ runs:
 
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
     - name: Set node version to ${{ inputs.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This updates the version of `pnpm/action-setup` used so it's no longer using a deprecated version of Node.js.
<!-- You can also add additional context here -->

### Checklist
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. **(With this PR, ci.yml shouldn't emit a Node.js 20 deprecation warning in its run, like [it does on `main`](https://github.com/vitest-dev/vitest/actions/runs/29095053286/job/86369502483))**
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.