### PR TITLE
feat(reporters): display `test.name` in GitHub Actions reporter summary header

### DIFF
--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -741,7 +741,9 @@ export default defineConfig({
 })
 ```
 
-The job summary title defaults to `Vitest Test Report`. You can use `jobSummary.title` to distinguish multiple Vitest invocations that append to the same job summary.
+The job summary title defaults to `Vitest Test Report` or `(${test.name}) Vitest Test Report` when [`test.name` is set](/config/name).
+
+You can customize the title by setting `jobSummary.title` to distinguish multiple Vitest invocations that append to the same job summary. Please note that `test.name` will not be displayed when using a custom title.
 
 ```ts
 export default defineConfig({

--- a/packages/vitest/src/node/reporters/github-actions.ts
+++ b/packages/vitest/src/node/reporters/github-actions.ts
@@ -2,6 +2,7 @@ import type { SerializedError } from '@vitest/utils'
 import type { TestAnnotation } from '../../runtime/runner/types'
 import type { Vitest } from '../core'
 import type { TestProject } from '../project'
+import type { ResolvedConfig } from '../types/config'
 import type { Reporter } from '../types/reporter'
 import type { TestCase, TestModule } from './reported-tasks'
 import { writeFileSync } from 'node:fs'
@@ -75,11 +76,14 @@ interface JobSummaryOptions {
 
 type ResolvedOptions = Required<GithubActionsReporterOptions>
 
+// we prepend `test.name` to the default title when set, custom titles don't follow this logic
+// we need to know when the user provides a custom one, so this is handled outside `defaultOptions`
+const DEFAULT_TITLE = 'Vitest Test Report'
+
 const defaultOptions: ResolvedOptions = {
   onWritePath: defaultOnWritePath,
   displayAnnotations: true,
   jobSummary: {
-    title: 'Vitest Test Report',
     enabled: true,
     outputPath: process.env.GITHUB_STEP_SUMMARY,
     fileLinks: {
@@ -182,7 +186,7 @@ export class GithubActionsReporter implements Reporter {
 
     if (this.options.jobSummary.enabled === true && this.options.jobSummary.outputPath) {
       const summary = renderSummary(
-        collectSummaryData(testModules),
+        collectSummaryData(testModules, this.ctx.config),
         this.options.jobSummary.title,
         this.options.jobSummary.fileLinks,
       )
@@ -258,6 +262,7 @@ function escapeProperty(s: string): string {
 type SummaryTestsStats = Record<'failed' | 'passed' | 'expectedFail' | 'skipped' | 'todo', number>
 
 interface SummaryData {
+  name: string | null
   fileStats: Pick<SummaryTestsStats, 'failed' | 'passed'>
   testsStats: SummaryTestsStats
   flakyTests: Array<{
@@ -277,8 +282,9 @@ interface SummaryData {
   }>
 }
 
-function collectSummaryData(testModules: ReadonlyArray<TestModule>): SummaryData {
+function collectSummaryData(testModules: ReadonlyArray<TestModule>, config: ResolvedConfig): SummaryData {
   const summaryData: SummaryData = {
+    name: config.name || null,
     fileStats: {
       failed: 0,
       passed: 0,
@@ -446,10 +452,16 @@ function renderStats({ fileStats, testsStats }: SummaryData): string {
   return output
 }
 
-function renderSummary(summaryData: SummaryData, title: string = defaultOptions.jobSummary.title!, fileLinks?: JobSummaryOptions['fileLinks']): string {
+function renderSummary(summaryData: SummaryData, title?: string, fileLinks?: JobSummaryOptions['fileLinks']): string {
   const fileLinkCreator = createGitHubFileLinkCreator(fileLinks)
+  const header = title
+    ?? (
+      summaryData.name
+        ? `(${summaryData.name}) ${DEFAULT_TITLE}`
+        : DEFAULT_TITLE
+    )
 
-  let summary = `## ${title}\n${renderStats(summaryData)}`
+  let summary = `## ${header}\n${renderStats(summaryData)}`
 
   if (summaryData.flakyTests.length > 0) {
     summary += '\n### Flaky Tests\n\nThese tests passed only after one or more retries, indicating potential instability.\n'

--- a/test/e2e/test/reporters/github-actions.test.ts
+++ b/test/e2e/test/reporters/github-actions.test.ts
@@ -137,9 +137,22 @@ describe(GithubActionsReporter, () => {
     it.for([
       { title: 'Custom Test Report', expectedTitle: 'Custom Test Report' },
       { title: undefined, expectedTitle: 'Vitest Test Report' },
-    ] as const)('uses $expectedTitle when title is $title', async ({ title, expectedTitle }, ctx) => {
+    ] as const)('uses a custom title when providing one', async ({ title, expectedTitle }, ctx) => {
       const summary = await createSummary({
         summaryConfig: { title },
+        ctx,
+      })
+
+      expect(summary.startsWith(`## ${expectedTitle}\n\n`)).toBe(true)
+    })
+
+    it.for([
+      { title: 'Custom Test Report', expectedTitle: 'Custom Test Report' },
+      { title: undefined, expectedTitle: '(suite-name) Vitest Test Report' },
+    ] as const)('displays `test.name` when not using a custom title', async ({ title, expectedTitle }, ctx) => {
+      const summary = await createSummary({
+        summaryConfig: { title },
+        vitestConfig: { name: 'suite-name' },
         ctx,
       })
 

--- a/test/e2e/test/reporters/github-actions.test.ts
+++ b/test/e2e/test/reporters/github-actions.test.ts
@@ -1,5 +1,7 @@
+import type { TestContext } from 'vitest'
+import type { RunVitestConfig } from '#test-utils'
 import { randomUUID } from 'node:crypto'
-import { access, readFile, rm } from 'node:fs/promises'
+import { readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { sep } from 'node:path'
 import { resolve } from 'pathe'
@@ -64,32 +66,43 @@ describe(GithubActionsReporter, () => {
   })
 
   describe('summary', () => {
-    it('writes one when enabled', async ({ onTestFinished }) => {
+    async function createSummary(options: {
+      summaryConfig: GithubActionsReporter['options']['jobSummary']
+      vitestConfig?: RunVitestConfig
+      ctx: TestContext
+    }): Promise<string> {
       const outputPath = resolve(tmpdir(), randomUUID())
 
-      onTestFinished(async () => {
-        await rm(outputPath).catch(() => {
-          console.error(`Could not remove ${outputPath}`)
-        })
+      options.ctx.onTestFinished(async () => {
+        await rm(outputPath).catch(() => {})
       })
 
-      const workspacePath = resolve(import.meta.dirname, '..', '..', '..', '..')
-
       await runVitest({
+        ...options.vitestConfig,
         reporters: new GithubActionsReporter({
           jobSummary: {
             outputPath,
-            fileLinks: {
-              commitHash: 'aaa',
-              repository: 'owner/repo',
-              workspacePath,
-            },
+            ...options.summaryConfig,
           },
         }),
         root: './fixtures/reporters/github-actions',
       })
 
-      const summary = await readFile(outputPath, 'utf8')
+      return readFile(outputPath, 'utf8')
+    }
+
+    it('writes one when enabled', async (ctx) => {
+      const workspacePath = resolve(import.meta.dirname, '..', '..', '..', '..')
+      const summary = await createSummary({
+        summaryConfig: {
+          fileLinks: {
+            commitHash: 'aaa',
+            repository: 'owner/repo',
+            workspacePath,
+          },
+        },
+        ctx,
+      })
 
       expect(summary).toMatchInlineSnapshot(`
         "## Vitest Test Report
@@ -124,51 +137,28 @@ describe(GithubActionsReporter, () => {
     it.for([
       { title: 'Custom Test Report', expectedTitle: 'Custom Test Report' },
       { title: undefined, expectedTitle: 'Vitest Test Report' },
-    ] as const)('uses $expectedTitle when title is $title', async ({ title, expectedTitle }, { onTestFinished }) => {
-      const outputPath = resolve(tmpdir(), randomUUID())
-
-      onTestFinished(async () => {
-        await rm(outputPath).catch(() => {
-          console.error(`Could not remove ${outputPath}`)
-        })
+    ] as const)('uses $expectedTitle when title is $title', async ({ title, expectedTitle }, ctx) => {
+      const summary = await createSummary({
+        summaryConfig: { title },
+        ctx,
       })
-
-      await runVitest({
-        reporters: new GithubActionsReporter({
-          jobSummary: {
-            title,
-            outputPath,
-          },
-        }),
-        root: './fixtures/reporters/github-actions',
-      })
-
-      const summary = await readFile(outputPath, 'utf8')
 
       expect(summary.startsWith(`## ${expectedTitle}\n\n`)).toBe(true)
     })
 
-    it.for([{ enabled: false }, { outputPath: undefined }] as const)('does not write one when disabled or without `outputPath`', async (options) => {
-      const outputPath = resolve(tmpdir(), randomUUID())
-
+    it.for([{ enabled: false }, { outputPath: undefined }] as const)('does not write one when disabled or without `outputPath`', async (options, ctx) => {
       const workspacePath = resolve(import.meta.dirname, '..', '..', '..', '..')
-
-      await runVitest({
-        reporters: new GithubActionsReporter({
-          jobSummary: {
-            outputPath,
-            ...options,
-            fileLinks: {
-              commitHash: 'aaa',
-              repository: 'owner/repo',
-              workspacePath,
-            },
+      const summary = await createSummary({
+        summaryConfig: {
+          ...options,
+          fileLinks: {
+            commitHash: 'aaa',
+            repository: 'owner/repo',
+            workspacePath,
           },
-        }),
-        root: './fixtures/reporters/github-actions',
-      })
-
-      const summary = await access(outputPath).then(() => true).catch(() => false)
+        },
+        ctx,
+      }).then(() => true).catch(() => false)
 
       expect(summary).toBe(false)
     })
@@ -177,33 +167,19 @@ describe(GithubActionsReporter, () => {
       { commitHash: undefined },
       { repository: undefined },
       { workspacePath: undefined },
-    ] as const)('writes one without links when one of `commitHash`, `repository` or `workspacePath` are not provided', async (options, { onTestFinished }) => {
-      const outputPath = resolve(tmpdir(), randomUUID())
-
-      onTestFinished(async () => {
-        await rm(outputPath).catch(() => {
-          console.error(`Could not remove ${outputPath}`)
-        })
-      })
-
+    ] as const)('writes one without links when one of `commitHash`, `repository` or `workspacePath` are not provided', async (options, ctx) => {
       const workspacePath = resolve(import.meta.dirname, '..', '..', '..', '..')
-
-      await runVitest({
-        reporters: new GithubActionsReporter({
-          jobSummary: {
-            outputPath,
-            fileLinks: {
-              commitHash: 'aaa',
-              repository: 'owner/repo',
-              workspacePath,
-              ...options,
-            },
+      const summary = await createSummary({
+        summaryConfig: {
+          fileLinks: {
+            commitHash: 'aaa',
+            repository: 'owner/repo',
+            workspacePath,
+            ...options,
           },
-        }),
-        root: './fixtures/reporters/github-actions',
+        },
+        ctx,
       })
-
-      const summary = await readFile(outputPath, 'utf8')
 
       expect(summary).toMatchInlineSnapshot(`
         "## Vitest Test Report


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #9992

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
