### PR TITLE
feat(cli): support -p shorthand for --project

### DIFF
--- a/docs/guide/cli-generated.md
+++ b/docs/guide/cli-generated.md
@@ -794,7 +794,7 @@ Minimum time in milliseconds it takes to spawn the typechecker
 
 ### project
 
-- **CLI:** `--project <name>`
+- **CLI:** `-p, --project <name>`
 
 The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: `--project=1 --project=2`. You can also filter projects using wildcards like `--project=packages*`, and exclude projects with `--project=!pattern`.
 

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -239,6 +239,7 @@ export function parseCLI(argv: string | string[], config: CliParseOptions = {}):
   let { args, options } = createCLI(config).parse(arrayArgs, {
     run: false,
   })
+  removeShorthandAliases(options)
   if (arrayArgs[2] === 'watch' || arrayArgs[2] === 'dev') {
     options.watch = true
   }
@@ -281,7 +282,18 @@ async function benchmark(cliFilters: string[], options: CliOptions): Promise<voi
   await start(cliFilters, options)
 }
 
+// cac copies the raw value of every aliased option to its shorthand key
+function removeShorthandAliases(argv: CliOptions): CliOptions {
+  for (const option of Object.values(cliOptionsConfig)) {
+    if (option?.shorthand) {
+      delete (argv as Record<string, unknown>)[option.shorthand]
+    }
+  }
+  return argv
+}
+
 function normalizeCliOptions(cliFilters: string[], argv: CliOptions): CliOptions {
+  removeShorthandAliases(argv)
   if (argv.exclude) {
     argv.cliExclude = toArray(argv.exclude)
     delete argv.exclude

--- a/packages/vitest/src/node/cli/cac.ts
+++ b/packages/vitest/src/node/cli/cac.ts
@@ -239,7 +239,6 @@ export function parseCLI(argv: string | string[], config: CliParseOptions = {}):
   let { args, options } = createCLI(config).parse(arrayArgs, {
     run: false,
   })
-  removeShorthandAliases(options)
   if (arrayArgs[2] === 'watch' || arrayArgs[2] === 'dev') {
     options.watch = true
   }
@@ -282,18 +281,7 @@ async function benchmark(cliFilters: string[], options: CliOptions): Promise<voi
   await start(cliFilters, options)
 }
 
-// cac copies the raw value of every aliased option to its shorthand key
-function removeShorthandAliases(argv: CliOptions): CliOptions {
-  for (const option of Object.values(cliOptionsConfig)) {
-    if (option?.shorthand) {
-      delete (argv as Record<string, unknown>)[option.shorthand]
-    }
-  }
-  return argv
-}
-
 function normalizeCliOptions(cliFilters: string[], argv: CliOptions): CliOptions {
-  removeShorthandAliases(argv)
   if (argv.exclude) {
     argv.cliExclude = toArray(argv.exclude)
     delete argv.exclude

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -743,6 +743,7 @@ export const cliOptionsConfig: VitestCLIOptions = {
     },
   },
   project: {
+    shorthand: 'p',
     description:
       'The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: `--project=1 --project=2`. You can also filter projects using wildcards like `--project=packages*`, and exclude projects with `--project=!pattern`.',
     argument: '<name>',

--- a/test/unit/test/cli-test.test.ts
+++ b/test/unit/test/cli-test.test.ts
@@ -216,15 +216,14 @@ test('maxConcurrency is parsed correctly', () => {
 })
 
 test('project is parsed correctly', () => {
-  const expected = { 'project': ['space_1'], '--': [], 'color': true }
-  expect(parseCLI('vitest --project space_1').options).toEqual(expected)
-  expect(parseCLI('vitest --project=space_1').options).toEqual(expected)
-  expect(parseCLI('vitest -p space_1').options).toEqual(expected)
-  expect(parseCLI('vitest -p=space_1').options).toEqual(expected)
-  expect(parseCLI('vitest -p space_1 -p space_2').options).toEqual({
-    'project': ['space_1', 'space_2'],
-    '--': [],
-    'color': true,
+  // cac copies the raw value to the shorthand key, it is ignored by vitest
+  expect(getCLIOptions('--project space_1')).toEqual({ project: ['space_1'], p: 'space_1' })
+  expect(getCLIOptions('--project=space_1')).toEqual({ project: ['space_1'], p: 'space_1' })
+  expect(getCLIOptions('-p space_1')).toEqual({ project: ['space_1'], p: 'space_1' })
+  expect(getCLIOptions('-p=space_1')).toEqual({ project: ['space_1'], p: 'space_1' })
+  expect(getCLIOptions('-p space_1 -p space_2')).toEqual({
+    project: ['space_1', 'space_2'],
+    p: ['space_1', 'space_2'],
   })
 })
 
@@ -407,6 +406,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'watch': true,
+      'w': true,
       '--': [],
       'color': true,
     },
@@ -458,6 +458,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space_1', 'space_2'],
+      'p': ['space_1', 'space_2'],
       '--': [],
       'color': true,
     },
@@ -467,6 +468,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space_1', 'space_2'],
+      'p': ['space_1', 'space_2'],
       '--': [],
       'color': true,
     },
@@ -476,6 +478,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space 1'],
+      'p': '"space 1"',
       '--': [],
       'color': true,
     },
@@ -485,6 +488,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space 1'],
+      'p': 'space 1',
       '--': [],
       'color': true,
     },
@@ -494,6 +498,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space 1'],
+      'p': 'space 1',
       '--': [],
       'color': true,
     },
@@ -503,6 +508,7 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'project': ['space 1', 'space 2'],
+      'p': ['"space 1"', '"space 2"'],
       '--': [],
       'color': true,
     },
@@ -512,6 +518,7 @@ test('public parseCLI works correctly', () => {
     filter: ['./test-1.js', './test-2.js'],
     options: {
       'project': ['space 1', 'space 2', 'space 3'],
+      'p': ['"space 1"', '"space 2"', '"space 3"'],
       '--': [],
       'color': true,
     },

--- a/test/unit/test/cli-test.test.ts
+++ b/test/unit/test/cli-test.test.ts
@@ -215,6 +215,19 @@ test('maxConcurrency is parsed correctly', () => {
   expect(getCLIOptions('--max-concurrency=1000')).toEqual({ maxConcurrency: 1000 })
 })
 
+test('project is parsed correctly', () => {
+  const expected = { 'project': ['space_1'], '--': [], 'color': true }
+  expect(parseCLI('vitest --project space_1').options).toEqual(expected)
+  expect(parseCLI('vitest --project=space_1').options).toEqual(expected)
+  expect(parseCLI('vitest -p space_1').options).toEqual(expected)
+  expect(parseCLI('vitest -p=space_1').options).toEqual(expected)
+  expect(parseCLI('vitest -p space_1 -p space_2').options).toEqual({
+    'project': ['space_1', 'space_2'],
+    '--': [],
+    'color': true,
+  })
+})
+
 test('injectCjsGlobals is parsed correctly', () => {
   expect(getCLIOptions('--injectCjsGlobals')).toEqual({ injectCjsGlobals: true })
   expect(getCLIOptions('--inject-cjs-globals')).toEqual({ injectCjsGlobals: true })
@@ -394,7 +407,6 @@ test('public parseCLI works correctly', () => {
     filter: [],
     options: {
       'watch': true,
-      'w': true,
       '--': [],
       'color': true,
     },
@@ -443,6 +455,15 @@ test('public parseCLI works correctly', () => {
   }).toThrow(`Expected "vitest" as the first argument, received "node"`)
 
   expect(parseCLI('vitest --project=space_1 --project=space_2')).toEqual({
+    filter: [],
+    options: {
+      'project': ['space_1', 'space_2'],
+      '--': [],
+      'color': true,
+    },
+  })
+
+  expect(parseCLI('vitest -p space_1 -p space_2')).toEqual({
     filter: [],
     options: {
       'project': ['space_1', 'space_2'],


### PR DESCRIPTION
## Description

Adds `-p` as a shorthand for `--project`:

```sh
vitest -p unit -p browser
```
