### PR TITLE
fix(browser): don't redirect vitest in client environment

### DIFF
--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -460,10 +460,13 @@ function resolveBrowserOptimizeDeps(
     'vitest/browser',
     '@vitest/browser/utils',
     '@vitest/browser/context',
-    // this is a real module but cannot be specified in `optimizeDeps.include`
-    // because `@vitest/browser` is only installed as a transitive dependency of
-    // provider-specific packages such as `@vitest/browser-playwright`
+    // these are real modules, but they cannot be specified in
+    // `optimizeDeps.include`: `@vitest/browser` is only installed as a
+    // transitive dependency of provider-specific packages such as
+    // `@vitest/browser-playwright`, so the optimizer cannot resolve them
+    // from the project root
     '@vitest/browser/locators',
+    '@vitest/browser/client',
     'msw',
     'msw/browser',
   ]
@@ -495,12 +498,12 @@ function resolveBrowserOptimizeDeps(
 
   // Pre-bundle the vitest runtime so the browser fetches a few optimized
   // chunks instead of ~20 separately-served dist chunks (faster startup).
-  // `vitest`, `vitest/internal/browser` and `@vitest/browser/client` are
-  // optimized together in a single pass, so esbuild dedupes their shared
-  // stateful chunks (the test collector, the runner, the RPC client) to a
-  // single instance — preserving module identity between the test files'
-  // `import 'vitest'` and the tester. Their transitive deps (@vitest/utils,
-  // @vitest/spy, pathe, tinyrainbow, …) are inlined into these bundles.
+  // `vitest` and `vitest/internal/browser` are optimized together in a single
+  // pass, so esbuild dedupes their shared stateful chunks (the test collector,
+  // the runner) to a single instance, preserving module identity between the
+  // test files' `import 'vitest'` and the tester. Their transitive deps
+  // (@vitest/utils, @vitest/spy, pathe, tinyrainbow, …) are inlined into
+  // these bundles.
   const include = [
     'vitest > expect-type',
     'vitest > magic-string',
@@ -509,7 +512,6 @@ function resolveBrowserOptimizeDeps(
     'vitest',
     'vitest/internal/browser',
     'vitest/internal/traces',
-    '@vitest/browser/client',
   ]
 
   const provider = testConfig.browser?.provider

--- a/packages/vitest/src/node/plugins/vitestResolver.ts
+++ b/packages/vitest/src/node/plugins/vitestResolver.ts
@@ -4,12 +4,14 @@ import { join, resolve } from 'pathe'
 import { distDir } from '../../paths'
 
 export function VitestProjectResolver(harness: PluginHarness): Plugin {
+  let browserEnabled = false
   const plugin: Plugin = {
     name: 'vitest:resolve-root',
     enforce: 'pre',
     config: {
       order: 'post',
-      handler() {
+      handler(config) {
+        browserEnabled = !!config.test?.browser?.enabled
         return {
           base: '/',
         }
@@ -17,6 +19,11 @@ export function VitestProjectResolver(harness: PluginHarness): Plugin {
     },
     async resolveId(id, _, { ssr }) {
       if (id === 'vitest' || id.startsWith('@vitest/') || id.startsWith('vitest/')) {
+        // the browser pre-bundles vitest, and the optimizer's copy must win
+        // so the tester and the test files share one module instance
+        if (browserEnabled && this.environment?.name === 'client') {
+          return
+        }
         // always redirect the request to the root vitest plugin since
         // it will be the one used to run Vitest
         const resolved = await harness.getVitest().vite.pluginContainer.resolveId(id, undefined, {
@@ -32,12 +39,14 @@ export function VitestProjectResolver(harness: PluginHarness): Plugin {
 
 export function VitestCoreResolver(): Plugin {
   let root: string
+  let browserEnabled = false
   return {
     name: 'vitest:resolve-core',
     enforce: 'pre',
     config: {
       order: 'post',
-      handler() {
+      handler(config) {
+        browserEnabled = !!config.test?.browser?.enabled
         return {
           base: '/',
         }
@@ -47,19 +56,12 @@ export function VitestCoreResolver(): Plugin {
       root = config.root
     },
     async resolveId(id) {
+      // the browser pre-bundles vitest, and the optimizer's copy must win
+      // so the tester and the test files share one module instance
+      if (browserEnabled && this.environment?.name === 'client') {
+        return
+      }
       if (id === 'vitest') {
-        // in environments that pre-bundle vitest (the browser `client`
-        // environment), the optimizer's copy must win: the tester and the
-        // test files have to share a single module instance, and returning
-        // the dist file directly would bypass the optimized dep resolution
-        if (this.environment?.config.optimizeDeps.include?.includes('vitest')) {
-          const resolved = await this.resolve(id, join(root, 'index.html'), {
-            skipSelf: true,
-          })
-          if (resolved) {
-            return resolved
-          }
-        }
         return resolve(distDir, 'index.js')
       }
       if (id.startsWith('@vitest/') || id.startsWith('vitest/')) {

--- a/test/browser/fixtures/dep-imports-vitest/basic.test.ts
+++ b/test/browser/fixtures/dep-imports-vitest/basic.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('passes', () => {
+  expect(1).toBe(1)
+})

--- a/test/browser/fixtures/dep-imports-vitest/node_modules/fake-browser-lib/index.js
+++ b/test/browser/fixtures/dep-imports-vitest/node_modules/fake-browser-lib/index.js
@@ -1,0 +1,3 @@
+import { beforeEach } from 'vitest'
+
+beforeEach(() => {})

--- a/test/browser/fixtures/dep-imports-vitest/node_modules/fake-browser-lib/package.json
+++ b/test/browser/fixtures/dep-imports-vitest/node_modules/fake-browser-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fake-browser-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/browser/fixtures/dep-imports-vitest/setup.ts
+++ b/test/browser/fixtures/dep-imports-vitest/setup.ts
@@ -1,0 +1,1 @@
+import 'fake-browser-lib'

--- a/test/browser/fixtures/dep-imports-vitest/vitest.config.ts
+++ b/test/browser/fixtures/dep-imports-vitest/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'tester',
+          setupFiles: ['./setup.ts'],
+          browser: {
+            enabled: true,
+            provider,
+            instances,
+          },
+        },
+      },
+    ],
+  },
+})

--- a/test/browser/specs/dep-imports-vitest.test.ts
+++ b/test/browser/specs/dep-imports-vitest.test.ts
@@ -1,0 +1,16 @@
+// https://github.com/vitest-dev/vitest/issues/10944
+
+import { expect, test } from 'vitest'
+import { instances, runBrowserTests } from './utils'
+
+test('pre-bundled dependency shares the vitest runtime with the tester', async () => {
+  const { stderr, stdout } = await runBrowserTests({
+    root: './fixtures/dep-imports-vitest',
+    reporters: 'verbose',
+  })
+
+  expect(stderr).toReportNoErrors()
+  instances.forEach(({ browser }) => {
+    expect(stdout).toReportPassedTest('basic.test.ts', `tester (${browser})`)
+  })
+})


### PR DESCRIPTION
With inline `projects`, the `vitest:resolve-root` plugin redirected `vitest` imports to the root server, which resolved them to raw dist files, while pre-bundled dependencies got the optimizer's copy of the runtime. The second copy has no runner state, failing any setup file that imports a package like `vitest-browser-react`. Both resolvers now stay out of the browser `client` environment, so everything resolves to the pre-bundled copy.

Also moves `@vitest/browser/client` from `optimizeDeps.include` to `exclude`: it is not resolvable from the project root under pnpm (see the `Failed to resolve dependency` warning in #10836), and the built file is self-contained, so pre-bundling it buys nothing.

Closes #10944
