### PR TITLE
perf(expect): stop rebuilding matcher state on every assertion

### DIFF
--- a/packages/expect/src/state.ts
+++ b/packages/expect/src/state.ts
@@ -43,11 +43,16 @@ export function setState<State extends MatcherState = MatcherState>(
   expect: ExpectStatic,
 ): void {
   const map = (globalThis as any)[MATCHERS_OBJECT]
-  const current = map.get(expect) || {}
-  // so it keeps getters from `testPath`
-  const results = Object.defineProperties(current, {
-    ...Object.getOwnPropertyDescriptors(current),
-    ...Object.getOwnPropertyDescriptors(state),
-  })
-  map.set(expect, results)
+  const current = map.get(expect)
+  // `defineProperties` rather than a spread so that accessors on `state`
+  // (e.g. the `testPath` getter) are copied as accessors, not invoked.
+  const descriptors = Object.getOwnPropertyDescriptors(state)
+  if (!current) {
+    map.set(expect, Object.defineProperties({}, descriptors))
+    return
+  }
+  // `defineProperties` mutates `current` in place, and `current` is already the
+  // value held in the map, so re-defining its own descriptors onto itself is a
+  // no-op. This runs once per `expect()` call, so skipping it matters.
+  Object.defineProperties(current, descriptors)
 }

--- a/test/unit/test/expect.test.ts
+++ b/test/unit/test/expect.test.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { Tester } from '@vitest/expect'
+import type { ExpectStatic, Tester } from '@vitest/expect'
 import { stripVTControlCharacters } from 'node:util'
+import { getState, setState } from '@vitest/expect'
 import { processError } from '@vitest/utils/error'
 import { Temporal } from 'temporal-polyfill'
 import { describe, expect, expectTypeOf, test, TestRunner, vi } from 'vitest'
@@ -793,5 +794,61 @@ describe('Standard Schema', () => {
       const stringSchemaFn = Object.assign(() => {}, stringSchema)
       expect('hello').toEqual(expect.schemaMatching(stringSchemaFn))
     })
+  })
+})
+
+describe('expect state', () => {
+  // `setState` is keyed by the `expect` instance, so a standalone key keeps
+  // these cases from touching the matcher state of the running test file.
+  const createStateKey = () => (() => {}) as unknown as ExpectStatic
+
+  test('merges partial updates into the existing state', () => {
+    const key = createStateKey()
+    setState({ assertionCalls: 0, currentTestName: 'example' }, key)
+    setState({ assertionCalls: 1 }, key)
+
+    expect(getState(key)).toMatchObject({
+      assertionCalls: 1,
+      currentTestName: 'example',
+    })
+  })
+
+  test('stores accessors as accessors instead of invoking them', () => {
+    const key = createStateKey()
+    let reads = 0
+
+    setState({
+      get testPath() {
+        reads++
+        return '/repo/example.test.ts'
+      },
+    }, key)
+
+    expect(reads).toBe(0)
+    expect(Object.getOwnPropertyDescriptor(getState(key), 'testPath')?.get).toBeTypeOf('function')
+    expect(getState(key).testPath).toBe('/repo/example.test.ts')
+    expect(reads).toBe(1)
+  })
+
+  test('keeps a stored accessor live across repeated updates', () => {
+    // `expect()` calls `setState` once per assertion, so the `testPath` getter
+    // added by the runner has to survive an unbounded number of updates.
+    const key = createStateKey()
+    let testPath = '/repo/first.test.ts'
+    setState({
+      assertionCalls: 0,
+      get testPath() {
+        return testPath
+      },
+    }, key)
+
+    for (let i = 1; i <= 100; i++) {
+      setState({ assertionCalls: i }, key)
+    }
+    testPath = '/repo/second.test.ts'
+
+    expect(Object.getOwnPropertyDescriptor(getState(key), 'testPath')?.get).toBeTypeOf('function')
+    expect(getState(key).testPath).toBe('/repo/second.test.ts')
+    expect(getState(key).assertionCalls).toBe(100)
   })
 })


### PR DESCRIPTION
### Description

`setState` in `packages/expect/src/state.ts` re-defines the matcher state's **own** property descriptors back onto itself on every call. That half of the merge cannot change anything, and `setState` runs once per `expect()` — so every assertion pays an `O(number of state keys)` descriptor rebuild to increment one counter.

Removing the dead half cuts **~1.7µs per assertion**. On an assertion-dense suite (200,000 assertions) that is **33% less wall clock** and **30% less CPU**.

#### Minimal reproduction

This needs no vitest run — it calls the real exported functions and replays exactly what `expect()` does per assertion ([`chai/index.ts#L20-L21`](https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/integrations/chai/index.ts#L20-L21)):

```js
// bench.mjs — run from inside packages/expect so `@vitest/utils` resolves
const { getState, setState } = await import('@vitest/expect')

// the exact 9-key state vitest installs (probed from a live run; testPath is an accessor)
const realState = () => ({
  assertionCalls: 0, isExpectingAssertions: false, isExpectingAssertionsError: null,
  expectedAssertionsNumber: null, expectedAssertionsNumberErrorGen: null,
  currentTestName: 'suite > case 1', environment: 'node', snapshotState: { added: 0 },
  get testPath() { return '/repo/test/example.test.ts' },
})

function timeIt(n) {
  const expect = () => {}
  setState(realState(), expect)
  const t0 = process.hrtime.bigint()
  for (let i = 0; i < n; i++) {              // exactly what `expect()` does
    const { assertionCalls } = getState(expect)
    setState({ assertionCalls: assertionCalls + 1 }, expect)
  }
  return Number(process.hrtime.bigint() - t0) / 1e6
}

const N = 100_000
for (let i = 0; i < 3; i++) timeIt(N)                       // warmup
const runs = []; for (let r = 0; r < 10; r++) runs.push(timeIt(N))
const mean = runs.reduce((a, b) => a + b) / runs.length
console.log(`${(mean * 1e6 / N).toFixed(0)} ns/call`)
```

| | ns per `expect()` |
|---|---|
| `main` | **2094 – 2235** |
| this PR | **344 – 391** |

Two microseconds to bump an integer is the tell.

#### Root cause

`packages/expect/src/state.ts:45-52` on `main`:

```ts
const map = (globalThis as any)[MATCHERS_OBJECT]
const current = map.get(expect) || {}
// so it keeps getters from `testPath`
const results = Object.defineProperties(current, {
  ...Object.getOwnPropertyDescriptors(current),   // ← line 49: dead work
  ...Object.getOwnPropertyDescriptors(state),
})
map.set(expect, results)                          // ← also redundant
```

`Object.defineProperties` **mutates `current` in place and returns it**, so `results === current` and the `map.set` re-stores the object that is already there. Re-defining `current`'s own descriptors onto `current` is a no-op by construction: for configurable properties it is an identity redefinition, and for non-configurable ones ECMA-262 explicitly permits redefinition with an identical descriptor. Only the descriptors coming from `state` can change anything.

That dead spread is not free. Per call it enumerates all own descriptors of `current`, allocates a fresh descriptor map and copies every descriptor into it, then makes `defineProperties` walk and re-define every existing property — including the `testPath` **accessor**. Repeatedly re-defining an accessor on the same object keeps it out of a stable fast-property representation, which is why the constant is microseconds rather than nanoseconds.

The line dates to #6472 (2024-09-11), which correctly moved `setState` to `defineProperties` so the `testPath` getter is copied as an accessor instead of being invoked. That fix is right and this PR keeps it — only the self-spread half is removed.

#### The fix

```ts
const map = (globalThis as any)[MATCHERS_OBJECT]
const current = map.get(expect)
const descriptors = Object.getOwnPropertyDescriptors(state)
if (!current) {
  map.set(expect, Object.defineProperties({}, descriptors))
  return
}
Object.defineProperties(current, descriptors)
```

Accessors on `state` are still copied as accessors, property insertion order is unchanged (redefining an existing key does not move it; new keys append in `state` order), and the `|| {}` falsy semantics are preserved via `if (!current)`. No signature or type change.

#### Evidence

**End-to-end**, 20 files × 40 tests × 250 assertions = 200,000 assertions, `pool: 'threads', isolate: false, maxWorkers: 1`, baseline and patched **interleaved** (never batched) over 12 reps each. Both variants grep-verified before every run, since `packages/vitest/dist` bundles its own inlined copy of `setState`:

| metric | `main` | this PR | delta |
|---|---|---|---|
| CPU (user+sys) | 1147.5ms ± 11.4 | 802.5ms ± 23.0 | **−30.1%**, 1725 ns/assertion |
| wall clock | 986.7ms ± 8.9 | 658.3ms ± 17.5 | **−33.3%**, 1642 ns/assertion |

Distributions do not overlap (baseline wall min 970ms > patched max 710ms). CPU time is reported because another process was loading the machine; it is the more robust metric here and it agrees with wall clock.

**Cross-validation.** The isolated microbenchmark and the end-to-end run were measured independently and agree to within ~6%, which is the main reason I trust the number:

| | ns removed per assertion |
|---|---|
| microbenchmark (real module, 100k calls) | ~1750 |
| end-to-end, CPU time (200k assertions) | 1725 |
| end-to-end, wall clock (200k assertions) | 1642 |

**Equivalence.** Differential test over the two **real built** `@vitest/expect` modules: 137,127 randomised `setState` applications across 50,000 trials, over states containing accessors, getter/setter pairs, setter-only and symbol keys, non-enumerable, non-configurable, non-writable and frozen properties, comparing full descriptor snapshots (kind / get / set / enumerable / configurable / writable / read-back value) plus thrown-error class after every step:

```
CLEAN divergences (non-throwing path) : 0
divergences: 13866 — all cases where BOTH versions throw the same error class
             and differ only in how much of a doomed update landed first
```

Those require a pre-existing **non-configurable** property on the matcher state. Probing a live run shows vitest never creates one — all 9 keys are `configurable: true`:

```
assertionCalls, isExpectingAssertions, isExpectingAssertionsError,
expectedAssertionsNumber, expectedAssertionsNumberErrorGen, currentTestName,
testPath (accessor), environment, snapshotState
ANY_NON_CONFIGURABLE=false
```

**Suite.** `pnpm run test:ci:unit` against a true baseline (`git show origin/main:packages/expect/src/state.ts` + full rebuild, with the old spread grep-confirmed present in `packages/vitest/dist`) and against this PR (grep-confirmed absent). Byte-identical, both exit 0:

```
Test Files  640 passed | 5 skipped (645)
     Tests  6154 passed | 63 expected fail | 254 skipped | 75 todo (6546)
```

No pre-existing failures to separate out — the baseline is fully green. `pnpm run typecheck` exit 0, `eslint` clean on both changed files.

#### On the tests I added — please read this bit

I added three cases under `expect state` in `test/unit/test/expect.test.ts`, and I want to be straight about what they are: **they pass on `main` too.** They are characterization tests, not regression tests.

That is unavoidable here. This PR removes provably dead work, so by construction no assertion about observable state can distinguish the two versions — anything that failed before and passed after would mean the change was not behaviour-preserving.

They are not vacuous, though. They pin the invariant from #6472 that this code has to keep. Replacing the body with the naive `Object.assign(current, state)` "simplification" makes **6 of them fail** (`expected 1 to be +0` — the getter was invoked; `expected undefined to be type of 'function'` — the accessor was flattened). So they are a guard on the thing most likely to be broken by a future cleanup of this function.

If you would rather not carry characterization tests, I am happy to drop them and keep this a one-file change.

#### What I did not verify

- Only the Node unit suite (`test:ci:unit`) was run locally. Browser and e2e suites were not — I do not have that environment set up; CI will cover them.
- The saving is a **fixed cost per assertion, not a percentage**, and on a normal suite it is invisible. I ran the same A/B on an assertion-light workload (20 files x 5 tests x 20 assertions = 2,000 assertions, 12 interleaved reps): CPU 310.8ms +/- 6.7 vs 308.3ms +/- 5.8, wall 284.2ms +/- 5.1 vs 279.2ms +/- 5.1 — **median delta 0.0ms on both metrics**, means well inside one standard deviation. Nobody should expect 30% on a typical suite; it takes tens of thousands of assertions before this is measurable at all.
- Measured on one machine (Apple M4, Node v26.7.0, macOS 26.6). Numbers will differ elsewhere; the script above reproduces the microbenchmark anywhere.

#### How it surfaced

Profile-guided, not code review. I generated a realistic vitest workload, ran it under `node --cpu-prof`, and aggregated `.cpuprofile` self-time by function. `setState` showed up far higher than a function whose only job is storing a counter has any business being. Reading the source explained why, and the microbenchmark above isolated it.

One caveat on method, since it cost me time: getting a profile of the **worker** is awkward. `--cpu-prof` is not honoured through `poolOptions.threads.execArgv` (worker_threads reject it), and the main-process profile is ~70% idle with zero `setState` frames because the work happens in the pool. The numbers I quote above are therefore all wall-clock/CPU-time A/B and microbenchmark measurements rather than profiler output.

Worth flagging for anyone re-running this: my first end-to-end A/B measured 0.4%, pure noise. `packages/vitest/dist` ships its **own inlined copy** of `setState`, so swapping `packages/expect/dist` alone changes nothing at runtime. The whole `packages/vitest/dist` has to be rebuilt, and I now grep-assert the shipped bundle before trusting any measurement.

#### Not in this PR

Even after this change, `expect()` still round-trips `getState` + `setState` through a WeakMap and a descriptor call just to increment a counter (the patched microbenchmark is still ~344 ns/call, against ~0 for a plain field increment). Incrementing the field directly would remove most of the remainder. That is a separate change and I have kept it out of this PR.

---

*AI disclosure, per [CONTRIBUTING.md](https://github.com/vitest-dev/vitest/blob/main/CONTRIBUTING.md#ai-contributions): Claude was used as an assistant for the profiling, benchmarking and differential testing described above. I have reviewed the change and the numbers, and I will respond to review myself.*

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it. — *not possible for a dead-code removal; see the section above*
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`. — `pnpm run test:ci:unit` exit 0 (Node unit suite; browser/e2e not run locally)
