### PR TITLE
fix: pick up prototype-inherited properties in toMatchObject diff (fix #6939)

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -783,8 +783,12 @@ export function getObjectSubset(
             })
           }
 
-          for (const key of getObjectKeys(object)) {
-            if (hasPropertyInObject(subset, key)) {
+          // Iterate subset's keys (not object's own enumerable keys) so that
+          // inherited/accessor properties -- e.g. DOM element properties
+          // like `tagName`, which live on the prototype chain -- are still
+          // picked up via the `in` operator. See #6939.
+          for (const key of getObjectKeys(subset)) {
+            if (key in object) {
               trimmed[key] = seenReferences.has(object[key])
                 ? seenReferences.get(object[key])
                 : getObjectSubsetWithContext(seenReferences)(
@@ -792,18 +796,20 @@ export function getObjectSubset(
                     subset[key],
                   )
             }
-            else {
-              if (!seenReferences.has(object[key])) {
-                stripped += 1
-                if (isObject(object[key])) {
-                  stripped += getObjectKeys(object[key]).length
-                }
+          }
 
-                getObjectSubsetWithContext(seenReferences)(
-                  object[key],
-                  subset[key],
-                )
+          // Preserve "N properties omitted from actual" messaging by still
+          // counting object's own extra keys not present in subset.
+          for (const key of getObjectKeys(object)) {
+            if (!hasPropertyInObject(subset, key) && !seenReferences.has(object[key])) {
+              stripped += 1
+              if (isObject(object[key])) {
+                stripped += getObjectKeys(object[key]).length
               }
+              getObjectSubsetWithContext(seenReferences)(
+                object[key],
+                subset[key],
+              )
             }
           }
 

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -1747,6 +1747,37 @@ it('toMatchObject error diff', () => {
       }",
     ]
   `)
+  // https://github.com/vitest-dev/vitest/issues/6939
+  // properties inherited via the prototype chain (e.g. DOM elements) should
+  // still be picked up when building the toMatchObject diff, instead of
+  // falling back to showing the raw object.
+  {
+    const proto = {
+      get tagName() {
+        return 'DIV'
+      },
+    }
+    const domLike = Object.create(proto)
+    domLike.id = 'root'
+
+    expect(domLike).toMatchObject({ tagName: 'DIV', id: 'root' })
+
+    expect(getError(() =>
+      expect(domLike).toMatchObject({ tagName: 'SPAN', id: 'root' }),
+    )).toMatchInlineSnapshot(`
+      [
+        "expected { id: 'root' } to match object { tagName: 'SPAN', id: 'root' }",
+        "- Expected
+      + Received
+
+        {
+          "id": "root",
+      -   "tagName": "SPAN",
+      +   "tagName": "DIV",
+        }",
+      ]
+    `)
+  }
 })
 
 it('toHaveProperty error diff', () => {


### PR DESCRIPTION
### Description
`toMatchObject` produces an unreadable diff when the actual value has properties that live on its prototype chain instead of as own enumerable properties - for example, DOM elements, where `tagName`, `id`, etc. are accessor properties on `Element.prototype`, not own properties on the instance.

**Root cause:** `getObjectSubset` (in `packages/expect/src/jest-utils.ts`) built the "actual" side of the diff by iterating `getObjectKeys(object)`, which only returns own enumerable keys. For a DOM element this returns an empty array, so the subset-building loop never ran and the function fell through to returning the raw object — which the pretty-print layer then serialized as `<div><img /></div>` instead of a plain-object diff.

**Fix:** iterate `getObjectKeys(subset)` instead, and check presence with `key in object`, which walks the prototype chain. `subset` is always the object literal the caller wrote, so its keys are reliable regardless of what `actual` is. The existing "N properties omitted from actual" counting logic is unchanged — it still iterates `object`'s own keys separately.

**Known related gap:** the one-line summary message (`"expected {...} to match object {...}"`) stringifies the actual value via a separate code path (`utils.getMessage`) not touched by this fix, so it may still omit inherited properties there even though the diff body is now correct. Flagging rather than silently leaving it out of scope — happy to follow up separately if useful.

Resolves #6939

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Ran the full `@vitest/test-unit` suite (640 files, 7600 tests, all passing, no type errors) and `pnpm test:ci`. The only failure in `test:ci` was a pre-existing, unrelated snapshot mismatch in `test-coverage` (`5.0.0-rc.1` vs `5.0.0-beta.7` version string), unrelated to this change.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

N/A — this is a bugfix to existing behavior, no new functionality introduced.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

I used Claude as an assistant while investigating and tracing the root cause through the codebase; the diagnosis, fix, and test above are ones I understand and can walk through.