### PR TITLE
fix(ui): fix code editor error and annotations gadgets layout shifts

### DIFF
--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -327,8 +327,8 @@ function createAnnotationElement(annotation: TestAnnotation) {
 }
 
 const { pause, resume } = watch(
-  [codemirrorRef, errors, annotations, finished] as const,
-  ([cmValue, errors, annotations, end]) => {
+  [codemirrorRef, errors, annotations, finished, loading] as const,
+  ([cmValue, errors, annotations, end, loadingFile]) => {
     if (!cmValue) {
       widgets.length = 0
       handles.length = 0
@@ -351,19 +351,21 @@ const { pause, resume } = watch(
     widgets.length = 0
     handles.length = 0
 
-    setTimeout(() => {
-      // add new data
-      errors.forEach(createErrorElement)
+    if (loadingFile) {
+      return
+    }
 
-      annotations.forEach(createAnnotationElement)
+    // add new data
+    errors.forEach(createErrorElement)
 
-      // Prevent getting access to initial state
-      if (!hasBeenEdited.value) {
-        cmValue.clearHistory()
-      }
+    annotations.forEach(createAnnotationElement)
 
-      cmValue.on('changes', codemirrorChanges)
-    }, 100)
+    // Prevent getting access to initial state
+    if (!hasBeenEdited.value) {
+      cmValue.clearHistory()
+    }
+
+    cmValue.on('changes', codemirrorChanges)
   },
   { flush: 'post' },
 )

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -365,7 +365,7 @@ const { pause, resume } = watch(
       cmValue.on('changes', codemirrorChanges)
     }
   },
-  { flush: 'post' },
+  { immediate: true },
 )
 
 watchDebounced(() => [finished.value, saving.value, currentPosition.value] as const, ([f, s], old) => {

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -351,21 +351,19 @@ const { pause, resume } = watch(
     widgets.length = 0
     handles.length = 0
 
-    if (loadingFile) {
-      return
+    if (!loadingFile) {
+      // add new data
+      errors.forEach(createErrorElement)
+
+      annotations.forEach(createAnnotationElement)
+
+      // Prevent getting access to initial state
+      if (!hasBeenEdited.value) {
+        cmValue.clearHistory()
+      }
+
+      cmValue.on('changes', codemirrorChanges)
     }
-
-    // add new data
-    errors.forEach(createErrorElement)
-
-    annotations.forEach(createAnnotationElement)
-
-    // Prevent getting access to initial state
-    if (!hasBeenEdited.value) {
-      cmValue.clearHistory()
-    }
-
-    cmValue.on('changes', codemirrorChanges)
   },
   { flush: 'post' },
 )


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The inline error and annotation gadgets currently rebuild through an unconditional 100 ms timeout. This makes the editor render first and then visibly shift when the gadgets appear.

This PR watches the code editor file loading state and renders gadgets synchronously at the same phase as code mirror initial render. The trace gutter already uses this pattern by watching the same loading state and updating synchronously.

<details><summary> 📸  Before and After </summary>

__Before__


https://github.com/user-attachments/assets/6b19b6fd-d1cb-4427-aa78-c586f250c3e7


__After__


https://github.com/user-attachments/assets/975a4082-1d7e-46a3-8b81-7ad147e6395c


</details>

<!-- You can also add additional context here -->

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
