### PR TITLE
docs: align README Node.js requirement with package.json engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Next generation testing framework powered by Vite.
 - Reporting Uncaught Errors
 - Run your tests in the browser natively
 
-> Vitest requires Vite >=v6.4.0 and Node >=v22.12.0
+> Vitest requires Vite >=v6.4.0 and Node.js ^22.12.0 || ^24.0.0 || >=26.0.0
 
 ```ts
 import { assert, describe, expect, it } from 'vitest'


### PR DESCRIPTION
## Description

Updates the README Node.js requirement to match the engines field defined in package.json.

The current README suggests that all Node.js versions >=22.12.0 are supported, while the package.json engines field explicitly supports:

^22.12.0 || ^24.0.0 || >=26.0.0

This change keeps the documentation consistent with the project's actual runtime requirements.

## Testing

- Verified README requirement
- Verified package.json engines field
- Documentation-only change