### PR TITLE
feat(browser)!: save failure screenshots in `attachmentsDir`

### DIFF
--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -17,6 +17,7 @@ import type {
 import type { VitestBrowserClientMocker } from './mocker'
 import type { CommandsManager } from './tester-utils'
 import { globalChannel, onCancel } from '@vitest/browser/client'
+import { basename, resolve } from 'pathe'
 import { recordArtifact, TestRunner } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import {
@@ -195,7 +196,13 @@ function createBrowserRunner(
       ) {
         const screenshot = await page.screenshot({
           timeout: this.config.browser.providerOptions?.actionTimeout ?? 5_000,
-        } as any /** TODO */).catch((err) => {
+          path: resolve(
+            this.config.attachmentsDir,
+            'failure-screenshots',
+            basename(task.file.filepath),
+            `${task.fullTestName.replace(/\W/g, '-')}.png`,
+          ),
+        }).catch((err) => {
           console.error('[vitest] Failed to take a screenshot', err)
         })
         if (screenshot) {

--- a/packages/vitest/src/node/config/serializeConfig.ts
+++ b/packages/vitest/src/node/config/serializeConfig.ts
@@ -161,6 +161,7 @@ export function serializeConfig(project: TestProject): SerializedConfig {
       ?? globalConfig.slowTestThreshold
       ?? configDefaults.slowTestThreshold,
     disableColors: isAgent && !isForceColor(),
+    attachmentsDir: config.attachmentsDir,
   }
 }
 

--- a/packages/vitest/src/runtime/config.ts
+++ b/packages/vitest/src/runtime/config.ts
@@ -170,6 +170,7 @@ export interface SerializedConfig {
   mergeReportsLabel: string | undefined
   slowTestThreshold: number | undefined
   disableColors: boolean
+  attachmentsDir: string
 }
 
 export interface SerializedCoverageConfig {

--- a/test/browser/specs/failure-screenshot.test.ts
+++ b/test/browser/specs/failure-screenshot.test.ts
@@ -30,6 +30,10 @@ async function runBrowserTests(
   })
 }
 
+function extractScreenshotPath(string: string): string | undefined {
+  return string.match(/- (vitest-test-.*?\.png)/)[1]
+}
+
 describe('failure screenshots', () => {
   describe('`toMatchScreenshot`', () => {
     test('usually does NOT produce a failure screenshot', async () => {
@@ -72,6 +76,10 @@ describe('failure screenshots', () => {
 
       expect(stderr).toContain('Could not capture a stable screenshot within 1ms.')
       expect(stderr).toContain('Failure screenshot:')
+
+      const screenshotPath = extractScreenshotPath(stderr)
+
+      expect(screenshotPath).toContain('.vitest/attachments/failure-screenshots/basic.test.ts/screenshot-unstable.png')
     })
 
     test('`expect.soft` produces a failure screenshot', async () => {
@@ -95,6 +103,10 @@ describe('failure screenshots', () => {
       expect(stderr).toContain('No existing reference screenshot found; a new one was created.')
       expect(stderr).toContain('expected 1 to be 2')
       expect(stderr).toContain('Failure screenshot:')
+
+      const screenshotPath = extractScreenshotPath(stderr)
+
+      expect(screenshotPath).toContain('.vitest/attachments/failure-screenshots/basic.test.ts/screenshot-soft-then-fail.png')
     })
   })
 })

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -292,7 +292,7 @@ test(`stack trace points to correct file in every browser when failed`, async ()
   // expect(stderr).toContain('Expected to be')
   // expect(stderr).toContain('But got')
   expect(stderr).toContain('Failure screenshot')
-  expect(stderr).toContain('__screenshots__/failing')
+  expect(stderr).toContain('.vitest/attachments/failure-screenshots/failing')
 
   expect(stderr).toContain('Access denied to "/inaccessible/path".')
 

--- a/test/e2e/snapshots/domain-aria-inline.test.ts
+++ b/test/e2e/snapshots/domain-aria-inline.test.ts
@@ -94,7 +94,7 @@ test('aria inline snapshot', async () => {
     Error: Snapshot \`semantic match with regex in snapshot 1\` mismatched
 
     Failure screenshot:
-      - snapshots/fixtures/domain-aria-inline/__screenshots__/basic.test.ts/semantic-match-with-regex-in-snapshot-1.png
+      - snapshots/fixtures/domain-aria-inline/.vitest/attachments/failure-screenshots/basic.test.ts/semantic-match-with-regex-in-snapshot.png
 
     - Expected
     + Received

--- a/test/e2e/snapshots/domain-aria.test.ts
+++ b/test/e2e/snapshots/domain-aria.test.ts
@@ -110,7 +110,7 @@ test('aria snapshot', { tags: ['browser'] }, async () => {
     Error: Snapshot \`semantic match with regex in snapshot 1\` mismatched
 
     Failure screenshot:
-      - snapshots/fixtures/domain-aria/__screenshots__/basic.test.ts/semantic-match-with-regex-in-snapshot-1.png
+      - snapshots/fixtures/domain-aria/.vitest/attachments/failure-screenshots/basic.test.ts/semantic-match-with-regex-in-snapshot.png
 
     - Expected
     + Received


### PR DESCRIPTION
### Description

Alternative approach to fix #10859

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
