### PR TITLE
fix: match force rerun triggers in dot directories (fix #10835)

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -134,7 +134,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import { createFile, editFile, resolvePath, runVitest } from '../../test-utils'
+import { createFile, editFile, resolvePath, runInlineTests, runVitest } from '../../test-utils'
 
 const fileName = 'fixtures/git-changed/related/rerun.temp'
 
@@ -32,6 +32,37 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
   })
+})
+
+it('matches a trigger path with a dot-prefixed directory', async () => {
+  const { stdout, stderr } = await runInlineTests({
+    'vitest.config.js': `
+      import path from 'node:path'
+      export default {
+        test: {
+          forceRerunTriggers: ['**/package.json'],
+          experimental: {
+            vcsProvider: {
+              async findChangedFiles({ root }) {
+                return [path.resolve(root, '.worktrees', 'project', 'package.json')]
+              },
+            },
+          },
+        },
+      }
+    `,
+    '.worktrees/project/package.json': '{}',
+    'trigger.test.js': `
+      import { test } from 'vitest'
+      test('trigger', () => {})
+    `,
+  }, {
+    changed: true,
+  })
+
+  expect(stderr).toBe('')
+  expect(stdout).toContain('1 passed')
+  expect(stdout).not.toContain('No test files found')
 })
 
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {

--- a/test/e2e/test/watch/file-watching.test.ts
+++ b/test/e2e/test/watch/file-watching.test.ts
@@ -1,7 +1,10 @@
+import crypto from 'node:crypto'
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import * as testUtils from '#test-utils'
+import { tmpdir } from 'node:os'
 
+import * as testUtils from '#test-utils'
 import { playwright } from '@vitest/browser-playwright'
+import { join } from 'pathe'
 import { afterEach, describe, expect, onTestFinished, test } from 'vitest'
 
 const sourceFile = 'fixtures/watch/math.ts'
@@ -63,6 +66,33 @@ test('editing force rerun trigger reruns all tests', async () => {
   await vitest.waitForStdout('RERUN  ../../force-watch/trigger.js')
   await vitest.waitForStdout('example.test.ts')
   await vitest.waitForStdout('math.test.ts')
+  await vitest.waitForStdout('2 passed')
+})
+
+test('editing a force rerun trigger in a dot-prefixed project path reruns all tests', async () => {
+  const root = join(tmpdir(), '.worktrees', crypto.randomUUID())
+  const fs = testUtils.useFS(root, {
+    'trigger.js': '',
+    'first.test.ts': `
+      import { test } from 'vitest'
+      test('first', () => {})
+    `,
+    'second.test.ts': `
+      import { test } from 'vitest'
+      test('second', () => {})
+    `,
+  }, false)
+  const { vitest } = await testUtils.runVitest({
+    root,
+    watch: true,
+    forceRerunTriggers: ['**/trigger.js'],
+  })
+
+  fs.editFile('trigger.js', content => `${content}\n`)
+
+  await vitest.waitForStdout('RERUN')
+  await vitest.waitForStdout('first.test.ts')
+  await vitest.waitForStdout('second.test.ts')
   await vitest.waitForStdout('2 passed')
 })
 


### PR DESCRIPTION
### Description

Fixes #10835.

`forceRerunTriggers` matched absolute changed and watched paths with picomatch's default `dot: false`, so patterns such as `**/package.json` did not match when a project path contained a dot-prefixed segment such as `.worktrees`.

This adds `{ dot: true }` only to the two `forceRerunTriggers` matcher calls used by `--changed` and watch mode. Test discovery, include/exclude behavior, and global Vite or chokidar watcher settings are unchanged.

Regression tests cover `--changed` and watch-mode trigger paths with dot-prefixed directory segments.

AI assistance disclosure: Codex was used as a personal assistant for investigation and implementation.

Human authorship confirmation: I have personally reviewed this change and stand behind its content.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [ ] Run the tests with `pnpm test:ci`.
  Focused validation:
  - `pnpm --filter vitest build`
  - `CI=true pnpm --filter @vitest/test-e2e test test/git-changed.test.ts` (6/6 passed)
  - `CI=true pnpm --filter @vitest/test-e2e test test/watch/file-watching.test.ts -t 'editing a force rerun trigger in a dot-prefixed project path reruns all tests'` (1/1 passed)
  - `pnpm lint`
  - `git diff --check`
  - The full local `test/watch/file-watching.test.ts` suite hangs in this environment; CI should verify that broader watcher suite.

### Documentation

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.
  This is a bug fix; no user-facing configuration or behavior is added.

### Changesets

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
