### PR TITLE
fix(ui): bound viewport animation frame wait (fix #10831)

### DIFF
--- a/packages/ui/client/composables/api.ts
+++ b/packages/ui/client/composables/api.ts
@@ -16,6 +16,28 @@ export const ui: BrowserUI = {
     if (browserState?.provider === 'webdriverio') {
       updateBrowserPanel()
     }
-    await new Promise(r => requestAnimationFrame(r))
+    await waitForAnimationFrame()
   },
+}
+
+const VIEWPORT_SETTLE_TIMEOUT = 250
+
+function waitForAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    let animationFrameId = 0
+    const timeoutId = window.setTimeout(done, VIEWPORT_SETTLE_TIMEOUT)
+
+    function done() {
+      if (settled) {
+        return
+      }
+      settled = true
+      window.clearTimeout(timeoutId)
+      window.cancelAnimationFrame(animationFrameId)
+      resolve()
+    }
+
+    animationFrameId = window.requestAnimationFrame(done)
+  })
 }


### PR DESCRIPTION
### Description

Bounds the browser UI viewport settle wait so `page.viewport()` cannot hang indefinitely when the orchestrator page misses or stops receiving `requestAnimationFrame` callbacks.

Root cause: `setIframeViewport` applies the iframe size synchronously, then waits for one animation frame before sending `viewport:done`. In Chromium, backgrounded/non-composited orchestrator pages may not receive that frame, leaving the browser-mode command waiting until the test timeout.

The fix keeps the existing "wait one frame when available" behavior, but races it with a short timeout so the already-applied resize can be acknowledged if the frame callback never arrives.

Resolves #10831

cc @sheremet-va for the browser/UI orchestration path.

### Verification

Local checks run:

- `pnpm --filter @vitest/ui typecheck:client`
- `pnpm --filter @vitest/ui build`
- `TEST_BROWSER=chromium BROWSER_NO_WEBKIT=true pnpm -C test/browser exec vitest --no-watch --config=vitest.config.unit.mts specs/viewport.test.ts`

CI evidence on the PR:

- Lint, diff, zizmor, unit, coverage, browser, Ubuntu e2e, macOS e2e, and Vite@7 jobs passed
- One Windows e2e job failed in `test/watch/file-watching.test.ts` while waiting for `JUNIT report written`; I inspected that log and noted it on the PR as unrelated to this viewport fallback change. I could not rerun the upstream job from my account.

### Risk / compatibility

The resize still happens synchronously as before, and the code still prefers the next animation frame when one is delivered. The compatibility risk is limited to the timeout value: it may acknowledge the resize without a painted frame in backgrounded pages, which is the intended fallback for the hang case.

### AI assistance disclosure

Codex via Jeeves assisted with implementation and local verification; Harsh reviewed and submitted the PR from his account.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it. Focused browser viewport coverage was run locally; a deterministic regression for the compositor/rAF starvation case was not added.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`. Focused UI/browser checks listed above were run instead.

### Documentation
- [x] If you introduce new functionality, document it. No user-facing API/docs change.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
