### PR TITLE
fix(mocker): mock timers imported from node:timers/node:timers/promises (fix #10871)

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -131,7 +131,7 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
 
   async runExternalModule(id: string): Promise<any> {
     if (id in this.stubs) {
-      return this.stubs[id]
+      return this._interopNamespace(this.stubs[id])
     }
 
     const file = this.convertIdToImportUrl(id)
@@ -164,10 +164,14 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
       return namespace
     }
 
+    return this._interopNamespace(namespace)
+  }
+
+  private _interopNamespace(namespace: any): any {
     const { mod, defaultExport } = interopModule(namespace)
     const { Proxy, Reflect } = this.primitives
 
-    const proxy = new Proxy(mod, {
+    return new Proxy(mod, {
       get(mod, prop) {
         if (prop === 'default') {
           return defaultExport
@@ -194,7 +198,6 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
         }
       },
     })
-    return proxy
   }
 
   async runInlinedModule(
@@ -529,6 +532,14 @@ const defaultClientStub = {
   removeStyle: () => {},
 }
 
+function getNodeTimersStubs(): Record<string, any> {
+  const require = createRequire(import.meta.url)
+  return {
+    'node:timers': require('node:timers'),
+    'node:timers/promises': require('node:timers/promises'),
+  }
+}
+
 export function getDefaultRequestStubs(context?: vm.Context): Record<string, any> {
   if (!context) {
     const clientStub = {
@@ -538,6 +549,7 @@ export function getDefaultRequestStubs(context?: vm.Context): Record<string, any
     }
     return {
       '/@vite/client': clientStub,
+      ...getNodeTimersStubs(),
     }
   }
   const clientStub = vm.runInContext(
@@ -546,6 +558,7 @@ export function getDefaultRequestStubs(context?: vm.Context): Record<string, any
   )(defaultClientStub)
   return {
     '/@vite/client': clientStub,
+    ...getNodeTimersStubs(),
   }
 }
 

--- a/patches/@sinonjs__fake-timers@15.4.0.patch
+++ b/patches/@sinonjs__fake-timers@15.4.0.patch
@@ -1,26 +1,30 @@
 diff --git a/src/fake-timers-src.js b/src/fake-timers-src.js
-index 241a7ad3eeb8b5eb691439fab31a87ef13c76345..2df1b2086670bfa06cdb148a9dbe61cd41680f2e 100644
+index 241a7ad3eeb8b5eb691439fab31a87ef13c76345..1891feeece613ca4894ad7cbb29984492d9418af 100644
 --- a/src/fake-timers-src.js
 +++ b/src/fake-timers-src.js
-@@ -2,14 +2,14 @@
+@@ -2,14 +2,18 @@
  
  const globalObject = require("@sinonjs/commons").global;
  let timersModule, timersPromisesModule;
 -if (typeof require === "function" && typeof module === "object") {
-+if (typeof __vitest_required__ !== 'undefined') {
++function resolveVitestRequiredTimers() {
++    if (typeof __vitest_required__ === 'undefined') {
++        return;
++    }
      try {
 -        timersModule = require("timers");
-+        timersModule = __vitest_required__.timers;
++        timersModule = timersModule || __vitest_required__.timers;
      } catch {
          // ignored
      }
      try {
 -        timersPromisesModule = require("timers/promises");
-+        timersPromisesModule = __vitest_required__.timersPromises;
++        timersPromisesModule =
++            timersPromisesModule || __vitest_required__.timersPromises;
      } catch {
          // ignored
      }
-@@ -537,7 +537,7 @@ function withGlobal(_global) {
+@@ -537,7 +541,7 @@ function withGlobal(_global) {
          isPresent.hrtime && typeof _global.process.hrtime.bigint === "function";
      isPresent.nextTick =
          _global.process && typeof _global.process.nextTick === "function";
@@ -29,3 +33,12 @@ index 241a7ad3eeb8b5eb691439fab31a87ef13c76345..2df1b2086670bfa06cdb148a9dbe61cd
      isPresent.performance =
          _global.performance && typeof _global.performance.now === "function";
      const hasPerformancePrototype =
+@@ -2704,6 +2708,8 @@ function withGlobal(_global) {
+             );
+         }
+ 
++        resolveVitestRequiredTimers();
++
+         // eslint-disable-next-line no-param-reassign
+         config = typeof config !== "undefined" ? config : {};
+         config.shouldAdvanceTime = config.shouldAdvanceTime || false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,7 +191,7 @@ overrides:
   vitest: workspace:*
 
 patchedDependencies:
-  '@sinonjs/fake-timers@15.4.0': 8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb
+  '@sinonjs/fake-timers@15.4.0': f53a1ce7bc2fed4c481f97572ace6da71fe562cf9e4eb55eb9ef7fbe8298c0e9
   acorn@8.11.3: 62f89b815dbd769c8a4d5b19b1f6852f28922ecb581d876c8a8377d05c2483c4
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
@@ -1059,7 +1059,7 @@ importers:
         version: 1.9.1
       '@sinonjs/fake-timers':
         specifier: 15.4.0
-        version: 15.4.0(patch_hash=8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb)
+        version: 15.4.0(patch_hash=f53a1ce7bc2fed4c481f97572ace6da71fe562cf9e4eb55eb9ef7fbe8298c0e9)
       '@types/istanbul-lib-coverage':
         specifier: 'catalog:'
         version: 2.0.6
@@ -13352,7 +13352,7 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
-  '@sinonjs/fake-timers@15.4.0(patch_hash=8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb)':
+  '@sinonjs/fake-timers@15.4.0(patch_hash=f53a1ce7bc2fed4c481f97572ace6da71fe562cf9e4eb55eb9ef7fbe8298c0e9)':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -18883,7 +18883,7 @@ snapshots:
   sinon@22.1.0:
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.4.0(patch_hash=8fb375421f30746697394082b6fcf4a218fe07a8db36474ac335c48aff32c0cb)
+      '@sinonjs/fake-timers': 15.4.0(patch_hash=f53a1ce7bc2fed4c481f97572ace6da71fe562cf9e4eb55eb9ef7fbe8298c0e9)
       '@sinonjs/samsam': 10.0.2
       diff: 9.0.0
 

--- a/test/unit/test/timers-node.test.ts
+++ b/test/unit/test/timers-node.test.ts
@@ -1,3 +1,86 @@
 // @vitest-environment node
 
+import { createRequire } from 'node:module'
+import timersNamespace, { setTimeout as namedSetTimeout } from 'node:timers'
+import { setTimeout as promisesSetTimeout } from 'node:timers/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
 import './fixtures/timers.suite'
+
+const require = createRequire(import.meta.url)
+
+describe('node:timers mocking', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not invoke a node:timers named-import setTimeout callback until fake time advances', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+
+    namedSetTimeout(callback, 100)
+
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invoke a node:timers default-import setTimeout callback until fake time advances', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+
+    timersNamespace.setTimeout(callback, 100)
+
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not invoke a dynamically namespace-imported node:timers setTimeout callback until fake time advances', async () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+    const timers = await import('node:timers')
+
+    timers.setTimeout(callback, 100)
+
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resolve a node:timers/promises setTimeout until fake time advances', async () => {
+    vi.useFakeTimers()
+    let resolved = false
+
+    const promise = promisesSetTimeout(5000).then(() => {
+      resolved = true
+    })
+
+    expect(resolved).toBe(false)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(resolved).toBe(true)
+
+    await promise
+  })
+
+  it('does not invoke a require("node:timers") setTimeout callback until fake time advances', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+
+    require('node:timers').setTimeout(callback, 100)
+
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the original node:timers setTimeout once real timers are restored', () => {
+    const realSetTimeout = require('node:timers').setTimeout
+
+    vi.useFakeTimers()
+    expect(require('node:timers').setTimeout).not.toBe(realSetTimeout)
+
+    vi.useRealTimers()
+    expect(require('node:timers').setTimeout).toBe(realSetTimeout)
+  })
+})


### PR DESCRIPTION
### Description

`vi.useFakeTimers()` did not patch timer functions imported from `node:timers` or `node:timers/promises`, even though #7097 was meant to add that support.

Resolves #10871

There are two independent bugs:

1. **Universal timing bug.** The vendored `@sinonjs/fake-timers` patch (`patches/@sinonjs__fake-timers@15.4.0.patch`) reads `globalThis.__vitest_required__.timers`/`.timersPromises` in top-level module-scope code. That code runs the first time `@sinonjs/fake-timers` is imported, which happens eagerly through the static import chain `public/index.ts` → `integrations/vi.ts` → `integrations/mock/timers.ts` → `@sinonjs/fake-timers`. Since that whole chain is itself pulled in via a static `import * as VitestIndex from '../public/index'` at the top of `runtime/setup-node.ts`/`runtime/runVmTests.ts`, it evaluates *before* those files' own function bodies run — and `globalThis.__vitest_required__` is only assigned inside those function bodies. So the check always saw `__vitest_required__` as `undefined`, and the module-scope `timersModule`/`timersPromisesModule` variables stayed `undefined` forever, in every pool.

   Fixed by moving the `__vitest_required__` read into a small function called lazily from inside `install()`, well after the worker has set the global.

2. **`vmThreads`/`vmForks`-specific snapshot bug.** Even with (1) fixed, VM pools resolve `node:timers` imports through `commonjs-executor.ts`'s `getCoreSyntheticModule()`, which copies the module's exports into a `vm.SyntheticModule` via `setExport()` exactly once and caches that module for the worker's lifetime. Since a test file's `node:timers` import is normally evaluated before `vi.useFakeTimers()` runs, this bakes in the original (unpatched) functions permanently.

   Fixed by stubbing `node:timers`/`node:timers/promises` directly in `moduleEvaluator.ts`'s `getDefaultRequestStubs()` (via `createRequire`), so these two specifiers bypass the snapshotting synthetic-module path entirely and always resolve to the same live, patchable object that the fake-timers patch mutates. The existing stub branch in `runExternalModule()` was also updated to go through the same interop/Proxy handling as the normal dynamic-import branch (extracted into `_interopNamespace()`), so default/namespace/named imports of stubbed modules behave consistently.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example. *(`pnpm-lock.yaml` only changes because `pnpm patch-commit` regenerates the `@sinonjs/fake-timers` patch hash — an unavoidable side effect of fixing bug 1.)*
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Ran `test/unit/test/timers-node.test.ts` (new tests) across `threads`, `forks`, and `vmThreads` pools — all pass.
- [x] Ran the full `test/unit` suite (`CI=true pnpm test`) — 640 files passed, no regressions.
- [x] `pnpm typecheck` and `pnpm lint:fix` are clean.

### Documentation
- [ ] No new functionality — no docs changes needed.

### Changesets
- [x] PR title follows the commit convention so the changelog is generated correctly.

### AI disclosure

This fix was investigated and implemented with the assistance of Claude Code (Anthropic), test-driven: tests were written first, confirmed failing (RED) against the current codebase, then the fix was implemented until green, following [CONTRIBUTING.md](https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md#ai-contributions). I reviewed and understand the root cause and the fix before opening this PR.

<!-- VITEST_AUTOMATED_PR -->
