### PR TITLE
fix: set non-zero exit code when teardown throws during close

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -1549,11 +1549,18 @@ export class Vitest {
         closePromises.push(...this._onClose.map(fn => fn()))
 
         await Promise.allSettled(closePromises).then((results) => {
-          [...results, ...teardownErrors.map(r => ({ status: 'rejected', reason: r }))].forEach((r) => {
-            if (r.status === 'rejected') {
-              this.logger.error('error during close', r.reason)
-            }
-          })
+          const errors = [
+            ...results
+              .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+              .map(r => r.reason),
+            ...teardownErrors,
+          ]
+
+          for (const error of errors) {
+            this.logger.error('error during close', error)
+          }
+
+          this._checkUnhandledErrors(errors)
         })
         await this._traces?.finish()
       })()

--- a/test/e2e/fixtures/global-setup-teardown-fail/example.test.ts
+++ b/test/e2e/fixtures/global-setup-teardown-fail/example.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('example test', () => {
+  expect(1 + 1).toBe(2)
+})

--- a/test/e2e/fixtures/global-setup-teardown-fail/globalSetup/error.ts
+++ b/test/e2e/fixtures/global-setup-teardown-fail/globalSetup/error.ts
@@ -1,0 +1,5 @@
+export default function () {
+  return () => {
+    throw new Error('teardown error')
+  }
+}

--- a/test/e2e/fixtures/global-setup-teardown-fail/vitest.config.ts
+++ b/test/e2e/fixtures/global-setup-teardown-fail/vitest.config.ts
@@ -1,0 +1,11 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    globalSetup: [
+      resolve(import.meta.dirname, './globalSetup/error.ts'),
+    ],
+  },
+})

--- a/test/e2e/test/global-setup.test.ts
+++ b/test/e2e/test/global-setup.test.ts
@@ -18,6 +18,14 @@ it('should fail', async () => {
   expect(stderr).toContain('globalSetup/error.ts:6:9')
 })
 
+it('fails with a non-zero exit code when teardown throws', async () => {
+  const root = resolve(import.meta.dirname, '../fixtures/global-setup-teardown-fail')
+  const { stderr, exitCode } = await runVitest({ root })
+
+  expect(exitCode).toBe(1)
+  expect(stderr).toContain('Error: teardown error')
+})
+
 it('runs global setup/teardown', async () => {
   const { stderr, errorTree } = await runVitest({
     root: './fixtures/global-setup',


### PR DESCRIPTION
### Description

Errors thrown while closing Vitest, most notably a failing `globalSetup` teardown, were logged but never affected the exit code. As a result `vitest run` exited 0 even though cleanup failed.

`vitest.close()` catches teardown errors since #9573, so that the rest of the shutdown still runs, and logs them via `logger.error('error during close', ...)`. However, nothing set a non-zero exit code afterwards, so any cleanup failure in a `globalSetup` teardown was silently swallowed.

This change routes the collected errors, meaning teardown errors plus any rejected close promises, through the existing `_checkUnhandledErrors`. That is the same mechanism used for unhandled test errors. It sets `process.exitCode` to 1 and honours `dangerouslyIgnoreUnhandledErrors`.

#### Reproduction

A `globalSetup` whose teardown throws, with otherwise passing tests:

```ts
// globalSetup.ts
export default function () {
  return () => {
    throw new Error('teardown error')
  }
}
```

Before this change, `vitest run` prints the error but exits 0. After, it exits 1.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
