### PR TITLE
fix: use require() for node built-in modules to ensure import/require equivalence

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -148,14 +148,39 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
         importer,
       },
     )
+    // Use require() for node built-in modules so that ESM imports and CJS
+    // requires return the same module object. This is important for tools
+    // like MSW that patch the module returned by require().
+    const loadModule = () => {
+      if (isBuiltin(id) || id.startsWith('node:')) {
+        // For node built-ins, use require to get the same object that
+        // CJS require() returns, ensuring import and require are equivalent.
+        // The base path for createRequire doesn't matter for built-ins,
+        // but we need a valid file path. Use importer if it's a file URL,
+        // otherwise fall back to process.cwd().
+        let requireBase: string
+        if (importer && (importer.startsWith('file://') || importer.startsWith('/'))) {
+          requireBase = importer.startsWith('file://') ? fileURLToPath(importer) : importer
+        }
+        else if (filename.startsWith('file://') || filename.startsWith('/')) {
+          requireBase = filename.startsWith('file://') ? fileURLToPath(filename) : filename
+        }
+        else {
+          requireBase = process.cwd()
+        }
+        const req = this.createRequire(requireBase)
+        return Promise.resolve(req(id))
+      }
+      return this.vm
+        ? this.vm.externalModulesExecutor.import(file)
+        : import(file)
+    }
     const namespace = await this._otel.$(
       'vitest.module.external',
       {
         attributes: { 'code.file.path': file },
       },
-      () => this.vm
-        ? this.vm.externalModulesExecutor.import(file)
-        : import(file),
+      () => loadModule(),
     ).finally(() => {
       this.options.moduleExecutionInfo?.set(filename, finishModuleExecutionInfo())
     })

--- a/test/unit/test/node-builtin-module-identity.test.ts
+++ b/test/unit/test/node-builtin-module-identity.test.ts
@@ -1,0 +1,36 @@
+import { expect, it } from 'vitest'
+import * as https from 'node:https'
+import * as timers from 'node:timers'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+
+// Regression test for https://github.com/vitest-dev/vitest/issues/10795
+// MSW (and similar tools) patch the module returned by require(), and expect
+// the same patched module to be used by ESM imports. This test verifies that
+// `import * as mod from 'node:mod'` returns the same object as `require('node:mod')`.
+it('import * as node:https returns same object as require', () => {
+  const httpsRequire = require('node:https')
+  expect(https).toBe(httpsRequire)
+  expect(https.get).toBe(httpsRequire.get)
+  expect(https.request).toBe(httpsRequire.request)
+})
+
+it('import * as node:timers returns same object as require', () => {
+  const timersRequire = require('node:timers')
+  expect(timers).toBe(timersRequire)
+  expect(timers.setTimeout).toBe(timersRequire.setTimeout)
+  expect(timers.setInterval).toBe(timersRequire.setInterval)
+})
+
+it('import * as node:path returns same object as require', () => {
+  const pathRequire = require('node:path')
+  expect(path).toBe(pathRequire)
+  expect(path.join).toBe(pathRequire.join)
+  expect(path.resolve).toBe(pathRequire.resolve)
+})
+
+it('import * as node:fs returns same object as require', () => {
+  const fsRequire = require('node:fs')
+  expect(fs).toBe(fsRequire)
+  expect(fs.readFileSync).toBe(fsRequire.readFileSync)
+})


### PR DESCRIPTION
## Summary

Node built-in modules (e.g., `node:https`, `node:timers`, `node:path`, `node:fs`) imported via ESM `import * as mod from 'node:mod'` were returning a different object than `require('node:mod')`. This is because ESM imports went through dynamic `import()` which returns a Module Namespace Object (potentially wrapped in a proxy for interop), while CJS `require()` returns the raw module exports directly.

This breaks tools like [MSW](https://mswjs.io/) that patch the module returned by `require()` and expect the same patched module to be used by ESM imports. See #10795 for the full reproduction.

## Root Cause

In `packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts`, the `runExternalModule()` method uses dynamic `import()` to load all external modules, including node built-ins. For node built-ins, `import('node:https')` returns a Module Namespace Object which is a different object from what `require('node:https')` returns.

## Fix

Modified `runExternalModule()` to use `require()` (via `createRequire`) for node built-in modules instead of dynamic `import()`. This ensures that both `import * as mod from 'node:mod'` and `require('node:mod')` return the same module object.

The base path for `createRequire` doesn't matter for built-in modules (they don't need relative resolution), so we use the importer's path if available, falling back to `process.cwd()`.

## Test

Added `test/unit/test/node-builtin-module-identity.test.ts` which verifies that `import * as mod` returns the same object as `require('node:mod')` for `node:https`, `node:timers`, `node:path`, and `node:fs`.

## Impact

- Fixes #10795 (MSW does not intercept all requests)
- Ensures module identity consistency between ESM and CJS imports of node built-ins
- No breaking changes - the behavior now matches plain Node.js where both import paths access the same underlying module