### PR TITLE
fix(browser): resolve `connectTimeout` from the project config (fix #10879)

### DIFF
--- a/packages/vitest/src/node/browser/sessions.ts
+++ b/packages/vitest/src/node/browser/sessions.ts
@@ -28,7 +28,7 @@ export class BrowserSessions {
     let isReady = false
     const timeout = setTimeout(() => {
       defer.reject(new Error(`Failed to connect to the browser session "${sessionId}" [${project.name}] within the timeout.`))
-    }, project.vitest.config.browser.connectTimeout ?? 60_000).unref()
+    }, project.config.browser.connectTimeout ?? 60_000).unref()
 
     const resolveIfReady = () => {
       if (!isConnected || !isReady) {

--- a/packages/vitest/src/node/types/browser.ts
+++ b/packages/vitest/src/node/types/browser.ts
@@ -321,7 +321,7 @@ export interface BrowserConfigOptions {
 
   /**
    * Timeout for connecting to the browser
-   * @default 30000
+   * @default 60000
    */
   connectTimeout?: number
 

--- a/test/unit/test/browser-sessions.test.ts
+++ b/test/unit/test/browser-sessions.test.ts
@@ -2,8 +2,12 @@ import type { TestProject } from 'vitest/node'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { BrowserSessions } from '../../../packages/vitest/src/node/browser/sessions'
 
-function createProject(connectTimeout = 100) {
-  return { name: 'browser', vitest: { config: { browser: { connectTimeout } } } } as TestProject
+function createProject(connectTimeout = 100, rootConnectTimeout = connectTimeout) {
+  return {
+    name: 'browser',
+    config: { browser: { connectTimeout } },
+    vitest: { config: { browser: { connectTimeout: rootConnectTimeout } } },
+  } as TestProject
 }
 
 describe('BrowserSessions', () => {
@@ -50,6 +54,22 @@ describe('BrowserSessions', () => {
       await vi.advanceTimersByTimeAsync(101)
 
       await timeoutError
+    })
+
+    test('times out with the project connect timeout instead of the root one', async () => {
+      const sessions = new BrowserSessions()
+      const promise = sessions.createSession('session-id', createProject(100, 10), { reject() {} })
+
+      let rejected = false
+      promise.catch(() => {
+        rejected = true
+      })
+
+      await vi.advanceTimersByTimeAsync(11)
+      expect(rejected).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(90)
+      expect(rejected).toBe(true)
     })
 
     test('fails the pool without waiting for the connect timeout', async () => {

--- a/test/unit/test/browser-sessions.test.ts
+++ b/test/unit/test/browser-sessions.test.ts
@@ -60,6 +60,10 @@ describe('BrowserSessions', () => {
       const sessions = new BrowserSessions()
       const promise = sessions.createSession('session-id', createProject(100, 10), { reject() {} })
 
+      const timeoutError = expect(promise).rejects.toThrowError(
+        'Failed to connect to the browser session "session-id" [browser] within the timeout.',
+      )
+
       let rejected = false
       promise.catch(() => {
         rejected = true
@@ -70,6 +74,8 @@ describe('BrowserSessions', () => {
 
       await vi.advanceTimersByTimeAsync(90)
       expect(rejected).toBe(true)
+
+      await timeoutError
     })
 
     test('fails the pool without waiting for the connect timeout', async () => {


### PR DESCRIPTION
### Description

The browser session handshake read `connectTimeout` off `project.vitest.config`, which is the root resolved config, so a value set inside a project never reached it and the 60s default was used instead. Every other `browser.*` option on that project is honoured, and the timeout error itself is per-session and names the project, so reading the project's own resolved config is what was meant here. Root-level and CLI values still apply, since projects inherit them during resolution.

While I was in the file I also fixed the JSDoc default for the option. It said 30000, but the code, the CLI help and the docs page all say 60000.

Resolves #10879

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

