### PR TITLE
fix(expect): reject nullish toHaveProperty subjects (fix #10735)

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -468,6 +468,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
 
       const actual = this._obj as any
       const [propertyName, expected] = args
+
+      if (actual == null) {
+        throw new TypeError(
+          `.toHaveProperty() expects to receive an object, but got ${inspect(actual)}`,
+        )
+      }
+
       const getValue = () => {
         const hasOwn = Object.hasOwn(
           actual,

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -1823,6 +1823,28 @@ it('toHaveProperty error diff', () => {
   `)
 })
 
+it('toHaveProperty on a nullish subject throws a matcher error (#10735)', () => {
+  expect(() => expect(null).toHaveProperty('x')).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: .toHaveProperty() expects to receive an object, but got null]`,
+  )
+
+  expect(() => expect(undefined).toHaveProperty('x')).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: .toHaveProperty() expects to receive an object, but got undefined]`,
+  )
+
+  expect(() => expect(null).toHaveProperty('x', 1)).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: .toHaveProperty() expects to receive an object, but got null]`,
+  )
+
+  expect(() => expect(null).not.toHaveProperty('x')).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: .toHaveProperty() expects to receive an object, but got null]`,
+  )
+
+  expect(() => expect(undefined).not.toHaveProperty('x')).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: .toHaveProperty() expects to receive an object, but got undefined]`,
+  )
+})
+
 function snapshotError(f: () => unknown) {
   try {
     f()


### PR DESCRIPTION
### Description

`expect(null).toHaveProperty('x')` crashed with a raw internal error —
`TypeError: Cannot convert undefined or null to object` pointing into Vitest
internals — because `getValue()` called `Object.hasOwn(actual, propertyName)`
before the null-safe `utils.getPathInfo` fallback could run. The negated form
`expect(null).not.toHaveProperty('x')` crashed the same way.

Per @sheremet-va's guidance in the issue, both forms now throw a clear matcher
error instead:

    TypeError: .toHaveProperty() expects to receive an object, but got null

The wording matches the existing `.toMatch()` error style in the same file.
The `.not` form also throws rather than passing because asserting properties
on a nullish subject is a test error; `expect(x).toBeDefined()` should come
first.

Resolves #10735

Disclosure: I used Claude Code to help develop this fix. I reviewed the
change and ran the listed checks before submitting.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Run the tests with `pnpm test:ci`.

Verification performed:

- `CI=true pnpm test jest-expect.test.ts`
  - 342 passed and 27 expected failures across forks, threads, and vmThreads.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:ci`
  - The affected suite passed. The broader local Windows run encountered unrelated coverage and workspace test failures involving coverage-directory races, timeouts, and existing snapshot differences.

### Documentation

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No documentation changes are needed for this bug fix.

### Changesets

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->