### PR TITLE
fix: [backport to v4] don't drop localStorage/sessionStorage from DOM environments on Node 25+

### DIFF
--- a/packages/vitest/src/integrations/env/edge-runtime.ts
+++ b/packages/vitest/src/integrations/env/edge-runtime.ts
@@ -43,7 +43,7 @@ export default <Environment>{
     return {
       teardown(global) {
         keys.forEach(key => delete global[key])
-        originals.forEach((v, k) => (global[k] = v))
+        originals.forEach((d, k) => Object.defineProperty(global, k, d))
       },
     }
   },

--- a/packages/vitest/src/integrations/env/happy-dom.ts
+++ b/packages/vitest/src/integrations/env/happy-dom.ts
@@ -82,7 +82,7 @@ export default <Environment>{
       async teardown(global) {
         await teardownWindow(win)
         keys.forEach(key => delete global[key])
-        originals.forEach((v, k) => (global[k] = v))
+        originals.forEach((d, k) => Object.defineProperty(global, k, d))
       },
     }
   },

--- a/packages/vitest/src/integrations/env/jsdom-keys.ts
+++ b/packages/vitest/src/integrations/env/jsdom-keys.ts
@@ -209,6 +209,7 @@ const OTHER_KEYS = [
   'innerHeight',
   'innerWidth',
   'length',
+  'localStorage',
   'location',
   'matchMedia',
   'moveBy',
@@ -241,6 +242,7 @@ const OTHER_KEYS = [
   'scrollX',
   'scrollY',
   'self',
+  'sessionStorage',
   /* 'setInterval', */
   /* 'setTimeout', */
   'stop',

--- a/packages/vitest/src/integrations/env/jsdom.ts
+++ b/packages/vitest/src/integrations/env/jsdom.ts
@@ -225,7 +225,7 @@ export default <Environment>{
         dom.window.close()
         delete global.jsdom
         keys.forEach(key => delete global[key])
-        originals.forEach((v, k) => (global[k] = v))
+        originals.forEach((d, k) => Object.defineProperty(global, k, d))
       },
     }
   },

--- a/packages/vitest/src/integrations/env/utils.ts
+++ b/packages/vitest/src/integrations/env/utils.ts
@@ -45,12 +45,12 @@ export function populateGlobal(
 ): {
   keys: Set<string>
   skipKeys: string[]
-  originals: Map<string | symbol, any>
+  originals: Map<string | symbol, PropertyDescriptor>
 } {
   const { bindFunctions = false } = options
   const keys = getWindowKeys(global, win, options.additionalKeys)
 
-  const originals = new Map<string | symbol, any>()
+  const originals = new Map<string | symbol, PropertyDescriptor>()
 
   const overriddenKeys = new Set([...KEYS, ...options.additionalKeys || []])
 
@@ -63,7 +63,12 @@ export function populateGlobal(
         && win[key].bind(win)
 
     if (overriddenKeys.has(key) && key in global) {
-      originals.set(key, global[key])
+      // capture the descriptor instead of the value to avoid invoking native
+      // lazy getters such as Node's `localStorage`, which warns when accessed
+      // without `--localstorage-file`
+      const descriptor = Object.getOwnPropertyDescriptor(global, key)
+        ?? { value: global[key], configurable: true, writable: true, enumerable: true }
+      originals.set(key, descriptor)
     }
 
     Object.defineProperty(global, key, {

--- a/test/core/test/env-runtime.test.ts
+++ b/test/core/test/env-runtime.test.ts
@@ -9,7 +9,40 @@ test('returns valid globals', () => {
   }
   const win = { Event: winEvent }
   const { originals } = populateGlobal(global, win)
-  expect(originals.get('Event')).toBe(globalEvent)
+  expect(originals.get('Event')?.value).toBe(globalEvent)
   expect(win.Event).toBe(winEvent)
   expect(global.Event).toBe(winEvent)
+})
+
+test('keeps DOM storage implementations when Node provides web storage globals (Node 25+)', () => {
+  // Simulate Node 25+, where `localStorage`/`sessionStorage` are lazy
+  // accessors on globalThis (they warn or return undefined without
+  // `--localstorage-file`)
+  let nativeGetterCalls = 0
+  const nativeGet = () => {
+    nativeGetterCalls++
+    return undefined
+  }
+  const global: any = {}
+  Object.defineProperty(global, 'localStorage', { get: nativeGet, configurable: true, enumerable: true })
+  Object.defineProperty(global, 'sessionStorage', { get: nativeGet, configurable: true, enumerable: true })
+
+  const localStorage = { getItem: vi.fn() }
+  const sessionStorage = { getItem: vi.fn() }
+  const win = { localStorage, sessionStorage }
+
+  const { keys, originals } = populateGlobal(global, win)
+
+  expect(global.localStorage).toBe(localStorage)
+  expect(global.sessionStorage).toBe(sessionStorage)
+  // capturing the originals must not invoke Node's lazy getter
+  expect(nativeGetterCalls).toBe(0)
+
+  // teardown, same as the jsdom/happy-dom environments
+  keys.forEach(key => delete global[key])
+  originals.forEach((d, k) => Object.defineProperty(global, k, d))
+
+  // the native accessor is restored intact
+  expect(Object.getOwnPropertyDescriptor(global, 'localStorage')?.get).toBe(nativeGet)
+  expect(nativeGetterCalls).toBe(0)
 })


### PR DESCRIPTION
### Description

Backports the environment portion of #10293 to the `v4` release line (fixes #10867, follow-up to #8757).

Since Node 25, `localStorage` and `sessionStorage` ship as lazy accessors on `globalThis`. `getWindowKeys` filters out any window key that already exists on the global unless it is allowlisted, so the jsdom/happy-dom `Storage` implementations were never copied and `window.localStorage` ended up `undefined` on Node 25/26 — a regression from the Node ≤24 behavior, where DOM environments always exposed their own storage.

This backport, matching what already landed on `main` in #10293:

- adds `localStorage`/`sessionStorage` to the jsdom key allowlist, so DOM environments expose their own `Storage` again;
- captures property descriptors (instead of values) in `populateGlobal`, so Node's lazy `localStorage` getter is never invoked while snapshotting originals (it warns without `--localstorage-file`);
- restores originals with `Object.defineProperty` on teardown, so Node's native accessors survive the environment intact.

The worker-startup changes from #10293 are intentionally not included.

Note for reviewers: the `originals` map of `populateGlobal` now holds descriptors, as on `main` (documented there in the v5 migration guide). If that is considered too intrusive for a v4 patch release, I'm happy to reduce this to the allowlist-only change.

The new test simulates the Node 25+ lazy accessors on a plain object, so it runs (and fails without the fix) on any Node version.

AI disclosure: prepared with assistance from Claude (Claude Code); I reviewed and tested every change.
