### PR TITLE
fix(runner): use globalThis for suite module state fallback

### DIFF
--- a/packages/vitest/src/runtime/runner/context.ts
+++ b/packages/vitest/src/runtime/runner/context.ts
@@ -10,7 +10,7 @@ const now = globalThis.performance
   ? globalThis.performance.now.bind(globalThis.performance)
   : Date.now
 
-export const collectorContext: RuntimeContext = {
+export const collectorContext: RuntimeContext = (globalThis as any).__vitest_collector_context__ ??= {
   tasks: [],
   currentSuite: null,
 }

--- a/packages/vitest/src/runtime/runner/suite.ts
+++ b/packages/vitest/src/runtime/runner/suite.ts
@@ -203,13 +203,15 @@ function assert(condition: any, message: string) {
 }
 
 export function getDefaultSuite(): SuiteCollector<object> {
-  assert(defaultSuite, 'the default suite')
-  return defaultSuite
+  const s = defaultSuite || (globalThis as any).__vitest_default_suite__
+  assert(s, 'the default suite')
+  return s
 }
 
 export function getRunner(): VitestRunner {
-  assert(runner, 'the runner')
-  return runner
+  const r = runner || (globalThis as any).__vitest_runner__
+  assert(r, 'the runner')
+  return r
 }
 
 function createDefaultSuite(runner: VitestRunner) {
@@ -230,8 +232,13 @@ export function clearCollectorContext(
 ): void {
   currentTestFilepath = file.filepath
   runner = currentRunner
-  if (!defaultSuite) {
+  ;(globalThis as any).__vitest_runner__ = currentRunner
+  if (!defaultSuite || !(globalThis as any).__vitest_default_suite__) {
     defaultSuite = createDefaultSuite(currentRunner)
+    ;(globalThis as any).__vitest_default_suite__ = defaultSuite
+  }
+  else {
+    defaultSuite = (globalThis as any).__vitest_default_suite__
   }
   defaultSuite.file = file
   collectorContext.tasks.length = 0


### PR DESCRIPTION
### Description

This PR fixes the issue where "Vitest failed to find the runner" in Browser Mode (#10944) when importing `vitest` internals inside a test setup file (e.g. `vitest-browser-react`).

The error occurs because Vite's `optimizeDeps` pre-bundles `"vitest"` for the setup file, but fails to pre-bundle `"vitest/internal/browser"` when it is dynamically imported by the `tester.ts` served via `/@fs/`. This leads to two isolated module scopes of the internal Vitest runtime (`runner`, `defaultSuite`, and `collectorContext`) being instantiated in the browser. 

This PR solves the problem by attaching the suite module state (`runner`, `defaultSuite`, `collectorContext`) to `globalThis` as a fallback. This guarantees that even if Vite loads two different module instances of the runner, they will securely access and synchronize the same state variables.

Resolves #10944

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
