### PR TITLE
fix(expect): `toBeOneOf` should not pass for an empty array or set

### DIFF
--- a/packages/expect/src/custom-matchers.ts
+++ b/packages/expect/src/custom-matchers.ts
@@ -34,13 +34,12 @@ ${printReceived(actual)}`,
     let pass: boolean
 
     if (Array.isArray(expected)) {
-      pass = expected.length === 0
-        || expected.some(item =>
-          equals(item, actual, customTesters),
-        )
+      pass = expected.some(item =>
+        equals(item, actual, customTesters),
+      )
     }
     else if (expected instanceof Set) {
-      pass = expected.size === 0 || expected.has(actual) || [...expected].some(item => equals(item, actual, customTesters))
+      pass = expected.has(actual) || [...expected].some(item => equals(item, actual, customTesters))
     }
     else {
       throw new TypeError(

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -722,6 +722,14 @@ describe('toBeOneOf()', () => {
     expect(null).not.toBeOneOf([undefined])
   })
 
+  it('nothing is one of an empty array or set', () => {
+    expect(0).not.toBeOneOf([])
+    expect(0).not.toBeOneOf(new Set())
+    expect(undefined).not.toBeOneOf([])
+    expect(undefined).not.toBeOneOf(new Set())
+    expect({ a: 0 }).not.toEqual(expect.toBeOneOf([]))
+  })
+
   it.fails('fail with missing negotiation', () => {
     expect(3).toBeOneOf([0, 1, 2])
     expect(3).toBeOneOf([expect.any(String)])


### PR DESCRIPTION
### Description

`toBeOneOf` short-circuits to a pass when the candidate list is empty:

```ts
pass = expected.length === 0 || expected.some(item => equals(item, actual, customTesters))
```

```ts
expect('anything').toBeOneOf([])          // passes
expect('anything').not.toBeOneOf([])      // fails
expect('anything').toBeOneOf(new Set())   // passes
```

Nothing is one of no values, and the documentation describes the matcher as asserting that the value matches one of the values in the provided array or set, so an empty list should never match. The short-circuit is also easy to hit by accident, since a candidate list built at runtime can come out empty and the assertion then passes silently instead of reporting that nothing matched.

This drops both short-circuits, for the array and the set branch, and lets the membership check decide.

The short-circuit dates back to the original `toBeOneOf` implementation in #6974 and has never been covered by a test or mentioned in the docs, so this looks unintentional rather than a documented escape hatch. It is still a behaviour change: an assertion that passes today against an empty list will start failing. Happy to gate it differently if you would rather not change this outside a major.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

`test/unit/test/jest-expect.test.ts` gets a case covering the array form, the set form and the asymmetric matcher. The full `test/unit` suite passes.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

The existing `toBeOneOf` docs already describe the behaviour this restores, so no change was needed.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
