### PR TITLE
fix(browser): configure internal optimizer dependencies

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -456,14 +456,15 @@ function resolveBrowserOptimizeDeps(
   // - vitest/browser, @vitest/browser/context, @vitest/browser/utils are
   //   VIRTUAL modules generated per-server (see pluginContext.ts) — optimizer
   //   cannot resolve/run their `load`, it would freeze stale/empty content.
-  // - @vitest/browser/locators is pre-built and loaded by provider init scripts.
-  //   It can be nested under the provider package and unavailable from the root.
   // - msw is a large, side-effectful service-worker library.
   const exclude = [
     'vitest/browser',
-    '@vitest/browser/locators',
     '@vitest/browser/utils',
     '@vitest/browser/context',
+    // this is a real module but cannot be specified in `optimizeDeps.include`
+    // because `@vitest/browser` is only installed as a transitive dependency of
+    // provider-specific packages such as `@vitest/browser-playwright`
+    '@vitest/browser/locators',
     'msw',
     'msw/browser',
   ]

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -456,9 +456,12 @@ function resolveBrowserOptimizeDeps(
   // - vitest/browser, @vitest/browser/context, @vitest/browser/utils are
   //   VIRTUAL modules generated per-server (see pluginContext.ts) — optimizer
   //   cannot resolve/run their `load`, it would freeze stale/empty content.
+  // - @vitest/browser/locators is pre-built and loaded by provider init scripts.
+  //   It can be nested under the provider package and unavailable from the root.
   // - msw is a large, side-effectful service-worker library.
   const exclude = [
     'vitest/browser',
+    '@vitest/browser/locators',
     '@vitest/browser/utils',
     '@vitest/browser/context',
     'msw',
@@ -505,6 +508,7 @@ function resolveBrowserOptimizeDeps(
     'vitest > vite/module-runner',
     'vitest',
     'vitest/internal/browser',
+    'vitest/internal/traces',
     '@vitest/browser/client',
   ]
 

--- a/test/e2e/test/config/browser-configs.test.ts
+++ b/test/e2e/test/config/browser-configs.test.ts
@@ -105,7 +105,7 @@ test('does not disable pre-transform requests in browser mode', async () => {
   })
 })
 
-test('pre-bundles vite module runner through vitest in browser mode', async () => {
+test('configures internal browser dependencies', async () => {
   const v = await vitest({
     browser: {
       enabled: true,
@@ -116,8 +116,21 @@ test('pre-bundles vite module runner through vitest in browser mode', async () =
     },
   })
 
-  expect(v.vite.config.optimizeDeps.include).toContain('vitest > vite/module-runner')
-  expect(v.vite.config.optimizeDeps.exclude).not.toContain('vite/module-runner')
+  const include = v.vite.config.optimizeDeps.include || []
+  const exclude = v.vite.config.optimizeDeps.exclude || []
+  expect({
+    moduleRunnerIncluded: include.includes('vitest > vite/module-runner'),
+    moduleRunnerExcluded: exclude.includes('vite/module-runner'),
+    tracesIncluded: include.includes('vitest/internal/traces'),
+    locatorsExcluded: exclude.includes('@vitest/browser/locators'),
+  }).toMatchInlineSnapshot(`
+    {
+      "locatorsExcluded": true,
+      "moduleRunnerExcluded": false,
+      "moduleRunnerIncluded": true,
+      "tracesIncluded": true,
+    }
+  `)
 })
 
 test('disables pre-transform requests in node mode', async () => {

--- a/test/e2e/test/config/browser-configs.test.ts
+++ b/test/e2e/test/config/browser-configs.test.ts
@@ -105,7 +105,7 @@ test('does not disable pre-transform requests in browser mode', async () => {
   })
 })
 
-test('configures internal browser dependencies', async () => {
+test('pre-bundles vite module runner through vitest in browser mode', async () => {
   const v = await vitest({
     browser: {
       enabled: true,
@@ -116,21 +116,8 @@ test('configures internal browser dependencies', async () => {
     },
   })
 
-  const include = v.vite.config.optimizeDeps.include || []
-  const exclude = v.vite.config.optimizeDeps.exclude || []
-  expect({
-    moduleRunnerIncluded: include.includes('vitest > vite/module-runner'),
-    moduleRunnerExcluded: exclude.includes('vite/module-runner'),
-    tracesIncluded: include.includes('vitest/internal/traces'),
-    locatorsExcluded: exclude.includes('@vitest/browser/locators'),
-  }).toMatchInlineSnapshot(`
-    {
-      "locatorsExcluded": true,
-      "moduleRunnerExcluded": false,
-      "moduleRunnerIncluded": true,
-      "tracesIncluded": true,
-    }
-  `)
+  expect(v.vite.config.optimizeDeps.include).toContain('vitest > vite/module-runner')
+  expect(v.vite.config.optimizeDeps.exclude).not.toContain('vite/module-runner')
 })
 
 test('disables pre-transform requests in node mode', async () => {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- closes https://github.com/vitest-dev/vitest/issues/10836

The fix is manually confirmed in the repro mentioned in https://github.com/vitest-dev/vitest/issues/10836#issuecomment-5248701871

Note that we cannot test this behavior inside monorepo because Vite doesn't kick in auto re-optimization for workspace packages.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
