### PR TITLE
fix: coalesce concurrent watch-mode restarts, deflake the pool stderr fixture

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -267,10 +267,7 @@ export class Vitest {
   // Restarts must not overlap: chokidar regularly delivers several change
   // events for one edit, and a restart that starts while another is still
   // re-creating the servers reports `onServerRestart` to reporters that were
-  // re-instantiated but not yet initialized (`ctx` is only assigned by
-  // `onInit`), crashing the run. Coalesce every request that arrives during a
-  // restart into a single trailing restart - it re-resolves the config from
-  // scratch, so it picks up whatever changed in the meantime.
+  // re-instantiated but not yet initialized.
   private _restart(reason?: string): Promise<void> {
     if (this._restartPromise) {
       this._restartQueued = true

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -261,7 +261,33 @@ export class Vitest {
     )
   }
 
-  private async _restart(reason?: string) {
+  private _restartPromise?: Promise<void>
+  private _restartQueued = false
+
+  // Restarts must not overlap: chokidar regularly delivers several change
+  // events for one edit, and a restart that starts while another is still
+  // re-creating the servers reports `onServerRestart` to reporters that were
+  // re-instantiated but not yet initialized (`ctx` is only assigned by
+  // `onInit`), crashing the run. Coalesce every request that arrives during a
+  // restart into a single trailing restart - it re-resolves the config from
+  // scratch, so it picks up whatever changed in the meantime.
+  private _restart(reason?: string): Promise<void> {
+    if (this._restartPromise) {
+      this._restartQueued = true
+      return this._restartPromise
+    }
+    this._restartPromise = (async () => {
+      do {
+        this._restartQueued = false
+        await this._restartNow(reason)
+      } while (this._restartQueued)
+    })().finally(() => {
+      this._restartPromise = undefined
+    })
+    return this._restartPromise
+  }
+
+  private async _restartNow(reason?: string) {
     await Promise.all(this._onRestartListeners.map(fn => fn(reason)))
     this.report('onServerRestart', reason)
     await this.close()

--- a/test/e2e/fixtures/pool/write-to-stdout-and-stderr.test.ts
+++ b/test/e2e/fixtures/pool/write-to-stdout-and-stderr.test.ts
@@ -1,11 +1,17 @@
 import { test } from 'vitest'
 import EventEmitter from 'node:events'
 
-test('write to streams', () => {
+test('write to streams', async () => {
   process.stdout.write('Worker writing to stdout')
   process.stderr.write('Worker writing to stderr')
 
+  // `emitWarning` prints to stderr asynchronously: without waiting for the
+  // event (plus one tick for the default handler's write), a fast worker
+  // teardown can exit before the warning reaches the captured stderr
+  const warning = new Promise<void>(resolve => process.once('warning', () => resolve()))
   triggerNodeWarning()
+  await warning
+  await new Promise(resolve => setImmediate(resolve))
 })
 
 function triggerNodeWarning() {

--- a/test/e2e/test/watch/restart-coalescing.test.ts
+++ b/test/e2e/test/watch/restart-coalescing.test.ts
@@ -1,0 +1,24 @@
+import { runVitest } from '#test-utils'
+import { expect, test } from 'vitest'
+
+// chokidar regularly delivers several change events for one config edit, each
+// triggering a restart. A restart that begins while another is still
+// re-creating the servers used to report `onServerRestart` to reporters that
+// were re-instantiated but not yet initialized, crashing the run with
+// "Cannot read properties of undefined (reading 'logger')".
+test('concurrent restarts are coalesced instead of overlapping', async () => {
+  const { ctx, vitest } = await runVitest({
+    root: 'fixtures/watch',
+    watch: true,
+  })
+
+  const restart = (ctx as any)._restart.bind(ctx)
+  await Promise.all([restart('config'), restart('config'), restart('config')])
+
+  expect(vitest.stdout).toContain('Restarting due to config changes')
+  expect(vitest.stderr).not.toContain('Cannot read properties')
+
+  // the restarted instance is functional: a rerun still works
+  await ctx!.rerunFiles()
+  expect(vitest.stdout).toContain('RERUN')
+})


### PR DESCRIPTION
Analysis of the recent CI failure increase across main and PR branches (runs from Jul 21-23). Two of the recurring clusters are root-caused and fixed here; the rest are catalogued below with evidence.

## Fixed

**1. Windows/macOS e2e: unhandled `TypeError: Cannot read properties of undefined (reading 'logger')`** (main runs [30009378686](https://github.com/vitest-dev/vitest/actions/runs/30009378686), [29992865327](https://github.com/vitest-dev/vitest/actions/runs/29992865327), [29926056935](https://github.com/vitest-dev/vitest/actions/runs/29926056935); attributed to `file-watching.test.ts`)

The stack is `_restart → report('onServerRestart') → VerboseReporter.log → this.ctx.logger`. `_start` re-creates the reporters (`this.reporters = await createReporters(...)`) but `ctx` is only assigned later by the `onInit` report. Chokidar regularly fires several change events for one config edit; a second `_restart` beginning inside that window reports `onServerRestart` to constructed-but-uninitialized reporters. Fix: requests arriving during an in-flight restart coalesce into one trailing restart (which re-resolves the config from scratch, so it picks up whatever changed meanwhile). Regression test drives three concurrent `_restart` calls and verifies the instance still reruns.

**2. e2e `pool.test.ts > can capture worker's stdout and stderr`** (main runs [29805385576](https://github.com/vitest-dev/vitest/actions/runs/29805385576), [29923860728](https://github.com/vitest-dev/vitest/actions/runs/29923860728); also on unrelated PR branches)

The fixture triggers a `MaxListenersExceededWarning` and the test asserts it in captured stderr, but `process.emitWarning` prints on a later tick and the test body was synchronous — a fast worker teardown exits before the warning reaches stderr. The fixture now awaits the `warning` event plus one tick.

## Catalogued, not fixed here

- **Browser CDP/mock race family** — `cdp.test.ts > cdp sends events correctly`, `mock-importActual` (browser+coverage), `mocking.test.ts > mocking dependency correctly invalidates it on rerun`, `1_mocked-on-watch-change`, and `runner.test.ts > tests are actually running` (fails on a stderr-must-be-empty assertion polluted by the cdp failure). One family: module mocks and CDP events race the module fetch because delivery is CDP-only. Needs dedicated work; a naive interceptor-fallback was already tried and hangs.
- **`pool-worker-exit.test.ts > worker death on a shared runner does not skip coverage finalization`** (macOS, main [30010040100](https://github.com/vitest-dev/vitest/actions/runs/30010040100)) — after two worker crashes, `3-crash.test.ts`/`4-third.test.ts` are entirely absent from the reported tree, i.e. the queued files were never scheduled onto a replacement worker before the run finalized. This is a crash-recovery scheduling race in the pool, not test timing — needs its own investigation.
- **Browser `hooks-timeout.test.ts`** — hook-timeout assertions sporadically observe Playwright's own `locator.click: Timeout 249ms exceeded` instead of the expected hook timeout; timing-margin dependent.
- **`import-durations.test.ts > should handle tests with no imports gracefully`** (main [29825620887](https://github.com/vitest-dev/vitest/actions/runs/29825620887)) — exit code 1 instead of 0; the captured log doesn't include the cause.

None of the failures on the three split PRs (#10820, #10821, #10710) are introduced by their changes — each maps to one of the clusters above, all of which reproduce on `main` or on unrelated branches.
