### PR TITLE
perf: initialize trace view in the orchestrator once per worker

### DIFF
--- a/packages/browser/src/client/orchestrator.ts
+++ b/packages/browser/src/client/orchestrator.ts
@@ -27,6 +27,13 @@ export class IframeOrchestrator {
   constructor() {
     debug('init orchestrator', getBrowserState().sessionId)
 
+    if (getConfig().browser.traceView.enabled) {
+      const domSnapshot = import('rrweb-snapshot')
+      // a load failure surfaces in the tester that awaits this
+      domSnapshot.catch(() => {})
+      getBrowserState().browserTraceDomSnapshotPromise = domSnapshot
+    }
+
     const otelConfig = getBrowserState().config.experimental.openTelemetry
     this.traces = new Traces({
       enabled: !!(otelConfig?.enabled && otelConfig.browserSdkPath),

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -92,10 +92,7 @@ function createBrowserRunner(
         return
       }
       if (shouldTraceView) {
-        getBrowserState().browserTraceDomSnapshot ??= await (
-          getOrchestratorState()?.browserTraceDomSnapshotPromise
-          ?? import('rrweb-snapshot')
-        )
+        getBrowserState().browserTraceDomSnapshot ??= await getOrchestratorState().browserTraceDomSnapshotPromise
         getBrowserState().browserTraceAttempts.set(test.id, { retry, repeats, startTime: now() })
       }
       else {

--- a/packages/browser/src/client/tester/runner.ts
+++ b/packages/browser/src/client/tester/runner.ts
@@ -29,7 +29,7 @@ import {
 } from 'vitest/internal/browser'
 import { createStackString, parseStacktrace } from '../../../../utils/src/source-map'
 import { getTestName } from '../../../../vitest/src/utils/tasks'
-import { getBrowserState, getWorkerState, moduleRunner, now } from '../utils'
+import { getBrowserState, getOrchestratorState, getWorkerState, moduleRunner, now } from '../utils'
 import { rpc } from './rpc'
 import { VitestBrowserSnapshotEnvironment } from './snapshot'
 import { recordBrowserTraceEntry } from './trace'
@@ -92,7 +92,10 @@ function createBrowserRunner(
         return
       }
       if (shouldTraceView) {
-        getBrowserState().browserTraceDomSnapshot = await import('rrweb-snapshot')
+        getBrowserState().browserTraceDomSnapshot ??= await (
+          getOrchestratorState()?.browserTraceDomSnapshotPromise
+          ?? import('rrweb-snapshot')
+        )
         getBrowserState().browserTraceAttempts.set(test.id, { retry, repeats, startTime: now() })
       }
       else {

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -120,7 +120,7 @@ export function getBrowserState(): BrowserRunnerState {
 }
 
 /* @__NO_SIDE_EFFECTS__ */
-export function getOrchestratorState(): BrowserRunnerState | undefined {
+export function getOrchestratorState(): BrowserRunnerState {
   // @ts-expect-error not typed global
   return window.parent.__vitest_browser_runner__
 }

--- a/packages/browser/src/client/utils.ts
+++ b/packages/browser/src/client/utils.ts
@@ -98,6 +98,8 @@ export interface BrowserRunnerState {
   browserTraceAttempts: Map<string, BrowserTraceAttempt>
   // lazily loaded only when traceView is enabled
   browserTraceDomSnapshot?: typeof import('rrweb-snapshot')
+  // import started by the orchestrator so every tester reuses one module instance
+  browserTraceDomSnapshotPromise?: Promise<typeof import('rrweb-snapshot')>
   selectorEngine: Ivya
   traces: Traces
   cleanups: Array<() => unknown>
@@ -115,6 +117,12 @@ export interface BrowserRunnerState {
 export function getBrowserState(): BrowserRunnerState {
   // @ts-expect-error not typed global
   return window.__vitest_browser_runner__
+}
+
+/* @__NO_SIDE_EFFECTS__ */
+export function getOrchestratorState(): BrowserRunnerState | undefined {
+  // @ts-expect-error not typed global
+  return window.parent.__vitest_browser_runner__
 }
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/patches/rrweb-snapshot@2.1.1.patch
+++ b/patches/rrweb-snapshot@2.1.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/rrweb-snapshot.js b/dist/rrweb-snapshot.js
-index 1c0fc62d7ede018a7797d3e707c73fa803166d2d..1770d23f71d86d08bd16409f5b3a0e45005934fc 100644
+index 1c0fc62d7ede018a7797d3e707c73fa803166d2d..eadcceb088ac1deef08655eb2ed1cdb95fdb515b 100644
 --- a/dist/rrweb-snapshot.js
 +++ b/dist/rrweb-snapshot.js
 @@ -603,7 +603,7 @@ function genId() {
@@ -11,16 +11,38 @@ index 1c0fc62d7ede018a7797d3e707c73fa803166d2d..1770d23f71d86d08bd16409f5b3a0e45
      return "form";
    }
    const processedTagName = toLowerCase(element.tagName);
-@@ -1057,7 +1057,7 @@ function serializeElementNode(n, options) {
+@@ -612,8 +612,16 @@ function getValidTagName(element) {
+   }
+   return processedTagName;
+ }
+-let canvasService;
+-let canvasCtx;
++const canvasServices = new WeakMap();
++function getCanvasService(doc) {
++  let service = canvasServices.get(doc);
++  if (!service) {
++    const canvas = doc.createElement("canvas");
++    service = { canvas, context: canvas.getContext("2d") };
++    canvasServices.set(doc, service);
++  }
++  return service;
++}
+ const SRCSET_NOT_SPACES = /^[^ \t\n\r\u000c]+/;
+ const SRCSET_COMMAS_OR_SPACES = /^[, \t\n\r\u000c]+/;
+ function getAbsoluteSrcsetString(doc, attributeValue) {
+@@ -1056,10 +1064,7 @@ function serializeElementNode(n, options) {
+     }
    }
    if (tagName === "img" && inlineImages) {
-     if (!canvasService) {
+-    if (!canvasService) {
 -      canvasService = doc.createElement("canvas");
-+      canvasService = document.createElement("canvas");
-       canvasCtx = canvasService.getContext("2d");
-     }
+-      canvasCtx = canvasService.getContext("2d");
+-    }
++    const { canvas: canvasService, context: canvasCtx } = getCanvasService(doc);
      const image = n;
-@@ -1536,6 +1536,18 @@ const pseudoClassPlugin = {
+     const imageSrc = image.currentSrc || image.getAttribute("src") || "<unknown-src>";
+     const priorCrossOrigin = image.crossOrigin;
+@@ -1536,6 +1541,18 @@ const pseudoClassPlugin = {
            if (selector.includes(":hover")) {
              rule2.selector += ",\n" + selector.replace(/:hover/g, ".\\:hover");
            }

--- a/patches/rrweb-snapshot@2.1.1.patch
+++ b/patches/rrweb-snapshot@2.1.1.patch
@@ -1,6 +1,25 @@
 diff --git a/dist/rrweb-snapshot.js b/dist/rrweb-snapshot.js
+index 1c0fc62d7ede018a7797d3e707c73fa803166d2d..1770d23f71d86d08bd16409f5b3a0e45005934fc 100644
 --- a/dist/rrweb-snapshot.js
 +++ b/dist/rrweb-snapshot.js
+@@ -603,7 +603,7 @@ function genId() {
+   return _id++;
+ }
+ function getValidTagName(element) {
+-  if (element instanceof HTMLFormElement) {
++  if (Object.prototype.toString.call(element) === "[object HTMLFormElement]") {
+     return "form";
+   }
+   const processedTagName = toLowerCase(element.tagName);
+@@ -1057,7 +1057,7 @@ function serializeElementNode(n, options) {
+   }
+   if (tagName === "img" && inlineImages) {
+     if (!canvasService) {
+-      canvasService = doc.createElement("canvas");
++      canvasService = document.createElement("canvas");
+       canvasCtx = canvasService.getContext("2d");
+     }
+     const image = n;
 @@ -1536,6 +1536,18 @@ const pseudoClassPlugin = {
            if (selector.includes(":hover")) {
              rule2.selector += ",\n" + selector.replace(/:hover/g, ".\\:hover");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ patchedDependencies:
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
   istanbul-lib-source-maps: be977704c4b9838da456619fe2421b5e24df2103a25967bd383b2246c88ddf6e
-  rrweb-snapshot@2.1.1: 1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b
+  rrweb-snapshot@2.1.1: b66b30796877352a5f887f3f4115c4e7265ddc11772af2223da4bd92293716f6
 
 importers:
 
@@ -597,7 +597,7 @@ importers:
         version: 2.0.3
       rrweb-snapshot:
         specifier: 2.1.1
-        version: 2.1.1(patch_hash=1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b)
+        version: 2.1.1(patch_hash=b66b30796877352a5f887f3f4115c4e7265ddc11772af2223da4bd92293716f6)
       vitest:
         specifier: workspace:*
         version: link:../vitest
@@ -934,7 +934,7 @@ importers:
         version: 4.62.4
       rrweb-snapshot:
         specifier: 2.1.1
-        version: 2.1.1(patch_hash=1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b)
+        version: 2.1.1(patch_hash=b66b30796877352a5f887f3f4115c4e7265ddc11772af2223da4bd92293716f6)
       splitpanes:
         specifier: ^4.1.2
         version: 4.1.2(vue@3.5.41(typescript@5.9.3))
@@ -18394,7 +18394,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
-  rrweb-snapshot@2.1.1(patch_hash=1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b):
+  rrweb-snapshot@2.1.1(patch_hash=b66b30796877352a5f887f3f4115c4e7265ddc11772af2223da4bd92293716f6):
     dependencies:
       postcss: 8.5.14
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ patchedDependencies:
   cac@6.7.14: a8f0f3517a47ce716ed90c0cfe6ae382ab763b021a664ada2a608477d0621588
   istanbul-lib-instrument: fa76adf262fdb0bf545d5c529c5420e0ae33df7f5e344a6c8a727a2ffc0b0b11
   istanbul-lib-source-maps: be977704c4b9838da456619fe2421b5e24df2103a25967bd383b2246c88ddf6e
-  rrweb-snapshot@2.1.1: 0b0dbc551d27a6f24438e9582c41a0ec34fd444760d383a4172013031d73c4e7
+  rrweb-snapshot@2.1.1: 1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b
 
 importers:
 
@@ -597,7 +597,7 @@ importers:
         version: 2.0.3
       rrweb-snapshot:
         specifier: 2.1.1
-        version: 2.1.1(patch_hash=0b0dbc551d27a6f24438e9582c41a0ec34fd444760d383a4172013031d73c4e7)
+        version: 2.1.1(patch_hash=1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b)
       vitest:
         specifier: workspace:*
         version: link:../vitest
@@ -934,7 +934,7 @@ importers:
         version: 4.62.4
       rrweb-snapshot:
         specifier: 2.1.1
-        version: 2.1.1(patch_hash=0b0dbc551d27a6f24438e9582c41a0ec34fd444760d383a4172013031d73c4e7)
+        version: 2.1.1(patch_hash=1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b)
       splitpanes:
         specifier: ^4.1.2
         version: 4.1.2(vue@3.5.41(typescript@5.9.3))
@@ -18394,7 +18394,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
-  rrweb-snapshot@2.1.1(patch_hash=0b0dbc551d27a6f24438e9582c41a0ec34fd444760d383a4172013031d73c4e7):
+  rrweb-snapshot@2.1.1(patch_hash=1052ec51fcca2449901a06c3b1ca44ecba910ace195fcdbc5b23472e301a148b):
     dependencies:
       postcss: 8.5.14
 


### PR DESCRIPTION
Loads rrweb only once per worker and starts doing it as early as possible. This saves ~170kb per iframe setup.