### PR TITLE
fix: prevent node builtins double prefix (fix #10630)

### DIFF
--- a/packages/vitest/src/node/plugins/runnerTransform.ts
+++ b/packages/vitest/src/node/plugins/runnerTransform.ts
@@ -117,7 +117,9 @@ export function ModuleRunnerTransform(): VitePlugin {
         // remove Vite's externalization logic because we have our own (unfortunately)
         config.resolve.external = [
           ...builtinModules,
-          ...builtinModules.map(m => `node:${m}`),
+          ...builtinModules
+            .filter(m => !m.startsWith('node:'))
+            .map(m => `node:${m}`),
         ]
 
         // by setting `noExternal` to `true`, we make sure that


### PR DESCRIPTION
Fix #10630

### Description

Some node builtins are natively prefixed and get prefixed a second time.

This should probably get a unit test, but I'm strained for time and the contributing doc did not have a lot of information on tests (`test/README.md` also seems a bit outdated).

Resolves #10630 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
