### PR TITLE
fix(browser): preserve undefined command arguments

### DIFF
--- a/packages/browser/src/client/tester/tester-utils.ts
+++ b/packages/browser/src/client/tester/tester-utils.ts
@@ -133,7 +133,6 @@ export class CommandsManager {
     const rpc = state.rpc as any as BrowserRPC
     const { sessionId, traces } = getBrowserState()
     const filepath = state.filepath || state.current?.file?.filepath
-    args = args.filter(arg => arg !== undefined) // remove optional fields
 
     const actionTraceGroupName = ACTION_TRACE_COMMANDS.has(command)
       ? `vitest:${command.slice('__vitest_'.length)}`

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -339,6 +339,7 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
           }
         },
         async triggerCommand(sessionId, command, testPath, payload) {
+          payload = payload.map(value => value === null ? undefined : value);
           debug?.('[%s] Triggering command "%s"', sessionId, command)
           const provider = project.browser!.provider
           if (!provider) {

--- a/packages/browser/src/node/rpc.ts
+++ b/packages/browser/src/node/rpc.ts
@@ -339,7 +339,7 @@ export function setupBrowserRpc(globalServer: ParentBrowserProject, defaultMocke
           }
         },
         async triggerCommand(sessionId, command, testPath, payload) {
-          payload = payload.map(value => value === null ? undefined : value);
+          payload = payload.map(value => value === null ? undefined : value)
           debug?.('[%s] Triggering command "%s"', sessionId, command)
           const provider = project.browser!.provider
           if (!provider) {

--- a/test/browser/test/commands.test.ts
+++ b/test/browser/test/commands.test.ts
@@ -45,19 +45,29 @@ it('can manipulate files', async () => {
 })
 
 it('can run custom commands', async () => {
-  const result = await myCustomCommand('arg1', 'arg2')
-  expect(result).toEqual({
-    testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
-    arg1: 'arg1',
-    arg2: 'arg2',
-  })
+  { const result = await myCustomCommand('arg1', 'arg2')
+    expect(result).toEqual({
+      testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
+      arg1: 'arg1',
+      arg2: 'arg2',
+    })
+  }
+
+  {
+    const result = await myCustomCommand(undefined, 'arg2')
+    expect(result).toEqual({
+      testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
+      arg1: undefined,
+      arg2: 'arg2',
+    })
+  }
 })
 
 declare module 'vitest/browser' {
   interface BrowserCommands {
-    myCustomCommand: (arg1: string, arg2: string) => Promise<{
+    myCustomCommand: (arg1: string | undefined, arg2: string) => Promise<{
       testPath: string
-      arg1: string
+      arg1: string | undefined
       arg2: string
     }>
 

--- a/test/browser/test/commands.test.ts
+++ b/test/browser/test/commands.test.ts
@@ -45,7 +45,8 @@ it('can manipulate files', async () => {
 })
 
 it('can run custom commands', async () => {
-  { const result = await myCustomCommand('arg1', 'arg2')
+  {
+    const result = await myCustomCommand('arg1', 'arg2')
     expect(result).toEqual({
       testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
       arg1: 'arg1',
@@ -61,13 +62,22 @@ it('can run custom commands', async () => {
       arg2: 'arg2',
     })
   }
+
+  {
+    const result = await myCustomCommand(null, 'arg2')
+    expect(result).toEqual({
+      testPath: expect.stringMatching('test/browser/test/commands.test.ts'),
+      arg1: null,
+      arg2: 'arg2',
+    })
+  }
 })
 
 declare module 'vitest/browser' {
   interface BrowserCommands {
-    myCustomCommand: (arg1: string | undefined, arg2: string) => Promise<{
+    myCustomCommand: (arg1: string | undefined | null, arg2: string) => Promise<{
       testPath: string
-      arg1: string | undefined
+      arg1: string | undefined | null
       arg2: string
     }>
 


### PR DESCRIPTION
### Description

Custom browser commands CANNOT read `undefined` arguments crossing the browser → Node RPC boundary. The entry was dropped from the argument array, shifting later arguments left. Example:
```ts
commands.myCustomCommand(undefined, 'file.ts')
// server received: { arg1: 'file.ts', arg2: undefined }
```
### Cause

Line 136 in packages/browser/src/client/tester/tester-utils.ts 
```ts
args = args.filter(arg => arg !== undefined);
```
This line filter out undefined values.

### Fix
Remove that line and add a mapping in packages/browser/src/node/rpc.ts
to map null to undefined to match the test case created by @AriPerkkio 

### Tests

Includes the failing test from #10865 (authored by @AriPerkkio), which
now passes.

Resolves #10864

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
