### PR TITLE
docs: add cjs support status in common errors

### DIFF
--- a/docs/config/injectcjsglobals.md
+++ b/docs/config/injectcjsglobals.md
@@ -43,5 +43,5 @@ ReferenceError: __dirname is not defined
 ::: warning
 This option doesn't affect externalized modules which are always executed by the native runtime. Node.js provides CommonJS variables to externalized CommonJS modules on its own.
 
-Note that inlined CommonJS modules are not processed by Vite plugins even when this option is enabled: `require` calls always leave the module runner, so features like mocking do not apply to them.
+Note that inlined CommonJS modules are not processed by Vite plugins even when this option is enabled: `require` calls always leave the module runner, so features like mocking do not apply to them. See [CommonJS source code is not fully supported](/guide/common-errors#commonjs-source-code-is-not-fully-supported) for configuration alternatives.
 :::

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -166,6 +166,52 @@ test('rejects for missing user', async () => {
 })
 ```
 
+## CommonJS source code is not fully supported
+
+Vitest is ESM-first. By default, source files run in Vite's [module runner](/config/experimental#experimental-vitemodulerunner), which provides CommonJS variables such as `require`, `module`, and `exports` for compatibility but does not reproduce Node.js CommonJS semantics completely.
+
+Calls to `require()` always use Node.js directly and leave the module runner. As a result:
+
+- Vite plugins, aliases, transforms, and module mocks do not apply to required files
+- requiring TypeScript or other files that Node.js cannot execute is not supported
+- importing and requiring the same file can evaluate it twice, which can break singleton state, object identity, or `instanceof` checks
+
+If your project uses CommonJS and doesn't need Vite transforms, disable the module runner so the whole module graph is loaded by the native runtime:
+
+```ts [vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    experimental: {
+      viteModuleRunner: false,
+    },
+  },
+})
+```
+
+In this mode, source files must be executable by the runtime. For example, compile TypeScript that uses CommonJS-only syntax such as `export =` before testing it if your Node.js version cannot run it directly.
+
+If the application uses ESM source but imports an internal CommonJS package, you can instead [externalize](/config/server#server-deps-external) the complete CommonJS package. This keeps its entry points and internal `require()` calls in the same native module cache:
+
+```ts [vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        external: [/\/packages\/legacy-cjs\//],
+      },
+    },
+  },
+})
+```
+
+Match the whole package directory so all entry points and subpaths are externalized. The externalized files must already be valid for Node.js to execute.
+
+If a package instead depends on bundler transformations, inline it as described in the next section.
+
 ## Package fails to load in Vitest but works in your app
 
 Some packages work in an app build but fail in Vitest because they are only valid after a bundler has rewritten or resolved them. When Vitest externalizes a dependency, Node.js loads it directly, so Node's ESM and package rules apply. See Node.js documentation on [ECMAScript modules](https://nodejs.org/docs/latest/api/esm.html) and [packages](https://nodejs.org/docs/latest/api/packages.html) for the precise rules.

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -228,7 +228,7 @@ Calls to `require()` always use Node.js directly and leave the module runner. As
 - requiring TypeScript or other files that Node.js cannot execute is not supported
 - importing and requiring the same file can evaluate it twice, which can break singleton state, object identity, or `instanceof` checks
 
-If your project uses CommonJS and doesn't need Vite transforms, disable the module runner so the whole module graph is loaded by the native runtime:
+If your project uses CommonJS and doesn't need Vite transforms, set [`experimental.viteModuleRunner`](/config/experimental#experimental-vitemodulerunner) to `false` so the whole module graph is loaded by the native runtime:
 
 ```ts [vitest.config.ts]
 import { defineConfig } from 'vitest/config'
@@ -242,9 +242,7 @@ export default defineConfig({
 })
 ```
 
-In this mode, source files must be executable by the runtime. See [`experimental.viteModuleRunner`](/config/experimental#experimental-vitemodulerunner) for requirements and limitations.
-
-If the application uses ESM source but imports an internal CommonJS package, you can instead [externalize](/config/server#server-deps-external) the complete CommonJS package. This keeps its entry points and internal `require()` calls in the same native module cache:
+If the application uses ESM source but imports a CommonJS package from the same monorepo, you can instead use [`server.deps.external`](/config/server#server-deps-external) to externalize the complete CommonJS package. This keeps its entry points and internal `require()` calls in the same native module cache. For example:
 
 ```ts [vitest.config.ts]
 import { defineConfig } from 'vitest/config'
@@ -259,7 +257,3 @@ export default defineConfig({
   },
 })
 ```
-
-Match the whole package directory so all entry points and subpaths are externalized. The externalized files must already be valid for Node.js to execute.
-
-If a package instead depends on bundler transformations, inline it as described in the next section.

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -166,52 +166,6 @@ test('rejects for missing user', async () => {
 })
 ```
 
-## CommonJS source code is not fully supported
-
-Vitest is ESM-first. By default, source files run in Vite's [module runner](/config/experimental#experimental-vitemodulerunner), which provides CommonJS variables such as `require`, `module`, and `exports` for compatibility but does not reproduce Node.js CommonJS semantics completely.
-
-Calls to `require()` always use Node.js directly and leave the module runner. As a result:
-
-- Vite plugins, aliases, transforms, and module mocks do not apply to required files
-- requiring TypeScript or other files that Node.js cannot execute is not supported
-- importing and requiring the same file can evaluate it twice, which can break singleton state, object identity, or `instanceof` checks
-
-If your project uses CommonJS and doesn't need Vite transforms, disable the module runner so the whole module graph is loaded by the native runtime:
-
-```ts [vitest.config.ts]
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    experimental: {
-      viteModuleRunner: false,
-    },
-  },
-})
-```
-
-In this mode, source files must be executable by the runtime. For example, compile TypeScript that uses CommonJS-only syntax such as `export =` before testing it if your Node.js version cannot run it directly.
-
-If the application uses ESM source but imports an internal CommonJS package, you can instead [externalize](/config/server#server-deps-external) the complete CommonJS package. This keeps its entry points and internal `require()` calls in the same native module cache:
-
-```ts [vitest.config.ts]
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    server: {
-      deps: {
-        external: [/\/packages\/legacy-cjs\//],
-      },
-    },
-  },
-})
-```
-
-Match the whole package directory so all entry points and subpaths are externalized. The externalized files must already be valid for Node.js to execute.
-
-If a package instead depends on bundler transformations, inline it as described in the next section.
-
 ## Package fails to load in Vitest but works in your app
 
 Some packages work in an app build but fail in Vitest because they are only valid after a bundler has rewritten or resolved them. When Vitest externalizes a dependency, Node.js loads it directly, so Node's ESM and package rules apply. See Node.js documentation on [ECMAScript modules](https://nodejs.org/docs/latest/api/esm.html) and [packages](https://nodejs.org/docs/latest/api/packages.html) for the precise rules.
@@ -263,3 +217,49 @@ export default defineConfig({
   },
 })
 ```
+
+## CommonJS source code is not fully supported
+
+Vitest is ESM-first. By default, source files run in Vite's [module runner](/config/experimental#experimental-vitemodulerunner), which provides CommonJS variables such as `require`, `module`, and `exports` for compatibility but does not reproduce Node.js CommonJS semantics completely.
+
+Calls to `require()` always use Node.js directly and leave the module runner. As a result:
+
+- Vite plugins, aliases, transforms, and module mocks do not apply to required files
+- requiring TypeScript or other files that Node.js cannot execute is not supported
+- importing and requiring the same file can evaluate it twice, which can break singleton state, object identity, or `instanceof` checks
+
+If your project uses CommonJS and doesn't need Vite transforms, disable the module runner so the whole module graph is loaded by the native runtime:
+
+```ts [vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    experimental: {
+      viteModuleRunner: false,
+    },
+  },
+})
+```
+
+In this mode, source files must be executable by the runtime. For example, compile TypeScript that uses CommonJS-only syntax such as `export =` before testing it if your Node.js version cannot run it directly.
+
+If the application uses ESM source but imports an internal CommonJS package, you can instead [externalize](/config/server#server-deps-external) the complete CommonJS package. This keeps its entry points and internal `require()` calls in the same native module cache:
+
+```ts [vitest.config.ts]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        external: [/\/packages\/legacy-cjs\//],
+      },
+    },
+  },
+})
+```
+
+Match the whole package directory so all entry points and subpaths are externalized. The externalized files must already be valid for Node.js to execute.
+
+If a package instead depends on bundler transformations, inline it as described in the next section.

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -242,7 +242,7 @@ export default defineConfig({
 })
 ```
 
-In this mode, source files must be executable by the runtime. For example, compile TypeScript that uses CommonJS-only syntax such as `export =` before testing it if your Node.js version cannot run it directly.
+In this mode, source files must be executable by the runtime. See [`experimental.viteModuleRunner`](/config/experimental#experimental-vitemodulerunner) for requirements and limitations.
 
 If the application uses ESM source but imports an internal CommonJS package, you can instead [externalize](/config/server#server-deps-external) the complete CommonJS package. This keeps its entry points and internal `require()` calls in the same native module cache:
 


### PR DESCRIPTION
### Description

- related https://github.com/vitest-dev/vitest/issues/10828

I was just triaging https://github.com/vitest-dev/vitest/issues/10828 but we've had many times closing similar issues before. This PR adds the cjs support status in common errors so we can link it easily in the future.

Some big list of past issues AI pulled up as a reference for doc addition:

- https://github.com/vitest-dev/vitest/issues/9147
- https://github.com/vitest-dev/vitest/issues/5522
- https://github.com/vitest-dev/vitest/issues/3987
- https://github.com/vitest-dev/vitest/issues/846
- https://github.com/vitest-dev/vitest/issues/4365
- https://github.com/vitest-dev/vitest/issues/7447
- https://github.com/vitest-dev/vitest/issues/6795

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [ ] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
