### PR TITLE
fix(runner): don't fail collection when accessing `error.stack` throws

### DIFF
--- a/packages/vitest/src/runtime/runner/artifact.ts
+++ b/packages/vitest/src/runtime/runner/artifact.ts
@@ -43,7 +43,7 @@ export async function recordArtifact<Artifact extends TestArtifact>(task: Test, 
 
   const stack = findTestFileStackTrace(
     task.file.filepath,
-    new Error('STACK_TRACE').stack!,
+    new Error('STACK_TRACE'),
   )
 
   if (stack) {

--- a/packages/vitest/src/runtime/runner/suite.ts
+++ b/packages/vitest/src/runtime/runner/suite.ts
@@ -436,8 +436,7 @@ function createSuiteCollector(
     }
 
     if (runner.config.includeTaskLocation) {
-      const error = stackTraceError.stack!
-      const stack = findTestFileStackTrace(currentTestFilepath, error)
+      const stack = findTestFileStackTrace(currentTestFilepath, stackTraceError)
       if (stack) {
         task.location = {
           line: stack.line,
@@ -523,7 +522,7 @@ function createSuiteCollector(
     if (runner && includeLocation && runner.config.includeTaskLocation) {
       const limit = Error.stackTraceLimit
       Error.stackTraceLimit = 15
-      const error = new Error('stacktrace').stack!
+      const error = new Error('stacktrace')
       Error.stackTraceLimit = limit
       const stack = findTestFileStackTrace(currentTestFilepath, error)
       if (stack) {

--- a/packages/vitest/src/runtime/runner/utils/collect.ts
+++ b/packages/vitest/src/runtime/runner/utils/collect.ts
@@ -1,13 +1,25 @@
 import type { ParsedStack } from '@vitest/utils'
 import { parseSingleStack } from '@vitest/utils/source-map'
 
-export function findTestFileStackTrace(testFilePath: string, error: string): ParsedStack | undefined {
+export function findTestFileStackTrace(testFilePath: string, error: Error): ParsedStack | undefined {
+  let stack: string | undefined
+  try {
+    stack = error.stack
+  }
+  catch {
+    // accessing `.stack` runs `Error.prepareStackTrace`, which can throw
+    // if the test froze `Object.prototype` (see vitest-dev/vscode#798)
+    return undefined
+  }
+  if (!stack) {
+    return undefined
+  }
   // first line is the error message
-  const lines = error.split('\n').slice(1)
+  const lines = stack.split('\n').slice(1)
   for (const line of lines) {
-    const stack = parseSingleStack(line)
-    if (stack && stack.file === testFilePath) {
-      return stack
+    const parsed = parseSingleStack(line)
+    if (parsed && parsed.file === testFilePath) {
+      return parsed
     }
   }
 }

--- a/test/e2e/fixtures/frozen-object-prototype/basic.test.ts
+++ b/test/e2e/fixtures/frozen-object-prototype/basic.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest'
+
+Object.freeze(Object.prototype)
+
+describe('with frozen Object.prototype', () => {
+  test('collects and runs', () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/test/e2e/test/frozen-object-prototype.test.ts
+++ b/test/e2e/test/frozen-object-prototype.test.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
+import { runVitest } from '../../test-utils'
+
+const root = resolve(__dirname, '..', 'fixtures', 'frozen-object-prototype')
+
+test('collects tests with includeTaskLocation when the test froze Object.prototype', async () => {
+  const { stderr, ctx } = await runVitest({
+    root,
+    includeTaskLocation: true,
+  })
+
+  expect(stderr).not.toContain('Cannot assign to read only property')
+
+  const files = ctx!.state.getFiles()
+  expect(files).toHaveLength(1)
+  expect(files[0].result?.state).toBe('pass')
+
+  const tests = files[0].tasks.flatMap(suite => suite.type === 'suite' ? suite.tasks : [suite])
+  expect(tests).toHaveLength(1)
+  expect(tests[0].result?.state).toBe('pass')
+})


### PR DESCRIPTION
### Description

With `includeTaskLocation` enabled, the runner reads `error.stack` for every registered test and suite. Reading `.stack` invokes Vite's `prepareStackTrace` sourcemap interceptor, which throws if the test file ran `Object.freeze(Object.prototype)` (root cause fixed in vitejs/vite#23073), failing collection of the whole file. Guard the `.stack` access in `findTestFileStackTrace` so the task only loses its location.

Fixes vitest-dev/vscode#798