### PR TITLE
fix: own the post-restart rerun, keep `process.exit` disabled in workers

### DIFF
--- a/packages/vitest/src/node/cache/files.ts
+++ b/packages/vitest/src/node/cache/files.ts
@@ -21,11 +21,14 @@ export class FilesStatsCache {
   }
 
   public async updateStats(fsPath: string, key: string): Promise<void> {
-    if (!fs.existsSync(fsPath)) {
-      return
+    try {
+      const stats = await fs.promises.stat(fsPath)
+      this.cache.set(key, { size: stats.size })
     }
-    const stats = await fs.promises.stat(fsPath)
-    this.cache.set(key, { size: stats.size })
+    catch {
+      // the file can be deleted while the stat is in flight; a file
+      // without stats only loses sorting heuristics
+    }
   }
 
   public removeStats(fsPath: string): void {

--- a/packages/vitest/src/node/cli/cli-api.ts
+++ b/packages/vitest/src/node/cli/cli-api.ts
@@ -129,12 +129,20 @@ export async function startVitest(
     stdinCleanup = registerConsoleShortcuts(ctx, stdin, stdout)
   }
 
-  ctx.onAfterSetServer(() => {
-    if (ctx.config.standalone) {
-      ctx.standalone()
+  ctx.onAfterSetServer(async () => {
+    if (ctx.closingPromise) {
+      return
     }
-    else {
-      ctx.start(cliFilters)
+    try {
+      if (ctx.config.standalone) {
+        await ctx.standalone()
+      }
+      else {
+        await ctx.start(cliFilters)
+      }
+    }
+    catch (error) {
+      reportStartError(ctx, error)
     }
   })
 
@@ -157,27 +165,7 @@ export async function startVitest(
     return ctx
   }
   catch (e) {
-    if (e instanceof FilesNotFoundError) {
-      return ctx
-    }
-
-    if (e instanceof GitNotFoundError) {
-      ctx.logger.error(e.message)
-      return ctx
-    }
-
-    if (
-      e instanceof IncludeTaskLocationDisabledError
-      || e instanceof RangeLocationFilterProvidedError
-      || e instanceof LocationFilterFileNotFoundError
-    ) {
-      ctx.logger.printError(e, { verbose: false })
-      return ctx
-    }
-
-    process.exitCode = 1
-    ctx.logger.printError(e, { fullStack: true, type: 'Unhandled Error' })
-    ctx.logger.error('\n\n')
+    reportStartError(ctx, e)
     return ctx
   }
   finally {
@@ -186,6 +174,30 @@ export async function startVitest(
       await ctx.close()
     }
   }
+}
+
+function reportStartError(ctx: Vitest, error: unknown): void {
+  if (error instanceof FilesNotFoundError) {
+    return
+  }
+
+  if (error instanceof GitNotFoundError) {
+    ctx.logger.error(error.message)
+    return
+  }
+
+  if (
+    error instanceof IncludeTaskLocationDisabledError
+    || error instanceof RangeLocationFilterProvidedError
+    || error instanceof LocationFilterFileNotFoundError
+  ) {
+    ctx.logger.printError(error, { verbose: false })
+    return
+  }
+
+  process.exitCode = 1
+  ctx.logger.printError(error, { fullStack: true, type: 'Unhandled Error' })
+  ctx.logger.error('\n\n')
 }
 
 export async function prepareVitest(

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -347,7 +347,10 @@ export class Vitest {
           || this.projects.some(p => p.vite.config.configFile === file)
           || this.config._containerConfigFiles?.includes(file)
         if (isConfig) {
-          await this._restart('config')
+          // a floating rejection in an event handler would crash the process
+          await this._restart('config').catch((error) => {
+            this.logger.printError(error, { fullStack: true, type: 'Restart Error' })
+          })
         }
       })
 

--- a/packages/vitest/src/runtime/workers/base.ts
+++ b/packages/vitest/src/runtime/workers/base.ts
@@ -27,10 +27,12 @@ async function startModuleRunner(options: ContextModuleRunnerOptions): Promise<T
     return _moduleRunner
   }
 
-  process.exit = (code = process.exitCode || 0): never => {
-    throw new Error(`process.exit unexpectedly called with "${code}"`)
-  }
   const state = () => getSafeWorkerState() || options.state
+
+  process.exit = (code = process.exitCode || 0): never => {
+    const filepath = state().filepath
+    throw new Error(`process.exit unexpectedly called with "${code}"${filepath ? ` (test file: ${filepath})` : ''}`)
+  }
 
   listenForErrors(state)
 

--- a/packages/vitest/src/runtime/workers/init-forks.ts
+++ b/packages/vitest/src/runtime/workers/init-forks.ts
@@ -41,20 +41,15 @@ export default function workerInit(options: {
     teardown: () => {
       processRemoveAllListeners('message')
       processOff('error', onError)
+      // the guard installed by the test runner stays active between test
+      // files: with `isolate: false` a late process.exit would kill the
+      // other files sharing this process
+      process.exit = processExit
     },
-    runTests: (state, traces) => executeTests('run', state, traces),
-    collectTests: (state, traces) => executeTests('collect', state, traces),
+    runTests: (state, traces) => runTests('run', state, traces),
+    collectTests: (state, traces) => runTests('collect', state, traces),
     setup: options.setup,
   })
-
-  async function executeTests(method: 'run' | 'collect', state: WorkerGlobalState, traces: Traces) {
-    try {
-      await runTests(method, state, traces)
-    }
-    finally {
-      process.exit = processExit
-    }
-  }
 }
 
 // Prevent leaving worker in loops where it tries to send message to closed main

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -119,7 +119,8 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
   })
 
   process.exit = (code = process.exitCode || 0): never => {
-    throw new Error(`process.exit unexpectedly called with "${code}"`)
+    const filepath = state.filepath
+    throw new Error(`process.exit unexpectedly called with "${code}"${filepath ? ` (test file: ${filepath})` : ''}`)
   }
 
   listenForErrors(() => state)

--- a/test/e2e/test/cli-config.test.ts
+++ b/test/e2e/test/cli-config.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { expect, it, test } from 'vitest'
+import { expect, it, onTestFinished, test } from 'vitest'
 import { createVitest } from 'vitest/node'
 import { runVitest, useFS } from '../../test-utils'
 
@@ -7,6 +7,7 @@ test('can pass down the config as a module', async () => {
   const vitest = await createVitest('test', {
     config: '@test/test-dep-config',
   })
+  onTestFinished(() => vitest.close())
 
   expect(vitest.vite.config.configFile).toBe(
     resolve(import.meta.dirname, '../deps/test-dep-config/index.js'),

--- a/test/e2e/test/config/browser-configs.test.ts
+++ b/test/e2e/test/config/browser-configs.test.ts
@@ -42,8 +42,12 @@ const vitest = vi.defineHelper(async (options: TestUserConfig & { $viteConfig?: 
     vitestOptions,
   )
   onTestFinished(async () => {
-    await vitest.vite.waitForRequestsIdle()
-    await vitest.close()
+    try {
+      await vitest.vite.waitForRequestsIdle()
+    }
+    finally {
+      await vitest.close()
+    }
   })
   return vitest
 })


### PR DESCRIPTION
The rerun that `startVitest` schedules after a watch-mode server restart ran as a floating promise with no error handling. Anything failing inside it became an unhandled rejection in whatever process hosted the Vitest instance. This was the source of most of the recent CI flakes: our meta-tests run Vitest inside shared `isolate: false` forks workers, where the real `process.exit` was restored after the first test file, so a late rejection could escalate into the whole worker being killed mid-run ("Worker forks emitted error").

The restart now awaits its rerun and reports failures the same way the initial run does, and workers keep `process.exit` disabled until teardown, so a stray exit call fails loudly with the test file in the message instead of taking down the process.