### PR TITLE
fix: resolve `globalSetup` against `test.root` again (fix #10908)

### DIFF
--- a/packages/vitest/src/node/plugins/index.ts
+++ b/packages/vitest/src/node/plugins/index.ts
@@ -22,7 +22,7 @@ export function VitestCorePlugin(harness: PluginHarness, options: CliOptions = {
       config: {
         order: 'post',
         handler(viteConfig) {
-          const root = resolve(options.root || viteConfig.test?.root || viteConfig.root || process.cwd())
+          const root = resolve(viteConfig.test?.root || options.root || viteConfig.root || process.cwd())
 
           return {
             base: '/',

--- a/packages/vitest/src/node/plugins/testConfig.ts
+++ b/packages/vitest/src/node/plugins/testConfig.ts
@@ -69,6 +69,14 @@ export function TestConfigPlugin(
         handler(config) {
           const { browser, ...options } = cliOptions
 
+          // an option the programmatic API left undefined was never specified,
+          // so it must not erase the value the config file declared
+          for (const key of Object.keys(options) as (keyof typeof options)[]) {
+            if (options[key] === undefined) {
+              delete options[key]
+            }
+          }
+
           // We don't want to use Vite's merge because we want to OVERRIDE options
           // By default, Vite extends arrays, for example, but CLI options should have the priority
           config.test = deepMerge({}, config.test ?? {}, options)

--- a/test/e2e/fixtures/global-setup-root/nested/example.test.ts
+++ b/test/e2e/fixtures/global-setup-root/nested/example.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('example test', () => {
+  expect(1 + 1).toBe(2)
+})

--- a/test/e2e/fixtures/global-setup-root/nested/global-setup.ts
+++ b/test/e2e/fixtures/global-setup-root/nested/global-setup.ts
@@ -1,0 +1,3 @@
+export function setup() {
+  // File should load without errors
+}

--- a/test/e2e/fixtures/global-setup-root/vitest.config.ts
+++ b/test/e2e/fixtures/global-setup-root/vitest.config.ts
@@ -1,0 +1,9 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    root: resolve(import.meta.dirname, './nested'),
+    globalSetup: './global-setup.ts',
+  },
+})

--- a/test/e2e/test/global-setup.test.ts
+++ b/test/e2e/test/global-setup.test.ts
@@ -69,3 +69,10 @@ it('runs global setup/teardown', async () => {
     }
   `)
 })
+
+it('respects root', async () => {
+  const config = resolve(import.meta.dirname, '../fixtures/global-setup-root/vitest.config.ts')
+  const { stderr } = await runVitest({ config })
+
+  expect(stderr).toBe('')
+})


### PR DESCRIPTION
### Description

`vitest:config:append` used to prefer the config file's `test.root` over the CLI root, and #10554 flipped that order. `resolveConfig` fills `options.root` in with the resolved cwd before any plugin runs, so the first branch always wins now and `test.root` is never read. Everything derived from the root moves with it, which is why `globalSetup` ended up being looked up next to the cwd.

The same value gets lost a second time when Vitest is started programmatically: `vitest:config:cli` merges the CLI options over `config.test`, and an option the caller passed as `undefined` overwrites what the config file declared. `runVitest` in the test utils passes `root: undefined` that way, so the fixture below only loads its `globalSetup` once both are fixed.

Test is from #10909, which this supersedes.

Resolves #10908

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
