### PR TITLE
fix(vitest): don't blank ?raw css imports when css processing is disabled

### DIFF
--- a/packages/vitest/src/node/plugins/cssEnabler.ts
+++ b/packages/vitest/src/node/plugins/cssEnabler.ts
@@ -8,6 +8,7 @@ const cssLangs = '\\.(?:css|less|sass|scss|styl|stylus|pcss|postcss)(?:$|\\?)'
 const cssLangRE = new RegExp(cssLangs)
 const cssModuleRE = new RegExp(`\\.module${cssLangs}`)
 const cssInlineRE = /[?&]inline(?:&|$)/
+const cssRawRE = /[?&]raw(?:&|$)/
 
 function isCSS(id: string) {
   return cssLangRE.test(id)
@@ -21,6 +22,12 @@ function isCSSModule(id: string) {
 // string content directly and not the proxy module
 function isInline(id: string) {
   return cssInlineRE.test(id)
+}
+
+// raw requests ask for the file source text and are served by
+// Vite's asset plugin, so css processing must not touch them
+function isRaw(id: string) {
+  return cssRawRE.test(id)
 }
 
 function getCSSModuleProxyReturn(
@@ -56,7 +63,7 @@ export function CSSEnablerPlugin(): VitePlugin[] {
       name: 'vitest:css-disable',
       enforce: 'pre',
       transform(_code, id) {
-        if (!isCSS(id)) {
+        if (!isCSS(id) || isRaw(id)) {
           return
         }
         // css plugin inside Vite won't do anything if the code is empty
@@ -73,7 +80,7 @@ export function CSSEnablerPlugin(): VitePlugin[] {
         viteConfig = config
       },
       transform(_, id) {
-        if (!isCSS(id) || shouldProcessCSS(id)) {
+        if (!isCSS(id) || isRaw(id) || shouldProcessCSS(id)) {
           return
         }
 

--- a/test/e2e/fixtures/css/test/raw-css.spec.ts
+++ b/test/e2e/fixtures/css/test/raw-css.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+
+describe('raw css imports bypass css processing', () => {
+  test('?raw returns the file source text', async () => {
+    const { default: raw } = await import('../App.css?raw')
+
+    expect(typeof raw).toBe('string')
+    expect(raw).toContain('.main {')
+    expect(raw).toContain('display: flex;')
+  })
+
+  test('?raw returns the source text for css modules too', async () => {
+    const { default: raw } = await import('../App.module.css?raw')
+
+    expect(typeof raw).toBe('string')
+    expect(raw).toContain('.module {')
+    expect(raw).toContain('width: 100px;')
+  })
+})

--- a/test/e2e/test/css-configs.test.ts
+++ b/test/e2e/test/css-configs.test.ts
@@ -3,13 +3,14 @@ import { runVitest } from '../../test-utils'
 
 it.each([
   ['test/default-css', {}],
+  ['test/raw-css', {}],
   ['test/process-css', { include: [/App\.css/] }],
   [['test/process-module', 'test/process-inline'], { include: [/App\.module\.css/] }],
   ['test/scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'scoped' as const } }],
   ['test/non-scope-module', { include: [/App\.module\.css/], modules: { classNameStrategy: 'non-scoped' as const } }],
 ])('testing %s', async (name, config) => {
   const names = Array.isArray(name) ? name : [name]
-  const { stderr } = await runVitest({
+  const { stderr, exitCode } = await runVitest({
     config: false,
     root: './fixtures/css',
     css: config,
@@ -18,4 +19,5 @@ it.each([
   }, names)
 
   expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
 })


### PR DESCRIPTION
### Description

Resolves #10788

`CSSEnablerPlugin` matches any css-language id, including ones carrying a `?raw` query. With css processing disabled (the default), the `vitest:css-disable` pre transform blanks the module and `vitest:css-empty-post` replaces it with `export default ""` – or the css-modules proxy object for `.module.css?raw`, so the import isn't even a string. Vite's asset plugin never gets to serve the source text, and a `?raw` import of a css file silently resolves to an empty string. As the issue notes, this makes assertions over the imported source pass vacuously.

This PR makes both transforms skip `?raw` requests (`[?&]raw(?:&|$)`), mirroring how Vite's own css plugin ignores special queries via `SPECIAL_QUERY_RE`, so the raw asset pipeline serves the file source text. Behaviour with css processing enabled is unchanged.

It also adds `expect(exitCode).toBe(0)` to the css-configs e2e assertions alongside the existing `expect(stderr).toBe('')`, to make the intent explicit for all rows.

The code was co-created with Claude Code.

### Tests

Added `test/raw-css` fixture spec covering both a plain css file and a css module imported with `?raw` under disabled css processing. Verified with a clean `experimental.fsModuleCache`:

- without the fix: `App.css?raw` resolves to `''` and `App.module.css?raw` resolves to the css-modules proxy object (both assertions fail, matching the issue)
- with the fix: both return the file source text; the whole `css-configs` suite passes (6/6)

One caveat worth mentioning for reviewers: while verifying "fails without the fix", a stale `experimental.fsModuleCache` entry from a fixed build kept serving the correct transform result after I reverted the plugin – the cache key includes plugin *names* but not their implementation, so plugin changes don't invalidate it. Not addressed here (relates to #10701), just flagging it since the e2e suite runs with `fsModuleCache: true`.

### Checklist

- [x] References an existing issue (#10788)
- [x] Includes a test that fails without this PR but passes with it
- [x] No changes to `pnpm-lock.yaml`
- [x] Allow edits by maintainers
