### PR TITLE
chore(deps): bump `ast-v8-to-istanbul` for perf improvements

### DIFF
--- a/packages/coverage-v8/package.json
+++ b/packages/coverage-v8/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@bcoe/v8-coverage": "^1.0.2",
     "@vitest/utils": "workspace:*",
-    "ast-v8-to-istanbul": "^1.0.0",
+    "ast-v8-to-istanbul": "^1.0.5",
     "istanbul-lib-coverage": "catalog:",
     "istanbul-lib-report": "catalog:",
     "istanbul-reports": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,8 +701,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       ast-v8-to-istanbul:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.5
+        version: 1.0.5
       istanbul-lib-coverage:
         specifier: 'catalog:'
         version: 3.2.2
@@ -6162,8 +6162,8 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@1.0.0:
-    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   ast-walker-scope@0.8.3:
     resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
@@ -15128,7 +15128,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@1.0.0:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3


### PR DESCRIPTION
### Description

Bump `ast-v8-to-istanbul` for perf improvements: https://github.com/AriPerkkio/ast-v8-to-istanbul/releases/tag/v1.0.5

Testing https://github.com/vitest-tests/coverage-large locally, logs from

https://github.com/vitest-dev/vitest/blob/3923cab3d98cd0063377ffd8e4c98b73d2f28db9/packages/coverage-v8/src/provider.ts#L119-L121


| v1.0.4                                                                                                                                                                                                                   | v1.0.5                                                                                                                                                                                                                   | Speed Up |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
| <code>Duration 56.54s (transform 26.77s, setup 0ms, import 39.01s, tests 968ms, environment 26ms)</code><br><br><code>Duration 57.59s (transform 27.43s, setup 0ms, import 38.90s, tests 972ms, environment 26ms)</code> | <code>Duration 40.14s (transform 27.91s, setup 0ms, import 39.22s, tests 957ms, environment 26ms)</code><br><br><code>Duration 40.51s (transform 28.38s, setup 0ms, import 39.94s, tests 964ms, environment 26ms)</code> | ~1.42× (29% faster) |
| <code>vitest:coverage Generate coverage total time 53090 ms</code><br><br><code>vitest:coverage Generate coverage total time 54051 ms</code>                                                                   | <code>vitest:coverage Generate coverage total time 32043 ms</code><br><br><code>vitest:coverage Generate coverage total time 32481 ms</code>                                                                   | ~1.66× (40% faster) |


On CI we see `3m30s -> 2m30s` total run improvement. 

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
