### PR TITLE
refactor(ui): make explorer tree dependencies explicit

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -11,8 +11,6 @@ import type { BrowserRunnerState } from '../../../types'
 import type { VitestClient } from './ws'
 import { computed, reactive as reactiveVue, ref, shallowRef, watch } from 'vue'
 import { explorerTree } from '~/composables/explorer'
-import { isFileNode } from '~/composables/explorer/utils'
-import { isSuite as isTaskSuite } from '~/utils/task'
 import { createFileTask, getTasks } from '../../../../vitest/src/utils/tasks'
 import { ui } from '../../composables/api'
 import { ENTRY_URL, isReport } from '../../constants'
@@ -45,7 +43,7 @@ export const client: VitestClient = (function createVitestClient() {
           testRunState.value = 'running'
         },
         onSpecsCollected(_specs, startTime) {
-          explorerTree.startTime = startTime || performance.now()
+          explorerTree.setRunStartTime(startTime)
         },
         onFinished(_files, errors, _coverage, executionTime) {
           explorerTree.endRun(executionTime)
@@ -90,51 +88,8 @@ export function runAll() {
   return runFiles(client.state.getFiles())
 }
 
-function clearTaskResult(task: RunnerTask) {
-  delete task.result
-  const node = explorerTree.nodes.get(task.id)
-  if (node) {
-    node.state = undefined
-    // update task mode to allow change icon on skipped tests
-    task.mode = 'run'
-    node.duration = undefined
-    if (isTaskSuite(task)) {
-      for (const t of task.tasks) {
-        clearTaskResult(t)
-      }
-    }
-  }
-}
-
-function clearResults(useFiles: RunnerTestFile[]) {
-  const map = explorerTree.nodes
-  useFiles.forEach((f) => {
-    delete f.result
-    getTasks(f).forEach((i) => {
-      delete i.result
-      if (map.has(i.id)) {
-        const task = map.get(i.id)
-        if (task) {
-          task.state = undefined
-          task.mode = 'run'
-          task.duration = undefined
-        }
-      }
-    })
-    const file = map.get(f.id)
-    if (file) {
-      file.state = undefined
-      file.mode = 'run'
-      file.duration = undefined
-      if (isFileNode(file)) {
-        file.collectDuration = undefined
-      }
-    }
-  })
-}
-
 export function runFiles(useFiles: RunnerTestFile[]) {
-  clearResults(useFiles)
+  explorerTree.clearResults(useFiles)
 
   explorerTree.startRun()
 
@@ -142,7 +97,7 @@ export function runFiles(useFiles: RunnerTestFile[]) {
 }
 
 export function runTask(task: RunnerTask) {
-  clearTaskResult(task)
+  explorerTree.clearTaskResult(task)
 
   explorerTree.startRun()
 

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -4,7 +4,6 @@ import type {
   RunnerTaskEventPack,
   RunnerTaskResultPack,
   RunnerTestFile,
-  SerializedRootConfig,
   TestAnnotation,
 } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
@@ -16,11 +15,12 @@ import { ui } from '../../composables/api'
 import { ENTRY_URL, isReport } from '../../constants'
 import { parseError } from '../error'
 import { activeFileId } from '../params'
-import { testRunState, unhandledErrors } from './state'
+import { availableProjects, config, testRunState, unhandledErrors } from './state'
 import { createStaticClient } from './static'
 import { createWsClient } from './ws'
 
 export { isReport } from '../../constants'
+export { availableProjects, config } from './state'
 
 export const client: VitestClient = (function createVitestClient() {
   if (isReport) {
@@ -66,9 +66,15 @@ export const client: VitestClient = (function createVitestClient() {
   }
 })()
 
-export const config = shallowRef<Partial<SerializedRootConfig>>({} as any)
+explorerTree.connect({
+  getTask: id => client.state.idMap.get(id),
+  getFile: id => client.state.idMap.get(id) as RunnerTestFile | undefined,
+  getFiles: () => client.state.getFiles(),
+  getSlowTestThreshold: () => config.value.slowTestThreshold,
+  setRunState: state => testRunState.value = state,
+})
+
 const status = ref<WebSocketStatus>('CONNECTING')
-export const availableProjects = shallowRef<string[]>([])
 
 export const current = computed(() => {
   const currentFileId = activeFileId.value

--- a/packages/ui/client/composables/client/state.ts
+++ b/packages/ui/client/composables/client/state.ts
@@ -3,16 +3,18 @@ import type {
   RunnerTask,
   RunnerTaskResultPack,
   RunnerTestFile,
+  SerializedRootConfig,
   TestTagDefinition,
   UserConsoleLog,
 } from 'vitest'
 import type { Ref } from 'vue'
 import type { RunState } from '../../../types'
-import { computed, ref } from 'vue'
-import { config } from '.'
+import { computed, ref, shallowRef } from 'vue'
 import { createFileTask } from '../../../../vitest/src/utils/tasks'
 
 export const testRunState: Ref<RunState> = ref('idle')
+export const config = shallowRef<Partial<SerializedRootConfig>>({} as any)
+export const availableProjects = shallowRef<string[]>([])
 export const finished = computed(() => testRunState.value === 'idle')
 export const unhandledErrors: Ref<TestError[]> = ref([])
 export const tagsDefinitions = computed(() => {

--- a/packages/ui/client/composables/explorer/collapse.ts
+++ b/packages/ui/client/composables/explorer/collapse.ts
@@ -1,5 +1,4 @@
-import type { UITaskTreeNode } from '~/composables/explorer/types'
-import { explorerTree } from '~/composables/explorer/index'
+import type { ExplorerTreeStructure, UITaskTreeNode } from '~/composables/explorer/types'
 import { openedTreeItems, treeFilter, uiEntries } from '~/composables/explorer/state'
 import { isFileNode, isParentNode } from '~/composables/explorer/utils'
 
@@ -16,10 +15,11 @@ import { isFileNode, isParentNode } from '~/composables/explorer/utils'
  * - remove opened tree items for the node and any children
  * - update uiEntries without child nodes
  *
+ * @param tree The explorer tree structure.
  * @param id The node id to collapse.
  */
-export function runCollapseNode(id: string) {
-  const node = explorerTree.nodes.get(id)
+export function runCollapseNode(tree: ExplorerTreeStructure, id: string) {
+  const node = tree.nodes.get(id)
   if (!node || !isParentNode(node)) {
     return
   }
@@ -49,9 +49,9 @@ export function runCollapseNode(id: string) {
  * - update uiEntries without child nodes
  *
  */
-export function runCollapseAllTask() {
+export function runCollapseAllTask(tree: ExplorerTreeStructure) {
   // collapse all nodes
-  collapseAllNodes(explorerTree.root.tasks)
+  collapseAllNodes(tree.root.tasks)
   const entries = [...uiEntries.value.filter(isFileNode)]
   collapseAllNodes(entries)
   // collapse all nodes

--- a/packages/ui/client/composables/explorer/collapse.ts
+++ b/packages/ui/client/composables/explorer/collapse.ts
@@ -1,4 +1,4 @@
-import type { ExplorerTreeStructure, UITaskTreeNode } from '~/composables/explorer/types'
+import type { ExplorerOperationContext, UITaskTreeNode } from '~/composables/explorer/types'
 import { openedTreeItems, treeFilter, uiEntries } from '~/composables/explorer/state'
 import { isFileNode, isParentNode } from '~/composables/explorer/utils'
 
@@ -15,11 +15,11 @@ import { isFileNode, isParentNode } from '~/composables/explorer/utils'
  * - remove opened tree items for the node and any children
  * - update uiEntries without child nodes
  *
- * @param tree The explorer tree structure.
+ * @param context The explorer operation context.
  * @param id The node id to collapse.
  */
-export function runCollapseNode(tree: ExplorerTreeStructure, id: string) {
-  const node = tree.nodes.get(id)
+export function runCollapseNode(context: ExplorerOperationContext, id: string) {
+  const node = context.nodes.get(id)
   if (!node || !isParentNode(node)) {
     return
   }
@@ -49,9 +49,9 @@ export function runCollapseNode(tree: ExplorerTreeStructure, id: string) {
  * - update uiEntries without child nodes
  *
  */
-export function runCollapseAllTask(tree: ExplorerTreeStructure) {
+export function runCollapseAllTask(context: ExplorerOperationContext) {
   // collapse all nodes
-  collapseAllNodes(tree.root.tasks)
+  collapseAllNodes(context.root.tasks)
   const entries = [...uiEntries.value.filter(isFileNode)]
   collapseAllNodes(entries)
   // collapse all nodes

--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -1,12 +1,11 @@
 import type { Arrayable } from '@vitest/utils'
 import type { RunnerTestFile as File, RunnerTask as Task, RunnerTaskResultPack as TaskResultPack, RunnerTestCase as Test, TestArtifact } from 'vitest'
-import type { CollectFilteredTests, CollectorInfo, Filter, FilteredTests, SearchMatcher } from '~/composables/explorer/types'
+import type { CollectFilteredTests, CollectorInfo, ExplorerTreeStructure, Filter, FilteredTests, SearchMatcher } from '~/composables/explorer/types'
 import { toArray } from '@vitest/utils/helpers'
 import { client, findById } from '~/composables/client'
 import { testRunState } from '~/composables/client/state'
 import { expandNodesOnEndRun } from '~/composables/explorer/expand'
 import { runFilter, testMatcher } from '~/composables/explorer/filter'
-import { explorerTree } from '~/composables/explorer/index'
 import {
   initialized,
   openedTreeItems,
@@ -27,6 +26,8 @@ import { hasFailedSnapshot } from '../../../../vitest/src/utils/tasks'
 export { hasFailedSnapshot }
 
 export function runLoadFiles(
+  tree: ExplorerTreeStructure,
+  colors: Map<string, string | undefined>,
   remoteFiles: File[],
   collect: boolean,
   search: SearchMatcher,
@@ -34,10 +35,10 @@ export function runLoadFiles(
 ) {
   remoteFiles.map(f => [`${f.filepath}:${f.projectName || ''}`, f] as const)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([, f]) => createOrUpdateFileNode(f, collect))
+    .map(([, f]) => createOrUpdateFileNode(tree, colors, f, collect))
 
-  uiFiles.value = [...explorerTree.root.tasks]
-  runFilter(search, {
+  uiFiles.value = [...tree.root.tasks]
+  runFilter(tree, search, {
     failed: filter.failed,
     success: filter.success,
     skipped: filter.skipped,
@@ -46,19 +47,18 @@ export function runLoadFiles(
   })
 }
 
-export function preparePendingTasks(packs: TaskResultPack[]) {
+export function preparePendingTasks(pendingTasks: Map<string, Set<string>>, packs: TaskResultPack[]) {
   queueMicrotask(() => {
-    const pending = explorerTree.pendingTasks
     const idMap = client.state.idMap
     for (const pack of packs) {
       const result = pack[1]
       if (result) {
         const task = idMap.get(pack[0])
         if (task) {
-          let file = pending.get(task.file.id)
+          let file = pendingTasks.get(task.file.id)
           if (!file) {
             file = new Set()
-            pending.set(task.file.id, file)
+            pendingTasks.set(task.file.id, file)
           }
           file.add(task.id)
         }
@@ -68,17 +68,17 @@ export function preparePendingTasks(packs: TaskResultPack[]) {
 }
 
 export function recordTestArtifact(
+  pendingTasks: Map<string, Set<string>>,
   id: string,
   artifact: TestArtifact,
 ) {
-  const pending = explorerTree.pendingTasks
   const idMap = client.state.idMap
   const test = idMap.get(id)
   if (test?.type === 'test') {
-    let file = pending.get(test.file.id)
+    let file = pendingTasks.get(test.file.id)
     if (!file) {
       file = new Set()
-      pending.set(test.file.id, file)
+      pendingTasks.set(test.file.id, file)
     }
     file.add(test.id)
 
@@ -92,6 +92,9 @@ export function recordTestArtifact(
 }
 
 export function runCollect(
+  tree: ExplorerTreeStructure,
+  colors: Map<string, string | undefined>,
+  pendingTasks: Map<string, Set<string>>,
   start: boolean,
   end: boolean,
   summary: CollectorInfo,
@@ -106,15 +109,15 @@ export function runCollect(
   const collect = !start
   queueMicrotask(() => {
     if (end) {
-      traverseFiles(collect)
+      traverseFiles(tree, colors, collect)
     }
     else {
-      traverseReceivedFiles(collect)
+      traverseReceivedFiles(tree, colors, pendingTasks, collect)
     }
   })
 
   queueMicrotask(() => {
-    collectData(summary, executionTime)
+    collectData(tree, summary, executionTime)
   })
 
   queueMicrotask(() => {
@@ -127,7 +130,7 @@ export function runCollect(
   })
 
   queueMicrotask(() => {
-    doRunFilter(search, filter, end)
+    doRunFilter(tree, search, filter, end)
   })
 }
 
@@ -150,18 +153,18 @@ function updateRunningTodoTests() {
   }
 }
 
-function traverseFiles(collect: boolean) {
+function traverseFiles(tree: ExplorerTreeStructure, colors: Map<string, string | undefined>, collect: boolean) {
   // add missing files: now we have only files with running tests on the initial ws open event
   const files = client.state.getFiles()
-  const currentFiles = explorerTree.nodes
+  const currentFiles = tree.nodes
   const missingFiles = files.filter(f => !currentFiles.has(f.id))
   for (let i = 0; i < missingFiles.length; i++) {
-    createOrUpdateFileNode(missingFiles[i], collect)
-    createOrUpdateEntry(missingFiles[i].tasks)
+    createOrUpdateFileNode(tree, colors, missingFiles[i], collect)
+    createOrUpdateEntry(tree, missingFiles[i].tasks)
   }
 
   // update pending tasks
-  const rootTasks = explorerTree.root.tasks
+  const rootTasks = tree.root.tasks
   // collect remote children
   for (let i = 0; i < rootTasks.length; i++) {
     const fileNode = rootTasks[i]
@@ -170,22 +173,27 @@ function traverseFiles(collect: boolean) {
       continue
     }
 
-    createOrUpdateFileNode(file, collect)
+    createOrUpdateFileNode(tree, colors, file, collect)
     const tasks = file.tasks
     if (!tasks?.length) {
       continue
     }
 
-    createOrUpdateEntry(file.tasks)
+    createOrUpdateEntry(tree, file.tasks)
   }
 }
 
-function traverseReceivedFiles(collect: boolean) {
-  const updatedFiles = new Map(explorerTree.pendingTasks.entries())
-  explorerTree.pendingTasks.clear()
+function traverseReceivedFiles(
+  tree: ExplorerTreeStructure,
+  colors: Map<string, string | undefined>,
+  pendingTasks: Map<string, Set<string>>,
+  collect: boolean,
+) {
+  const updatedFiles = new Map(pendingTasks.entries())
+  pendingTasks.clear()
 
   // add missing files: now we have only files with running tests on the initial ws open event
-  const currentFiles = explorerTree.nodes
+  const currentFiles = tree.nodes
   const missingFiles = Array
     .from(updatedFiles.keys())
     .filter(id => !currentFiles.has(id))
@@ -195,15 +203,15 @@ function traverseReceivedFiles(collect: boolean) {
   let newFile: File
   for (let i = 0; i < missingFiles.length; i++) {
     newFile = missingFiles[i]
-    createOrUpdateFileNode(newFile, false)
-    createOrUpdateEntry(newFile.tasks)
+    createOrUpdateFileNode(tree, colors, newFile, false)
+    createOrUpdateEntry(tree, newFile.tasks)
     // remove the file from the updated files
     updatedFiles.delete(newFile.id)
   }
 
   // collect remote children
   const idMap = client.state.idMap
-  const rootTasks = explorerTree.root.tasks
+  const rootTasks = tree.root.tasks
   for (let i = 0; i < rootTasks.length; i++) {
     const fileNode = rootTasks[i]
     const file = findById(fileNode.id)
@@ -214,12 +222,13 @@ function traverseReceivedFiles(collect: boolean) {
     if (!entries) {
       continue
     }
-    createOrUpdateFileNode(file, collect)
-    createOrUpdateEntry(Array.from(entries, id => idMap.get(id)).filter(Boolean) as Task[])
+    createOrUpdateFileNode(tree, colors, file, collect)
+    createOrUpdateEntry(tree, Array.from(entries, id => idMap.get(id)).filter(Boolean) as Task[])
   }
 }
 
 function doRunFilter(
+  tree: ExplorerTreeStructure,
   search: SearchMatcher,
   filter: Filter,
   end = false,
@@ -231,7 +240,7 @@ function doRunFilter(
 
   // refresh explorer
   queueMicrotask(() => {
-    refreshExplorer(search, filter, end)
+    refreshExplorer(tree, search, filter, end)
   })
 
   // initialize the explorer
@@ -253,13 +262,13 @@ function doRunFilter(
     })
     // refresh explorer
     queueMicrotask(() => {
-      refreshExplorer(search, filter, end)
+      refreshExplorer(tree, search, filter, end)
     })
   }
 }
 
-function refreshExplorer(search: SearchMatcher, filter: Filter, end: boolean) {
-  runFilter(search, filter)
+function refreshExplorer(tree: ExplorerTreeStructure, search: SearchMatcher, filter: Filter, end: boolean) {
+  runFilter(tree, search, filter)
   // update only at the end
   if (end) {
     updateRunningTodoTests()
@@ -267,15 +276,15 @@ function refreshExplorer(search: SearchMatcher, filter: Filter, end: boolean) {
   }
 }
 
-function createOrUpdateEntry(tasks: Task[]) {
+function createOrUpdateEntry(tree: ExplorerTreeStructure, tasks: Task[]) {
   let task: Task
   for (let i = 0; i < tasks.length; i++) {
     task = tasks[i]
     if (isSuite(task)) {
-      createOrUpdateSuiteTask(task.id, true)
+      createOrUpdateSuiteTask(tree, task.id, true)
     }
     else {
-      createOrUpdateNodeTask(task.id)
+      createOrUpdateNodeTask(tree, task.id)
     }
   }
 }
@@ -301,11 +310,12 @@ function resetCollectorInfo(summary: CollectorInfo) {
 }
 
 function collectData(
+  tree: ExplorerTreeStructure,
   summary: CollectorInfo,
   time: number,
 ) {
   const idMap = client.state.idMap
-  const filesMap = new Map(explorerTree.root.tasks.filter(f => idMap.has(f.id)).map(f => [f.id, f]))
+  const filesMap = new Map(tree.root.tasks.filter(f => idMap.has(f.id)).map(f => [f.id, f]))
   const useFiles = Array.from(filesMap.values(), file => [file.id, findById(file.id)] as const)
   const data = {
     files: filesMap.size,

--- a/packages/ui/client/composables/explorer/collector.ts
+++ b/packages/ui/client/composables/explorer/collector.ts
@@ -1,9 +1,7 @@
 import type { Arrayable } from '@vitest/utils'
 import type { RunnerTestFile as File, RunnerTask as Task, RunnerTaskResultPack as TaskResultPack, RunnerTestCase as Test, TestArtifact } from 'vitest'
-import type { CollectFilteredTests, CollectorInfo, ExplorerTreeStructure, Filter, FilteredTests, SearchMatcher } from '~/composables/explorer/types'
+import type { CollectFilteredTests, CollectorInfo, ExplorerOperationContext, Filter, FilteredTests, SearchMatcher } from '~/composables/explorer/types'
 import { toArray } from '@vitest/utils/helpers'
-import { client, findById } from '~/composables/client'
-import { testRunState } from '~/composables/client/state'
 import { expandNodesOnEndRun } from '~/composables/explorer/expand'
 import { runFilter, testMatcher } from '~/composables/explorer/filter'
 import {
@@ -26,8 +24,7 @@ import { hasFailedSnapshot } from '../../../../vitest/src/utils/tasks'
 export { hasFailedSnapshot }
 
 export function runLoadFiles(
-  tree: ExplorerTreeStructure,
-  colors: Map<string, string | undefined>,
+  context: ExplorerOperationContext,
   remoteFiles: File[],
   collect: boolean,
   search: SearchMatcher,
@@ -35,10 +32,10 @@ export function runLoadFiles(
 ) {
   remoteFiles.map(f => [`${f.filepath}:${f.projectName || ''}`, f] as const)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([, f]) => createOrUpdateFileNode(tree, colors, f, collect))
+    .map(([, f]) => createOrUpdateFileNode(context, f, collect))
 
-  uiFiles.value = [...tree.root.tasks]
-  runFilter(tree, search, {
+  uiFiles.value = [...context.root.tasks]
+  runFilter(context, search, {
     failed: filter.failed,
     success: filter.success,
     skipped: filter.skipped,
@@ -47,18 +44,17 @@ export function runLoadFiles(
   })
 }
 
-export function preparePendingTasks(pendingTasks: Map<string, Set<string>>, packs: TaskResultPack[]) {
+export function preparePendingTasks(context: ExplorerOperationContext, packs: TaskResultPack[]) {
   queueMicrotask(() => {
-    const idMap = client.state.idMap
     for (const pack of packs) {
       const result = pack[1]
       if (result) {
-        const task = idMap.get(pack[0])
+        const task = context.dataSource.getTask(pack[0])
         if (task) {
-          let file = pendingTasks.get(task.file.id)
+          let file = context.pendingTasks.get(task.file.id)
           if (!file) {
             file = new Set()
-            pendingTasks.set(task.file.id, file)
+            context.pendingTasks.set(task.file.id, file)
           }
           file.add(task.id)
         }
@@ -68,17 +64,16 @@ export function preparePendingTasks(pendingTasks: Map<string, Set<string>>, pack
 }
 
 export function recordTestArtifact(
-  pendingTasks: Map<string, Set<string>>,
+  context: ExplorerOperationContext,
   id: string,
   artifact: TestArtifact,
 ) {
-  const idMap = client.state.idMap
-  const test = idMap.get(id)
+  const test = context.dataSource.getTask(id)
   if (test?.type === 'test') {
-    let file = pendingTasks.get(test.file.id)
+    let file = context.pendingTasks.get(test.file.id)
     if (!file) {
       file = new Set()
-      pendingTasks.set(test.file.id, file)
+      context.pendingTasks.set(test.file.id, file)
     }
     file.add(test.id)
 
@@ -92,9 +87,7 @@ export function recordTestArtifact(
 }
 
 export function runCollect(
-  tree: ExplorerTreeStructure,
-  colors: Map<string, string | undefined>,
-  pendingTasks: Map<string, Set<string>>,
+  context: ExplorerOperationContext,
   start: boolean,
   end: boolean,
   summary: CollectorInfo,
@@ -109,28 +102,28 @@ export function runCollect(
   const collect = !start
   queueMicrotask(() => {
     if (end) {
-      traverseFiles(tree, colors, collect)
+      traverseFiles(context, collect)
     }
     else {
-      traverseReceivedFiles(tree, colors, pendingTasks, collect)
+      traverseReceivedFiles(context, collect)
     }
   })
 
   queueMicrotask(() => {
-    collectData(tree, summary, executionTime)
+    collectData(context, summary, executionTime)
   })
 
   queueMicrotask(() => {
     if (end) {
       summary.failedSnapshot = uiFiles.value && hasFailedSnapshot(
-        uiFiles.value.map(f => findById(f.id)!),
+        uiFiles.value.map(f => context.dataSource.getFile(f.id)!),
       )
       summary.failedSnapshotEnabled = true
     }
   })
 
   queueMicrotask(() => {
-    doRunFilter(tree, search, filter, end)
+    doRunFilter(context, search, filter, end)
   })
 }
 
@@ -138,14 +131,13 @@ function* collectRunningTodoTests() {
   yield* uiEntries.value.filter(isRunningTestNode)
 }
 
-function updateRunningTodoTests() {
-  const idMap = client.state.idMap
+function updateRunningTodoTests(context: ExplorerOperationContext) {
   let task: Task | undefined
   for (const test of collectRunningTodoTests()) {
     // lookup the parent
-    task = idMap.get(test.parentId)
+    task = context.dataSource.getTask(test.parentId)
     if (task && isSuite(task) && task.mode === 'todo') {
-      task = idMap.get(test.id)
+      task = context.dataSource.getTask(test.id)
       if (task) {
         task.mode = 'todo'
       }
@@ -153,68 +145,65 @@ function updateRunningTodoTests() {
   }
 }
 
-function traverseFiles(tree: ExplorerTreeStructure, colors: Map<string, string | undefined>, collect: boolean) {
+function traverseFiles(context: ExplorerOperationContext, collect: boolean) {
   // add missing files: now we have only files with running tests on the initial ws open event
-  const files = client.state.getFiles()
-  const currentFiles = tree.nodes
+  const files = context.dataSource.getFiles()
+  const currentFiles = context.nodes
   const missingFiles = files.filter(f => !currentFiles.has(f.id))
   for (let i = 0; i < missingFiles.length; i++) {
-    createOrUpdateFileNode(tree, colors, missingFiles[i], collect)
-    createOrUpdateEntry(tree, missingFiles[i].tasks)
+    createOrUpdateFileNode(context, missingFiles[i], collect)
+    createOrUpdateEntry(context, missingFiles[i].tasks)
   }
 
   // update pending tasks
-  const rootTasks = tree.root.tasks
+  const rootTasks = context.root.tasks
   // collect remote children
   for (let i = 0; i < rootTasks.length; i++) {
     const fileNode = rootTasks[i]
-    const file = findById(fileNode.id)
+    const file = context.dataSource.getFile(fileNode.id)
     if (!file) {
       continue
     }
 
-    createOrUpdateFileNode(tree, colors, file, collect)
+    createOrUpdateFileNode(context, file, collect)
     const tasks = file.tasks
     if (!tasks?.length) {
       continue
     }
 
-    createOrUpdateEntry(tree, file.tasks)
+    createOrUpdateEntry(context, file.tasks)
   }
 }
 
 function traverseReceivedFiles(
-  tree: ExplorerTreeStructure,
-  colors: Map<string, string | undefined>,
-  pendingTasks: Map<string, Set<string>>,
+  context: ExplorerOperationContext,
   collect: boolean,
 ) {
-  const updatedFiles = new Map(pendingTasks.entries())
-  pendingTasks.clear()
+  const updatedFiles = new Map(context.pendingTasks.entries())
+  context.pendingTasks.clear()
 
   // add missing files: now we have only files with running tests on the initial ws open event
-  const currentFiles = tree.nodes
+  const currentFiles = context.nodes
   const missingFiles = Array
     .from(updatedFiles.keys())
     .filter(id => !currentFiles.has(id))
-    .map(id => findById(id))
+    .map(id => context.dataSource.getFile(id))
     .filter(Boolean) as File[]
 
   let newFile: File
   for (let i = 0; i < missingFiles.length; i++) {
     newFile = missingFiles[i]
-    createOrUpdateFileNode(tree, colors, newFile, false)
-    createOrUpdateEntry(tree, newFile.tasks)
+    createOrUpdateFileNode(context, newFile, false)
+    createOrUpdateEntry(context, newFile.tasks)
     // remove the file from the updated files
     updatedFiles.delete(newFile.id)
   }
 
   // collect remote children
-  const idMap = client.state.idMap
-  const rootTasks = tree.root.tasks
+  const rootTasks = context.root.tasks
   for (let i = 0; i < rootTasks.length; i++) {
     const fileNode = rootTasks[i]
-    const file = findById(fileNode.id)
+    const file = context.dataSource.getFile(fileNode.id)
     if (!file) {
       continue
     }
@@ -222,13 +211,13 @@ function traverseReceivedFiles(
     if (!entries) {
       continue
     }
-    createOrUpdateFileNode(tree, colors, file, collect)
-    createOrUpdateEntry(tree, Array.from(entries, id => idMap.get(id)).filter(Boolean) as Task[])
+    createOrUpdateFileNode(context, file, collect)
+    createOrUpdateEntry(context, Array.from(entries, id => context.dataSource.getTask(id)).filter(Boolean) as Task[])
   }
 }
 
 function doRunFilter(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   search: SearchMatcher,
   filter: Filter,
   end = false,
@@ -240,7 +229,7 @@ function doRunFilter(
 
   // refresh explorer
   queueMicrotask(() => {
-    refreshExplorer(tree, search, filter, end)
+    refreshExplorer(context, search, filter, end)
   })
 
   // initialize the explorer
@@ -262,29 +251,29 @@ function doRunFilter(
     })
     // refresh explorer
     queueMicrotask(() => {
-      refreshExplorer(tree, search, filter, end)
+      refreshExplorer(context, search, filter, end)
     })
   }
 }
 
-function refreshExplorer(tree: ExplorerTreeStructure, search: SearchMatcher, filter: Filter, end: boolean) {
-  runFilter(tree, search, filter)
+function refreshExplorer(context: ExplorerOperationContext, search: SearchMatcher, filter: Filter, end: boolean) {
+  runFilter(context, search, filter)
   // update only at the end
   if (end) {
-    updateRunningTodoTests()
-    testRunState.value = 'idle'
+    updateRunningTodoTests(context)
+    context.dataSource.setRunState('idle')
   }
 }
 
-function createOrUpdateEntry(tree: ExplorerTreeStructure, tasks: Task[]) {
+function createOrUpdateEntry(context: ExplorerOperationContext, tasks: Task[]) {
   let task: Task
   for (let i = 0; i < tasks.length; i++) {
     task = tasks[i]
     if (isSuite(task)) {
-      createOrUpdateSuiteTask(tree, task.id, true)
+      createOrUpdateSuiteTask(context, task.id, true)
     }
     else {
-      createOrUpdateNodeTask(tree, task.id)
+      createOrUpdateNodeTask(context, task.id)
     }
   }
 }
@@ -310,13 +299,12 @@ function resetCollectorInfo(summary: CollectorInfo) {
 }
 
 function collectData(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   summary: CollectorInfo,
   time: number,
 ) {
-  const idMap = client.state.idMap
-  const filesMap = new Map(tree.root.tasks.filter(f => idMap.has(f.id)).map(f => [f.id, f]))
-  const useFiles = Array.from(filesMap.values(), file => [file.id, findById(file.id)] as const)
+  const filesMap = new Map(context.root.tasks.filter(f => context.dataSource.getFile(f.id)).map(f => [f.id, f]))
+  const useFiles = Array.from(filesMap.values(), file => [file.id, context.dataSource.getFile(file.id)] as const)
   const data = {
     files: filesMap.size,
     time: time > 1000 ? `${(time / 1000).toFixed(2)}s` : `${Math.round(time)}ms`,
@@ -370,7 +358,7 @@ function collectData(
       todo,
       expectedFail,
       slow,
-    } = collectTests(f)
+    } = collectTests(context, f)
 
     data.totalTests += total
     data.testsFailed += failed
@@ -400,7 +388,7 @@ function collectData(
   summary.totalTests = data.totalTests
 }
 
-function collectTests(file: File, search: SearchMatcher = () => true, filter?: Filter) {
+function collectTests(context: ExplorerOperationContext, file: File, search: SearchMatcher = () => true, filter?: Filter) {
   const data = {
     failed: 0,
     success: 0,
@@ -414,9 +402,9 @@ function collectTests(file: File, search: SearchMatcher = () => true, filter?: F
   } satisfies CollectFilteredTests
 
   for (const t of testsCollector(file)) {
-    if (!filter || testMatcher(t, search, filter)) {
+    if (!filter || testMatcher(context, t, search, filter)) {
       data.total++
-      if (isSlowTestTask(t)) {
+      if (isSlowTestTask(context, t)) {
         data.slow++
       }
       if (t.result?.state === 'fail') {
@@ -448,6 +436,7 @@ function collectTests(file: File, search: SearchMatcher = () => true, filter?: F
 }
 
 export function collectTestsTotalData(
+  context: ExplorerOperationContext,
   filtered: boolean,
   onlyTests: boolean,
   tests: File[],
@@ -458,7 +447,7 @@ export function collectTestsTotalData(
   if (onlyTests) {
     // todo: apply similar logic when filtered
     return tests
-      .map(file => collectTests(file, search, filter))
+      .map(file => collectTests(context, file, search, filter))
       .reduce((acc, {
         failed,
         success,

--- a/packages/ui/client/composables/explorer/expand.ts
+++ b/packages/ui/client/composables/explorer/expand.ts
@@ -1,7 +1,6 @@
-import type { Filter, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
+import type { ExplorerTreeStructure, Filter, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
 import { findById } from '~/composables/client'
 import { filterAll, filterNode } from '~/composables/explorer/filter'
-import { explorerTree } from '~/composables/explorer/index'
 import { filteredFiles, openedTreeItems, treeFilter, uiEntries } from '~/composables/explorer/state'
 import { createOrUpdateNode, createOrUpdateSuiteTask, isFileNode, isParentNode } from '~/composables/explorer/utils'
 
@@ -19,16 +18,19 @@ import { createOrUpdateNode, createOrUpdateSuiteTask, isFileNode, isParentNode }
  * - remove opened tree items for the node and any children
  * - update uiEntries including child nodes
  *
+ * @param tree The explorer tree structure.
  * @param id The node id to expand.
  * @param search The search applied.
  * @param filter The filter applied.
  */
 export function runExpandNode(
+  tree: ExplorerTreeStructure,
   id: string,
   search: SearchMatcher,
   filter: Filter,
 ) {
   const entry = createOrUpdateSuiteTask(
+    tree,
     id,
     false,
   )
@@ -40,7 +42,7 @@ export function runExpandNode(
 
   // create only direct children
   for (const subtask of task.tasks) {
-    createOrUpdateNode(node.id, subtask, false)
+    createOrUpdateNode(tree, node.id, subtask, false)
   }
 
   // expand the node
@@ -51,6 +53,7 @@ export function runExpandNode(
   // collect children
   // the first node is itself only when it is a file
   const children = new Set(filterNode(
+    tree,
     node,
     search,
     filter,
@@ -82,15 +85,18 @@ export function runExpandNode(
  * - update the filtered expandAll state to false
  * - update uiEntries with child nodes
  *
+ * @param tree The explorer tree structure.
  * @param search The search applied.
  * @param filter The filter applied.
  */
 export function runExpandAll(
+  tree: ExplorerTreeStructure,
   search: SearchMatcher,
   filter: Filter,
 ) {
-  expandAllNodes(explorerTree.root.tasks, false)
+  expandAllNodes(tree.root.tasks, false)
   const entries = [...filterAll(
+    tree,
     search,
     filter,
   )]

--- a/packages/ui/client/composables/explorer/expand.ts
+++ b/packages/ui/client/composables/explorer/expand.ts
@@ -1,5 +1,4 @@
-import type { ExplorerTreeStructure, Filter, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
-import { findById } from '~/composables/client'
+import type { ExplorerOperationContext, Filter, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
 import { filterAll, filterNode } from '~/composables/explorer/filter'
 import { filteredFiles, openedTreeItems, treeFilter, uiEntries } from '~/composables/explorer/state'
 import { createOrUpdateNode, createOrUpdateSuiteTask, isFileNode, isParentNode } from '~/composables/explorer/utils'
@@ -18,19 +17,19 @@ import { createOrUpdateNode, createOrUpdateSuiteTask, isFileNode, isParentNode }
  * - remove opened tree items for the node and any children
  * - update uiEntries including child nodes
  *
- * @param tree The explorer tree structure.
+ * @param context The explorer operation context.
  * @param id The node id to expand.
  * @param search The search applied.
  * @param filter The filter applied.
  */
 export function runExpandNode(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   id: string,
   search: SearchMatcher,
   filter: Filter,
 ) {
   const entry = createOrUpdateSuiteTask(
-    tree,
+    context,
     id,
     false,
   )
@@ -42,7 +41,7 @@ export function runExpandNode(
 
   // create only direct children
   for (const subtask of task.tasks) {
-    createOrUpdateNode(tree, node.id, subtask, false)
+    createOrUpdateNode(context, node.id, subtask, false)
   }
 
   // expand the node
@@ -53,7 +52,7 @@ export function runExpandNode(
   // collect children
   // the first node is itself only when it is a file
   const children = new Set(filterNode(
-    tree,
+    context,
     node,
     search,
     filter,
@@ -85,25 +84,25 @@ export function runExpandNode(
  * - update the filtered expandAll state to false
  * - update uiEntries with child nodes
  *
- * @param tree The explorer tree structure.
+ * @param context The explorer operation context.
  * @param search The search applied.
  * @param filter The filter applied.
  */
 export function runExpandAll(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   search: SearchMatcher,
   filter: Filter,
 ) {
-  expandAllNodes(tree.root.tasks, false)
+  expandAllNodes(context.root.tasks, false)
   const entries = [...filterAll(
-    tree,
+    context,
     search,
     filter,
   )]
   treeFilter.value.expandAll = false
   openedTreeItems.value = []
   uiEntries.value = entries
-  filteredFiles.value = entries.filter(isFileNode).map(f => findById(f.id)!)
+  filteredFiles.value = entries.filter(isFileNode).map(f => context.dataSource.getFile(f.id)!)
 }
 
 export function expandNodesOnEndRun(

--- a/packages/ui/client/composables/explorer/filter.ts
+++ b/packages/ui/client/composables/explorer/filter.ts
@@ -1,7 +1,6 @@
 import type { RunnerTask as Task } from 'vitest'
-import type { FileTreeNode, Filter, FilterResult, ParentTreeNode, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
+import type { ExplorerTreeStructure, FileTreeNode, Filter, FilterResult, ParentTreeNode, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
 import { client, config, findById } from '~/composables/client'
-import { explorerTree } from '~/composables/explorer/index'
 import { currentProjectName, filteredFiles, projectSort, uiEntries } from '~/composables/explorer/state'
 import {
   getSortedRootTasks,
@@ -16,14 +15,17 @@ export function testMatcher(task: Task, search: SearchMatcher, filter: Filter) {
 /**
  * Filter child nodes using search, filter and only tests.
  *
+ * @param tree The explorer tree structure.
  * @param search The search applied.
  * @param filter The filter applied.
  */
 export function runFilter(
+  tree: ExplorerTreeStructure,
   search: SearchMatcher,
   filter: Filter,
 ) {
   const entries = [...filterAll(
+    tree,
     search,
     filter,
   )]
@@ -32,21 +34,23 @@ export function runFilter(
 }
 
 export function* filterAll(
+  tree: ExplorerTreeStructure,
   search: SearchMatcher,
   filter: Filter,
 ) {
   const project = currentProjectName.value
-  const tasks = getSortedRootTasks(projectSort.value)
+  const tasks = getSortedRootTasks(projectSort.value, tree.root.tasks)
 
   for (const node of tasks) {
     if (project && node.projectName !== project) {
       continue
     }
-    yield* filterNode(node, search, filter)
+    yield* filterNode(tree, node, search, filter)
   }
 }
 
 export function* filterNode(
+  tree: ExplorerTreeStructure,
   node: UITaskTreeNode,
   search: SearchMatcher,
   filter: Filter,
@@ -60,6 +64,7 @@ export function* filterNode(
 
   if (filter.onlyTests) {
     for (const [match, child] of visitNode(
+      tree,
       node,
       treeNodes,
       n => matcher(n, search, filter),
@@ -69,6 +74,7 @@ export function* filterNode(
   }
   else {
     for (const [match, child] of visitNode(
+      tree,
       node,
       treeNodes,
       n => matcher(n, search, filter),
@@ -98,6 +104,7 @@ export function* filterNode(
   const filesToShow = new Set<string>()
 
   const entries = [...filterParents(
+    tree,
     list,
     filter.onlyTests,
     treeNodes,
@@ -111,7 +118,7 @@ export function* filterNode(
   // For example, if we have a suite with only one test, when collapsing the suite node,
   // we still need to show the suite, but the test must be removed from the list to render.
 
-  const map = explorerTree.nodes
+  const map = tree.nodes
 
   // When searching, expand parent nodes of matching tests so they are visible
   for (const id of treeNodes) {
@@ -134,6 +141,7 @@ export function* filterNode(
 }
 
 function expandCollapseNode(
+  tree: ExplorerTreeStructure,
   match: boolean,
   child: FileTreeNode | ParentTreeNode,
   treeNodes: Set<string>,
@@ -150,7 +158,7 @@ function expandCollapseNode(
     }
     // show the parent if at least one child matches the filter
     if (treeNodes.has(child.id)) {
-      const parent = explorerTree.nodes.get(child.parentId)
+      const parent = tree.nodes.get(child.parentId)
       if (parent && isFileNode(parent)) {
         filesToShow.add(parent.id)
       }
@@ -161,7 +169,7 @@ function expandCollapseNode(
   else {
     // show the parent if matches the filter or at least one child matches the filter
     if (match || treeNodes.has(child.id) || filesToShow.has(child.id)) {
-      const parent = explorerTree.nodes.get(child.parentId)
+      const parent = tree.nodes.get(child.parentId)
       if (parent && isFileNode(parent)) {
         filesToShow.add(parent.id)
       }
@@ -172,6 +180,7 @@ function expandCollapseNode(
 }
 
 function* filterParents(
+  tree: ExplorerTreeStructure,
   list: FilterResult[],
   collapseParents: boolean,
   treeNodes: Set<string>,
@@ -185,13 +194,13 @@ function* filterParents(
       if (isParent) {
         treeNodes.add(child.id)
       }
-      let parent = explorerTree.nodes.get(child.parentId)
+      let parent = tree.nodes.get(child.parentId)
       while (parent) {
         treeNodes.add(parent.id)
         if (isFileNode(parent)) {
           filesToShow.add(parent.id)
         }
-        parent = explorerTree.nodes.get(parent.parentId)
+        parent = tree.nodes.get(parent.parentId)
       }
       yield child
       continue
@@ -199,6 +208,7 @@ function* filterParents(
 
     if (isParent) {
       const node = expandCollapseNode(
+        tree,
         match,
         child,
         treeNodes,
@@ -210,7 +220,7 @@ function* filterParents(
       }
     }
     else if (match) {
-      const parent = explorerTree.nodes.get(child.parentId)
+      const parent = tree.nodes.get(child.parentId)
       if (parent && isFileNode(parent)) {
         filesToShow.add(parent.id)
       }
@@ -269,6 +279,7 @@ function matchTask(
 }
 
 function* visitNode(
+  tree: ExplorerTreeStructure,
   node: UITaskTreeNode,
   treeNodes: Set<string>,
   matcher: (node: UITaskTreeNode) => boolean,
@@ -277,10 +288,10 @@ function* visitNode(
 
   if (match) {
     if (isTestNode(node)) {
-      let parent = explorerTree.nodes.get(node.parentId)
+      let parent = tree.nodes.get(node.parentId)
       while (parent) {
         treeNodes.add(parent.id)
-        parent = explorerTree.nodes.get(parent.parentId)
+        parent = tree.nodes.get(parent.parentId)
       }
     }
     else if (isFileNode(node)) {
@@ -288,10 +299,10 @@ function* visitNode(
     }
     else {
       treeNodes.add(node.id)
-      let parent = explorerTree.nodes.get(node.parentId)
+      let parent = tree.nodes.get(node.parentId)
       while (parent) {
         treeNodes.add(parent.id)
-        parent = explorerTree.nodes.get(parent.parentId)
+        parent = tree.nodes.get(parent.parentId)
       }
     }
   }
@@ -299,7 +310,7 @@ function* visitNode(
   yield [match, node]
   if (isParentNode(node)) {
     for (let i = 0; i < node.tasks.length; i++) {
-      yield* visitNode(node.tasks[i], treeNodes, matcher)
+      yield* visitNode(tree, node.tasks[i], treeNodes, matcher)
     }
   }
 }

--- a/packages/ui/client/composables/explorer/filter.ts
+++ b/packages/ui/client/composables/explorer/filter.ts
@@ -1,6 +1,5 @@
 import type { RunnerTask as Task } from 'vitest'
-import type { ExplorerTreeStructure, FileTreeNode, Filter, FilterResult, ParentTreeNode, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
-import { client, config, findById } from '~/composables/client'
+import type { ExplorerOperationContext, FileTreeNode, Filter, FilterResult, ParentTreeNode, SearchMatcher, UITaskTreeNode } from '~/composables/explorer/types'
 import { currentProjectName, filteredFiles, projectSort, uiEntries } from '~/composables/explorer/state'
 import {
   getSortedRootTasks,
@@ -9,48 +8,48 @@ import {
   isTestNode,
 } from '~/composables/explorer/utils'
 
-export function testMatcher(task: Task, search: SearchMatcher, filter: Filter) {
-  return task ? matchTask(task, search, filter) : false
+export function testMatcher(context: ExplorerOperationContext, task: Task, search: SearchMatcher, filter: Filter) {
+  return task ? matchTask(context, task, search, filter) : false
 }
 /**
  * Filter child nodes using search, filter and only tests.
  *
- * @param tree The explorer tree structure.
+ * @param context The explorer operation context.
  * @param search The search applied.
  * @param filter The filter applied.
  */
 export function runFilter(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   search: SearchMatcher,
   filter: Filter,
 ) {
   const entries = [...filterAll(
-    tree,
+    context,
     search,
     filter,
   )]
   uiEntries.value = entries
-  filteredFiles.value = entries.filter(isFileNode).map(f => findById(f.id)!)
+  filteredFiles.value = entries.filter(isFileNode).map(f => context.dataSource.getFile(f.id)!)
 }
 
 export function* filterAll(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   search: SearchMatcher,
   filter: Filter,
 ) {
   const project = currentProjectName.value
-  const tasks = getSortedRootTasks(projectSort.value, tree.root.tasks)
+  const tasks = getSortedRootTasks(projectSort.value, context.root.tasks)
 
   for (const node of tasks) {
     if (project && node.projectName !== project) {
       continue
     }
-    yield* filterNode(tree, node, search, filter)
+    yield* filterNode(context, node, search, filter)
   }
 }
 
 export function* filterNode(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   node: UITaskTreeNode,
   search: SearchMatcher,
   filter: Filter,
@@ -64,20 +63,20 @@ export function* filterNode(
 
   if (filter.onlyTests) {
     for (const [match, child] of visitNode(
-      tree,
+      context,
       node,
       treeNodes,
-      n => matcher(n, search, filter),
+      n => matcher(context, n, search, filter),
     )) {
       list.push([match, child])
     }
   }
   else {
     for (const [match, child] of visitNode(
-      tree,
+      context,
       node,
       treeNodes,
-      n => matcher(n, search, filter),
+      n => matcher(context, n, search, filter),
     )) {
       if (isParentNode(child)) {
         parentsMap.set(child.id, match)
@@ -104,7 +103,7 @@ export function* filterNode(
   const filesToShow = new Set<string>()
 
   const entries = [...filterParents(
-    tree,
+    context,
     list,
     filter.onlyTests,
     treeNodes,
@@ -118,7 +117,7 @@ export function* filterNode(
   // For example, if we have a suite with only one test, when collapsing the suite node,
   // we still need to show the suite, but the test must be removed from the list to render.
 
-  const map = tree.nodes
+  const map = context.nodes
 
   // When searching, expand parent nodes of matching tests so they are visible
   for (const id of treeNodes) {
@@ -141,7 +140,7 @@ export function* filterNode(
 }
 
 function expandCollapseNode(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   match: boolean,
   child: FileTreeNode | ParentTreeNode,
   treeNodes: Set<string>,
@@ -158,7 +157,7 @@ function expandCollapseNode(
     }
     // show the parent if at least one child matches the filter
     if (treeNodes.has(child.id)) {
-      const parent = tree.nodes.get(child.parentId)
+      const parent = context.nodes.get(child.parentId)
       if (parent && isFileNode(parent)) {
         filesToShow.add(parent.id)
       }
@@ -169,7 +168,7 @@ function expandCollapseNode(
   else {
     // show the parent if matches the filter or at least one child matches the filter
     if (match || treeNodes.has(child.id) || filesToShow.has(child.id)) {
-      const parent = tree.nodes.get(child.parentId)
+      const parent = context.nodes.get(child.parentId)
       if (parent && isFileNode(parent)) {
         filesToShow.add(parent.id)
       }
@@ -180,7 +179,7 @@ function expandCollapseNode(
 }
 
 function* filterParents(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   list: FilterResult[],
   collapseParents: boolean,
   treeNodes: Set<string>,
@@ -194,13 +193,13 @@ function* filterParents(
       if (isParent) {
         treeNodes.add(child.id)
       }
-      let parent = tree.nodes.get(child.parentId)
+      let parent = context.nodes.get(child.parentId)
       while (parent) {
         treeNodes.add(parent.id)
         if (isFileNode(parent)) {
           filesToShow.add(parent.id)
         }
-        parent = tree.nodes.get(parent.parentId)
+        parent = context.nodes.get(parent.parentId)
       }
       yield child
       continue
@@ -208,7 +207,7 @@ function* filterParents(
 
     if (isParent) {
       const node = expandCollapseNode(
-        tree,
+        context,
         match,
         child,
         treeNodes,
@@ -220,7 +219,7 @@ function* filterParents(
       }
     }
     else if (match) {
-      const parent = tree.nodes.get(child.parentId)
+      const parent = context.nodes.get(child.parentId)
       if (parent && isFileNode(parent)) {
         filesToShow.add(parent.id)
       }
@@ -229,10 +228,10 @@ function* filterParents(
   }
 }
 
-function matchState(task: Task, filter: Filter) {
+function matchState(context: ExplorerOperationContext, task: Task, filter: Filter) {
   if (filter.slow) {
     if (task.type === 'test') {
-      const threshold = config.value.slowTestThreshold
+      const threshold = context.dataSource.getSlowTestThreshold()
       if (typeof threshold === 'number' && typeof task.result?.duration === 'number' && task.result.duration > threshold) {
         return true
       }
@@ -258,6 +257,7 @@ function matchState(task: Task, filter: Filter) {
 }
 
 function matchTask(
+  context: ExplorerOperationContext,
   task: Task,
   search: SearchMatcher,
   filter: Filter,
@@ -266,7 +266,7 @@ function matchTask(
   if (search(task)) {
     const hasStatusFilter = filter.success || filter.failed || filter.skipped || filter.slow
     if (hasStatusFilter) {
-      if (matchState(task, filter)) {
+      if (matchState(context, task, filter)) {
         return true
       }
     }
@@ -279,7 +279,7 @@ function matchTask(
 }
 
 function* visitNode(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   node: UITaskTreeNode,
   treeNodes: Set<string>,
   matcher: (node: UITaskTreeNode) => boolean,
@@ -288,10 +288,10 @@ function* visitNode(
 
   if (match) {
     if (isTestNode(node)) {
-      let parent = tree.nodes.get(node.parentId)
+      let parent = context.nodes.get(node.parentId)
       while (parent) {
         treeNodes.add(parent.id)
-        parent = tree.nodes.get(parent.parentId)
+        parent = context.nodes.get(parent.parentId)
       }
     }
     else if (isFileNode(node)) {
@@ -299,10 +299,10 @@ function* visitNode(
     }
     else {
       treeNodes.add(node.id)
-      let parent = tree.nodes.get(node.parentId)
+      let parent = context.nodes.get(node.parentId)
       while (parent) {
         treeNodes.add(parent.id)
-        parent = tree.nodes.get(parent.parentId)
+        parent = context.nodes.get(parent.parentId)
       }
     }
   }
@@ -310,12 +310,12 @@ function* visitNode(
   yield [match, node]
   if (isParentNode(node)) {
     for (let i = 0; i < node.tasks.length; i++) {
-      yield* visitNode(tree, node.tasks[i], treeNodes, matcher)
+      yield* visitNode(context, node.tasks[i], treeNodes, matcher)
     }
   }
 }
 
-function matcher(node: UITaskTreeNode, search: SearchMatcher, filter: Filter) {
-  const task = client.state.idMap.get(node.id)
-  return task ? matchTask(task, search, filter) : false
+function matcher(context: ExplorerOperationContext, node: UITaskTreeNode, search: SearchMatcher, filter: Filter) {
+  const task = context.dataSource.getTask(node.id)
+  return task ? matchTask(context, task, search, filter) : false
 }

--- a/packages/ui/client/composables/explorer/search.ts
+++ b/packages/ui/client/composables/explorer/search.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import type { SortUIType } from '~/composables/explorer/types'
+import type { FilteredTests, SortUIType } from '~/composables/explorer/types'
 import { debouncedWatch } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import { explorerTree } from '~/composables/explorer'
@@ -18,10 +18,32 @@ import {
   projectSort,
   search,
   searchMatcher,
-  testsTotal,
   treeFilter,
   uiEntries,
 } from './state'
+
+const testsTotal = computed<FilteredTests>(() => {
+  const filtered = isFiltered.value
+  const filteredByStatus = isFilteredByStatus.value
+  const project = currentProjectName.value
+  const onlyTests = filter.onlyTests
+  const failed = explorerTree.summary.filesFailed
+  const success = explorerTree.summary.filesSuccess
+  const skipped = explorerTree.summary.filesSkipped
+  const running = explorerTree.summary.filesRunning
+  const files = filteredFiles.value
+  return explorerTree.collectTestsTotal(
+    filtered || filteredByStatus || !!project,
+    onlyTests,
+    files,
+    {
+      failed,
+      success,
+      skipped,
+      running,
+    },
+  )
+})
 
 export function useSearch(
   searchBox: Ref<HTMLInputElement | undefined>,

--- a/packages/ui/client/composables/explorer/state.ts
+++ b/packages/ui/client/composables/explorer/state.ts
@@ -1,5 +1,5 @@
 import type { RunnerTestFile as File, RunnerTask as Task } from 'vitest'
-import type { FileTreeNode, Filter, FilteredTests, SortUIType, TreeFilterState, UITaskTreeNode } from './types'
+import type { FileTreeNode, Filter, SortUIType, TreeFilterState, UITaskTreeNode } from './types'
 import { useLocalStorage } from '@vueuse/core'
 import { computed, reactive, ref, shallowRef } from 'vue'
 import { availableProjects } from '~/composables/client'
@@ -7,7 +7,6 @@ import { caseInsensitiveMatch } from '~/utils/task'
 // importing from the source because we need to bundle it
 import { createTagsFilter } from '../../../../vitest/src/runtime/runner/utils/tags'
 import { config } from '../client'
-import { explorerTree } from './index'
 
 export const uiFiles = shallowRef<FileTreeNode[]>([])
 export const uiEntries = shallowRef<UITaskTreeNode[]>([])
@@ -127,26 +126,4 @@ export const shouldShowExpandAll = computed(() => {
   }
 
   return expandAll !== false
-})
-export const testsTotal = computed<FilteredTests>(() => {
-  const filtered = isFiltered.value
-  const filteredByStatus = isFilteredByStatus.value
-  const project = currentProjectName.value
-  const onlyTests = filter.onlyTests
-  const failed = explorerTree.summary.filesFailed
-  const success = explorerTree.summary.filesSuccess
-  const skipped = explorerTree.summary.filesSkipped
-  const running = explorerTree.summary.filesRunning
-  const files = filteredFiles.value
-  return explorerTree.collectTestsTotal(
-    filtered || filteredByStatus || !!project,
-    onlyTests,
-    files,
-    {
-      failed,
-      success,
-      skipped,
-      running,
-    },
-  )
 })

--- a/packages/ui/client/composables/explorer/state.ts
+++ b/packages/ui/client/composables/explorer/state.ts
@@ -2,11 +2,10 @@ import type { RunnerTestFile as File, RunnerTask as Task } from 'vitest'
 import type { FileTreeNode, Filter, SortUIType, TreeFilterState, UITaskTreeNode } from './types'
 import { useLocalStorage } from '@vueuse/core'
 import { computed, reactive, ref, shallowRef } from 'vue'
-import { availableProjects } from '~/composables/client'
+import { availableProjects, config } from '~/composables/client/state'
 import { caseInsensitiveMatch } from '~/utils/task'
 // importing from the source because we need to bundle it
 import { createTagsFilter } from '../../../../vitest/src/runtime/runner/utils/tags'
-import { config } from '../client'
 
 export const uiFiles = shallowRef<FileTreeNode[]>([])
 export const uiEntries = shallowRef<UITaskTreeNode[]>([])

--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -1,4 +1,4 @@
-import type { RunnerTestFile as File, RunnerTaskEventPack, RunnerTaskResultPack as TaskResultPack, TestArtifact } from 'vitest'
+import type { RunnerTestFile as File, RunnerTask, RunnerTaskEventPack, RunnerTaskResultPack as TaskResultPack, TestArtifact } from 'vitest'
 import type {
   CollectorInfo,
   FilteredTests,
@@ -15,11 +15,14 @@ import {
   filter,
   searchMatcher,
 } from '~/composables/explorer/state'
+import { isFileNode } from '~/composables/explorer/utils'
+import { isSuite as isTaskSuite } from '~/utils/task'
+import { getTasks } from '../../../../vitest/src/utils/tasks'
 
 export class ExplorerTree {
   private rafCollector: ReturnType<typeof useRafFn>
   private resumeEndRunId: ReturnType<typeof setTimeout> | undefined
-  public startTime: number = 0
+  private startTime: number = 0
   public executionTime: number = 0
   constructor(
     public projects: string[] = [],
@@ -66,6 +69,8 @@ export class ExplorerTree {
     this.colors = new Map(projects.map(p => [p.name, p.color]))
 
     runLoadFiles(
+      this,
+      this.colors,
       remoteFiles,
       true,
       searchMatcher.value.matcher,
@@ -85,8 +90,52 @@ export class ExplorerTree {
     this.collect(true, false)
   }
 
+  setRunStartTime(startTime?: number) {
+    this.startTime = startTime || performance.now()
+  }
+
+  clearTaskResult(task: RunnerTask) {
+    delete task.result
+    const node = this.nodes.get(task.id)
+    if (node) {
+      node.state = undefined
+      // update task mode to allow change icon on skipped tests
+      task.mode = 'run'
+      node.duration = undefined
+      if (isTaskSuite(task)) {
+        for (const child of task.tasks) {
+          this.clearTaskResult(child)
+        }
+      }
+    }
+  }
+
+  clearResults(files: File[]) {
+    files.forEach((f) => {
+      delete f.result
+      getTasks(f).forEach((task) => {
+        delete task.result
+        const node = this.nodes.get(task.id)
+        if (node) {
+          node.state = undefined
+          node.mode = 'run'
+          node.duration = undefined
+        }
+      })
+      const file = this.nodes.get(f.id)
+      if (file) {
+        file.state = undefined
+        file.mode = 'run'
+        file.duration = undefined
+        if (isFileNode(file)) {
+          file.collectDuration = undefined
+        }
+      }
+    })
+  }
+
   recordTestArtifact(testId: string, artifact: TestArtifact) {
-    recordTestArtifact(testId, artifact)
+    recordTestArtifact(this.pendingTasks, testId, artifact)
     if (!this.onTaskUpdateCalled) {
       clearTimeout(this.resumeEndRunId)
       this.onTaskUpdateCalled = true
@@ -96,7 +145,7 @@ export class ExplorerTree {
   }
 
   resumeRun(packs: TaskResultPack[], _events: RunnerTaskEventPack[]) {
-    preparePendingTasks(packs)
+    preparePendingTasks(this.pendingTasks, packs)
     if (!this.onTaskUpdateCalled) {
       clearTimeout(this.resumeEndRunId)
       this.onTaskUpdateCalled = true
@@ -120,6 +169,9 @@ export class ExplorerTree {
     if (task) {
       queueMicrotask(() => {
         runCollect(
+          this,
+          this.colors,
+          this.pendingTasks,
           start,
           end,
           this.summary,
@@ -137,6 +189,9 @@ export class ExplorerTree {
     }
     else {
       runCollect(
+        this,
+        this.colors,
+        this.pendingTasks,
         start,
         end,
         this.summary,
@@ -170,13 +225,13 @@ export class ExplorerTree {
 
   collapseNode(id: string) {
     queueMicrotask(() => {
-      runCollapseNode(id)
+      runCollapseNode(this, id)
     })
   }
 
   expandNode(id: string) {
     queueMicrotask(() => {
-      runExpandNode(id, searchMatcher.value.matcher, {
+      runExpandNode(this, id, searchMatcher.value.matcher, {
         failed: filter.failed,
         success: filter.success,
         skipped: filter.skipped,
@@ -188,13 +243,13 @@ export class ExplorerTree {
 
   collapseAllNodes() {
     queueMicrotask(() => {
-      runCollapseAllTask()
+      runCollapseAllTask(this)
     })
   }
 
   expandAllNodes() {
     queueMicrotask(() => {
-      runExpandAll(searchMatcher.value.matcher, {
+      runExpandAll(this, searchMatcher.value.matcher, {
         failed: filter.failed,
         success: filter.success,
         skipped: filter.skipped,
@@ -206,7 +261,7 @@ export class ExplorerTree {
 
   filterNodes() {
     queueMicrotask(() => {
-      runFilter(searchMatcher.value.matcher, {
+      runFilter(this, searchMatcher.value.matcher, {
         failed: filter.failed,
         success: filter.success,
         skipped: filter.skipped,

--- a/packages/ui/client/composables/explorer/tree.ts
+++ b/packages/ui/client/composables/explorer/tree.ts
@@ -1,6 +1,8 @@
 import type { RunnerTestFile as File, RunnerTask, RunnerTaskEventPack, RunnerTaskResultPack as TaskResultPack, TestArtifact } from 'vitest'
 import type {
   CollectorInfo,
+  ExplorerDataSource,
+  ExplorerOperationContext,
   FilteredTests,
   RootTreeNode,
   UITaskTreeNode,
@@ -24,44 +26,67 @@ export class ExplorerTree {
   private resumeEndRunId: ReturnType<typeof setTimeout> | undefined
   private startTime: number = 0
   public executionTime: number = 0
+  public projects: string[] = []
+  public colors = new Map<string, string | undefined>()
+  private onTaskUpdateCalled: boolean = false
+  private root = <RootTreeNode>{
+    id: 'vitest-root-node',
+    expandable: true,
+    expanded: true,
+    tasks: [],
+  }
+
+  private pendingTasks = new Map<string, Set<string>>()
+  private nodes = new Map<string, UITaskTreeNode>()
+  public summary = reactive<CollectorInfo>({
+    files: 0,
+    time: '',
+    filesFailed: 0,
+    filesSuccess: 0,
+    filesIgnore: 0,
+    filesRunning: 0,
+    filesSkipped: 0,
+    filesSnapshotFailed: 0,
+    filesTodo: 0,
+    testsFailed: 0,
+    testsSuccess: 0,
+    testsIgnore: 0,
+    testsSkipped: 0,
+    testsTodo: 0,
+    testsExpectedFail: 0,
+    testsSlow: 0,
+    totalTests: 0,
+    failedSnapshot: false,
+    failedSnapshotEnabled: false,
+  })
+
   constructor(
-    public projects: string[] = [],
-    public colors = new Map<string, string | undefined>(),
-    private onTaskUpdateCalled: boolean = false,
+    private dataSource?: ExplorerDataSource,
     private resumeEndTimeout = 500,
-    public root = <RootTreeNode>{
-      id: 'vitest-root-node',
-      expandable: true,
-      expanded: true,
-      tasks: [],
-    },
-    public pendingTasks = new Map<string, Set<string>>(),
-    public nodes = new Map<string, UITaskTreeNode>(),
-    public summary = reactive<CollectorInfo>({
-      files: 0,
-      time: '',
-      filesFailed: 0,
-      filesSuccess: 0,
-      filesIgnore: 0,
-      filesRunning: 0,
-      filesSkipped: 0,
-      filesSnapshotFailed: 0,
-      filesTodo: 0,
-      testsFailed: 0,
-      testsSuccess: 0,
-      testsIgnore: 0,
-      testsSkipped: 0,
-      testsTodo: 0,
-      testsExpectedFail: 0,
-      testsSlow: 0,
-      totalTests: 0,
-      failedSnapshot: false,
-      failedSnapshotEnabled: false,
-    }),
   ) {
     // will run runCollect every ~100ms: 1000/10 = 100ms
     // (beware increasing fpsLimit, it can be too much for the browser)
     this.rafCollector = useRafFn(this.runCollect.bind(this), { fpsLimit: 10, immediate: false })
+  }
+
+  connect(dataSource: ExplorerDataSource) {
+    if (this.dataSource) {
+      throw new Error('ExplorerTree data source is already configured')
+    }
+    this.dataSource = dataSource
+  }
+
+  private getContext(): ExplorerOperationContext {
+    if (!this.dataSource) {
+      throw new Error('ExplorerTree data source is not configured')
+    }
+    return {
+      root: this.root,
+      nodes: this.nodes,
+      colors: this.colors,
+      pendingTasks: this.pendingTasks,
+      dataSource: this.dataSource,
+    }
   }
 
   loadFiles(remoteFiles: File[], projects: { name: string; color?: string }[]) {
@@ -69,8 +94,7 @@ export class ExplorerTree {
     this.colors = new Map(projects.map(p => [p.name, p.color]))
 
     runLoadFiles(
-      this,
-      this.colors,
+      this.getContext(),
       remoteFiles,
       true,
       searchMatcher.value.matcher,
@@ -85,6 +109,7 @@ export class ExplorerTree {
   }
 
   startRun() {
+    this.getContext()
     this.startTime = performance.now()
     this.resumeEndRunId = setTimeout(() => this.endRun(), this.resumeEndTimeout)
     this.collect(true, false)
@@ -135,7 +160,7 @@ export class ExplorerTree {
   }
 
   recordTestArtifact(testId: string, artifact: TestArtifact) {
-    recordTestArtifact(this.pendingTasks, testId, artifact)
+    recordTestArtifact(this.getContext(), testId, artifact)
     if (!this.onTaskUpdateCalled) {
       clearTimeout(this.resumeEndRunId)
       this.onTaskUpdateCalled = true
@@ -145,7 +170,7 @@ export class ExplorerTree {
   }
 
   resumeRun(packs: TaskResultPack[], _events: RunnerTaskEventPack[]) {
-    preparePendingTasks(this.pendingTasks, packs)
+    preparePendingTasks(this.getContext(), packs)
     if (!this.onTaskUpdateCalled) {
       clearTimeout(this.resumeEndRunId)
       this.onTaskUpdateCalled = true
@@ -166,12 +191,11 @@ export class ExplorerTree {
   }
 
   private collect(start: boolean, end: boolean, task = true) {
+    const context = this.getContext()
     if (task) {
       queueMicrotask(() => {
         runCollect(
-          this,
-          this.colors,
-          this.pendingTasks,
+          context,
           start,
           end,
           this.summary,
@@ -189,9 +213,7 @@ export class ExplorerTree {
     }
     else {
       runCollect(
-        this,
-        this.colors,
-        this.pendingTasks,
+        context,
         start,
         end,
         this.summary,
@@ -214,7 +236,7 @@ export class ExplorerTree {
     tests: File[],
     filesSummary: FilteredTests,
   ) {
-    return collectTestsTotalData(filtered, onlyTests, tests, filesSummary, searchMatcher.value.matcher, {
+    return collectTestsTotalData(this.getContext(), filtered, onlyTests, tests, filesSummary, searchMatcher.value.matcher, {
       failed: filter.failed,
       success: filter.success,
       skipped: filter.skipped,
@@ -224,14 +246,16 @@ export class ExplorerTree {
   }
 
   collapseNode(id: string) {
+    const context = this.getContext()
     queueMicrotask(() => {
-      runCollapseNode(this, id)
+      runCollapseNode(context, id)
     })
   }
 
   expandNode(id: string) {
+    const context = this.getContext()
     queueMicrotask(() => {
-      runExpandNode(this, id, searchMatcher.value.matcher, {
+      runExpandNode(context, id, searchMatcher.value.matcher, {
         failed: filter.failed,
         success: filter.success,
         skipped: filter.skipped,
@@ -242,14 +266,16 @@ export class ExplorerTree {
   }
 
   collapseAllNodes() {
+    const context = this.getContext()
     queueMicrotask(() => {
-      runCollapseAllTask(this)
+      runCollapseAllTask(context)
     })
   }
 
   expandAllNodes() {
+    const context = this.getContext()
     queueMicrotask(() => {
-      runExpandAll(this, searchMatcher.value.matcher, {
+      runExpandAll(context, searchMatcher.value.matcher, {
         failed: filter.failed,
         success: filter.success,
         skipped: filter.skipped,
@@ -260,8 +286,9 @@ export class ExplorerTree {
   }
 
   filterNodes() {
+    const context = this.getContext()
     queueMicrotask(() => {
-      runFilter(this, searchMatcher.value.matcher, {
+      runFilter(context, searchMatcher.value.matcher, {
         failed: filter.failed,
         success: filter.success,
         skipped: filter.skipped,

--- a/packages/ui/client/composables/explorer/types.ts
+++ b/packages/ui/client/composables/explorer/types.ts
@@ -1,4 +1,5 @@
-import type { RunMode, RunnerTask as Task, TaskState } from 'vitest'
+import type { RunnerTestFile as File, RunMode, RunnerTask as Task, TaskState } from 'vitest'
+import type { RunState } from '../../../types'
 
 export type FilterResult = [match: boolean, node: UITaskTreeNode]
 
@@ -34,6 +35,20 @@ export interface RootTreeNode extends TaskTreeNode {
 export interface ExplorerTreeStructure {
   root: RootTreeNode
   nodes: Map<string, UITaskTreeNode>
+}
+
+export interface ExplorerDataSource {
+  getTask: (id: string) => Task | undefined
+  getFile: (id: string) => File | undefined
+  getFiles: () => File[]
+  getSlowTestThreshold: () => number | undefined
+  setRunState: (state: RunState) => void
+}
+
+export interface ExplorerOperationContext extends ExplorerTreeStructure {
+  colors: Map<string, string | undefined>
+  pendingTasks: Map<string, Set<string>>
+  dataSource: ExplorerDataSource
 }
 
 export type TaskTreeNodeType = 'file' | 'suite' | 'test'

--- a/packages/ui/client/composables/explorer/types.ts
+++ b/packages/ui/client/composables/explorer/types.ts
@@ -31,6 +31,11 @@ export interface RootTreeNode extends TaskTreeNode {
   tasks: FileTreeNode[]
 }
 
+export interface ExplorerTreeStructure {
+  root: RootTreeNode
+  nodes: Map<string, UITaskTreeNode>
+}
+
 export type TaskTreeNodeType = 'file' | 'suite' | 'test'
 
 export interface UITaskTreeNode extends TaskTreeNode {

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -1,5 +1,6 @@
 import type { RunnerTestFile as File, RunnerTask as Task } from 'vitest'
 import type {
+  ExplorerTreeStructure,
   FileTreeNode,
   ParentTreeNode,
   SortUIType,
@@ -8,7 +9,6 @@ import type {
   UITaskTreeNode,
 } from '~/composables/explorer/types'
 import { client, config } from '~/composables/client'
-import { explorerTree } from '~/composables/explorer/index'
 import { openedTreeItemsSet } from '~/composables/explorer/state'
 import { getBadgeNameColor, isSuite as isTaskSuite } from '~/utils/task'
 
@@ -42,7 +42,7 @@ export function isSlowTestTask(task: Task) {
   return typeof threshold === 'number' && duration > threshold
 }
 
-export function getSortedRootTasks(sort: SortUIType, tasks = explorerTree.root.tasks) {
+export function getSortedRootTasks(sort: SortUIType, tasks: FileTreeNode[]) {
   const sorted = [...tasks]
 
   sorted.sort((a, b) => {
@@ -72,10 +72,12 @@ export function getSortedRootTasks(sort: SortUIType, tasks = explorerTree.root.t
 }
 
 export function createOrUpdateFileNode(
+  tree: ExplorerTreeStructure,
+  colors: Map<string, string | undefined>,
   file: File,
   collect = false,
 ) {
-  let fileNode = explorerTree.nodes.get(file.id) as FileTreeNode | undefined
+  let fileNode = tree.nodes.get(file.id) as FileTreeNode | undefined
 
   if (fileNode) {
     fileNode.typecheck = !!file.meta && 'typecheck' in file.meta
@@ -108,28 +110,29 @@ export function createOrUpdateFileNode(
       slow: false,
       filepath: file.filepath,
       projectName: file.projectName || '',
-      projectNameColor: explorerTree.colors.get(file.projectName || '') || getBadgeNameColor(file.projectName),
+      projectNameColor: colors.get(file.projectName || '') || getBadgeNameColor(file.projectName),
       collectDuration: file.collectDuration,
       setupDuration: file.setupDuration,
       environmentLoad: file.environmentLoad,
       prepareDuration: file.prepareDuration,
       state: file.result?.state,
     }
-    explorerTree.nodes.set(file.id, fileNode)
-    explorerTree.root.tasks.push(fileNode)
+    tree.nodes.set(file.id, fileNode)
+    tree.root.tasks.push(fileNode)
   }
   if (collect) {
     for (let i = 0; i < file.tasks.length; i++) {
-      createOrUpdateNode(file.id, file.tasks[i], true)
+      createOrUpdateNode(tree, file.id, file.tasks[i], true)
     }
   }
 }
 
 export function createOrUpdateSuiteTask(
+  tree: ExplorerTreeStructure,
   id: string,
   all: boolean,
 ) {
-  const node = explorerTree.nodes.get(id)
+  const node = tree.nodes.get(id)
   if (!node || !isParentNode(node)) {
     return
   }
@@ -141,13 +144,13 @@ export function createOrUpdateSuiteTask(
   }
 
   // update the node
-  createOrUpdateNode(node.parentId, task, all && task.tasks.length > 0)
+  createOrUpdateNode(tree, node.parentId, task, all && task.tasks.length > 0)
 
   return [node, task] as const
 }
 
-export function createOrUpdateNodeTask(id: string) {
-  const node = explorerTree.nodes.get(id)
+export function createOrUpdateNodeTask(tree: ExplorerTreeStructure, id: string) {
+  const node = tree.nodes.get(id)
   if (!node) {
     return
   }
@@ -158,21 +161,22 @@ export function createOrUpdateNodeTask(id: string) {
     return
   }
 
-  createOrUpdateNode(node.parentId, task, false)
+  createOrUpdateNode(tree, node.parentId, task, false)
 }
 
 export function createOrUpdateNode(
+  tree: ExplorerTreeStructure,
   parentId: string,
   task: Task,
   createAll: boolean,
 ) {
-  const node = explorerTree.nodes.get(parentId) as ParentTreeNode | undefined
+  const node = tree.nodes.get(parentId) as ParentTreeNode | undefined
   let taskNode: UITaskTreeNode | undefined
   const duration = typeof task.result?.duration === 'number'
     ? Math.round(task.result.duration)
     : undefined
   if (node) {
-    taskNode = explorerTree.nodes.get(task.id)
+    taskNode = tree.nodes.get(task.id)
     if (taskNode) {
       if (!node.children.has(task.id)) {
         node.tasks.push(taskNode)
@@ -221,14 +225,14 @@ export function createOrUpdateNode(
           state: task.result?.state,
         } as SuiteTreeNode
       }
-      explorerTree.nodes.set(task.id, taskNode)
+      tree.nodes.set(task.id, taskNode)
       node.tasks.push(taskNode)
       node.children.add(task.id)
     }
 
     if (taskNode && createAll && isTaskSuite(task)) {
       for (let i = 0; i < task.tasks.length; i++) {
-        createOrUpdateNode(taskNode.id, task.tasks[i], createAll)
+        createOrUpdateNode(tree, taskNode.id, task.tasks[i], createAll)
       }
     }
   }

--- a/packages/ui/client/composables/explorer/utils.ts
+++ b/packages/ui/client/composables/explorer/utils.ts
@@ -1,6 +1,6 @@
 import type { RunnerTestFile as File, RunnerTask as Task } from 'vitest'
 import type {
-  ExplorerTreeStructure,
+  ExplorerOperationContext,
   FileTreeNode,
   ParentTreeNode,
   SortUIType,
@@ -8,7 +8,6 @@ import type {
   TestTreeNode,
   UITaskTreeNode,
 } from '~/composables/explorer/types'
-import { client, config } from '~/composables/client'
 import { openedTreeItemsSet } from '~/composables/explorer/state'
 import { getBadgeNameColor, isSuite as isTaskSuite } from '~/utils/task'
 
@@ -28,7 +27,7 @@ export function isParentNode(node: UITaskTreeNode): node is FileTreeNode | Suite
   return node.type === 'file' || node.type === 'suite'
 }
 
-export function isSlowTestTask(task: Task) {
+export function isSlowTestTask(context: ExplorerOperationContext, task: Task) {
   if (task.type !== 'test') {
     return false
   }
@@ -38,7 +37,7 @@ export function isSlowTestTask(task: Task) {
     return false
   }
 
-  const threshold = config.value.slowTestThreshold
+  const threshold = context.dataSource.getSlowTestThreshold()
   return typeof threshold === 'number' && duration > threshold
 }
 
@@ -72,12 +71,11 @@ export function getSortedRootTasks(sort: SortUIType, tasks: FileTreeNode[]) {
 }
 
 export function createOrUpdateFileNode(
-  tree: ExplorerTreeStructure,
-  colors: Map<string, string | undefined>,
+  context: ExplorerOperationContext,
   file: File,
   collect = false,
 ) {
-  let fileNode = tree.nodes.get(file.id) as FileTreeNode | undefined
+  let fileNode = context.nodes.get(file.id) as FileTreeNode | undefined
 
   if (fileNode) {
     fileNode.typecheck = !!file.meta && 'typecheck' in file.meta
@@ -110,73 +108,73 @@ export function createOrUpdateFileNode(
       slow: false,
       filepath: file.filepath,
       projectName: file.projectName || '',
-      projectNameColor: colors.get(file.projectName || '') || getBadgeNameColor(file.projectName),
+      projectNameColor: context.colors.get(file.projectName || '') || getBadgeNameColor(file.projectName),
       collectDuration: file.collectDuration,
       setupDuration: file.setupDuration,
       environmentLoad: file.environmentLoad,
       prepareDuration: file.prepareDuration,
       state: file.result?.state,
     }
-    tree.nodes.set(file.id, fileNode)
-    tree.root.tasks.push(fileNode)
+    context.nodes.set(file.id, fileNode)
+    context.root.tasks.push(fileNode)
   }
   if (collect) {
     for (let i = 0; i < file.tasks.length; i++) {
-      createOrUpdateNode(tree, file.id, file.tasks[i], true)
+      createOrUpdateNode(context, file.id, file.tasks[i], true)
     }
   }
 }
 
 export function createOrUpdateSuiteTask(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   id: string,
   all: boolean,
 ) {
-  const node = tree.nodes.get(id)
+  const node = context.nodes.get(id)
   if (!node || !isParentNode(node)) {
     return
   }
 
-  const task = client.state.idMap.get(id)
+  const task = context.dataSource.getTask(id)
   // if no children just return
   if (!task || !isTaskSuite(task)) {
     return
   }
 
   // update the node
-  createOrUpdateNode(tree, node.parentId, task, all && task.tasks.length > 0)
+  createOrUpdateNode(context, node.parentId, task, all && task.tasks.length > 0)
 
   return [node, task] as const
 }
 
-export function createOrUpdateNodeTask(tree: ExplorerTreeStructure, id: string) {
-  const node = tree.nodes.get(id)
+export function createOrUpdateNodeTask(context: ExplorerOperationContext, id: string) {
+  const node = context.nodes.get(id)
   if (!node) {
     return
   }
 
-  const task = client.state.idMap.get(id)
+  const task = context.dataSource.getTask(id)
   // if it is not a test just return
   if (!task || task.type !== 'test') {
     return
   }
 
-  createOrUpdateNode(tree, node.parentId, task, false)
+  createOrUpdateNode(context, node.parentId, task, false)
 }
 
 export function createOrUpdateNode(
-  tree: ExplorerTreeStructure,
+  context: ExplorerOperationContext,
   parentId: string,
   task: Task,
   createAll: boolean,
 ) {
-  const node = tree.nodes.get(parentId) as ParentTreeNode | undefined
+  const node = context.nodes.get(parentId) as ParentTreeNode | undefined
   let taskNode: UITaskTreeNode | undefined
   const duration = typeof task.result?.duration === 'number'
     ? Math.round(task.result.duration)
     : undefined
   if (node) {
-    taskNode = tree.nodes.get(task.id)
+    taskNode = context.nodes.get(task.id)
     if (taskNode) {
       if (!node.children.has(task.id)) {
         node.tasks.push(taskNode)
@@ -186,7 +184,7 @@ export function createOrUpdateNode(
       taskNode.name = task.name
       taskNode.mode = task.mode
       taskNode.duration = duration
-      taskNode.slow = isSlowTestTask(task)
+      taskNode.slow = isSlowTestTask(context, task)
       taskNode.state = task.result?.state
     }
     else {
@@ -202,7 +200,7 @@ export function createOrUpdateNode(
           expanded: false,
           indent: node.indent + 1,
           duration,
-          slow: isSlowTestTask(task),
+          slow: isSlowTestTask(context, task),
           state: task.result?.state,
         } as TestTreeNode
       }
@@ -225,14 +223,14 @@ export function createOrUpdateNode(
           state: task.result?.state,
         } as SuiteTreeNode
       }
-      tree.nodes.set(task.id, taskNode)
+      context.nodes.set(task.id, taskNode)
       node.tasks.push(taskNode)
       node.children.add(task.id)
     }
 
     if (taskNode && createAll && isTaskSuite(task)) {
       for (let i = 0; i < task.tasks.length; i++) {
-        createOrUpdateNode(tree, taskNode.id, task.tasks[i], createAll)
+        createOrUpdateNode(context, taskNode.id, task.tasks[i], createAll)
       }
     }
   }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resolves #issue-number

Pure refactoring of UI code to reduce singleton access and make data flow more explicit. Mostly mechanically done by agents. Not ready to land, but just seeing the diff like this already helps picturing the flow, so draft PR.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
