### PR TITLE
fix(browser): dispose CDP listeners on disconnect (fix #10810)

### DIFF
--- a/packages/browser/src/node/cdp.ts
+++ b/packages/browser/src/node/cdp.ts
@@ -51,4 +51,12 @@ export class BrowserServerCDPHandler {
   once(event: string, listener: string): void {
     this.on(event, listener, true)
   }
+
+  dispose(): void {
+    for (const [event, listener] of Object.entries(this.listeners)) {
+      this.session.off(event as any, listener)
+    }
+    this.listenerIds = {}
+    this.listeners = {}
+  }
 }

--- a/packages/browser/src/node/projectParent.ts
+++ b/packages/browser/src/node/projectParent.ts
@@ -229,8 +229,9 @@ export class ParentBrowserProject {
     return handler
   }
 
-  removeCDPHandler(sessionId: string): void {
-    this.cdps.delete(sessionId)
+  removeCDPHandler(rpcId: string): void {
+    this.cdps.get(rpcId)?.dispose()
+    this.cdps.delete(rpcId)
   }
 
   async formatScripts(scripts: BrowserScript[] | undefined): Promise<HtmlTagDescriptor[]> {

--- a/test/browser/specs/cdp.test.ts
+++ b/test/browser/specs/cdp.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import { instances, provider, runInlineBrowserTests } from './utils'
+
+test.runIf(provider.name === 'playwright')('removes CDP listeners when a tester disconnects', async () => {
+  const chromium = instances.find(instance => instance.browser === 'chromium')
+  expect.assert(chromium)
+
+  const { stderr, testTree } = await runInlineBrowserTests(
+    {
+      'a.test.ts': `
+        import { test } from 'vitest'
+        import { cdp } from 'vitest/browser'
+
+        test('subscribes to console events', async () => {
+          await cdp().send('Console.enable')
+          cdp().on('Console.messageAdded', () => {})
+          await cdp().send('Runtime.evaluate', { expression: 'undefined' })
+        })
+      `,
+      'b.test.ts': `
+        import { expect, test } from 'vitest'
+
+        test('runs after the subscribed file', async () => {
+          console.log('TRIGGER STALE CDP LISTENER')
+          await new Promise(resolve => setTimeout(resolve, 50))
+          expect(1).toBe(1)
+        })
+      `,
+    },
+    {
+      fileParallelism: false,
+      browser: {
+        instances: [chromium],
+      },
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "a.test.ts": {
+        "subscribes to console events": "passed",
+      },
+      "b.test.ts": {
+        "runs after the subscribed file": "passed",
+      },
+    }
+  `)
+})


### PR DESCRIPTION
### Description

Fixes #10810

- Detach every provider CDP listener before removing a tester's server-side handler.
- Clear the handler bookkeeping so disconnected tester RPCs cannot receive later page events.
- Add a real Chromium regression with two sequential test files; it fails on `main` with `[birpc] rpc is closed, cannot call "cdpEvent"` and passes with this cleanup.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
  - Coverage portion: 176 test files passed, 429 tests passed, 9 skipped.
  - E2E portion: 165 files passed; 3 unrelated local failures remained in ANSI color detection, module-graph ordering, and a stale watch-report fixture.
- [x] `CI=true pnpm test:browser:playwright` — 38 files passed, 1 skipped; 95 tests passed, 1 skipped across Chromium, Firefox, and WebKit.
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`

### Documentation
- [x] No public API or user-facing functionality changed, so documentation is not required.

### Changesets
- [x] The PR title uses the required `fix:` prefix and describes the user-visible fix.

AI assistance disclosure: OpenAI Codex assisted with issue selection, implementation, regression testing, and PR preparation at the account owner's request.

<!-- VITEST_AUTOMATED_PR -->