### PR TITLE
fix(pool): report the worker exit instead of a pipe error that raced it

### DIFF
--- a/packages/vitest/src/node/pools/poolRunner.ts
+++ b/packages/vitest/src/node/pools/poolRunner.ts
@@ -37,6 +37,9 @@ interface StopOptions {
 
 const START_TIMEOUT = 60_000
 const STOP_TIMEOUT = 60_000
+// how long a failed pipe write may wait for the worker's 'exit' event
+// before it is reported as the worker error itself
+const PIPE_ERROR_EXIT_GRACE = 1_000
 
 /** @experimental */
 export class PoolRunner {
@@ -277,6 +280,9 @@ export class PoolRunner {
     try {
       this._state = RunnerState.STOPPING
 
+      clearTimeout(this._pipeErrorTimer)
+      this._pipeErrorTimer = undefined
+
       // Remove exit listener early to avoid "unexpected exit" errors during shutdown
       this.worker.off('exit', this.emitUnexpectedExit)
 
@@ -355,8 +361,30 @@ export class PoolRunner {
     this._eventEmitter.off(event, callback)
   }
 
+  private _pipeErrorTimer: ReturnType<typeof setTimeout> | undefined
+
   private emitWorkerError = (maybeError: unknown): void => {
     const error = maybeError instanceof Error ? maybeError : new Error(String(maybeError))
+
+    // A write into a dying worker fails with EPIPE (or a closed IPC channel)
+    // and can be observed before the worker's 'exit' event, especially on
+    // macOS. The exit event knows the exit code, the signal and the affected
+    // test files, so hold the write error and let `emitUnexpectedExit` report
+    // instead. The timer covers a broken channel whose process never exits.
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'EPIPE' || code === 'ERR_IPC_CHANNEL_CLOSED') {
+      if (this._pipeErrorTimer) {
+        return
+      }
+      this._pipeErrorTimer = setTimeout(() => {
+        this._pipeErrorTimer = undefined
+        if (this._eventEmitter.listenerCount('error')) {
+          this._eventEmitter.emit('error', error)
+        }
+      }, PIPE_ERROR_EXIT_GRACE)
+      this._pipeErrorTimer.unref()
+      return
+    }
 
     this._eventEmitter.emit('error', error)
   }
@@ -378,6 +406,8 @@ export class PoolRunner {
   }
 
   private emitUnexpectedExit = (code?: number, signal?: string): void => {
+    clearTimeout(this._pipeErrorTimer)
+    this._pipeErrorTimer = undefined
     const hasCode = typeof code === 'number'
     const errorDetails = hasCode || signal
       ? `with ${hasCode ? `exit code ${code} ` : ''}${signal ? `signal ${signal} ` : ''}`

--- a/packages/vitest/src/node/pools/poolRunner.ts
+++ b/packages/vitest/src/node/pools/poolRunner.ts
@@ -37,9 +37,6 @@ interface StopOptions {
 
 const START_TIMEOUT = 60_000
 const STOP_TIMEOUT = 60_000
-// how long a failed pipe write may wait for the worker's 'exit' event
-// before it is reported as the worker error itself
-const PIPE_ERROR_EXIT_GRACE = 1_000
 
 /** @experimental */
 export class PoolRunner {
@@ -280,11 +277,10 @@ export class PoolRunner {
     try {
       this._state = RunnerState.STOPPING
 
-      clearTimeout(this._pipeErrorTimer)
-      this._pipeErrorTimer = undefined
-
-      // Remove exit listener early to avoid "unexpected exit" errors during shutdown
+      // Remove exit and error listeners early to avoid "unexpected exit" and
+      // channel teardown errors during shutdown
       this.worker.off('exit', this.emitUnexpectedExit)
+      this.worker.off('error', this.emitWorkerError)
 
       const stopSpan = this.startTracesSpan('vitest.worker.stop')
       await this.withTimeout(
@@ -361,30 +357,8 @@ export class PoolRunner {
     this._eventEmitter.off(event, callback)
   }
 
-  private _pipeErrorTimer: ReturnType<typeof setTimeout> | undefined
-
   private emitWorkerError = (maybeError: unknown): void => {
     const error = maybeError instanceof Error ? maybeError : new Error(String(maybeError))
-
-    // A write into a dying worker fails with EPIPE (or a closed IPC channel)
-    // and can be observed before the worker's 'exit' event, especially on
-    // macOS. The exit event knows the exit code, the signal and the affected
-    // test files, so hold the write error and let `emitUnexpectedExit` report
-    // instead. The timer covers a broken channel whose process never exits.
-    const code = (error as NodeJS.ErrnoException).code
-    if (code === 'EPIPE' || code === 'ERR_IPC_CHANNEL_CLOSED') {
-      if (this._pipeErrorTimer) {
-        return
-      }
-      this._pipeErrorTimer = setTimeout(() => {
-        this._pipeErrorTimer = undefined
-        if (this._eventEmitter.listenerCount('error')) {
-          this._eventEmitter.emit('error', error)
-        }
-      }, PIPE_ERROR_EXIT_GRACE)
-      this._pipeErrorTimer.unref()
-      return
-    }
 
     this._eventEmitter.emit('error', error)
   }
@@ -406,8 +380,6 @@ export class PoolRunner {
   }
 
   private emitUnexpectedExit = (code?: number, signal?: string): void => {
-    clearTimeout(this._pipeErrorTimer)
-    this._pipeErrorTimer = undefined
     const hasCode = typeof code === 'number'
     const errorDetails = hasCode || signal
       ? `with ${hasCode ? `exit code ${code} ` : ''}${signal ? `signal ${signal} ` : ''}`

--- a/packages/vitest/src/node/pools/workers/forksWorker.ts
+++ b/packages/vitest/src/node/pools/workers/forksWorker.ts
@@ -2,10 +2,14 @@ import type { ChildProcess } from 'node:child_process'
 import type { Writable } from 'node:stream'
 import type { PoolOptions, PoolWorker, WorkerRequest } from '../types'
 import { fork } from 'node:child_process'
+import { EventEmitter } from 'node:events'
 import { resolve } from 'node:path'
 import { streamFlushed } from './utils'
 
 const SIGKILL_TIMEOUT = 500 /** jest does 500ms by default, let's follow it */
+// how long a failed pipe write may wait for the process's 'exit' event
+// before it is reported as the worker error itself
+const PIPE_ERROR_EXIT_GRACE = 1_000
 
 /** @experimental */
 export class ForksPoolWorker implements PoolWorker {
@@ -20,6 +24,9 @@ export class ForksPoolWorker implements PoolWorker {
   private stdout: NodeJS.WriteStream | Writable
   private stderr: NodeJS.WriteStream | Writable
 
+  private _errorEmitter = new EventEmitter<{ error: [Error] }>()
+  private _pipeErrorTimer: ReturnType<typeof setTimeout> | undefined
+
   constructor(options: PoolOptions) {
     this.execArgv = options.execArgv
     this.env = options.env
@@ -31,11 +38,21 @@ export class ForksPoolWorker implements PoolWorker {
   }
 
   on(event: string, callback: (...args: any[]) => void): void {
-    this.fork.on(event, callback)
+    if (event === 'error') {
+      this._errorEmitter.on('error', callback)
+    }
+    else {
+      this.fork.on(event, callback)
+    }
   }
 
   off(event: string, callback: (...args: any[]) => void): void {
-    this.fork.off(event, callback)
+    if (event === 'error') {
+      this._errorEmitter.off('error', callback)
+    }
+    else {
+      this.fork.off(event, callback)
+    }
   }
 
   send(message: WorkerRequest): void {
@@ -49,6 +66,8 @@ export class ForksPoolWorker implements PoolWorker {
       stdio: 'pipe',
       serialization: 'advanced',
     })
+
+    this._fork.on('error', this.emitError)
 
     // `end: false`: the logger streams are shared by every worker, so one
     // ending worker stream must not end them for everyone else
@@ -106,6 +125,40 @@ export class ForksPoolWorker implements PoolWorker {
 
   deserialize(data: unknown): unknown {
     return data
+  }
+
+  private emitError = (error: Error): void => {
+    // A write into a dying child process fails with EPIPE (or a closed IPC
+    // channel) and can be observed before the process's 'exit' event,
+    // especially on macOS. The exit event knows the exit code, the signal and
+    // the affected test files, so hold the write error and let the 'exit'
+    // listeners report instead. The timer covers a broken channel whose
+    // process never exits; a process that exited while the error was held was
+    // already reported through the exit event, and a process whose listeners
+    // were detached is being shut down deliberately — drop the error in both
+    // cases.
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'EPIPE' || code === 'ERR_IPC_CHANNEL_CLOSED') {
+      if (this._pipeErrorTimer) {
+        return
+      }
+      this._pipeErrorTimer = setTimeout(() => {
+        this._pipeErrorTimer = undefined
+        const fork = this._fork
+        if (
+          fork
+          && fork.exitCode == null
+          && fork.signalCode == null
+          && this._errorEmitter.listenerCount('error')
+        ) {
+          this._errorEmitter.emit('error', error)
+        }
+      }, PIPE_ERROR_EXIT_GRACE)
+      this._pipeErrorTimer.unref()
+      return
+    }
+
+    this._errorEmitter.emit('error', error)
   }
 
   private get fork() {


### PR DESCRIPTION
When a forks worker dies mid-run, the parent usually has an IPC reply in flight, and on macOS the failed write's `EPIPE` `'error'` event can be observed before the worker's `'exit'` event. The task then rejects with `Caused by: write EPIPE` instead of the exit code, signal and affected files, and because only the exit handler marks the runner terminated, the pool can reuse the dead runner for queued `isolate: false` files and silently lose them from the report (flaked on macOS CI in `pool-worker-exit.test.ts`).

This can't be fixed at the call sites or in the test: the parent only learns about the death when `'exit'`/`'error'` is delivered, so there is always a window where sends target a dead process, and the pipe error itself carries no exit information to report. The runner now holds pipe errors briefly and lets the `'exit'` event report the death; a grace timer still surfaces the pipe error in case the channel breaks without the process dying.