### PR TITLE
chore(deps): update dependency magic-string to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "changelogithub": "^14.0.0",
     "esbuild": "^0.27.3",
     "eslint": "^10.7.0",
-    "magic-string": "^0.30.21",
+    "magic-string": "^1.0.0",
     "pathe": "^2.0.3",
     "premove": "^4.0.0",
     "rollup": "^4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ catalogs:
       specifier: ^3.2.1
       version: 3.2.1
     magic-string:
-      specifier: ^0.30.21
-      version: 0.30.21
+      specifier: ^1.0.0
+      version: 1.0.0
     magicast:
       specifier: ^0.5.2
       version: 0.5.2
@@ -251,8 +251,8 @@ importers:
         specifier: ^10.7.0
         version: 10.7.0(jiti@2.6.1)
       magic-string:
-        specifier: ^0.30.21
-        version: 0.30.21
+        specifier: ^1.0.0
+        version: 1.0.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -545,7 +545,7 @@ importers:
         version: link:../utils
       magic-string:
         specifier: 'catalog:'
-        version: 0.30.21
+        version: 1.0.0
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
@@ -781,7 +781,7 @@ importers:
         version: 3.0.3
       magic-string:
         specifier: 'catalog:'
-        version: 0.30.21
+        version: 1.0.0
     devDependencies:
       '@types/estree':
         specifier: 'catalog:'
@@ -834,7 +834,7 @@ importers:
         version: link:../utils
       magic-string:
         specifier: 'catalog:'
-        version: 0.30.21
+        version: 1.0.0
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -1040,7 +1040,7 @@ importers:
         version: 1.3.0
       magic-string:
         specifier: 'catalog:'
-        version: 0.30.21
+        version: 1.0.0
       obug:
         specifier: 'catalog:'
         version: 2.1.1
@@ -1275,8 +1275,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1
       magic-string:
-        specifier: ^0.30.21
-        version: 0.30.21
+        specifier: ^1.0.0
+        version: 1.0.0
       magicast:
         specifier: ^0.5.2
         version: 0.5.2
@@ -8432,6 +8432,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.0.0:
+    resolution: {integrity: sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA==}
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
@@ -17645,6 +17648,10 @@ snapshots:
       sourcemap-codec: 1.4.8
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.0.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,7 +78,7 @@ catalog:
   istanbul-lib-source-maps: ^5.0.6
   istanbul-reports: ^3.2.0
   loupe: ^3.2.1
-  magic-string: ^0.30.21
+  magic-string: ^1.0.0
   magicast: ^0.5.2
   msw: ^2.12.10
   obug: ^2.1.1

--- a/test/coverage-test/package.json
+++ b/test/coverage-test/package.json
@@ -20,7 +20,7 @@
     "happy-dom": "^20.10.6",
     "istanbul-lib-coverage": "catalog:",
     "istanbul-lib-report": "catalog:",
-    "magic-string": "^0.30.21",
+    "magic-string": "^1.0.0",
     "magicast": "^0.5.2",
     "sass-embedded": "^1.97.3",
     "unplugin-swc": "^1.5.9",


### PR DESCRIPTION
### Description

This PR updates magic-string to ^1.0.0. The breaking change in this release line is that it is ESM-only. The affected Vitest packages already ship as ESM, and Vitest's CommonJS entry points target Node.js versions with `require(esm)` support, so this should not be a problem.

Prepared with Codex.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
