### PR TITLE
fix: make `import.meta.env` follow a reassigned `process.env`

### DIFF
--- a/packages/vitest/src/runtime/importMetaEnv.ts
+++ b/packages/vitest/src/runtime/importMetaEnv.ts
@@ -1,0 +1,69 @@
+import type { MetaEnv } from '../types/worker'
+
+// packages/vitest/src/node/plugins/index.ts:146
+const booleanKeys = ['DEV', 'PROD', 'SSR']
+
+/**
+ * `import.meta.env` is a view over `process.env`, not a copy of it. Every trap
+ * reads `process.env` again instead of the proxy target because test code can
+ * replace the whole object (`process.env = {}`), which leaves the target
+ * pointing at the detached one.
+ */
+export function createImportMetaEnvProxy(): MetaEnv {
+  return new Proxy(process.env, {
+    get(_, key) {
+      if (typeof key !== 'string') {
+        return undefined
+      }
+      if (booleanKeys.includes(key)) {
+        return !!process.env[key]
+      }
+      return process.env[key]
+    },
+    set(_, key, value) {
+      if (typeof key !== 'string') {
+        return true
+      }
+
+      if (booleanKeys.includes(key)) {
+        process.env[key] = value ? '1' : ''
+      }
+      else {
+        process.env[key] = value
+      }
+
+      return true
+    },
+    deleteProperty(_, key) {
+      if (typeof key !== 'string') {
+        return true
+      }
+
+      delete process.env[key]
+
+      return true
+    },
+    has(_, key) {
+      if (typeof key !== 'string') {
+        return false
+      }
+      return key in process.env
+    },
+    ownKeys() {
+      return Reflect.ownKeys(process.env)
+    },
+    getOwnPropertyDescriptor(_, key) {
+      if (typeof key !== 'string' || !Object.hasOwn(process.env, key)) {
+        return undefined
+      }
+      return {
+        value: booleanKeys.includes(key)
+          ? !!process.env[key]
+          : process.env[key],
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      }
+    },
+  }) as MetaEnv
+}

--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -21,6 +21,7 @@ import {
   ssrModuleExportsKey,
 } from 'vite/module-runner'
 import { Traces } from '../../utils/traces'
+import { createImportMetaEnvProxy } from '../importMetaEnv'
 import { ModuleDebug } from './moduleDebug'
 
 const isWindows = process.platform === 'win32'
@@ -465,36 +466,6 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
     // TODO: should also skip for `.js` with `type="module"`
     return !path.endsWith('.mjs') && 'default' in mod
   }
-}
-
-export function createImportMetaEnvProxy(): ModuleRunnerImportMeta['env'] {
-  // packages/vitest/src/node/plugins/index.ts:146
-  const booleanKeys = ['DEV', 'PROD', 'SSR']
-  return new Proxy(process.env, {
-    get(_, key) {
-      if (typeof key !== 'string') {
-        return undefined
-      }
-      if (booleanKeys.includes(key)) {
-        return !!process.env[key]
-      }
-      return process.env[key]
-    },
-    set(_, key, value) {
-      if (typeof key !== 'string') {
-        return true
-      }
-
-      if (booleanKeys.includes(key)) {
-        process.env[key] = value ? '1' : ''
-      }
-      else {
-        process.env[key] = value
-      }
-
-      return true
-    },
-  }) as ModuleRunnerImportMeta['env']
 }
 
 function updateStyle(id: string, css: string) {

--- a/packages/vitest/src/runtime/workers/init.ts
+++ b/packages/vitest/src/runtime/workers/init.ts
@@ -1,5 +1,5 @@
 import type { WorkerRequest, WorkerResponse } from '../../node/pools/types'
-import type { MetaEnv, WorkerSetupContext } from '../../types/worker'
+import type { WorkerSetupContext } from '../../types/worker'
 import type { FileSpecification } from '../runner/types'
 import type { VitestWorker } from './types'
 // default import: `flushCompileCache` only exists since Node 22.10, a named
@@ -8,36 +8,10 @@ import Module from 'node:module'
 import { serializeError } from '@vitest/utils/error'
 import { disableDefaultColors } from 'tinyrainbow'
 import { Traces } from '../../utils/traces'
+import { createImportMetaEnvProxy } from '../importMetaEnv'
 import * as listeners from '../listeners'
 import { createRuntimeRpc } from '../rpc'
 import * as entrypoint from '../worker'
-
-function createImportMetaEnvProxy(): MetaEnv {
-  const booleanKeys = ['DEV', 'PROD', 'SSR']
-  return new Proxy(process.env, {
-    get(_, key) {
-      if (typeof key !== 'string') {
-        return undefined
-      }
-      if (booleanKeys.includes(key)) {
-        return !!process.env[key]
-      }
-      return process.env[key]
-    },
-    set(_, key, value) {
-      if (typeof key !== 'string') {
-        return true
-      }
-      if (booleanKeys.includes(key)) {
-        process.env[key] = value ? '1' : ''
-      }
-      else {
-        process.env[key] = value
-      }
-      return true
-    },
-  }) as MetaEnv
-}
 
 const importMetaEnvProxy = createImportMetaEnvProxy()
 

--- a/test/unit/test/stubs.test.ts
+++ b/test/unit/test/stubs.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable vars-on-top */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 declare global {
 
@@ -142,5 +142,46 @@ describe('stubbing envs', () => {
     vi.unstubAllEnvs()
     expect(import.meta.env.VITE_TEST_UPDATE_ENV).toBe('development')
     expect(process.env.VITE_TEST_UPDATE_ENV).toBe('development')
+  })
+})
+
+describe('stubbing envs after process.env was replaced', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, VITE_TEST_UPDATE_ENV: 'development' }
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    process.env = originalEnv
+  })
+
+  it('stubs and restores env', () => {
+    vi.stubEnv('VITE_TEST_UPDATE_ENV', 'production')
+    expect(import.meta.env.VITE_TEST_UPDATE_ENV).toBe('production')
+    expect(process.env.VITE_TEST_UPDATE_ENV).toBe('production')
+    vi.unstubAllEnvs()
+    expect(import.meta.env.VITE_TEST_UPDATE_ENV).toBe('development')
+    expect(process.env.VITE_TEST_UPDATE_ENV).toBe('development')
+  })
+
+  it('stubs to undefined and restores env', () => {
+    vi.stubEnv('VITE_TEST_UPDATE_ENV', undefined)
+    expect(import.meta.env.VITE_TEST_UPDATE_ENV).toBeUndefined()
+    expect(process.env.VITE_TEST_UPDATE_ENV).toBeUndefined()
+    vi.unstubAllEnvs()
+    expect(import.meta.env.VITE_TEST_UPDATE_ENV).toBe('development')
+    expect(process.env.VITE_TEST_UPDATE_ENV).toBe('development')
+  })
+
+  it('lists the keys of the current process.env', () => {
+    process.env.VITE_TEST_LATE_ENV = 'late'
+    expect('VITE_TEST_LATE_ENV' in import.meta.env).toBe(true)
+    expect(Object.keys(import.meta.env)).toContain('VITE_TEST_LATE_ENV')
+
+    delete process.env.VITE_TEST_LATE_ENV
+    expect('VITE_TEST_LATE_ENV' in import.meta.env).toBe(false)
+    expect(Object.keys(import.meta.env)).not.toContain('VITE_TEST_LATE_ENV')
   })
 })


### PR DESCRIPTION
### Description

Resolves #10525

`import.meta.env` is a `Proxy` whose target is the `process.env` object that existed when the worker started. Its `get` and `set` traps read `process.env` again on every call, so they keep working after test code replaces the object with `process.env = {}`. Every other operation has no trap and falls through to the original, now detached, target.

That is what breaks `vi.stubEnv(key, undefined)`. It removes the key with `delete env[name]`, the delete lands on the detached object, and the variable is still there afterwards. `key in import.meta.env` and `Object.keys(import.meta.env)` go stale for the same reason.

This adds `deleteProperty`, `has`, `ownKeys` and `getOwnPropertyDescriptor` traps that read the current `process.env`, so the proxy stays a view over whatever `process.env` points at rather than a view over one snapshot of it.

The worker entry and the module evaluator each carried their own copy of this proxy, so the fix would have had to be written twice. They now share one module.

Minimal reproduction, from the issue:

```js
import { beforeEach, describe, expect, it, vi } from 'vitest'

describe('vi.stubEnv with undefined', () => {
  beforeEach(() => {
    process.env = {}
    vi.stubEnv('foo', 'initial-value')
  })

  it('stubEnv(key, undefined) should make process.env[key] === undefined', () => {
    vi.stubEnv('foo', undefined)
    expect(process.env.foo).toBeUndefined()
  })
})
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

`test/unit/test/stubs.test.ts` gets a `stubbing envs after process.env was replaced` block covering stubbing, stubbing to `undefined`, unstubbing, and key enumeration. All three cases fail on `main` across `threads`, `forks` and `vmThreads`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No new functionality, the documented behaviour of `vi.stubEnv(key, undefined)` is what this restores.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
