### PR TITLE
fix(browser): dispose CDP listeners when tester disconnects (fix #10810)

### DIFF
--- a/packages/browser/src/node/cdp.ts
+++ b/packages/browser/src/node/cdp.ts
@@ -51,4 +51,12 @@ export class BrowserServerCDPHandler {
   once(event: string, listener: string): void {
     this.on(event, listener, true)
   }
+
+  dispose(): void {
+    for (const [event, listener] of Object.entries(this.listeners)) {
+      this.session.off(event as any, listener)
+    }
+    this.listenerIds = {}
+    this.listeners = {}
+  }
 }

--- a/packages/browser/src/node/projectParent.ts
+++ b/packages/browser/src/node/projectParent.ts
@@ -216,8 +216,9 @@ export class ParentBrowserProject {
     return handler
   }
 
-  removeCDPHandler(sessionId: string): void {
-    this.cdps.delete(sessionId)
+  removeCDPHandler(rpcId: string): void {
+    this.cdps.get(rpcId)?.dispose()
+    this.cdps.delete(rpcId)
   }
 
   async formatScripts(scripts: BrowserScript[] | undefined): Promise<HtmlTagDescriptor[]> {

--- a/test/browser/specs/cdp.test.ts
+++ b/test/browser/specs/cdp.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest'
+import { instances, provider, runInlineBrowserTests } from './utils'
+
+test.runIf(provider.name === 'playwright')('removes CDP listeners when a tester disconnects', async () => {
+  const chromium = instances.find(instance => instance.browser === 'chromium')
+
+  expect.assert(chromium)
+
+  const { stderr, testTree } = await runInlineBrowserTests(
+    {
+      'a.test.ts': `
+        import { test } from 'vitest'
+        import { cdp } from 'vitest/browser'
+
+        test('subscribes to console events', async () => {
+          await cdp().send('Console.enable')
+          cdp().on('Console.messageAdded', () => {})
+
+          await cdp().send('Runtime.evaluate', { expression: 'undefined' })
+        })
+      `,
+      'b.test.ts': `
+        import { expect, test } from 'vitest'
+
+        test('runs after the subscribed file', async () => {
+          console.log('TRIGGER STALE CDP LISTENER')
+          await new Promise(resolve => setTimeout(resolve, 50))
+          expect(1).toBe(1)
+        })
+      `,
+    },
+    {
+      fileParallelism: false,
+      browser: {
+        instances: [chromium],
+      },
+    },
+  )
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "a.test.ts": {
+        "subscribes to console events": "passed",
+      },
+      "b.test.ts": {
+        "runs after the subscribed file": "passed",
+      },
+    }
+  `)
+})

--- a/test/core/test/browser-cdp-handler.test.ts
+++ b/test/core/test/browser-cdp-handler.test.ts
@@ -1,0 +1,68 @@
+import type { CDPSession } from 'vitest/node'
+import type { WebSocketBrowserRPC } from '../../../packages/browser/src/types'
+import { describe, expect, test, vi } from 'vitest'
+import { BrowserServerCDPHandler } from '../../../packages/browser/src/node/cdp'
+
+function createSession() {
+  const listeners = new Map<string, (payload: unknown) => void>()
+  return {
+    send: vi.fn(),
+    on: vi.fn((event: string, listener: (payload: unknown) => void) => {
+      listeners.set(event, listener)
+    }),
+    off: vi.fn((event: string) => {
+      listeners.delete(event)
+    }),
+    once: vi.fn(),
+    emit(event: string, payload: unknown) {
+      listeners.get(event)?.(payload)
+    },
+  } as unknown as CDPSession & { emit: (event: string, payload: unknown) => void }
+}
+
+function createTester() {
+  return {
+    cdpEvent: vi.fn(),
+  } as unknown as WebSocketBrowserRPC
+}
+
+describe('BrowserServerCDPHandler', () => {
+  test('forwards session events to the tester while subscribed', () => {
+    const session = createSession()
+    const tester = createTester()
+    const handler = new BrowserServerCDPHandler(session, tester)
+
+    handler.on('Console.messageAdded', 'listener-1')
+    session.emit('Console.messageAdded', { text: 'hello' })
+
+    expect(tester.cdpEvent).toHaveBeenCalledWith('Console.messageAdded', { text: 'hello' })
+  })
+
+  test('dispose() removes every registered listener from the session', () => {
+    const session = createSession()
+    const tester = createTester()
+    const handler = new BrowserServerCDPHandler(session, tester)
+
+    handler.on('Console.messageAdded', 'listener-1')
+    handler.on('Debugger.scriptParsed', 'listener-2')
+
+    handler.dispose()
+
+    expect(session.off).toHaveBeenCalledWith('Console.messageAdded', expect.any(Function))
+    expect(session.off).toHaveBeenCalledWith('Debugger.scriptParsed', expect.any(Function))
+  })
+
+  test('dispose() stops forwarding events that fire after teardown', () => {
+    const session = createSession()
+    const tester = createTester()
+    const handler = new BrowserServerCDPHandler(session, tester)
+
+    handler.on('Console.messageAdded', 'listener-1')
+    handler.dispose()
+
+    // simulates a stale CDP event arriving after the tester's RPC channel closed
+    session.emit('Console.messageAdded', { text: 'stale' })
+
+    expect(tester.cdpEvent).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Description

Fixes a crash in browser mode where stale CDP event listeners cause the entire test run to abort mid-way.

**Root cause:** `removeCDPHandler()` in `packages/browser/src/node/projectParent.ts` only deleted the `BrowserServerCDPHandler` from its internal map when a tester's WebSocket disconnected — it never unregistered the listeners that handler had registered on the underlying Playwright `CDPSession`. Since a browser page/CDP session can outlive a single test file's connection, a listener registered by one file could still be attached when a later file triggered the same CDP event. The listener would then call `tester.cdpEvent(...)` on a birpc channel that was already closed, and birpc throws synchronously in that case (`[birpc] rpc is closed, cannot call "cdpEvent"`). That throw happens inside Playwright's internal event dispatch with nothing to catch it, so it crashes the whole run instead of just failing one test.

**Fix:** added `BrowserServerCDPHandler.dispose()`, which calls `session.off()` for every event the handler ever registered and clears its internal state. `removeCDPHandler()` now calls `dispose()` before removing the handler from the map, so no listener is left attached to the CDP session once a tester disconnects.

Resolves #10810

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Includes a test that fails without this PR but passes with it (verified locally by reverting the fix and confirming the new test reproduces the exact crash).
- [x] No changes to `pnpm-lock.yaml`.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).

### Tests
- [x] Ran the tests with `pnpm test:ci` (targeted: `test/core/test/browser-cdp-handler.test.ts` and `test/browser/specs/cdp.test.ts`).

### Documentation
- [x] N/A — internal bugfix, no public API change.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

### Base branch note
This targets `v4` directly (not `main`) so the fix ships in the next Vitest 4.x patch release.

### AI disclosure
Claude Code assisted in diagnosing the root cause, implementing the fix, and writing the regression tests for this PR.
