### PR TITLE
refactor(ui): consolidate ws handlers definition and remove unused code

### DIFF
--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -35,12 +35,12 @@ else {
 }
 
 function createVitestClient(): VitestClient {
-  let transport: VitestClient
+  let client: VitestClient
   if (isReport) {
-    transport = createStaticClient()
+    client = createStaticClient()
   }
   else {
-    transport = createWsClient(ENTRY_URL, {
+    client = createWsClient(ENTRY_URL, {
       handlers: {
         onTestAnnotate(testId: string, annotation: TestAnnotation) {
           explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })
@@ -84,8 +84,8 @@ function createVitestClient(): VitestClient {
       },
     })
   }
-  transport.state = state
-  return transport
+  client.state = state
+  return client
 }
 
 export const client: VitestClient = createVitestClient()

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -38,7 +38,7 @@ else {
   state.idMap = shallowRef(state.idMap) as unknown as StateManager['idMap']
 }
 
-export const client: VitestClient = (function createVitestClient() {
+function createVitestClient(): VitestClient {
   let transport: VitestClientTransport
   if (isReport) {
     transport = createStaticClient()
@@ -91,7 +91,9 @@ export const client: VitestClient = (function createVitestClient() {
     })
   }
   return Object.assign(transport, { state })
-})()
+}
+
+export const client: VitestClient = createVitestClient()
 
 export const config = shallowRef<Partial<SerializedRootConfig>>({} as any)
 const status = ref<WebSocketStatus>('CONNECTING')

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -8,7 +8,7 @@ import type {
   TestAnnotation,
 } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
-import type { VitestClientTransport } from './ws'
+import type { VitestClient } from './ws'
 import { computed, reactive as reactiveVue, ref, shallowRef, watch } from 'vue'
 import { explorerTree } from '~/composables/explorer'
 import { isFileNode } from '~/composables/explorer/utils'
@@ -24,14 +24,10 @@ import { createWsClient } from './ws'
 
 export { isReport } from '../../constants'
 
-export interface VitestClient extends VitestClientTransport {
-  state: StateManager
-}
-
-const state = reactiveVue(new StateManager())
+const state = reactiveVue(new StateManager()) as StateManager
 if (isReport) {
-  state.filesMap = reactiveVue(state.filesMap)
-  state.idMap = reactiveVue(state.idMap)
+  state.filesMap = reactiveVue(state.filesMap) as any
+  state.idMap = reactiveVue(state.idMap) as any
 }
 else {
   state.filesMap = shallowRef(state.filesMap) as any
@@ -39,7 +35,7 @@ else {
 }
 
 function createVitestClient(): VitestClient {
-  let transport: VitestClientTransport
+  let transport: VitestClient
   if (isReport) {
     transport = createStaticClient()
   }
@@ -89,7 +85,8 @@ function createVitestClient(): VitestClient {
       },
     })
   }
-  return Object.assign(transport, { state })
+  transport.state = state
+  return transport
 }
 
 export const client: VitestClient = createVitestClient()

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -25,6 +25,9 @@ import { createWsClient } from './ws'
 export { isReport } from '../../constants'
 
 const state = reactiveVue(new StateManager()) as StateManager
+// TODO: This switch is effectively a no-op: `state` already exposes reactive Map
+// proxies, and `shallowRef` wraps those same proxies. Revisit and remove it; it was
+// intended as an optimization in https://github.com/vitest-dev/vitest/pull/5906.
 if (isReport) {
   state.filesMap = reactiveVue(state.filesMap) as any
   state.idMap = reactiveVue(state.idMap) as any

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -8,7 +8,7 @@ import type {
   TestAnnotation,
 } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
-import type { VitestClient } from './ws'
+import type { VitestClientEvents, VitestClientTransport } from './ws'
 import { computed, reactive as reactiveVue, ref, shallowRef, watch } from 'vue'
 import { explorerTree } from '~/composables/explorer'
 import { isFileNode } from '~/composables/explorer/utils'
@@ -18,54 +18,79 @@ import { ui } from '../../composables/api'
 import { ENTRY_URL, isReport } from '../../constants'
 import { parseError } from '../error'
 import { activeFileId } from '../params'
-import { testRunState, unhandledErrors } from './state'
+import { StateManager, testRunState, unhandledErrors } from './state'
 import { createStaticClient } from './static'
 import { createWsClient } from './ws'
 
 export { isReport } from '../../constants'
 
+export interface VitestClient extends VitestClientTransport {
+  state: StateManager
+}
+
+const state = reactiveVue(new StateManager()) as StateManager
+if (isReport) {
+  state.filesMap = reactiveVue(state.filesMap) as StateManager['filesMap']
+  state.idMap = reactiveVue(state.idMap) as StateManager['idMap']
+}
+else {
+  state.filesMap = shallowRef(state.filesMap) as unknown as StateManager['filesMap']
+  state.idMap = shallowRef(state.idMap) as unknown as StateManager['idMap']
+}
+
 export const client: VitestClient = (function createVitestClient() {
+  let transport: VitestClientTransport
   if (isReport) {
-    return createStaticClient()
+    transport = createStaticClient()
   }
   else {
-    return createWsClient(ENTRY_URL, {
-      reactive: (data, ctxKey) => {
-        return ctxKey === 'state' ? reactiveVue(data as any) as any : shallowRef(data)
+    const handlers: VitestClientEvents = {
+      onTestAnnotate(testId: string, annotation: TestAnnotation) {
+        explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })
       },
-      handlers: {
-        onTestAnnotate(testId: string, annotation: TestAnnotation) {
-          explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })
-        },
-        onTestArtifactRecord(testId, artifact) {
-          explorerTree.recordTestArtifact(testId, artifact)
-        },
-        onTaskUpdate(packs: RunnerTaskResultPack[], events: RunnerTaskEventPack[]) {
-          explorerTree.resumeRun(packs, events)
-          testRunState.value = 'running'
-        },
-        onSpecsCollected(_specs, startTime) {
-          explorerTree.startTime = startTime || performance.now()
-        },
-        onFinished(_files, errors, _coverage, executionTime) {
-          explorerTree.endRun(executionTime)
-          // don't change the testRunState.value here:
-          // - when saving the file in the codemirror requires explorer tree endRun to finish (multiple microtasks)
-          // - if we change here the state before the tasks states are updated, the cursor position will be lost
-          // - line moved to composables/explorer/collector.ts::refreshExplorer after calling updateRunningTodoTests
-          // testRunState.value = 'idle'
-          unhandledErrors.value = (errors || []).map(parseError)
-        },
-        onFinishedReportCoverage() {
-          // reload coverage iframe
-          const iframe = document.querySelector('iframe#vitest-ui-coverage')
-          if (iframe instanceof HTMLIFrameElement && iframe.contentWindow) {
-            iframe.contentWindow.location.reload()
-          }
-        },
+      onTestArtifactRecord(testId, artifact) {
+        explorerTree.recordTestArtifact(testId, artifact)
       },
+      onSpecsCollected(specs, startTime) {
+        specs?.forEach(([config, file]) => {
+          state.clearFiles({ config }, [file])
+        })
+        explorerTree.startTime = startTime || performance.now()
+      },
+      onCollected(files) {
+        state.collectFiles(files)
+      },
+      onTaskUpdate(packs: RunnerTaskResultPack[], events: RunnerTaskEventPack[]) {
+        state.updateTasks(packs)
+        explorerTree.resumeRun(packs, events)
+        testRunState.value = 'running'
+      },
+      onUserConsoleLog(log) {
+        state.updateUserLog(log)
+      },
+      onFinished(_files, errors, _coverage, executionTime) {
+        explorerTree.endRun(executionTime)
+        // don't change the testRunState.value here:
+        // - when saving the file in the codemirror requires explorer tree endRun to finish (multiple microtasks)
+        // - if we change here the state before the tasks states are updated, the cursor position will be lost
+        // - line moved to composables/explorer/collector.ts::refreshExplorer after calling updateRunningTodoTests
+        // testRunState.value = 'idle'
+        unhandledErrors.value = (errors || []).map(parseError)
+      },
+      onFinishedReportCoverage() {
+        // reload coverage iframe
+        const iframe = document.querySelector('iframe#vitest-ui-coverage')
+        if (iframe instanceof HTMLIFrameElement && iframe.contentWindow) {
+          iframe.contentWindow.location.reload()
+        }
+      },
+    }
+    transport = createWsClient(ENTRY_URL, {
+      reactive: data => reactiveVue(data) as unknown as typeof data,
+      handlers,
     })
   }
+  return Object.assign(transport, { state })
 })()
 
 export const config = shallowRef<Partial<SerializedRootConfig>>({} as any)

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -21,7 +21,6 @@ import { activeFileId } from '../params'
 import { StateManager, testRunState, unhandledErrors } from './state'
 import { createStaticClient } from './static'
 import { createWsClient } from './ws'
-import { WebSocketEvents } from 'vitest'
 
 export { isReport } from '../../constants'
 
@@ -45,50 +44,49 @@ function createVitestClient(): VitestClient {
     transport = createStaticClient()
   }
   else {
-    const handlers: WebSocketEvents = {
-      onTestAnnotate(testId: string, annotation: TestAnnotation) {
-        explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })
-      },
-      onTestArtifactRecord(testId, artifact) {
-        explorerTree.recordTestArtifact(testId, artifact)
-      },
-      onSpecsCollected(specs, startTime) {
-        specs?.forEach(([config, file]) => {
-          state.clearFiles({ config }, [file])
-        })
-        explorerTree.startTime = startTime || performance.now()
-      },
-      onCollected(files) {
-        state.collectFiles(files)
-      },
-      onTaskUpdate(packs: RunnerTaskResultPack[], events: RunnerTaskEventPack[]) {
-        state.updateTasks(packs)
-        explorerTree.resumeRun(packs, events)
-        testRunState.value = 'running'
-      },
-      onUserConsoleLog(log) {
-        state.updateUserLog(log)
-      },
-      onFinished(_files, errors, _coverage, executionTime) {
-        explorerTree.endRun(executionTime)
-        // don't change the testRunState.value here:
-        // - when saving the file in the codemirror requires explorer tree endRun to finish (multiple microtasks)
-        // - if we change here the state before the tasks states are updated, the cursor position will be lost
-        // - line moved to composables/explorer/collector.ts::refreshExplorer after calling updateRunningTodoTests
-        // testRunState.value = 'idle'
-        unhandledErrors.value = (errors || []).map(parseError)
-      },
-      onFinishedReportCoverage() {
-        // reload coverage iframe
-        const iframe = document.querySelector('iframe#vitest-ui-coverage')
-        if (iframe instanceof HTMLIFrameElement && iframe.contentWindow) {
-          iframe.contentWindow.location.reload()
-        }
-      },
-    }
     transport = createWsClient(ENTRY_URL, {
       reactive: reactiveVue as any,
-      handlers,
+      handlers: {
+        onTestAnnotate(testId: string, annotation: TestAnnotation) {
+          explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })
+        },
+        onTestArtifactRecord(testId, artifact) {
+          explorerTree.recordTestArtifact(testId, artifact)
+        },
+        onSpecsCollected(specs, startTime) {
+          specs?.forEach(([config, file]) => {
+            state.clearFiles({ config }, [file])
+          })
+          explorerTree.startTime = startTime || performance.now()
+        },
+        onCollected(files) {
+          state.collectFiles(files)
+        },
+        onTaskUpdate(packs: RunnerTaskResultPack[], events: RunnerTaskEventPack[]) {
+          state.updateTasks(packs)
+          explorerTree.resumeRun(packs, events)
+          testRunState.value = 'running'
+        },
+        onUserConsoleLog(log) {
+          state.updateUserLog(log)
+        },
+        onFinished(_files, errors, _coverage, executionTime) {
+          explorerTree.endRun(executionTime)
+          // don't change the testRunState.value here:
+          // - when saving the file in the codemirror requires explorer tree endRun to finish (multiple microtasks)
+          // - if we change here the state before the tasks states are updated, the cursor position will be lost
+          // - line moved to composables/explorer/collector.ts::refreshExplorer after calling updateRunningTodoTests
+          // testRunState.value = 'idle'
+          unhandledErrors.value = (errors || []).map(parseError)
+        },
+        onFinishedReportCoverage() {
+        // reload coverage iframe
+          const iframe = document.querySelector('iframe#vitest-ui-coverage')
+          if (iframe instanceof HTMLIFrameElement && iframe.contentWindow) {
+            iframe.contentWindow.location.reload()
+          }
+        },
+      },
     })
   }
   return Object.assign(transport, { state })

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -8,7 +8,7 @@ import type {
   TestAnnotation,
 } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
-import type { VitestClientEvents, VitestClientTransport } from './ws'
+import type { VitestClientTransport } from './ws'
 import { computed, reactive as reactiveVue, ref, shallowRef, watch } from 'vue'
 import { explorerTree } from '~/composables/explorer'
 import { isFileNode } from '~/composables/explorer/utils'
@@ -21,6 +21,7 @@ import { activeFileId } from '../params'
 import { StateManager, testRunState, unhandledErrors } from './state'
 import { createStaticClient } from './static'
 import { createWsClient } from './ws'
+import { WebSocketEvents } from 'vitest'
 
 export { isReport } from '../../constants'
 
@@ -44,7 +45,7 @@ function createVitestClient(): VitestClient {
     transport = createStaticClient()
   }
   else {
-    const handlers: VitestClientEvents = {
+    const handlers: WebSocketEvents = {
       onTestAnnotate(testId: string, annotation: TestAnnotation) {
         explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })
       },

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -28,14 +28,14 @@ export interface VitestClient extends VitestClientTransport {
   state: StateManager
 }
 
-const state = reactiveVue(new StateManager()) as StateManager
+const state = reactiveVue(new StateManager())
 if (isReport) {
-  state.filesMap = reactiveVue(state.filesMap) as StateManager['filesMap']
-  state.idMap = reactiveVue(state.idMap) as StateManager['idMap']
+  state.filesMap = reactiveVue(state.filesMap)
+  state.idMap = reactiveVue(state.idMap)
 }
 else {
-  state.filesMap = shallowRef(state.filesMap) as unknown as StateManager['filesMap']
-  state.idMap = shallowRef(state.idMap) as unknown as StateManager['idMap']
+  state.filesMap = shallowRef(state.filesMap) as any
+  state.idMap = shallowRef(state.idMap) as any
 }
 
 function createVitestClient(): VitestClient {

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -87,7 +87,7 @@ function createVitestClient(): VitestClient {
       },
     }
     transport = createWsClient(ENTRY_URL, {
-      reactive: data => reactiveVue(data) as unknown as typeof data,
+      reactive: reactiveVue as any,
       handlers,
     })
   }

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -65,7 +65,7 @@ function createVitestClient(): VitestClient {
           unhandledErrors.value = (errors || []).map(parseError)
         },
         onFinishedReportCoverage() {
-        // reload coverage iframe
+          // reload coverage iframe
           const iframe = document.querySelector('iframe#vitest-ui-coverage')
           if (iframe instanceof HTMLIFrameElement && iframe.contentWindow) {
             iframe.contentWindow.location.reload()

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -9,7 +9,7 @@ import type {
 } from 'vitest'
 import type { BrowserRunnerState } from '../../../types'
 import type { VitestClient } from './ws'
-import { computed, reactive as reactiveVue, ref, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 import { explorerTree } from '~/composables/explorer'
 import { isFileNode } from '~/composables/explorer/utils'
 import { isSuite as isTaskSuite } from '~/utils/task'
@@ -18,24 +18,11 @@ import { ui } from '../../composables/api'
 import { ENTRY_URL, isReport } from '../../constants'
 import { parseError } from '../error'
 import { activeFileId } from '../params'
-import { StateManager, testRunState, unhandledErrors } from './state'
+import { testRunState, unhandledErrors } from './state'
 import { createStaticClient } from './static'
 import { createWsClient } from './ws'
 
 export { isReport } from '../../constants'
-
-const state = reactiveVue(new StateManager()) as StateManager
-// TODO: This switch is effectively a no-op: `state` already exposes reactive Map
-// proxies, and `shallowRef` wraps those same proxies. Revisit and remove it; it was
-// intended as an optimization in https://github.com/vitest-dev/vitest/pull/5906.
-if (isReport) {
-  state.filesMap = reactiveVue(state.filesMap) as any
-  state.idMap = reactiveVue(state.idMap) as any
-}
-else {
-  state.filesMap = shallowRef(state.filesMap) as any
-  state.idMap = shallowRef(state.idMap) as any
-}
 
 function createVitestClient(): VitestClient {
   let client: VitestClient
@@ -53,20 +40,20 @@ function createVitestClient(): VitestClient {
         },
         onSpecsCollected(specs, startTime) {
           specs?.forEach(([config, file]) => {
-            state.clearFiles({ config }, [file])
+            client.state.clearFiles({ config }, [file])
           })
           explorerTree.startTime = startTime || performance.now()
         },
         onCollected(files) {
-          state.collectFiles(files)
+          client.state.collectFiles(files)
         },
         onTaskUpdate(packs: RunnerTaskResultPack[], events: RunnerTaskEventPack[]) {
-          state.updateTasks(packs)
+          client.state.updateTasks(packs)
           explorerTree.resumeRun(packs, events)
           testRunState.value = 'running'
         },
         onUserConsoleLog(log) {
-          state.updateUserLog(log)
+          client.state.updateUserLog(log)
         },
         onFinished(_files, errors, _coverage, executionTime) {
           explorerTree.endRun(executionTime)
@@ -87,7 +74,6 @@ function createVitestClient(): VitestClient {
       },
     })
   }
-  client.state = state
   return client
 }
 

--- a/packages/ui/client/composables/client/index.ts
+++ b/packages/ui/client/composables/client/index.ts
@@ -41,7 +41,6 @@ function createVitestClient(): VitestClient {
   }
   else {
     transport = createWsClient(ENTRY_URL, {
-      reactive: reactiveVue as any,
       handlers: {
         onTestAnnotate(testId: string, annotation: TestAnnotation) {
           explorerTree.recordTestArtifact(testId, { type: 'internal:annotation', annotation, location: annotation.location })

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -3,11 +3,10 @@ import type {
   RunnerTestFile,
   SerializedRootConfig,
 } from 'vitest'
-import type { VitestClient, VitestClientRpc } from './ws'
+import type { VitestClientRpc, VitestClientTransport } from './ws'
 import { decompressSync, strFromU8 } from 'fflate'
 import { parse } from 'flatted'
 import { reactive } from 'vue'
-import { StateManager } from './state'
 
 export interface HTMLReportMetadata {
   files: RunnerTestFile[]
@@ -63,17 +62,13 @@ function deserializeReportMetadata(metadata: HTMLReportMetadata) {
   return rpc
 }
 
-export function createStaticClient(): VitestClient {
-  const ctx = reactive<VitestClient>({
+export function createStaticClient(): VitestClientTransport {
+  const ctx = reactive<VitestClientTransport>({
     ws: new EventTarget() as WebSocket,
-    state: new StateManager(),
     rpc: undefined!,
     reconnect: () => registerMetadata(),
     waitForConnection: async () => {},
-  }) as VitestClient
-
-  ctx.state.filesMap = reactive(ctx.state.filesMap) as StateManager['filesMap']
-  ctx.state.idMap = reactive(ctx.state.idMap) as StateManager['idMap']
+  }) as VitestClientTransport
 
   async function registerMetadata() {
     const content = await window.HTML_REPORT_METADATA!

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -67,7 +67,6 @@ export function createStaticClient(): VitestClientTransport {
     ws: new EventTarget() as WebSocket,
     rpc: undefined!,
     reconnect: () => registerMetadata(),
-    waitForConnection: async () => {},
   }) as VitestClientTransport
 
   async function registerMetadata() {

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -3,7 +3,7 @@ import type {
   RunnerTestFile,
   SerializedRootConfig,
 } from 'vitest'
-import type { VitestClientRpc, VitestClientTransport } from './ws'
+import type { VitestClient, VitestClientRpc } from './ws'
 import { decompressSync, strFromU8 } from 'fflate'
 import { parse } from 'flatted'
 import { reactive } from 'vue'
@@ -62,12 +62,14 @@ function deserializeReportMetadata(metadata: HTMLReportMetadata) {
   return rpc
 }
 
-export function createStaticClient(): VitestClientTransport {
-  const ctx = reactive<VitestClientTransport>({
+export function createStaticClient(): VitestClient {
+  const ctx = reactive<VitestClient>({
     ws: new EventTarget() as WebSocket,
     rpc: undefined!,
     reconnect: async () => {},
-  })
+    // Lazily initialized in createVitestClient.
+    state: undefined!,
+  }) as VitestClient
 
   async function registerMetadata() {
     const content = await window.HTML_REPORT_METADATA!

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -65,10 +65,9 @@ function deserializeReportMetadata(metadata: HTMLReportMetadata) {
 export function createStaticClient(): VitestClient {
   const ctx = reactive<VitestClient>({
     ws: new EventTarget() as WebSocket,
+    state: undefined!, // initialized in createVitestClient
     rpc: undefined!,
     reconnect: async () => {},
-    // Lazily initialized in createVitestClient.
-    state: undefined!,
   }) as VitestClient
 
   async function registerMetadata() {

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -71,9 +71,6 @@ export function createStaticClient(): VitestClient {
     reconnect: async () => {},
   }) as VitestClient
 
-  ctx.state.filesMap = reactive(ctx.state.filesMap) as any
-  ctx.state.idMap = reactive(ctx.state.idMap) as any
-
   async function registerMetadata() {
     const content = await window.HTML_REPORT_METADATA!
     let metadata: HTMLReportMetadata

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -7,6 +7,7 @@ import type { VitestClient, VitestClientRpc } from './ws'
 import { decompressSync, strFromU8 } from 'fflate'
 import { parse } from 'flatted'
 import { reactive } from 'vue'
+import { StateManager } from './state'
 
 export interface HTMLReportMetadata {
   files: RunnerTestFile[]
@@ -65,10 +66,13 @@ function deserializeReportMetadata(metadata: HTMLReportMetadata) {
 export function createStaticClient(): VitestClient {
   const ctx = reactive<VitestClient>({
     ws: new EventTarget() as WebSocket,
-    state: undefined!, // initialized in createVitestClient
+    state: new StateManager(),
     rpc: undefined!,
     reconnect: async () => {},
   }) as VitestClient
+
+  ctx.state.filesMap = reactive(ctx.state.filesMap) as any
+  ctx.state.idMap = reactive(ctx.state.idMap) as any
 
   async function registerMetadata() {
     const content = await window.HTML_REPORT_METADATA!

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -66,7 +66,7 @@ export function createStaticClient(): VitestClientTransport {
   const ctx = reactive<VitestClientTransport>({
     ws: new EventTarget() as WebSocket,
     rpc: undefined!,
-    reconnect: async () => {}
+    reconnect: async () => {},
   })
 
   async function registerMetadata() {

--- a/packages/ui/client/composables/client/static.ts
+++ b/packages/ui/client/composables/client/static.ts
@@ -66,8 +66,8 @@ export function createStaticClient(): VitestClientTransport {
   const ctx = reactive<VitestClientTransport>({
     ws: new EventTarget() as WebSocket,
     rpc: undefined!,
-    reconnect: () => registerMetadata(),
-  }) as VitestClientTransport
+    reconnect: async () => {}
+  })
 
   async function registerMetadata() {
     const content = await window.HTML_REPORT_METADATA!

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -1,9 +1,9 @@
 import type { BirpcOptions, PromisifyFn } from 'birpc'
 import type { WebSocketEvents, WebSocketHandlers } from 'vitest'
-import type { StateManager } from './state'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
-import { reactive } from 'vue'
+import { reactive, shallowRef } from 'vue'
+import { StateManager } from './state'
 
 export interface VitestClientOptions {
   handlers: WebSocketEvents
@@ -30,10 +30,16 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
   let tries = reconnectTries
   const ctx = reactive<VitestClient>({
     ws: new WebSocket(url),
-    state: undefined!, // initialized in createVitestClient
+    state: new StateManager(),
     rpc: undefined!,
     reconnect,
   }) as VitestClient
+
+  // TODO: This is effectively a no-op: `state` already exposes reactive Map proxies,
+  // and `shallowRef` wraps those same proxies. Revisit the intended optimization from
+  // https://github.com/vitest-dev/vitest/pull/5906.
+  ctx.state.filesMap = shallowRef(ctx.state.filesMap) as any
+  ctx.state.idMap = shallowRef(ctx.state.idMap) as any
 
   let onMessage: (data: any) => void
   const birpcHandlers = {

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -21,10 +21,6 @@ export interface VitestClient {
 }
 
 export function createWsClient(url: string, options: VitestClientOptions): VitestClient {
-  const {
-    handlers,
-  } = options
-
   const reconnectInterval = 2000
   const reconnectTries = 10
   let tries = reconnectTries
@@ -61,7 +57,7 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
   } satisfies BirpcOptions<WebSocketHandlers>
 
   ctx.rpc = createBirpc<WebSocketHandlers, WebSocketEvents>(
-    handlers,
+    options.handlers,
     birpcHandlers,
   )
 

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -1,5 +1,6 @@
 import type { BirpcOptions, PromisifyFn } from 'birpc'
 import type { WebSocketEvents, WebSocketHandlers } from 'vitest'
+import type { StateManager } from './state'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
 
@@ -12,13 +13,14 @@ export type VitestClientRpc = {
   [K in keyof WebSocketHandlers]: PromisifyFn<WebSocketHandlers[K]>
 }
 
-export interface VitestClientTransport {
+export interface VitestClient {
   ws: WebSocket
   rpc: VitestClientRpc
   reconnect: () => Promise<void>
+  state: StateManager
 }
 
-export function createWsClient(url: string, options: VitestClientOptions): VitestClientTransport {
+export function createWsClient(url: string, options: VitestClientOptions): VitestClient {
   const {
     handlers,
     reactive,
@@ -27,10 +29,12 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
   const reconnectInterval = 2000
   const reconnectTries = 10
   let tries = reconnectTries
-  const ctx = reactive<VitestClientTransport>({
+  const ctx = reactive<VitestClient>({
     ws: new WebSocket(url),
     rpc: undefined!,
     reconnect,
+    // Lazily initialized in createVitestClient.
+    state: undefined!,
   })
 
   let onMessage: (data: any) => void

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -3,10 +3,8 @@ import type { WebSocketEvents, WebSocketHandlers } from 'vitest'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
 
-export type VitestClientEvents = Required<Omit<WebSocketEvents, 'onPathsCollected'>>
-
 export interface VitestClientOptions {
-  handlers: VitestClientEvents
+  handlers: WebSocketEvents
   reactive: <T extends object>(v: T) => T
 }
 

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -15,9 +15,9 @@ export type VitestClientRpc = {
 
 export interface VitestClient {
   ws: WebSocket
+  state: StateManager
   rpc: VitestClientRpc
   reconnect: () => Promise<void>
-  state: StateManager
 }
 
 export function createWsClient(url: string, options: VitestClientOptions): VitestClient {
@@ -31,10 +31,9 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
   let tries = reconnectTries
   const ctx = reactive<VitestClient>({
     ws: new WebSocket(url),
+    state: undefined!, // initialized in createVitestClient
     rpc: undefined!,
     reconnect,
-    // Lazily initialized in createVitestClient.
-    state: undefined!,
   })
 
   let onMessage: (data: any) => void

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -7,11 +7,7 @@ export type VitestClientEvents = Required<Omit<WebSocketEvents, 'onPathsCollecte
 
 export interface VitestClientOptions {
   handlers: VitestClientEvents
-  autoReconnect?: boolean
-  reconnectInterval?: number
-  reconnectTries?: number
-  reactive?: <T extends object>(v: T) => T
-  WebSocketConstructor?: typeof WebSocket
+  reactive: <T extends object>(v: T) => T
 }
 
 export type VitestClientRpc = {
@@ -27,16 +23,14 @@ export interface VitestClientTransport {
 export function createWsClient(url: string, options: VitestClientOptions): VitestClientTransport {
   const {
     handlers,
-    autoReconnect = true,
-    reconnectInterval = 2000,
-    reconnectTries = 10,
-    reactive = v => v,
-    WebSocketConstructor = globalThis.WebSocket,
+    reactive,
   } = options
 
+  const reconnectInterval = 2000
+  const reconnectTries = 10
   let tries = reconnectTries
   const ctx = reactive<VitestClientTransport>({
-    ws: new WebSocketConstructor(url),
+    ws: new WebSocket(url),
     rpc: undefined!,
     reconnect,
   })
@@ -65,11 +59,8 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
     birpcHandlers,
   )
 
-  async function reconnect(reset = false) {
-    if (reset) {
-      tries = reconnectTries
-    }
-    ctx.ws = new WebSocketConstructor(url)
+  async function reconnect() {
+    ctx.ws = new WebSocket(url)
     registerWS()
   }
 
@@ -82,7 +73,7 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
     })
     ctx.ws.addEventListener('close', () => {
       tries -= 1
-      if (autoReconnect && tries > 0) {
+      if (tries > 0) {
         setTimeout(reconnect, reconnectInterval)
       }
     })

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -35,7 +35,7 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
     reconnect,
   }) as VitestClient
 
-  // TODO: This is effectively a no-op: `state` already exposes reactive Map proxies,
+  // TODO: This seems effectively a no-op: `state` already exposes reactive Map proxies,
   // and `shallowRef` wraps those same proxies. Revisit the intended optimization from
   // https://github.com/vitest-dev/vitest/pull/5906.
   ctx.state.filesMap = shallowRef(ctx.state.filesMap) as any

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -3,10 +3,10 @@ import type { WebSocketEvents, WebSocketHandlers } from 'vitest'
 import type { StateManager } from './state'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
+import { reactive } from 'vue'
 
 export interface VitestClientOptions {
   handlers: WebSocketEvents
-  reactive: <T extends object>(v: T) => T
 }
 
 export type VitestClientRpc = {
@@ -23,7 +23,6 @@ export interface VitestClient {
 export function createWsClient(url: string, options: VitestClientOptions): VitestClient {
   const {
     handlers,
-    reactive,
   } = options
 
   const reconnectInterval = 2000
@@ -34,7 +33,7 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
     state: undefined!, // initialized in createVitestClient
     rpc: undefined!,
     reconnect,
-  })
+  }) as VitestClient
 
   let onMessage: (data: any) => void
   const birpcHandlers = {

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -10,7 +10,6 @@ export interface VitestClientOptions {
   autoReconnect?: boolean
   reconnectInterval?: number
   reconnectTries?: number
-  connectTimeout?: number
   reactive?: <T extends object>(v: T) => T
   WebSocketConstructor?: typeof WebSocket
 }
@@ -22,8 +21,6 @@ export type VitestClientRpc = {
 export interface VitestClientTransport {
   ws: WebSocket
   rpc: VitestClientRpc
-  // TODO: unused
-  waitForConnection: () => Promise<void>
   reconnect: () => Promise<void>
 }
 
@@ -33,17 +30,14 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
     autoReconnect = true,
     reconnectInterval = 2000,
     reconnectTries = 10,
-    connectTimeout = 60000,
     reactive = v => v,
     WebSocketConstructor = globalThis.WebSocket,
   } = options
 
   let tries = reconnectTries
-  let openPromise: Promise<void>
   const ctx = reactive<VitestClientTransport>({
     ws: new WebSocketConstructor(url),
     rpc: undefined!,
-    waitForConnection: () => openPromise,
     reconnect,
   })
 
@@ -80,23 +74,8 @@ export function createWsClient(url: string, options: VitestClientOptions): Vites
   }
 
   function registerWS() {
-    openPromise = new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(
-          new Error(
-            `Cannot connect to the server in ${connectTimeout / 1000} seconds`,
-          ),
-        )
-      }, connectTimeout)
-      if (ctx.ws.OPEN === ctx.ws.readyState) {
-        resolve()
-      }
-      // still have a listener even if it's already open to update tries
-      ctx.ws.addEventListener('open', () => {
-        tries = reconnectTries
-        resolve()
-        clearTimeout(timeout)
-      })
+    ctx.ws.addEventListener('open', () => {
+      tries = reconnectTries
     })
     ctx.ws.addEventListener('message', (v) => {
       onMessage(v.data)

--- a/packages/ui/client/composables/client/ws.ts
+++ b/packages/ui/client/composables/client/ws.ts
@@ -2,16 +2,16 @@ import type { BirpcOptions, PromisifyFn } from 'birpc'
 import type { WebSocketEvents, WebSocketHandlers } from 'vitest'
 import { createBirpc } from 'birpc'
 import { parse, stringify } from 'flatted'
-import { StateManager } from './state'
+
+export type VitestClientEvents = Required<Omit<WebSocketEvents, 'onPathsCollected'>>
 
 export interface VitestClientOptions {
-  handlers?: Partial<WebSocketEvents>
+  handlers: VitestClientEvents
   autoReconnect?: boolean
   reconnectInterval?: number
   reconnectTries?: number
   connectTimeout?: number
-  reactive?: <T>(v: T, forKey: 'state' | 'idMap' | 'filesMap') => T
-  ref?: <T>(v: T) => { value: T }
+  reactive?: <T extends object>(v: T) => T
   WebSocketConstructor?: typeof WebSocket
 }
 
@@ -19,18 +19,17 @@ export type VitestClientRpc = {
   [K in keyof WebSocketHandlers]: PromisifyFn<WebSocketHandlers[K]>
 }
 
-export interface VitestClient {
+export interface VitestClientTransport {
   ws: WebSocket
-  state: StateManager
   rpc: VitestClientRpc
   // TODO: unused
   waitForConnection: () => Promise<void>
   reconnect: () => Promise<void>
 }
 
-export function createWsClient(url: string, options: VitestClientOptions = {}): VitestClient {
+export function createWsClient(url: string, options: VitestClientOptions): VitestClientTransport {
   const {
-    handlers = {},
+    handlers,
     autoReconnect = true,
     reconnectInterval = 2000,
     reconnectTries = 10,
@@ -41,51 +40,14 @@ export function createWsClient(url: string, options: VitestClientOptions = {}): 
 
   let tries = reconnectTries
   let openPromise: Promise<void>
-  const ctx = reactive<VitestClient>({
+  const ctx = reactive<VitestClientTransport>({
     ws: new WebSocketConstructor(url),
-    state: new StateManager(),
     rpc: undefined!,
     waitForConnection: () => openPromise,
     reconnect,
-  }, 'state')
-
-  ctx.state.filesMap = reactive(ctx.state.filesMap, 'filesMap')
-  ctx.state.idMap = reactive(ctx.state.idMap, 'idMap')
+  })
 
   let onMessage: (data: any) => void
-  const functions: WebSocketEvents = {
-    onTestAnnotate(testId, annotation) {
-      handlers.onTestAnnotate?.(testId, annotation)
-    },
-    onTestArtifactRecord(testId, artifact) {
-      handlers.onTestArtifactRecord?.(testId, artifact)
-    },
-    onSpecsCollected(specs, startTime) {
-      specs?.forEach(([config, file]) => {
-        ctx.state.clearFiles({ config }, [file])
-      })
-      handlers.onSpecsCollected?.(specs, startTime)
-    },
-    onCollected(files) {
-      ctx.state.collectFiles(files)
-      handlers.onCollected?.(files)
-    },
-    onTaskUpdate(packs, events) {
-      ctx.state.updateTasks(packs)
-      handlers.onTaskUpdate?.(packs, events)
-    },
-    onUserConsoleLog(log) {
-      ctx.state.updateUserLog(log)
-      handlers.onUserConsoleLog?.(log)
-    },
-    onFinished(files, errors, coverage, executionTime) {
-      handlers.onFinished?.(files, errors, coverage, executionTime)
-    },
-    onFinishedReportCoverage() {
-      handlers.onFinishedReportCoverage?.()
-    },
-  }
-
   const birpcHandlers = {
     post: msg => ctx.ws.send(msg),
     on: fn => (onMessage = fn),
@@ -105,7 +67,7 @@ export function createWsClient(url: string, options: VitestClientOptions = {}): 
   } satisfies BirpcOptions<WebSocketHandlers>
 
   ctx.rpc = createBirpc<WebSocketHandlers, WebSocketEvents>(
-    functions,
+    handlers,
     birpcHandlers,
   )
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Minor detour from https://github.com/vitest-dev/vitest/pull/10941. Currently ws handler definition are scattered in `client/index.ts` and `client/ws.ts`, which makes it harder to follow the overall client flow.

This PR consolidates them in `client/index.ts`. Additionally, it also cleans up unused code and unused abstraction from `client/ws.ts`.

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
