### PR TITLE
refactor(ui): consolidate CodeMirror options prop

### DIFF
--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import type { EditorFromTextArea } from 'codemirror'
+import type { EditorConfiguration, EditorFromTextArea } from 'codemirror'
 import type { Ref } from 'vue'
-import { onMounted, ref, useAttrs } from 'vue'
+import { onMounted, ref } from 'vue'
 import { codemirrorRef, useCodeMirror } from '~/composables/codemirror'
 
-const { mode, readOnly } = defineProps<{
+const { mode, options, readOnly } = defineProps<{
   mode?: string
+  options?: EditorConfiguration
   readOnly?: boolean
   saving?: boolean
 }>()
@@ -16,8 +17,6 @@ const emit = defineEmits<{
 }>()
 
 const modelValue = defineModel<string>()
-
-const attrs = useAttrs()
 
 const modeMap: Record<string, any> = {
   html: 'htmlmixed',
@@ -38,7 +37,7 @@ const el = ref<HTMLTextAreaElement>()
 onMounted(async () => {
   // useCodeMirror will remove the codemirrorRef.value on onUnmounted callback
   const codemirror = useCodeMirror(el, modelValue as unknown as Ref<string>, {
-    ...attrs,
+    ...options,
     mode: modeMap[mode || ''] || mode,
     readOnly: readOnly ? true : undefined,
     extraKeys: {

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -307,7 +307,7 @@ onKeyStroke('Escape', () => {
           h-full
           :model-value="source"
           read-only
-          v-bind="{ lineNumbers: true }"
+          :options="{ lineNumbers: true }"
           :mode="ext"
           @codemirror="markImportDurations($event)"
         />
@@ -316,7 +316,7 @@ onKeyStroke('Escape', () => {
           h-full
           :model-value="code"
           read-only
-          v-bind="{ lineNumbers: true }"
+          :options="{ lineNumbers: true }"
           mode="js"
         />
       </div>
@@ -327,7 +327,7 @@ onKeyStroke('Escape', () => {
         <CodeMirrorContainer
           :model-value="sourceMap.mappings"
           read-only
-          v-bind="{ lineNumbers: true }"
+          :options="{ lineNumbers: true }"
         />
       </div>
     </template>

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -455,10 +455,10 @@ onBeforeUnmount(clearListeners)
     ref="editor"
     v-model="code"
     h-full
-    v-bind="{
+    :read-only="isReport || !config.api?.allowWrite"
+    :saving="saving"
+    :options="{
       lineNumbers: true,
-      readOnly: isReport || !config.api?.allowWrite,
-      saving,
       gutters: ['CodeMirror-linenumbers', ...traceGutterConfigs],
     }"
     :mode="ext"


### PR DESCRIPTION
> Recreated in the upstream repository by OpenCode (gpt-5.6-sol) on behalf of @hi-ogawa to test stacked PR behavior. This automated recreation has not been human-reviewed.
> Original PR: #11001\n> Stacked on #11005.

### Description

Minor pure refactor. The mixed usage of `v-bind, defineProps, useAttrs` is confusing and also untyped. This consolidated them to use normal props.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->