### PR TITLE
fix: second ctrl+c forcefully exits

### DIFF
--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -85,14 +85,18 @@ export function registerConsoleShortcuts(
       || str === '\x1B'
       || (key && key.ctrl && key.name === 'c')
     ) {
-      if (!ctx.isCancelling) {
-        ctx.logger.log(
-          c.red('Cancelling test run. Press CTRL+c again to exit forcefully.\n'),
-        )
-        process.exitCode = 130
-
-        await ctx.cancelCurrentRun('keyboard-input')
+      // Already cancelling: this is the second press. Exit forcefully and
+      // unconditionally, without waiting for teardown to finish.
+      if (ctx.isCancelling) {
+        process.exit(130)
       }
+
+      ctx.logger.log(
+        c.red('Cancelling test run. Press CTRL+c again to exit forcefully.\n'),
+      )
+      process.exitCode = 130
+
+      await ctx.cancelCurrentRun('keyboard-input')
       return ctx.exit(true)
     }
 


### PR DESCRIPTION
### Description

As already implied by the log message, a second ctrl+c/SIGINT should forcefully exit the process. I do not want to wait for the test cleanup to run. I do not want to wait to see if the dev s3 server is going to respond. If I am pressing ctrl+c again, I want it to forcefully exit, not wait essentially indefinitely for a network response.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed. - fix aligned with existing messaging, not a breaking change for any user using a single ctrl+c, or following the expected output, or without slow test shutdown.
- [ ] Ideally, include a test that fails without this PR but passes with it. - very hard to test this kind of behaviour in the existing test framework, so left it out of scope, let me know.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
