### PR TITLE
docs(expect): correct the resolved matcher JSDoc examples

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -719,42 +719,65 @@ export interface Assertion<R extends void | Promise<void> = void, T = unknown>
   toHaveBeenCalledAfter: (mock: MockInstance, failIfNoFirstInvocation?: boolean) => R
 
   /**
-   * Checks that a promise resolves successfully at least once.
+   * Checks that a mock function resolved successfully at least once.
+   * Requires a spy function to be passed to `expect`.
    *
    * @example
-   * await expect(promise).toHaveResolved();
+   * const mockAsyncFunc = vi.fn(async () => 'success');
+   * await mockAsyncFunc();
+   *
+   * expect(mockAsyncFunc).toHaveResolved();
    */
   toHaveResolved: () => R
 
   /**
-   * Checks that a promise resolves to a specific value.
+   * Checks that a mock function resolved to a specific value at least once.
+   * Requires a spy function to be passed to `expect`.
    *
    * @example
-   * await expect(promise).toHaveResolvedWith('success');
+   * const mockAsyncFunc = vi.fn(async () => 'success');
+   * await mockAsyncFunc();
+   *
+   * expect(mockAsyncFunc).toHaveResolvedWith('success');
    */
   toHaveResolvedWith: <E>(value: E) => R
 
   /**
-   * Ensures a promise resolves a specific number of times.
+   * Ensures a mock function resolved a specific number of times.
+   * Requires a spy function to be passed to `expect`.
    *
    * @example
+   * const mockAsyncFunc = vi.fn(async () => 'success');
+   * await mockAsyncFunc();
+   * await mockAsyncFunc();
+   * await mockAsyncFunc();
+   *
    * expect(mockAsyncFunc).toHaveResolvedTimes(3);
    */
   toHaveResolvedTimes: (times: number) => R
 
   /**
-   * Asserts that the last resolved value of a promise matches an expected value.
+   * Asserts that the value a mock function resolved to when it was last called
+   * matches an expected value. Requires a spy function to be passed to `expect`.
    *
    * @example
-   * await expect(mockAsyncFunc).toHaveLastResolvedWith('finalResult');
+   * const mockAsyncFunc = vi.fn(async () => 'finalResult');
+   * await mockAsyncFunc();
+   *
+   * expect(mockAsyncFunc).toHaveLastResolvedWith('finalResult');
    */
   toHaveLastResolvedWith: <E>(value: E) => R
 
   /**
-   * Ensures a specific value was returned by a promise on the nth resolution.
+   * Ensures a mock function resolved to a specific value on its nth call.
+   * Requires a spy function to be passed to `expect`.
    *
    * @example
-   * await expect(mockAsyncFunc).toHaveNthResolvedWith(2, 'secondResult');
+   * const mockAsyncFunc = vi.fn(async (result: string) => result);
+   * await mockAsyncFunc('firstResult');
+   * await mockAsyncFunc('secondResult');
+   *
+   * expect(mockAsyncFunc).toHaveNthResolvedWith(2, 'secondResult');
    */
   toHaveNthResolvedWith: <E>(nthCall: number, value: E) => R
 


### PR DESCRIPTION
### Description

Fixes #10870.

The JSDoc on `toHaveResolved` (and its siblings) documented an example that cannot work:

```ts
await expect(promise).toHaveResolved();
```

Following it fails with `TypeError: Promise{…} is not a spy or a call to a spy!`, because these matchers read `spy.mock.settledResults` and require a spy — not a promise. `docs/api/expect.md` already documents them correctly ("Requires a spy function to be passed to `expect`"); only the inline JSDoc, which is what shows up in editor hover/IntelliSense, was wrong.

This corrects all five resolved matchers in `packages/expect/src/types.ts`:

- `toHaveResolved` and `toHaveResolvedWith` — replaced the bare `promise` with a spy.
- `toHaveResolvedTimes`, `toHaveLastResolvedWith`, `toHaveNthResolvedWith` — these already named a spy, but the example never called it, so the assertion as written would fail. Added the calls that produce the settled results being asserted on.
- Dropped the stray `await` on the assertions themselves — they are synchronous.
- Added the "Requires a spy function to be passed to `expect`" note to each, matching the prose docs.

Descriptions were also reworded from "a promise resolves" to "a mock function resolved", since the subject of the assertion is the spy's settled results, not a promise.

### Validation

Docs-only change (JSDoc comments), no runtime behaviour touched. I verified each corrected example actually passes by running them as a temporary test against a locally built `packages/expect` — all five assert green — then removed the scratch file since a JSDoc fix doesn't warrant a permanent test. `pnpm build` and `eslint packages/expect/src/types.ts` are clean.

<!-- VITEST_AUTOMATED_PR -->
