### PR TITLE
fix: revive global concurrency limit for test lifecycle

### DIFF
--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -38,6 +38,7 @@ const now = globalThis.performance ? globalThis.performance.now.bind(globalThis.
 const unixNow = Date.now
 const { clearTimeout, setTimeout } = getSafeTimers()
 let limitMaxConcurrency: ConcurrencyLimiter
+let limitTestConcurrency: ConcurrencyLimiter
 
 /**
  * Normalizes retry configuration to extract individual values.
@@ -988,7 +989,7 @@ async function runSuiteChild(c: Task, runner: VitestRunner) {
         'code.line.number': c.location?.line,
         'code.column.number': c.location?.column,
       },
-      () => runTest(c, runner),
+      () => limitTestConcurrency(() => runTest(c, runner)),
     )
   }
   else if (c.type === 'suite') {
@@ -1009,6 +1010,7 @@ async function runSuiteChild(c: Task, runner: VitestRunner) {
 
 async function runFiles(files: File[], runner: VitestRunner): Promise<void> {
   limitMaxConcurrency ??= limitConcurrency(runner.config.maxConcurrency)
+  limitTestConcurrency ??= limitConcurrency(runner.config.maxConcurrency)
 
   for (const file of files) {
     if (!file.tasks.length && !runner.config.passWithNoTests) {

--- a/test/e2e/test/concurrent.test.ts
+++ b/test/e2e/test/concurrent.test.ts
@@ -1295,25 +1295,29 @@ test('non-sibling suite sequential lifecycle non-guarantee', async () => {
   const result = await runInlineTests({
     'basic.test.ts': `
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+let inFlight = 0
+
+function logInFlight(change: number, ...names: string[]) {
+  const previous = inFlight
+  inFlight += change
+  console.log(previous, "->", inFlight, ...names)
+}
 
 describe.for(["a0", "a1"])("%s", { concurrent: true }, () => {
   describe.for(["b0", "b1"])("%s", { concurrent: true }, () => {
     beforeAll(async ({}, suite) => {
-      console.log("!> beforeAll", suite.suite.name, suite.name)
+      logInFlight(1, "beforeAll", suite.suite.name, suite.name)
       await sleep(10)
-      console.log("!< beforeAll", suite.suite.name, suite.name)
     })
 
     afterAll(async ({}, suite) => {
-      console.log("!> afterAll", suite.suite.name, suite.name)
       await sleep(10)
-      console.log("!< afterAll", suite.suite.name, suite.name)
+      logInFlight(-1, "afterAll", suite.suite.name, suite.name)
     })
 
     test("test", async ({ task }) => {
-      console.log("!> test", task.suite.suite.name, task.suite.name, task.name)
+      logInFlight(0, "test", task.suite.suite.name, task.suite.name, task.name)
       await sleep(10)
-      console.log("!< test", task.suite.suite.name, task.suite.name, task.name)
     })
   })
 })
@@ -1325,30 +1329,18 @@ describe.for(["a0", "a1"])("%s", { concurrent: true }, () => {
 
   expect(extractLogs(result.stdout)).toMatchInlineSnapshot(`
     "
-    !> beforeAll a0 b0
-    !> beforeAll a0 b1
-    !< beforeAll a0 b0
-    !> beforeAll a1 b0
-    !< beforeAll a0 b1
-    !> beforeAll a1 b1
-    !< beforeAll a1 b0
-    !> test a0 b0 test
-    !< beforeAll a1 b1
-    !> test a0 b1 test
-    !< test a0 b0 test
-    !> test a1 b0 test
-    !< test a0 b1 test
-    !> afterAll a0 b0
-    !< test a1 b0 test
-    !> test a1 b1 test
-    !< afterAll a0 b0
-    !> afterAll a0 b1
-    !< test a1 b1 test
-    !> afterAll a1 b0
-    !< afterAll a0 b1
-    !> afterAll a1 b1
-    !< afterAll a1 b0
-    !< afterAll a1 b1
+    0 -> 1 beforeAll a0 b0
+    1 -> 2 beforeAll a0 b1
+    2 -> 3 beforeAll a1 b0
+    3 -> 4 beforeAll a1 b1
+    4 -> 4 test a0 b0 test
+    4 -> 4 test a0 b1 test
+    4 -> 4 test a1 b0 test
+    4 -> 4 test a1 b1 test
+    4 -> 3 afterAll a0 b0
+    3 -> 2 afterAll a0 b1
+    2 -> 1 afterAll a1 b0
+    1 -> 0 afterAll a1 b1
     "
   `)
 

--- a/test/e2e/test/concurrent.test.ts
+++ b/test/e2e/test/concurrent.test.ts
@@ -1096,7 +1096,7 @@ test('aroundAll enforces teardown timeout when inner error is caught', async () 
 })
 
 function extractLogs(log: string) {
-  const result = log.split('\n').filter(line => line.match(/^![<>]/)).join('\n')
+  const result = log.split('\n').filter(line => line.match(/^(?:![<>]|\d+ -> \d+)/)).join('\n')
   return `\n${result.trim()}\n`
 }
 
@@ -1218,25 +1218,29 @@ test('non-sibling test sequential lifecycle guarantee', async () => {
   const result = await runInlineTests({
     'basic.test.ts': `
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+let inFlight = 0
+
+function logInFlight(change: number, ...names: string[]) {
+  const previous = inFlight
+  inFlight += change
+  console.log(previous, "->", inFlight, ...names)
+}
 
 describe.for(["a0", "a1"])("%s", { concurrent: true }, () => {
   describe.for(["b0", "b1"])("%s", { concurrent: true }, () => {
     beforeEach(async ({ task }) => {
-      console.log("!> beforeEach", task.suite.suite.name, task.suite.name, task.name)
+      logInFlight(1, "beforeEach", task.suite.suite.name, task.suite.name, task.name)
       await sleep(10)
-      console.log("!< beforeEach", task.suite.suite.name, task.suite.name, task.name)
     })
 
     afterEach(async ({ task }) => {
-      console.log("!> afterEach", task.suite.suite.name, task.suite.name, task.name)
       await sleep(10)
-      console.log("!< afterEach", task.suite.suite.name, task.suite.name, task.name)
+      logInFlight(-1, "afterEach", task.suite.suite.name, task.suite.name, task.name)
     })
 
     test("test", async ({ task }) => {
-      console.log("!> test", task.suite.suite.name,task.suite.name, task.name)
+      logInFlight(0, "test", task.suite.suite.name, task.suite.name, task.name)
       await sleep(10)
-      console.log("!< test", task.suite.suite.name,task.suite.name, task.name)
     })
   })
 })
@@ -1248,30 +1252,18 @@ describe.for(["a0", "a1"])("%s", { concurrent: true }, () => {
 
   expect(extractLogs(result.stdout)).toMatchInlineSnapshot(`
     "
-    !> beforeEach a0 b0 test
-    !> beforeEach a0 b1 test
-    !< beforeEach a0 b0 test
-    !> test a0 b0 test
-    !< beforeEach a0 b1 test
-    !> test a0 b1 test
-    !< test a0 b0 test
-    !> afterEach a0 b0 test
-    !< test a0 b1 test
-    !> afterEach a0 b1 test
-    !< afterEach a0 b0 test
-    !> beforeEach a1 b0 test
-    !< afterEach a0 b1 test
-    !> beforeEach a1 b1 test
-    !< beforeEach a1 b0 test
-    !> test a1 b0 test
-    !< beforeEach a1 b1 test
-    !> test a1 b1 test
-    !< test a1 b0 test
-    !> afterEach a1 b0 test
-    !< test a1 b1 test
-    !> afterEach a1 b1 test
-    !< afterEach a1 b0 test
-    !< afterEach a1 b1 test
+    0 -> 1 beforeEach a0 b0 test
+    1 -> 2 beforeEach a0 b1 test
+    2 -> 2 test a0 b0 test
+    2 -> 2 test a0 b1 test
+    2 -> 1 afterEach a0 b0 test
+    1 -> 2 beforeEach a1 b0 test
+    2 -> 1 afterEach a0 b1 test
+    1 -> 2 beforeEach a1 b1 test
+    2 -> 2 test a1 b0 test
+    2 -> 2 test a1 b1 test
+    2 -> 1 afterEach a1 b0 test
+    1 -> 0 afterEach a1 b1 test
     "
   `)
 

--- a/test/e2e/test/concurrent.test.ts
+++ b/test/e2e/test/concurrent.test.ts
@@ -1214,11 +1214,7 @@ describe.for(["a", "b"])("%s", { concurrent: true }, () => {
   `)
 })
 
-// we could enforce this by adding yet another limit globally at `runTest`
-// (like we originally had before https://github.com/vitest-dev/vitest/pull/9653)
-// but there's no way to achieve the same for deep suite-level hooks anyways,
-// so we don't do that (yet).
-test('non-sibling test sequential lifecycle non-guarantee', async () => {
+test('non-sibling test sequential lifecycle guarantee', async () => {
   const result = await runInlineTests({
     'basic.test.ts': `
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
@@ -1255,24 +1251,24 @@ describe.for(["a0", "a1"])("%s", { concurrent: true }, () => {
     !> beforeEach a0 b0 test
     !> beforeEach a0 b1 test
     !< beforeEach a0 b0 test
-    !> beforeEach a1 b0 test
-    !< beforeEach a0 b1 test
-    !> beforeEach a1 b1 test
-    !< beforeEach a1 b0 test
     !> test a0 b0 test
-    !< beforeEach a1 b1 test
+    !< beforeEach a0 b1 test
     !> test a0 b1 test
     !< test a0 b0 test
-    !> test a1 b0 test
-    !< test a0 b1 test
-    !> test a1 b1 test
-    !< test a1 b0 test
     !> afterEach a0 b0 test
-    !< test a1 b1 test
+    !< test a0 b1 test
     !> afterEach a0 b1 test
     !< afterEach a0 b0 test
-    !> afterEach a1 b0 test
+    !> beforeEach a1 b0 test
     !< afterEach a0 b1 test
+    !> beforeEach a1 b1 test
+    !< beforeEach a1 b0 test
+    !> test a1 b0 test
+    !< beforeEach a1 b1 test
+    !> test a1 b1 test
+    !< test a1 b0 test
+    !> afterEach a1 b0 test
+    !< test a1 b1 test
     !> afterEach a1 b1 test
     !< afterEach a1 b0 test
     !< afterEach a1 b1 test
@@ -1350,12 +1346,12 @@ describe.for(["a0", "a1"])("%s", { concurrent: true }, () => {
     !< test a0 b0 test
     !> test a1 b0 test
     !< test a0 b1 test
-    !> test a1 b1 test
-    !< test a1 b0 test
     !> afterAll a0 b0
-    !< test a1 b1 test
-    !> afterAll a0 b1
+    !< test a1 b0 test
+    !> test a1 b1 test
     !< afterAll a0 b0
+    !> afterAll a0 b1
+    !< test a1 b1 test
     !> afterAll a1 b0
     !< afterAll a0 b1
     !> afterAll a1 b1


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- closes https://github.com/vitest-dev/vitest/issues/10530
- follow-up history
  - https://github.com/vitest-dev/vitest/pull/9653
  - https://github.com/vitest-dev/vitest/pull/10179

This PR brings back the original global `runTest`-level (test-lifecycle of beforeEach/test/afterEach etc.) concurrency bound that was replaced in https://github.com/vitest-dev/vitest/pull/9653.

While https://github.com/vitest-dev/vitest/pull/10179 ensured a concurrency bound per branches e.g.

```js
// with concurrencyLimit = 2, inFlightRunTest won't exceed 2
describe.concurrent("ok", () => {
  let inFlightRunTest = 0;
  beforeEach(async () => {
    inFlightRunTest++;
    return () => inFlightRunTest--
  })
  test("1")
  test("2")
  test("3")
  test("4")
})
```

it was still possible to exceed the bound when nesting suites e.g.

```js
// with concurrencyLimit =2, inFlightRunTest reaches 4
describe.concurrent("ok", () => {
  let inFlightRunTest = 0;
  beforeEach(async () => {
    inFlightRunTest++;
    return () => inFlightRunTest--
  })
  describe("inner", () => {
    test("1")
    test("2")
  })
  describe("inner2", () => {
    test("3")
    test("4")
  })
})
```

The global `runTest`-level concurrency guarantees that `inFlightRunTest` is bound by `concurrencyLimit` regardless of suite/test nesting structure.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
