### PR TITLE
fix(ui): require auth for coverage report and all UI subtree requests

### DIFF
--- a/packages/ui/node/index.ts
+++ b/packages/ui/node/index.ts
@@ -1,4 +1,6 @@
+import type { IncomingMessage } from 'node:http'
 import type { PluginHarness, Vite } from 'vitest/node'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import { parse as parseCookie, serialize as serializeCookie } from 'cookie'
 import { join, resolve } from 'pathe'
@@ -11,6 +13,7 @@ import { distClientRoot } from './paths'
 export { distClientRoot }
 
 const UI_TOKEN_COOKIE = 'vitest-ui-token'
+const AUTH_REQUIRED_MESSAGE = 'Vitest UI requires authentication. Open the URL with the token printed in the terminal, e.g. http://localhost:51204/__vitest__/?token=...'
 
 export default (harness: PluginHarness): Vite.Plugin => {
   if (harness.version !== version) {
@@ -32,6 +35,49 @@ export default (harness: PluginHarness): Vite.Plugin => {
         const ctx = harness.getVitest()
         const uiOptions = ctx.config
         const base = uiOptions.uiBase
+
+        function serializeTokenCookie(): string {
+          return serializeCookie(UI_TOKEN_COOKIE, ctx.config.api.token, {
+            path: base,
+            httpOnly: true,
+            sameSite: 'strict',
+          })
+        }
+
+        function hasValidTokenCookie(req: IncomingMessage): boolean {
+          const cookieToken = parseCookie(req.headers.cookie ?? '')[UI_TOKEN_COOKIE]
+          if (!cookieToken) {
+            return false
+          }
+          try {
+            return crypto.timingSafeEqual(
+              Buffer.from(cookieToken),
+              Buffer.from(ctx.config.api.token),
+            )
+          }
+          catch {
+            return false
+          }
+        }
+
+        // Authenticate the whole UI subtree in one place. Mounted on `base` so
+        // Connect matches it exactly like the static handlers below, which it
+        // routes case-insensitively and on `.`/`/` boundaries; a pathname
+        // comparison here would diverge and be bypassable (e.g. /__vitest__/Coverage).
+        // eslint-disable-next-line prefer-arrow-callback
+        server.middlewares.use(base, function vitestUiAuth(req, res, next) {
+          // a valid `?token=` bootstraps the cookie so later cookie-only
+          // requests (the coverage iframe and its child assets) stay authorized
+          if (isValidApiRequest(ctx.config, req)) {
+            res.setHeader('Set-Cookie', serializeTokenCookie())
+            return next()
+          }
+          if (hasValidTokenCookie(req)) {
+            return next()
+          }
+          res.statusCode = 403
+          res.end(AUTH_REQUIRED_MESSAGE)
+        })
 
         // Serve coverage HTML at ./coverage if configured
         const coverageHtmlDir = ctx.config.coverage?.htmlDir
@@ -98,21 +144,12 @@ export default (harness: PluginHarness): Vite.Plugin => {
           if (req.url) {
             const url = new URL(req.url, 'http://localhost')
             if (url.pathname === base) {
+              // vitestUiAuth already validated the request and set the cookie;
+              // redirect to strip the token from the URL
               if (isValidApiRequest(ctx.config, req)) {
                 res.statusCode = 302
-                res.setHeader('Set-Cookie', serializeCookie(UI_TOKEN_COOKIE, ctx.config.api.token, {
-                  path: base,
-                  httpOnly: true,
-                  sameSite: 'strict',
-                }))
                 res.setHeader('Location', base)
                 res.end()
-                return
-              }
-              const cookieToken = parseCookie(req.headers.cookie ?? '')[UI_TOKEN_COOKIE]
-              if (cookieToken !== ctx.config.api.token) {
-                res.statusCode = 403
-                res.end('Vitest UI requires authentication. Open the URL with the token printed in the terminal, e.g. http://localhost:51204/__vitest__/?token=...')
                 return
               }
               const html = clientIndexHtml.replace(

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -60,6 +60,28 @@ test.describe('ui', () => {
     await expect(badToken.text()).resolves.toContain('Vitest UI requires authentication.')
   })
 
+  test('blocks unauthenticated coverage requests', async ({ request }) => {
+    const base = new URL(pageUrl)
+    base.search = ''
+
+    const entry = new URL('coverage/index.html', base).toString()
+    const tokenless = await request.get(entry)
+    expect(tokenless.status()).toBe(403)
+    await expect(tokenless.text()).resolves.toContain('Vitest UI requires authentication.')
+
+    // Connect matches the mount case-insensitively and treats `.` as a
+    // boundary, so these must be gated too, not just the `/`-delimited path.
+    for (const path of ['Coverage/index.html', 'coverage.', 'coverage./index.html']) {
+      const res = await request.get(new URL(path, base).toString())
+      expect(res.status(), path).toBe(403)
+    }
+
+    const withToken = new URL(entry)
+    withToken.searchParams.set('token', vitest!.config.api.token)
+    const authed = await request.get(withToken.toString())
+    expect(authed.status()).toBe(200)
+  })
+
   test('does not serve the api token file', async ({ request }) => {
     const { tokenPath } = resolveApiToken(vitest!.config.root)
     expect(existsSync(tokenPath)).toBe(true)


### PR DESCRIPTION
The coverage report at `/__vitest__/coverage` was served without an auth check, so anyone who could reach the UI port could read it.

Auth now lives in a single middleware mounted on the UI base, so the whole `/__vitest__/` subtree (coverage included) requires the token or cookie.