### PR TITLE
fix(browser): inlined awaited import should not trigger syntax error after transform

### DIFF
--- a/packages/mocker/src/node/dynamicImportPlugin.ts
+++ b/packages/mocker/src/node/dynamicImportPlugin.ts
@@ -68,7 +68,7 @@ export function injectDynamicImport(
     },
     onDynamicImport(node) {
       const globalThisAccessor = options.globalThisAccessor || '"__vitest_mocker__"'
-      const replaceString = `globalThis[${globalThisAccessor}].wrapDynamicImport(() => import(`
+      const replaceString = `globalThis[${globalThisAccessor}].wrapDynamicImport(async () => import(`
       const importSubstring = code.substring(node.start, node.end)
       const hasIgnore = importSubstring.includes('/* @vite-ignore */')
       s.overwrite(

--- a/test/unit/test/injector-esm.test.ts
+++ b/test/unit/test/injector-esm.test.ts
@@ -14,5 +14,12 @@ test('dynamic import', async () => {
   const result = injectSimpleCode(
     'export const i = () => import(\'./foo\')',
   )
-  expect(result).toMatchInlineSnapshot(`"export const i = () => globalThis["__vitest_mocker__"].wrapDynamicImport(() => import('./foo'))"`)
+  expect(result).toMatchInlineSnapshot(`"export const i = () => globalThis["__vitest_mocker__"].wrapDynamicImport(async () => import('./foo'))"`)
+})
+
+test('dynamic import with await in the argument', async () => {
+  const result = injectSimpleCode(
+    'export const i = async () => import(await getSpecifier())',
+  )
+  expect(result).toMatchInlineSnapshot(`"export const i = async () => globalThis["__vitest_mocker__"].wrapDynamicImport(async () => import(await getSpecifier()))"`)
 })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This issue surfaced in module-federation merge request https://github.com/module-federation/core/pull/4827/changes#diff-e24668613f9a8380a2e508fece5c8c5b59f18aed3698d1252cd512a01e313ac1R204 when awaiting an inlined promise in the import statement. Even though module-federation itself just switched to rstest from vitest, it is still worth fixing this edge cases here because its downstream package may still use vitest and it will break once module-federation makes a new release.

It resolves a syntax error issue with inlined awaited import.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
