### PR TITLE
feat(ui): highlight editor source locations

### DIFF
--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -71,10 +71,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div
-    relative font-mono text-sm class="codemirror-scrolls"
-    :class="{ 'codemirror-busy': saving, 'codemirror-hide-cursor': readOnly }"
-  >
+  <div relative font-mono text-sm class="codemirror-scrolls" :class="{ 'codemirror-busy': saving, 'codemirror-hide-cursor': readOnly }">
     <textarea ref="el" />
   </div>
 </template>

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -4,8 +4,7 @@ import type { Ref } from 'vue'
 import { onMounted, ref, useAttrs } from 'vue'
 import { codemirrorRef, useCodeMirror } from '~/composables/codemirror'
 
-const { hideCursor, mode, readOnly } = defineProps<{
-  hideCursor?: boolean
+const { mode, readOnly } = defineProps<{
   mode?: string
   readOnly?: boolean
   saving?: boolean
@@ -79,7 +78,7 @@ onMounted(async () => {
     class="codemirror-scrolls"
     :class="{
       'codemirror-busy': saving,
-      'codemirror-hide-cursor': hideCursor,
+      'codemirror-hide-cursor': readOnly,
     }"
   >
     <textarea ref="el" />

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -72,14 +72,8 @@ onMounted(async () => {
 
 <template>
   <div
-    relative
-    font-mono
-    text-sm
-    class="codemirror-scrolls"
-    :class="{
-      'codemirror-busy': saving,
-      'codemirror-hide-cursor': readOnly,
-    }"
+    relative font-mono text-sm class="codemirror-scrolls"
+    :class="{ 'codemirror-busy': saving, 'codemirror-hide-cursor': readOnly }"
   >
     <textarea ref="el" />
   </div>

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -71,7 +71,16 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div relative font-mono text-sm class="codemirror-scrolls" :class="{ 'codemirror-busy': saving, 'codemirror-hide-cursor': readOnly }">
+  <div
+    relative
+    font-mono
+    text-sm
+    class="codemirror-scrolls"
+    :class="{
+      'codemirror-busy': saving,
+      'codemirror-hide-cursor': readOnly,
+    }"
+  >
     <textarea ref="el" />
   </div>
 </template>

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -4,7 +4,8 @@ import type { Ref } from 'vue'
 import { onMounted, ref, useAttrs } from 'vue'
 import { codemirrorRef, useCodeMirror } from '~/composables/codemirror'
 
-const { mode, readOnly } = defineProps<{
+const { hideCursor, mode, readOnly } = defineProps<{
+  hideCursor?: boolean
   mode?: string
   readOnly?: boolean
   saving?: boolean
@@ -71,7 +72,16 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div relative font-mono text-sm class="codemirror-scrolls" :class="saving ? 'codemirror-busy' : undefined">
+  <div
+    relative
+    font-mono
+    text-sm
+    class="codemirror-scrolls"
+    :class="{
+      'codemirror-busy': saving,
+      'codemirror-hide-cursor': hideCursor,
+    }"
+  >
     <textarea ref="el" />
   </div>
 </template>

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -62,7 +62,6 @@ watch(
 
     await nextTick()
 
-    // fire focusing editor after loading
     loading.value = false
   },
   { immediate: true },
@@ -81,15 +80,9 @@ watch(() => [loading.value, saving.value, props.file, lineNumber.value, columnNu
         else {
           codemirrorRef.value?.scrollIntoView(line, 100)
           nextTick(() => {
-            codemirrorRef.value?.focus()
             codemirrorRef.value?.setCursor(line)
           })
         }
-      })
-    }
-    else {
-      nextTick(() => {
-        codemirrorRef.value?.focus()
       })
     }
   }
@@ -459,8 +452,10 @@ onBeforeUnmount(clearListeners)
       lineNumbers: true,
       readOnly: isReport || !config.api?.allowWrite,
       saving,
+      styleActiveLine: true,
       gutters: ['CodeMirror-linenumbers', ...traceGutterConfigs],
     }"
+    :hide-cursor="isReport"
     :mode="ext"
     data-testid="code-mirror"
     @save="onSave"

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -62,6 +62,7 @@ watch(
 
     await nextTick()
 
+    // fire focusing editor after loading
     loading.value = false
   },
   { immediate: true },
@@ -80,9 +81,15 @@ watch(() => [loading.value, saving.value, props.file, lineNumber.value, columnNu
         else {
           codemirrorRef.value?.scrollIntoView(line, 100)
           nextTick(() => {
+            codemirrorRef.value?.focus()
             codemirrorRef.value?.setCursor(line)
           })
         }
+      })
+    }
+    else {
+      nextTick(() => {
+        codemirrorRef.value?.focus()
       })
     }
   }

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -32,6 +32,7 @@ const serverCode = shallowRef<string | undefined>(undefined)
 const draft = ref(false)
 const loading = ref(true)
 const saving = ref(false)
+const readOnly = computed(() => isReport || !config.value.api?.allowWrite)
 const currentPosition = ref<CodeMirror.Position | undefined>()
 
 watch(
@@ -450,12 +451,11 @@ onBeforeUnmount(clearListeners)
     h-full
     v-bind="{
       lineNumbers: true,
-      readOnly: isReport || !config.api?.allowWrite,
+      readOnly,
       saving,
       styleActiveLine: true,
       gutters: ['CodeMirror-linenumbers', ...traceGutterConfigs],
     }"
-    :hide-cursor="isReport"
     :mode="ext"
     data-testid="code-mirror"
     @save="onSave"

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -32,7 +32,6 @@ const serverCode = shallowRef<string | undefined>(undefined)
 const draft = ref(false)
 const loading = ref(true)
 const saving = ref(false)
-const readOnly = computed(() => isReport || !config.value.api?.allowWrite)
 const currentPosition = ref<CodeMirror.Position | undefined>()
 
 watch(
@@ -451,7 +450,7 @@ onBeforeUnmount(clearListeners)
     h-full
     v-bind="{
       lineNumbers: true,
-      readOnly,
+      readOnly: isReport || !config.api?.allowWrite,
       saving,
       styleActiveLine: true,
       gutters: ['CodeMirror-linenumbers', ...traceGutterConfigs],

--- a/packages/ui/client/composables/codemirror.ts
+++ b/packages/ui/client/composables/codemirror.ts
@@ -13,6 +13,7 @@ import 'codemirror/mode/xml/xml'
 import 'codemirror/mode/htmlmixed/htmlmixed'
 import 'codemirror/mode/jsx/jsx'
 import 'codemirror/addon/display/placeholder'
+import 'codemirror/addon/selection/active-line'
 import 'codemirror/addon/scroll/simplescrollbars'
 import 'codemirror/addon/scroll/simplescrollbars.css'
 

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -91,6 +91,10 @@ html.dark {
   background: var(--cm-line-highlight-background);
 }
 
+/*
+ * Unlike readOnly: 'nocursor', hiding only the caret preserves text selection
+ * and lets the active line follow clicks.
+ */
 .codemirror-hide-cursor .CodeMirror-cursors {
   visibility: hidden !important;
 }

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -51,7 +51,8 @@ html.dark {
   --cm-regex: #ab5e3f;
   --cm-json-property: #698c96;
   --cm-line-number-gutter: #f8f8f8;
-  --cm-line-highlight-background: rgb(59 130 246 / 12%);
+  /* blue-500, with higher opacity in dark mode */
+  --cm-line-highlight-background: rgb(59 130 246 / 10%);
   /* scrollbars colors */
   --cm-ttc-c-thumb: #eee;
   --cm-ttc-c-track: white;

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -51,6 +51,7 @@ html.dark {
   --cm-regex: #ab5e3f;
   --cm-json-property: #698c96;
   --cm-line-number-gutter: #f8f8f8;
+  --cm-line-highlight-background: rgb(59 130 246 / 12%);
   /* scrollbars colors */
   --cm-ttc-c-thumb: #eee;
   --cm-ttc-c-track: white;
@@ -79,11 +80,19 @@ html.dark {
   --cm-json-property: #6b8b9e;
   --cm-line-number: #888888;
   --cm-line-number-gutter: #161616;
-  --cm-line-highlight-background: #444444;
+  --cm-line-highlight-background: rgb(59 130 246 / 18%);
   --cm-selection-background: #44444450;
   /* scrollbars colors */
   --cm-ttc-c-thumb: #222;
   --cm-ttc-c-track: #111;
+}
+
+.CodeMirror-activeline-background {
+  background: var(--cm-line-highlight-background);
+}
+
+.codemirror-hide-cursor .CodeMirror-cursors {
+  visibility: hidden !important;
 }
 
 .splitpanes__pane {

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -92,8 +92,8 @@ html.dark {
 }
 
 /*
- * Unlike readOnly: 'nocursor', hiding only the caret preserves text selection
- * and lets the active line follow clicks.
+ * readOnly: 'nocursor' disables CodeMirror's input and prevents focus.
+ * Hide only the caret so read-only code remains focusable and selectable.
  */
 .codemirror-hide-cursor .CodeMirror-cursors {
   visibility: hidden !important;

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -92,7 +92,7 @@ html.dark {
 }
 
 /*
- * code mirror has readOnly: 'nocursor' option, but it would disable entire editor input and prevent focus.
+ * code mirror has readOnly: 'nocursor' option, but it would disable editor input and prevent focus.
  * this only hides the cursor caret while keeping the editor region focusable and selectable.
  */
 .codemirror-hide-cursor .CodeMirror-cursors {

--- a/packages/ui/client/styles/main.css
+++ b/packages/ui/client/styles/main.css
@@ -92,8 +92,8 @@ html.dark {
 }
 
 /*
- * readOnly: 'nocursor' disables CodeMirror's input and prevents focus.
- * Hide only the caret so read-only code remains focusable and selectable.
+ * code mirror has readOnly: 'nocursor' option, but it would disable entire editor input and prevent focus.
+ * this only hides the cursor caret while keeping the editor region focusable and selectable.
  */
 .codemirror-hide-cursor .CodeMirror-cursors {
   visibility: hidden !important;

--- a/test/ui/test/trace.spec.ts
+++ b/test/ui/test/trace.spec.ts
@@ -151,7 +151,6 @@ async function testBasic(page: Page) {
   await expect(page.getByTestId('btn-report')).toContainClass('tab-button-active')
   await traceStepNames.getByText('Render simple').click()
   await expect(page.getByTestId('btn-code')).toContainClass('tab-button-active')
-  await expect(traceSteps.nth(0)).toBeFocused()
 
   // verify source location highlight
   const activeLine = page.getByTestId('editor').locator('.CodeMirror-activeline')

--- a/test/ui/test/trace.spec.ts
+++ b/test/ui/test/trace.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test'
 import type { PreviewServer } from 'vite'
 import type { Vitest } from 'vitest/node'
 import { expect, test } from '@playwright/test'
-import { assertTestCounts, evaluateEditor, openExplorerItem, startHtmlReportPreview, startVitestUi } from './helper'
+import { assertTestCounts, openExplorerItem, startHtmlReportPreview, startVitestUi } from './helper'
 
 test.describe('ui', () => {
   let vitest: Vitest | undefined
@@ -151,10 +151,11 @@ async function testBasic(page: Page) {
   await expect(page.getByTestId('btn-report')).toContainClass('tab-button-active')
   await traceStepNames.getByText('Render simple').click()
   await expect(page.getByTestId('btn-code')).toContainClass('tab-button-active')
+  await expect(traceSteps.nth(0)).toBeFocused()
 
-  // verify editor cursor position
-  const getEditorCursor = () => evaluateEditor(page, editor => editor.getCursor())
-  await expect.poll(() => getEditorCursor()).toEqual({ line: 9, ch: 33 })
+  // verify source location highlight
+  const activeLine = page.getByTestId('editor').locator('.CodeMirror-activeline')
+  await expect(activeLine).toContainText('Render simple')
 
   // markers ordered by 'test finished' > 'Render simple' > 'Render another'
   const traceEditorMarkers = page.getByTestId('editor').getByTestId('trace-editor-marker')
@@ -172,7 +173,7 @@ async function testBasic(page: Page) {
   // selecting 2nd trace step and verify again
   await traceStepNames.getByText('Render another').click()
   await expect(traceFrame.getByRole('button', { name: 'Another' })).toBeVisible()
-  await expect.poll(() => getEditorCursor()).toEqual({ line: 12, ch: 33 })
+  await expect(activeLine).toContainText('Render another')
   await expect(traceSteps.nth(1)).toHaveAttribute('aria-current', 'step')
   await expect(traceEditorMarkers.nth(1)).not.toHaveAttribute('aria-current', 'step')
   await expect(traceEditorMarkers.nth(2)).toHaveAttribute('aria-current', 'step')

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -650,9 +650,7 @@ async function testWriteFile(page: Page, options: { enabled: boolean }) {
   const editor = page.getByTestId('editor')
   await expect(editor).toContainText('expect(1 + 1).toEqual(2)')
   await editor.click()
-  if (!options.enabled) {
-    await expect(editor.locator('.CodeMirror-cursors')).toHaveCSS('visibility', 'hidden')
-  }
+  await expect(editor.locator('.CodeMirror-cursors')).toHaveCSS('visibility', options.enabled ? 'visible' : 'hidden')
   await page.keyboard.type('\n// edited \n')
   if (options.enabled) {
     await expect(editor).toContainText('// edited')

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -277,7 +277,7 @@ test.describe('html report', () => {
 
   test('cannot edit file', async ({ page }) => {
     await page.goto(pageUrl)
-    await testWriteFile(page, { enabled: false, hideCursor: true })
+    await testWriteFile(page, { enabled: false })
   })
 
   test('cannot execute', async ({ page }) => {
@@ -642,7 +642,7 @@ async function testCrossOriginAccess(page: Page, pageUrl: string) {
   expect(wsResult).toBe('error')
 }
 
-async function testWriteFile(page: Page, options: { enabled: boolean; hideCursor?: boolean }) {
+async function testWriteFile(page: Page, options: { enabled: boolean }) {
   await getExplorerItem(page, 'add').click()
   const codeTabButton = page.getByTestId('btn-code')
   await expect(codeTabButton).toHaveText('Code')
@@ -650,7 +650,7 @@ async function testWriteFile(page: Page, options: { enabled: boolean; hideCursor
   const editor = page.getByTestId('editor')
   await expect(editor).toContainText('expect(1 + 1).toEqual(2)')
   await editor.click()
-  if (options.hideCursor) {
+  if (!options.enabled) {
     await expect(editor.locator('.CodeMirror-cursors')).toHaveCSS('visibility', 'hidden')
   }
   await page.keyboard.type('\n// edited \n')

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -649,7 +649,6 @@ async function testWriteFile(page: Page, options: { enabled: boolean }) {
   await codeTabButton.click()
   const editor = page.getByTestId('editor')
   await expect(editor).toContainText('expect(1 + 1).toEqual(2)')
-  await editor.click()
   await expect(editor.locator('.CodeMirror-cursors')).toHaveCSS('visibility', options.enabled ? 'visible' : 'hidden')
   await page.keyboard.type('\n// edited \n')
   if (options.enabled) {

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -277,7 +277,7 @@ test.describe('html report', () => {
 
   test('cannot edit file', async ({ page }) => {
     await page.goto(pageUrl)
-    await testWriteFile(page, { enabled: false })
+    await testWriteFile(page, { enabled: false, hideCursor: true })
   })
 
   test('cannot execute', async ({ page }) => {
@@ -642,13 +642,17 @@ async function testCrossOriginAccess(page: Page, pageUrl: string) {
   expect(wsResult).toBe('error')
 }
 
-async function testWriteFile(page: Page, options: { enabled: boolean }) {
+async function testWriteFile(page: Page, options: { enabled: boolean; hideCursor?: boolean }) {
   await getExplorerItem(page, 'add').click()
   const codeTabButton = page.getByTestId('btn-code')
   await expect(codeTabButton).toHaveText('Code')
   await codeTabButton.click()
   const editor = page.getByTestId('editor')
   await expect(editor).toContainText('expect(1 + 1).toEqual(2)')
+  await editor.click()
+  if (options.hideCursor) {
+    await expect(editor.locator('.CodeMirror-cursors')).toHaveCSS('visibility', 'hidden')
+  }
   await page.keyboard.type('\n// edited \n')
   if (options.enabled) {
     await expect(editor).toContainText('// edited')


### PR DESCRIPTION
> Recreated in the upstream repository by OpenCode (gpt-5.6-sol) on behalf of @hi-ogawa to test stacked PR behavior. This automated recreation has not been human-reviewed.\n> Original PR: #10989

### Description

Currently UI has action to open code view with a line information (e.g. artifact link, error link, trace step), but the opened code editor only shows a fainted cursor and it has a very limited UX value.

This PR adds an editor line highlight style to make the active line obvious. 

<details><summary> 📸 Demo </summary>

Tested on merge report run https://github.com/vitest-dev/vitest/actions/runs/32203733745/job/95924081848

https://github.com/user-attachments/assets/593244b8-d44e-4e03-a407-768e8b95910d

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->