### PR TITLE
fix: combine multiple negated --project filters

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -1246,6 +1246,12 @@ export function matchesProjectFilter(projects: string[], name: string): boolean 
   if (!projects.length) {
     return true
   }
+  // a negated pattern is an exclusion: it wins over every other pattern,
+  // otherwise `!a !b` would keep `a` (it doesn't match `!a`, but it does
+  // match `!b`) and the two exclusions would cancel each other out
+  if (isExcludedByProjectFilter(projects, name)) {
+    return false
+  }
   return projects.some((project) => {
     const regexp = wildcardPatternToRegExp(project)
     return regexp.test(name)

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -1133,6 +1133,12 @@ function matchesEntryFilter(
   if (!filter.length) {
     return true
   }
+  // a negated pattern is an exclusion: it wins over every other pattern,
+  // otherwise `!a !b` would keep `a` (it doesn't match `!a`, but it does
+  // match `!b`) and the two exclusions would cancel each other out
+  if (isEntryExcludedByFilter(filter, name, ancestors)) {
+    return false
+  }
   const names = [name, ...(ancestors || [])]
   return filter.some((project) => {
     const regexp = wildcardPatternToRegExp(project)

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -1039,6 +1039,9 @@ describe('project filtering', () => {
     { pattern: '!project_1', expected: ['project_2', 'space_1'] },
     { pattern: '!project*', expected: ['space_1'] },
     { pattern: '!project', expected: allProjects },
+    // every negated pattern excludes: they must not cancel each other out
+    { pattern: ['!project_1', '!project_2'], expected: ['space_1'] },
+    { pattern: ['!project_1', '!space*'], expected: ['project_2'] },
   ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
     const { ctx, stderr, stdout } = await runVitest({
       root: 'fixtures/project',
@@ -1059,5 +1062,12 @@ describe('project filtering', () => {
     }
 
     expect(ctx?.projects.map(p => p.name).sort()).toEqual(expected)
+
+    // the public `vitest.matchesProjectFilter` API must agree with the
+    // projects that were actually resolved
+    for (const project of allProjects) {
+      expect([project, ctx?.matchesProjectFilter(project)])
+        .toEqual([project, expected.includes(project)])
+    }
   })
 })


### PR DESCRIPTION
### Description

Resolves #10491

A single `--project=!name` works, but two or more negations exclude nothing and every project runs.

> **AI disclosure (per [CONTRIBUTING.md](https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md#ai-contributions)):** Claude Code assisted with this change. I read the issue and all of its comments, reviewed the diff, ran everything reported below myself, and I stand behind it. Happy to answer any questions directly.

#### Problem

```console
$ vitest run --project='!project_1' --project='!project_2'

 ✓ |project_1| base.test.ts >  1ms
 ✓ |project_2| base.test.ts >  1ms
 ✓ |space_1| base.test.ts >  1ms

 Test Files  3 passed (3)
```

Both explicitly excluded projects ran.

#### Root cause

Both filter matchers OR-combine every `--project` pattern with `.some()`, and a negated pattern is compiled by `wildcardPatternToRegExp` into a *negative lookahead* rather than being treated as an exclusion. So each negation "matches" every name it is **not** about, and two negations cancel each other out.

- `packages/vitest/src/node/config/resolveConfig.ts:1244` — `matchesProjectFilter()`
- `packages/vitest/src/node/projects/resolveProjects.ts:1128` — `matchesEntryFilter()` (its per-pattern `names.every(...)` branch only handles ancestor names, not sibling patterns)

With `!a !b`: name `a` fails `!a` but passes `!b`, so `.some()` returns true and `a` is kept; symmetrically for `b`.

`matchesProjectFilter` is also the implementation behind the documented public API `vitest.matchesProjectFilter(name)` ([docs/api/advanced/vitest.md:500](https://github.com/vitest-dev/vitest/blob/main/docs/api/advanced/vitest.md)), so the bug is reachable through the reporter/UI-facing API too, not only the CLI.

#### Fix

The codebase already contains the correct rule and applies it in one path only: `isExcludedByProjectFilter()` and `isEntryExcludedByFilter()` implement "matched by ANY negation ⇒ excluded". They arrived with merged PR #10131 and are consulted before browser-instance expansion (`resolveProjects.ts:854`) but not on the main entry-filter path — hence the inconsistency.

This PR checks those existing helpers first in both matchers (2 guards, 12 lines). No new filter semantics are introduced.

I deliberately did **not** use the "partition into positive/negative lists" rewrite: exclusion-first plus the untouched `.some()` changes the outcome **only** for names that some negation matches, so every other input keeps its current result bit-for-bit. A partition rewrite additionally makes positive patterns gate inclusion, which silently narrows the mixed case — a second behaviour change the issue does not ask for.

#### Before / after

Same fixture (`test/e2e/fixtures/project`, projects `project_1`, `project_2`, `space_1`), against a freshly built `packages/vitest`:

| `--project` args | before | after |
| --- | --- | --- |
| `!project_1` `!project_2` | **3 passed** (`project_1`, `project_2`, `space_1`) | **1 passed** (`space_1`) |
| `!project_1` `!space*` | **3 passed** (all) | **1 passed** (`project_2`) |
| `!project_1` | 2 passed (`project_2`, `space_1`) | 2 passed — unchanged |
| `project_1` `!project_2` | 2 passed (`project_1`, `space_1`) | 2 passed — unchanged |

Full exclusion (`!project_1 !project_2 !space_1`) now lands in the pre-existing startup error path, worded exactly like an unmatched positive filter:

```
Error: No projects were found. Make sure your configuration is correct.
The filter matched no projects: !project_1, !project_2, !space_1.
The projects definition: [ "packages/*" ].
```

#### Tests

Two rows added to the existing `describe('project filtering')` table in `test/e2e/test/projects.test.ts` (`project` already accepts `string | string[]`, so no harness change), plus one assertion appended to the shared body so **every** row — old and new — also pins the public `vitest.matchesProjectFilter` API.

Fail-on-baseline / pass-with-fix, in `test/e2e` with `CI=true npx vitest run test/projects.test.ts`:

- **True baseline** — both source files restored with `git show origin/main:<path> > <path>` and `packages/vitest` rebuilt; I grepped for the added comment and got 0 hits in `src` **and** 0 hits in `packages/vitest/dist/chunks/*.js`, so the compiled output really was unfixed:
  `Tests  2 failed | 52 passed (54)` — the failures are exactly the two new rows.
- **With fix:** `Tests  54 passed (54)`, `Type Errors  no errors`.

Each of the two source edits is independently covered — neither is dead weight:

- reverting **only** `resolveConfig.ts` still fails both rows, at the new API assertion (`expected [ 'project_1', true ] to deeply equal [ 'project_1', false ]`);
- reverting **only** `resolveProjects.ts` still fails both rows, at `expect(stdout).not.toContain('project_1')`.

#### What I ran

- `pnpm install --frozen-lockfile`, `pnpm run build` — exit 0
- `pnpm typecheck` — exit 0
- `eslint` on the three changed files — exit 0
- **`test/e2e` full suite, with fix:** `Test Files  4 failed | 172 passed | 2 skipped (178)`, `Tests  6 failed | 1320 passed | 88 skipped | 1 todo (1415)`. The 6 failures are in `console-color.test.ts` (x2), `exec-args.test.ts` (x2), `reporters/default.test.ts > project name color`, `reporters/merge-reports.test.ts > module graph and html reporter node`. **Re-running those same four files on the untouched baseline build reproduces the identical six `FAIL` lines**, so they are pre-existing and TTY/ANSI-colour dependent, not caused by this change. I did not attempt to fix them (out of scope).
- **Browser path:** `test/browser` `specs/prewarm.test.ts` — including `prewarm receives only the instances matching the --project filter`, which exercises the instance-name filtering at `resolveProjects.ts:861` — passes with the fix (`Tests 4 passed (4)`) and passes identically on the baseline. So it demonstrates no regression on that path rather than being a regression test for it.

#### What I could not verify

- The **full** `test/browser` unit suite does not complete in my environment — it segfaults partway and `specs/errors.test.ts` fails 7 tests on a browser-provider mismatch. I confirmed those same 7 failures on the untouched baseline, so they are environmental and unrelated, but I cannot report a green full browser run and am not implying CI-equivalent coverage there.
- I did not run `pnpm test:ci` end to end; I ran the `test/e2e` suite (which contains the affected code path) plus the targeted browser spec.

#### Observation, deliberately out of scope

The mixed case `--project=a --project=!b` still admits an unrelated project `c`, because a positive pattern does not gate inclusion — visible in the table above, where `project_1` `!project_2` keeps `space_1`, both before and after this PR. That is arguably its own bug, but it is a separate behaviour change from what #10491 reports, so I left it untouched rather than widening this diff. Happy to open a follow-up if maintainers agree it should change.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`. — see "What I ran" above for exactly which suites I ran and what I did not.

### Documentation
- [x] If you introduce new functionality, document it. — no docs change needed: `docs/guide/cli-generated.md` already documents both repetition of `--project` and `!pattern` exclusion, so this restores documented behaviour rather than changing it.

### Changesets
- [x] Changes in changelog are generated from PR name.
