### PR TITLE
docs: sync AGENTS.md Node version with package.json engines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Vitest is a next-generation testing framework powered by Vite. This is a monorep
 
 - **Language**: TypeScript/JavaScript (ESM-first)
 - **Package Manager**: pnpm (required)
-- **Node Version**: ^20.0.0 || ^22.0.0 || >=24.0.0
+- **Node Version**: ^22.12.0 || ^24.0.0 || >=26.0.0
 - **Build System**: Vite + Rollup
 - **Monorepo Structure**: 15+ packages in `packages/` directory
 


### PR DESCRIPTION
Hi, and thank you for Vitest.

`AGENTS.md` (line 11) lists the supported Node version as:
```
- **Node Version**: ^20.0.0 || ^22.0.0 || >=24.0.0
```
but `package.json` `engines.node` says `^22.12.0 || ^24.0.0 || >=26.0.0`. This updates AGENTS.md to match the authoritative `engines` field.

For transparency: I used AI assistance to spot and draft this; I verified AGENTS.md and package.json against the current source myself.