### PR TITLE
test: use top-level fsModuleCache option

### DIFF
--- a/test/e2e/test/config/injectCjsGlobals.test.ts
+++ b/test/e2e/test/config/injectCjsGlobals.test.ts
@@ -101,7 +101,7 @@ test('cjs dep served from the warm-modules snapshot keeps the module scope when 
     isolate: true,
     fileParallelism: false,
     injectCjsGlobals: false,
-    experimental: { fsModuleCache: true },
+    fsModuleCache: true,
   })
   expect(stderr).toBe('')
   expect(exitCode).toBe(0)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- follow up https://github.com/vitest-dev/vitest/pull/10734

CI is failing with the deprecated warning on e2e.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
