### PR TITLE
fix(vitest): match forceRerunTriggers across dot-prefixed path segments (fix #10835)

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/fixtures/git-changed/.dotdir/related/not-related.test.ts
+++ b/test/e2e/fixtures/git-changed/.dotdir/related/not-related.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+import { B } from './src/sourceB'
+
+test('shouldn\'t run', () => {
+  expect(B).toBe('B')
+  expect.fail()
+})

--- a/test/e2e/fixtures/git-changed/.dotdir/related/related.test.ts
+++ b/test/e2e/fixtures/git-changed/.dotdir/related/related.test.ts
@@ -1,0 +1,11 @@
+import { access } from 'node:fs'
+import { sep } from 'pathe'
+import { expect, test } from 'vitest'
+import { A } from './src/sourceA'
+
+test('A equals A', () => {
+  expect(A).toBe('A')
+  expect(typeof sep).toBe('string')
+  // doesn't throw
+  expect(typeof access).toBe('function')
+})

--- a/test/e2e/fixtures/git-changed/.dotdir/related/src/sourceA.ts
+++ b/test/e2e/fixtures/git-changed/.dotdir/related/src/sourceA.ts
@@ -1,0 +1,1 @@
+export const A = 'A'

--- a/test/e2e/fixtures/git-changed/.dotdir/related/src/sourceB.ts
+++ b/test/e2e/fixtures/git-changed/.dotdir/related/src/sourceB.ts
@@ -1,0 +1,1 @@
+export const B = 'B'

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -32,6 +32,20 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
   })
+
+  it('should fire the trigger when the project root is inside a dot-prefixed directory', async () => {
+    const dotFileName = 'fixtures/git-changed/.dotdir/related/rerun.temp'
+    createFile(dotFileName, '')
+    const { stdout, stderr } = await runVitest({
+      root: join(process.cwd(), 'fixtures/git-changed/.dotdir/related'),
+      include: ['related.test.ts'],
+      forceRerunTriggers: ['**/rerun.temp/**'],
+      changed: true,
+    })
+    expect(stderr).toBe('')
+    expect(stdout).toContain('1 passed')
+    expect(stdout).toContain('related.test.ts')
+  })
 })
 
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {


### PR DESCRIPTION
### Description

`forceRerunTriggers` globs were compiled with picomatch's defaults (`dot: false`).
picomatch's `**` does not cross a dot-prefixed path segment under that setting, so
a trigger such as the default `**/package.json` matched nothing when the project's
absolute root contained a dot-prefixed segment — e.g. `/.worktrees/`, `/.cache/`,
`/.builds/`, a CI checkout under a dot-directory, etc.

The failure is silent and reads as success: `vitest run --changed <base>` reports
`No test files found, exiting with code 0`, so a change to `package.json` or a
config file — exactly what `forceRerunTriggers` exists to catch — selects zero
tests, and in CI that is a green run.

### Fix

Pass `{ dot: true }` at both matcher call sites so trigger globs behave identically
regardless of where the repo was cloned:

- `packages/vitest/src/node/specifications.ts` — the `--changed` path
- `packages/vitest/src/node/watcher.ts` — the watch path

Trigger globs are opt-in paths the user has explicitly named, so there is no reason
for them to skip dotfiles / dot-directories.

### Testing

- Added a regression test in `test/e2e/test/git-changed.test.ts` that runs the
  suite from a fixture rooted inside a dot-prefixed directory
  (`fixtures/git-changed/.dotdir/related`) with `forceRerunTriggers: ['**/rerun.temp/**']`
  and `changed: true`.
- RED: on `main` the trigger does not fire → `No test files found`, test fails.
- GREEN: with the fix the trigger fires → `1 passed`, test passes.
- Existing `git-changed.test.ts` (5 tests) and the `force` subset of
  `file-watching.test.ts` still pass; `pnpm typecheck` and `pnpm lint:fix` clean.

### Linked issue

Closes #10835

<!-- VITEST_AUTOMATED_PR -->
