### PR TITLE
fix(browser): preserve `undefined` argument positions in custom commands

### DIFF
--- a/packages/browser/src/client/tester/tester-utils.ts
+++ b/packages/browser/src/client/tester/tester-utils.ts
@@ -1,0 +1,354 @@
+import type { Locator, SelectorOptions, SerializedLocator, UserEventWheelDeltaOptions, UserEventWheelOptions } from 'vitest/browser'
+import type { BrowserRPC } from '../client'
+import type { BrowserTraceEntryStatus } from './trace'
+import { __INTERNAL } from 'vitest/internal/browser'
+import { getBrowserState, getWorkerState, now } from '../utils'
+import { createBrowserTraceRangeId, recordBrowserTraceEntry } from './trace'
+
+/* @__NO_SIDE_EFFECTS__ */
+export function convertElementToCssSelector(element: Element): string {
+  if (!element || !(element instanceof Element)) {
+    throw new Error(
+      `Expected DOM element to be an instance of Element, received ${typeof element}`,
+    )
+  }
+
+  return getUniqueCssSelector(element)
+}
+
+function escapeIdForCSSSelector(id: string) {
+  return id
+    .split('')
+    .map((char) => {
+      const code = char.charCodeAt(0)
+
+      if (char === ' ' || char === '#' || char === '.' || char === ':' || char === '[' || char === ']' || char === '>' || char === '+' || char === '~' || char === '\\') {
+        // Escape common special characters with backslashes
+        return `\\${char}`
+      }
+      else if (code >= 0x10000) {
+        // Unicode escape for characters outside the BMP
+        return `\\${code.toString(16).toUpperCase().padStart(6, '0')} `
+      }
+      else if (code < 0x20 || code === 0x7F) {
+        // Non-printable ASCII characters (0x00-0x1F and 0x7F) are escaped
+        return `\\${code.toString(16).toUpperCase().padStart(2, '0')} `
+      }
+      else if (code >= 0x80) {
+        // Non-ASCII characters (0x80 and above) are escaped
+        return `\\${code.toString(16).toUpperCase().padStart(2, '0')} `
+      }
+      else {
+        // Allowable characters are used directly
+        return char
+      }
+    })
+    .join('')
+}
+
+function getUniqueCssSelector(el: Element) {
+  const path = []
+  let parent: null | ParentNode
+  let hasShadowRoot = false
+  // eslint-disable-next-line no-cond-assign
+  while (parent = getParent(el)) {
+    if ((parent as Element).shadowRoot) {
+      hasShadowRoot = true
+    }
+
+    const tag = el.tagName
+    if (el.id) {
+      path.push(`#${escapeIdForCSSSelector(el.id)}`)
+    }
+    else if (!el.nextElementSibling && !el.previousElementSibling) {
+      path.push(tag.toLowerCase())
+    }
+    else {
+      let index = 0
+      let sameTagSiblings = 0
+      let elementIndex = 0
+
+      for (const sibling of parent.children) {
+        index++
+        if (sibling.tagName === tag) {
+          sameTagSiblings++
+        }
+        if (sibling === el) {
+          elementIndex = index
+        }
+      }
+
+      if (sameTagSiblings > 1) {
+        path.push(`${tag.toLowerCase()}:nth-child(${elementIndex})`)
+      }
+      else {
+        path.push(tag.toLowerCase())
+      }
+    }
+    el = parent as Element
+  };
+  return `${getBrowserState().provider === 'webdriverio' && hasShadowRoot ? '>>>' : ''}${path.reverse().join(' > ')}`
+}
+
+function getParent(el: Element) {
+  const parent = el.parentNode
+  if (parent instanceof ShadowRoot) {
+    return parent.host
+  }
+  return parent
+}
+
+const ACTION_TRACE_COMMANDS = new Set([
+  '__vitest_click',
+  '__vitest_dblClick',
+  '__vitest_tripleClick',
+  '__vitest_wheel',
+  '__vitest_type',
+  '__vitest_clear',
+  '__vitest_fill',
+  '__vitest_selectOptions',
+  '__vitest_dragAndDrop',
+  '__vitest_hover',
+  '__vitest_upload',
+  '__vitest_tab',
+  '__vitest_keyboard',
+  '__vitest_takeScreenshot',
+])
+
+export class CommandsManager {
+  private _listeners: ((command: string, args: any[]) => void)[] = []
+
+  public onCommand(listener: (command: string, args: any[]) => void): void {
+    this._listeners.push(listener)
+  }
+
+  public async triggerCommand<T>(
+    command: string,
+    args: any[],
+    // error makes sure the stack trace is correct on webkit,
+    // if we make the error here, it looses the context
+    clientError: Error = new Error('empty'),
+  ): Promise<T> {
+    const state = getWorkerState()
+    const rpc = state.rpc as any as BrowserRPC
+    const { sessionId, traces } = getBrowserState()
+    const filepath = state.filepath || state.current?.file?.filepath
+
+    const actionTraceGroupName = ACTION_TRACE_COMMANDS.has(command)
+      ? `vitest:${command.slice('__vitest_'.length)}`
+      : undefined
+    const currentTest = getWorkerState().current
+    const hasActiveTrace = !!actionTraceGroupName
+      && !!currentTest
+      && getBrowserState().activeTraceTaskIds.has(currentTest.id)
+    const hasActiveTraceView = !!actionTraceGroupName
+      && !!currentTest
+      && getBrowserState().browserTraceAttempts.has(currentTest.id)
+
+    if (this._listeners.length) {
+      await Promise.all(this._listeners.map(listener => listener(command, args)))
+    }
+    return traces.$(
+      'vitest.browser.tester.command',
+      {
+        attributes: {
+          'vitest.browser.command': command,
+          'code.file.path': filepath,
+        },
+      },
+      async () => {
+        if (hasActiveTrace) {
+          await rpc.triggerCommand<void>(
+            sessionId,
+            '__vitest_groupTraceStart',
+            filepath,
+            [{
+              name: actionTraceGroupName,
+              stack: clientError.stack,
+            }],
+          )
+        }
+        let status: BrowserTraceEntryStatus = 'pass'
+        const traceRangeId = hasActiveTraceView ? createBrowserTraceRangeId() : undefined
+        const element = typeof args[0] === 'object' && 'selector' in args[0] && 'locator' in args[0] ? args[0] : undefined
+        if (hasActiveTraceView) {
+          // Covers provider-backed actionability/waiting after command dispatch.
+          // Local pre-command resolution, such as serializeElement/findElement paths
+          // is not coverd within by this action trace range.
+          await recordBrowserTraceEntry(currentTest, {
+            name: actionTraceGroupName,
+            kind: 'action',
+            range: { id: traceRangeId!, phase: 'start' },
+            element,
+            stack: clientError.stack,
+          })
+        }
+        try {
+          return await rpc.triggerCommand<T>(sessionId, command, filepath, args)
+        }
+        catch (err: any) {
+          status = 'fail'
+          // rethrow an error to keep the stack trace in browser
+          clientError.message = err.message
+          clientError.name = err.name
+          clientError.stack = clientError.stack?.replace(clientError.message, err.message)
+          throw clientError
+        }
+        finally {
+          if (hasActiveTraceView) {
+            await recordBrowserTraceEntry(currentTest, {
+              name: actionTraceGroupName,
+              kind: 'action',
+              range: { id: traceRangeId!, phase: 'end' },
+              status,
+              element,
+              stack: clientError.stack,
+            })
+          }
+          if (hasActiveTrace) {
+            await rpc.triggerCommand<void>(
+              sessionId,
+              '__vitest_groupTraceEnd',
+              filepath,
+              [],
+            )
+          }
+        }
+      },
+    )
+  }
+}
+
+export function processTimeoutOptions<T extends { timeout?: number }>(options_: T | undefined): T | undefined {
+  if (
+    // if timeout is set, keep it
+    (options_ && options_.timeout != null)
+  ) {
+    return options_
+  }
+  // if there is a default action timeout, use it
+  if (getWorkerState().config.browser.providerOptions.actionTimeout != null) {
+    return options_
+  }
+  const runner = getBrowserState().runner
+  const startTime = runner._currentTaskStartTime
+  // ignore timeout if this is called outside of a test
+  if (!startTime) {
+    return options_
+  }
+  const timeout = runner._currentTaskTimeout
+  if (timeout === 0 || timeout == null || timeout === Number.POSITIVE_INFINITY) {
+    return options_
+  }
+  options_ = options_ || {} as T
+  const currentTime = now()
+  const endTime = startTime + timeout
+  const remainingTime = Math.floor(endTime - currentTime)
+  // keep some buffer to process the timeout, but always hand the provider a
+  // positive value so it surfaces a descriptive, source-mapped locator error
+  // instead of letting the task timer win the race with a generic timeout;
+  // the buffer covers the provider->server->client round-trip of the rejection,
+  // which can exceed 100ms on loaded CI machines running several browsers
+  options_.timeout = Math.max(remainingTime - 250, 1)
+  return options_
+}
+
+export function getIframeScale(): number {
+  const iframe = window.frameElement
+
+  if (!iframe) {
+    throw new Error(`Cannot find iframe element. This is a bug in Vitest. Please, open a new issue with reproduction.`)
+  }
+
+  // DOMMatrix parses the computed 2D transform matrix [a, b, c, d, e, f]
+  // `a` and `d` are the x and y scale factors - since we only apply uniform scaling, `a === d`
+  const scale = new DOMMatrix(getComputedStyle(iframe).transform).a
+
+  return scale
+}
+
+function escapeRegexForSelector(re: RegExp): string {
+  // Unicode mode does not allow "identity character escapes", so we do not escape and
+  // hope that it does not contain quotes and/or >> signs.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape
+  // TODO: rework RE usages in internal selectors away from literal representation to json, e.g. {source,flags}.
+  if (re.unicode || (re as any).unicodeSets) {
+    return String(re)
+  }
+  // Even number of backslashes followed by the quote -> insert a backslash.
+  return String(re).replace(/(^|[^\\])(\\\\)*(["'`])/g, '$1$2\\$3').replace(/>>/g, '\\>\\>')
+}
+
+export function escapeForTextSelector(text: string | RegExp, exact: boolean): string {
+  if (typeof text !== 'string') {
+    return escapeRegexForSelector(text)
+  }
+  return `${JSON.stringify(text)}${exact ? 's' : 'i'}`
+}
+
+const provider = getBrowserState().provider
+const kElementLocator = Symbol.for('$$vitest:locator-resolved')
+
+export async function serializeElement(elementOrLocator: Element | Locator, options?: SelectorOptions): Promise<SerializedLocator> {
+  if (!elementOrLocator) {
+    throw new Error('Expected element or locator to be defined.')
+  }
+  if (elementOrLocator instanceof Element) {
+    const selector = convertElementToCssSelector(elementOrLocator)
+    return { selector, locator: __INTERNAL._asLocator('javascript', selector) }
+  }
+  if (isLocator(elementOrLocator)) {
+    if (provider === 'playwright' || kElementLocator in elementOrLocator) {
+      return elementOrLocator.serialize()
+    }
+    const element = await elementOrLocator.findElement(options)
+    const selector = convertElementToCssSelector(element)
+    const locator = __INTERNAL._asLocator('javascript', selector)
+    return { selector, locator }
+  }
+  throw new Error('Expected element or locator to be an instance of Element or Locator.')
+}
+
+const kLocator = Symbol.for('$$vitest:locator')
+
+export function isLocator(element: unknown): element is Locator {
+  return (!!element && typeof element === 'object' && kLocator in element)
+}
+
+const DEFAULT_WHEEL_DELTA = 100
+
+export function resolveUserEventWheelOptions(options: UserEventWheelOptions): UserEventWheelDeltaOptions {
+  let delta: UserEventWheelDeltaOptions['delta']
+
+  if (options.delta) {
+    delta = options.delta
+  }
+  else {
+    switch (options.direction) {
+      case 'up': {
+        delta = { y: -DEFAULT_WHEEL_DELTA }
+        break
+      }
+
+      case 'down': {
+        delta = { y: DEFAULT_WHEEL_DELTA }
+        break
+      }
+
+      case 'left': {
+        delta = { x: -DEFAULT_WHEEL_DELTA }
+        break
+      }
+
+      case 'right': {
+        delta = { x: DEFAULT_WHEEL_DELTA }
+        break
+      }
+    }
+  }
+
+  return {
+    delta,
+    times: options.times,
+  }
+}

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -1,0 +1,497 @@
+import type { MockerRegistry } from '@vitest/mocker'
+import type { IncomingMessage } from 'node:http'
+import type { Duplex } from 'node:stream'
+import type { TestError } from 'vitest'
+import type { BrowserCommandContext, ResolveSnapshotPathHandlerContext, TestProject } from 'vitest/node'
+import type { WebSocket } from 'ws'
+import type { WebSocketBrowserEvents, WebSocketBrowserHandlers } from '../types'
+import type { ParentBrowserProject } from './projectParent'
+import type { BrowserServerState } from './state'
+import { existsSync, promises as fs } from 'node:fs'
+import { AutomockedModule, AutospiedModule, ManualMockedModule, RedirectedModule } from '@vitest/mocker'
+import { ServerMockResolver } from '@vitest/mocker/node'
+import { extractSourcemapFromFile } from '@vitest/utils/source-map/node'
+import { createBirpc } from 'birpc'
+import { parse, stringify } from 'flatted'
+import { dirname, join, resolve } from 'pathe'
+import { createDebugger, isFileLoadingAllowed, isValidApiRequest } from 'vitest/node'
+import { WebSocketServer } from 'ws'
+
+const debug = createDebugger('vitest:browser:api')
+
+const BROWSER_API_PATH = '/__vitest_browser_api__'
+
+export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMockerRegistry: MockerRegistry): void {
+  const vite = globalServer.vite
+  const vitest = globalServer.vitest
+
+  const wss = new WebSocketServer({ noServer: true })
+
+  vite.httpServer?.on('upgrade', (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+    if (!request.url) {
+      return
+    }
+
+    const { pathname, searchParams } = new URL(request.url, 'http://localhost')
+    if (pathname !== BROWSER_API_PATH) {
+      return
+    }
+
+    if (!isValidApiRequest(vitest.config, request)) {
+      socket.destroy()
+      return
+    }
+
+    const type = searchParams.get('type')
+    const rpcId = searchParams.get('rpcId')
+    const sessionId = searchParams.get('sessionId')
+    const projectName = searchParams.get('projectName')
+
+    if (type !== 'tester' && type !== 'orchestrator') {
+      return error(
+        new Error(`[vitest] Type query in ${request.url} is invalid. Type should be either "tester" or "orchestrator".`),
+      )
+    }
+
+    if (!sessionId || !rpcId || projectName == null) {
+      return error(
+        new Error(`[vitest] Invalid URL ${request.url}. "projectName", "sessionId" and "rpcId" queries are required.`),
+      )
+    }
+
+    const sessions = vitest._browserSessions
+
+    if (!sessions.sessionIds.has(sessionId)) {
+      const ids = [...sessions.sessionIds].join(', ')
+      return error(
+        new Error(`[vitest] Unknown session id "${sessionId}". Expected one of ${ids}.`),
+      )
+    }
+
+    if (type === 'orchestrator') {
+      const session = sessions.getSession(sessionId)
+      // it's possible the session was already resolved by the preview provider,
+      // but we still mark the websocket connection when the page reconnects
+      session?.connected()
+    }
+
+    const project = vitest.getProjectByName(projectName)
+
+    if (!project) {
+      return error(
+        new Error(`[vitest] Project "${projectName}" not found.`),
+      )
+    }
+
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit('connection', ws, request)
+
+      const { rpc, offCancel } = setupClient(project, rpcId, ws, { sessionId })
+      const state = project.browser!.state as BrowserServerState
+      const clients = type === 'tester' ? state.testers : state.orchestrators
+      clients.set(rpcId, rpc)
+
+      debug?.('[%s] Browser API connected to %s', rpcId, type)
+
+      ws.on('close', () => {
+        debug?.('[%s] Browser API disconnected from %s', rpcId, type)
+        offCancel()
+        clients.delete(rpcId)
+        globalServer.removeCDPHandler(rpcId)
+        if (type === 'orchestrator') {
+          sessions.destroySession(sessionId)
+        }
+        // this will reject any hanging methods if there are any
+        rpc.$close(
+          new Error(`[vitest] Browser connection was closed while running tests. Was the page closed unexpectedly?`),
+        )
+      })
+    })
+  })
+
+  // we don't throw an error inside a stream because this can segfault the process
+  function error(err: Error) {
+    console.error(err)
+    vitest.state.catchError(err, 'RPC Error')
+  }
+
+  function checkFileAccess(path: string) {
+    if (!isFileLoadingAllowed(vite.config, path)) {
+      throw new Error(
+        `Access denied to "${path}". See Vite config documentation for "server.fs": https://vitejs.dev/config/server-options.html#server-fs-strict.`,
+      )
+    }
+  }
+
+  function canWrite(project: TestProject) {
+    return (
+      project.config.api.allowWrite
+      && project.vitest.config.api.allowWrite
+    )
+  }
+
+  function isCdpAllowed(project: TestProject) {
+    return (
+      project.config.api.allowExec
+      && project.vitest.config.api.allowExec
+      && project.config.api.allowWrite
+      && project.vitest.config.api.allowWrite
+    )
+  }
+
+  function assertCdpAllowed(project: TestProject) {
+    if (!isCdpAllowed(project)) {
+      throw new Error(
+        `Cannot use CDP because browser API write or exec operations are disabled. See https://vitest.dev/config/api.`,
+      )
+    }
+  }
+
+  function setupClient(
+    project: TestProject,
+    rpcId: string,
+    ws: WebSocket,
+    options: {
+      sessionId: string
+    },
+  ) {
+    const mockResolver = new ServerMockResolver(globalServer.vite, {
+      moduleDirectories: project.config?.deps?.moduleDirectories,
+    })
+    const mocker = project.browser?.provider.mocker
+
+    const rpc = createBirpc<WebSocketBrowserEvents, WebSocketBrowserHandlers>(
+      {
+        onOrchestratorReady() {
+          const sessions = vitest._browserSessions
+          sessions.getSession(options.sessionId)?.ready()
+        },
+        async onUnhandledError(error, type) {
+          if (error && typeof error === 'object') {
+            const _error = error as TestError
+            _error.stacks = globalServer.parseErrorStacktrace(_error)
+          }
+          vitest.state.catchError(error, type)
+        },
+        async onQueued(method, file) {
+          if (method === 'collect') {
+            vitest.state.collectFiles(project, [file])
+          }
+          else {
+            await vitest._testRun.enqueued(project, file)
+          }
+        },
+        async onCollected(method, files) {
+          if (method === 'collect') {
+            vitest.state.collectFiles(project, files)
+          }
+          else {
+            await vitest._testRun.collected(project, files)
+          }
+        },
+        async onTaskArtifactRecord(id, artifact) {
+          if (!canWrite(project)) {
+            if (artifact.type === 'internal:annotation' && artifact.annotation.attachment) {
+              artifact.annotation.attachment = undefined
+              vitest.logger.error(
+                `[vitest] Cannot record annotation attachment because file writing is disabled. See https://vitest.dev/config/api.`,
+              )
+            }
+            // remove attachments if cannot write
+            if (artifact.attachments?.length) {
+              const attachments = artifact.attachments.map(n => n.path).filter(r => !!r).join('", "')
+              artifact.attachments = []
+              vitest.logger.error(
+                `[vitest] Cannot record attachments ("${attachments}") because file writing is disabled, removing attachments from artifact "${artifact.type}". See https://vitest.dev/config/api.`,
+              )
+            }
+          }
+          else {
+            // attachment files are copied into `attachmentsDir`, so confine
+            // client-supplied paths to Vite's `server.fs` boundary
+            const attachments = artifact.type === 'internal:annotation'
+              ? (artifact.annotation.attachment ? [artifact.annotation.attachment] : [])
+              : (artifact.attachments ?? [])
+            for (const attachment of attachments) {
+              const path = attachment.path
+              if (path && !path.startsWith('http://') && !path.startsWith('https://')) {
+                checkFileAccess(resolve(project.config.root, path))
+              }
+            }
+          }
+
+          return vitest._testRun.recordArtifact(id, artifact)
+        },
+        async onTestBenchmark(testId, benchmark) {
+          return vitest._testRun.recordBenchmark(testId, benchmark)
+        },
+        async readBenchmarkResult(relativePath) {
+          checkFileAccess(project.benchmark.resolve(relativePath))
+          return project.benchmark.readResult(relativePath)
+        },
+        async writeBenchmarkResult(relativePath, data) {
+          if (!canWrite(project)) {
+            vitest.logger.error(
+              `[vitest] Cannot write benchmark artifact "${relativePath}" because file writing is disabled. See https://vitest.dev/config/api.`,
+            )
+            return
+          }
+          checkFileAccess(project.benchmark.resolve(relativePath))
+          return project.benchmark.writeResult(relativePath, data)
+        },
+        async onTaskUpdate(method, packs, events) {
+          if (method === 'collect') {
+            vitest.state.updateTasks(packs)
+          }
+          else {
+            await vitest._testRun.updated(packs, events)
+          }
+        },
+        onAfterSuiteRun(meta) {
+          vitest.coverageProvider?.onAfterSuiteRun(meta)
+        },
+        async sendLog(method, log) {
+          if (method === 'collect') {
+            vitest.state.updateUserLog(log)
+          }
+          else {
+            await vitest._testRun.log(log)
+          }
+        },
+        resolveSnapshotPath(testPath) {
+          return vitest.snapshot.resolvePath<ResolveSnapshotPathHandlerContext>(testPath, {
+            config: project.serializedConfig,
+          })
+        },
+        resolveSnapshotRawPath(testPath, rawPath) {
+          return vitest.snapshot.resolveRawPath(testPath, rawPath)
+        },
+        snapshotSaved(snapshot) {
+          vitest.snapshot.add(snapshot)
+        },
+        async readSnapshotFile(snapshotPath) {
+          checkFileAccess(snapshotPath)
+          if (!existsSync(snapshotPath)) {
+            return null
+          }
+          return fs.readFile(snapshotPath, 'utf-8')
+        },
+        async saveSnapshotFile(id, content) {
+          checkFileAccess(id)
+          if (!canWrite(project)) {
+            vitest.logger.error(
+              `[vitest] Cannot save snapshot file "${id}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/api.`,
+            )
+            return
+          }
+          await fs.mkdir(dirname(id), { recursive: true })
+          await fs.writeFile(id, content, 'utf-8')
+        },
+        async removeSnapshotFile(id) {
+          checkFileAccess(id)
+          if (!canWrite(project)) {
+            vitest.logger.error(
+              `[vitest] Cannot remove snapshot file "${id}". File writing is disabled because server is exposed to the internet, see https://vitest.dev/config/api.`,
+            )
+            return
+          }
+          if (!existsSync(id)) {
+            throw new Error(`Snapshot file "${id}" does not exist.`)
+          }
+          await fs.unlink(id)
+        },
+        getBrowserFileSourceMap(id) {
+          const mod = globalServer.vite.moduleGraph.getModuleById(id)
+          const result = mod?.transformResult
+          // handle non-inline source map such as pre-bundled deps in node_modules/.vite
+          if (result && !result.map) {
+            const filePath = id.split('?')[0]
+            const extracted = extractSourcemapFromFile(result.code, filePath)
+            return extracted?.map
+          }
+          return result?.map
+        },
+        cancelCurrentRun(reason) {
+          vitest.cancelCurrentRun(reason)
+        },
+        async resolveId(id, importer) {
+          return mockResolver.resolveId(id, importer)
+        },
+        debug(...args) {
+          vitest.logger.console.debug(...args)
+        },
+        getCountOfFailedTests() {
+          return vitest.state.getCountOfFailedTests()
+        },
+        async wdioSwitchContext(direction) {
+          const provider = project.browser!.provider
+          if (!provider) {
+            throw new Error('Commands are only available for browser tests.')
+          }
+          if (provider.name !== 'webdriverio') {
+            throw new Error('Switch context is only available for WebDriverIO provider.')
+          }
+          if (direction === 'iframe') {
+            await (provider as any).switchToTestFrame()
+          }
+          else {
+            await (provider as any).switchToMainFrame()
+          }
+        },
+        async triggerCommand(sessionId, command, testPath, payload) {
+          debug?.('[%s] Triggering command "%s"', sessionId, command)
+          const provider = project.browser!.provider
+          if (!provider) {
+            throw new Error('Commands are only available for browser tests.')
+          }
+          const context = Object.assign(
+            {
+              testPath,
+              project,
+              provider,
+              contextId: sessionId,
+              sessionId,
+              mark: async (name: string, options?: any) => {
+                const tester = (project.browser!.state as BrowserServerState).testers.get(rpcId)
+                await tester?.pageMark(name, options)
+              },
+              triggerCommand: (name: string, ...args: any[]) => {
+                return project.browser!.triggerCommand(
+                  name as any,
+                  context,
+                  ...args,
+                )
+              },
+              __ensureCDPHandler: () => globalServer.ensureCDPHandler(sessionId, rpcId),
+            },
+            provider.getCommandsContext(sessionId),
+          ) as any as BrowserCommandContext
+          return await project.browser!.triggerCommand(
+            command as any,
+            context,
+            ...payload.map(value => value === null ? undefined : value),
+          )
+        },
+        resolveMock(rawId, importer, options) {
+          return mockResolver.resolveMock(rawId, importer, options)
+        },
+        invalidate(ids) {
+          return mockResolver.invalidate(ids)
+        },
+
+        async registerMock(sessionId, module) {
+          if (!mocker) {
+            // make sure modules are not processed yet in case they were imported before
+            // and were not mocked
+            mockResolver.invalidate([module.id])
+
+            if (module.type === 'manual') {
+              const mock = ManualMockedModule.fromJSON(module, async () => {
+                try {
+                  const { keys } = await rpc.resolveManualMock(module.url)
+                  return Object.fromEntries(keys.map(key => [key, null]))
+                }
+                catch (err) {
+                  vitest.state.catchError(err, 'Manual Mock Resolver Error')
+                  return {}
+                }
+              })
+              defaultMockerRegistry.add(mock)
+            }
+            else {
+              if (module.type === 'redirect') {
+                const redirectUrl = new URL(module.redirect)
+                module.redirect = join(vite.config.root, redirectUrl.pathname)
+              }
+              defaultMockerRegistry.register(module)
+            }
+            return
+          }
+
+          if (module.type === 'manual') {
+            const manualModule = ManualMockedModule.fromJSON(module, async () => {
+              const { keys } = await rpc.resolveManualMock(module.url)
+              return Object.fromEntries(keys.map(key => [key, null]))
+            })
+            await mocker.register(sessionId, manualModule)
+          }
+          else if (module.type === 'redirect') {
+            await mocker.register(sessionId, RedirectedModule.fromJSON(module))
+          }
+          else if (module.type === 'automock') {
+            await mocker.register(sessionId, AutomockedModule.fromJSON(module))
+          }
+          else if (module.type === 'autospy') {
+            await mocker.register(sessionId, AutospiedModule.fromJSON(module))
+          }
+        },
+        clearMocks(sessionId) {
+          if (!mocker) {
+            return defaultMockerRegistry.clear()
+          }
+          return mocker.clear(sessionId)
+        },
+        unregisterMock(sessionId, id) {
+          if (!mocker) {
+            return defaultMockerRegistry.delete(id)
+          }
+          return mocker.delete(sessionId, id)
+        },
+
+        // CDP
+        async sendCdpEvent(sessionId: string, event: string, payload?: Record<string, unknown>) {
+          assertCdpAllowed(project)
+          const cdp = await globalServer.ensureCDPHandler(sessionId, rpcId)
+          return cdp.send(event, payload)
+        },
+        async trackCdpEvent(sessionId: string, type: 'on' | 'once' | 'off', event: string, listenerId: string) {
+          assertCdpAllowed(project)
+          const cdp = await globalServer.ensureCDPHandler(sessionId, rpcId)
+          cdp[type](event, listenerId)
+        },
+      },
+      {
+        post: msg => ws.send(msg),
+        on: fn => ws.on('message', fn),
+        eventNames: ['onCancel', 'cdpEvent'],
+        serialize: (data: any) => stringify(data, stringifyReplace),
+        deserialize: parse,
+        timeout: -1, // createTesters can take a long time
+      },
+    )
+
+    const offCancel = vitest.onCancel(reason => rpc.onCancel(reason))
+
+    return { rpc, offCancel }
+  }
+}
+
+// Serialization support utils.
+function cloneByOwnProperties(value: any) {
+  // Clones the value's properties into a new Object. The simpler approach of
+  // Object.assign() won't work in the case that properties are not enumerable.
+  const clone: Record<string, unknown> = {}
+  for (const prop of Object.getOwnPropertyNames(value)) {
+    clone[prop] = value[prop]
+  }
+  return clone
+}
+
+/**
+ * Replacer function for serialization methods such as JS.stringify() or
+ * flatted.stringify().
+ */
+function stringifyReplace(key: string, value: any): any {
+  if (value instanceof Error) {
+    const cloned = cloneByOwnProperties(value)
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...cloned,
+    }
+  }
+  else {
+    return value
+  }
+}

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -124,7 +124,7 @@ declare global {
     }
 
     // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-    // @ts-ignore build namspace conflict
+    // @ts-ignore build namespace conflict
     type VitestAssertion<A, T> = {
       [K in keyof A]: A[K] extends Chai.Assertion
         ? Assertion<T>

--- a/packages/vitest/src/integrations/chai/jest-expect.ts
+++ b/packages/vitest/src/integrations/chai/jest-expect.ts
@@ -489,13 +489,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
   def(['toHaveReturnedTimes', 'toReturnTimes'], function (times: number) {
     const spy = getSpy(this)
     const spyName = spy.getMockName()
-    const successfullReturns = spy.mock.results.reduce((success, { type }) => type === 'throw' ? success : ++success, 0)
+    const successfulReturns = spy.mock.results.reduce((success, { type }) => type === 'throw' ? success : ++success, 0)
     this.assert(
-      successfullReturns === times,
+      successfulReturns === times,
       `expected "${spyName}" to be successfully called ${times} times`,
       `expected "${spyName}" to not be successfully called ${times} times`,
       `expected number of returns: ${times}`,
-      `received number of returns: ${successfullReturns}`,
+      `received number of returns: ${successfulReturns}`,
     )
   })
   def(['toHaveReturnedWith', 'toReturnWith'], function (value: any) {

--- a/packages/vitest/src/integrations/coverage.ts
+++ b/packages/vitest/src/integrations/coverage.ts
@@ -82,7 +82,7 @@ export async function reportCoverage(ctx: Vitest) {
 
   // This is a magic number. It corresponds to the amount of code
   // that we add in packages/vite-node/src/client.ts:114 (vm.runInThisContext)
-  // TODO: Include our transformations in soucemaps
+  // TODO: Include our transformations in sourcemaps
   const offset = 203
 
   report._getSourceMap = (coverage: Profiler.ScriptCoverage) => {

--- a/test/browser/test/commands.test.ts
+++ b/test/browser/test/commands.test.ts
@@ -1,0 +1,78 @@
+import { expect, it } from 'vitest'
+import { server } from 'vitest/browser'
+
+const { readFile, writeFile, removeFile, myCustomCommand } = server.commands
+
+it('can manipulate files', async () => {
+  // all browser instances run this file against the same cwd in parallel,
+  // so the file name must be unique per instance to avoid races
+  const file = `./test-${server.browser}.txt`
+
+  try {
+    await readFile(file)
+    expect.unreachable()
+  }
+  catch (err) {
+    expect(err.message).toMatch(`ENOENT: no such file or directory, open`)
+    if (server.platform === 'win32') {
+      expect(err.message).toMatch(`test\\browser\\test-${server.browser}.txt`)
+    }
+    else {
+      expect(err.message).toMatch(`test/browser/test-${server.browser}.txt`)
+    }
+  }
+
+  await writeFile(file, 'hello world')
+  const content = await readFile(file)
+
+  expect(content).toBe('hello world')
+
+  await removeFile(file)
+
+  try {
+    await readFile(file)
+    expect.unreachable()
+  }
+  catch (err) {
+    expect(err.message).toMatch(`ENOENT: no such file or directory, open`)
+    if (server.platform === 'win32') {
+      expect(err.message).toMatch(`test\\browser\\test-${server.browser}.txt`)
+    }
+    else {
+      expect(err.message).toMatch(`test/browser/test-${server.browser}.txt`)
+    }
+  }
+})
+
+it('can run custom commands', async () => {
+  { const result = await myCustomCommand('arg1', 'arg2')
+    expect(result).toEqual({
+      testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
+      arg1: 'arg1',
+      arg2: 'arg2',
+    })
+  }
+
+  {
+    const result = await myCustomCommand(undefined, 'arg2')
+    expect(result).toEqual({
+      testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
+      arg1: undefined,
+      arg2: 'arg2',
+    })
+  }
+})
+
+declare module 'vitest/browser' {
+  interface BrowserCommands {
+    myCustomCommand: (arg1: string | undefined, arg2: string) => Promise<{
+      testPath: string
+      arg1: string | undefined
+      arg2: string
+    }>
+
+    stripVTControlCharacters: (text: string) => Promise<string>
+    startTrace: () => Promise<void>
+    stopTrace: () => Promise<void>
+  }
+}

--- a/test/core/test/date-mock.test.ts
+++ b/test/core/test/date-mock.test.ts
@@ -5,7 +5,7 @@ describe('testing date mock functionality', () => {
     vi.useRealTimers()
   })
 
-  test('seting time in the past', () => {
+  test('setting time in the past', () => {
     const date = new Date(2000, 1, 1)
 
     vi.setSystemTime(date)


### PR DESCRIPTION
## What

Fixes #10864: custom browser commands silently **shift their arguments** whenever one of the passed arguments is `undefined`.

`CommandsManager.triggerCommand` in `packages/browser/src/client/tester/tester-utils.ts` ran:

```ts
args = args.filter(arg => arg !== undefined) // remove optional fields
```

That **drops** `undefined` values from the argument list and shifts the remaining values left. So `commands.readConfig(undefined, "file.ts")` reached the server as `readConfig("file.ts")` — the first argument was silently replaced by the second one, and the second argument became `undefined`.

## Fix

1. **`packages/browser/src/client/tester/tester-utils.ts`** — removed the `args.filter(arg => arg !== undefined)` line so `undefined` arguments keep their original positions.
2. **`packages/browser/src/node/rpc.ts`** — the WebSocket RPC transport (flatted / JSON) serializes `undefined` array elements as `null`, so the server-side `triggerCommand` dispatch now maps those `null`s back to `undefined` before invoking the command, preserving the exact values the caller passed.

## Tests

Added the regression case from @AriPerkkio's failing-test PR #10865 to `test/browser/test/commands.test.ts`: `myCustomCommand(undefined, 'arg2')` must reach the server as `{ arg1: undefined, arg2: 'arg2' }`.

- **RED**: on `main` the test fails — the filter turns the server-side call into `myCustomCommand('arg2')`, so `arg1` is `'arg2'` and `arg2` is `undefined`.
- **GREEN**: with the fix the server receives `{ arg1: undefined, arg2: 'arg2' }` and the test passes.

Fixes #10864