### PR TITLE
fix(expect): treat symbol keys with undefined values like string keys

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -289,7 +289,7 @@ function isErrorEqual(
   return result
 }
 
-function keys(obj: object, hasKey: (obj: object, key: string) => boolean) {
+function keys(obj: object, hasKey: (obj: object, key: string | symbol) => boolean) {
   const keys = []
 
   for (const key in obj) {
@@ -301,16 +301,17 @@ function keys(obj: object, hasKey: (obj: object, key: string) => boolean) {
     (Object.getOwnPropertySymbols(obj) as Array<any>).filter(
       symbol =>
         (Object.getOwnPropertyDescriptor(obj, symbol) as PropertyDescriptor)
-          .enumerable,
+          .enumerable
+          && hasKey(obj, symbol),
     ),
   )
 }
 
-function hasDefinedKey(obj: any, key: string) {
+function hasDefinedKey(obj: any, key: string | symbol) {
   return hasKey(obj, key) && obj[key] !== undefined
 }
 
-function hasKey(obj: any, key: string) {
+function hasKey(obj: any, key: string | symbol) {
   return Object.hasOwn(obj, key)
 }
 

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -294,6 +294,17 @@ describe('jest-expect', () => {
     await expect(async () => await expect(null).toBeTestedPromise()).rejects.toThrow('toBeTestedPromise')
   })
 
+  it('ignores symbol keys with undefined values, like string keys', () => {
+    const a = Symbol('a')
+    const b = Symbol('b')
+
+    expect({ [a]: undefined }).toEqual({})
+    expect({}).toEqual({ [a]: undefined })
+    expect({ [a]: undefined, [b]: 2 }).toEqual({ [b]: 2 })
+    expect({ [a]: undefined }).not.toEqual({ [a]: 2 })
+    expect({ [a]: undefined }).toEqual({ [b]: undefined })
+  })
+
   it('object', () => {
     expect({}).toEqual({})
     expect({ apples: 13 }).toEqual({ apples: 13 })
@@ -578,6 +589,15 @@ describe('.toStrictEqual()', () => {
   it('does not ignore keys with undefined values', () => {
     expect({
       a: undefined,
+      b: 2,
+    }).not.toStrictEqual({ b: 2 })
+  })
+
+  it('does not ignore symbol keys with undefined values', () => {
+    const a = Symbol('a')
+
+    expect({
+      [a]: undefined,
       b: 2,
     }).not.toStrictEqual({ b: 2 })
   })


### PR DESCRIPTION
### Description

Resolves #8342

`toEqual` treats a key holding `undefined` as absent, so `expect({ a: undefined }).toEqual({})` passes. The same object with a symbol key fails:

```js
const sym = Symbol('sym')

expect({ a: undefined }).toEqual({})       // passes
expect({ [sym]: undefined }).toEqual({})   // fails
```

`keys()` in `jest-utils.ts` collects string keys through the `hasKey` predicate, which is `hasDefinedKey` for `toEqual` and `hasKey` for `toStrictEqual`, but appends every enumerable symbol without consulting it. Symbols therefore never get the `undefined` filtering that string keys get.

This applies the predicate to symbols as well. `toEqual` now ignores symbol keys holding `undefined`, and `toStrictEqual` keeps reporting them as a difference, matching how it already treats string keys.

One thing worth flagging for the reviewers: Jest's `@jest/expect-utils` has the same shape here, so this is a deliberate divergence rather than a Jest compatibility fix. The argument for making the change is the inconsistency inside Vitest itself, where the same value is ignored or not depending only on whether the key is a string or a symbol.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

Two tests in `test/unit/test/jest-expect.test.ts`: one covering the `toEqual` parity with string keys, one asserting `toStrictEqual` still reports the symbol key. The full `test/unit` suite passes.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No new API surface.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->
