### PR TITLE
docs: explain vm pool worker recycling cost

### DIFF
--- a/docs/config/pool.md
+++ b/docs/config/pool.md
@@ -28,7 +28,7 @@ This makes tests run faster, but the VM module is unstable when running [ESM cod
 ::: warning Worker recycling is expensive in `vmThreads`
 Restarting a worker thread is not free: Node.js runs a full garbage collection over everything the worker accumulated before the thread can exit, and that work runs on a small pool of background threads shared by every worker in the process. When a large test suite hits [`vmMemoryLimit`](/config/vmmemorylimit) repeatedly, these teardowns pile up and also slow down the workers that are still running tests.
 
-The `vmForks` pool recycles workers by letting the child process exit, and the operating system reclaims the memory. If your test suite is large enough to recycle workers, `vmForks` is usually noticeably faster than `vmThreads`, even though its communication with the main process is slower. This is also why small benchmarks tend to favor `vmThreads`: they never run long enough to recycle a worker.
+The `vmForks` pool recycles workers by letting the child process exit, and the operating system reclaims the memory. If your test suite is large enough to recycle workers, `vmForks` is usually noticeably faster than `vmThreads`, even though its communication with the main process is slower.
 :::
 
 ::: warning

--- a/docs/config/pool.md
+++ b/docs/config/pool.md
@@ -23,7 +23,13 @@ Similar as `threads` pool but uses `child_process` instead of `worker_threads`. 
 
 Run tests using [VM context](https://nodejs.org/api/vm.html) (inside a sandboxed environment) in a `threads` pool.
 
-This makes tests run faster, but the VM module is unstable when running [ESM code](https://github.com/nodejs/node/issues/37648). Your tests will [leak memory](https://github.com/nodejs/node/issues/33439) - to battle that, consider manually editing [`vmMemoryLimit`](/config/vmmemorylimit) value.
+This makes tests run faster, but the VM module is unstable when running [ESM code](https://github.com/nodejs/node/issues/37648). Your tests will [leak memory](https://github.com/nodejs/node/issues/33439) - to battle that, workers are restarted when they exceed [`vmMemoryLimit`](/config/vmmemorylimit).
+
+::: warning Worker recycling is expensive in `vmThreads`
+Restarting a worker thread is not free: Node.js runs a full garbage collection over everything the worker accumulated before the thread can exit, and that work runs on a small pool of background threads shared by every worker in the process. When a large test suite hits [`vmMemoryLimit`](/config/vmmemorylimit) repeatedly, these teardowns pile up and also slow down the workers that are still running tests.
+
+The `vmForks` pool recycles workers by letting the child process exit, and the operating system reclaims the memory. If your test suite is large enough to recycle workers, `vmForks` is usually noticeably faster than `vmThreads`, even though its communication with the main process is slower. This is also why small benchmarks tend to favor `vmThreads`: they never run long enough to recycle a worker.
+:::
 
 ::: warning
 Running code in a sandbox has some advantages (faster tests), but also comes with a number of disadvantages.
@@ -48,3 +54,5 @@ Please, be aware of these issues when using this option. Vitest team cannot fix 
 ## vmForks
 
 Similar as `vmThreads` pool but uses `child_process` instead of `worker_threads`. Communication between tests and the main process is not as fast as with `vmThreads` pool. Process related APIs such as `process.chdir()` are available in `vmForks` pool. Please be aware that this pool has the same pitfalls listed in `vmThreads`.
+
+Unlike `vmThreads`, recycling a worker that exceeded [`vmMemoryLimit`](/config/vmmemorylimit) only requires the child process to exit, so it is much cheaper. On large test suites that recycle workers regularly, prefer `vmForks` over `vmThreads`.

--- a/docs/config/vmmemorylimit.md
+++ b/docs/config/vmmemorylimit.md
@@ -10,7 +10,11 @@ outline: deep
 
 This option affects only `vmForks` and `vmThreads` pools.
 
-Specifies the memory limit for workers before they are recycled. This value heavily depends on your environment, so it's better to specify it manually instead of relying on the default. By default, the total system memory is split evenly between workers, so increasing [`maxWorkers`](/config/maxworkers) also makes every worker recycle more often.
+Specifies the memory limit for workers before they are recycled.
+
+By default, the total system memory is split evenly between workers. By increasing [`maxWorkers`](/config/maxworkers), workers have less memory available, so they're recycled more often.
+
+This value heavily depends on your environment, so it's better to specify it manually instead of relying on the default. 
 
 Recycling exists because VM contexts [leak memory](https://github.com/nodejs/node/issues/33439): a worker's memory usage grows with every test file it runs, so a worker cannot live forever. The limit is a trade-off:
 

--- a/docs/config/vmmemorylimit.md
+++ b/docs/config/vmmemorylimit.md
@@ -6,11 +6,16 @@ outline: deep
 # vmMemoryLimit
 
 - **Type:** `string | number`
-- **Default:** `1 / CPU Cores`
+- **Default:** `1 / maxWorkers`
 
 This option affects only `vmForks` and `vmThreads` pools.
 
-Specifies the memory limit for workers before they are recycled. This value heavily depends on your environment, so it's better to specify it manually instead of relying on the default.
+Specifies the memory limit for workers before they are recycled. This value heavily depends on your environment, so it's better to specify it manually instead of relying on the default. By default, the total system memory is split evenly between workers, so increasing [`maxWorkers`](/config/maxworkers) also makes every worker recycle more often.
+
+Recycling exists because VM contexts [leak memory](https://github.com/nodejs/node/issues/33439): a worker's memory usage grows with every test file it runs, so a worker cannot live forever. The limit is a trade-off:
+
+- A low limit recycles workers frequently. In the `vmThreads` pool this is expensive, because destroying a worker thread runs a full garbage collection over the worker's memory and competes with running tests for the process' shared background threads. The `vmForks` pool recycles workers by letting the child process exit, which makes frequent recycling much cheaper there.
+- A high limit lets workers accumulate memory. When the combined memory usage of all workers approaches what the machine can hold, every pool slows down.
 
 ::: tip
 The implementation is based on Jest's [`workerIdleMemoryLimit`](https://jestjs.io/docs/configuration#workeridlememorylimit-numberstring).


### PR DESCRIPTION
Documents why worker recycling is expensive in the `vmThreads` pool and cheap in `vmForks`, and expands `vmMemoryLimit` with the trade-off between a low and a high limit.

Background: profiling a large jsdom suite (zammad, 638 files) showed that when workers hit the default `vmMemoryLimit` (total memory / maxWorkers), `vmThreads` pays a full garbage collection over the dying worker's heap inside the shared process. Thread stack samples showed 5-6 workers blocked in `Isolate::Deinit` -> `MarkCompact` for 15+ seconds each while the process-shared V8 background threads were saturated with marking work, starving live workers. `vmForks` recycles by process exit, which the kernel reclaims in O(1); the same suite ran 130s on `vmForks` vs 235s on `vmThreads`. Raising the limit so recycling never happens made both pools slower, so recycling is necessary and the difference between the pools is the cost per recycle.

Also corrects the documented `vmMemoryLimit` default: it is `1 / maxWorkers`, not `1 / CPU Cores`.