### PR TITLE
docs(browser): clarify special keys supported by userEvent.keyboard (closes #7118)

### DIFF
--- a/docs/api/browser/interactivity.md
+++ b/docs/api/browser/interactivity.md
@@ -281,7 +281,14 @@ function keyboard(text: string): Promise<void>
 
 The `userEvent.keyboard` allows you to trigger keyboard strokes. If any input has a focus, it will type characters into that input. Otherwise, it will trigger keyboard events on the currently focused element (`document.body` if there are no focused elements).
 
-This API supports [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard).
+This API supports [user-event `keyboard` syntax](https://testing-library.com/docs/user-event/keyboard). Common special keys that can be referenced inside the braces include:
+
+- **Modifiers:** `{Shift}`, `{Control}`, `{Alt}`, `{Meta}`
+- **Navigation:** `{ArrowUp}`, `{ArrowDown}`, `{ArrowLeft}`, `{ArrowRight}`, `{Home}`, `{End}`, `{PageUp}`, `{PageDown}`
+- **Editing:** `{Backspace}`, `{Delete}`, `{Insert}`, `{Tab}`, `{Enter}`, `{Escape}`
+- **Function keys:** `{F1}` through `{F12}`
+
+Note: The exact set of supported keys may vary depending on the underlying browser provider (Playwright vs WebdriverIO). If a key press doesn't trigger the expected behavior, consult your provider's documentation or file an issue.
 
 ```ts
 import { userEvent } from 'vitest/browser'


### PR DESCRIPTION
## What
Adds a list of supported special keys to the `userEvent.keyboard` documentation.

## Why
Closes #7118. The `userEvent.keyboard` API supports user-event's keyboard syntax, but the list of supported special keys wasn't documented. This made it unclear which keys could be referenced inside the braces.

## Changes
- Added a categorized list of common special keys (Modifiers, Navigation, Editing, Function keys)
- Added a note about provider differences (Playwright vs WebdriverIO)
- Linked to user-event keyboard syntax docs for full reference

## Test plan
- [x] Docs only change — no code affected
- [x] Existing keyboard tests still pass (if applicable)