### PR TITLE
feat: support disposable cleanups in before hooks

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -50,6 +50,21 @@ beforeEach(async () => {
 })
 ```
 
+Instead of a function, the hook can return a [disposable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Resource_management) object. Vitest calls its `[Symbol.asyncDispose]` or `[Symbol.dispose]` method at the same point where a returned cleanup function would run. This works well with `AsyncDisposableStack`:
+
+```ts
+import { beforeEach } from 'vitest'
+
+beforeEach(async () => {
+  await using stack = new AsyncDisposableStack()
+
+  const resource = stack.use(await prepareSomething())
+  const other = stack.use(await someOtherThing())
+
+  return stack.move()
+})
+```
+
 ## afterEach
 
 ```ts
@@ -117,6 +132,8 @@ beforeAll(async () => {
   }
 })
 ```
+
+Like `beforeEach`, the hook can also return a disposable object instead of a function. Its `[Symbol.asyncDispose]` or `[Symbol.dispose]` method is called where the cleanup function would run.
 
 ## afterAll
 

--- a/packages/vitest/src/runtime/runner/hooks.ts
+++ b/packages/vitest/src/runtime/runner/hooks.ts
@@ -33,7 +33,8 @@ const AROUND_TIMEOUT_KEY = Symbol.for('VITEST_AROUND_TIMEOUT')
 const AROUND_STACK_TRACE_KEY = Symbol.for('VITEST_AROUND_STACK_TRACE')
 
 export function getBeforeHookCleanupCallback(hook: Function, result: any, context?: TestContext): Function | undefined {
-  if (typeof result === 'function') {
+  const cleanup = getCleanupFunction(result)
+  if (typeof cleanup === 'function') {
     const timeout
       = CLEANUP_TIMEOUT_KEY in hook && typeof hook[CLEANUP_TIMEOUT_KEY] === 'number'
         ? hook[CLEANUP_TIMEOUT_KEY]
@@ -43,7 +44,7 @@ export function getBeforeHookCleanupCallback(hook: Function, result: any, contex
         ? hook[CLEANUP_STACK_TRACE_KEY]
         : undefined
     return withTimeout(
-      result,
+      cleanup,
       timeout,
       true,
       stackTraceError,
@@ -53,6 +54,21 @@ export function getBeforeHookCleanupCallback(hook: Function, result: any, contex
         }
       },
     )
+  }
+}
+
+function getCleanupFunction(result: any): ((...args: any[]) => any) | undefined {
+  if (typeof result === 'function') {
+    return result
+  }
+  if (typeof result !== 'object' || result === null) {
+    return undefined
+  }
+  if (Symbol.asyncDispose && typeof result[Symbol.asyncDispose] === 'function') {
+    return () => result[Symbol.asyncDispose]()
+  }
+  if (Symbol.dispose && typeof result[Symbol.dispose] === 'function') {
+    return () => result[Symbol.dispose]()
   }
 }
 

--- a/test/unit/test/hooks.test.ts
+++ b/test/unit/test/hooks.test.ts
@@ -183,3 +183,74 @@ suite('hooks are called for dynamically skipped tests', () => {
     ])
   })
 })
+
+suite.runIf(Symbol.dispose && Symbol.asyncDispose)('hooks cleanup with disposables', () => {
+  let cleanUpCount = 0
+  suite('run', () => {
+    beforeAll(() => {
+      cleanUpCount += 10
+      return {
+        [Symbol.dispose]() {
+          cleanUpCount -= 10
+        },
+      }
+    })
+    beforeEach(() => {
+      cleanUpCount += 1
+      return {
+        async [Symbol.asyncDispose]() {
+          cleanUpCount -= 1
+        },
+      }
+    })
+
+    it('one', () => {
+      expect(cleanUpCount).toBe(11)
+    })
+    it('two', () => {
+      expect(cleanUpCount).toBe(11)
+    })
+  })
+  it('end', () => {
+    expect(cleanUpCount).toBe(0)
+  })
+
+  suite('asyncDispose takes precedence over dispose', () => {
+    beforeEach(() => {
+      cleanUpCount += 1
+      return {
+        [Symbol.dispose]() {
+          cleanUpCount -= 100
+        },
+        async [Symbol.asyncDispose]() {
+          cleanUpCount -= 1
+        },
+      }
+    })
+
+    it('one', () => {
+      expect(cleanUpCount).toBe(1)
+    })
+  })
+  it('end', () => {
+    expect(cleanUpCount).toBe(0)
+  })
+
+  suite('disposable stack', () => {
+    beforeEach(() => {
+      const stack = new AsyncDisposableStack()
+      cleanUpCount += 1
+      stack.defer(() => {
+        cleanUpCount -= 1
+      })
+      return stack.move()
+    })
+
+    it('one', () => {
+      expect(cleanUpCount).toBe(1)
+    })
+  })
+  it('end', () => {
+    expect(cleanUpCount).toBe(0)
+  })
+})


### PR DESCRIPTION
### Description

`beforeEach` and `beforeAll` can return a cleanup function. This PR extends that contract to objects implementing `[Symbol.asyncDispose]` or `[Symbol.dispose]`, so a hook can return a disposable resource directly, or an `AsyncDisposableStack` through `stack.move()`. The dispose method runs exactly where the returned cleanup function would, with the same timeout and abort handling. `asyncDispose` takes precedence when both are present. Symbol lookups are guarded the same way as the existing `Symbol.dispose` usage in `vi` and `@vitest/spy`, and plain objects without dispose symbols keep being ignored, covered by the existing tests.

Resolves #10793

The new tests fail without the change (6 failed, 17 passed on the hooks suite) and pass with it on the threads, forks and vmThreads pools. Docs updated for `beforeEach` and `beforeAll`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

This PR was prepared with AI assistance (Claude Code). I reviewed the change and I own its maintenance.

<!-- VITEST_AUTOMATED_PR -->
