### PR TITLE
docs(guide): fix dead Node.js debugging link in debug guide

### DIFF
--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -130,6 +130,6 @@ vitest --inspect-brk --no-file-parallelism
 vitest --inspect-brk --browser --no-file-parallelism
 ```
 
-Once Vitest starts it will stop execution and wait for you to open developer tools that can connect to [Node.js inspector](https://nodejs.org/en/docs/guides/debugging-getting-started/). You can use Chrome DevTools for this by opening `chrome://inspect` on browser.
+Once Vitest starts it will stop execution and wait for you to open developer tools that can connect to [Node.js inspector](https://nodejs.org/en/learn/getting-started/debugging). You can use Chrome DevTools for this by opening `chrome://inspect` on browser.
 
 In watch mode you can keep the debugger open during test re-runs by using the `--isolate false` options.


### PR DESCRIPTION
## Summary

Fixes a dead external link in the debug guide.

- `docs/guide/debugging.md:133`: `https://nodejs.org/en/docs/guides/debugging-getting-started/` (HTTP 404) replaced with the canonical `https://nodejs.org/en/learn/getting-started/debugging` (200). nodejs.org retired the `/en/docs/guides/` subpath in favor of `/en/learn/`.

Single-line change, single file. Verified the replacement returns 200.