### PR TITLE
docs: clarify class mock prototype methods behavior

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -606,11 +606,11 @@ const spy = vi.spyOn(cart, 'Apples')
   })
   // with a custom class
   .mockImplementation(class MockApples {
-    getApples() {
-      return 0
-    }
+    getApples = () => 0
   })
 ```
+
+Define instance methods as class fields instead of prototype methods. See [Mocking Classes](/guide/mocking/classes) for details.
 
 If you provide an arrow function, you will get [`<anonymous> is not a constructor` error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_constructor) when the mock is called.
 

--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -610,9 +610,9 @@ const spy = vi.spyOn(cart, 'Apples')
   })
 ```
 
-Define instance methods as class fields instead of prototype methods. See [Mocking Classes](/guide/mocking/classes) for details.
-
 If you provide an arrow function, you will get [`<anonymous> is not a constructor` error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_a_constructor) when the mock is called.
+
+With a class implementation, only instance methods defined as class fields are available on the constructed mock, while prototype methods are not. See [Mocking Classes](/guide/mocking/classes) for details.
 
 ::: tip
 In environments that support [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management), you can use `using` instead of `const` to automatically call `mockRestore` on any mocked function when the containing block is exited. This is especially useful for spied methods:

--- a/docs/guide/mocking/classes.md
+++ b/docs/guide/mocking/classes.md
@@ -44,6 +44,27 @@ const Dog = vi.fn(class {
 ```
 
 ::: warning
+When Vitest constructs a class mock, the instance inherits from the mock function's `prototype` instead of the implementation class's `prototype`. This keeps the instance compatible with the mock function, but prototype methods from the implementation class are not available:
+
+```ts
+class MockDog {
+  speak() {
+    return 'loud bark!'
+  }
+}
+
+const Dog = vi.fn(MockDog)
+const dog = new Dog()
+
+dog instanceof Dog // true
+dog instanceof MockDog // false
+dog.speak // undefined
+```
+
+Define mocked instance methods as class fields, as shown in the example above, because class fields are assigned directly to the instance during construction.
+:::
+
+::: warning
 If a non-primitive is returned from the constructor function, that value will become the result of the new expression. In this case the `[[Prototype]]` may not be correctly bound:
 
 ```ts

--- a/docs/guide/mocking/classes.md
+++ b/docs/guide/mocking/classes.md
@@ -44,26 +44,23 @@ const Dog = vi.fn(class {
 ```
 
 ::: warning
-When Vitest constructs a class mock, the instance inherits from the mock function's `prototype` instead of the implementation class's `prototype`. This keeps the instance compatible with the mock function, but prototype methods from the implementation class are not available:
+Prototype methods are not supported when a class is used as a mock implementation. They are unavailable both during and after construction, while instance methods defined as class fields are available:
 
 ```ts
-class OriginalDog {
+class MockDog {
   greet = () => 'greet mocked!'
+
   speak() {
     return 'speak mocked!'
   }
 }
 
-const MockedDog = vi.fn(OriginalDog)
-const mocked = new MockedDog()
+const Dog = vi.fn(MockDog)
+const dog = new Dog()
 
-mocked instanceof MockedDog // true
-mocked instanceof OriginalDog // false
-mocked.greet // defined
-mocked.speak // undefined
+dog.greet() // greet mocked!
+dog.speak // undefined
 ```
-
-Define mocked instance methods as class fields, as shown in the example above, because class fields are assigned directly to the instance during construction.
 :::
 
 ::: warning

--- a/docs/guide/mocking/classes.md
+++ b/docs/guide/mocking/classes.md
@@ -47,18 +47,20 @@ const Dog = vi.fn(class {
 When Vitest constructs a class mock, the instance inherits from the mock function's `prototype` instead of the implementation class's `prototype`. This keeps the instance compatible with the mock function, but prototype methods from the implementation class are not available:
 
 ```ts
-class MockDog {
+class OriginalDog {
+  greet = () => 'greet mocked!'
   speak() {
-    return 'loud bark!'
+    return 'speak mocked!'
   }
 }
 
-const Dog = vi.fn(MockDog)
-const dog = new Dog()
+const MockedDog = vi.fn(OriginalDog)
+const mocked = new MockedDog()
 
-dog instanceof Dog // true
-dog instanceof MockDog // false
-dog.speak // undefined
+mocked instanceof MockedDog // true
+mocked instanceof OriginalDog // false
+mocked.greet // defined
+mocked.speak // undefined
 ```
 
 Define mocked instance methods as class fields, as shown in the example above, because class fields are assigned directly to the instance during construction.

--- a/docs/guide/mocking/classes.md
+++ b/docs/guide/mocking/classes.md
@@ -47,7 +47,7 @@ const Dog = vi.fn(class {
 Prototype methods are not supported when a class is used as a mock implementation. They are unavailable both during and after construction, while instance methods defined as class fields are available:
 
 ```ts
-class MockDog {
+class OriginalDog {
   greet = () => 'greet mocked!'
 
   speak() {
@@ -55,11 +55,13 @@ class MockDog {
   }
 }
 
-const Dog = vi.fn(MockDog)
-const dog = new Dog()
+const MockedDog = vi.fn(OriginalDog)
+const mocked = new MockedDog()
 
-dog.greet() // greet mocked!
-dog.speak // undefined
+mocked instanceof MockedDog // true
+mocked instanceof OriginalDog // false
+mocked.greet() // greet mocked!
+mocked.speak // undefined
 ```
 :::
 

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -801,10 +801,14 @@ describe('vi.fn() implementations', () => {
 
   test('vi.fn(class) and prototype methods', () => {
     let newTarget: unknown
+    let constructorMembers!: { field: unknown; method: unknown }
     class ActualClass {
       constructor() {
         newTarget = new.target
-        // TODO: also this.field vs this.method availablility here
+        constructorMembers = {
+          field: this.field,
+          method: this.method,
+        }
       }
 
       field = () => 'field'
@@ -822,6 +826,7 @@ describe('vi.fn() implementations', () => {
     expect(mocked).toBeInstanceOf(MockClass)
     expect(mocked).not.toBeInstanceOf(ActualClass)
     expect(newTarget).toBe(MockClass)
+    expect(constructorMembers).toEqual({ field: mocked.field, method: undefined })
     expect(mocked.field()).toBe('field')
     expect(mocked.method).toBeUndefined()
 
@@ -830,6 +835,7 @@ describe('vi.fn() implementations', () => {
     expect(Object.getPrototypeOf(actual)).toBe(ActualClass.prototype)
     expect(actual).toBeInstanceOf(ActualClass)
     expect(newTarget).toBe(ActualClass)
+    expect(constructorMembers).toEqual({ field: actual.field, method: actual.method })
     expect(actual.field()).toBe('field')
     expect(actual.method()).toBe('prototype')
   })
@@ -843,14 +849,12 @@ describe('vi.fn() implementations', () => {
     }
     class FirstActualClass {
       firstField = 'first'
-
       firstMethod() {
         return 'first prototype'
       }
     }
     class SecondActualClass {
       secondField = 'second'
-
       secondMethod() {
         return 'second prototype'
       }

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -806,6 +806,7 @@ describe('vi.fn() implementations', () => {
         newTarget = new.target
         // TODO: also this.field vs this.method availablility here
       }
+
       field = () => 'field'
       method() {
         return 'prototype'
@@ -886,6 +887,7 @@ describe('vi.fn() implementations', () => {
       constructor() {
         return returned as any
       }
+
       field = () => 'field'
       method() {
         return 'prototype'
@@ -897,12 +899,14 @@ describe('vi.fn() implementations', () => {
     expect(mocked).toBe(returned)
     expect(mocked).not.toBeInstanceOf(MockClass)
     expect(mocked).not.toBeInstanceOf(ActualClass)
+    expect(mocked.field).toBeUndefined()
     expect(mocked.method).toBeUndefined()
 
     // actual case for comparison
     const actual = new ActualClass()
     expect(actual).toBe(returned)
     expect(actual).not.toBeInstanceOf(ActualClass)
+    expect(actual.field).toBeUndefined()
     expect(actual.method).toBeUndefined()
   })
 

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -826,6 +826,8 @@ describe('vi.fn() implementations', () => {
     expect(mocked).toBeInstanceOf(MockClass)
     expect(mocked).not.toBeInstanceOf(ActualClass)
     expect(newTarget).toBe(MockClass)
+    // Copying prototype methods after construction would still leave them
+    // unavailable inside the constructor, resulting in partial class semantics.
     expect(constructorMembers).toEqual({ field: mocked.field, method: undefined })
     expect(mocked.field()).toBe('field')
     expect(mocked.method).toBeUndefined()

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -826,7 +826,8 @@ describe('vi.fn() implementations', () => {
     expect(mocked).toBeInstanceOf(MockClass)
     expect(mocked).not.toBeInstanceOf(ActualClass)
     expect(newTarget).toBe(MockClass)
-    // Copying prototype methods after construction would still leave them
+    // Copying prototype methods after construction, as in
+    // https://github.com/vitest-dev/vitest/pull/10561, would still leave them
     // unavailable inside the constructor, resulting in partial class semantics.
     expect(constructorMembers).toEqual({ field: mocked.field, method: undefined })
     expect(mocked.field()).toBe('field')

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -799,61 +799,38 @@ describe('vi.fn() implementations', () => {
     expect(Mock.mock.calls).toEqual([['test', 42]])
   })
 
-  test('vi.fn(class) constructs the main implementation with the mock prototype', () => {
-    let target: unknown
+  test('vi.fn(class) and prototype methods', () => {
+    let newTarget: unknown
     class ActualClass {
-      field = () => 'field'
-
       constructor() {
-        target = new.target
+        newTarget = new.target
+        // also this.field vs this.method availablility here
       }
-
+      field = () => 'field'
       method() {
         return 'prototype'
       }
     }
 
-    const actual = new ActualClass()
-    expect(Object.getPrototypeOf(actual)).toBe(ActualClass.prototype)
-    expect(actual).toBeInstanceOf(ActualClass)
-    expect(target).toBe(ActualClass)
-    expect(actual.field()).toBe('field')
-    expect(actual.method()).toBe('prototype')
-
+    // mocked instance has MockClass as prototype and thus:
+    // - it's not an instance of ActualClass
+    // - it doesn't have ActualClass prototype methods
     const MockClass = vi.fn(ActualClass)
     const mocked = new MockClass()
-
     expect(Object.getPrototypeOf(mocked)).toBe(MockClass.prototype)
     expect(mocked).toBeInstanceOf(MockClass)
     expect(mocked).not.toBeInstanceOf(ActualClass)
-    expect(target).toBe(MockClass)
+    expect(newTarget).toBe(MockClass)
     expect(mocked.field()).toBe('field')
     expect(mocked.method).toBeUndefined()
-  })
 
-  test('vi.fn(class) preserves an object returned from the constructor', () => {
-    const returned = { custom: true }
-    class ActualClass {
-      constructor() {
-        return returned as any
-      }
-
-      method() {
-        return 'prototype'
-      }
-    }
-
+    // actual case for comparison
     const actual = new ActualClass()
-    const MockClass = vi.fn(ActualClass)
-    const mocked = new MockClass()
-
-    expect(actual).toBe(returned)
-    expect(actual).not.toBeInstanceOf(ActualClass)
-    expect(actual.method).toBeUndefined()
-    expect(mocked).toBe(returned)
-    expect(mocked).not.toBeInstanceOf(MockClass)
-    expect(mocked).not.toBeInstanceOf(ActualClass)
-    expect(mocked.method).toBeUndefined()
+    expect(Object.getPrototypeOf(actual)).toBe(ActualClass.prototype)
+    expect(actual).toBeInstanceOf(ActualClass)
+    expect(newTarget).toBe(ActualClass)
+    expect(actual.field()).toBe('field')
+    expect(actual.method()).toBe('prototype')
   })
 
   test('vi.fn(class) keeps a shared mock prototype across once implementations', () => {
@@ -901,6 +878,32 @@ describe('vi.fn() implementations', () => {
     expect(second.secondField).toBe('second')
     expect(second.secondMethod).toBeUndefined()
     expect(second.firstField).toBeUndefined()
+  })
+
+  test('vi.fn(class) preserves an object returned from the constructor', () => {
+    const returned = { custom: true }
+    class ActualClass {
+      constructor() {
+        return returned as any
+      }
+
+      method() {
+        return 'prototype'
+      }
+    }
+
+    const MockClass = vi.fn(ActualClass)
+    const mocked = new MockClass()
+    expect(mocked).toBe(returned)
+    expect(mocked).not.toBeInstanceOf(MockClass)
+    expect(mocked).not.toBeInstanceOf(ActualClass)
+    expect(mocked.method).toBeUndefined()
+
+    // actual case for comparison
+    const actual = new ActualClass()
+    expect(actual).toBe(returned)
+    expect(actual).not.toBeInstanceOf(ActualClass)
+    expect(actual.method).toBeUndefined()
   })
 
   test('vi.fn() with mockReturnValue throws when called with new', () => {

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -804,7 +804,7 @@ describe('vi.fn() implementations', () => {
     class ActualClass {
       constructor() {
         newTarget = new.target
-        // also this.field vs this.method availablility here
+        // TODO: also this.field vs this.method availablility here
       }
       field = () => 'field'
       method() {
@@ -886,7 +886,7 @@ describe('vi.fn() implementations', () => {
       constructor() {
         return returned as any
       }
-
+      field = () => 'field'
       method() {
         return 'prototype'
       }

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -841,12 +841,6 @@ describe('vi.fn() implementations', () => {
   })
 
   test('vi.fn(class) keeps a shared mock prototype across once implementations', () => {
-    interface Instance {
-      firstField?: string
-      firstMethod?: () => string
-      secondField?: string
-      secondMethod?: () => string
-    }
     class FirstActualClass {
       firstField = 'first'
       firstMethod() {
@@ -860,15 +854,7 @@ describe('vi.fn() implementations', () => {
       }
     }
 
-    const actualFirst = new FirstActualClass()
-    const actualSecond = new SecondActualClass()
-
-    expect(Object.getPrototypeOf(actualFirst)).toBe(FirstActualClass.prototype)
-    expect(Object.getPrototypeOf(actualSecond)).toBe(SecondActualClass.prototype)
-    expect(actualFirst.firstMethod()).toBe('first prototype')
-    expect(actualSecond.secondMethod()).toBe('second prototype')
-
-    const MockClass = vi.fn<new () => Instance>()
+    const MockClass = vi.fn<any>()
       .mockImplementationOnce(FirstActualClass)
       .mockImplementation(SecondActualClass)
 
@@ -880,9 +866,11 @@ describe('vi.fn() implementations', () => {
     expect(first.firstField).toBe('first')
     expect(first.firstMethod).toBeUndefined()
     expect(first.secondField).toBeUndefined()
+    expect(first.secondMethod).toBeUndefined()
     expect(second.secondField).toBe('second')
     expect(second.secondMethod).toBeUndefined()
     expect(second.firstField).toBeUndefined()
+    expect(second.firstMethod).toBeUndefined()
   })
 
   test('vi.fn(class) preserves an object returned from the constructor', () => {

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -799,6 +799,110 @@ describe('vi.fn() implementations', () => {
     expect(Mock.mock.calls).toEqual([['test', 42]])
   })
 
+  test('vi.fn(class) constructs the main implementation with the mock prototype', () => {
+    let target: unknown
+    class Implementation {
+      field = () => 'field'
+
+      constructor() {
+        target = new.target
+      }
+
+      method() {
+        return 'prototype'
+      }
+    }
+
+    const actual = new Implementation()
+    expect(Object.getPrototypeOf(actual)).toBe(Implementation.prototype)
+    expect(actual).toBeInstanceOf(Implementation)
+    expect(target).toBe(Implementation)
+    expect(actual.field()).toBe('field')
+    expect(actual.method()).toBe('prototype')
+
+    const Mock = vi.fn(Implementation)
+    const instance = new Mock()
+
+    expect(Object.getPrototypeOf(instance)).toBe(Mock.prototype)
+    expect(instance).toBeInstanceOf(Mock)
+    expect(instance).not.toBeInstanceOf(Implementation)
+    expect(target).toBe(Mock)
+    expect(instance.field()).toBe('field')
+    expect(instance.method).toBeUndefined()
+  })
+
+  test('vi.fn(class) preserves an object returned from the constructor', () => {
+    const returned = { custom: true }
+    class Implementation {
+      constructor() {
+        return returned as any
+      }
+
+      method() {
+        return 'prototype'
+      }
+    }
+
+    const actual = new Implementation()
+    const Mock = vi.fn(Implementation)
+    const instance = new Mock()
+
+    expect(actual).toBe(returned)
+    expect(actual).not.toBeInstanceOf(Implementation)
+    expect(actual.method).toBeUndefined()
+    expect(instance).toBe(returned)
+    expect(instance).not.toBeInstanceOf(Mock)
+    expect(instance).not.toBeInstanceOf(Implementation)
+    expect(instance.method).toBeUndefined()
+  })
+
+  test('vi.fn(class) keeps a shared mock prototype across once implementations', () => {
+    interface Instance {
+      firstField?: string
+      firstMethod?: () => string
+      secondField?: string
+      secondMethod?: () => string
+    }
+    class FirstImplementation {
+      firstField = 'first'
+
+      firstMethod() {
+        return 'first prototype'
+      }
+    }
+    class SecondImplementation {
+      secondField = 'second'
+
+      secondMethod() {
+        return 'second prototype'
+      }
+    }
+
+    const actualFirst = new FirstImplementation()
+    const actualSecond = new SecondImplementation()
+
+    expect(Object.getPrototypeOf(actualFirst)).toBe(FirstImplementation.prototype)
+    expect(Object.getPrototypeOf(actualSecond)).toBe(SecondImplementation.prototype)
+    expect(actualFirst.firstMethod()).toBe('first prototype')
+    expect(actualSecond.secondMethod()).toBe('second prototype')
+
+    const Mock = vi.fn<new () => Instance>()
+      .mockImplementationOnce(FirstImplementation)
+      .mockImplementation(SecondImplementation)
+
+    const first = new Mock()
+    const second = new Mock()
+
+    expect(Object.getPrototypeOf(first)).toBe(Mock.prototype)
+    expect(Object.getPrototypeOf(second)).toBe(Mock.prototype)
+    expect(first.firstField).toBe('first')
+    expect(first.firstMethod).toBeUndefined()
+    expect(first.secondField).toBeUndefined()
+    expect(second.secondField).toBe('second')
+    expect(second.secondMethod).toBeUndefined()
+    expect(second.firstField).toBeUndefined()
+  })
+
   test('vi.fn() with mockReturnValue throws when called with new', () => {
     const Mock = vi.fn()
     Mock.mockReturnValue(42)

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -801,7 +801,7 @@ describe('vi.fn() implementations', () => {
 
   test('vi.fn(class) constructs the main implementation with the mock prototype', () => {
     let target: unknown
-    class Implementation {
+    class ActualClass {
       field = () => 'field'
 
       constructor() {
@@ -813,27 +813,27 @@ describe('vi.fn() implementations', () => {
       }
     }
 
-    const actual = new Implementation()
-    expect(Object.getPrototypeOf(actual)).toBe(Implementation.prototype)
-    expect(actual).toBeInstanceOf(Implementation)
-    expect(target).toBe(Implementation)
+    const actual = new ActualClass()
+    expect(Object.getPrototypeOf(actual)).toBe(ActualClass.prototype)
+    expect(actual).toBeInstanceOf(ActualClass)
+    expect(target).toBe(ActualClass)
     expect(actual.field()).toBe('field')
     expect(actual.method()).toBe('prototype')
 
-    const Mock = vi.fn(Implementation)
-    const instance = new Mock()
+    const MockClass = vi.fn(ActualClass)
+    const mocked = new MockClass()
 
-    expect(Object.getPrototypeOf(instance)).toBe(Mock.prototype)
-    expect(instance).toBeInstanceOf(Mock)
-    expect(instance).not.toBeInstanceOf(Implementation)
-    expect(target).toBe(Mock)
-    expect(instance.field()).toBe('field')
-    expect(instance.method).toBeUndefined()
+    expect(Object.getPrototypeOf(mocked)).toBe(MockClass.prototype)
+    expect(mocked).toBeInstanceOf(MockClass)
+    expect(mocked).not.toBeInstanceOf(ActualClass)
+    expect(target).toBe(MockClass)
+    expect(mocked.field()).toBe('field')
+    expect(mocked.method).toBeUndefined()
   })
 
   test('vi.fn(class) preserves an object returned from the constructor', () => {
     const returned = { custom: true }
-    class Implementation {
+    class ActualClass {
       constructor() {
         return returned as any
       }
@@ -843,17 +843,17 @@ describe('vi.fn() implementations', () => {
       }
     }
 
-    const actual = new Implementation()
-    const Mock = vi.fn(Implementation)
-    const instance = new Mock()
+    const actual = new ActualClass()
+    const MockClass = vi.fn(ActualClass)
+    const mocked = new MockClass()
 
     expect(actual).toBe(returned)
-    expect(actual).not.toBeInstanceOf(Implementation)
+    expect(actual).not.toBeInstanceOf(ActualClass)
     expect(actual.method).toBeUndefined()
-    expect(instance).toBe(returned)
-    expect(instance).not.toBeInstanceOf(Mock)
-    expect(instance).not.toBeInstanceOf(Implementation)
-    expect(instance.method).toBeUndefined()
+    expect(mocked).toBe(returned)
+    expect(mocked).not.toBeInstanceOf(MockClass)
+    expect(mocked).not.toBeInstanceOf(ActualClass)
+    expect(mocked.method).toBeUndefined()
   })
 
   test('vi.fn(class) keeps a shared mock prototype across once implementations', () => {
@@ -863,14 +863,14 @@ describe('vi.fn() implementations', () => {
       secondField?: string
       secondMethod?: () => string
     }
-    class FirstImplementation {
+    class FirstActualClass {
       firstField = 'first'
 
       firstMethod() {
         return 'first prototype'
       }
     }
-    class SecondImplementation {
+    class SecondActualClass {
       secondField = 'second'
 
       secondMethod() {
@@ -878,23 +878,23 @@ describe('vi.fn() implementations', () => {
       }
     }
 
-    const actualFirst = new FirstImplementation()
-    const actualSecond = new SecondImplementation()
+    const actualFirst = new FirstActualClass()
+    const actualSecond = new SecondActualClass()
 
-    expect(Object.getPrototypeOf(actualFirst)).toBe(FirstImplementation.prototype)
-    expect(Object.getPrototypeOf(actualSecond)).toBe(SecondImplementation.prototype)
+    expect(Object.getPrototypeOf(actualFirst)).toBe(FirstActualClass.prototype)
+    expect(Object.getPrototypeOf(actualSecond)).toBe(SecondActualClass.prototype)
     expect(actualFirst.firstMethod()).toBe('first prototype')
     expect(actualSecond.secondMethod()).toBe('second prototype')
 
-    const Mock = vi.fn<new () => Instance>()
-      .mockImplementationOnce(FirstImplementation)
-      .mockImplementation(SecondImplementation)
+    const MockClass = vi.fn<new () => Instance>()
+      .mockImplementationOnce(FirstActualClass)
+      .mockImplementation(SecondActualClass)
 
-    const first = new Mock()
-    const second = new Mock()
+    const first = new MockClass()
+    const second = new MockClass()
 
-    expect(Object.getPrototypeOf(first)).toBe(Mock.prototype)
-    expect(Object.getPrototypeOf(second)).toBe(Mock.prototype)
+    expect(Object.getPrototypeOf(first)).toBe(MockClass.prototype)
+    expect(Object.getPrototypeOf(second)).toBe(MockClass.prototype)
     expect(first.firstField).toBe('first')
     expect(first.firstMethod).toBeUndefined()
     expect(first.secondField).toBeUndefined()


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Supersedes https://github.com/vitest-dev/vitest/pull/10561
- Closes https://github.com/vitest-dev/vitest/issues/10553
  - Closes as an unsupported behavior

This PR updates docs to call out that prototype methods becomes undefined in mocked instance. Some tests are copied over from the original fix attempt https://github.com/vitest-dev/vitest/pull/10561 to add missing coverage and show current limitation.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
