### PR TITLE
fix(vitest): remove broken "./src/*" export from package.json

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -23,6 +23,9 @@
       "unresolved",
       "exports"
     ],
+    // The "./src/*" package export used to make every src file a public entry
+    // point, hiding dead code from Knip. TODO(follow-up) Clean these up and drop the ignore.
+    "packages/vitest/src/**": ["files", "exports", "types"],
     "packages/vitest/src/integrations/vi.ts": ["duplicates"],
     "packages/vitest/src/runtime/runner/suite.ts": ["duplicates"]
   },
@@ -92,7 +95,20 @@
       ]
     },
     "packages/vitest": {
-      "entry": ["*.{cjs,d.cts,d.ts,mjs}"],
+      // Keep src entries in sync with rollup.config.js: Knip does not read
+      // rollup configs here (the rollup plugin is not enabled per-workspace),
+      // and package.json exports only point to dist.
+      "entry": [
+        "*.{cjs,d.cts,d.ts,mjs}",
+        "src/paths.ts",
+        "src/public/*.ts",
+        "src/node/cli.ts",
+        "src/integrations/spy.ts",
+        "src/runtime/nodejsWorkerLoader.ts",
+        "src/runtime/runVmTests.ts",
+        "src/runtime/workers/*.ts",
+        "src/utils/tasks.ts"
+      ],
       "ignoreDependencies": [
         // Dynamically imported providers remain optional for Vitest users.
         "@vitest/browser-playwright",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -52,7 +52,6 @@
     "./optional-runtime-types.js": {
       "types": "./optional-runtime-types.d.ts"
     },
-    "./src/*": "./src/*",
     "./globals": {
       "types": "./globals.d.ts"
     },

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -1,7 +1,7 @@
 import type { RunnerTestFile as File, RunnerTestCase as Test } from 'vitest'
 import type { TestUserConfig, Vitest } from 'vitest/node'
-import type { MergeReport } from 'vitest/src/node/reporters/blob.js'
 import type { RunVitestConfig } from '#test-utils'
+import type { MergeReport } from '../../../../packages/vitest/src/node/reporters/blob.js'
 import { cpSync, existsSync, readdirSync, readFileSync, rmSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -10,8 +10,8 @@ import { stringify } from 'flatted'
 import { dirname, resolve } from 'pathe'
 import { beforeEach, expect, test, TestRunner } from 'vitest'
 import { version } from 'vitest/package.json'
-import { getModuleGraph } from 'vitest/src/utils/graph.js'
 import { buildTestTree, runVitest, useFS, useTmpFS } from '#test-utils'
+import { getModuleGraph } from '../../../../packages/vitest/src/utils/graph.js'
 
 // always relative to CWD because it's used only from the CLI,
 // so we need to correctly resolve it here

--- a/test/e2e/test/reporters/utils.ts
+++ b/test/e2e/test/reporters/utils.ts
@@ -1,10 +1,10 @@
 import type { ModuleGraph, ViteDevServer } from 'vite'
 import type { RunnerTestCase, RunnerTestSuite, TestError } from 'vitest'
-import type { Vitest } from 'vitest/src/node/core.js'
-import type { Logger } from 'vitest/src/node/logger.js'
-import type { StateManager } from 'vitest/src/node/state.js'
-import type { ResolvedConfig } from 'vitest/src/node/types/config.js'
-import type { RunnerTestFile } from 'vitest/src/public/index.js'
+import type { Vitest } from '../../../../packages/vitest/src/node/core.js'
+import type { Logger } from '../../../../packages/vitest/src/node/logger.js'
+import type { StateManager } from '../../../../packages/vitest/src/node/state.js'
+import type { ResolvedConfig } from '../../../../packages/vitest/src/node/types/config.js'
+import type { RunnerTestFile } from '../../../../packages/vitest/src/public/index.js'
 import { TestRunner } from 'vitest'
 
 export function trimReporterOutput(report: string) {

--- a/test/e2e/test/workers-option.test.ts
+++ b/test/e2e/test/workers-option.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
-import { getWorkersCountByPercentage } from 'vitest/src/utils/workers.js'
 import * as testUtils from '#test-utils'
+import { getWorkersCountByPercentage } from '../../../packages/vitest/src/utils/workers.js'
 
 vi.mock(import('node:os'), async importOriginal => ({
   ...(await importOriginal()),

--- a/test/unit/test/memory-limit.test.ts
+++ b/test/unit/test/memory-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getWorkerMemoryLimit } from 'vitest/src/utils/memory-limit.js'
+import { getWorkerMemoryLimit } from '../../../packages/vitest/src/utils/memory-limit.js'
 
 describe('getWorkerMemoryLimit', () => {
   it('should prioritize vmMemoryLimit', () => {

--- a/test/unit/test/vm-code-cache.test.ts
+++ b/test/unit/test/vm-code-cache.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { CodeCache } from 'vitest/src/runtime/vm/code-cache.js'
+import { CodeCache } from '../../../packages/vitest/src/runtime/vm/code-cache.js'
 
 test('returns the stored data only for the exact same source', () => {
   const cache = new CodeCache()


### PR DESCRIPTION
Removes the `./src/*` subpath export, which is broken in the published package because the `src` directory is not shipped, and updates internal tests that relied on it to use relative imports.

Closes #10797