### PR TITLE
ci: cache `playwright install-deps` by using custom Docker image

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -39,16 +39,10 @@ runs:
         restore-keys: |
           ${{ runner.os }}-playwright-${{ inputs.browsers }}-
 
-    # webkit/firefox link against apt system libraries (e.g. webkit's libwoff2dec)
-    # that are NOT stored in the browser cache, so install them on Linux whenever
-    # the full set is requested, even on a cache hit. chromium needs none, and
+    # System libraries are never installed here: Linux jobs that need them run
+    # inside the playwright-deps container image (see .github/docker/Dockerfile), and
     # Windows/macOS need no system deps (--with-deps on Windows is a slow ~3min
     # Media Foundation DISM).
-    - name: Install Playwright system deps (Linux)
-      shell: bash
-      if: runner.os == 'Linux' && inputs.browsers == 'all'
-      run: pnpm exec playwright install-deps
-
     - name: Install Playwright chromium (cache miss)
       shell: bash
       if: steps.playwright-cache.outputs.cache-hit != 'true' && inputs.browsers != 'all'

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,16 @@
+# CI image with Playwright system dependencies pre-installed, so Linux browser
+# jobs skip `playwright install-deps` on every run. Browser binaries are NOT
+# baked in; jobs install them through the setup-playwright cache.
+# git and ca-certificates are required by actions/checkout inside container
+# jobs; zstd keeps actions/cache archives compatible with the runner VMs.
+FROM node:24-bookworm-slim
+
+ARG PLAYWRIGHT_VERSION
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates zstd \
+  && npx -y "playwright@${PLAYWRIGHT_VERSION}" install-deps \
+  && rm -rf /var/lib/apt/lists/*
+
+# CI runs the container with --user 1001 (the GitHub runner user, which owns
+# the mounted volumes); create it so passwd lookups resolve
+RUN useradd -m -u 1001 runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,60 @@ jobs:
             docs/**
             .github/**
             !.github/workflows/ci.yml
+            !.github/docker/**
             **.md
+
+  # Ensures the playwright-deps image exists in GHCR: a no-op manifest check
+  # when the tag for the locked Playwright version + Dockerfile hash already
+  # exists, otherwise builds and pushes it. Fork PRs get a read-only token and
+  # cannot push a missing tag; changes to the tag inputs must come from a
+  # branch in this repository.
+  playwright-deps-image:
+    runs-on: ubuntu-latest
+    name: 'Image: playwright-deps, ubuntu-latest'
+    timeout-minutes: 15
+    permissions:
+      packages: write # push the playwright-deps image to GHCR
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve image tag
+        id: image
+        run: |
+          version="$(node -e "
+            const fs = require('fs');
+            const lockfile = fs.readFileSync('./pnpm-lock.yaml', 'utf8');
+            const match = lockfile.match(/playwright:\s+specifier: [\s\w.^]+version: (\d+\.\d+\.\d+)/);
+            if (!match) throw new Error('Failed to resolve playwright version');
+            console.log(match[1]);
+          ")"
+          hash="$(sha256sum .github/docker/Dockerfile | cut -c1-12)"
+          echo "image=ghcr.io/${GITHUB_REPOSITORY@L}/playwright-deps:${version}-${hash}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Build and push if missing
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          PLAYWRIGHT_VERSION: ${{ steps.image.outputs.version }}
+        run: |
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "$IMAGE already exists, skipping build"
+          else
+            docker build --build-arg "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" -t "$IMAGE" .github/docker
+            if ! docker push "$IMAGE"; then
+              echo "::error::Failed to publish $IMAGE. Fork PRs cannot push to GHCR - a Vitest maintainer needs to run CI from a vitest-dev/vitest branch to publish the playwright-deps:$PLAYWRIGHT_VERSION image."
+              exit 1
+            fi
+          fi
 
   test:
     needs: changed
@@ -172,33 +225,77 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
-  test-browser:
+  # runner.test.ts is the heaviest spec (~28% of the suite, ~70% of whichever
+  # shard it lands in). Windows isolates it in its own job and shards the other
+  # 32 specs; Ubuntu shards the whole suite 2 ways (runner rides in one shard).
+  # Every spec, runner included, runs on both OSes. Ubuntu runs inside the
+  # playwright-deps container so `playwright install-deps` is never needed;
+  # Windows needs no system deps.
+  test-browser-windows:
     needs: changed
-    name: 'Browsers: ${{ matrix.name }}, node-24, ${{ matrix.os }}'
+    name: 'Browsers: ${{ matrix.name }}, node-24, windows-latest'
     if: needs.changed.outputs.should_skip != 'true'
 
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     strategy:
-      # runner.test.ts is the heaviest spec (~28% of the suite, ~70% of whichever
-      # shard it lands in). Windows isolates it in its own job and shards the other
-      # 32 specs; Ubuntu shards the whole suite 2 ways (runner rides in one shard).
-      # Every spec, runner included, runs on both OSes.
       matrix:
         include:
-          - os: windows-latest
-            name: runner
+          - name: runner
             command: pnpm run test:browser:playwright runner.test.ts
-          - os: windows-latest
-            name: rest 1/2
+          - name: rest 1/2
             command: "pnpm run test:browser:playwright --exclude 'specs/runner.test.ts' --shard=1/2"
-          - os: windows-latest
-            name: rest 2/2
+          - name: rest 2/2
             command: "pnpm run test:browser:playwright --exclude 'specs/runner.test.ts' --shard=2/2"
-          - os: ubuntu-latest
-            name: shard 1/2
+      fail-fast: false
+
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-and-cache
+        with:
+          node-version: 24
+
+      - name: Install
+        run: pnpm i --filter '!docs'
+
+      - uses: ./.github/actions/setup-playwright
+        with:
+          browsers: all
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test Browser (playwright)
+        # matrix.command is a fixed, workflow-defined string
+        run: ${{ matrix.command }} # zizmor: ignore[template-injection]
+
+  test-browser-linux:
+    needs:
+      - changed
+      - playwright-deps-image
+    name: 'Browsers: ${{ matrix.name }}, node-24, ubuntu-latest'
+    if: needs.changed.outputs.should_skip != 'true'
+
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read # pull the playwright-deps image from GHCR
+    container:
+      # the tag is version-keyed, built by playwright-deps-image in this workflow
+      image: ${{ needs.playwright-deps-image.outputs.image }} # zizmor: ignore[unpinned-images]
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001
+    strategy:
+      matrix:
+        include:
+          - name: shard 1/2
             command: pnpm run test:browser:playwright --shard=1/2
-          - os: ubuntu-latest
-            name: shard 2/2
+          - name: shard 2/2
             command: pnpm run test:browser:playwright --shard=2/2
       fail-fast: false
 
@@ -228,11 +325,22 @@ jobs:
         run: ${{ matrix.command }} # zizmor: ignore[template-injection]
 
   test-vite7:
-    needs: changed
+    needs:
+      - changed
+      - playwright-deps-image
     # Runs on ubuntu to keep macOS under its ~5 concurrent-runner limit.
     name: 'Test: vite@7, ${{ matrix.suite }}, node-24, ubuntu-latest'
     if: needs.changed.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: read # pull the playwright-deps image from GHCR
+    container:
+      # the tag is version-keyed, built by playwright-deps-image in this workflow
+      image: ${{ needs.playwright-deps-image.outputs.image }} # zizmor: ignore[unpinned-images]
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001
 
     timeout-minutes: 30
 
@@ -256,6 +364,8 @@ jobs:
       - name: Install
         run: |
           pnpm override-vite7
+          # the container user does not own the workspace volume, and checkout's safe.directory entry does not survive into later steps
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # ubuntu runners have no default git identity; set one for this commit
           git add . && git -c user.email=ci@vitest.dev -c user.name=vitest-ci commit -m "ci" && pnpm i --prefer-offline --no-frozen-lockfile --filter '!docs'
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -5,7 +5,6 @@
     "test/e2e/dts/*",
     "test/e2e/fixtures/conditions-pkg"
   ],
-  "ignoreBinaries": ["yq"],
   "ignoreIssues": {
     "docs/.vitepress/blog.data.ts": ["files"],
     "docs/.vitepress/components/*.vue": ["files"],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ui:build": "vite build packages/ui",
     "ui:dev": "npm -C packages/ui run dev:client",
     "ui:test": "npm -C packages/ui run test:run",
-    "override-vite7": "yq -i '.overrides.vite = \"npm:vite@7\"' pnpm-workspace.yaml",
+    "override-vite7": "node scripts/override-vite7.ts",
     "test:browser:playwright": "pnpm -C test/browser run test:playwright"
   },
   "devDependencies": {

--- a/scripts/override-vite7.ts
+++ b/scripts/override-vite7.ts
@@ -1,0 +1,11 @@
+import fs from 'node:fs'
+
+const file = 'pnpm-workspace.yaml'
+const content = fs.readFileSync(file, 'utf8')
+const updated = content.replace(`vite: 'catalog:'`, 'vite: npm:vite@7')
+
+if (updated === content) {
+  throw new Error(`Expected to find the "vite: 'catalog:'" override in ${file}`)
+}
+
+fs.writeFileSync(file, updated)

--- a/test/e2e/fixtures/global-setup/globalSetup/another-vite-instance.ts
+++ b/test/e2e/fixtures/global-setup/globalSetup/another-vite-instance.ts
@@ -7,6 +7,7 @@ export async function setup() {
   const server = await createServer({
     root: resolve(import.meta.dirname, '..'),
     server: {
+      host: '127.0.0.1',
       port: 9988,
     },
   })

--- a/test/e2e/fixtures/global-setup/test/global-setup.test.ts
+++ b/test/e2e/fixtures/global-setup/test/global-setup.test.ts
@@ -22,7 +22,7 @@ test('server running', async () => {
 })
 
 test('vite instance running', async () => {
-  const res = await (await fetch('http://localhost:9988')).text()
+  const res = await (await fetch('http://127.0.0.1:9988')).text()
   expect(res).toContain('<script type="module" src="/@vite/client">')
   expect(res).toContain('Hello Vitest\n')
 })

--- a/test/e2e/test/mocker-redirect-traversal.test.ts
+++ b/test/e2e/test/mocker-redirect-traversal.test.ts
@@ -14,6 +14,7 @@ async function createMockerServer() {
     configFile: false,
     logLevel: 'silent',
     server: {
+      host: '127.0.0.1',
       fs: { allow: [root] },
     },
     plugins: [
@@ -37,7 +38,7 @@ async function createMockerServer() {
 
 function registerRedirect(port: string, redirect: string) {
   return new Promise<void>((resolve, reject) => {
-    const ws = new WebSocket(`ws://localhost:${port}`, 'vite-hmr')
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, 'vite-hmr')
     const timeout = setTimeout(() => {
       ws.close()
       reject(new Error('timed out waiting for the register result'))


### PR DESCRIPTION
### Description

The `playwright install-deps` can sometimes hang completely on Github Actions. Installing the packages just takes forever.

<img width="600"  src="https://github.com/user-attachments/assets/6632ceae-28ff-4127-8e78-d170c8314ed4" />

Even on successful installs the `install-deps` can take between 1min30s to 4mins. After this PR this step takes 10-20s **consistently**.

This PR adds a custom Docker image that's published in Vitest's Github Packages. Compared to the official `mcr.microsoft.com/playwright:v1.62.1-noble`, this one is ~50% lighter and should load in ~15s compared to Playwright's ~40s.

🤖-assisted PR, all ideas are mine.

🤖 says:

> ## CI timing: `main` (install-deps every run) vs this PR (prebuilt container image)
> 
> Comparing the four affected Linux jobs between the last run of this PR
> ([32230774051](https://github.com/vitest-dev/vitest/actions/runs/32230774051)) and the latest full run on `main`
> ([32124232652](https://github.com/vitest-dev/vitest/actions/runs/32124232652)). "Setup" on `main` is the
> `setup-playwright` step (apt `install-deps` + browser cache restore); on this PR it's the container image pull
> ("Initialize containers") + `setup-playwright` (cache restore only, deps are baked into the image).
> 
> | Job                              | `main`: setup | PR: image pull + setup  | Δ infra time          |
> | -------------------------------- | ------------- | ----------------------- | --------------------- |
> | Browsers: shard 1/2, ubuntu      | 48s           | 17s + 4s = 21s          | **−27s**              |
> | Browsers: shard 2/2, ubuntu      | 26s           | 25s + 5s = 30s          | +4s                   |
> | Test: vite@7, e2e                | 62s           | 20s + 6s = 26s          | **−36s**              |
> | Test: vite@7, browser            | 31s           | 16s + 4s = 20s          | **−11s**              |
> | Image: playwright-deps (new job) | —             | 8s (tag exists → no-op) | +8s, runs in parallel |
> 
> ### `install-deps` hangs observed today (2026-08-19)
> 
> `apt` inside `playwright install-deps` hung until the 30-minute job timeout killed the job
> (log shows the last apt fetch from archive.ubuntu.com, then silence for ~29 min):
> 
> - [Browsers: shard 1/2 — 29m50s, killed](https://github.com/vitest-dev/vitest/actions/runs/32222665763/job/95976228165) (PR #11008 branch)
> - [Browsers: shard 2/2 — 29m47s, killed](https://github.com/vitest-dev/vitest/actions/runs/32225223027/job/95983994886) (**on `main`**)
> - [Test: vite@7, e2e — 29m35s, killed](https://github.com/vitest-dev/vitest/actions/runs/32225223027/job/95983994859) (same `main` run)
> - [Test: vite@7, e2e — 29m41s, killed](https://github.com/vitest-dev/vitest/actions/runs/32225657766/job/95985385849) (PR #10769 branch)
> - [Test: vite@7, browser — 29m38s, killed](https://github.com/vitest-dev/vitest/actions/runs/32225657766/job/95985385896) (same run)
> 
> Runs that eventually recovered but spent 8–14 minutes in `install-deps`:
> 
> - [Browsers: shard 2/2 — 13m41s in setup](https://github.com/vitest-dev/vitest/actions/runs/32222705060/job/95976301648)
> - [Test: vite@7, e2e — 13m19s in setup](https://github.com/vitest-dev/vitest/actions/runs/32222665763/job/95976228138)
> - [Test: vite@7, browser — 8m25s in setup](https://github.com/vitest-dev/vitest/actions/runs/32231209643/job/96002206960)
> 
> With this PR, apt runs once at image build time; these jobs pull a prebuilt image in ~15–25s instead.
> 
> ### Notes
> 
> - `main`'s setup step varies a lot between runs (26–62s here) because apt runs on every single run; the image pull is steadier (16–25s). Net effect ≈ 10–35s saved per job on typical runs, and the worst-case apt outliers are gone.
> - The image is rebuilt only when the locked Playwright version or the Dockerfile changes (~2–3 min, once); otherwise the image job is a ~8s manifest check. Fork PRs cannot publish a missing image — CI fails with an annotation asking a maintainer to run CI from a repo branch.
> - Browser binaries stay in the existing `actions/cache`; containerization changed the cache version (path `/__w/...` vs `/home/runner/...`), so the first run per PR re-downloads browsers until this lands on `main` and seeds the container-flavored cache entry. One-time cost.
> - Windows/macOS jobs are unchanged (they never ran `install-deps`).
> 
> The honest headline: roughly 10–35 seconds saved per affected job on typical runs, with the bigger structural wins being predictability (no more apt-mirror-lottery 60s+ outliers like the vite7 e2e leg had) and install-deps being fully removed from the per-run critical path. Total job durations aren't compared directly since test execution time dominates them and varies run to run.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
