### PR TITLE
fix(ui): distinguish suites from tests in explorer (fix #10696)

### DIFF
--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -219,7 +219,7 @@ const tagsBgGradient = computed(() => {
     <div flex items-baseline gap-2 overflow-hidden>
       <div v-if="type === 'file' && typecheck" v-tooltip.bottom="'This is a typecheck test. It won\'t report results of the runtime tests'" class="i-logos:typescript-icon" flex-shrink-0 />
       <span v-if="type === 'file' && label" class="rounded-sm px-1 text-xs font-light bg-cyan-500/20 text-cyan-700 dark:text-cyan-300" flex-shrink-0>{{ label }}</span>
-      <span text-sm truncate font-light>
+      <span text-sm truncate :class="type === 'test' ? 'font-light' : 'font-medium'">
         <span v-if="type === 'file' && projectName" class="rounded-full py-0.5 px-2 mr-1 text-xs" :style="{ backgroundColor: projectNameColor, color: projectNameTextColor }">
           {{ projectName }}
         </span>

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -158,6 +158,11 @@ test.describe('ui', () => {
     await page.goto(pageUrl)
     await testModuleGraph(page)
   })
+
+  test('explorer distinguishes suites from tests', async ({ page }) => {
+    await page.goto(pageUrl)
+    await testExplorerSuiteDistinction(page)
+  })
 })
 
 test.describe('html report', () => {
@@ -251,6 +256,11 @@ test.describe('html report', () => {
     await page.goto(pageUrl)
     await testModuleGraph(page)
   })
+
+  test('explorer distinguishes suites from tests', async ({ page }) => {
+    await page.goto(pageUrl)
+    await testExplorerSuiteDistinction(page)
+  })
 })
 
 async function testBasic(page: Page, pageUrl: string) {
@@ -296,6 +306,13 @@ async function testModuleGraph(page: Page) {
   await page.getByTestId('btn-graph').click()
   await expect(page.locator('[data-testid=graph] text')).toBeVisible()
   await expect(page.locator('[data-testid=graph] text')).toHaveText('sample-browser.test.ts')
+}
+
+async function testExplorerSuiteDistinction(page: Page) {
+  await expect(getExplorerItem(page, 'console.test.ts').locator('[truncate]')).toHaveCSS('font-weight', '500')
+  await expect(getExplorerItem(page, 'suite').locator('[truncate]')).toHaveCSS('font-weight', '500')
+  await expect(getExplorerItem(page, 'nested suite').locator('[truncate]')).toHaveCSS('font-weight', '500')
+  await expect(getExplorerItem(page, 'test').locator('[truncate]')).toHaveCSS('font-weight', '300')
 }
 
 async function testCoverage(page: Page) {


### PR DESCRIPTION
### Description

Suites and tests look the same in the explorer tree, so it's easy to misclick and collapse a suite while trying to check why a test failed. This gives suite and file names a heavier font weight than test names so they're easier to tell apart at a glance.

Resolves #10696

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
