### PR TITLE
fix(cli): exit on `CTRL+c` even when `globalSetup` runs blocked code

### DIFF
--- a/packages/vitest/src/node/stdin.ts
+++ b/packages/vitest/src/node/stdin.ts
@@ -91,8 +91,12 @@ export function registerConsoleShortcuts(
         )
         process.exitCode = 130
 
+        // Unregister raw mode so that second CTRL+c is handled by Node.js as SIGINT
+        off()
+
         await ctx.cancelCurrentRun('keyboard-input')
       }
+
       return ctx.exit(true)
     }
 

--- a/test/e2e/test/cancel-run.test.ts
+++ b/test/e2e/test/cancel-run.test.ts
@@ -31,7 +31,7 @@ test('can force cancel a run via CLI', async () => {
 
   const stdin = new Readable({ read: () => '' }) as NodeJS.ReadStream
   stdin.isTTY = true
-  stdin.setRawMode = () => stdin
+  stdin.setRawMode = vi.fn().mockReturnValue(stdin)
   registerConsoleShortcuts(vitest, stdin, new Writable())
 
   const onLog = vi.spyOn(vitest.logger, 'log').mockImplementation(() => {})
@@ -48,8 +48,11 @@ test('can force cancel a run via CLI', async () => {
   const logs = onLog.mock.calls.map(log => stripVTControlCharacters(log[0] || '').trim())
   expect(logs).toContain('Cancelling test run. Press CTRL+c again to exit forcefully.')
 
-  // Second CTRL+c should stop run
-  stdin.emit('data', CTRL_C)
+  // Second CTRL+c should stop run. Raw mode should be disabled so Node handles the second CTRL+c as SIGINT and exit forcefully.
+  expect.soft(stdin.setRawMode).toHaveBeenLastCalledWith(false)
+
+  // Test cleanup:
+  vitest.exit(true)
   await promise
 
   // `exit()` calls `process.exit` only after `close()` finishes — poll instead


### PR DESCRIPTION
### Description

Closes https://github.com/vitest-dev/vitest/pull/10840

Unregister `stdin` after first `CTRL+c` so that Node takes the wheel and can terminate main thread's blocking code.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
