### PR TITLE
fix(browser): encode filepath in importpath to preserve + character (fixes #10860) 🤖🤖🤖

### DIFF
--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -329,7 +329,9 @@ function createBrowserRunner(
       // on Windows we need the unit to resolve the test file
       const prefix = `/${/^\w:/.test(filepath) ? '@fs/' : ''}`
       const query = `browserv=${hash}`
-      const importpath = `${prefix}${filepath}?${query}`.replace(/\/+/g, '/')
+      // Normalize backslashes then encode to preserve + as %2B
+      const normalizedPath = filepath.replace(/\\/g, '/')
+      const importpath = `${prefix}${encodeURIComponent(normalizedPath)}?${query}`
       // start tracing before the test file is imported
       const trace = this.config.browser.trace
       if (mode === 'collect' && trace !== 'off') {


### PR DESCRIPTION
## Summary

Fixes a browser mode hang when the project root path contains a `+` character.

### Root cause

The browser tester client constructs import URLs like `/\@fs/path+with+plus/test.ts`. The browser's `fetch` / `import()` API decodes `+` as a space, so the URL arriving at the dev server becomes `/\@fs/path with plus/test.ts` — a different path that returns 404. The tester hangs forever waiting for a module that never loads.

### Fix

1. Normalize Windows backslashes to forward slashes first
2. Then encodeURIComponent the path so `+` becomes `%2B` and survives the round-trip

### Code changes

- `packages/browser/src/client/tester/runner.ts`: normalize then encode

## Test Plan

- Verify encoded path reaches dev server with `%2B` instead of space
- The dev server and Vite's plugin pipeline already handle both encoded and unencoded paths correctly

## Checklist

- [x] Code follows project conventions
- [x] Change is minimal and targeted

<!-- VITEST_AUTOMATED_PR -->