### PR TITLE
chore: reference local knip schema instead of unpkg

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
+  "$schema": "./node_modules/knip/schema.json",
   "ignoreWorkspaces": [
     "examples/*",
     "test/e2e/dts/*",


### PR DESCRIPTION
Points `$schema` in `knip.jsonc` at the schema shipped in `node_modules` because VS Code treats the unpkg URL as an untrusted location.