### PR TITLE
fix(snapshot): don't delete toMatchFileSnapshot files at the default snapshot path

### DIFF
--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -75,6 +75,7 @@ export default class SnapshotState {
   private _snapshotFormat: PrettyFormatOptions
   private _environment: SnapshotEnvironment
   private _fileExists: boolean
+  private _fileIsSnapshotFormat: boolean
   expand: boolean
 
   // getter/setter for jest-image-snapshot compat
@@ -100,6 +101,8 @@ export default class SnapshotState {
   ) {
     const { data, dirty } = getSnapshotData(snapshotContent, options)
     this._fileExists = snapshotContent != null // TODO: update on watch?
+    this._fileIsSnapshotFormat = snapshotContent != null
+      && snapshotContent.startsWith(options.snapshotEnvironment.getHeader())
     this._initialData = { ...data }
     this._snapshotData = { ...data }
     this._dirty = dirty
@@ -419,7 +422,9 @@ export default class SnapshotState {
 
       status.saved = true
     }
-    else if (!hasExternalSnapshots && this._fileExists) {
+    // don't delete files that were not written by the snapshot client,
+    // e.g. when `toMatchFileSnapshot` targets the default snapshot path
+    else if (!hasExternalSnapshots && this._fileExists && this._fileIsSnapshotFormat) {
       if (this._updateSnapshot === 'all') {
         await this._environment.removeSnapshotFile(this.snapshotPath)
         this._fileExists = false

--- a/test/e2e/test/snapshot.test.ts
+++ b/test/e2e/test/snapshot.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { runInlineTests, runVitest } from '../../test-utils'
 
 test('resolveSnapshotPath context', async () => {
   const { stderr, ctx } = await runVitest({
@@ -16,4 +16,25 @@ test('resolveSnapshotPath context', async () => {
       "project2|basic.test.ts": "pass",
     }
   `)
+})
+
+// https://github.com/vitest-dev/vitest/issues/8655
+test('toMatchFileSnapshot targeting the default snapshot path is not deleted', async () => {
+  const { fs, root, exitCode } = await runInlineTests({
+    'src/basic.test.ts': `
+import { expect, it } from 'vitest'
+
+it('collides with the default snapshot path', async () => {
+  await expect('foobar').toMatchFileSnapshot('__snapshots__/basic.test.ts.snap')
+})
+`,
+  }, { update: true })
+  expect(exitCode).toBe(0)
+  expect(fs.readFile('src/__snapshots__/basic.test.ts.snap')).toBe('foobar')
+
+  // the file matches on the second run, so there is nothing to write and
+  // it used to be removed as if it were an obsolete snapshot file
+  const second = await runVitest({ root, update: true })
+  expect(second.exitCode).toBe(0)
+  expect(fs.readFile('src/__snapshots__/basic.test.ts.snap')).toBe('foobar')
 })


### PR DESCRIPTION
### Description

When `toMatchFileSnapshot` targets the path that `toMatchSnapshot` would use by default (`__snapshots__/<file>.snap`), running with `--update` deletes the file on every second run. If the file content already matches, the raw snapshot never registers in `SnapshotState`, so `save` sees a state with no snapshots and an existing file at `snapshotPath` and removes it as if it were an obsolete snapshot file. The next run recreates it, which is the alternating behavior reported in #8655.

The fix makes the obsolete-file cleanup ownership-aware: the state now remembers whether the file it loaded actually starts with the snapshot environment's header, and only deletes files that do. Files written by `toMatchFileSnapshot` (or any other file that happens to sit at a default snapshot path) are left alone. This also covers the case from the issue comments where the target collides with a different test file's default path, since that file's own state will refuse to delete content it didn't write. Cleanup of genuinely obsolete snapshot files under `--update` is unchanged, which the existing suites cover.

The regression test runs the reproduction twice with `update: true` and asserts the file survives the second run; it fails with `ENOENT` without the fix.

Resolves #8655

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
