### PR TITLE
docs: fix incorrect @default JSDoc values in config types

### DIFF
--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -208,7 +208,7 @@ export interface BrowserConfigOptions {
     testIdAttribute?: string
     /**
      * Should locators match the text exactly by default
-     * @default false
+     * @default true
      */
     exact?: boolean
     /**

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -668,7 +668,7 @@ export interface InlineConfig {
    *
    * When excluded, the CSS files will be replaced with empty strings to bypass the subsequent processing.
    *
-   * @default { include: [], modules: { classNameStrategy: false } }
+   * @default { include: [], modules: { classNameStrategy: 'stable' } }
    */
   css?:
     | boolean


### PR DESCRIPTION
Two `@default` JSDoc annotations in the config type definitions do not match the values applied in `resolveConfig`:

**1. `browser.locators.exact`** — documented as `@default false`, but resolved to `true`:
```ts
// packages/vitest/src/node/config/resolveConfig.ts
resolved.browser.locators.exact ??= true
```

**2. `css.modules.classNameStrategy`** — documented as `@default false`, which is not even a valid `CSSModuleScopeStrategy` (`'stable' | 'scoped' | 'non-scoped'`). Resolved to `'stable'`:
```ts
// packages/vitest/src/node/config/resolveConfig.ts
resolved.css.modules.classNameStrategy ??= 'stable'
```

Both changes are JSDoc-only; no runtime behavior is affected. These annotations surface in editor tooltips and generated config docs, so the corrected values now match the actual defaults.

<!-- VITEST_AUTOMATED_PR -->