### PR TITLE
fix: match forceRerunTriggers across dot-prefixed path segments (fix #10835)

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,12 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    // dot: true — trigger globs are opt-in paths a user explicitly named, so
+    // `**` should cross dot-prefixed path segments (e.g. a checkout under
+    // `.worktrees/` or `.cache/`). With picomatch's default `dot: false`, every
+    // trigger silently matched nothing when the project path contained one.
+    // https://github.com/vitest-dev/vitest/issues/10835
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,12 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    // dot: true — trigger globs are opt-in paths a user explicitly named, so
+    // `**` should cross dot-prefixed path segments (e.g. a checkout under
+    // `.worktrees/` or `.cache/`). With picomatch's default `dot: false`, every
+    // trigger silently matched nothing when the project path contained one.
+    // https://github.com/vitest-dev/vitest/issues/10835
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -32,6 +32,20 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
   })
+
+  // https://github.com/vitest-dev/vitest/issues/10835
+  // forceRerunTriggers are compiled with picomatch's default `dot: false`, so
+  // `**` does not cross a dot-prefixed path segment. When the project path
+  // contains one (e.g. `.worktrees`, `.claude`, `.cache`), every trigger
+  // silently matched nothing and `--changed` reported no test files.
+  it('should run the whole test suite if the trigger file is in a dot-prefixed directory', async () => {
+    createFile('fixtures/git-changed/related/.dotdir/rerun.temp', '')
+    const { stdout, stderr } = await run()
+    expect(stderr).toBe('')
+    expect(stdout).toContain('1 passed')
+    expect(stdout).toContain('related.test.ts')
+    expect(stdout).not.toContain('not-related.test.ts')
+  })
 })
 
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {


### PR DESCRIPTION
### Description

Fixes #10835.

`forceRerunTriggers` are compiled with picomatch's default `dot: false`, so `**` does not cross a **dot-prefixed path segment**. When a project checkout sits under one (`.worktrees/`, `.cache/`, `.claude/`, a CI checkout under `.builds/`, ...), every trigger — including the default `**/package.json` — silently matches nothing, and `vitest run --changed <base>` reports **no test files found and exits 0**. A change to `package.json` or a config file (exactly what `forceRerunTriggers` exists to catch) then selects zero tests and CI goes green.

The changed paths fed to the matcher are absolute (`findChangedFiles` ends in `resolve(options.root, file)`), so the behaviour depended only on where the repo happened to be cloned.

This passes `{ dot: true }` at the two matcher call sites:

- `packages/vitest/src/node/specifications.ts` — the `--changed` path (`pm(forceRerunTriggers, { dot: true })`)
- `packages/vitest/src/node/watcher.ts` — the watch path (`pm.isMatch(filepath, forceRerunTriggers, { dot: true })`)

Trigger globs are opt-in paths a user explicitly named, so there is no reason for them to skip dotfiles or dot-directories. Test discovery, `include`/`exclude` behaviour, and the global Vite/chokidar watcher settings are unchanged.

### Tests

- `CI=true pnpm --filter @vitest/test-e2e test test/git-changed.test.ts -t "dot-prefixed"` — new regression test that puts the trigger file inside a dot-prefixed directory (`fixtures/git-changed/related/.dotdir/rerun.temp`) and asserts the whole suite reruns. It fails on `main` (`No test files found, exiting with code 0`) and passes with this fix.
- Existing `test/git-changed.test.ts` tests still pass.
- `pnpm build` / `pnpm --filter vitest build` succeed; `git diff --check` clean.

### Prior / related attempts

Two PRs for this exact issue were submitted earlier and closed **unmerged** — #10837 and #10857. Both proposed the same `{ dot: true }` fix (which is the minimal correct change; the issue reporter suggested it in the issue body). They were closed by the repository's automated-PR policy after being labeled `maybe automated`, not because of any technical rejection by maintainers — there were no review comments on either. This submission keeps the same minimal, verified fix with a focused regression test on the deterministic `--changed` path (avoiding the watch suite, which is known to be flaky/hang-prone in this environment).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Documentation

- [x] This is a bug fix; no user-facing configuration or behaviour is added, so no docs change is needed.

### Changesets

- [x] Changes in changelog are generated from PR name (prefixed `fix:`).

---

AI-assisted with Claude Code. I have personally reviewed this change and stand behind its content.

<!-- VITEST_AUTOMATED_PR -->
