### PR TITLE
test(browser): update browser mode snapshot error assertion

### DIFF
--- a/test/browser/specs/errors.test.ts
+++ b/test/browser/specs/errors.test.ts
@@ -125,7 +125,7 @@ test('cannot use fs commands if write is disabled', async () => {
     `Cannot save snapshot file "${fs.resolveFile('./__snapshots__/fs-commands.test.ts.snap')}". File writing is disabled because server is exposed to the internet`,
   )
   expect(stderr).toContain(
-    `Cannot remove snapshot file "${fs.resolveFile('./__snapshots__/basic.test.js.snap')}". File writing is disabled because server is exposed to the internet`,
+    'Cannot read snapshot file because browser API exec operations are disabled',
   )
 
   // we don't throw an error if cannot write attachment, just warn


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- follow-up https://github.com/vitest-dev/vitest/pull/10665

Oops, https://github.com/vitest-dev/vitest/pull/10665 broke the CI.

The test exercises `toMatchSnapshot()` with `allowExec: false, allowWrite: false`. Previously the error message was `Cannot remove snapshot file`, but now fails with `Cannot read snapshot file.`

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
