### PR TITLE
fix: swap replace() arguments so timeout error stack shows the real message

### DIFF
--- a/packages/vitest/src/runtime/runner/context.ts
+++ b/packages/vitest/src/runtime/runner/context.ts
@@ -259,7 +259,7 @@ function makeTimeoutError(isHook: boolean, timeout: number, stackTraceError?: Er
   }".`
   const error = new Error(message)
   if (stackTraceError?.stack) {
-    error.stack = stackTraceError.stack.replace(error.message, stackTraceError.message)
+    error.stack = stackTraceError.stack.replace(stackTraceError.message, error.message)
   }
   return error
 }

--- a/test/e2e/test/hook-timeout.test.ts
+++ b/test/e2e/test/hook-timeout.test.ts
@@ -7,3 +7,22 @@ test('timeout error with stack trace', async () => {
   })
   expect(stderr).toMatchSnapshot()
 })
+
+test('timeout error stack starts with the timeout message', async () => {
+  const { ctx } = await runVitest({
+    root: './fixtures/hook-timeout',
+  })
+  const errors = ctx!.state.getFiles().flatMap(f =>
+    f.tasks.flatMap(t => t.result?.errors ?? []),
+  )
+  expect(
+    errors.map(e => e.stack?.split('\n')[0]),
+  ).toMatchInlineSnapshot(`
+    [
+      "Error: Hook timed out in 10ms.",
+      "Error: Hook timed out in 30ms.",
+      "Error: Hook timed out in 50ms.",
+      "Error: Test timed out in 123ms.",
+    ]
+  `)
+})


### PR DESCRIPTION
When a test or hook times out, `error.stack` starts with `Error: STACK_TRACE_ERROR` instead of the timeout message. `makeTimeoutError` takes its frames from a placeholder error captured at definition time, but the two `replace()` arguments are swapped: it searches the placeholder's stack for the real timeout message, which is never there, so nothing changes and the placeholder header stays.

Swapping the arguments puts the real timeout message on the placeholder's frames. The default reporter hides this since it prints `message` on its own, but the JSON reporter builds `failureMessages` from `stack`, so every timeout there reads as a bare `Error: STACK_TRACE_ERROR` with no sign a timeout happened at all.

Fixes #10872
