### PR TITLE
fix(browser): bound trace attachment filenames (fix #9006)

### DIFF
--- a/packages/vitest/src/node/test-run.ts
+++ b/packages/vitest/src/node/test-run.ts
@@ -26,6 +26,8 @@ import { extractSourcemapFromFile } from '@vitest/utils/source-map/node'
 import mime from 'mime/lite'
 import { basename, extname, resolve } from 'pathe'
 
+const MAX_FILENAME_BYTES = 255
+
 export class TestRun {
   constructor(private vitest: Vitest) {}
 
@@ -294,9 +296,22 @@ export class TestRun {
     if (path && !path.startsWith('http://') && !path.startsWith('https://')) {
       const currentPath = resolve(project.config.root, path)
       const hash = createHash('sha1').update(currentPath).digest('hex')
+      const extension = extname(currentPath)
+      const attachmentHash = filename
+        ? createHash('sha1').update(currentPath).update('\0').update(filename).digest('hex')
+        : hash
+      const hashedFilename = `${attachmentHash}${extension}`
+      const readableFilename = filename
+        ? `${sanitizeFilePath(filename)}-${hashedFilename}`
+        : hashedFilename
+      const attachmentFilename = Buffer.byteLength(readableFilename) <= MAX_FILENAME_BYTES
+        ? readableFilename
+        : Buffer.byteLength(hashedFilename) <= MAX_FILENAME_BYTES
+          ? hashedFilename
+          : attachmentHash
       const newPath = resolve(
         project.config.attachmentsDir,
-        `${filename ? `${sanitizeFilePath(filename)}-` : ''}${hash}${extname(currentPath)}`,
+        attachmentFilename,
       )
       if (!existsSync(project.config.attachmentsDir)) {
         await mkdir(project.config.attachmentsDir, { recursive: true })

--- a/test/e2e/test/annotations.test.ts
+++ b/test/e2e/test/annotations.test.ts
@@ -38,6 +38,56 @@ describe('suite', () => {
 `
 
 describe('API', () => {
+  test('long trace annotation attachment names stay within filesystem limits', async () => {
+    const { root, stderr } = await runInlineTests({
+      'basic.test.ts': `
+        import { writeFile } from 'node:fs/promises'
+        import { dirname, resolve } from 'node:path'
+        import { test } from 'vitest'
+
+        test('annotation with a long message', async ({ annotate, task }) => {
+          const message = '__traces__/basic.test.ts/chromium-' + 'long-'.repeat(60) + 'trace.zip'
+          await annotate(message + '-first', { path: './trace.zip' })
+          await writeFile(resolve(dirname(task.file.filepath), 'trace.zip'), 'second trace content')
+          await annotate(message + '-second', { path: './trace.zip' })
+        })
+      `,
+      'trace.zip': 'trace content',
+    })
+
+    expect(stderr).toBe('')
+    const attachmentsDir = resolve(root, '.vitest/attachments')
+    const attachments = readdirSync(attachmentsDir)
+    expect(attachments).toHaveLength(2)
+    expect(attachments.every(attachment => Buffer.byteLength(attachment) <= 255)).toBe(true)
+    expect(attachments.every(attachment => /^[\da-f]{40}\.zip$/.test(attachment))).toBe(true)
+    expect(attachments.map(attachment => readFileSync(resolve(attachmentsDir, attachment), 'utf-8')).sort()).toEqual([
+      'second trace content',
+      'trace content',
+    ])
+  })
+
+  test('long attachment extensions preserve message uniqueness', async () => {
+    const longExtensionFile = `trace.${'x'.repeat(220)}`
+    const { root, stderr } = await runInlineTests({
+      'basic.test.ts': `
+        import { test } from 'vitest'
+
+        test('annotations with a long extension', async ({ annotate }) => {
+          const message = 'long-'.repeat(60)
+          await annotate(message + '-first', { path: './${longExtensionFile}' })
+          await annotate(message + '-second', { path: './${longExtensionFile}' })
+        })
+      `,
+      [longExtensionFile]: 'trace content',
+    })
+
+    expect(stderr).toBe('')
+    const attachments = readdirSync(resolve(root, '.vitest/attachments'))
+    expect(attachments).toHaveLength(2)
+    expect(attachments.every(attachment => /^[\da-f]{40}$/.test(attachment))).toBe(true)
+  })
+
   test.for([
     { name: 'forks', pool: 'forks' },
     { name: 'threads', pool: 'threads' },


### PR DESCRIPTION
### Description

Local attachment names currently concatenate the full sanitized annotation message with a hash. Playwright trace annotations can make that filename exceed the filesystem limit before the reporter copies the trace.

This change keeps the readable filename when it fits within 255 bytes, otherwise falls back to a message-and-source hash while retaining the extension when possible. Different annotations for the same source remain distinct even in the fallback paths.

Resolves #9006

Codex assisted with implementation, tests, and verification.

### Please do not delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] The PR references an issue where the behavior was discussed.
- [x] The PR includes tests that fail before the fix and pass after it.
- [x] `pnpm-lock.yaml` is unchanged.
- [x] Allow edits by maintainers is enabled.

### Tests
- [ ] `CI=true pnpm test:ci` was not run in full.
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `CI=true pnpm -C test/e2e test annotations.test.ts` (15 passed)
- [x] `CI=true pnpm -C test/e2e test artifacts.test.ts -t '^(?!.*(verbose non-tty|default)$).*'` (8 passed, 2 skipped)

The two excluded reporter cases currently differ from the default-branch RC snapshot baseline (`v<version>-rc.1` versus `v<version>`). The standalone Playwright trace suite could not complete on this veLinux host because WebKit system libraries are unavailable; the annotation and Chromium browser paths pass locally.

### Documentation
- [x] No public API or new functionality is introduced, so no documentation change is needed.

### Changesets
- [x] The PR title uses the `fix:` convention and describes the change.

<!-- VITEST_AUTOMATED_PR -->