### PR TITLE
types: disallow filter-only options in getBy* locators (fix #10295)

### DIFF
--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -520,8 +520,6 @@ function filter(options: LocatorFilterOptions): Locator
 
 This methods narrows down the locator according to the options, such as filtering by text. It can be chained to apply multiple filters.
 
-Note that the options below are specific to `filter` and are not accepted by the `getBy*` methods. To narrow a query down by text, chain `filter` onto it: `page.getByRole('button').filter({ hasText: 'Submit' })`.
-
 ### has
 
 - **Type:** `Locator`

--- a/docs/api/browser/locators.md
+++ b/docs/api/browser/locators.md
@@ -515,10 +515,12 @@ page.getByRole('button')
 ## filter
 
 ```ts
-function filter(options: LocatorOptions): Locator
+function filter(options: LocatorFilterOptions): Locator
 ```
 
 This methods narrows down the locator according to the options, such as filtering by text. It can be chained to apply multiple filters.
+
+Note that the options below are specific to `filter` and are not accepted by the `getBy*` methods. To narrow a query down by text, chain `filter` onto it: `page.getByRole('button').filter({ hasText: 'Submit' })`.
 
 ### has
 

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -449,34 +449,10 @@ export interface LocatorOptions {
   exact?: boolean
 }
 
-/**
- * Options to narrow down an existing locator with [`.filter()`](https://vitest.dev/api/browser/locators#filter).
- *
- * Note that these options are not accepted by the `getBy*` methods. To narrow a query down by
- * inner text or a child element, chain `.filter()` onto it instead:
- *
- * ```ts
- * page.getByRole('button').filter({ hasText: 'Submit' })
- * ```
- */
 export interface LocatorFilterOptions {
-  /**
-   * Matches elements containing the specified text somewhere inside, possibly in a child or a descendant element.
-   * When passed a string, matching is case-insensitive and searches for a substring.
-   */
   hasText?: string | RegExp
-  /**
-   * Matches elements that do _not_ contain the specified text somewhere inside, possibly in a child or a descendant
-   * element. When passed a string, matching is case-insensitive and searches for a substring.
-   */
   hasNotText?: string | RegExp
-  /**
-   * Matches elements containing an element that matches the provided locator.
-   */
   has?: Locator
-  /**
-   * Matches elements that do _not_ contain an element that matches the provided locator.
-   */
   hasNot?: Locator
 }
 

--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -447,9 +447,36 @@ export interface LocatorOptions {
    * regular expression. Note that exact match still trims whitespace.
    */
   exact?: boolean
+}
+
+/**
+ * Options to narrow down an existing locator with [`.filter()`](https://vitest.dev/api/browser/locators#filter).
+ *
+ * Note that these options are not accepted by the `getBy*` methods. To narrow a query down by
+ * inner text or a child element, chain `.filter()` onto it instead:
+ *
+ * ```ts
+ * page.getByRole('button').filter({ hasText: 'Submit' })
+ * ```
+ */
+export interface LocatorFilterOptions {
+  /**
+   * Matches elements containing the specified text somewhere inside, possibly in a child or a descendant element.
+   * When passed a string, matching is case-insensitive and searches for a substring.
+   */
   hasText?: string | RegExp
+  /**
+   * Matches elements that do _not_ contain the specified text somewhere inside, possibly in a child or a descendant
+   * element. When passed a string, matching is case-insensitive and searches for a substring.
+   */
   hasNotText?: string | RegExp
+  /**
+   * Matches elements containing an element that matches the provided locator.
+   */
   has?: Locator
+  /**
+   * Matches elements that do _not_ contain an element that matches the provided locator.
+   */
   hasNot?: Locator
 }
 
@@ -766,7 +793,7 @@ export interface Locator extends LocatorSelectors {
    * Narrows existing locator according to the options.
    * @see {@link https://vitest.dev/api/browser/locators#filter}
    */
-  filter(options: LocatorOptions): Locator
+  filter(options: LocatorFilterOptions): Locator
   /**
    * This method returns an element matching the locator.
    * Unlike [`.element()`](https://vitest.dev/api/browser/locators#element),

--- a/packages/browser/src/client/tester/locators.ts
+++ b/packages/browser/src/client/tester/locators.ts
@@ -1,6 +1,7 @@
 import type { ParsedSelector } from 'ivya'
 import type {
   LocatorByRoleOptions,
+  LocatorFilterOptions,
   LocatorOptions,
   LocatorScreenshotOptions,
   MarkOptions,
@@ -273,7 +274,7 @@ export abstract class Locator {
     return this.locator(getByTitleSelector(title, options))
   }
 
-  public filter(filter: LocatorOptions): Locator {
+  public filter(filter: LocatorFilterOptions): Locator {
     const selectors = []
 
     if (filter?.hasText) {

--- a/packages/ui/client/components/artifacts/visual-regression/VisualRegressionSlider.spec.ts
+++ b/packages/ui/client/components/artifacts/visual-regression/VisualRegressionSlider.spec.ts
@@ -76,10 +76,8 @@ describe('VisualRegressionSlider', () => {
 
     const container = page.getByLabelText(containerLabel)
     const input = page.getByLabelText(inputLabel)
-    const status = page.getByRole(
-      'status',
-      { hasText: 'Showing 50% reference, 50% actual' },
-    )
+    const status = page.getByRole('status')
+      .filter({ hasText: 'Showing 50% reference, 50% actual' })
 
     // container with accessible label should exist and contain input and status
     await expect.element(container).toBeInTheDocument()

--- a/test/browser/test/locators.test-d.ts
+++ b/test/browser/test/locators.test-d.ts
@@ -1,55 +1,11 @@
-import { expectTypeOf, test } from 'vitest'
+import { test } from 'vitest'
 import { page } from 'vitest/browser'
 
-test('filter-only options are not accepted by getBy* methods', () => {
-  // `hasText`, `hasNotText`, `has` and `hasNot` are only implemented by `.filter()`.
-  // They used to be part of `LocatorOptions`, which made them silently available
-  // (and silently ignored) on every `getBy*` method.
-  // https://github.com/vitest-dev/vitest/issues/10295
-
-  // @ts-expect-error -- `hasText` is a filter-only option
+test('filter options are not accepted by getBy* methods', () => {
+  // @ts-expect-error -- `hasText` is only supported by `.filter()`
   page.getByRole('button', { hasText: 'A' })
-  // @ts-expect-error -- `hasNotText` is a filter-only option
-  page.getByRole('button', { hasNotText: 'A' })
-  // @ts-expect-error -- `has` is a filter-only option
-  page.getByRole('button', { has: page.getByRole('img') })
-  // @ts-expect-error -- `hasNot` is a filter-only option
-  page.getByRole('button', { hasNot: page.getByRole('img') })
-  // @ts-expect-error -- `hasText` is a filter-only option
+  // @ts-expect-error -- `hasText` is only supported by `.filter()`
   page.getByText('hello', { hasText: 'A' })
-  // @ts-expect-error -- `hasText` is a filter-only option
-  page.getByLabelText('hello', { hasText: 'A' })
-  // @ts-expect-error -- `hasText` is a filter-only option
-  page.getByAltText('hello', { hasText: 'A' })
-  // @ts-expect-error -- `hasText` is a filter-only option
-  page.getByPlaceholder('hello', { hasText: 'A' })
-  // @ts-expect-error -- `hasText` is a filter-only option
-  page.getByTitle('hello', { hasText: 'A' })
-})
 
-test('getBy* methods accept their own options', () => {
-  expectTypeOf(page.getByRole).toBeCallableWith('button', { name: 'A', exact: true })
-  expectTypeOf(page.getByRole).toBeCallableWith('heading', { level: 2 })
-  expectTypeOf(page.getByRole).toBeCallableWith('checkbox', { checked: true })
-  expectTypeOf(page.getByText).toBeCallableWith('hello', { exact: true })
-  expectTypeOf(page.getByLabelText).toBeCallableWith('hello', { exact: true })
-  expectTypeOf(page.getByAltText).toBeCallableWith('hello', { exact: true })
-  expectTypeOf(page.getByPlaceholder).toBeCallableWith('hello', { exact: true })
-  expectTypeOf(page.getByTitle).toBeCallableWith('hello', { exact: true })
-})
-
-test('filter accepts filter options, but not `exact`', () => {
-  const locator = page.getByRole('button')
-
-  expectTypeOf(locator.filter).toBeCallableWith({ hasText: 'A' })
-  expectTypeOf(locator.filter).toBeCallableWith({ hasText: /A/ })
-  expectTypeOf(locator.filter).toBeCallableWith({ hasNotText: 'A' })
-  expectTypeOf(locator.filter).toBeCallableWith({ has: page.getByRole('img') })
-  expectTypeOf(locator.filter).toBeCallableWith({ hasNot: page.getByRole('img') })
-
-  // the documented way to narrow a role query down by text
-  expectTypeOf(locator.filter({ hasText: 'A' })).toEqualTypeOf(locator)
-
-  // @ts-expect-error -- `exact` is not a filter option
-  locator.filter({ exact: true })
+  page.getByRole('button').filter({ hasText: 'A' })
 })

--- a/test/browser/test/locators.test-d.ts
+++ b/test/browser/test/locators.test-d.ts
@@ -1,0 +1,55 @@
+import { expectTypeOf, test } from 'vitest'
+import { page } from 'vitest/browser'
+
+test('filter-only options are not accepted by getBy* methods', () => {
+  // `hasText`, `hasNotText`, `has` and `hasNot` are only implemented by `.filter()`.
+  // They used to be part of `LocatorOptions`, which made them silently available
+  // (and silently ignored) on every `getBy*` method.
+  // https://github.com/vitest-dev/vitest/issues/10295
+
+  // @ts-expect-error -- `hasText` is a filter-only option
+  page.getByRole('button', { hasText: 'A' })
+  // @ts-expect-error -- `hasNotText` is a filter-only option
+  page.getByRole('button', { hasNotText: 'A' })
+  // @ts-expect-error -- `has` is a filter-only option
+  page.getByRole('button', { has: page.getByRole('img') })
+  // @ts-expect-error -- `hasNot` is a filter-only option
+  page.getByRole('button', { hasNot: page.getByRole('img') })
+  // @ts-expect-error -- `hasText` is a filter-only option
+  page.getByText('hello', { hasText: 'A' })
+  // @ts-expect-error -- `hasText` is a filter-only option
+  page.getByLabelText('hello', { hasText: 'A' })
+  // @ts-expect-error -- `hasText` is a filter-only option
+  page.getByAltText('hello', { hasText: 'A' })
+  // @ts-expect-error -- `hasText` is a filter-only option
+  page.getByPlaceholder('hello', { hasText: 'A' })
+  // @ts-expect-error -- `hasText` is a filter-only option
+  page.getByTitle('hello', { hasText: 'A' })
+})
+
+test('getBy* methods accept their own options', () => {
+  expectTypeOf(page.getByRole).toBeCallableWith('button', { name: 'A', exact: true })
+  expectTypeOf(page.getByRole).toBeCallableWith('heading', { level: 2 })
+  expectTypeOf(page.getByRole).toBeCallableWith('checkbox', { checked: true })
+  expectTypeOf(page.getByText).toBeCallableWith('hello', { exact: true })
+  expectTypeOf(page.getByLabelText).toBeCallableWith('hello', { exact: true })
+  expectTypeOf(page.getByAltText).toBeCallableWith('hello', { exact: true })
+  expectTypeOf(page.getByPlaceholder).toBeCallableWith('hello', { exact: true })
+  expectTypeOf(page.getByTitle).toBeCallableWith('hello', { exact: true })
+})
+
+test('filter accepts filter options, but not `exact`', () => {
+  const locator = page.getByRole('button')
+
+  expectTypeOf(locator.filter).toBeCallableWith({ hasText: 'A' })
+  expectTypeOf(locator.filter).toBeCallableWith({ hasText: /A/ })
+  expectTypeOf(locator.filter).toBeCallableWith({ hasNotText: 'A' })
+  expectTypeOf(locator.filter).toBeCallableWith({ has: page.getByRole('img') })
+  expectTypeOf(locator.filter).toBeCallableWith({ hasNot: page.getByRole('img') })
+
+  // the documented way to narrow a role query down by text
+  expectTypeOf(locator.filter({ hasText: 'A' })).toEqualTypeOf(locator)
+
+  // @ts-expect-error -- `exact` is not a filter option
+  locator.filter({ exact: true })
+})


### PR DESCRIPTION
### Description

`LocatorOptions` mixed together two sets of options that aren't interchangeable:

- `exact`, which the `getBy*` methods forward to the selector builders
- `hasText`, `hasNotText`, `has` and `hasNot`, which only `.filter()` ever reads

Since `LocatorByRoleOptions extends LocatorOptions`, all of the `getBy*` methods
advertised the filter options in their types while silently dropping them at
runtime. That's what made the reported call type check and then match both
buttons:

```ts
page.getByRole('button', { hasText: 'A' }) // no error, matches every button
```

So this keeps `exact` on `LocatorOptions` and moves the four filter options to a
new `LocatorFilterOptions`, which is what `.filter()` now takes. Passing them to
a `getBy*` method is a type error from here on, and the user gets pushed towards
`.filter({ hasText: 'A' })` or `{ name: 'A' }`, both of which already work.

No behaviour change — the fix is entirely in the types. The selector builders in
`ivya` only ever accepted `exact` (plus the role attributes for
`getByRoleSelector`), so there was never anywhere for `hasText` to be forwarded
to. `.filter()` is untouched apart from its parameter type.

I also gave the four options doc comments while moving them, since they had none
before, and added a note under `## filter` in the docs saying they don't work on
`getBy*`.

Resolves #10295

One thing worth calling out: this is technically breaking for anyone currently
passing `hasText` to a `getBy*` call. That code is already silently broken at
runtime, so I'd argue surfacing it is the point, but it's your call whether that
needs a note in the release. `filter({ exact: true })` is now rejected too — it
was always ignored.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Added `test/browser/test/locators.test-d.ts`, following the existing
`cdp.test-d.ts` in the same directory. It asserts the filter options are
rejected on every `getBy*` method and still accepted by `.filter()`. The
`@ts-expect-error` directives fail as unused if the interfaces get merged back
together, so it pins the regression.

`pnpm typecheck` and `pnpm lint` are clean, and the `fixtures/locators` suite
passes (14/14) — including the existing cases that use `filter({ hasText })` and
`filter({ has })`, which confirms runtime behaviour didn't move.

I couldn't get a full clean `test:ci` locally: the wider `test/browser` unit
suite has failures on `main` for me before this change too (the screenshot specs
want the full Chromium download rather than just the headless shell), and the
count moves around between runs. I checked the locator-specific ones
(`specs/locator-error-format.test.ts`) fail identically with and without the
patch, so I'm fairly confident it's my setup rather than the change, but CI is
the better judge here.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

Updated the `filter` signature in `docs/api/browser/locators.md` to
`LocatorFilterOptions` and added a line clarifying the scope. The options were
already documented only under `## filter`, which was correct — the types were
the part that disagreed.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

---

Disclosure per the AI Contributions section of CONTRIBUTING.md: I used Claude as
an assistant while putting this together. I read the issue and your comment on it
first, confirmed the `ivya` signatures myself to check the implementation really
was correct, and ran the tests locally. Happy to take this in a different
direction if you'd rather the filter options simply be removed from the
`getBy*` types without introducing a second interface.
