### PR TITLE
perf(coverage): reduce RPC data and unnecessary serializations

### DIFF
--- a/packages/coverage-istanbul/package.json
+++ b/packages/coverage-istanbul/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "default": "./dist/browser.js"
+    },
     "./*": "./*"
   },
   "main": "./dist/index.js",

--- a/packages/coverage-istanbul/rollup.config.js
+++ b/packages/coverage-istanbul/rollup.config.js
@@ -12,6 +12,7 @@ const pkg = require('./package.json')
 
 const entries = {
   index: 'src/index.ts',
+  browser: 'src/browser.ts',
   provider: 'src/provider.ts',
 }
 

--- a/packages/coverage-istanbul/src/base.ts
+++ b/packages/coverage-istanbul/src/base.ts
@@ -1,0 +1,48 @@
+import type { CoverageMapData } from 'istanbul-lib-coverage'
+import type { IstanbulCoverageProvider } from './provider'
+import { COVERAGE_STORE_KEY } from './constants'
+
+export const BaseCoverageProviderModule = {
+  takeCoverage(): CoverageMapData | undefined {
+    // @ts-expect-error -- untyped global
+    return globalThis[COVERAGE_STORE_KEY]
+  },
+
+  // Reset coverage map to prevent duplicate results if this is called twice in row
+  startCoverage(): void {
+    // @ts-expect-error -- untyped global
+    const coverageMap = globalThis[COVERAGE_STORE_KEY] as CoverageMapData
+
+    // When isolated, there are no previous results
+    if (!coverageMap) {
+      return
+    }
+
+    for (const filename in coverageMap) {
+      const branches = coverageMap[filename].b
+
+      for (const key in branches) {
+        branches[key] = branches[key].map(() => 0)
+      }
+
+      for (const metric of ['f', 's'] as const) {
+        const entry = coverageMap[filename][metric]
+
+        for (const key in entry) {
+          entry[key] = 0
+        }
+      }
+    }
+  },
+
+  async getProvider(): Promise<IstanbulCoverageProvider> {
+    // to not bundle the provider
+    const providerPath = './provider.js'
+    const { IstanbulCoverageProvider } = (await import(
+      /* @vite-ignore */
+      providerPath,
+    )) as typeof import('./provider')
+
+    return new IstanbulCoverageProvider()
+  },
+}

--- a/packages/coverage-istanbul/src/browser.ts
+++ b/packages/coverage-istanbul/src/browser.ts
@@ -1,20 +1,19 @@
 import type { CoverageProviderModule } from 'vitest/node'
-import assert from 'node:assert'
 import { BaseCoverageProviderModule } from './base'
-import { writeCoverageFile } from './commands'
+
+function triggerCommand(command: string, args: any[] = []): Promise<any> {
+  return (globalThis as any).__vitest_browser_runner__?.commands?.triggerCommand?.(command, args)
+}
 
 const mod: CoverageProviderModule = {
-  takeCoverage(options) {
+  takeCoverage() {
     const coverage = BaseCoverageProviderModule.takeCoverage()
 
     if (!coverage) {
       return
     }
 
-    const coverageFilesDirectory = options?.coverageFilesDirectory
-    assert(coverageFilesDirectory, 'coverageFilesDirectory is required')
-
-    return writeCoverageFile(coverageFilesDirectory, coverage)
+    return triggerCommand('__vitest_writeCoverageFile', [coverage])
   },
 
   startCoverage() {

--- a/packages/coverage-istanbul/src/commands.ts
+++ b/packages/coverage-istanbul/src/commands.ts
@@ -1,0 +1,38 @@
+import type { BrowserCommand } from 'vitest/node'
+import type { IstanbulCoverageProvider } from './provider'
+import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'pathe'
+
+export const commands: Record<string, BrowserCommand<any[]>> = {
+  writeCoverageFile(context, coverage: unknown) {
+    const provider = context.project.vitest.coverageProvider as IstanbulCoverageProvider
+
+    return writeCoverageFile(provider.coverageFilesDirectory, coverage)
+  },
+}
+
+export async function writeCoverageFile(coverageFilesDirectory: string, coverage: unknown): Promise<string> {
+  // Write results on file system directly and transfer only the filename over RPC
+  const filename = resolve(
+    coverageFilesDirectory,
+    `coverage-${randomUUID()}.json`,
+  )
+
+  try {
+    await writeFile(filename, JSON.stringify(coverage), 'utf-8')
+  }
+  catch (error) {
+    if (!existsSync(coverageFilesDirectory)) {
+      throw new Error(
+        `Something removed the coverage directory "${coverageFilesDirectory}" Vitest created earlier. Make sure you are not running multiple Vitests with the same "coverage.reportsDirectory" at the same time.`,
+        { cause: error },
+      )
+    }
+
+    throw error
+  }
+
+  return filename
+}

--- a/packages/coverage-istanbul/src/provider.ts
+++ b/packages/coverage-istanbul/src/provider.ts
@@ -17,6 +17,7 @@ import { createDebug } from 'obug'
 import c from 'tinyrainbow'
 import { BaseCoverageProvider, isCSSRequest } from 'vitest/node'
 import { version } from '../package.json' with { type: 'json' }
+import { commands } from './commands'
 import { COVERAGE_STORE_KEY } from './constants'
 
 const debug = createDebug('vitest:coverage')
@@ -30,6 +31,14 @@ export class IstanbulCoverageProvider extends BaseCoverageProvider implements Co
 
   initialize(ctx: Vitest): void {
     this._initialize(ctx)
+
+    for (const project of ctx.projects) {
+      if (project.isBrowserEnabled() && project.browser) {
+        for (const [name, command] of Object.entries(commands)) {
+          project.browser.registerCommand(`__vitest_${name}` as any, command)
+        }
+      }
+    }
 
     if (this.options.instrumenter) {
       this.instrumenter = this.options.instrumenter({

--- a/packages/coverage-v8/src/browser.ts
+++ b/packages/coverage-v8/src/browser.ts
@@ -1,11 +1,8 @@
-import type { Profiler } from 'node:inspector'
 import type { CoverageProviderModule } from 'vitest/node'
 import type { V8CoverageProvider } from './provider'
 import { loadProvider } from './load-provider'
 
 let enabled = false
-
-type ScriptCoverage = Profiler.TakePreciseCoverageReturnType
 
 function triggerCommand(command: string, args: any[] = []): Promise<any> {
   return (globalThis as any).__vitest_browser_runner__.commands.triggerCommand(command, args)
@@ -22,21 +19,8 @@ const mod: CoverageProviderModule = {
     await triggerCommand('__vitest_startV8Coverage')
   },
 
-  async takeCoverage(): Promise<{ result: any[] }> {
-    const coverage: ScriptCoverage = await triggerCommand('__vitest_takeV8Coverage')
-    const result: typeof coverage.result = []
-
-    // Reduce amount of data sent over rpc by doing some early result filtering
-    for (const entry of coverage.result) {
-      if (filterResult(entry)) {
-        result.push({
-          ...entry,
-          url: decodeURIComponent(entry.url.replace(window.location.origin, '')),
-        })
-      }
-    }
-
-    return { result }
+  async takeCoverage(): Promise<unknown> {
+    return triggerCommand('__vitest_takeV8Coverage', [window.location.href])
   },
 
   stopCoverage() {
@@ -48,35 +32,3 @@ const mod: CoverageProviderModule = {
   },
 }
 export default mod
-
-function filterResult(coverage: ScriptCoverage['result'][number]): boolean {
-  if (!coverage.url.startsWith(window.location.origin)) {
-    return false
-  }
-
-  if (coverage.url.includes('/node_modules/')) {
-    return false
-  }
-
-  if (coverage.url.includes('__vitest_browser__')) {
-    return false
-  }
-
-  if (coverage.url.includes('__vitest__/assets')) {
-    return false
-  }
-
-  if (coverage.url === window.location.href) {
-    return false
-  }
-
-  if (coverage.url.includes('/@id/@vitest/')) {
-    return false
-  }
-
-  if (coverage.url.includes('/@vite/client')) {
-    return false
-  }
-
-  return true
-}

--- a/packages/coverage-v8/src/commands.ts
+++ b/packages/coverage-v8/src/commands.ts
@@ -1,7 +1,12 @@
 import type { CDPSession } from '@vitest/browser-playwright'
 import type { BrowserCommand, BrowserCommandContext } from 'vitest/node'
+import type { V8CoverageProvider } from './provider'
+import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { resolve } from 'pathe'
 
-export const commands: Record<string, BrowserCommand> = {
+export const commands: Record<string, BrowserCommand<any[]>> = {
   startV8Coverage,
   takeV8Coverage,
 }
@@ -15,7 +20,77 @@ async function startV8Coverage(context: BrowserCommandContext): Promise<void> {
   })
 }
 
-async function takeV8Coverage(context: BrowserCommandContext): Promise<any> {
+async function takeV8Coverage(context: BrowserCommandContext, pageUrl: string): Promise<string> {
   const session: CDPSession = await context.__ensureCDPHandler()
-  return session.send('Profiler.takePreciseCoverage')
+  const coverage = await session.send('Profiler.takePreciseCoverage')
+
+  const origin = new URL(pageUrl).origin
+  const result: typeof coverage.result = []
+
+  for (const entry of coverage.result) {
+    if (filterResult(entry.url, origin, pageUrl)) {
+      entry.url = decodeURIComponent(entry.url.replace(origin, ''))
+      result.push(entry)
+    }
+  }
+
+  const provider = context.project.vitest.coverageProvider as V8CoverageProvider
+
+  return await writeCoverageFile(provider.coverageFilesDirectory, { result })
+}
+
+export async function writeCoverageFile(coverageFilesDirectory: string, coverage: unknown): Promise<string> {
+  // Write results on file system directly and transfer only the filename over RPC
+  const filename = resolve(
+    coverageFilesDirectory,
+    `coverage-${randomUUID()}.json`,
+  )
+
+  try {
+    await writeFile(filename, JSON.stringify(coverage), 'utf-8')
+  }
+  catch (error) {
+    if (!existsSync(coverageFilesDirectory)) {
+      throw new Error(
+        `Something removed the coverage directory "${coverageFilesDirectory}" Vitest created earlier. Make sure you are not running multiple Vitests with the same "coverage.reportsDirectory" at the same time.`,
+        { cause: error },
+      )
+    }
+
+    throw error
+  }
+
+  return filename
+}
+
+function filterResult(url: string, origin: string, pageUrl: string): boolean {
+  if (!url.startsWith(origin)) {
+    return false
+  }
+
+  if (url.includes('/node_modules/')) {
+    return false
+  }
+
+  if (url.includes('__vitest_browser__')) {
+    return false
+  }
+
+  if (url.includes('__vitest__/assets')) {
+    return false
+  }
+
+  if (url === pageUrl) {
+    return false
+  }
+
+  if (url.includes('/@id/@vitest/')) {
+    return false
+  }
+
+  if (url.includes('/@vite/client')) {
+    return false
+  }
+
+  return true
 }

--- a/packages/coverage-v8/src/index.ts
+++ b/packages/coverage-v8/src/index.ts
@@ -1,6 +1,7 @@
 import type { Profiler } from 'node:inspector'
 import type { CoverageProviderModule } from 'vitest/node'
 import type { ScriptCoverageWithOffset, V8CoverageProvider } from './provider'
+import assert from 'node:assert'
 import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { readdir, readFile, rm } from 'node:fs/promises'
@@ -9,6 +10,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { normalize } from 'pathe'
 import { provider } from 'std-env'
+import { writeCoverageFile } from './commands'
 import { loadProvider } from './load-provider'
 
 let enabled = false
@@ -41,9 +43,9 @@ const mod: CoverageProviderModule & {
     await session.post('Profiler.startPreciseCoverage', { callCount: true, detailed: true })
   },
 
-  async takeCoverage(options): Promise<{ result: ScriptCoverageWithOffset[] }> {
+  async takeCoverage(options): Promise<string | undefined> {
     if (provider === 'stackblitz') {
-      return { result: [] }
+      return
     }
 
     const session = this.session as inspector.Session
@@ -93,7 +95,10 @@ const mod: CoverageProviderModule & {
       }
     }
 
-    return { result }
+    const coverageFilesDirectory = options?.coverageFilesDirectory
+    assert(coverageFilesDirectory, 'coverageFilesDirectory is required')
+
+    return await writeCoverageFile(coverageFilesDirectory, { result })
   },
 
   async stopCoverage({ isolate }) {

--- a/packages/vitest/src/integrations/coverage.ts
+++ b/packages/vitest/src/integrations/coverage.ts
@@ -27,7 +27,10 @@ export async function takeCoverageInsideWorker(
   const coverageModule = await resolveCoverageProviderModule(options, loader)
 
   if (coverageModule) {
-    return coverageModule.takeCoverage?.({ moduleExecutionInfo: loader.moduleExecutionInfo })
+    return coverageModule.takeCoverage?.({
+      moduleExecutionInfo: loader.moduleExecutionInfo,
+      coverageFilesDirectory: options.coverageFilesDirectory,
+    })
   }
 
   return null

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -3,6 +3,7 @@ import type { SerializedConfig } from '../../runtime/config'
 import type { TestProject } from '../project'
 import { resolve } from 'node:path'
 import { configDefaults } from '../../defaults'
+import { getCoverageFilesDirectory } from '../../utils/coverage'
 import { isAgent, isForceColor } from '../../utils/env'
 
 export function serializeConfig(project: TestProject): SerializedConfig {
@@ -51,8 +52,10 @@ export function serializeConfig(project: TestProject): SerializedConfig {
     snapshotEnvironment: config.snapshotEnvironment,
     passWithNoTests: config.passWithNoTests,
     coverage: ((coverage) => {
+      const reportsDirectory = resolve(globalConfig.root, coverage.reportsDirectory)
       return {
-        reportsDirectory: resolve(globalConfig.root, coverage.reportsDirectory),
+        reportsDirectory,
+        coverageFilesDirectory: getCoverageFilesDirectory(reportsDirectory, globalConfig.shard),
         provider: coverage.provider,
         enabled: coverage.enabled,
         customProviderModule: 'customProviderModule' in coverage

--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -18,7 +18,7 @@ import { glob } from 'tinyglobby'
 import c from 'tinyrainbow'
 import { coverageConfigDefaults } from '../defaults'
 import { resolveCoverageReporters } from '../node/config/resolveConfig'
-import { resolveCoverageProviderModule } from '../utils/coverage'
+import { getCoverageFilesDirectory, resolveCoverageProviderModule } from '../utils/coverage'
 
 type Threshold = 'lines' | 'functions' | 'statements' | 'branches'
 
@@ -65,7 +65,6 @@ const THRESHOLD_KEYS: Readonly<Threshold[]> = [
 ]
 const GLOBAL_THRESHOLDS_KEY = 'global'
 const DEFAULT_PROJECT: unique symbol = Symbol.for('default-project')
-let uniqueId = 0
 
 export async function getCoverageProvider(
   options: SerializedCoverageConfig | undefined,
@@ -90,7 +89,6 @@ export class BaseCoverageProvider {
   globMatchers?: { matchExclude: (file: string) => boolean; matchInclude: (file: string) => boolean }
 
   coverageFiles: CoverageFiles = new Map()
-  pendingPromises: Promise<void>[] = []
   coverageFilesDirectory!: string
   reportsDirectoryLock!: ReportsDirectoryLock
   roots: string[] = []
@@ -137,14 +135,9 @@ export class BaseCoverageProvider {
       },
     }
 
-    const shard = this.ctx.config.shard
-    const tempDirectory = `.tmp${
-      shard ? `-${shard.index}-${shard.count}` : ''
-    }`
-
-    this.coverageFilesDirectory = resolve(
+    this.coverageFilesDirectory = getCoverageFilesDirectory(
       this.options.reportsDirectory,
-      tempDirectory,
+      this.ctx.config.shard,
     )
     this.reportsDirectoryLock = new ReportsDirectoryLock(resolve(this.options.reportsDirectory))
 
@@ -289,29 +282,17 @@ export class BaseCoverageProvider {
     await fs.mkdir(this.coverageFilesDirectory, { recursive: true })
 
     this.coverageFiles = new Map()
-    this.pendingPromises = []
-  }
-
-  private normalizeCoverageFileError(error: unknown): unknown {
-    if (
-      error instanceof Error
-      && 'code' in error
-      && error.code === 'ENOENT'
-      && !existsSync(this.coverageFilesDirectory)
-    ) {
-      return new Error(
-        `Something removed the coverage directory "${this.coverageFilesDirectory}" Vitest created earlier. Make sure you are not running multiple Vitests with the same "coverage.reportsDirectory" at the same time.`,
-        { cause: error },
-      )
-    }
-
-    return error
   }
 
   onAfterSuiteRun({ coverage, environment, projectName, testFiles }: AfterSuiteRunMeta): void {
     if (!coverage) {
       return
     }
+
+    if (typeof coverage !== 'string') {
+      throw new TypeError(`Expected string coverage payload, received ${typeof coverage}, ${JSON.stringify(coverage)}`)
+    }
+    const filename = coverage
 
     let entry = this.coverageFiles.get(projectName || DEFAULT_PROJECT)
 
@@ -321,20 +302,9 @@ export class BaseCoverageProvider {
     }
 
     const testFilenames = testFiles.join()
-    const filename = resolve(
-      this.coverageFilesDirectory,
-      `coverage-${uniqueId++}.json`,
-    )
-
     entry[environment] ??= {}
     // If there's a result from previous run, overwrite it
     entry[environment][testFilenames] = filename
-
-    const promise = fs.writeFile(filename, JSON.stringify(coverage), 'utf-8')
-      .catch((error) => {
-        throw this.normalizeCoverageFileError(error)
-      })
-    this.pendingPromises.push(promise)
   }
 
   async readCoverageFiles<CoverageType>({ onFileRead, onFinished, onDebug }: {
@@ -345,10 +315,7 @@ export class BaseCoverageProvider {
     onDebug: ((...logs: any[]) => void) & { enabled: boolean }
   }): Promise<void> {
     let index = 0
-    const total = this.pendingPromises.length
-
-    await Promise.all(this.pendingPromises)
-    this.pendingPromises = []
+    const total = this.coverageFiles.size
 
     for (const [projectName, coveragePerProject] of this.coverageFiles.entries()) {
       for (const [environment, coverageByTestfiles] of Object.entries(coveragePerProject) as Entries<typeof coveragePerProject>) {
@@ -363,9 +330,6 @@ export class BaseCoverageProvider {
 
           await Promise.all(chunk.map(async (filename) => {
             const contents = await fs.readFile(filename, 'utf-8')
-              .catch((error) => {
-                throw this.normalizeCoverageFileError(error)
-              })
             const coverage = JSON.parse(contents)
 
             onFileRead(coverage)

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -175,6 +175,8 @@ export interface SerializedConfig {
 export interface SerializedCoverageConfig {
   provider: 'istanbul' | 'v8' | 'custom' | undefined
   reportsDirectory: string
+  /** Directory where workers write raw coverage results, shard-aware */
+  coverageFilesDirectory: string
   htmlDir: string | undefined
   enabled: boolean
   customProviderModule: string | undefined

--- a/packages/vitest/src/utils/coverage.ts
+++ b/packages/vitest/src/utils/coverage.ts
@@ -1,4 +1,12 @@
 import type { SerializedCoverageConfig } from '../runtime/config'
+import { resolve } from 'pathe'
+
+export function getCoverageFilesDirectory(
+  reportsDirectory: string,
+  shard: { index: number; count: number } | undefined,
+): string {
+  return resolve(reportsDirectory, `.tmp${shard ? `-${shard.index}-${shard.count}` : ''}`)
+}
 
 export interface RuntimeCoverageModuleLoader {
   import: (id: string) => Promise<{ default: RuntimeCoverageProviderModule }>
@@ -26,7 +34,10 @@ export interface RuntimeCoverageProviderModule {
   /**
    * Executed on after each run in the worker thread. Possible to return a payload passed to the provider
    */
-  takeCoverage?: (runtimeOptions?: { moduleExecutionInfo?: Map<string, { startOffset: number }> }) => unknown | Promise<unknown>
+  takeCoverage?: (runtimeOptions?: {
+    moduleExecutionInfo?: Map<string, { startOffset: number }>
+    coverageFilesDirectory: string
+  }) => unknown | Promise<unknown>
 
   /**
    * Executed after all tests have been run in the worker thread.
@@ -52,7 +63,7 @@ export async function resolveCoverageProviderModule(
   if (provider === 'v8' || provider === 'istanbul') {
     let builtInModule = CoverageProviderMap[provider]
 
-    if (provider === 'v8' && loader.isBrowser) {
+    if (loader.isBrowser) {
       builtInModule += '/browser'
     }
 

--- a/test/coverage-test/test/mixed-versions-warning.unit.test.ts
+++ b/test/coverage-test/test/mixed-versions-warning.unit.test.ts
@@ -39,6 +39,7 @@ test('istanbul provider logs warning if versions do not match', async () => {
     logger: { warn },
     config: configDefaults,
     _coverageOptions: configDefaults.coverage,
+    projects: [],
   } as any)
 
   expect(warn).toHaveBeenCalled()

--- a/test/coverage-test/test/temporary-files.unit.test.ts
+++ b/test/coverage-test/test/temporary-files.unit.test.ts
@@ -1,25 +1,9 @@
 import { spawn } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve, sep } from 'node:path'
+import { join, sep } from 'node:path'
 import { assert, expect, onTestFinished, test } from 'vitest'
 import { BaseCoverageProvider } from 'vitest/node'
-
-test('missing coverage temp directory throws an actionable error', async () => {
-  const provider = new BaseCoverageProvider()
-  provider.coverageFilesDirectory = resolve('missing-coverage-directory', '.tmp')
-
-  provider.onAfterSuiteRun({
-    coverage: { '/src/math.ts': {} },
-    environment: 'ssr',
-    projectName: '',
-    testFiles: ['math.test.ts'],
-  } as any)
-
-  await expect(Promise.all(provider.pendingPromises)).rejects.toThrow(
-    `Something removed the coverage directory "${provider.coverageFilesDirectory}" Vitest created earlier. Make sure you are not running multiple Vitests with the same "coverage.reportsDirectory" at the same time.`,
-  )
-})
 
 test('clean() acquires the reportsDirectory lock and cleanAfterRun() releases it', async () => {
   const { provider, lockFile } = createProvider()

--- a/test/coverage-test/vitest.config.ts
+++ b/test/coverage-test/vitest.config.ts
@@ -13,6 +13,10 @@ const FIXTURES = '**/fixtures/**'
 export default defineConfig({
   test: {
     fsModuleCache: true,
+    watchTriggerPatterns: [{
+      pattern: /test\/coverage-test\/fixtures/,
+      testsToRun: () => [],
+    }],
     reporters: process.env.CI ? 'minimal' : 'verbose',
     isolate: false,
     setupFiles: ['./setup.ts'],


### PR DESCRIPTION
### Description

Adds two performance improvements I've had in mind long time:

1. Currently we are sending coverage JSON data from Node side workers to main thread, and then writing that to file system. Now we'll write the data directly in the worker and just pass the path to main thread. Initially I thought writing in workers would be worse, but it should actually be faster. RPC always requires serialization that's costly.

2. When reviewing https://github.com/vitest-dev/vitest/pull/10444 I realized browser mode v8 coverage is doing unnecessary RPC hops:
- Browser command to call CDP on server side to get V8 script coverage, pass that to browser via WS RPC
- In browser we just filter out stuff from the JSON
- Send the filtered JSON again to main thread to the coverage provider.

Now we'll instead just write the results to file system in the first call, and never pass the V8 script coverage to browser.

#### LLM Generated analysis of perf changes

Prompted Claude to run `vitest-coverage-large` locally with `main` and this PR. There's noticeable perf change in `browser + v8`, as now we don't bounce the results unnecessary over the WS RPC. 🔥 

> ### Performance
> 
> <details>
> Measured with [`coverage-large`](https://github.com/AriPerkkio/coverage-large) using `pkg.pr.new` builds of this PR and its parent commit. The fixture was generated in a payload-heavy shape where each test file imports a 300-module graph, so that per-test coverage payloads are large (~6 MB for `v8`, ~1.9 GB total across the run):
> 
> ```sh
> COVERED_FILE_COUNT=300 UNCOVERED_FILE_COUNT=0 FUNCTION_COUNT=100 IMPORTS_PER_TEST=300 node ./generate-files.mjs
> ```
> 
> Durations are medians of 3 runs (2 runs for `istanbul`). Memory is the main process' peak RSS.
>
> </details>
> 
> #### Duration
> 
> | Case | [Before (`0f8e63f`)](https://github.com/vitest-dev/vitest/commit/0f8e63f54) | [After (`b7e2ad6`)](https://github.com/vitest-dev/vitest/commit/b7e2ad69b) | Speed-up |
> | --- | --- | --- | --- |
> | `node` + `v8` | 39.0 s | 33.9 s | ~1.15× |
> | `node` + `istanbul` | 527 s | 365 s | ~1.4× |
> | `browser` + `v8` | 103 s | 38.2 s | ~2.7× |
> | `node` + `v8`, default fixture ¹ | 28.3 s | 26.8 s | ~1.06× |
> 
> #### Main process peak memory
> 
> | Case | Before (`0f8e63f`) | After (`b7e2ad6`) | Change |
> | --- | --- | --- | --- |
> | `node` + `v8` | 1 322 MB | 1 245 MB | −6 % |
> | `node` + `istanbul` | 4 111 MB | 3 121 MB | −24 % |
> | `browser` + `v8` | 1 370 MB | 1 297 MB | −5 % |
> 
> <details>
> 
> ¹ No-regression control: the stock `coverage-large` shape (600 + 600 files, one covered file per test) has tiny per-test payloads, so little change is expected — or observed.
> 
> `browser` + `istanbul` is excluded from the payload-heavy comparison: at this payload size it does not complete reliably on either side of this PR (before: 190–201 of 300 test files in 26–28 min; after: 206 of 300). The istanbul coverage map only exists inside the browser page, so it must cross the WebSocket in both versions — this PR removes the return trip and main-process re-serialization, but not the dominant page-side transfer. On the stock fixture it completes fine on both sides (139–181 s before, ~136 s after).
> 
> </details>

#### LLM Generated sequence diagrams before-after

Output of following prompt below.

> Now, draw a sequence diagram that shows how data is moved across main thread, workers and browser. Show how it was done previously and how it's now. 

<details>

### How coverage results move between processes

#### Node pools (`threads`, `forks`, `vmThreads`, `vmForks`)

**Before** — full results cross the worker↔main boundary and are serialized twice more on the main process:

```mermaid
sequenceDiagram
    participant Worker as Test worker
    participant Main as Main process
    participant FS as File system

    Worker->>Worker: takeCoverage() - collect and filter results
    Worker->>Main: onAfterSuiteRun(results)<br/>structured clone (threads) / v8.serialize (forks)<br/>full results, MBs on large projects
    Main->>Main: JSON.stringify(results)
    Main->>FS: write .tmp/coverage-N.json
    Note over Main,FS: at report time
    FS->>Main: read + JSON.parse each file
    Main->>Main: merge, remap, report
```

**After** — workers write their own results in parallel; only a filename crosses the boundary:

```mermaid
sequenceDiagram
    participant Worker as Test worker
    participant Main as Main process
    participant FS as File system

    Worker->>Worker: takeCoverage() - collect and filter results
    Worker->>FS: JSON.stringify(results)<br/>write .tmp/coverage-uuid.json
    Worker->>Main: onAfterSuiteRun(filename)<br/>plain string, few bytes
    Note over Main,FS: at report time
    FS->>Main: read + JSON.parse each file
    Main->>Main: merge, remap, report
```

#### Browser mode

**Before** — the v8 CDP payload made a round trip to the page and back over WebSocket (flatted), unfiltered on the way out:

```mermaid
sequenceDiagram
    participant Page as Tester page
    participant Main as Main process
    participant FS as File system

    rect rgba(128, 128, 128, 0.1)
    Note right of Page: v8
    Page->>Main: __vitest_takeV8Coverage command
    Main->>Main: Profiler.takePreciseCoverage via CDP
    Main->>Page: unfiltered results over WebSocket<br/>MBs, includes node_modules and vite client
    Page->>Page: filter + rewrite URLs
    Page->>Main: onAfterSuiteRun(results) over WebSocket - MBs
    end

    rect rgba(128, 128, 128, 0.1)
    Note right of Page: istanbul
    Page->>Main: onAfterSuiteRun(coverage map) over WebSocket - full map
    end

    Main->>Main: JSON.stringify(results)
    Main->>FS: write .tmp/coverage-N.json
```

**After** — v8 results never leave the main process; istanbul's map crosses the WebSocket once (it only exists in the page):

```mermaid
sequenceDiagram
    participant Page as Tester page
    participant Main as Main process
    participant FS as File system

    rect rgba(128, 128, 128, 0.1)
    Note right of Page: v8
    Page->>Main: __vitest_takeV8Coverage(location.href) - few bytes
    Main->>Main: Profiler.takePreciseCoverage via CDP<br/>filter + rewrite URLs
    Main->>FS: write .tmp/coverage-uuid.json
    Main->>Page: filename
    end

    rect rgba(128, 128, 128, 0.1)
    Note right of Page: istanbul
    Page->>Main: __vitest_writeCoverageFile(coverage map)<br/>one WebSocket transfer
    Main->>FS: write .tmp/coverage-uuid.json
    Main->>Page: filename
    end

    Page->>Main: onAfterSuiteRun(filename) - few bytes
```

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
