### PR TITLE
fix: combine negated `--project` filters with AND

### DIFF
--- a/packages/vitest/src/node/config/resolveConfig.ts
+++ b/packages/vitest/src/node/config/resolveConfig.ts
@@ -1246,7 +1246,17 @@ export function matchesProjectFilter(projects: string[], name: string): boolean 
   if (!projects.length) {
     return true
   }
-  return projects.some((project) => {
+  // exclusions are combined with AND: with `!a !b`, `.some()` would keep `a`
+  // because it doesn't match `!b`, and keep `b` because it doesn't match `!a`
+  if (isExcludedByProjectFilter(projects, name)) {
+    return false
+  }
+  const included = projects.filter(project => !project.startsWith('!'))
+  // only exclusions were passed, so everything they didn't remove is included
+  if (!included.length) {
+    return true
+  }
+  return included.some((project) => {
     const regexp = wildcardPatternToRegExp(project)
     return regexp.test(name)
   })

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -1134,13 +1134,18 @@ function matchesEntryFilter(
     return true
   }
   const names = [name, ...(ancestors || [])]
-  return filter.some((project) => {
+  // exclusions are combined with AND, and remove the whole subtree they match
+  if (isEntryExcludedByFilter(filter, name, ancestors)) {
+    return false
+  }
+  const included = filter.filter(project => !project.startsWith('!'))
+  // only exclusions were passed, so everything they didn't remove is included
+  if (!included.length) {
+    return true
+  }
+  return included.some((project) => {
     const regexp = wildcardPatternToRegExp(project)
-    // a negated pattern compiles into a negative lookahead: the entry is kept
-    // only when neither its name nor any of its containers match the exclusion
-    return project.startsWith('!')
-      ? names.every(candidate => regexp.test(candidate))
-      : names.some(candidate => regexp.test(candidate))
+    return names.some(candidate => regexp.test(candidate))
   })
 }
 

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -1039,6 +1039,9 @@ describe('project filtering', () => {
     { pattern: '!project_1', expected: ['project_2', 'space_1'] },
     { pattern: '!project*', expected: ['space_1'] },
     { pattern: '!project', expected: allProjects },
+    { pattern: ['!project_1', '!project_2'], expected: ['space_1'] },
+    { pattern: ['project_1', 'space_1'], expected: ['project_1', 'space_1'] },
+    { pattern: ['project*', '!project_2'], expected: ['project_1'] },
   ])('should match projects correctly: $pattern', async ({ pattern, expected }) => {
     const { ctx, stderr, stdout } = await runVitest({
       root: 'fixtures/project',
@@ -1059,5 +1062,15 @@ describe('project filtering', () => {
     }
 
     expect(ctx?.projects.map(p => p.name).sort()).toEqual(expected)
+  })
+
+  it('fails when every project is excluded', async () => {
+    const { stderr } = await runVitest({
+      root: 'fixtures/project',
+      reporters: ['default'],
+      project: ['!project_1', '!project_2', '!space_1'],
+    })
+
+    expect(stderr).toContain('The filter matched no projects: !project_1, !project_2, !space_1')
   })
 })


### PR DESCRIPTION
### Description

Resolves #10491

`matchesProjectFilter` runs all `--project` patterns through `.some()`, so two negations cancel out: `a` doesn't match `!b`, `b` doesn't match `!a`, and `--project=!a --project=!b` runs everything. `--project=project* --project=!project_2` breaks the same way.

Exclusions are now checked first and combined with AND; positive patterns are still OR-ed. `matchesEntryFilter` in `resolveProjects.ts` had the same `.some()`.

Excluding every project now hits the existing "The filter matched no projects" error instead of silently running all of them.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster.

### Tests
- [x] `test/e2e/test/projects.test.ts` — new cases in the existing filter table, plus one for the all-excluded error. They fail on `main`.

### Documentation
- [x] No new API.

### Changesets
- [x] `fix:` prefix.

<!-- VITEST_AUTOMATED_PR -->
