### PR TITLE
fix(typecheck): report a checker crash on Windows instead of a spawn failure

### DIFF
--- a/packages/vitest/src/node/pools/workers/typecheckWorker.ts
+++ b/packages/vitest/src/node/pools/workers/typecheckWorker.ts
@@ -7,7 +7,7 @@ import type { TestRunEndReason } from '../../types/reporter'
 import type { PoolOptions, PoolWorker, WorkerRequest, WorkerResponse } from '../types'
 import EventEmitter from 'node:events'
 import { createDefer } from '@vitest/utils/helpers'
-import { Typechecker } from '../../../typecheck/typechecker'
+import { OOM_OUTPUT_PATTERN, Typechecker } from '../../../typecheck/typechecker'
 import { hasFailed } from '../../../utils/tasks'
 
 /** @experimental */
@@ -130,8 +130,7 @@ function createRunner(vitest: Vitest) {
 
       if (exitCode || signal) {
         const output = checker.getOutput()
-        const looksLikeOom = signal === 'SIGABRT'
-          || /JavaScript heap out of memory|Reached heap limit|Allocation failed/i.test(output)
+        const looksLikeOom = signal === 'SIGABRT' || OOM_OUTPUT_PATTERN.test(output)
 
         let message: string
         if (signal || looksLikeOom) {

--- a/packages/vitest/src/typecheck/typechecker.ts
+++ b/packages/vitest/src/typecheck/typechecker.ts
@@ -18,6 +18,9 @@ import { createLocationsIndexMap } from '../utils/base'
 import { convertTasksToEvents } from '../utils/tasks'
 import { getRawErrsMapFromTsCompile } from './parse'
 
+// the V8 fatal output of a checker that ran out of memory
+export const OOM_OUTPUT_PATTERN: RegExp = /JavaScript heap out of memory|Reached heap limit|Allocation failed/i
+
 export class TypeCheckError extends Error {
   name = 'TypeCheckError'
 
@@ -428,7 +431,9 @@ export class Typechecker {
 
       if (process.platform === 'win32') {
         child.process.once('close', (code) => {
-          if (code != null && code !== 0 && !dataReceived) {
+          // an OOM abort writes only to stderr, but the checker did start;
+          // `start` awaits the process and reports the crash from its output
+          if (code != null && code !== 0 && !dataReceived && !OOM_OUTPUT_PATTERN.test(this._output)) {
             onError(new Error(`The ${typecheck.checker} command exited with code ${code}.`))
           }
           else if (!resolved) {

--- a/test/typescript/fixtures/typecheck-crash/fake-tsc.cmd
+++ b/test/typescript/fixtures/typecheck-crash/fake-tsc.cmd
@@ -1,0 +1,2 @@
+@rem Windows can't execute .mjs files directly, run the fake checker with node
+@node "%~dp0fake-tsc.mjs" %*

--- a/test/typescript/test/typechecker.test.ts
+++ b/test/typescript/test/typechecker.test.ts
@@ -23,15 +23,18 @@ describe('Typechecker', () => {
         enabled: true,
         checker: resolve(
           import.meta.dirname,
-          '../fixtures/typecheck-crash/fake-tsc.mjs',
+          // Windows can't execute an .mjs file, the .cmd shim runs it with node
+          process.platform === 'win32'
+            ? '../fixtures/typecheck-crash/fake-tsc.cmd'
+            : '../fixtures/typecheck-crash/fake-tsc.mjs',
         ),
       },
     })
 
     // A checker that aborts (OOM) without producing diagnostics must NOT be
     // reported as passing — the run has to fail with a clear error. The abort
-    // surfaces as a signal (SIGABRT) on POSIX and as exit code 134 on Windows;
-    // both paths must be treated as an abnormal, failing exit.
+    // surfaces as a signal (SIGABRT) on POSIX and as a non-zero exit code on
+    // Windows; both paths must be treated as an abnormal, failing exit.
     expect(exitCode).toBe(1)
     expect(stderr).toContain('Typecheck Error')
     expect(stderr).toContain('before type checking finished')


### PR DESCRIPTION
### Description

The `fails the run when the typechecker crashes (OOM)` test added in #10705 always fails on `windows-unit` with `Spawning typechecker failed - is typescript installed?` instead of the expected `Typecheck Error`. Two Windows-specific problems combine:

1. tinyexec wraps any non-`.exe` command in `cmd.exe /c`, and cmd has no file association for `.mjs`, so the `fake-tsc.mjs` fixture never executed at all. The fixture now ships a `fake-tsc.cmd` shim that runs it with node, and the test picks the shim on Windows.
2. Even with a runnable fixture, the Windows `close` handler in `Typechecker.spawn` treats any non-zero exit without stdout output as a spawn failure. A V8 OOM abort writes only to stderr, so a checker that started and crashed was misclassified. The handler now lets the exit through when the captured output matches the V8 OOM pattern, and `start` reports the crash properly. The `!dataReceived` heuristic itself stays, since cmd's "is not recognized" error for a missing checker also surfaces as a non-zero exit with stderr-only output.

The OOM pattern is now shared between `Typechecker` and the typecheck worker instead of being duplicated.

Verified on macOS (both typechecker tests pass); the Windows path needs CI to confirm.