### PR TITLE
fix: match forceRerunTriggers glob across dot dirs

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -134,7 +134,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -34,6 +34,29 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
   })
 })
 
+// fixes #10835
+describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger with a dot-prefixed path segment', () => {
+  const dottedFileName = 'fixtures/git-changed/related/.dotted-trigger/rerun.temp'
+
+  async function run() {
+    return runVitest({
+      root: join(process.cwd(), 'fixtures/git-changed/related'),
+      include: ['related.test.ts'],
+      forceRerunTriggers: ['**/rerun.temp/**'],
+      changed: true,
+    })
+  }
+
+  it('should still run the whole test suite if the trigger file is inside a dot-prefixed directory', async () => {
+    createFile(dottedFileName, '')
+    const { stdout, stderr } = await run()
+    expect(stderr).toBe('')
+    expect(stdout).toContain('1 passed')
+    expect(stdout).toContain('related.test.ts')
+    expect(stdout).not.toContain('not-related.test.ts')
+  })
+})
+
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {
   const { stdout, stderr } = await runVitest({
     related: 'src/sourceA.ts',


### PR DESCRIPTION
### Description
picomatch compiles glob patterns with `dot: false` by default, so `**` in a forceRerunTriggers pattern does not cross a dot-prefixed path segment (e.g. `.worktrees/`, `.cache/`, `.claude/`). When a project checkout sits under such a path, every configured trigger (including the default `**/package.json`) silently matches nothing, and `vitest run --changed` reports no test files and exits 0.

Pass `{ dot: true }` at both matcher call sites in specifications.ts and watcher.ts. forceRerunTriggers entries are opt-in paths a user explicitly configured, so there is no reason to skip dotfiles or dot-directories.

Resolves #10835

The 3 failing checks (unit/e2e/Browsers on windows-latest) are pre-existing flakiness on `main`, not caused by this change — e.g. `unit, node-24, windows-latest` has failed on the last 4 main CI runs (https://github.com/vitest-dev/vitest/actions/runs/30535867089, .../30462327741, .../30455033668, .../30432214400), and `e2e, node-24, windows-latest` on 3 of those 4. The failures are in `test/typechecker.test.ts` and `test/watch/file-watching.test.ts`, unrelated to `specifications.ts` / `watcher.ts` / `git-changed.test.ts`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Ran `pnpm build`, `pnpm lint:fix`, `pnpm typecheck`, and the e2e suite covering this change (`test/e2e/test/git-changed.test.ts`) locally. Full `pnpm test:ci` was covered by GitHub Actions on this PR (see the CI note above for the unrelated pre-existing failures).

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

---

AI-assisted with Claude Code.

<!-- VITEST_AUTOMATED_PR -->
