### PR TITLE
fix(cache): improve `fsModuleCache` resiliency during external modifications

### DIFF
--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -324,16 +324,23 @@ export class FileSystemModuleCache {
 
     // no metadata found, just store a new one, don't reset the cache
     if (!metadata) {
-      if (!existsSync(this.rootCache)) {
-        mkdirSync(this.rootCache, { recursive: true })
-      }
       debugFs?.(`fs metadata file was created with hash ${currentLockfileHash}`)
 
-      await writeFile(
-        this.metadataFilePath,
-        JSON.stringify({ lockfileHash: currentLockfileHash }, null, 2),
-        'utf-8',
-      )
+      try {
+        if (!existsSync(this.rootCache)) {
+          mkdirSync(this.rootCache, { recursive: true })
+        }
+        await writeFile(
+          this.metadataFilePath,
+          JSON.stringify({ lockfileHash: currentLockfileHash }, null, 2),
+          'utf-8',
+        )
+      }
+      catch (error) {
+        // Recording the metadata is best-effort and losing the file shouldn't
+        // abort the entire execution
+        debugFs?.(`failed to write fs cache metadata: ${error}`)
+      }
       return
     }
 

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -11,11 +11,17 @@ import { readFile } from 'node:fs/promises'
 import { isExternalUrl, unwrapId } from '@vitest/utils/helpers'
 import { join } from 'pathe'
 import { fetchModule } from 'vite'
+import { createDebugger } from '../../utils/debugger'
 import { hash } from '../hash'
 import { detectModuleType } from '../resolver'
 import { normalizeResolvedIdToUrl } from './normalizeUrl'
 
-const saveCachePromises = new Map<string, Promise<VitestFetchResult>>()
+const debugFs = createDebugger('vitest:cache:fs')
+
+const saveCachePromises = new Map<
+  string,
+  Promise<VitestFetchResult | FetchCachedFileSystemResult>
+>()
 const readFilePromises = new Map<string, Promise<string | null>>()
 
 /**
@@ -252,6 +258,13 @@ class ModuleFetcher {
     importer: string | undefined,
   ): Promise<FetchResult | FetchCachedFileSystemResult | undefined> {
     if (moduleGraphModule.transformResult?.__vitestTmp) {
+      if (!existsSync(moduleGraphModule.transformResult.__vitestTmp)) {
+        debugFs?.(
+          `cached file ${moduleGraphModule.transformResult.__vitestTmp} disappeared, re-transforming`,
+        )
+        moduleGraphModule.transformResult.__vitestTmp = undefined
+        return undefined
+      }
       return {
         cached: true as const,
         file: moduleGraphModule.file,
@@ -388,21 +401,23 @@ class ModuleFetcher {
       : result
 
     if (saveCachePromises.has(cachePath)) {
-      await saveCachePromises.get(cachePath)
-      return returnResult
+      return saveCachePromises.get(cachePath)!
     }
 
     const savePromise = this.fsCache
       .saveCachedModule(cachePath, result, importedUrls, mappings)
-      .then(() => result)
+      .then(() => returnResult)
+      .catch((error) => {
+        debugFs?.(`failed to cache ${cachePath}, serving it inline: ${error}`)
+        return result
+      })
       .finally(() => {
         saveCachePromises.delete(cachePath)
       })
 
     saveCachePromises.set(cachePath, savePromise)
-    await savePromise
 
-    return returnResult
+    return savePromise
   }
 
   private readFileConcurrently(file: string): Promise<string | null> {

--- a/test/e2e/test/fs-module-cache-resiliency.test.ts
+++ b/test/e2e/test/fs-module-cache-resiliency.test.ts
@@ -14,7 +14,9 @@ afterEach(() => {
   restore.splice(0).forEach(fn => fn())
 })
 
-test('a cache directory that cannot be written to does not fail the run', async () => {
+// Windows ignores the POSIX mode bits `chmodSync` sets on a directory, so there
+// the cache stays writable and this scenario cannot be staged at all.
+test.skipIf(process.platform === 'win32')('a cache directory that cannot be written to does not fail the run', async () => {
   const cachePath = join(
     import.meta.dirname,
     '../fixtures/.tmp-readonly-module-cache',

--- a/test/e2e/test/fs-module-cache-resiliency.test.ts
+++ b/test/e2e/test/fs-module-cache-resiliency.test.ts
@@ -1,0 +1,147 @@
+import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
+import { join } from 'pathe'
+import { afterEach, expect, test } from 'vitest'
+import { runInlineTests } from '#test-utils'
+
+// The on-disk module cache is an optimisation. It lives in a directory nobody
+// owns exclusively — CI images sweep it mid-run, disks fill up, mounts are
+// mounted read-only — so every failure to write or read it has to degrade to
+// serving the module inline instead of failing the run.
+
+const restore: Array<() => void> = []
+
+afterEach(() => {
+  restore.splice(0).forEach(fn => fn())
+})
+
+test('a cache directory that cannot be written to does not fail the run', async () => {
+  const cachePath = join(
+    import.meta.dirname,
+    '../fixtures/.tmp-readonly-module-cache',
+  )
+  rmSync(cachePath, { force: true, recursive: true })
+  mkdirSync(cachePath, { recursive: true })
+  chmodSync(cachePath, 0o555)
+  restore.push(() => {
+    chmodSync(cachePath, 0o755)
+    rmSync(cachePath, { force: true, recursive: true })
+  })
+
+  const { stderr, testTree } = await runInlineTests(
+    {
+      'sum.js': `export const sum = (a, b) => a + b`,
+      'basic.test.js': /* js */ `
+      import { expect, test } from "vitest"
+      import { sum } from "./sum.js"
+      test("still runs without a writable cache", () => {
+        expect(sum(1, 2)).toBe(3)
+      })
+    `,
+    },
+    {
+      fsModuleCache: true,
+      fsModuleCachePath: cachePath,
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchObject({
+    'basic.test.js': {
+      'still runs without a writable cache': 'passed',
+    },
+  })
+  // nothing could be written, and that is fine
+  expect(readdirSync(cachePath)).toEqual([])
+})
+
+test('a cached file removed mid-run is re-transformed instead of failing', async () => {
+  const cachePath = join(
+    import.meta.dirname,
+    '../fixtures/.tmp-swept-module-cache',
+  )
+  rmSync(cachePath, { force: true, recursive: true })
+  restore.push(() => rmSync(cachePath, { force: true, recursive: true }))
+
+  // `a` imports the shared module (populating the cache and the server's
+  // in-memory pointer to it), then deletes the cache from under the run. `b`
+  // imports the same module afterwards, so the server has to notice its
+  // pointer is dangling and re-transform rather than hand back a dead path.
+  const { stderr, testTree } = await runInlineTests(
+    {
+      'shared.js': `export const shared = "shared-value"`,
+      'a.test.js': /* js */ `
+      import { rmSync } from "node:fs"
+      import { expect, test } from "vitest"
+      import { shared } from "./shared.js"
+      test("populates the cache, then sweeps it", () => {
+        expect(shared).toBe("shared-value")
+        rmSync(${JSON.stringify(cachePath)}, { force: true, recursive: true })
+      })
+    `,
+      'b.test.js': /* js */ `
+      import { expect, test } from "vitest"
+      import { shared } from "./shared.js"
+      test("still resolves the swept module", () => {
+        expect(shared).toBe("shared-value")
+      })
+    `,
+    },
+    {
+      fsModuleCache: true,
+      fsModuleCachePath: cachePath,
+      // run the files in order in one process so `a` reliably sweeps the cache
+      // before `b` asks the server for the same module
+      fileParallelism: false,
+      maxWorkers: 1,
+      minWorkers: 1,
+      sequence: { shuffle: false },
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchObject({
+    'a.test.js': {
+      'populates the cache, then sweeps it': 'passed',
+    },
+    'b.test.js': {
+      'still resolves the swept module': 'passed',
+    },
+  })
+})
+
+test('the cache is still populated and reused when nothing interferes', async () => {
+  const cachePath = join(
+    import.meta.dirname,
+    '../fixtures/.tmp-healthy-module-cache',
+  )
+  rmSync(cachePath, { force: true, recursive: true })
+  restore.push(() => rmSync(cachePath, { force: true, recursive: true }))
+
+  const structure = {
+    'sum.js': `export const sum = (a, b) => a + b`,
+    'basic.test.js': /* js */ `
+      import { expect, test } from "vitest"
+      import { sum } from "./sum.js"
+      test("adds", () => {
+        expect(sum(1, 2)).toBe(3)
+      })
+    `,
+  }
+  const config = {
+    fsModuleCache: true,
+    fsModuleCachePath: cachePath,
+  }
+
+  const cold = await runInlineTests(structure, config)
+  expect(cold.stderr).toBe('')
+  expect(existsSync(cachePath)).toBe(true)
+  const written = readdirSync(cachePath).length
+  // the degradation paths must not have turned caching off altogether
+  expect(written).toBeGreaterThan(0)
+
+  const warm = await runInlineTests(structure, config)
+  expect(warm.stderr).toBe('')
+  expect(warm.testTree()).toMatchObject({
+    'basic.test.js': { adds: 'passed' },
+  })
+})


### PR DESCRIPTION
### Description

Make the `fsModuleCache` resilient to external modifications and avoid returning stale cache references that no longer exist.  This is an issue for long-lived CI workers that perform periodic disk space maintenance.

- `ensureCacheIntegrity` wrote the metadata file unguarded, before any test ran, so an unwritable cache directory aborted the whole run.
- `cacheResult` awaited an unguarded `saveCachedModule`. A failed write rejected the module fetch. Catching it is not enough on its own: the result handed back is a pointer to the cache file, so the fallback has to serve the module inline instead of pointing the worker at a file that was never written.
- `getCachedModule` short-circuited on `__vitestTmp` without checking the file still existed, so a worker that failed to read a stale cache file got the same dangling pointer back on every retry. The worker now retries once, and the server drops the stale result and re-transforms.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
