### PR TITLE
fix(utils): resolve source offsets in files with mixed line endings

### DIFF
--- a/packages/utils/src/offset.ts
+++ b/packages/utils/src/offset.ts
@@ -1,20 +1,25 @@
 export const lineSplitRE: RegExp = /\r?\n/
 
+// a single `\r\n` anywhere used to make every line count as two characters
+// wide, so walk the line breaks instead of assuming the file uses one style
+function lineEndOffset(source: string, from: number): number {
+  const newline = source.indexOf('\n', from)
+  return newline === -1 ? source.length : newline + 1
+}
+
 export function positionToOffset(
   source: string,
   lineNumber: number,
   columnNumber: number,
 ): number {
-  const lines = source.split(lineSplitRE)
-  const nl = /\r\n/.test(source) ? 2 : 1
   let start = 0
 
-  if (lineNumber > lines.length) {
-    return source.length
-  }
+  for (let line = 1; line < lineNumber; line++) {
+    if (start >= source.length) {
+      return source.length
+    }
 
-  for (let i = 0; i < lineNumber - 1; i++) {
-    start += lines[i].length + nl
+    start = lineEndOffset(source, start)
   }
 
   return start + columnNumber
@@ -26,17 +31,19 @@ export function offsetToLineNumber(source: string, offset: number): number {
       `offset is longer than source length! offset ${offset} > length ${source.length}`,
     )
   }
-  const lines = source.split(lineSplitRE)
-  const nl = /\r\n/.test(source) ? 2 : 1
-  let counted = 0
-  let line = 0
-  for (; line < lines.length; line++) {
-    const lineLength = lines[line].length + nl
-    if (counted + lineLength >= offset) {
+
+  let line = 1
+  let start = 0
+
+  while (start < source.length) {
+    const end = lineEndOffset(source, start)
+    if (end >= offset) {
       break
     }
 
-    counted += lineLength
+    start = end
+    line++
   }
-  return line + 1
+
+  return line
 }

--- a/test/unit/test/inline-snap.test.ts
+++ b/test/unit/test/inline-snap.test.ts
@@ -1,3 +1,4 @@
+import { positionToOffset } from '@vitest/utils/offset'
 import MagicString from 'magic-string'
 import { describe, expect, it } from 'vitest'
 import { replaceInlineSnap } from '../../../packages/snapshot/src/port/inlineSnapshot'
@@ -20,6 +21,23 @@ expect('foo').toMatchInlineSnapshot(\`{
         "bar
         foo"
       \`)
+      "
+    `)
+  })
+
+  it('replaceInlineSnap in a file with mixed line endings', async () => {
+    // a single `\r\n` used to make every `\n` line count as two characters, so
+    // the offset drifted one character per preceding line and the replacement
+    // landed on the next assertion instead
+    const header = Array.from({ length: 40 }, (_, i) => `const v${i} = ${i}\n`).join('')
+    const code = `${header}expect('a').toMatchInlineSnapshot()\r\nexpect('b').toMatchInlineSnapshot()\n`
+
+    const s = new MagicString(code)
+    replaceInlineSnap(code, s, positionToOffset(code, 41, 0), '"a"')
+
+    expect(s.toString().slice(header.length)).toMatchInlineSnapshot(`
+      "expect('a').toMatchInlineSnapshot(\`"a"\`)
+      expect('b').toMatchInlineSnapshot()
       "
     `)
   })

--- a/test/unit/test/utils.spec.ts
+++ b/test/unit/test/utils.spec.ts
@@ -1,4 +1,5 @@
 import { assertTypes, deepClone, deepMerge, isNegativeNaN, objectAttr, toArray } from '@vitest/utils/helpers'
+import { offsetToLineNumber, positionToOffset } from '@vitest/utils/offset'
 import { parseSingleFFOrSafariStack } from '@vitest/utils/source-map'
 import { EvaluatedModules } from 'vite/module-runner'
 import { beforeAll, describe, expect, test } from 'vitest'
@@ -376,5 +377,34 @@ describe('parseSingleFFOrSafariStack', () => {
     }
 
     parseSingleFFOrSafariStack(new PrettyError(obj).stack!)
+  })
+})
+
+describe('positionToOffset', () => {
+  const lf = 'const a = 1;\nconst b = 2;\nconst c = 3;'
+  const crlf = 'const a = 1;\r\nconst b = 2;\r\nconst c = 3;'
+  const mixed = 'const a = 1;\nconst b = 2;\r\nconst c = 3;'
+
+  test.each([
+    ['lf', lf],
+    ['crlf', crlf],
+    ['mixed', mixed],
+  ])('points at the start of every line (%s)', (_, source) => {
+    expect(source.slice(positionToOffset(source, 1, 0), positionToOffset(source, 1, 12))).toBe('const a = 1;')
+    expect(source.slice(positionToOffset(source, 2, 0), positionToOffset(source, 2, 12))).toBe('const b = 2;')
+    expect(source.slice(positionToOffset(source, 3, 0), positionToOffset(source, 3, 12))).toBe('const c = 3;')
+  })
+
+  test('clamps to the end of the source past the last line', () => {
+    expect(positionToOffset(lf, 4, 0)).toBe(lf.length)
+    expect(positionToOffset(mixed, 9, 0)).toBe(mixed.length)
+  })
+
+  test('round trips with offsetToLineNumber', () => {
+    for (const source of [lf, crlf, mixed]) {
+      for (let line = 1; line <= 3; line++) {
+        expect(offsetToLineNumber(source, positionToOffset(source, line, 1))).toBe(line)
+      }
+    }
   })
 })


### PR DESCRIPTION
### Description

`positionToOffset` and `offsetToLineNumber` in `@vitest/utils/offset` decide how wide a line break is once for the whole file:

```ts
const nl = /\r\n/.test(source) ? 2 : 1
```

A single `\r\n` anywhere makes every line count as ending in two characters, so in a file that mixes both styles the computed offset drifts by one character for every `\n` line that precedes the position being resolved.

```js
const code = 'const a = 1;\nconst b = 2;\r\nconst c = 3;'

positionToOffset(code, 2, 0) // 14, should be 13
positionToOffset(code, 3, 0) // 28, should be 26
```

This is how inline snapshots end up in the wrong place. `saveInlineSnapshots` turns the recorded line and column into an offset and then searches forward from it for the matcher call. A small drift is absorbed by the search, but once the drift grows past the end of the target call the search finds the next assertion instead and writes the snapshot into it, silently corrupting the file. The added `test/unit/test/inline-snap.test.ts` case reproduces exactly that: on `main` the snapshot for the first assertion lands inside the second one.

Mixed line endings are easy to end up with on Windows, or in any repository without `.gitattributes` where files have been touched by different tools.

Both functions now walk the actual line breaks instead of assuming a uniform style. Files that use one style throughout behave exactly as before, including the clamp to the end of the source when the line number is past the last line.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

`test/unit/test/utils.spec.ts` covers `positionToOffset` against LF, CRLF and mixed sources, the clamp past the last line, and a round trip through `offsetToLineNumber`. `test/unit/test/inline-snap.test.ts` covers the user visible effect. The mixed cases fail on `main`, the LF and CRLF ones pass on both.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

Internal utility, nothing to document.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
