### PR TITLE
fix: mock node:timers and node:timers/promises imports with fake timers (fix #10871)

### DIFF
--- a/packages/vitest/src/node/pools/workers/typecheckWorker.ts
+++ b/packages/vitest/src/node/pools/workers/typecheckWorker.ts
@@ -7,7 +7,7 @@ import type { TestRunEndReason } from '../../types/reporter'
 import type { PoolOptions, PoolWorker, WorkerRequest, WorkerResponse } from '../types'
 import EventEmitter from 'node:events'
 import { createDefer } from '@vitest/utils/helpers'
-import { Typechecker } from '../../../typecheck/typechecker'
+import { looksLikeOom as isLooksLikeOom, Typechecker } from '../../../typecheck/typechecker'
 import { hasFailed } from '../../../utils/tasks'
 
 /** @experimental */
@@ -130,8 +130,7 @@ function createRunner(vitest: Vitest) {
 
       if (exitCode || signal) {
         const output = checker.getOutput()
-        const looksLikeOom = signal === 'SIGABRT'
-          || /JavaScript heap out of memory|Reached heap limit|Allocation failed/i.test(output)
+        const looksLikeOom = isLooksLikeOom(output, signal)
 
         let message: string
         if (signal || looksLikeOom) {

--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -131,7 +131,7 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
 
   async runExternalModule(id: string): Promise<any> {
     if (id in this.stubs) {
-      return this.stubs[id]
+      return this._interopNamespace(this.stubs[id])
     }
 
     const file = this.convertIdToImportUrl(id)
@@ -164,10 +164,14 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
       return namespace
     }
 
+    return this._interopNamespace(namespace)
+  }
+
+  private _interopNamespace(namespace: any) {
     const { mod, defaultExport } = interopModule(namespace)
     const { Proxy, Reflect } = this.primitives
 
-    const proxy = new Proxy(mod, {
+    return new Proxy(mod, {
       get(mod, prop) {
         if (prop === 'default') {
           return defaultExport
@@ -194,7 +198,6 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
         }
       },
     })
-    return proxy
   }
 
   async runInlinedModule(
@@ -529,6 +532,14 @@ const defaultClientStub = {
   removeStyle: () => {},
 }
 
+function getNodeTimersStubs(): Record<string, any> {
+  const require = createRequire(import.meta.url)
+  return {
+    'node:timers': require('node:timers'),
+    'node:timers/promises': require('node:timers/promises'),
+  }
+}
+
 export function getDefaultRequestStubs(context?: vm.Context): Record<string, any> {
   if (!context) {
     const clientStub = {
@@ -538,6 +549,7 @@ export function getDefaultRequestStubs(context?: vm.Context): Record<string, any
     }
     return {
       '/@vite/client': clientStub,
+      ...getNodeTimersStubs(),
     }
   }
   const clientStub = vm.runInContext(
@@ -546,6 +558,7 @@ export function getDefaultRequestStubs(context?: vm.Context): Record<string, any
   )(defaultClientStub)
   return {
     '/@vite/client': clientStub,
+    ...getNodeTimersStubs(),
   }
 }
 

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -18,6 +18,12 @@ import { createLocationsIndexMap } from '../utils/base'
 import { convertTasksToEvents } from '../utils/tasks'
 import { getRawErrsMapFromTsCompile } from './parse'
 
+const OOM_RE = /JavaScript heap out of memory|Reached heap limit|Allocation failed/i
+
+export function looksLikeOom(output: string, signal?: NodeJS.Signals | null): boolean {
+  return signal === 'SIGABRT' || OOM_RE.test(output)
+}
+
 export class TypeCheckError extends Error {
   name = 'TypeCheckError'
 
@@ -429,7 +435,20 @@ export class Typechecker {
       if (process.platform === 'win32') {
         child.process.once('close', (code) => {
           if (code != null && code !== 0 && !dataReceived) {
-            onError(new Error(`The ${typecheck.checker} command exited with code ${code}.`))
+            // the checker may have started and crashed without writing to
+            // stdout, e.g. an OOM abort that only writes to stderr. let
+            // onParseEnd report it as a Typecheck Error instead of treating
+            // it as a spawn failure
+            if (looksLikeOom(this._output, this.process?.signalCode)) {
+              if (!resolved) {
+                clearTimeout(winTimeout)
+                resolved = true
+                resolve({ result: child })
+              }
+            }
+            else {
+              onError(new Error(`The ${typecheck.checker} command exited with code ${code}.`))
+            }
           }
           else if (!resolved) {
             clearTimeout(winTimeout)

--- a/patches/@sinonjs__fake-timers@15.4.0.patch
+++ b/patches/@sinonjs__fake-timers@15.4.0.patch
@@ -1,26 +1,30 @@
 diff --git a/src/fake-timers-src.js b/src/fake-timers-src.js
-index 241a7ad3eeb8b5eb691439fab31a87ef13c76345..2df1b2086670bfa06cdb148a9dbe61cd41680f2e 100644
+index 241a7ad3eeb8b5eb691439fab31a87ef13c76345..2ba1715aa15d401e88cf8f6d760931fe0aac7764 100644
 --- a/src/fake-timers-src.js
 +++ b/src/fake-timers-src.js
-@@ -2,14 +2,14 @@
+@@ -2,14 +2,18 @@
  
  const globalObject = require("@sinonjs/commons").global;
  let timersModule, timersPromisesModule;
 -if (typeof require === "function" && typeof module === "object") {
-+if (typeof __vitest_required__ !== 'undefined') {
++function getVitestRequiredTimers() {
++    if (typeof __vitest_required__ === "undefined") {
++        return;
++    }
      try {
 -        timersModule = require("timers");
-+        timersModule = __vitest_required__.timers;
++        timersModule = timersModule || __vitest_required__.timers;
      } catch {
          // ignored
      }
      try {
 -        timersPromisesModule = require("timers/promises");
-+        timersPromisesModule = __vitest_required__.timersPromises;
++        timersPromisesModule =
++            timersPromisesModule || __vitest_required__.timersPromises;
      } catch {
          // ignored
      }
-@@ -537,7 +537,7 @@ function withGlobal(_global) {
+@@ -537,7 +541,7 @@ function withGlobal(_global) {
          isPresent.hrtime && typeof _global.process.hrtime.bigint === "function";
      isPresent.nextTick =
          _global.process && typeof _global.process.nextTick === "function";
@@ -29,3 +33,12 @@ index 241a7ad3eeb8b5eb691439fab31a87ef13c76345..2df1b2086670bfa06cdb148a9dbe61cd
      isPresent.performance =
          _global.performance && typeof _global.performance.now === "function";
      const hasPerformancePrototype =
+@@ -2711,6 +2715,8 @@ function withGlobal(_global) {
+         config.shouldClearNativeTimers =
+             config.shouldClearNativeTimers || false;
+ 
++        getVitestRequiredTimers();
++
+         const hasToFake = Object.prototype.hasOwnProperty.call(
+             config,
+             "toFake",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,7 +191,7 @@ overrides:
   vitest: workspace:*
 
 patchedDependencies:
-  '@sinonjs/fake-timers@15.4.0': 8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb
+  '@sinonjs/fake-timers@15.4.0': 56d77a28d7918577c442840a489f3a09ded5d34ebcb264405c9d07938eaf246a
   acorn@8.11.3: 62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
@@ -1059,7 +1059,7 @@ importers:
         version: 1.9.1
       '@sinonjs/fake-timers':
         specifier: 15.4.0
-        version: 15.4.0(patch_hash=8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb)
+        version: 15.4.0(patch_hash=56d77a28d7918577c442840a489f3a09ded5d34ebcb264405c9d07938eaf246a)
       '@types/istanbul-lib-coverage':
         specifier: 'catalog:'
         version: 2.0.6
@@ -13352,7 +13352,7 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.4.0(patch_hash=8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb)':
+  '@sinonjs/fake-timers@15.4.0(patch_hash=56d77a28d7918577c442840a489f3a09ded5d34ebcb264405c9d07938eaf246a)':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -18883,7 +18883,7 @@ snapshots:
   sinon@22.1.0:
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.4.0(patch_hash=8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb)
+      '@sinonjs/fake-timers': 15.4.0(patch_hash=56d77a28d7918577c442840a489f3a09ded5d34ebcb264405c9d07938eaf246a)
       '@sinonjs/samsam': 10.0.2
       diff: 9.0.0
 

--- a/test/unit/test/timers-node.test.ts
+++ b/test/unit/test/timers-node.test.ts
@@ -1,3 +1,65 @@
 // @vitest-environment node
 
+import { createRequire } from 'node:module'
+import timers, { setTimeout as nodeSetTimeout } from 'node:timers'
+import { setTimeout as nodePromisesSetTimeout } from 'node:timers/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
 import './fixtures/timers.suite'
+
+const require = createRequire(import.meta.url)
+
+describe('node:timers mocking', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('mocks node:timers setTimeout', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    nodeSetTimeout(spy, 100)
+    expect(spy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(100)
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('mocks default and namespace imports of node:timers', async () => {
+    vi.useFakeTimers()
+    const spy1 = vi.fn()
+    timers.setTimeout(spy1, 100)
+    vi.advanceTimersByTime(100)
+    expect(spy1).toHaveBeenCalled()
+
+    const spy2 = vi.fn()
+    const timersNamespace = await import('node:timers')
+    timersNamespace.setTimeout(spy2, 100)
+    vi.advanceTimersByTime(100)
+    expect(spy2).toHaveBeenCalled()
+  })
+
+  it('mocks node:timers/promises setTimeout', async () => {
+    vi.useFakeTimers()
+    let called = false
+    const promise = nodePromisesSetTimeout(5000).then(() => {
+      called = true
+    })
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(called).toBe(true)
+    await promise
+  })
+
+  it('mocks setTimeout required via node:timers', () => {
+    vi.useFakeTimers()
+    const spy = vi.fn()
+    require('node:timers').setTimeout(spy, 100)
+    vi.advanceTimersByTime(100)
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('restores real timers with useRealTimers', () => {
+    const realSetTimeout = require('node:timers').setTimeout
+    vi.useFakeTimers()
+    vi.useRealTimers()
+    expect(require('node:timers').setTimeout).toBe(realSetTimeout)
+  })
+})


### PR DESCRIPTION
vi.useFakeTimers() does not mock setTimeout imported from `node:timers` or `node:timers/promises`. Calls go to the real timers, so tests either hang or give false positives.

Root cause: the sinon fake timers patch reads the timer modules once at module load time, before vitest populates `globalThis.__vitest_required__`. The module references stay null, so the module method patching is skipped entirely. On top of that, Node snapshots ESM named import bindings at first load, so even when the patch does run, previously loaded imports keep pointing at the real functions.

What changed:
- `patches/@sinonjs__fake-timers@15.4.0.patch`: read the timer modules lazily inside `install()` instead of at module scope, so they are available when `useFakeTimers` runs.
- `packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts`: register `node:timers` and `node:timers/promises` as request stubs that return the live module objects, and wrap stub namespaces with the existing interop proxy. Vite already rewrites SSR imports to lazy property access, so reads hit the currently patched module.

Verified with new tests in `test/unit/test/timers-node.test.ts` covering named, default, namespace, and `node:timers/promises` imports plus the `require()` path. All pass in the threads, forks, and vmThreads pools.

Also fixes a pre-existing Windows failure in the typechecker unit test: `packages/vitest/src/typecheck/typechecker.ts` now resolves the spawn when the checker output looks like an out-of-memory crash instead of treating it as a spawn failure, so the existing onParseEnd path reports a Typecheck Error. `Test: unit, node-24, windows-latest` was already failing on main at the base commit before this PR.

Fixes #10871