### PR TITLE
fix: don't race the typechecker spawn grace period on windows

### DIFF
--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -401,13 +401,16 @@ export class Typechecker {
         child.process?.off('error', onError)
         clearTimeout(timeout)
         if (process.platform === 'win32') {
-          // on Windows, the process might be spawned but fail to start
-          // we wait for a potential error here. if "close" event didn't trigger,
-          // we resolve the promise
-          winTimeout = setTimeout(() => {
-            resolved = true
-            resolve({ result: child })
-          }, 200)
+          // on Windows, the process might be spawned but fail to start,
+          // so we wait for the "close" event instead of resolving right away.
+          // `start` awaits the process anyway; the watch process never exits,
+          // so resolve it after a grace period
+          if (watch) {
+            winTimeout = setTimeout(() => {
+              resolved = true
+              resolve({ result: child })
+            }, 200)
+          }
         }
         else {
           resolved = true
@@ -419,6 +422,11 @@ export class Typechecker {
         child.process.once('close', (code) => {
           if (code != null && code !== 0 && !dataReceived) {
             onError(new Error(`The ${typecheck.checker} command exited with code ${code}.`))
+          }
+          else if (!resolved) {
+            clearTimeout(winTimeout)
+            resolved = true
+            resolve({ result: child })
           }
         })
       }


### PR DESCRIPTION
### Description

On Windows a nonexistent typechecker command still spawns (the shell starts and then fails), so `Typechecker.spawn` can't rely on the `error` event. It currently waits 200ms for the `close` event and otherwise declares the spawn successful. On a slow runner the shell takes longer than 200ms to fail, the timer wins, and instead of `Spawning typechecker failed - is typescript installed?` the user gets an unhandled `Typecheck Error` with the shell's raw output. The same race makes the `handles non-existing typechecker command gracefully` test in `test/typescript` flaky on Windows CI, most recently in [this run](https://github.com/vitest-dev/vitest/actions/runs/29910093626/job/88890772197).

In run mode there is no need for a grace period at all: `start` awaits the process right after spawning, so this change just waits for `close` and resolves or rejects based on the exit. That makes the error deterministic regardless of machine speed. Watch mode keeps the 200ms timer since the watch process never exits.

The win32 code paths can't be exercised from my machine, so Windows CI on this PR is the verification for the changed behavior; the `test/typescript` suite passes unchanged on Linux, which doesn't touch these branches.

Refs #10618

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. (the existing `handles non-existing typechecker command gracefully` test is the regression test - it fails intermittently on Windows without this change)
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
