### PR TITLE
feat: support non-ascii characters in `for/each` title placeholders

### DIFF
--- a/packages/vitest/src/runtime/runner/suite.ts
+++ b/packages/vitest/src/runtime/runner/suite.ts
@@ -1019,7 +1019,7 @@ function formatTitle(template: string, items: any[], idx: number) {
 
   const isObjectItem = isObject(items[0])
   function formatAttribute(s: string) {
-    return s.replace(/\$([$\w.]+)/g, (_, key: string) => {
+    return s.replace(/\$([$\p{ID_Continue}.]+)/gu, (_, key: string) => {
       const isArrayKey = /^\d+$/.test(key)
       if (!isObjectItem && !isArrayKey) {
         return `$${key}`

--- a/test/e2e/test/each-non-ascii-placeholders.test.ts
+++ b/test/e2e/test/each-non-ascii-placeholders.test.ts
@@ -1,0 +1,29 @@
+import { runInlineTests } from '#test-utils'
+import { expect, test } from 'vitest'
+
+test('formatting of non-ascii placeholders in test.each', async () => {
+  const { stderr, ctx } = await runInlineTests({
+    'basic.test.js': `
+      test.each\`
+        时间戳 | 结果
+        \${1}  | \${5}
+        \${2}  | \${10}
+      \`('returns $结果 given $时间戳', ({ 结果, 时间戳 }) => {
+        expect(结果).toBeGreaterThan(时间戳)
+      })
+    `,
+    'vitest.config.js': {
+      test: {
+        globals: true,
+      },
+    },
+  })
+
+  expect(stderr).toBe('')
+  expect(ctx?.state.getTestModules()[0].children.array()).toStrictEqual(
+    [
+      expect.objectContaining({ name: 'returns 5 given 1' }),
+      expect.objectContaining({ name: 'returns 10 given 2' }),
+    ],
+  )
+})

--- a/test/unit/test/each.test.ts
+++ b/test/unit/test/each.test.ts
@@ -226,6 +226,14 @@ ${{ val: 3 }}   | ${'b'} | ${'3b'}
 })
 
 test.each`
+  ω    | Σ
+  ${1} | ${5}
+  ${2} | ${10}
+`('returns true when $ω is < $Σ', ({ ω, Σ }) => {
+  expect(Σ).toBeGreaterThan(ω)
+})
+
+test.each`
 a       | b       | expected
 ${true} | ${true} | ${true}
 `('($a && $b) -> $expected', ({ a, b, expected }) => {


### PR DESCRIPTION
### Description

although it's unusual, it's theoretically possible to use non-ascii characters in variable names. For example:

```js

// math-heavy code might use greek letters:
it.each`
  ω    | Σ
  ${1} | ${5}
  ${2} | ${10}
`('returns true when $ω is < $Σ', ({ ω, Σ }) => {
  // ...
});


// and I suppose this works in some other languages too:
it.each`
  时间戳 | 结果
  ${1}  | ${5}
  ${2}  | ${10}
`('returns $结果 given $时间戳', ({ 结果, 时间戳 }) => {
  // ...
});
```

currently, the test title formatter use RegEx `\w`, so it doesn't support non-ascii values. [`\p{ID_Continue}`](https://www.unicode.org/reports/tr31/#D1) has been [supported since node v10](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape), see Unicode's [UAX31-D1](https://www.unicode.org/reports/tr31/#D1) for more info.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="282" height="32" alt="image" src="https://github.com/user-attachments/assets/54314c32-0a8a-49ab-8d8d-37924d362217" />
 <td><img width="286" height="37" alt="image" src="https://github.com/user-attachments/assets/f118dc31-f24d-4b12-88d0-2df604b720a2" />
</table>
 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] ~~If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.~~

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
