### PR TITLE
feat(ui): navigate trace steps with keyboard and remove indirect editor focus

### DIFF
--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -29,6 +29,32 @@ function onSelectStep(index: number) {
   }
 }
 
+function onStepKeydown(event: KeyboardEvent, index: number) {
+  let nextIndex: number
+  if (event.key === 'ArrowUp') {
+    nextIndex = Math.max(index - 1, 0)
+  }
+  else if (event.key === 'ArrowDown') {
+    nextIndex = Math.min(index + 1, entries.value.length - 1)
+  }
+  else if (event.key === 'Home') {
+    nextIndex = 0
+  }
+  else if (event.key === 'End') {
+    nextIndex = entries.value.length - 1
+  }
+  else {
+    return
+  }
+
+  event.preventDefault()
+  onSelectStep(nextIndex)
+  const nextButton = (event.currentTarget as HTMLButtonElement).parentElement?.children[nextIndex]
+  if (nextButton instanceof HTMLButtonElement) {
+    nextButton.focus()
+  }
+}
+
 watch([selectedStep, iframeEl], ([step, iframe]) => {
   if (!step || !iframe) {
     return
@@ -154,7 +180,9 @@ function isTraceStepInProgress(step: NormalizedBrowserTraceEntry) {
           :class="getStepButtonClass(step, index)"
           :style="{ paddingInlineStart: `${0.5 + step.depth}rem` }"
           :aria-current="selection.selectedStepIndex === index ? 'step' : undefined"
+          :tabindex="selection.selectedStepIndex === index ? 0 : -1"
           @click="onSelectStep(index)"
+          @keydown="onStepKeydown($event, index)"
         >
           <span
             v-if="step.depth > 0"

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -169,17 +169,24 @@ function isTraceStepInProgress(step: NormalizedBrowserTraceEntry) {
     class="h-full min-h-0"
   >
     <Pane :size="30" min-size="20">
-      <div class="h-full min-h-0 p-4" flex="~ col gap-1" overflow-auto>
+      <div
+        class="h-full min-h-0 p-4"
+        flex="~ col gap-1"
+        overflow-auto
+        role="listbox"
+        aria-label="Trace steps"
+      >
         <button
           v-for="(step, index) of entries"
           :key="index"
           type="button"
+          role="option"
           data-testid="trace-step"
           :data-test-range="step.range?.phase"
           class="relative w-full text-left px-2 py-1 rounded text-sm"
           :class="getStepButtonClass(step, index)"
           :style="{ paddingInlineStart: `${0.5 + step.depth}rem` }"
-          :aria-current="selection.selectedStepIndex === index ? 'step' : undefined"
+          :aria-selected="selection.selectedStepIndex === index"
           :tabindex="selection.selectedStepIndex === index ? 0 : -1"
           @click="onSelectStep(index)"
           @keydown="onStepKeydown($event, index)"

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -48,6 +48,9 @@ function onStepKeydown(event: KeyboardEvent, index: number) {
   }
 
   event.preventDefault()
+  if (nextIndex === index) {
+    return
+  }
   onSelectStep(nextIndex)
   const nextButton = (event.currentTarget as HTMLButtonElement).parentElement?.children[nextIndex]
   if (nextButton instanceof HTMLButtonElement) {

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -62,7 +62,6 @@ watch(
 
     await nextTick()
 
-    // fire focusing editor after loading
     loading.value = false
   },
   { immediate: true },
@@ -81,15 +80,9 @@ watch(() => [loading.value, saving.value, props.file, lineNumber.value, columnNu
         else {
           codemirrorRef.value?.scrollIntoView(line, 100)
           nextTick(() => {
-            codemirrorRef.value?.focus()
             codemirrorRef.value?.setCursor(line)
           })
         }
-      })
-    }
-    else {
-      nextTick(() => {
-        codemirrorRef.value?.focus()
       })
     }
   }

--- a/test/ui/test/trace-stream.spec.ts
+++ b/test/ui/test/trace-stream.spec.ts
@@ -66,7 +66,7 @@ test.describe('trace stream', () => {
     ])
 
     // first step is selected by default
-    await expect(traceSteps.nth(0)).toHaveAttribute('aria-current', 'step')
+    await expect(traceSteps.nth(0)).toHaveAttribute('aria-selected', 'true')
 
     // progresses up-to `render-b`
     await writeFile(resolve(gatesDir, 'b.txt'), 'open')
@@ -77,7 +77,7 @@ test.describe('trace stream', () => {
 
     // select next step
     await traceStepNames.nth(1).click()
-    await expect(traceSteps.nth(1)).toHaveAttribute('aria-current', 'step')
+    await expect(traceSteps.nth(1)).toHaveAttribute('aria-selected', 'true')
 
     // continue test and wait for finishes
     await writeFile(resolve(gatesDir, 'c.txt'), 'open')
@@ -89,7 +89,7 @@ test.describe('trace stream', () => {
       'test finished',
     ])
     // last selected step is preserved
-    await expect(traceSteps.nth(1)).toHaveAttribute('aria-current', 'step')
+    await expect(traceSteps.nth(1)).toHaveAttribute('aria-selected', 'true')
 
     // re-run and verify trace view is cleared
     await rm(gatesDir, { recursive: true, force: true })
@@ -100,7 +100,7 @@ test.describe('trace stream', () => {
     await expect.poll(() => traceStepNames.allInnerTexts()).toEqual([
       'render-a',
     ])
-    await expect(traceSteps.nth(0)).toHaveAttribute('aria-current', 'step')
+    await expect(traceSteps.nth(0)).toHaveAttribute('aria-selected', 'true')
     await writeFile(resolve(gatesDir, 'b.txt'), 'open')
     await writeFile(resolve(gatesDir, 'c.txt'), 'open')
     await expect.poll(() => traceStepNames.allInnerTexts()).toEqual([

--- a/test/ui/test/trace.spec.ts
+++ b/test/ui/test/trace.spec.ts
@@ -149,8 +149,9 @@ async function testBasic(page: Page) {
 
   // selecting steps should open source code view
   await expect(page.getByTestId('btn-report')).toContainClass('tab-button-active')
-  await traceStepNames.getByText('Render simple').click()
+  await traceSteps.nth(0).click()
   await expect(page.getByTestId('btn-code')).toContainClass('tab-button-active')
+  await expect(traceSteps.nth(0)).toBeFocused()
 
   // verify editor cursor position
   const getEditorCursor = () => evaluateEditor(page, editor => editor.getCursor())
@@ -169,13 +170,25 @@ async function testBasic(page: Page) {
   // verify selector highlight
   await expect(traceFrame.getByTestId('trace-view-highlight')).toBeVisible()
 
-  // selecting 2nd trace step and verify again
-  await traceStepNames.getByText('Render another').click()
+  // selecting 2nd trace step with keyboard and verify again
+  await traceSteps.nth(0).press('ArrowDown')
   await expect(traceFrame.getByRole('button', { name: 'Another' })).toBeVisible()
   await expect.poll(() => getEditorCursor()).toEqual({ line: 12, ch: 33 })
+  await expect(traceSteps.nth(1)).toBeFocused()
   await expect(traceSteps.nth(1)).toHaveAttribute('aria-current', 'step')
   await expect(traceEditorMarkers.nth(1)).not.toHaveAttribute('aria-current', 'step')
   await expect(traceEditorMarkers.nth(2)).toHaveAttribute('aria-current', 'step')
+
+  await traceSteps.nth(1).press('End')
+  await expect(traceSteps.nth(2)).toBeFocused()
+  await expect(traceSteps.nth(2)).toHaveAttribute('aria-current', 'step')
+  await traceSteps.nth(2).press('ArrowDown')
+  await expect(traceSteps.nth(2)).toBeFocused()
+  await traceSteps.nth(2).press('Home')
+  await expect(traceSteps.nth(0)).toBeFocused()
+  await expect(traceSteps.nth(0)).toHaveAttribute('aria-current', 'step')
+  await traceSteps.nth(0).press('ArrowUp')
+  await expect(traceSteps.nth(0)).toBeFocused()
 
   // selecting 1st trace step from editor and verify again
   await traceEditorMarkers.nth(1).click()

--- a/test/ui/test/trace.spec.ts
+++ b/test/ui/test/trace.spec.ts
@@ -175,18 +175,18 @@ async function testBasic(page: Page) {
   await expect(traceFrame.getByRole('button', { name: 'Another' })).toBeVisible()
   await expect.poll(() => getEditorCursor()).toEqual({ line: 12, ch: 33 })
   await expect(traceSteps.nth(1)).toBeFocused()
-  await expect(traceSteps.nth(1)).toHaveAttribute('aria-current', 'step')
+  await expect(traceSteps.nth(1)).toHaveAttribute('aria-selected', 'true')
   await expect(traceEditorMarkers.nth(1)).not.toHaveAttribute('aria-current', 'step')
   await expect(traceEditorMarkers.nth(2)).toHaveAttribute('aria-current', 'step')
 
   await traceSteps.nth(1).press('End')
   await expect(traceSteps.nth(2)).toBeFocused()
-  await expect(traceSteps.nth(2)).toHaveAttribute('aria-current', 'step')
+  await expect(traceSteps.nth(2)).toHaveAttribute('aria-selected', 'true')
   await traceSteps.nth(2).press('ArrowDown')
   await expect(traceSteps.nth(2)).toBeFocused()
   await traceSteps.nth(2).press('Home')
   await expect(traceSteps.nth(0)).toBeFocused()
-  await expect(traceSteps.nth(0)).toHaveAttribute('aria-current', 'step')
+  await expect(traceSteps.nth(0)).toHaveAttribute('aria-selected', 'true')
   await traceSteps.nth(0).press('ArrowUp')
   await expect(traceSteps.nth(0)).toBeFocused()
 
@@ -195,7 +195,7 @@ async function testBasic(page: Page) {
   await expect(traceFrame.getByRole('button', { name: 'Simple' })).toBeVisible()
   await expect(traceEditorMarkers.nth(1)).toHaveAttribute('aria-current', 'step')
   await expect(traceEditorMarkers.nth(2)).not.toHaveAttribute('aria-current', 'step')
-  await expect(traceSteps.nth(0)).toHaveAttribute('aria-current', 'step')
+  await expect(traceSteps.nth(0)).toHaveAttribute('aria-selected', 'true')
 
   // verify selecting another test switches trace viewer
   await openExplorerItem(page, 'switch-target')

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -649,6 +649,7 @@ async function testWriteFile(page: Page, options: { enabled: boolean }) {
   await codeTabButton.click()
   const editor = page.getByTestId('editor')
   await expect(editor).toContainText('expect(1 + 1).toEqual(2)')
+  await editor.click()
   await page.keyboard.type('\n// edited \n')
   if (options.enabled) {
     await expect(editor).toContainText('// edited')


### PR DESCRIPTION
> Recreated in the upstream repository by OpenCode (gpt-5.6-sol) on behalf of @hi-ogawa to test stacked PR behavior. This automated recreation has not been human-reviewed.\n> Original PR: #10986

### Description

- closes https://github.com/vitest-dev/vitest/issues/10985

Trace steps currently require repeated clicks of each steps to go through and this can be cumbersome for quick skim. 

This PR adds standard keyboard arrow/home/end navigation so it allows going up and down easily.

One fundamental editor behavior change is required for this, which is now "open editor" actions won't automatically move the browser focus to editor cursor at all. This behavior seems natural since if it's static report view, then moving the cursor there is meaningless, and even if it's editable watch UI, I don't think people would immediately start typing after such indirect cursor focus jump where you don't even know which column it jumped to.

<details><summary> 📸 Demo </summary>

Demo from merge reports https://github.com/vitest-dev/vitest/actions/runs/32121156949/job/95663338646

https://github.com/user-attachments/assets/ddb62102-e15e-4c6e-b885-ce67b001bcd6

</details>

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->