### PR TITLE
fix: retract unhandled rejections with late handler via `rejectionHandled`

### DIFF
--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -48,7 +48,10 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
   // `rejectionHandled` can retract the exact errors it added to the shared state.
   // Scoped to this RPC instance, which is created per worker, so the worker-local
   // rejection ids cannot collide with another worker's.
-  const reportedRejections = new Map<number, unknown[]>()
+  // Rejections that are never retracted stay here for the life of the worker, and
+  // the pool outlives a watch rerun while `clearErrors` empties the error set, so
+  // the errors are referenced weakly to avoid pinning them past that point.
+  const reportedRejections = new Map<number, WeakRef<object>[]>()
 
   function getEnvironment(environmentName: string): DevEnvironment {
     const environment = project.vite.environments[environmentName]
@@ -339,7 +342,7 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
     onUnhandledError(err, type, rejectionId) {
       const collected = vitest.state.catchError(err, type)
       if (rejectionId != null && collected.length) {
-        reportedRejections.set(rejectionId, collected)
+        reportedRejections.set(rejectionId, collected.map(error => new WeakRef(error)))
       }
     },
     onUnhandledRejectionHandled(rejectionId) {
@@ -348,7 +351,12 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         return
       }
       reportedRejections.delete(rejectionId)
-      collected.forEach(error => vitest.state.removeUnhandledError(error))
+      collected.forEach((ref) => {
+        const error = ref.deref()
+        if (error) {
+          vitest.state.removeUnhandledError(error)
+        }
+      })
     },
     onAsyncLeaks(leaks) {
       vitest.state.catchLeaks(leaks)

--- a/packages/vitest/src/node/pools/rpc.ts
+++ b/packages/vitest/src/node/pools/rpc.ts
@@ -44,6 +44,12 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
   }
   project.vitest.state.metadata[project.name].dumpDir = project.config.dumpDir
 
+  // unhandled rejections reported by this worker, kept so that a later
+  // `rejectionHandled` can retract the exact errors it added to the shared state.
+  // Scoped to this RPC instance, which is created per worker, so the worker-local
+  // rejection ids cannot collide with another worker's.
+  const reportedRejections = new Map<number, unknown[]>()
+
   function getEnvironment(environmentName: string): DevEnvironment {
     const environment = project.vite.environments[environmentName]
     if (!environment) {
@@ -330,8 +336,19 @@ export function createMethodsRPC(project: TestProject, methodsOptions: MethodsOp
         await vitest._testRun.log(log)
       }
     },
-    onUnhandledError(err, type) {
-      vitest.state.catchError(err, type)
+    onUnhandledError(err, type, rejectionId) {
+      const collected = vitest.state.catchError(err, type)
+      if (rejectionId != null && collected.length) {
+        reportedRejections.set(rejectionId, collected)
+      }
+    },
+    onUnhandledRejectionHandled(rejectionId) {
+      const collected = reportedRejections.get(rejectionId)
+      if (!collected) {
+        return
+      }
+      reportedRejections.delete(rejectionId)
+      collected.forEach(error => vitest.state.removeUnhandledError(error))
     },
     onAsyncLeaks(leaks) {
       vitest.state.catchLeaks(leaks)

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -59,9 +59,15 @@ export class StateManager {
     this.onUnhandledError = options.onUnhandledError
   }
 
-  catchError(error: unknown, type: string): void {
+  /**
+   * Returns the errors that were actually collected, which callers can hold on to
+   * in order to remove them again later via {@link removeUnhandledError}. An
+   * `AggregateError` contributes one entry per inner error, and an error that was
+   * filtered out by `onUnhandledError` contributes none.
+   */
+  catchError(error: unknown, type: string): unknown[] {
     if (isAggregateError(error)) {
-      return error.errors.forEach(error => this.catchError(error, type))
+      return error.errors.flatMap(error => this.catchError(error, type))
     }
 
     if (typeof error === 'object' && error !== null) {
@@ -80,12 +86,19 @@ export class StateManager {
         task.result.state = 'skip'
         task.result.note = _error.note
       }
-      return
+      return []
     }
 
     if (!this.onUnhandledError || this.onUnhandledError(error as any) !== false) {
       this.errorsSet.add(error)
+      return [error]
     }
+
+    return []
+  }
+
+  removeUnhandledError(error: unknown): void {
+    this.errorsSet.delete(error)
   }
 
   catchLeaks(leaks: AsyncLeak[]): void {

--- a/packages/vitest/src/node/state.ts
+++ b/packages/vitest/src/node/state.ts
@@ -63,21 +63,24 @@ export class StateManager {
    * Returns the errors that were actually collected, which callers can hold on to
    * in order to remove them again later via {@link removeUnhandledError}. An
    * `AggregateError` contributes one entry per inner error, and an error that was
-   * filtered out by `onUnhandledError` contributes none.
+   * filtered out by `onUnhandledError` contributes none. Primitive errors are
+   * wrapped, so every collected entry is an object.
    */
-  catchError(error: unknown, type: string): unknown[] {
+  catchError(error: unknown, type: string): object[] {
     if (isAggregateError(error)) {
       return error.errors.flatMap(error => this.catchError(error, type))
     }
 
+    let collected: object
     if (typeof error === 'object' && error !== null) {
       (error as Record<string, unknown>).type = type
+      collected = error
     }
     else {
-      error = { type, message: error }
+      collected = { type, message: error }
     }
 
-    const _error = error as Record<string, any>
+    const _error = collected as Record<string, any>
     if (_error && typeof _error === 'object' && _error.code === 'VITEST_PENDING') {
       const task = this.idMap.get(_error.taskId)
       if (task) {
@@ -89,9 +92,9 @@ export class StateManager {
       return []
     }
 
-    if (!this.onUnhandledError || this.onUnhandledError(error as any) !== false) {
-      this.errorsSet.add(error)
-      return [error]
+    if (!this.onUnhandledError || this.onUnhandledError(collected as any) !== false) {
+      this.errorsSet.add(collected)
+      return [collected]
     }
 
     return []

--- a/packages/vitest/src/runtime/moduleRunner/errorCatcher.ts
+++ b/packages/vitest/src/runtime/moduleRunner/errorCatcher.ts
@@ -8,11 +8,19 @@ const processOff = process.off.bind(process)
 
 const dispose: (() => void)[] = []
 
+// workerd reports `unhandledRejection` eagerly and fires `rejectionHandled` once a
+// handler attaches later; Node defers the check until the microtask queue drains, so
+// it never reports this case at all. Track reported promises so a late handler can retract them.
+// The id only has to be unique within this worker: the main thread keys it by the
+// worker's own RPC instance, so counters from different workers never collide.
+let unhandledRejectionId = 0
+const pendingRejections = new WeakMap<Promise<any>, number>()
+
 export function listenForErrors(state: () => WorkerGlobalState): void {
   dispose.forEach(fn => fn())
   dispose.length = 0
 
-  function catchError(err: any, type: string, event: 'uncaughtException' | 'unhandledRejection') {
+  function catchError(err: any, type: string, event: 'uncaughtException' | 'unhandledRejection', promise?: Promise<any>) {
     const worker = state()
 
     const listeners = processListeners(event as 'uncaughtException')
@@ -30,17 +38,33 @@ export function listenForErrors(state: () => WorkerGlobalState): void {
         error.VITEST_TEST_PATH = worker.filepath
       }
     }
-    state().rpc.onUnhandledError(error, type)
+
+    let rejectionId: number | undefined
+    if (promise) {
+      rejectionId = unhandledRejectionId++
+      pendingRejections.set(promise, rejectionId)
+    }
+
+    state().rpc.onUnhandledError(error, type, rejectionId)
   }
 
   const uncaughtException = (e: Error) => catchError(e, 'Uncaught Exception', 'uncaughtException')
-  const unhandledRejection = (e: Error) => catchError(e, 'Unhandled Rejection', 'unhandledRejection')
+  const unhandledRejection = (e: Error, promise: Promise<any>) => catchError(e, 'Unhandled Rejection', 'unhandledRejection', promise)
+  const rejectionHandled = (promise: Promise<any>) => {
+    const id = pendingRejections.get(promise)
+    if (id != null) {
+      pendingRejections.delete(promise)
+      state().rpc.onUnhandledRejectionHandled(id)
+    }
+  }
 
   processOn('uncaughtException', uncaughtException)
   processOn('unhandledRejection', unhandledRejection)
+  processOn('rejectionHandled', rejectionHandled)
 
   dispose.push(() => {
     processOff('uncaughtException', uncaughtException)
     processOff('unhandledRejection', unhandledRejection)
+    processOff('rejectionHandled', rejectionHandled)
   })
 }

--- a/packages/vitest/src/types/rpc.ts
+++ b/packages/vitest/src/types/rpc.ts
@@ -29,7 +29,13 @@ export interface RuntimeRPC {
   transform: (id: string) => Promise<{ code?: string }>
 
   onUserConsoleLog: (log: UserConsoleLog) => void
-  onUnhandledError: (err: unknown, type: string) => void
+  /**
+   * `rejectionId` is set for unhandled rejections, and identifies the promise
+   * within the reporting worker so a later `onUnhandledRejectionHandled` can
+   * retract the error.
+   */
+  onUnhandledError: (err: unknown, type: string, rejectionId?: number) => void
+  onUnhandledRejectionHandled: (rejectionId: number) => void
   onAsyncLeaks: (leak: AsyncLeak[]) => void
   onQueued: (file: File) => void
   onCollected: (files: File[]) => Promise<void>

--- a/test/e2e/test/unhandled-rejections.test.ts
+++ b/test/e2e/test/unhandled-rejections.test.ts
@@ -66,3 +66,101 @@ test('unhandled rejections of main thread are reported even when no reporter is 
   expect(stderr).toContain('Error: intentional unhandled rejection')
   expect(stderr).toContain('setup-unhandled-rejections.js:3:48')
 })
+
+// Node never fires `unhandledRejection` and `rejectionHandled` for the same promise, so
+// these tests simulate an eager-reporting runtime (e.g. workerd) by emitting them by hand.
+describe('rejectionHandled', () => {
+  test('retracted rejection is not reported', async () => {
+    const { stderr, exitCode } = await runInlineTests({
+      'retracted.test.js': /* js */`
+        import { test } from "vitest"
+
+        test("passes", () => {
+          const promise = Promise.resolve()
+          process.emit('unhandledRejection', new Error('handled late'), promise)
+          process.emit('rejectionHandled', promise)
+        })
+      `,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toContain('Unhandled Rejection')
+  })
+
+  test('retracting in one worker keeps another worker\'s rejection', async () => {
+    // Rejection ids are worker-local counters, so two concurrent workers both report
+    // id 0. The sleeps interleave them deliberately: "retracts" reports first, "keeps"
+    // reports the same id while that is still pending, then "retracts" retracts. If the
+    // ids were not scoped per worker, the retraction would drop the surviving error.
+    // `runInlineTests` defaults to `maxWorkers: 1`, so both worker options are required
+    // for the two files to overlap at all. A scheduler slow enough to miss the window
+    // makes this pass without exercising the overlap, but never fail spuriously.
+    const { stderr, exitCode } = await runInlineTests({
+      'retracts.test.js': /* js */`
+        import { test } from "vitest"
+
+        test("retracts its own rejection", async () => {
+          const promise = Promise.resolve()
+          process.emit('unhandledRejection', new Error('retracted rejection'), promise)
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          process.emit('rejectionHandled', promise)
+        })
+      `,
+      'keeps.test.js': /* js */`
+        import { test } from "vitest"
+
+        test("leaves its rejection unhandled", async () => {
+          await new Promise(resolve => setTimeout(resolve, 100))
+          process.emit('unhandledRejection', new Error('surviving rejection'), Promise.resolve())
+        })
+      `,
+    }, {
+      isolate: true,
+      fileParallelism: true,
+      minWorkers: 2,
+      maxWorkers: 2,
+    }, { fails: true })
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Error: surviving rejection')
+    expect(stderr).not.toContain('Error: retracted rejection')
+    expect(stderr).toContain('Vitest caught 1 unhandled error during the test run')
+  })
+
+  test('retracts a rejection with a primitive reason', async () => {
+    const { stderr, exitCode } = await runInlineTests({
+      'primitive.test.js': /* js */`
+        import { test } from "vitest"
+
+        test("passes", () => {
+          const promise = Promise.resolve()
+          process.emit('unhandledRejection', 'a string reason', promise)
+          process.emit('rejectionHandled', promise)
+        })
+      `,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr).not.toContain('a string reason')
+  })
+
+  test('reporting does not depend on globals that tests can stub', async () => {
+    // The error catcher must not reach for globals like `crypto` at report time:
+    // a test is free to replace them, and throwing inside the `unhandledRejection`
+    // handler would escalate to an uncaught exception.
+    const { stderr, exitCode } = await runInlineTests({
+      'stubbed.test.js': /* js */`
+        import { test, vi } from "vitest"
+
+        test("stubs globals then leaves a rejection unhandled", () => {
+          vi.stubGlobal('crypto', { subtle: {} })
+          process.emit('unhandledRejection', new Error('still reported'), Promise.resolve())
+        })
+      `,
+    }, {}, { fails: true })
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Error: still reported')
+    expect(stderr).not.toContain('is not a function')
+  })
+})


### PR DESCRIPTION
### Description

Runtimes like workerd report `unhandledRejection` as soon as a promise rejects with no handler attached, then emit `rejectionHandled` once a handler attaches later. Node instead defers the check until the microtask queue drains, so the same code never reports there. Vitest's error catcher only listened for `unhandledRejection`, so pools running on eager reporting runtimes (e.g. `@cloudflare/vitest-pool-workers`) failed the run for rejections that were actually handled.

Resolves #10960 - see that issue for a deeper explanation.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
