### PR TITLE
docs: fix misleading `toHaveResolved` JSDoc examples

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -719,7 +719,7 @@ export interface Assertion<R extends void | Promise<void> = void, T = unknown>
   toHaveBeenCalledAfter: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => R
 
   /**
-   * Checks that a mock function resolved a value at least once.
+   * Checks that at least one of the mock function's calls has resolved.
    *
    * @example
    * await expect(mockAsyncFunc).toHaveResolved();
@@ -727,7 +727,7 @@ export interface Assertion<R extends void | Promise<void> = void, T = unknown>
   toHaveResolved: () => R
 
   /**
-   * Checks that a mock function resolved to a specific value.
+   * Checks that at least one of the mock function's calls has resolved to a specific value.
    *
    * @example
    * await expect(mockAsyncFunc).toHaveResolvedWith('success');

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -722,7 +722,7 @@ export interface Assertion<R extends void | Promise<void> = void, T = unknown>
    * Checks that at least one of the mock function's calls has resolved.
    *
    * @example
-   * await expect(mockAsyncFunc).toHaveResolved();
+   * expect(mockAsyncFunc).toHaveResolved();
    */
   toHaveResolved: () => R
 
@@ -730,7 +730,7 @@ export interface Assertion<R extends void | Promise<void> = void, T = unknown>
    * Checks that at least one of the mock function's calls has resolved to a specific value.
    *
    * @example
-   * await expect(mockAsyncFunc).toHaveResolvedWith('success');
+   * expect(mockAsyncFunc).toHaveResolvedWith('success');
    */
   toHaveResolvedWith: <E>(value: E) => R
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -719,18 +719,18 @@ export interface Assertion<R extends void | Promise<void> = void, T = unknown>
   toHaveBeenCalledAfter: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => R
 
   /**
-   * Checks that a promise resolves successfully at least once.
+   * Checks that a mock function resolved a value at least once.
    *
    * @example
-   * await expect(promise).toHaveResolved();
+   * await expect(mockAsyncFunc).toHaveResolved();
    */
   toHaveResolved: () => R
 
   /**
-   * Checks that a promise resolves to a specific value.
+   * Checks that a mock function resolved to a specific value.
    *
    * @example
-   * await expect(promise).toHaveResolvedWith('success');
+   * await expect(mockAsyncFunc).toHaveResolvedWith('success');
    */
   toHaveResolvedWith: <E>(value: E) => R
 


### PR DESCRIPTION
### Description

Both matchers need a spy, but their JSDoc examples pass a bare promise. Follow the example and you get `TypeError: Promise{…} is not a spy or a call to a spy!`. The examples now use a mock function, same as the docs site and the other resolved matchers.

Resolves #10870

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.