### PR TITLE
fix(expect): handle nullish toHaveProperty values (fix #10735)

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -467,6 +467,11 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
       }
 
       const actual = this._obj as any
+      if (actual == null) {
+        throw new TypeError(
+          `.toHaveProperty() expects to receive a valid object, but got ${actual}`,
+        )
+      }
       const [propertyName, expected] = args
       const getValue = () => {
         const hasOwn = Object.hasOwn(

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -384,6 +384,21 @@ describe('jest-expect', () => {
     }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { a: { b: { c: 1 } } } to deeply equal { a: { b: { c: 2 } } }]`)
   })
 
+  it('fails cleanly when toHaveProperty receives a nullish value', () => {
+    expect(() => expect(null).toHaveProperty('value')).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: .toHaveProperty() expects to receive a valid object, but got null]`,
+    )
+    expect(() => expect(null).not.toHaveProperty('value')).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: .toHaveProperty() expects to receive a valid object, but got null]`,
+    )
+    expect(() => expect(undefined).toHaveProperty('value')).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: .toHaveProperty() expects to receive a valid object, but got undefined]`,
+    )
+    expect(() => expect(undefined).not.toHaveProperty('value')).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: .toHaveProperty() expects to receive a valid object, but got undefined]`,
+    )
+  })
+
   it('assertions', () => {
     expect(1).toBe(1)
     expect(1).toBe(1)


### PR DESCRIPTION
### Description

`toHaveProperty` called `Object.hasOwn` before validating its received value, so `null` and `undefined` leaked the runtime error `Cannot convert undefined or null to object`.

This validates nullish inputs first and reports a matcher-specific `TypeError` for both regular and negated assertions. The regression test covers `null` and `undefined` in all four cases.

Resolves #10735

Codex was used as a personal assistant for this contribution. The issue, implementation, diff, and local validation were reviewed before submission.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] `CI=true pnpm -C test/unit test --run test/jest-expect.test.ts` (342 passed, 27 expected failures across threads, vmThreads, and forks)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm lint:fix`

### Documentation
- [x] No new functionality or documentation change is required.

### Changesets
- [x] The PR title uses the repository's changelog convention.

<!-- VITEST_AUTOMATED_PR -->
