### PR TITLE
feat!: support nested projects

### DIFF
--- a/docs/config/projects.md
+++ b/docs/config/projects.md
@@ -3,9 +3,11 @@ title: projects | Config
 outline: deep
 ---
 
-# projects <CRoot />
+# projects
 
 - **Type:** `TestProjectConfiguration[]`
 - **Default:** `[]`
 
 An array of [projects](/guide/projects).
+
+A config file that declares `projects` doesn't run tests itself, it only provides the projects that do. This also applies to project config files: a referenced config that declares `projects` becomes a container for [nested projects](/guide/projects#nested-projects). The option is not supported inside an inline project configuration.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -110,6 +110,34 @@ export default defineConfig({
 })
 ```
 
+### Referenced Config Files Can Define Their Own Projects
+
+A config file referenced in [`test.projects`](/guide/projects) that declares `projects` itself is now treated like the root config: it doesn't run tests on its own, it only provides the [nested projects](/guide/projects#nested-projects) it declares. Their names are prefixed with the name of the declaring config, e.g. `app (unit)`.
+
+In Vitest 4 the `projects` field of a referenced config was silently ignored and the config ran as a single project. Check that your project configs don't carry a `projects` field unknowingly. The most common way to do that is merging a config that defines it:
+
+```ts [packages/app/vitest.config.ts]
+import { defineProject, mergeConfig } from 'vitest/config'
+import rootConfig from '../../vitest.config' // [!code --]
+import sharedConfig from '../../vitest.shared' // [!code ++]
+
+export default mergeConfig(
+  // the root config defines `test.projects`, so merging it
+  // would turn this project into a container for those projects
+  rootConfig, // [!code --]
+  sharedConfig, // [!code ++]
+  defineProject({
+    test: {
+      environment: 'jsdom',
+    },
+  }),
+)
+```
+
+Since the inherited `projects` paths resolve relative to the referenced config, this misconfiguration usually fails loudly at startup with `Projects definition references a non-existing file or a directory`, `No projects were found in "..."`, or a circular `projects` definition error.
+
+Inline configurations continue to ignore the `projects` field at runtime, but it is now also excluded from their `ProjectConfig` type.
+
 ### Hoisted Mocking Calls Must Be at the Top Level
 
 [`vi.mock`](/api/vi#vi-mock), [`vi.unmock`](/api/vi#vi-unmock), and [`vi.hoisted`](/api/vi#vi-hoisted) are hoisted to the top of the file and run before any surrounding code. Calling them inside a function, block, or `describe`/`test` callback previously only logged a warning. Vitest 5.0 now throws, because the call does not execute where it is written:

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -340,9 +340,9 @@ export default defineConfig({
 ```
 
 ```ts [packages/app/vitest.config.ts]
-import { defineConfig } from 'vitest/config'
+import { defineProject } from 'vitest/config'
 
-export default defineConfig({
+export default defineProject({
   test: {
     name: 'app',
     projects: [
@@ -370,9 +370,9 @@ The names of nested projects are prefixed with the name of the config that decla
 To also run the tests of the config that declares `projects`, reference its own config file:
 
 ```ts [packages/app/vitest.config.ts]
-import { defineConfig } from 'vitest/config'
+import { defineProject } from 'vitest/config'
 
-export default defineConfig({
+export default defineProject({
   test: {
     name: 'app',
     include: ['**/*.test.ts'],

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -324,3 +324,70 @@ Some of the configuration options are not allowed in a project config. Most nota
 
 All configuration options that are not supported inside a project configuration are marked with a <CRoot /> icon next to their name. They can only be defined once in the root config file.
 :::
+
+## Nested Projects
+
+A project referenced as a config file (or a directory containing one) can declare `projects` itself. Such a config behaves like the root config: it doesn't run any tests on its own, it only provides the projects that do. This makes it possible to reference a workspace that already defines its own projects:
+
+```ts [vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: ['./packages/app/vitest.config.ts'],
+  },
+})
+```
+
+```ts [packages/app/vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'app',
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['**/*.unit.test.ts'],
+        },
+      },
+      {
+        test: {
+          name: 'e2e',
+          include: ['**/*.e2e.test.ts'],
+        },
+      },
+    ],
+  },
+})
+```
+
+Nested projects work the same way as projects defined in the root config: inline configurations extend the config that declares them (the `app` config here, not the root one), `extends` paths are resolved relative to it, and its own `globalSetup` is inherited by the extending projects [like any other non-root config](#configuration).
+
+The names of nested projects are prefixed with the name of the config that declares them, so the example above creates the `app (unit)` and `app (e2e)` projects. The `--project` filter matches the prefix as well: `--project app` runs every project of the `app` config, while `--project "app (unit)"` runs only one of them.
+
+To also run the tests of the config that declares `projects`, reference its own config file:
+
+```ts [packages/app/vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'app',
+    include: ['**/*.test.ts'],
+    projects: [
+      // the "app" project runs its own "include" alongside "app (unit)"
+      './vitest.config.ts',
+      {
+        test: {
+          name: 'unit',
+          include: ['**/*.unit.test.ts'],
+        },
+      },
+    ],
+  },
+})
+```
+
+Note that only config files can define nested projects. The `projects` option inside an inline configuration is not supported.

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -335,11 +335,18 @@ export class Vitest {
         await this._restart()
       }
 
+      // container configs have no Vite server (and might be outside the root),
+      // so their files are watched explicitly
+      if (resolved._containerConfigFiles?.length) {
+        server.watcher.add(resolved._containerConfigFiles)
+      }
+
       // since we set `server.hmr: false`, Vite does not auto restart itself
       server.watcher.on('change', async (file) => {
         file = normalize(file)
         const isConfig = file === server.config.configFile
           || this.projects.some(p => p.vite.config.configFile === file)
+          || this.config._containerConfigFiles?.includes(file)
         if (isConfig) {
           await this._restart('config')
         }

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -16,13 +16,14 @@ import type {
   UserConfig,
   UserWorkspaceConfig,
 } from '../types/config'
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import os from 'node:os'
 import { deepClone } from '@vitest/utils/helpers'
 import { basename, dirname, relative, resolve } from 'pathe'
 import { glob, isDynamicPattern } from 'tinyglobby'
 import { mergeConfig, resolveConfig as viteResolveConfig } from 'vite'
 import { configFiles as defaultConfigFiles } from '../../constants'
+import { wildcardPatternToRegExp } from '../../utils/base'
 import { limitConcurrency } from '../../utils/limit-concurrency'
 import { isExcludedByProjectFilter, matchesProjectFilter, resolveTestConfig } from '../config/resolveConfig'
 import { BrowserLoaderPlugin, createClusterServer } from '../plugins/browserLoader'
@@ -74,6 +75,9 @@ const PROJECT_CLI_OVERRIDES = [
  * - If the user declared `test.projects`, each declared project gets its own
  *   resolved Vite config plus per-project Vitest test config.
  * - Otherwise the root config is used as the single base entry.
+ * - A file-based project whose config declares `projects` itself is a
+ *   container: like the root, it doesn't run tests and is replaced by the
+ *   projects it declares (recursively).
  * - Browser instances expand each entry with `browser.enabled` into one entry
  *   per instance (sharing `viteConfig` with the parent).
  * - Benchmarks add a benchmark variant for each entry whose
@@ -96,12 +100,35 @@ export async function resolveProjectEntries(
   // falls through to the default root-project entry.
   let baseEntries: ResolvedProjectEntry[]
   if (definitions !== undefined) {
-    baseEntries = await resolveDeclaredProjectEntries(
+    const cliOverrides = PROJECT_CLI_OVERRIDES.reduce((acc, name) => {
+      if (name in globalConfig.cliOptions) {
+        acc[name] = globalConfig.cliOptions[name] as any
+      }
+      return acc
+    }, {} as UserConfig)
+    const containerConfigFiles: string[] = []
+    const context: ProjectsResolutionContext = {
       harness,
-      globalViteConfig,
-      globalConfig,
-      definitions,
-    )
+      rootViteConfig: globalViteConfig,
+      rootConfig: globalConfig,
+      parentViteConfig: globalViteConfig,
+      parentConfig: globalConfig,
+      cliOverrides,
+      ancestors: [],
+      chain: globalViteConfig.configFile
+        ? [safeRealpath(globalViteConfig.configFile)]
+        : [],
+      containerConfigFiles,
+    }
+    baseEntries = await resolveDeclaredProjectEntries(context, definitions)
+    if (containerConfigFiles.length) {
+      // appended rather than assigned so `injectTestProjects` containers
+      // are also watched
+      globalConfig._containerConfigFiles = [
+        ...(globalConfig._containerConfigFiles || []),
+        ...containerConfigFiles,
+      ]
+    }
   }
   else {
     baseEntries = [{ viteConfig: globalViteConfig, projectConfig: globalConfig }]
@@ -260,58 +287,80 @@ async function applyBrowserOptimizeDeps(
   )
 }
 
+/**
+ * The set of values threaded through (possibly recursive) project resolution.
+ *
+ * The `root*` pair is the true root config: it carries run-wide values (CLI
+ * options, the `--project` filter, the programmatic config). The `parent*`
+ * pair is the config the current `projects` array is declared in — the root
+ * itself or a container config — and provides the default `extends` target,
+ * env defaults and the base for resolving relative definitions.
+ */
+interface ProjectsResolutionContext {
+  harness: PluginHarness
+  rootViteConfig: ResolvedViteConfig
+  rootConfig: ResolvedConfig
+  parentViteConfig: ResolvedViteConfig
+  parentConfig: ResolvedConfig
+  /** CLI options projects may override, computed once from the root's `cliOptions` */
+  cliOverrides: UserConfig
+  /** names of the containers above this level, outermost first */
+  ancestors: string[]
+  /** realpaths of the config files above this level, the cycle guard */
+  chain: string[]
+  /** shared across levels; collects container config files for the watcher */
+  containerConfigFiles: string[]
+}
+
 async function resolveDeclaredProjectEntries(
-  harness: PluginHarness,
-  globalViteConfig: ResolvedViteConfig,
-  globalConfig: ResolvedConfig,
+  context: ProjectsResolutionContext,
   definitions: TestProjectConfiguration[],
 ): Promise<ResolvedProjectEntry[]> {
+  const { parentViteConfig, parentConfig } = context
   const { configFiles, projectConfigs, nonConfigDirectories } = await resolveTestProjectConfigs(
-    globalViteConfig,
-    globalConfig,
+    parentViteConfig,
+    parentConfig,
     definitions,
   )
 
-  const cliOverrides = PROJECT_CLI_OVERRIDES.reduce((acc, name) => {
-    if (name in globalConfig.cliOptions) {
-      acc[name] = globalConfig.cliOptions[name] as any
-    }
-    return acc
-  }, {} as UserConfig)
   const concurrent = limitConcurrency(os.availableParallelism?.() || os.cpus().length || 5)
   const fileProjects = [...configFiles, ...nonConfigDirectories]
 
   const promises: Promise<ResolvedProjectEntry>[] = []
 
   projectConfigs.forEach((options, index) => {
-    const configRoot = globalConfig.root
+    const configRoot = parentConfig.root
     // if extends a config file, resolve the file path
     const configFile = typeof options.extends === 'string'
       ? resolve(configRoot, options.extends)
       : options.extends !== false
-        ? (globalViteConfig.configFile || false)
+        ? (parentViteConfig.configFile || false)
         : false
-    // if `root` is configured, resolve it relative to vite root (like other options)
-    // if `root` is not specified, inline configs use the same root as the root project
+    // if `root` is configured, resolve it relative to the declaring config's
+    // root (like other options); if `root` is not specified, inline configs
+    // use the same root as the declaring config
     const rawRoot = options.test?.root ?? options.root
     const root = rawRoot
       ? resolve(configRoot, rawRoot)
       : configRoot
 
-    promises.push(concurrent(() => resolveSingleProjectEntry(harness, globalViteConfig, globalConfig, {
+    promises.push(concurrent(() => resolveSingleProjectEntry(context, {
       ...options,
       root,
       configFile,
-    }, index, cliOverrides)))
+    }, index)))
   })
 
   for (const path of fileProjects) {
-    // if file leads to the root config, then we can just reuse it because we already initialized it
-    if (globalViteConfig.configFile === path) {
-      // The root viteConfig is already resolved; emit it as an entry directly.
+    // if the file leads to the declaring config itself, reuse the already
+    // resolved pair: the root (or the container) also runs as a regular project
+    if (parentViteConfig.configFile === path) {
       promises.push(Promise.resolve({
-        viteConfig: globalViteConfig,
-        projectConfig: globalConfig,
+        viteConfig: parentViteConfig,
+        projectConfig: parentConfig,
+        ancestors: context.ancestors.length > 1
+          ? context.ancestors.slice(0, -1)
+          : undefined,
       }))
       continue
     }
@@ -320,12 +369,9 @@ async function resolveDeclaredProjectEntries(
     const projectRoot = path.endsWith('/') ? path : dirname(path)
 
     promises.push(concurrent(() => resolveSingleProjectEntry(
-      harness,
-      globalViteConfig,
-      globalConfig,
+      context,
       { root: projectRoot, configFile },
       path,
-      cliOverrides,
     )))
   }
 
@@ -348,18 +394,86 @@ async function resolveDeclaredProjectEntries(
     )
   }
 
-  return entries
+  return flattenContainerEntries(context, entries)
+}
+
+/**
+ * Replace container entries (file-based configs that declare `projects`) with
+ * the projects they declare, recursively. A container behaves like the root
+ * config: it doesn't run tests and never gets a Vite server; its projects
+ * extend it by default and their names are prefixed with the container's name.
+ */
+async function flattenContainerEntries(
+  context: ProjectsResolutionContext,
+  entries: ResolvedProjectEntry[],
+): Promise<ResolvedProjectEntry[]> {
+  const result: ResolvedProjectEntry[] = []
+  for (const entry of entries) {
+    const definitions = entry.projectConfig.projects
+    // inline projects cannot declare `projects`; the declaring config's own
+    // entry (emitted when it references its own config file) is kept as-is —
+    // its `projects` are the definitions currently being resolved
+    if (entry.inline || definitions === undefined || entry.projectConfig === context.parentConfig) {
+      result.push(entry)
+      continue
+    }
+
+    const configFile = entry.viteConfig.configFile
+    const relativeFile = configFile
+      ? relative(context.rootConfig.root, configFile)
+      : entry.projectConfig.name
+    let chain = context.chain
+    if (configFile) {
+      const realConfigFile = safeRealpath(configFile)
+      if (chain.includes(realConfigFile)) {
+        throw new Error(
+          [
+            `Found a circular "projects" definition: `,
+            [...chain, realConfigFile].map(file => `"${relative(context.rootConfig.root, file)}"`).join(' -> '),
+            '. Make sure your configuration is correct.',
+          ].join(''),
+        )
+      }
+      chain = [...chain, realConfigFile]
+      context.containerConfigFiles.push(configFile)
+    }
+
+    const childContext: ProjectsResolutionContext = {
+      ...context,
+      parentViteConfig: entry.viteConfig,
+      parentConfig: entry.projectConfig,
+      ancestors: [...context.ancestors, entry.projectConfig.name],
+      chain,
+    }
+    const children = await resolveDeclaredProjectEntries(childContext, definitions)
+    if (!children.length) {
+      throw new Error(
+        `No projects were found in "${relativeFile}". Make sure your configuration is correct.`,
+      )
+    }
+    result.push(...children)
+  }
+  return result
+}
+
+function safeRealpath(path: string): string {
+  try {
+    return realpathSync(path)
+  }
+  catch {
+    return path
+  }
 }
 
 // `name` must stay unique per project, `projects` would redefine the whole workspace
 const NON_INHERITED_OPTIONS = ['name', 'projects'] as const
 
 // the root `globalSetup` already runs once per test run; a non-root
-// config keeps it because nothing else runs it
+// config (a shared config or a container) keeps it because nothing else runs it
 const NON_INHERITED_ROOT_OPTIONS = [...NON_INHERITED_OPTIONS, 'globalSetup'] as const
 
-function ProjectInheritancePlugin(options: ViteInlineConfig, extendsRootConfig: boolean): VitePlugin {
-  const nonInheritedOptions = extendsRootConfig
+function ProjectInheritancePlugin(options: ViteInlineConfig, extendsTrueRootConfig: boolean): VitePlugin {
+  const nonInheritedOptions = extendsTrueRootConfig
     ? NON_INHERITED_ROOT_OPTIONS
     : NON_INHERITED_OPTIONS
   return {
@@ -405,10 +519,10 @@ function ProjectInheritancePlugin(options: ViteInlineConfig, extendsRootConfig: 
  *   same guard in `CliOverride`)
  */
 function inheritRootViteOverrides(
-  globalConfig: ResolvedConfig,
+  rootConfig: ResolvedConfig,
   options: ViteInlineConfig,
 ): ViteInlineConfig {
-  const { plugins: _plugins, ...rootViteOverrides } = globalConfig.viteOverrides
+  const { plugins: _plugins, ...rootViteOverrides } = rootConfig.viteOverrides
   // cloned so plugins that mutate inherited arrays in place don't share
   // them between the root and every project
   const inherited = deepClone(rootViteOverrides)
@@ -418,13 +532,11 @@ function inheritRootViteOverrides(
 }
 
 async function resolveSingleProjectEntry(
-  harness: PluginHarness,
-  globalViteConfig: ResolvedViteConfig,
-  globalConfig: ResolvedConfig,
+  context: ProjectsResolutionContext,
   options: ViteInlineConfig & { extends?: string | boolean },
   workspacePath: string | number,
-  cliOverrides: UserConfig,
 ): Promise<ResolvedProjectEntry> {
+  const { harness, rootViteConfig, rootConfig, parentViteConfig, parentConfig, cliOverrides } = context
   const { configFile, ...restOptions } = options
 
   const browserHolder: BrowserContributionHolder = {}
@@ -432,57 +544,66 @@ async function resolveSingleProjectEntry(
   // only inline entries (keyed by their index) extend another config;
   // file-based projects own all of their values
   const isInlineEntry = typeof workspacePath === 'number'
-  const inheritsRootConfig = isInlineEntry
+  const inheritsParentConfig = isInlineEntry
     && options.extends !== false
     && typeof options.extends !== 'string'
-  // `extends: './path'` can still point back to the root config file
-  const extendsRootConfig = inheritsRootConfig
-    || (!!configFile && configFile === globalViteConfig.configFile)
+  // the root `globalSetup` runs once per test run, so it is stripped from
+  // projects extending the root config file (directly or via `extends: true`
+  // at the top level); a container's `globalSetup` stays inherited because
+  // nothing else runs it, like any other non-root extended config
+  const extendsTrueRootConfig = (inheritsParentConfig && parentConfig === rootConfig)
+    || (!!configFile && configFile === rootViteConfig.configFile)
 
-  const inlineOptions = inheritsRootConfig
-    ? inheritRootViteOverrides(globalConfig, restOptions)
+  // the programmatic config is part of the effective root config; a container
+  // is fully described by its file, so only root-level projects inherit it
+  const inlineOptions = inheritsParentConfig && parentConfig === rootConfig
+    ? inheritRootViteOverrides(rootConfig, restOptions)
     : restOptions
 
   const projectInline: ViteInlineConfig = {
     ...inlineOptions,
     configFile,
-    configLoader: globalViteConfig.inlineConfig.configLoader,
+    configLoader: parentViteConfig.inlineConfig.configLoader,
     // this will make "mode": "test" inside defineConfig
-    mode: options.test?.mode || options.mode || globalConfig.mode,
+    mode: options.test?.mode || options.mode || parentConfig.mode,
     plugins: [
       CliOverride(cliOverrides),
       ...(options.plugins || []),
       ...WorkspaceVitestPlugin(
         harness,
-        globalViteConfig,
-        globalConfig,
+        parentViteConfig,
+        rootConfig,
         options,
       ),
       ...BrowserLoaderPlugin(browserHolder, harness),
       ...(isInlineEntry
-        ? [ProjectInheritancePlugin(options, extendsRootConfig)]
+        ? [ProjectInheritancePlugin(options, extendsTrueRootConfig)]
         : []),
     ],
   }
 
   const projectViteConfig = await viteResolveConfig(projectInline, 'serve')
 
-  // inherit the root's resolved env as defaults; a project's own env wins,
-  // like every other option a project can override
-  for (const key in globalViteConfig.env) {
-    projectViteConfig.env[key] ??= globalViteConfig.env[key]
+  // inherit the declaring config's resolved env as defaults; a project's own
+  // env wins, like every other option a project can override
+  for (const key in parentViteConfig.env) {
+    projectViteConfig.env[key] ??= parentViteConfig.env[key]
   }
 
   const mergedOptions = (projectViteConfig.test ?? {}) as UserConfig
 
   // resolved after `viteResolveConfig` so a plugin can still set `test.name`
-  mergedOptions.name = resolveProjectName(mergedOptions.name, workspacePath)
+  mergedOptions.name = resolveProjectName(
+    mergedOptions.name,
+    workspacePath,
+    context.ancestors.at(-1),
+  )
 
   const projectConfig = resolveTestConfig(
     harness.logger,
     mergedOptions,
     projectViteConfig,
-    globalConfig,
+    parentConfig,
   )
 
   projectViteConfig.test = projectConfig
@@ -496,6 +617,7 @@ async function resolveSingleProjectEntry(
     viteConfig: projectViteConfig,
     projectConfig,
     inline: isInlineEntry,
+    ancestors: context.ancestors.length ? [...context.ancestors] : undefined,
   }
 }
 
@@ -533,11 +655,11 @@ function expandBrowserInstancesInEntries(
     const parentName = projectConfig.name
 
     const instances = projectConfig.browser.instances ?? []
-    if (instances.length === 0 || isExcludedByProjectFilter(globalConfig.project, parentName)) {
+    if (instances.length === 0 || isEntryExcludedByFilter(globalConfig.project, parentName, entry.ancestors)) {
       continue
     }
 
-    const keepAllInstances = matchesProjectFilter(globalConfig.project, parentName)
+    const keepAllInstances = matchesEntryFilter(globalConfig.project, parentName, entry.ancestors)
     const filteredInstances = keepAllInstances
       ? instances
       : instances.filter(instance => matchesProjectFilter(globalConfig.project, instance.name!))
@@ -641,6 +763,7 @@ function expandBrowserInstancesInEntries(
       result.push({
         viteConfig, // shared with parent
         projectConfig: clonedConfig,
+        ancestors: entry.ancestors,
       })
     })
   }
@@ -714,6 +837,7 @@ function expandBenchmarksInEntries(
     result.push({
       viteConfig: entry.viteConfig, // shared with non-benchmark counterpart
       projectConfig: benchmarkConfig,
+      ancestors: entry.ancestors,
     })
   }
 
@@ -747,7 +871,7 @@ function applyProjectFilter(
       // Browser instance: already filtered during expansion.
       return true
     }
-    return matchesProjectFilter(filter, entry.projectConfig.name)
+    return matchesEntryFilter(filter, entry.projectConfig.name, entry.ancestors)
   })
 }
 
@@ -799,9 +923,42 @@ function cloneProjectConfigForBrowserInstance(
   } satisfies ResolvedConfig, overrideConfig) as ResolvedConfig
 }
 
+/**
+ * Match an entry against the `--project` filter. In addition to the entry's
+ * own name, the names of the containers it is nested under are considered,
+ * so a container name selects (or excludes) its whole subtree.
+ */
+function matchesEntryFilter(
+  filter: string[],
+  name: string,
+  ancestors: string[] | undefined,
+): boolean {
+  if (!filter.length) {
+    return true
+  }
+  const names = [name, ...(ancestors || [])]
+  return filter.some((project) => {
+    const regexp = wildcardPatternToRegExp(project)
+    // a negated pattern compiles into a negative lookahead: the entry is kept
+    // only when neither its name nor any of its containers match the exclusion
+    return project.startsWith('!')
+      ? names.every(candidate => regexp.test(candidate))
+      : names.some(candidate => regexp.test(candidate))
+  })
+}
+
+function isEntryExcludedByFilter(
+  filter: string[],
+  name: string,
+  ancestors: string[] | undefined,
+): boolean {
+  return isExcludedByProjectFilter(filter, name)
+    || !!ancestors?.some(ancestor => isExcludedByProjectFilter(filter, ancestor))
+}
+
 async function resolveTestProjectConfigs(
-  globalViteConfig: ResolvedViteConfig,
-  globalConfig: ResolvedConfig,
+  parentViteConfig: ResolvedViteConfig,
+  parentConfig: ResolvedConfig,
   projectsDefinition: TestProjectConfiguration[],
 ) {
   // project configurations that were specified directly
@@ -818,11 +975,11 @@ async function resolveTestProjectConfigs(
 
   for (const definition of projectsDefinition) {
     if (typeof definition === 'string') {
-      const stringOption = definition.replace('<rootDir>', globalConfig.root)
+      const stringOption = definition.replace('<rootDir>', parentConfig.root)
       // if the string doesn't contain a glob, we can resolve it directly
       // ['./vitest.config.js']
       if (!isDynamicPattern(stringOption)) {
-        const file = resolve(globalConfig.root, stringOption)
+        const file = resolve(parentConfig.root, stringOption)
 
         if (!existsSync(file)) {
           throw new Error(`Projects definition references a non-existing file or a directory: ${file}`)
@@ -834,7 +991,7 @@ async function resolveTestProjectConfigs(
           const name = basename(file)
           if (!CONFIG_REGEXP.test(name)) {
             throw new Error(
-              `The file "${relative(globalConfig.root, file)}" must start with "vitest.config"/"vite.config" `
+              `The file "${relative(parentConfig.root, file)}" must start with "vitest.config"/"vite.config" `
               + `or match the pattern "(vitest|vite).*.config.*" to be a valid project config.`,
             )
           }
@@ -867,7 +1024,7 @@ async function resolveTestProjectConfigs(
     else if (typeof definition === 'function') {
       projectsOptions.push(await definition({
         command: 'serve',
-        mode: globalViteConfig.mode,
+        mode: parentViteConfig.mode,
         isPreview: false,
         isSsrBuild: false,
       }))
@@ -883,7 +1040,7 @@ async function resolveTestProjectConfigs(
       absolute: true,
       dot: true,
       onlyFiles: false,
-      cwd: globalConfig.root,
+      cwd: parentConfig.root,
       expandDirectories: false,
       ignore: [
         '**/node_modules/**',
@@ -912,7 +1069,7 @@ async function resolveTestProjectConfigs(
         const name = basename(path)
         if (!CONFIG_REGEXP.test(name)) {
           throw new Error(
-            `The projects glob matched a file "${relative(globalConfig.root, path)}", `
+            `The projects glob matched a file "${relative(parentConfig.root, path)}", `
             + `but it should also either start with "vitest.config"/"vite.config" `
             + `or match the pattern "(vitest|vite).*.config.*".`,
           )
@@ -945,33 +1102,41 @@ function resolveDirectoryConfig(directory: string) {
 /**
  * Resolve a project's name, falling back to the `package.json` name or the
  * directory/index when neither the config nor a plugin provided one.
+ *
+ * Projects declared by a container config are namespaced by the container's
+ * name: the "unit" project of an "app" container is named "app (unit)".
  */
 function resolveProjectName(
   name: string | ProjectName | undefined,
   workspacePath: string | number,
+  containerLabel: string | undefined,
 ): ProjectName {
   let { label, color }: ProjectName = typeof name === 'string'
     ? { label: name }
     : { label: '', ...name }
 
-  if (label) {
-    return { label, color }
+  if (!label) {
+    if (typeof workspacePath === 'number') {
+      label = workspacePath.toString()
+    }
+    else {
+      const dir = workspacePath.endsWith('/')
+        ? workspacePath.slice(0, -1)
+        : dirname(workspacePath)
+      const pkgJsonPath = resolve(dir, 'package.json')
+      if (existsSync(pkgJsonPath)) {
+        label = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')).name
+      }
+      if (typeof label !== 'string' || !label) {
+        label = basename(dir)
+      }
+    }
   }
 
-  if (typeof workspacePath === 'number') {
-    return { label: workspacePath.toString(), color }
+  if (containerLabel) {
+    label = `${containerLabel} (${label})`
   }
 
-  const dir = workspacePath.endsWith('/')
-    ? workspacePath.slice(0, -1)
-    : dirname(workspacePath)
-  const pkgJsonPath = resolve(dir, 'package.json')
-  if (existsSync(pkgJsonPath)) {
-    label = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')).name
-  }
-  if (typeof label !== 'string' || !label) {
-    label = basename(dir)
-  }
   return { label, color }
 }
 

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -396,7 +396,12 @@ export interface InlineConfig {
   fileParallelism?: boolean
 
   /**
-   * Options for projects
+   * Options for projects.
+   *
+   * When a project is referenced as a config file (or a directory with one) and
+   * that config declares `projects` itself, it becomes a container: it doesn't
+   * run tests, only provides the projects it declares. Inline configurations
+   * cannot declare `projects`.
    */
   projects?: TestProjectConfiguration[]
 
@@ -1280,6 +1285,14 @@ export interface ResolvedConfig
   viteOverrides: ViteUserConfig
   resolvedProjects: ResolvedProjectEntry[]
   /**
+   * Config files that declared `projects` and act as containers (the file
+   * itself doesn't run tests). Set only on the root config; used to restart
+   * on change since containers have no Vite server of their own.
+   *
+   * @internal
+   */
+  _containerConfigFiles?: string[]
+  /**
    * Browser server contribution captured by the `vitest:browser:loader` plugin
    * during this config's resolution (set only when `browser.enabled`). Used by
    * server creation to build the single Vite server shared by `project.vite` and
@@ -1319,6 +1332,14 @@ export interface ResolvedProjectEntry {
    * by default), not a file of its own.
    */
   inline?: boolean
+  /**
+   * Names of the container configs this project is nested under, outermost
+   * first. The `--project` filter matches these in addition to the project's
+   * own name, so a container name selects its whole subtree.
+   *
+   * @internal
+   */
+  ancestors?: string[]
 }
 
 type NonProjectOptions
@@ -1378,6 +1399,9 @@ export interface ServerDepsOptions {
 export type ProjectConfig = Omit<
   InlineConfig,
   NonProjectOptions
+  // `projects` is only respected in config files; a container config is
+  // root-like and should be authored with `defineConfig`
+  | 'projects'
   | 'sequence'
   | 'deps'
 > & {

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -1400,7 +1400,7 @@ export type ProjectConfig = Omit<
   InlineConfig,
   NonProjectOptions
   // `projects` is only respected in config files; a container config is
-  // root-like and should be authored with `defineConfig`
+  // root-like and should be authored with `defineConfig`/`defineProject`
   | 'projects'
   | 'sequence'
   | 'deps'
@@ -1421,10 +1421,9 @@ export type ResolvedProjectConfig = Omit<
 >
 
 export interface UserWorkspaceConfig extends ViteUserConfig {
-  test?: ProjectConfig
+  test?: ProjectConfig & { projects?: TestProjectConfiguration[] }
 }
 
-// TODO: remove types when "workspace" support is removed
 export type UserProjectConfigFn = (
   env: ConfigEnv,
 ) => UserWorkspaceConfig | Promise<UserWorkspaceConfig>

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -342,6 +342,409 @@ describe('the config file names', () => {
   })
 })
 
+describe('nested projects', () => {
+  const basicTest = ts`
+    import { test } from 'vitest'
+    test('runs', () => {})
+  `
+
+  it('a file-based project with `projects` becomes a container and only its projects run', async () => {
+    const { stderr, ctx, results } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: [
+            { test: { name: 'unit', include: ['**/*.unit.test.js'] } },
+            { test: { name: 'e2e', include: ['**/*.e2e.test.js'] } },
+          ],
+        },
+      },
+      'app/basic.unit.test.js': basicTest,
+      'app/basic.e2e.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.name)).toEqual([
+      'app (unit)',
+      'app (e2e)',
+    ])
+    // the container's own include doesn't run anything
+    expect(results).toHaveLength(2)
+  })
+
+  it('a directory reference with a config declaring `projects` becomes a container', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: [
+            { test: { name: 'unit' } },
+          ],
+        },
+      },
+      'app/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.name)).toEqual(['app (unit)'])
+  })
+
+  it('file-based projects of a container are namespaced with derived names', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: ['./unit/vitest.config.js'],
+        },
+      },
+      'app/unit/vitest.config.js': {},
+      'app/unit/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.name)).toEqual(['app (unit)'])
+  })
+
+  it('nested containers namespace their projects recursively', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: ['./sub/vitest.config.js'],
+        },
+      },
+      'app/sub/vitest.config.js': {
+        test: {
+          name: 'sub',
+          projects: [
+            { test: { name: 'leaf' } },
+          ],
+        },
+      },
+      'app/sub/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.name)).toEqual(['app (sub) (leaf)'])
+  })
+
+  it('inline projects ignore the `projects` field', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: [
+            {
+              test: {
+                name: 'main',
+                // inline projects cannot spawn other projects
+                projects: [{ test: { name: 'ignored' } }],
+              } as import('vitest/node').ProjectConfig,
+            },
+          ],
+        },
+      },
+      'basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.name)).toEqual(['main'])
+  })
+
+  it('a container can list its own config file to also run its tests', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          include: ['self.test.js'],
+          projects: [
+            './vitest.config.js',
+            { test: { name: 'unit', include: ['unit.test.js'] } },
+          ],
+        },
+      },
+      'app/self.test.js': basicTest,
+      'app/unit.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    // inline projects always come before file-based projects
+    expect(ctx!.projects.map(project => project.name)).toEqual([
+      'app (unit)',
+      'app',
+    ])
+  })
+
+  it('fails on a circular projects definition', async () => {
+    const { stderr } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./vitest.a.config.js'],
+        },
+      },
+      'vitest.a.config.js': {
+        test: { name: 'a', projects: ['./vitest.b.config.js'] },
+      },
+      'vitest.b.config.js': {
+        test: { name: 'b', projects: ['./vitest.a.config.js'] },
+      },
+    }, {}, { fails: true })
+    expect(stderr).toContain(
+      'Found a circular "projects" definition: "vitest.config.js" -> "vitest.a.config.js" -> "vitest.b.config.js" -> "vitest.a.config.js". Make sure your configuration is correct.',
+    )
+  })
+
+  it('fails when a container has no projects', async () => {
+    const { stderr } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: { name: 'app', projects: [] },
+      },
+    }, {}, { fails: true })
+    expect(stderr).toContain('No projects were found in "app/vitest.config.js". Make sure your configuration is correct.')
+  })
+
+  it('fails when nested project names collide', async () => {
+    const { stderr } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: [
+            { test: { name: 'unit' } },
+            { test: { name: 'unit' } },
+          ],
+        },
+      },
+      'app/basic.test.js': basicTest,
+    }, {}, { fails: true })
+    expect(stderr).toContain('Project name "app (unit)" is not unique.')
+  })
+
+  describe('the --project filter', () => {
+    const structure = {
+      'vitest.config.js': {
+        test: {
+          projects: [
+            { test: { name: 'main', include: ['main.test.js'] } },
+            './app/vitest.config.js',
+          ],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: [
+            { test: { name: 'unit', include: ['**/*.unit.test.js'] } },
+            { test: { name: 'e2e', include: ['**/*.e2e.test.js'] } },
+          ],
+        },
+      },
+      'main.test.js': basicTest,
+      'app/basic.unit.test.js': basicTest,
+      'app/basic.e2e.test.js': basicTest,
+    } satisfies Parameters<typeof runInlineTests>[0]
+
+    it('the container name selects the whole subtree', async () => {
+      const { stderr, ctx } = await runInlineTests(structure, { project: 'app' })
+      expect(stderr).toBe('')
+      expect(ctx!.projects.map(project => project.name)).toEqual([
+        'app (unit)',
+        'app (e2e)',
+      ])
+    })
+
+    it('the qualified name selects a single project', async () => {
+      const { stderr, ctx } = await runInlineTests(structure, { project: 'app (unit)' })
+      expect(stderr).toBe('')
+      expect(ctx!.projects.map(project => project.name)).toEqual(['app (unit)'])
+    })
+
+    it('excluding the container name excludes the whole subtree', async () => {
+      const { stderr, ctx } = await runInlineTests(structure, { project: '!app' })
+      expect(stderr).toBe('')
+      expect(ctx!.projects.map(project => project.name)).toEqual(['main'])
+    })
+  })
+
+  it('projects extend the container config by default, not the root', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          testTimeout: 1111,
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          testTimeout: 2222,
+          projects: [
+            { test: { name: 'inherited' } },
+            { extends: false, test: { name: 'isolated' } },
+            { extends: './vitest.shared.js', test: { name: 'shared' } },
+          ],
+        },
+      },
+      'app/vitest.shared.js': {
+        test: { testTimeout: 3333 },
+      },
+      'app/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    const timeouts = Object.fromEntries(
+      ctx!.projects.map(project => [project.name, project.config.testTimeout]),
+    )
+    expect(timeouts).toEqual({
+      'app (inherited)': 2222,
+      'app (isolated)': 5000,
+      'app (shared)': 3333,
+    })
+  })
+
+  it('the container globalSetup runs for every project extending it', async () => {
+    const { stderr, fs } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/globalSetup.js': ts`
+        import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+        import { resolve } from 'node:path'
+
+        export default function setup(project) {
+          const file = resolve(project.config.root, 'setup-runs.txt')
+          const runs = existsSync(file) ? Number(readFileSync(file, 'utf-8')) : 0
+          writeFileSync(file, String(runs + 1))
+        }
+      `,
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          globalSetup: './globalSetup.js',
+          projects: [
+            { test: { name: 'a' } },
+            { test: { name: 'b' } },
+          ],
+        },
+      },
+      'app/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(fs.readFile('app/setup-runs.txt')).toBe('2')
+  })
+
+  it('cli overrides reach nested projects', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          testTimeout: 2222,
+          projects: [
+            { test: { name: 'unit' } },
+          ],
+        },
+      },
+      'app/basic.test.js': basicTest,
+    }, { $cliOptions: { testTimeout: 999 } })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.config.testTimeout)).toEqual([999])
+  })
+
+  it('benchmark projects are created for nested projects', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          passWithNoTests: true,
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: [
+            { test: { name: 'unit', benchmark: { enabled: true } } },
+          ],
+        },
+      },
+      'app/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.name)).toEqual([
+      'app (unit)',
+      'app (unit) (bench)',
+    ])
+  })
+
+  it('editing a container config restarts and picks up new projects', async () => {
+    const { vitest, fs } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': ts`
+        export default {
+          test: {
+            name: 'app',
+            projects: [
+              { test: { name: 'one', include: ['one.test.js'] } },
+              // extra
+            ],
+          },
+        }
+      `,
+      'app/one.test.js': basicTest,
+      'app/two.test.js': basicTest,
+    }, { watch: true })
+
+    await vitest.waitForStdout('Waiting for file changes')
+    expect(vitest.stdout).toContain('app (one)')
+    expect(vitest.stdout).not.toContain('app (two)')
+    vitest.resetOutput()
+
+    fs.editFile('app/vitest.config.js', content => content.replace(
+      '// extra',
+      `{ test: { name: 'two', include: ['two.test.js'] } },`,
+    ))
+
+    await vitest.waitForStdout('Waiting for file changes')
+    expect(vitest.stdout).toContain('app (two)')
+  })
+})
+
 describe('project filtering', () => {
   const allProjects = ['project_1', 'project_2', 'space_1']
 


### PR DESCRIPTION
### Description

A project referenced as a config file (or a directory containing one) that declares `test.projects` now becomes a container, like the root config: it doesn't run tests itself and only provides the projects it declares, recursively.

- Nested project names are prefixed with the declaring config's name: `app (unit)`, `app (e2e)`.
- The `--project` filter also matches container names, selecting or excluding whole subtrees.
- Nested projects extend the container config by default; `extends` paths resolve relative to it.
- A container can reference its own config file to also run its own tests.
- Circular definitions and containers without any projects throw an error.
- Editing a container config file restarts Vitest in watch mode.
- Inline configurations still ignore `projects`; the option is now also excluded from the `ProjectConfig` type.

Resolves #8544