### PR TITLE
fix: resolve Vitest's dist directory case-insensitively on Windows so only one runtime instance loads

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
+++ b/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
@@ -9,6 +9,27 @@ const normalizedDistDir = normalize(distDir)
 const relativeIds: Record<string, string> = {}
 const externalizeMap = new Map<string, string>()
 
+const fileUrlDriveRegexp = /^(file:\/\/\/)([a-z])(?=:)/i
+const distDirDrive = /^([a-z])(?=:)/i.exec(distDir)?.[1]
+
+// Windows keeps the drive letter of a path in the case it was written in, so
+// Vitest can be loaded through `c:\…` (the working directory the process was
+// started from) while Vite normalizes module ids to `C:/…`. Node keys its
+// module registry on the URL, so externalizing a test file's `vitest` import
+// to the other spelling evaluates a second copy of the runtime. That copy
+// never goes through `clearCollectorContext`, so its `runner` is undefined and
+// the first `describe()` in the file throws. Always hand back the drive letter
+// Vitest itself was loaded with.
+function withLoadedVitestDrive(externalize: string): string {
+  if (!distDirDrive) {
+    return externalize
+  }
+  return externalize.replace(fileUrlDriveRegexp, (match, prefix: string, drive: string) =>
+    drive.toLowerCase() === distDirDrive.toLowerCase()
+      ? `${prefix}${distDirDrive}`
+      : match)
+}
+
 // all Vitest imports always need to be externalized
 export function getCachedVitestImport(
   id: string,
@@ -27,9 +48,9 @@ export function getCachedVitestImport(
   const relativeRoot = relativeIds[root] ?? (relativeIds[root] = normalizedDistDir.slice(root.length))
   if (id.includes(distDir) || id.includes(normalizedDistDir)) {
     const { file, postfix } = splitFileAndPostfix(id)
-    const externalize = id.startsWith('file://')
+    const externalize = withLoadedVitestDrive(id.startsWith('file://')
       ? id
-      : `${pathToFileURL(file)}${postfix}`
+      : `${pathToFileURL(file)}${postfix}`)
     externalizeMap.set(id, externalize)
     return { externalize, type: 'module' }
   }
@@ -40,7 +61,7 @@ export function getCachedVitestImport(
   ) {
     const { file, postfix } = splitFileAndPostfix(id)
     const path = join(root, file)
-    const externalize = `${pathToFileURL(path)}${postfix}`
+    const externalize = withLoadedVitestDrive(`${pathToFileURL(path)}${postfix}`)
     externalizeMap.set(id, externalize)
     return { externalize, type: 'module' }
   }

--- a/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
+++ b/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
@@ -9,25 +9,46 @@ const normalizedDistDir = normalize(distDir)
 const relativeIds: Record<string, string> = {}
 const externalizeMap = new Map<string, string>()
 
-const fileUrlDriveRegexp = /^(file:\/\/\/)([a-z])(?=:)/i
-const distDirDrive = /^([a-z])(?=:)/i.exec(distDir)?.[1]
+// Windows paths are case-insensitive, so the same file can be spelled several
+// ways. `distDir` comes from `import.meta.url` and keeps the case the CLI was
+// invoked with, while ids come from Vite and carry the case of `process.cwd()`
+// with an uppercase drive. Node keys its module registry on the URL, so
+// externalizing a test file's `vitest` import to a different spelling of the
+// same file evaluates a second copy of the runtime. That copy never goes
+// through `clearCollectorContext`, so its `runner` is undefined and the first
+// `describe()` in the file throws. Match Vitest's own dist directory
+// regardless of case, and always hand back the spelling Vitest was loaded
+// with. Only on Windows: elsewhere two spellings really are two files.
+const isWindows = process.platform === 'win32'
+const distDirUrl = pathToFileURL(distDir).href
+const lowerDistDir = distDir.toLowerCase()
+const lowerNormalizedDistDir = normalizedDistDir.toLowerCase()
+const lowerDistDirUrl = distDirUrl.toLowerCase()
 
-// Windows keeps the drive letter of a path in the case it was written in, so
-// Vitest can be loaded through `c:\…` (the working directory the process was
-// started from) while Vite normalizes module ids to `C:/…`. Node keys its
-// module registry on the URL, so externalizing a test file's `vitest` import
-// to the other spelling evaluates a second copy of the runtime. That copy
-// never goes through `clearCollectorContext`, so its `runner` is undefined and
-// the first `describe()` in the file throws. Always hand back the drive letter
-// Vitest itself was loaded with.
-function withLoadedVitestDrive(externalize: string): string {
-  if (!distDirDrive) {
+function isVitestDistId(id: string): boolean {
+  if (id.includes(distDir) || id.includes(normalizedDistDir)) {
+    return true
+  }
+  if (!isWindows) {
+    return false
+  }
+  const lowerId = id.toLowerCase()
+  return lowerId.includes(lowerDistDir)
+    || lowerId.includes(lowerNormalizedDistDir)
+    || lowerId.includes(lowerDistDirUrl)
+}
+
+function withLoadedVitestCasing(externalize: string): string {
+  if (!isWindows) {
     return externalize
   }
-  return externalize.replace(fileUrlDriveRegexp, (match, prefix: string, drive: string) =>
-    drive.toLowerCase() === distDirDrive.toLowerCase()
-      ? `${prefix}${distDirDrive}`
-      : match)
+  const index = externalize.toLowerCase().indexOf(lowerDistDirUrl)
+  if (index === -1) {
+    return externalize
+  }
+  return externalize.slice(0, index)
+    + distDirUrl
+    + externalize.slice(index + distDirUrl.length)
 }
 
 // all Vitest imports always need to be externalized
@@ -46,11 +67,11 @@ export function getCachedVitestImport(
   // so we already have it cached by Node.js
   const root = state().config.root
   const relativeRoot = relativeIds[root] ?? (relativeIds[root] = normalizedDistDir.slice(root.length))
-  if (id.includes(distDir) || id.includes(normalizedDistDir)) {
+  if (isVitestDistId(id)) {
     const { file, postfix } = splitFileAndPostfix(id)
-    const externalize = withLoadedVitestDrive(id.startsWith('file://')
-      ? id
-      : `${pathToFileURL(file)}${postfix}`)
+    const externalize = id.startsWith('file://')
+      ? withLoadedVitestCasing(id)
+      : `${withLoadedVitestCasing(pathToFileURL(file).href)}${postfix}`
     externalizeMap.set(id, externalize)
     return { externalize, type: 'module' }
   }
@@ -61,7 +82,7 @@ export function getCachedVitestImport(
   ) {
     const { file, postfix } = splitFileAndPostfix(id)
     const path = join(root, file)
-    const externalize = withLoadedVitestDrive(`${pathToFileURL(path)}${postfix}`)
+    const externalize = `${withLoadedVitestCasing(pathToFileURL(path).href)}${postfix}`
     externalizeMap.set(id, externalize)
     return { externalize, type: 'module' }
   }

--- a/test/e2e/test/windows-drive-case.test.ts
+++ b/test/e2e/test/windows-drive-case.test.ts
@@ -28,11 +28,14 @@ test.runIf(process.platform === 'win32')(`works on windows with a lowercase driv
 // up importing a second copy of the runtime with no collector state.
 test.runIf(process.platform === 'win32')('loads a single Vitest instance when the CLI is resolved through a lowercase drive', async () => {
   const lowercaseCli = cli.replace(/^[A-Z]:\\/i, r => r.toLowerCase())
+  // Guard the premise: on a UNC path there is no drive letter to lowercase and
+  // the test would pass without exercising anything.
+  expect(lowercaseCli).toMatch(/^[a-z]:\\/)
+
   const { stdout, stderr } = await x('node', [lowercaseCli, 'run', '--no-watch', '--maxWorkers=1'], {
     nodeOptions: { cwd, env: { ...process.env, AI_AGENT: '' } },
   })
 
-  expect(lowercaseCli[0]).toEqual(lowercaseCli[0].toLowerCase())
   expect(stderr).not.toContain('failed to find the current suite')
   expect(stdout).toContain('1 passed')
 })

--- a/test/e2e/test/windows-drive-case.test.ts
+++ b/test/e2e/test/windows-drive-case.test.ts
@@ -1,10 +1,13 @@
+import { fileURLToPath } from 'node:url'
 import { join } from 'pathe'
+import { x } from 'tinyexec'
 import { expect, test } from 'vitest'
 import { runVitestCli } from '../../test-utils'
 
 const _DRIVE_LETTER_START_RE = /^[A-Z]:\//i
 const root = join(import.meta.dirname, '../fixtures/windows-drive-case')
 const cwd = root.replace(_DRIVE_LETTER_START_RE, r => r.toLowerCase())
+const cli = fileURLToPath(new URL('../../../packages/vitest/vitest.mjs', import.meta.url))
 
 test.runIf(process.platform === 'win32')(`works on windows with a lowercase drive: ${cwd}`, async () => {
   const { stderr, stdout } = await runVitestCli({
@@ -15,5 +18,21 @@ test.runIf(process.platform === 'win32')(`works on windows with a lowercase driv
 
   expect(cwd[0]).toEqual(cwd[0].toLowerCase())
   expect(stderr).toBe('')
+  expect(stdout).toContain('1 passed')
+})
+
+// Running the CLI through a lowercase drive is what happens with a local
+// install: `npx vitest` resolves the binary through the working directory, so
+// Vitest is loaded from `c:\…` while Vite normalizes module ids to `C:/…`.
+// Node treats the two URLs as different modules, and the test file used to end
+// up importing a second copy of the runtime with no collector state.
+test.runIf(process.platform === 'win32')('loads a single Vitest instance when the CLI is resolved through a lowercase drive', async () => {
+  const lowercaseCli = cli.replace(/^[A-Z]:\\/i, r => r.toLowerCase())
+  const { stdout, stderr } = await x('node', [lowercaseCli, 'run', '--no-watch', '--maxWorkers=1'], {
+    nodeOptions: { cwd, env: { ...process.env, AI_AGENT: '' } },
+  })
+
+  expect(lowercaseCli[0]).toEqual(lowercaseCli[0].toLowerCase())
+  expect(stderr).not.toContain('failed to find the current suite')
   expect(stdout).toContain('1 passed')
 })

--- a/test/e2e/test/windows-drive-case.test.ts
+++ b/test/e2e/test/windows-drive-case.test.ts
@@ -21,21 +21,33 @@ test.runIf(process.platform === 'win32')(`works on windows with a lowercase driv
   expect(stdout).toContain('1 passed')
 })
 
-// Running the CLI through a lowercase drive is what happens with a local
-// install: `npx vitest` resolves the binary through the working directory, so
-// Vitest is loaded from `c:\…` while Vite normalizes module ids to `C:/…`.
-// Node treats the two URLs as different modules, and the test file used to end
-// up importing a second copy of the runtime with no collector state.
-test.runIf(process.platform === 'win32')('loads a single Vitest instance when the CLI is resolved through a lowercase drive', async () => {
-  const lowercaseCli = cli.replace(/^[A-Z]:\\/i, r => r.toLowerCase())
-  // Guard the premise: on a UNC path there is no drive letter to lowercase and
-  // the test would pass without exercising anything.
-  expect(lowercaseCli).toMatch(/^[a-z]:\\/)
+// The case that breaks is Vitest being *loaded* through a differently spelled
+// path, which is what a local install does: `npx vitest` resolves the binary
+// through the working directory, so Vitest comes from `c:\…` while Vite
+// normalizes module ids to `C:/…`. Node treats the two URLs as different
+// modules, and the test file used to end up importing a second copy of the
+// runtime with no collector state. Depending on where the file's first call
+// lands, that surfaces as "failed to find the current suite" or as
+// "Cannot read properties of undefined (reading 'config')".
+const spellings = {
+  'a lowercase drive letter': (path: string) => path.replace(/^[A-Z]:\\/i, r => r.toLowerCase()),
+  'an entirely lowercase path': (path: string) => path.toLowerCase(),
+}
 
-  const { stdout, stderr } = await x('node', [lowercaseCli, 'run', '--no-watch', '--maxWorkers=1'], {
-    nodeOptions: { cwd, env: { ...process.env, AI_AGENT: '' } },
+for (const [name, spell] of Object.entries(spellings)) {
+  test.runIf(process.platform === 'win32')(`loads a single Vitest instance when the CLI is resolved through ${name}`, async () => {
+    const spelledCli = spell(cli)
+    // Guard the premise: on a UNC path there is no drive letter to respell and
+    // the test would pass without exercising anything.
+    expect(spelledCli).toMatch(/^[a-z]:\\/)
+
+    const { stdout, stderr, exitCode } = await x('node', [spelledCli, 'run', '--no-watch', '--maxWorkers=1'], {
+      nodeOptions: { cwd, env: { ...process.env, AI_AGENT: '' } },
+    })
+
+    expect(stderr).not.toContain('failed to find the current suite')
+    expect(stderr).not.toContain('reading \'config\'')
+    expect(stdout).toContain('1 passed')
+    expect(exitCode).toBe(0)
   })
-
-  expect(stderr).not.toContain('failed to find the current suite')
-  expect(stdout).toContain('1 passed')
-})
+}


### PR DESCRIPTION
### Description

Resolves #10692.

On Windows a path keeps the drive letter in the case it was written in. `npx vitest` resolves the local binary through the working directory, so after `cd /d c:\project` Vitest itself is loaded from `c:\project\node_modules\vitest\dist\index.js`, while Vite normalizes module ids to `C:/project/...`.

`getCachedVitestImport` builds the externalized specifier from the id, so the test file's `import { describe } from 'vitest'` becomes `file:///C:/project/node_modules/vitest/dist/index.js`. Node keys its module registry on the URL string, so that is a different module from the `file:///c:/project/...` copy the worker already loaded. The test file then gets a second copy of the runtime, one that never went through `clearCollectorContext`, so its module-level `runner` and `defaultSuite` are undefined and the first `describe()` fails with either

```
Error: Vitest failed to find the current suite. One of the following is possible:
```

or

```
TypeError: Cannot read properties of undefined (reading 'config')
```

The fix makes the resolver recognize Vitest's own dist directory regardless of case and hand back the spelling Vitest was actually loaded with, so every spelling maps to one module instance. It is gated to Windows, since on a case-sensitive filesystem two spellings really are two files.

### Reproduction

`cmd.exe` preserves the drive letter as typed. PowerShell uppercases it on `Set-Location`, so it cannot show this, and `--root c:\...` cannot either because an explicit root is normalized. The lowercase drive has to arrive through the working directory.

```
> cmd /d /c "cd /d C:\project && npx vitest run"
 Test Files  1 passed (1)

> cmd /d /c "cd /d c:\project && npx vitest run"
TypeError: Cannot read properties of undefined (reading 'config')
 Test Files  1 failed (1)   Tests  no tests
```

Reproduced on 4.1.10 and on 5.0.0-beta.7, Node 24.15.0, Windows 11 Pro 26200.

### Tests

`test/e2e/test/windows-drive-case.test.ts` already covered a lowercase **root**, which passes both before and after this change: `runVitestCli` spawns the CLI by its real path, so Vitest is still loaded with the canonical drive letter and only `config.root` differs. The case that breaks is Vitest being *loaded* through the lowercase drive, which is what a local install does. The added test spawns the CLI through a lowercased path with the fixture as the working directory.

The added cases cover two spellings, a lowercase drive letter and an entirely lowercase CLI path, and assert the exit code as well as both error spellings. Both fail on `main` and pass with this change. The pre-existing case in that file passes either way.

Run on Windows 11 Pro 26200, Node 24.15.0:

- `cd test/e2e && pnpm exec vitest run windows-drive-case` — 3 passed with the change, 2 of the 3 fail with the resolver reverted to `main`
- `cd test/unit && pnpm exec vitest run` — 627 files, 7379 tests, green
- `pnpm run test:ci` — 43 files failed, 133 passed. I then ran the same command on a clean checkout of the parent commit and got the identical result: the same 43 files, the same 40 failing test names, all in the coverage suite. Diffing the two failure lists gives an empty set in both directions, so none of it comes from this change. I have not tried to work out why the coverage suite fails on this machine.
- `pnpm exec eslint` on both changed files — clean
- `pnpm exec tsc --noEmit -p packages/vitest/tsconfig.json` — the two `CDPSession.send` errors in `packages/vitest/src/node/pools/browser.ts` are present on the parent commit as well

Both tests are gated on `process.platform === 'win32'`.

### Scope and limits

Only the drive letter can differ. Windows resolves the rest of the path to its real casing, which I checked by starting a shell with an entirely lowercase path and printing `process.cwd()`.

### Why this layer

The authoritative fact is the URL Node used to load Vitest, and that is fixed by how the CLI was invoked. Normalizing `config.root` does not help: with an explicit canonical root and a lowercase working directory the failure is unchanged.

```
> cmd /d /c "cd /d c:\project && npx vitest run --root C:\project"
 RUN  v5.0.0-beta.7 C:/project
TypeError: Cannot read properties of undefined (reading 'config')
 Test Files  1 failed (1)
```

So the mismatch has to be reconciled where the externalized specifier is built, against the path Vitest was actually loaded from.

The two spellings can differ in more than the drive letter. `distDir` is derived from `import.meta.url`, which keeps whatever case the CLI path was written in, while ids come from Vite and carry `process.cwd()`'s case with an uppercase drive. Windows canonicalizes the components of a working directory but not of a path passed to `node`, so the mismatch is not limited to one character. The matching is therefore case-insensitive over the whole dist directory rather than a drive-letter rewrite.

Things this deliberately does not cover:

- The `bareVitestRegexp` branch hands the bare specifier to Node, so there is no path to rewrite. Making it resolve through `distDir` would mean returning an absolute URL and changing how subpath exports resolve, which seemed like the wrong trade.
- Browser mode and the vm pool are untested for this, though the `file://` id path the vm pool produces does go through the same helper now.

Unrelated, spotted while reading the neighbours and left alone: `runtime/workers/native.ts:71-72,159` and `packages/browser/src/node/index.ts:373` compare `distDir` (a backslash path from `node:path.resolve`) against `file://` URLs, so on Windows those checks look like they can never match. `node/plugins/mocks.ts:12` normalizes first and is fine. Happy to open a separate issue if that is useful.

I have not confirmed whether this also explains #10812, which reports the same `reading 'config'` variant intermittently at full-suite scale. It looked close enough to be worth mentioning, but I did not verify it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

---

AI disclosure, per CONTRIBUTING.md: I used Claude Code as an assistant while investigating this. The reproduction, the bisect down to `getCachedVitestImport`, and the before/after runs were done on my own Windows machine, and I can answer questions about any part of it.
