### PR TITLE
fix(ui): reveal explorer virtual scroller on resize

### DIFF
--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -235,8 +235,8 @@ const {
         <FilterStatus v-model="filter.slow" :label="`Slow${slowTime}`" />
       </div>
     </div>
-    <div flex-auto min-h-0 py-1 overflow-hidden>
-      <ResultsPanel h-full min-h-0 flex="~ col">
+    <div flex-auto py-1 overflow-hidden>
+      <ResultsPanel h-full flex="~ col">
         <template v-if="initialized" #summary>
           <div grid="~ items-center gap-x-1 cols-[auto_min-content_auto] rows-[min-content_min-content]">
             <span text-red-700 dark:text-red-500>
@@ -316,7 +316,6 @@ const {
           <RecycleScroller
             class="scrolls"
             flex-auto
-            min-h-0
             key-field="id"
             :item-size="28"
             :items="uiEntries"

--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -235,8 +235,8 @@ const {
         <FilterStatus v-model="filter.slow" :label="`Slow${slowTime}`" />
       </div>
     </div>
-    <div class="scrolls" flex-auto py-1 @scroll.passive="hideAllPoppers">
-      <ResultsPanel>
+    <div flex-auto min-h-0 py-1 overflow-hidden>
+      <ResultsPanel h-full min-h-0 flex="~ col">
         <template v-if="initialized" #summary>
           <div grid="~ items-center gap-x-1 cols-[auto_min-content_auto] rows-[min-content_min-content]">
             <span text-red-700 dark:text-red-500>
@@ -314,11 +314,14 @@ const {
         </template>
         <template v-else>
           <RecycleScroller
-            page-mode
+            class="scrolls"
+            flex-auto
+            min-h-0
             key-field="id"
             :item-size="28"
             :items="uiEntries"
             :buffer="100"
+            @scroll.passive="hideAllPoppers"
           >
             <template #default="{ item }">
               <ExplorerItem

--- a/test/ui/fixtures/main/browser/aa-first-file.test.ts
+++ b/test/ui/fixtures/main/browser/aa-first-file.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('first test', () => {
+  expect(true).toBe(true)
+})

--- a/test/ui/fixtures/main/node/zz-last-file.test.ts
+++ b/test/ui/fixtures/main/node/zz-last-file.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('last test', () => {
+  expect(true).toBe(true)
+})

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -612,9 +612,9 @@ async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
 }
 
 async function testFilterInitiallyInvisibleItem(page: Page) {
-  await expect(getExplorerItem(page, 'sample.test.ts')).not.toBeVisible()
-  await page.getByPlaceholder('Search...').fill('sample.test.ts')
-  await expect(getExplorerItem(page, 'sample.test.ts')).toBeVisible()
+  await expect(getExplorerItem(page, 'zz-last-file.test.ts')).not.toBeVisible()
+  await page.getByPlaceholder('Search...').fill('zz-last-file.test.ts')
+  await expect(getExplorerItem(page, 'zz-last-file.test.ts')).toBeVisible()
 }
 
 async function testCrossOriginAccess(page: Page, pageUrl: string) {

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -157,6 +157,22 @@ test.describe('ui', () => {
     await testFilterInitiallyInvisibleItem(page)
   })
 
+  test('resizes the explorer virtual scroller with the viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1000, height: 500 })
+    await page.goto(pageUrl)
+    await page.getByTestId('collapse-all').click()
+    await page.getByTestId('expand-all').click()
+
+    const scroller = page.locator('.vue-recycle-scroller')
+    const initialHeight = await scroller.evaluate(element => element.clientHeight)
+    const initialItems = await page.locator('[data-testid="explorer-item"]:visible').count()
+
+    await page.setViewportSize({ width: 1000, height: 800 })
+
+    await expect.poll(() => scroller.evaluate(element => element.clientHeight)).toBeGreaterThan(initialHeight)
+    await expect.poll(() => page.locator('[data-testid="explorer-item"]:visible').count()).toBeGreaterThan(initialItems)
+  })
+
   test('tags filter', async ({ page }) => {
     await page.goto(pageUrl)
     await testTagsFilter(page)

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -8,10 +8,10 @@ import { resolveApiToken } from '../../../packages/vitest/src/node/config/apiTok
 import { assertDownloadAttachment, assertImageAttachment, assertTestCounts, getExplorerItem, openExplorerFileItem, openExplorerItem, startHtmlReportPreview, startVitestUi } from './helper'
 
 const TEST_COUNTS = {
-  pass: 18,
+  pass: 20,
   fail: 3,
   files: {
-    pass: 7,
+    pass: 9,
   },
 }
 
@@ -157,20 +157,16 @@ test.describe('ui', () => {
     await testFilterInitiallyInvisibleItem(page)
   })
 
-  test('resizes the explorer virtual scroller with the viewport', async ({ page }) => {
+  test('renders explorer items revealed by a viewport resize', async ({ page }) => {
     await page.setViewportSize({ width: 1000, height: 500 })
     await page.goto(pageUrl)
-    await page.getByTestId('collapse-all').click()
-    await page.getByTestId('expand-all').click()
 
-    const scroller = page.locator('.vue-recycle-scroller')
-    const initialHeight = await scroller.evaluate(element => element.clientHeight)
-    const initialItems = await page.locator('[data-testid="explorer-item"]:visible').count()
+    await expect(getExplorerItem(page, 'aa-first-file.test.ts')).toBeVisible()
+    await expect(getExplorerItem(page, 'zz-last-file.test.ts')).not.toBeVisible()
 
-    await page.setViewportSize({ width: 1000, height: 800 })
+    await page.setViewportSize({ width: 1000, height: 1300 })
 
-    await expect.poll(() => scroller.evaluate(element => element.clientHeight)).toBeGreaterThan(initialHeight)
-    await expect.poll(() => page.locator('[data-testid="explorer-item"]:visible').count()).toBeGreaterThan(initialItems)
+    await expect(getExplorerItem(page, 'zz-last-file.test.ts')).toBeInViewport()
   })
 
   test('tags filter', async ({ page }) => {


### PR DESCRIPTION
### Description

There was a minor paper cut where resizing the window could leave the explorer stuck at its previous smaller size.

This PR simplify scroll dom structure and removes `RecycleScroller`'s "page mode" since "page mode" is what makes automatic size change handling to be disabled.

The issue was notably visible for my workflow where I open UI on vscode integrated browser above integrated terminal. 

<details><summary> 📸 Before and After </summary>

- Before

https://github.com/user-attachments/assets/f7e96e66-51b2-4a8d-9c21-55be6fa52f10

- After

https://github.com/user-attachments/assets/ec38c83b-e3c6-4549-8856-9ae0b25218d7

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
