### PR TITLE
fix(snapshot): escape line endings in snapshot keys

### DIFF
--- a/packages/snapshot/src/port/utils.ts
+++ b/packages/snapshot/src/port/utils.ts
@@ -15,8 +15,11 @@ import { getSerializers } from './plugins'
 
 // TODO: rewrite and clean up
 
+// Escape line endings in keys so that titles with `\r\n`, `\r` and `\n`
+// don't collide when the snapshot file is parsed back (template literals
+// normalize CRLF to LF in source)
 export function testNameToKey(testName: string, count: number): string {
-  return `${testName} ${count}`
+  return `${testName.replace(/[\r\n]/g, c => (c === '\r' ? '\\r' : '\\n'))} ${count}`
 }
 
 export function keyToTestName(key: string): string {
@@ -24,7 +27,9 @@ export function keyToTestName(key: string): string {
     throw new Error('Snapshot keys must end with a number.')
   }
 
-  return key.replace(/ \d+$/, '')
+  return key
+    .replace(/ \d+$/, '')
+    .replace(/\\r|\\n/g, c => (c === '\\r' ? '\r' : '\n'))
 }
 
 export function getSnapshotData(

--- a/test/e2e/snapshots/snapshots.test.ts
+++ b/test/e2e/snapshots/snapshots.test.ts
@@ -119,3 +119,48 @@ test.fails('soft', () => {
     }
   `)
 })
+
+// https://github.com/vitest-dev/vitest/issues/7305
+test('test names with different line endings get distinct snapshots', async () => {
+  const { fs, root, exitCode } = await runInlineTests({
+    'basic.test.ts': `
+import { expect, test } from 'vitest'
+
+test.for([
+  'a\\nb',
+  'a\\r\\nb',
+])('%s', (input) => {
+  expect(input.split('')).toMatchSnapshot()
+})
+`,
+  }, { update: true })
+  expect(exitCode).toBe(0)
+  expect(fs.readFile('__snapshots__/basic.test.ts.snap')).toMatchInlineSnapshot(`
+    "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+    exports[\`a\\\\nb 1\`] = \`
+    [
+      "a",
+      "
+    ",
+      "b",
+    ]
+    \`;
+
+    exports[\`a\\\\r\\\\nb 1\`] = \`
+    [
+      "a",
+      "
+    ",
+      "
+    ",
+      "b",
+    ]
+    \`;
+    "
+  `)
+
+  // the saved snapshots have to match when the file is parsed back
+  const second = await runVitest({ root })
+  expect(second.exitCode).toBe(0)
+})


### PR DESCRIPTION
### Description

Snapshot keys are saved as backtick template literals, so a test name containing `\r\n` is written with a literal CR character. When the snapshot file is parsed back, template literal semantics normalize CRLF to LF in source, which makes the key collide with the same title using `\n`. In the reproduction from #7305, the second test always compares against the first test's snapshot and fails on every run after the first.

This escapes `\r` and `\n` as `\\r` and `\\n` when building the key in `testNameToKey` and reverses the escaping in `keyToTestName`, the same approach Jest took for the identical issue in jestjs/jest#15708. Snapshot values are not affected; they keep the existing newline normalization.

Note that snapshot files written before this change store multiline test names with raw line endings, so tests with such names will report their snapshots as new and need a one-time `vitest -u`.

Resolves #7305

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
