### PR TITLE
fix: preserve messages for thrown non-Error objects

### DIFF
--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -48,7 +48,14 @@ export function processError(
   catch {}
 
   try {
-    return serializeValue(err)
+    const serializedError = serializeValue(err)
+    if (typeof serializedError?.message === 'string') {
+      return serializedError
+    }
+    return {
+      message: `Non-Error value thrown: ${formatThrownValue(serializedError, diffOptions)}`,
+      serializedValue: serializedError,
+    }
   }
   catch (e: any) {
     return serializeValue(
@@ -56,6 +63,20 @@ export function processError(
         `Failed to fully serialize error: ${e?.message}\nInner error message: ${err?.message}`,
       ),
     )
+  }
+}
+
+function formatThrownValue(value: unknown, options?: DiffOptions): string {
+  try {
+    return prettyFormat(value, getDefaultFormatOptions(options))
+  }
+  catch {
+    try {
+      return String(value)
+    }
+    catch {
+      return '<unknown>'
+    }
   }
 }
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -30,6 +30,7 @@ export interface ParsedStack {
 
 export interface SerializedError {
   message: string
+  serializedValue?: unknown
   stacks?: ParsedStack[]
   stack?: string
   name?: string

--- a/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
+++ b/test/e2e/test/reporters/__snapshots__/junit.test.ts.snap
@@ -135,10 +135,14 @@ AssertionError: expected { hello: &apos;x&apos; } to deeply equal { hello: &apos
         <testcase classname="error.test.ts" name="unhandled" time="...">
         </testcase>
         <testcase classname="error.test.ts" name="no name object" time="...">
-            <failure>
-{ noName: &apos;hi&apos;, stacks: [] }
+            <failure message="Non-Error value thrown: {
+  &quot;noName&quot;: &quot;hi&quot;,
+}">
+Unknown Error: Non-Error value thrown: {
+  &quot;noName&quot;: &quot;hi&quot;,
+}
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-Serialized Error: { noName: &apos;hi&apos; }
+Serialized Error: { serializedValue: { noName: &apos;hi&apos; } }
             </failure>
         </testcase>
         <testcase classname="error.test.ts" name="string" time="...">
@@ -152,8 +156,14 @@ Unknown Error: 1234
             </failure>
         </testcase>
         <testcase classname="error.test.ts" name="number name object" time="...">
-            <failure type="1234">
-{ name: 1234, stacks: [] }
+            <failure message="Non-Error value thrown: {
+  &quot;name&quot;: 1234,
+}">
+Unknown Error: Non-Error value thrown: {
+  &quot;name&quot;: 1234,
+}
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+Serialized Error: { serializedValue: { name: 1234 } }
             </failure>
         </testcase>
         <testcase classname="error.test.ts" name="xml" time="...">

--- a/test/e2e/test/reporters/tap.test.ts
+++ b/test/e2e/test/reporters/tap.test.ts
@@ -13,7 +13,9 @@ test('handle custom error without name', async () => {
             ---
             error:
                 name: "Unknown Error"
-                message: "undefined"
+                message: "Non-Error value thrown: {
+      \\"noName\\": \\"hi\\",
+    }"
             ...
         not ok 2 - string # time=[...]
             ---
@@ -30,8 +32,10 @@ test('handle custom error without name', async () => {
         not ok 4 - number name object # time=[...]
             ---
             error:
-                name: "1234"
-                message: "undefined"
+                name: "Unknown Error"
+                message: "Non-Error value thrown: {
+      \\"name\\": 1234,
+    }"
             ...
     }
     "
@@ -49,7 +53,9 @@ test('tap-flat handles custom error without name', async () => {
         ---
         error:
             name: "Unknown Error"
-            message: "undefined"
+            message: "Non-Error value thrown: {
+      \\"noName\\": \\"hi\\",
+    }"
         ...
     not ok 2 - basic.test.ts > string # time=[...]
         ---
@@ -66,8 +72,10 @@ test('tap-flat handles custom error without name', async () => {
     not ok 4 - basic.test.ts > number name object # time=[...]
         ---
         error:
-            name: "1234"
-            message: "undefined"
+            name: "Unknown Error"
+            message: "Non-Error value thrown: {
+      \\"name\\": 1234,
+    }"
         ...
     "
   `)

--- a/test/e2e/test/reporters/verbose.test.ts
+++ b/test/e2e/test/reporters/verbose.test.ts
@@ -1,6 +1,6 @@
 import type { TestSpecification } from 'vitest/node'
 import { expect, test } from 'vitest'
-import { runVitest } from '#test-utils'
+import { runInlineTests, runVitest } from '#test-utils'
 
 test('duration', async () => {
   const { stdout } = await runVitest({
@@ -23,6 +23,24 @@ test('prints error properties', async () => {
   })
 
   expect(result.stderr).toContain(`Serialized Error: { code: 404, status: 'not found' }`)
+})
+
+test('prints a message when an AggregateError contains a non-Error value', async () => {
+  const { stdout } = await runInlineTests({
+    'array-error.test.ts': `
+      import { test } from 'vitest'
+
+      test('array error', () => {
+        throw new AggregateError([['nested-array']], 'outer')
+      })
+    `,
+  }, {
+    reporters: [['verbose', { isTTY: false, summary: false }]],
+  })
+
+  expect(stdout).toContain('Non-Error value thrown: [')
+  expect(stdout).toContain('"nested-array"')
+  expect(stdout).not.toContain('→ undefined')
 })
 
 test('prints skipped tests by default', async () => {

--- a/test/unit/test/error.test.ts
+++ b/test/unit/test/error.test.ts
@@ -111,3 +111,26 @@ test('error with toJSON doesn\'t override nessage, stack and name if it\'s there
   expect(serialisedError.stack).toBe('custom stack')
   expect(serialisedError.message).toBe('custom message')
 })
+
+test.each([
+  {
+    thrown: ['foo', { code: 404 }],
+    message: `Non-Error value thrown: [
+  "foo",
+  {
+    "code": 404,
+  },
+]`,
+  },
+  {
+    thrown: { code: 500 },
+    message: `Non-Error value thrown: {
+  "code": 500,
+}`,
+  },
+])('non-Error objects have a message and retain their serialized value', ({ thrown, message }) => {
+  expect(processError(thrown)).toEqual({
+    message,
+    serializedValue: thrown,
+  })
+})


### PR DESCRIPTION
### Description

`processError()` is typed to return a `TestError`, whose `message` property is required. However, when a test throws an object or an array, `processError()` currently returns the serialized value directly without adding a message.

This becomes especially visible when an `AggregateError` contains a non-Error value: the runner expands the aggregate, and the verbose reporter prints `→ undefined` for the nested value. Custom reporters that rely on the public `SerializedError.message` contract observe the same missing message.

This PR makes `processError()` uphold its return type contract for every thrown value. Non-Error objects receive a readable `Non-Error value thrown: ...` message while their original serialized representation is retained in `serializedValue`.

It adds unit coverage for thrown arrays and plain objects, plus an end-to-end regression test for `AggregateError([["nested-array"]])` through the verbose reporter.

Codex assisted with analysis, implementation, and test preparation. I am the real person responsible for this contribution and will handle review feedback.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [ ] Run the tests with `pnpm test:ci`.
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `CI=true pnpm test test/error.test.ts`
- [x] `CI=true pnpm --filter @vitest/test-e2e test reporters/verbose.test.ts`

### Documentation

- [x] No new functionality requiring documentation.

### Changesets

- [x] The PR title uses the `fix:` prefix and describes the change.

<!-- VITEST_AUTOMATED_PR -->
