### PR TITLE
fix(browser): mock window.print to avoid hanging (fix #7375)

### DIFF
--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -588,7 +588,7 @@ test('renders a message', async () => {
 
 ### Thread Blocking Dialogs
 
-When using Vitest Browser, it's important to note that thread blocking dialogs like `alert` or `confirm` cannot be used natively. This is because they block the web page, which means Vitest cannot continue communicating with the page, causing the execution to hang.
+When using Vitest Browser, it's important to note that thread blocking dialogs like `alert`, `confirm` or `print` cannot be used natively. This is because they block the web page, which means Vitest cannot continue communicating with the page, causing the execution to hang.
 
 In such situations, Vitest provides default mocks with default returned values for these APIs. This ensures that if the user accidentally uses synchronous popup web APIs, the execution would not hang. However, it's still recommended for the user to mock these web APIs for a better experience. Read more in [Mocking](/guide/mocking).
 

--- a/packages/browser/src/client/tester/dialog.ts
+++ b/packages/browser/src/client/tester/dialog.ts
@@ -21,5 +21,6 @@ expect(${name}).toHaveBeenCalledWith(${formattedParams})
 export function setupDialogsSpy(): void {
   globalThis.alert = showPopupWarning('alert', undefined)
   globalThis.confirm = showPopupWarning('confirm', false, true)
+  globalThis.print = showPopupWarning('print', undefined)
   globalThis.prompt = showPopupWarning('prompt', null, 'your value')
 }

--- a/test/browser/fixtures/print-logs/test/dialog.test.ts
+++ b/test/browser/fixtures/print-logs/test/dialog.test.ts
@@ -13,3 +13,7 @@ it('prompt', async () => {
 it('confirm', async () => {
   expect(confirm('test')).toBe(false)
 })
+
+it('print', async () => {
+  expect(print()).toBeUndefined()
+})

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -242,6 +242,7 @@ error with a stack
   test('popup apis should log a warning', () => {
     expect(stderr).toContain('Vitest encountered a `alert("test")`')
     expect(stderr).toContain('Vitest encountered a `confirm("test")`')
+    expect(stderr).toContain('Vitest encountered a `print()`')
     expect(stderr).toContain('Vitest encountered a `prompt("test")`')
   })
 })


### PR DESCRIPTION
### Description

Resolves #7375

Calling `window.print()` in browser mode hangs the test run because it blocks the page, same as `alert` and `confirm`, which already have default mocks. This pull request fixes this by adding `print` to the existing dialog mocks so it logs the usual warning and returns `undefined`, with a test in the print-logs fixture and a mention in the browser docs.

Disclosure: drafted with help from Cursor. I reviewed the change and tested it myself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.