### PR TITLE
fix(browser): encode iframeId in tester iframe URL [backport to v4]

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -350,7 +350,7 @@ export class IframeOrchestrator {
 
   private createTestIframe(iframeId: string) {
     const iframe = document.createElement('iframe')
-    const src = `/?sessionId=${getBrowserState().sessionId}&iframeId=${iframeId}`
+    const src = `/?sessionId=${getBrowserState().sessionId}&iframeId=${encodeURIComponent(iframeId)}`
     iframe.setAttribute('loading', 'eager')
     iframe.setAttribute('src', src)
     iframe.setAttribute('data-vitest', 'true')

--- a/test/browser/fixtures/file-path-encoding/a+b.test.ts
+++ b/test/browser/fixtures/file-path-encoding/a+b.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('runs a test from a file whose path contains a plus sign', () => {
+  expect(true).toBe(true)
+})

--- a/test/browser/fixtures/file-path-encoding/vitest.config.ts
+++ b/test/browser/fixtures/file-path-encoding/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+    },
+  },
+})

--- a/test/browser/specs/file-path-encoding.test.ts
+++ b/test/browser/specs/file-path-encoding.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { instances, provider, runBrowserTests } from './utils'
+
+test('runs tests from files whose path contains a plus sign', async () => {
+  const { stderr, stdout, exitCode } = await runBrowserTests({
+    root: './fixtures/file-path-encoding',
+    reporters: ['verbose'],
+    browser: {
+      provider,
+      instances,
+    },
+  })
+
+  expect(stderr).toBe('')
+  expect(exitCode).toBe(0)
+
+  instances.forEach(({ browser }) => {
+    expect(stdout).toReportPassedTest('a+b.test.ts', browser)
+  })
+})


### PR DESCRIPTION
Backport of #10521 to `v4`.

`createTestIframe` builds the tester iframe URL by interpolating the test-file path (`iframeId`) into the query string without encoding. A `+` in the path is decoded back as a space, so the spec no longer matches a real file, the iframe never runs the test, and browser mode hangs at `0 passed` with no error. Encode the value with `encodeURIComponent`; it is read back with standard URL decoding (`URLSearchParams.get`).

Clean cherry-pick of c8bf19f6675e5cadf401a991b944ba1901aaa772 apart from one context-only conflict in `orchestrator.ts` (`const config = getConfig()` exists only on `main`). Includes the regression test from the original PR.