### PR TITLE
feat!: fail the test when an asynchronous assertion is not awaited

### DIFF
--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1872,9 +1872,7 @@ test('buyApples returns new stock id', async () => {
 ```
 
 :::warning
-If the assertion is not awaited, then you will have a false-positive test that will pass every time. To make sure that assertions are actually called, you may use [`expect.assertions(number)`](#expect-assertions).
-
-Since Vitest 3, if a method is not awaited, Vitest will show a warning at the end of the test. In Vitest 4, the test will be marked as "failed" if the assertion is not awaited.
+If the assertion is not awaited, the test will be marked as "failed" at the end of the test.
 :::
 
 ## rejects
@@ -1903,9 +1901,7 @@ test('buyApples throws an error when no id provided', async () => {
 ```
 
 :::warning
-If the assertion is not awaited, then you will have a false-positive test that will pass every time. To make sure that assertions were actually called, you can use [`expect.assertions(number)`](#expect-assertions).
-
-Since Vitest 3, if a method is not awaited, Vitest will show a warning at the end of the test. In Vitest 4, the test will be marked as "failed" if the assertion is not awaited.
+If the assertion is not awaited, the test will be marked as "failed" at the end of the test.
 :::
 
 ## expect.assertions

--- a/docs/guide/learn/async.md
+++ b/docs/guide/learn/async.md
@@ -46,7 +46,7 @@ test('rejects with an error', async () => {
 ```
 
 ::: warning
-Don't forget the `await` before `expect`. Vitest will detect unawaited assertions and print a warning at the end of the test, but it's best to always include `await` explicitly. Vitest will also wait for all pending promises in `Promise.all` before starting the next test, but relying on this behavior makes tests harder to understand.
+Don't forget the `await` before `expect`. Vitest will detect unawaited assertions and fail the test at the end of it.
 :::
 
 ## Assertion Counting

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -303,6 +303,21 @@ await expect.poll(async ({ signal }) => {
 
 A poll that legitimately needs more time should raise its `timeout`. Otherwise it fails with `expect.poll() function didn't resolve in time.` (or `expect.poll() assertion didn't resolve in time.`).
 
+### Unawaited Asynchronous Assertions Fail the Test
+
+Asynchronous assertions, like `resolves`, `rejects` and `toMatchFileSnapshot`, now fail the test if they are not awaited. Previously, Vitest auto-awaited them at the end of the test and printed a warning:
+
+```ts
+test('unawaited assertion', async () => {
+  // v4: prints a warning, the test passes // [!code --]
+  // v5: the test fails // [!code ++]
+  expect(promise).resolves.toBe(1) // [!code --]
+  await expect(promise).resolves.toBe(1) // [!code ++]
+})
+```
+
+The reported error points to the assertion that was not awaited.
+
 ### Test Titles and Inspected Values Use `pretty-format`
 
 Vitest now formats values with [`pretty-format`](https://www.npmjs.com/package/pretty-format) instead of `loupe` when it inspects them, including the values interpolated into [`test.each`](/api/test#test-each) and [`test.for`](/api/test#test-for) titles. The rendering of some values changes, so snapshots or assertions that capture inspected output may need updating.

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -54,14 +54,13 @@ export function recordAsyncExpect(
     test.onFinished ??= []
     test.onFinished.push(() => {
       if (!resolved) {
-        const processor = (globalThis as any).__vitest_worker__?.onFilterStackTrace || ((s: string) => s || '')
-        const stack = processor(error.stack)
-        console.warn([
-          `Promise returned by \`${assertion}\` was not awaited. `,
-          'Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. ',
-          'Please remember to await the assertion.\n',
-          stack,
-        ].join(''))
+        const awaitError = new Error(
+          `Promise returned by \`${assertion}\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:\n\nawait ${assertion}\n`,
+        )
+        if (error.stack) {
+          awaitError.stack = error.stack.replace(error.message, awaitError.message)
+        }
+        throw awaitError
       }
     })
 

--- a/test/e2e/test/__snapshots__/fails.test.ts.snap
+++ b/test/e2e/test/__snapshots__/fails.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`should fail .dot-folder/dot-test.test.ts 1`] = `"AssertionError: expected true to be false // Object.is equality"`;
 
 exports[`should fail async-assertion.test.ts 1`] = `
-"AssertionError: expected 'xx' to be 'zz' // Object.is equality
+"Error: Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+Error: Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+AssertionError: expected 'xx' to be 'zz' // Object.is equality
 AssertionError: expected 'xx' to be 'yy' // Object.is equality"
 `;
 
@@ -98,7 +100,8 @@ exports[`should fail test-extend/test-rest-props.test.ts 1`] = `"FixtureParseErr
 exports[`should fail test-extend/test-without-destructuring.test.ts 1`] = `"FixtureParseError: The 1st argument inside a fixture must use object destructuring pattern, e.g. ({ task } => {}). Instead, received "context"."`;
 
 exports[`should fail test-timeout.test.ts 1`] = `
-"Error: Test timed out in 20ms.
+"Error: Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+Error: Test timed out in 20ms.
 Error: Test timed out in 200ms.
 Error: Test timed out in 100ms.
 Error: Hook timed out in 17ms.

--- a/test/e2e/test/fails.test.ts
+++ b/test/e2e/test/fails.test.ts
@@ -49,8 +49,8 @@ it('should not report coverage when "coverage.reportOnFailure" has default value
   expect(stdout).not.toMatch('Coverage report from istanbul')
 })
 
-it('prints a warning if the assertion is not awaited', async () => {
-  const { stderr, root, errorTree } = await runInlineTests({
+it('fails if the assertion is not awaited', async () => {
+  const { errorTree } = await runInlineTests({
     'base.test.js': ts`
     import { expect, test } from 'vitest';
 
@@ -79,41 +79,53 @@ it('prints a warning if the assertion is not awaited', async () => {
   }, {
     update: true,
   })
-  expect(errorTree()).toMatchInlineSnapshot(`
+  expect(errorTree({ stackTrace: true })).toMatchInlineSnapshot(`
     {
       "base.test.js": {
         "not awaited and failed": [
-          "expected 1 to be 2 // Object.is equality",
+          "expected 1 to be 2 // Object.is equality
+        at base.test.js:15:17",
+          "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect(actual).resolves.toBe(expected)
+
+        at base.test.js:14:33",
         ],
-        "several not awaited": "passed",
-        "single not awaited": "passed",
-        "soft + toMatchFileSnapshot not awaited": "passed",
-        "toMatchFileSnapshot not awaited": "passed",
+        "several not awaited": [
+          "Promise returned by \`expect(actual).rejects.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect(actual).rejects.toBe(expected)
+
+        at base.test.js:10:32",
+          "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect(actual).resolves.toBe(expected)
+
+        at base.test.js:9:33",
+        ],
+        "single not awaited": [
+          "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect(actual).resolves.toBe(expected)
+
+        at base.test.js:5:33",
+        ],
+        "soft + toMatchFileSnapshot not awaited": [
+          "Promise returned by \`expect.soft(actual).toMatchFileSnapshot(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect.soft(actual).toMatchFileSnapshot(expected)
+
+        at base.test.js:23:22",
+        ],
+        "toMatchFileSnapshot not awaited": [
+          "Promise returned by \`expect(actual).toMatchFileSnapshot(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect(actual).toMatchFileSnapshot(expected)
+
+        at base.test.js:19:17",
+        ],
       },
     }
-  `)
-  const warnings: string[] = []
-  const lines = stderr.split('\n')
-  lines.forEach((line, index) => {
-    if (line.includes('Promise returned by')) {
-      warnings.push(lines.slice(index, index + 2).join('\n').replace(`${root}/`, '<rootDir>/'))
-    }
-  })
-  expect(warnings).toMatchInlineSnapshot(`
-    [
-      "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. Please remember to await the assertion.
-        at <rootDir>/base.test.js:5:33",
-      "Promise returned by \`expect(actual).rejects.toBe(expected)\` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. Please remember to await the assertion.
-        at <rootDir>/base.test.js:10:32",
-      "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. Please remember to await the assertion.
-        at <rootDir>/base.test.js:9:33",
-      "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. Please remember to await the assertion.
-        at <rootDir>/base.test.js:14:33",
-      "Promise returned by \`expect(actual).toMatchFileSnapshot(expected)\` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. Please remember to await the assertion.
-        at <rootDir>/base.test.js:19:17",
-      "Promise returned by \`expect.soft(actual).toMatchFileSnapshot(expected)\` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in the next Vitest major. Please remember to await the assertion.
-        at <rootDir>/base.test.js:23:22",
-    ]
   `)
 })
 
@@ -230,8 +242,8 @@ it('no async tracking after then/catch/finally', async () => {
   `)
 })
 
-it('prints a warning if the assertion is not awaited in the browser mode', async () => {
-  const { stderr } = await runInlineTests({
+it('fails if the assertion is not awaited in the browser mode', async () => {
+  const { errorTree } = await runInlineTests({
     'base.test.js': ts`
     import { expect, test } from 'vitest';
 
@@ -247,8 +259,19 @@ it('prints a warning if the assertion is not awaited in the browser mode', async
       headless: true,
     },
   })
-  expect(stderr).toContain('Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited')
-  expect(stderr).toContain('base.test.js:5:33')
+  expect(errorTree({ stackTrace: true })).toMatchInlineSnapshot(`
+    {
+      "base.test.js": {
+        "single not awaited": [
+          "Promise returned by \`expect(actual).resolves.toBe(expected)\` was not awaited. This assertion is asynchronous and must be awaited; otherwise, it is not guaranteed to complete before the test finishes:
+
+    await expect(actual).resolves.toBe(expected)
+
+        at base.test.js:5:33",
+        ],
+      },
+    }
+  `)
 })
 
 it('reports test file if it failed to load', async () => {

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -3,7 +3,7 @@ import nodeAssert, { AssertionError } from 'node:assert'
 import { stripVTControlCharacters } from 'node:util'
 import { generateToBeMessage } from '@vitest/expect'
 import { processError } from '@vitest/utils/error'
-import { assert, beforeAll, describe, expect, it, vi } from 'vitest'
+import { assert, describe, expect, it, vi } from 'vitest'
 
 class TestError extends Error {}
 
@@ -1232,12 +1232,6 @@ describe('async expect', () => {
   })
 
   describe('promise auto queuing', () => {
-    // silence warning
-    beforeAll(() => {
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      return () => spy.mockRestore()
-    })
-
     it.fails('fails', () => {
       expect(new Promise((resolve, reject) => setTimeout(reject, 500)))
         .resolves
@@ -1246,7 +1240,7 @@ describe('async expect', () => {
 
     let value = 0
 
-    it('pass first', () => {
+    it.fails('not awaited fails', () => {
       expect((async () => {
         await new Promise(resolve => setTimeout(resolve, 500))
         value += 1
@@ -1256,8 +1250,7 @@ describe('async expect', () => {
         .toBe(1)
     })
 
-    it('pass second', () => {
-    // even if 'pass first' is sync, we will still wait the expect to resolve
+    it('not awaited assertion is still resolved', () => {
       expect(value).toBe(1)
     })
   })


### PR DESCRIPTION
## Description

Un-awaited `resolves`/`rejects`/`toMatchFileSnapshot` assertions now fail the test with an error pointing at the assertion, instead of printing a warning. The error follows the same format as `expect.poll`. Vitest still settles the recorded promises at the end of the test, so a failing un-awaited assertion also reports its own error and doesn't leak an unhandled rejection.

Resolves #9089