### PR TITLE
docs(browser): clarify vi.mock placement for module mocking

### DIFF
--- a/docs/api/vi.md
+++ b/docs/api/vi.md
@@ -39,6 +39,8 @@ Substitutes all imported modules from provided `path` with another module. You c
 
 It is recommended to use `vi.mock` or `vi.hoisted` only inside test files. If Vite's [module runner](/config/experimental#experimental-vitemodulerunner) is disabled, they will not be hoisted. This is a performance optimisation to avoid ready unnecessary files.
 
+In [Browser Mode](/guide/browser/#mocking-modules), `vi.mock` must appear in the test file or a [setup file](/config/setupfiles). A separate mock helper imported with a static `import` will not reliably register before modules are fetched.
+
 ::: warning
 `vi.mock` works only for modules that were imported with the `import` keyword. It doesn't work with `require`.
 
@@ -653,7 +655,7 @@ console.log(cart.getApples()) // still 42!
 :::
 
 ::: tip
-It is not possible to spy on exported methods in [Browser Mode](/guide/browser/). Instead, you can spy on every exported method by calling `vi.mock("./file-path.js", { spy: true })`. This will mock every export but keep its implementation intact, allowing you to assert if the method was called correctly.
+It is not possible to spy on exported methods in [Browser Mode](/guide/browser/#spying-on-module-exports). Instead, you can spy on every exported method by calling `vi.mock("./file-path.js", { spy: true })`. This will mock every export but keep its implementation intact, allowing you to assert if the method was called correctly. As with other mocks, place `vi.mock` in the test file or a [setup file](/config/setupfiles) — see [Mocking Modules](/guide/browser/#mocking-modules).
 
 ```ts
 import { calculator } from './src/calculator.ts'

--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -592,6 +592,43 @@ When using Vitest Browser, it's important to note that thread blocking dialogs l
 
 In such situations, Vitest provides default mocks with default returned values for these APIs. This ensures that if the user accidentally uses synchronous popup web APIs, the execution would not hang. However, it's still recommended for the user to mock these web APIs for a better experience. Read more in [Mocking](/guide/mocking).
 
+### Mocking Modules
+
+`vi.mock` works in Browser Mode, but the mock must be registered before the browser starts fetching modules.
+
+When Vitest sees `vi.mock` or `vi.hoisted` in a file, it rewrites that file's static imports into dynamic ones so modules load one by one after the mock is registered. If the test file only has static imports, the browser fetches them in parallel — and a mock defined elsewhere can register too late.
+
+Put `vi.mock` in the test file itself (or in a [setup file](/config/setupfiles) when the same mock should apply to every test):
+
+```ts
+import { expect, test, vi } from 'vitest'
+import { randomString } from './random.js'
+
+vi.mock('./random.js', () => {
+  return {
+    randomString: () => '__MOCK__',
+  }
+})
+
+test('randomString', () => {
+  expect(randomString()).toBe('__MOCK__')
+})
+```
+
+::: danger
+Do not put `vi.mock` in a separate helper and import it statically from the test:
+
+```ts
+// ❌ Does not work reliably in Browser Mode
+import './random.mock.js' // contains vi.mock('./random.js', ...)
+import { randomString } from './random.js'
+```
+
+The browser may fetch `./random.js` before the mock is registered. Move the `vi.mock` call into the test file or a setup file instead.
+:::
+
+See [Mocking Modules](/guide/mocking/modules) for factories, automocking, and how the transform works.
+
 ### Spying on Module Exports
 
 Browser Mode uses the browser's native ESM support to serve modules. The module namespace object is sealed and can't be reconfigured, unlike in Node.js tests where Vitest can patch the Module Runner. This means you can't call `vi.spyOn` on an imported object:
@@ -603,7 +640,7 @@ import * as module from './module.js'
 vi.spyOn(module, 'method') // ❌ throws an error
 ```
 
-To bypass this limitation, Vitest supports `{ spy: true }` option in `vi.mock('./module.js')`. This will automatically spy on every export in the module without replacing them with fake ones.
+To bypass this limitation, Vitest supports `{ spy: true }` option in `vi.mock('./module.js')`. This will automatically spy on every export in the module without replacing them with fake ones. As with other mocks, call `vi.mock` in the test file or a [setup file](/config/setupfiles) — see [Mocking Modules](#mocking-modules) above.
 
 ```ts
 import { vi } from 'vitest'

--- a/docs/guide/mocking.md
+++ b/docs/guide/mocking.md
@@ -45,7 +45,7 @@ vi.spyOn(exports, 'getter', 'get').mockReturnValue('mocked')
 ```
 
 ::: warning
-This will not work in the Browser Mode. For a workaround, see [Limitations](/guide/browser/#spying-on-module-exports).
+This will not work in the Browser Mode. For a workaround, see [Spying on Module Exports](/guide/browser/#spying-on-module-exports). For where to place `vi.mock` in Browser Mode, see [Mocking Modules](/guide/browser/#mocking-modules).
 :::
 
 ### Mock an exported function
@@ -53,7 +53,7 @@ This will not work in the Browser Mode. For a workaround, see [Limitations](/gui
 1. Example with `vi.mock`:
 
 ::: warning
-Don't forget that a `vi.mock` call is hoisted to top of the file. It will always be executed before all imports.
+Don't forget that a `vi.mock` call is hoisted to top of the file. It will always be executed before all imports. In Browser Mode, the call must also live in the test file or a [setup file](/config/setupfiles) — see [Mocking Modules](/guide/browser/#mocking-modules).
 :::
 
 ```ts [example.js]
@@ -75,7 +75,7 @@ vi.spyOn(exports, 'method').mockImplementation(() => {})
 ```
 
 ::: warning
-`vi.spyOn` example will not work in the Browser Mode. For a workaround, see [Limitations](/guide/browser/#spying-on-module-exports).
+`vi.spyOn` example will not work in the Browser Mode. For a workaround, see [Spying on Module Exports](/guide/browser/#spying-on-module-exports).
 :::
 
 ### Mock an exported class implementation
@@ -106,7 +106,7 @@ vi.spyOn(mod, 'SomeClass').mockImplementation(class FakeClass {
 ```
 
 ::: warning
-`vi.spyOn` example will not work in the Browser Mode. For a workaround, see [Limitations](/guide/browser/#spying-on-module-exports).
+`vi.spyOn` example will not work in the Browser Mode. For a workaround, see [Spying on Module Exports](/guide/browser/#spying-on-module-exports).
 :::
 
 ### Spy on an object returned from a function

--- a/docs/guide/mocking/modules.md
+++ b/docs/guide/mocking/modules.md
@@ -57,6 +57,8 @@ vi.mock(import('./example.js'), () => {
 
 ::: tip
 Remember that you can call `vi.mock` in a [setup file](/config/setupfiles) to apply the module mock in every test file automatically.
+
+In [Browser Mode](/guide/browser/#mocking-modules), the mock must live in the test file or a setup file. Importing a separate mock helper with a static `import` is not enough — the browser can fetch modules in parallel before the mock is registered.
 :::
 
 ::: tip
@@ -115,7 +117,7 @@ expect(exampleObject.answer).toHaveBeenCalled()
 ```
 
 ::: danger Browser Mode Support
-This will not work in the [Browser Mode](/guide/browser/) because it uses the browser's native ESM support to serve modules. The module namespace object is sealed and can't be reconfigured. To bypass this limitation, Vitest supports `{ spy: true }` option in `vi.mock('./example.js')`. This will automatically spy on every export in the module without replacing them with fake ones.
+This will not work in the [Browser Mode](/guide/browser/) because it uses the browser's native ESM support to serve modules. The module namespace object is sealed and can't be reconfigured. To bypass this limitation, Vitest supports `{ spy: true }` option in `vi.mock('./example.js')`. This will automatically spy on every export in the module without replacing them with fake ones. Place the `vi.mock` call in the test file or a [setup file](/config/setupfiles) — see [Browser Mode: Mocking Modules](/guide/browser/#mocking-modules).
 
 ```ts
 import { vi } from 'vitest'
@@ -287,7 +289,7 @@ vi.mock(import('vscode'), () => {
 
 ## How it Works
 
-Vitest implements different module mocking mechanisms depending on the environment. The only feature they share is the plugin transformer. When Vitest sees that a file has `vi.mock` inside, it will transform every static import into a dynamic one and move the `vi.mock` call to the top of the file. This allows Vitest to register the mock before the import happens without breaking the ESM rule of hoisted imports.
+Vitest implements different module mocking mechanisms depending on the environment. The only feature they share is the plugin transformer. When Vitest sees that a file has `vi.mock` inside, it will transform every static import into a dynamic one and move the `vi.mock` call to the top of the file. This allows Vitest to register the mock before the import happens without breaking the ESM rule of hoisted imports. That rewrite only applies to files that contain `vi.mock` or `vi.hoisted` themselves — which is why a separate statically imported mock helper does not work reliably in [Browser Mode](/guide/browser/#mocking-modules).
 
 ::: code-group
 ```ts [example.js]
@@ -360,6 +362,20 @@ ${resolvedFactoryKeys.map(key => `export const ${key} = __private_module__["${ke
 This module can now be served back to the browser. You can inspect the code in the devtools when you run the tests.
 
 ## Mocking Modules Pitfalls
+
+### Browser Mode: `vi.mock` Must Be in the Test or Setup File
+
+In [Browser Mode](/guide/browser/#mocking-modules), Vitest only rewrites static imports in files that contain `vi.mock` or `vi.hoisted`. If you define the mock in another file and import that helper statically, the browser may load the module under test before the mock is registered:
+
+```ts
+// ❌ Unreliable in Browser Mode
+import './random.mock.js'
+import { randomString } from './random.js'
+```
+
+Call `vi.mock` in the test file, or in a [setup file](/config/setupfiles) for shared mocks. See [Browser Mode limitations](/guide/browser/#mocking-modules) for a full example.
+
+### Same-File Method Calls Cannot Be Mocked
 
 Beware that it is not possible to mock calls to methods that are called inside other methods of the same file. For example, in this code:
 


### PR DESCRIPTION
## Summary

- Documents that in Browser Mode, `vi.mock` / `vi.hoisted` must live in the **test file** or a **setup file** so Vitest can rewrite static imports before the browser fetches modules
- Warns against the common pitfall of putting mocks in a separate helper and importing it statically (the case from #8246)
- Cross-links the browser limitations, mocking guide, and `vi.mock` API, and clarifies that `{ spy: true }` follows the same placement rules

Fixes #8246

## Test plan

- [ ] Open `/guide/browser/#mocking-modules` and confirm the example + danger callout render correctly
- [ ] Follow links from `/guide/mocking/modules`, `/guide/mocking`, and `/api/vi#vi-mock` to the new section
- [ ] Confirm `#spying-on-module-exports` still works and mentions placement