### PR TITLE
perf(cache): hash the environment-invariant part of the fs module cache key once

### DIFF
--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -40,6 +40,8 @@ export class FileSystemModuleCache {
 
   private version = '1.0.0-beta.5'
   private fsCacheRoots = new WeakMap<ResolvedConfig, string>()
+  // sha1 of everything in the cache key that depends only on the environment
+  // (serialized config, config file contents, versions), computed once
   private fsEnvironmentHashMap = new WeakMap<DevEnvironment, string>()
   private fsCacheKeyGenerators = new Set<CacheKeyIdGenerator>()
   private warnedDeprecatedIgnore = new Set<string>()
@@ -228,9 +230,9 @@ export class FileSystemModuleCache {
     // coverage provider is dynamic, so we also clear the whole cache if
     // vitest.enableCoverage/vitest.disableCoverage is called
     const coverageAffectsCache = String(this.vitest.config.coverage.enabled && this.vitest.coverageProvider?.requiresTransform?.(id))
-    let cacheConfig = this.fsEnvironmentHashMap.get(environment)
-    if (!cacheConfig) {
-      cacheConfig = JSON.stringify(
+    let environmentHash = this.fsEnvironmentHashMap.get(environment)
+    if (!environmentHash) {
+      const cacheConfig = JSON.stringify(
         {
           root: config.root,
           // at the moment, Vitest always forces base to be /
@@ -258,14 +260,20 @@ export class FileSystemModuleCache {
           return value
         },
       )
-      this.fsEnvironmentHashMap.set(environment, cacheConfig)
+      // The serialized config embeds the config files' contents and can run
+      // to hundreds of kilobytes; hashing it once per environment instead of
+      // once per module keeps key generation off the main thread's profile.
+      environmentHash = hash(
+        'sha1',
+        (process.env.NODE_ENV ?? '') + this.version + cacheConfig,
+        'hex',
+      )
+      this.fsEnvironmentHashMap.set(environment, environmentHash)
     }
 
     hashString += id
       + fileContent
-      + (process.env.NODE_ENV ?? '')
-      + this.version
-      + cacheConfig
+      + environmentHash
       + coverageAffectsCache
 
     const cacheKey = hash('sha1', hashString, 'hex')

--- a/packages/vitest/src/node/cache/fsModuleCache.ts
+++ b/packages/vitest/src/node/cache/fsModuleCache.ts
@@ -38,10 +38,8 @@ export class FileSystemModuleCache {
   private rootCache: string
   private metadataFilePath: string
 
-  private version = '1.0.0-beta.5'
+  private version = '1.0.0-beta.6'
   private fsCacheRoots = new WeakMap<ResolvedConfig, string>()
-  // sha1 of everything in the cache key that depends only on the environment
-  // (serialized config, config file contents, versions), computed once
   private fsEnvironmentHashMap = new WeakMap<DevEnvironment, string>()
   private fsCacheKeyGenerators = new Set<CacheKeyIdGenerator>()
   private warnedDeprecatedIgnore = new Set<string>()
@@ -260,9 +258,7 @@ export class FileSystemModuleCache {
           return value
         },
       )
-      // The serialized config embeds the config files' contents and can run
-      // to hundreds of kilobytes; hashing it once per environment instead of
-      // once per module keeps key generation off the main thread's profile.
+      // everything in the key that does not depend on the module, as one digest
       environmentHash = hash(
         'sha1',
         (process.env.NODE_ENV ?? '') + this.version + cacheConfig,


### PR DESCRIPTION
### Description

`FileSystemModuleCache.generateCachePath()` builds every module's cache key by concatenating the serialized environment config (`cacheConfig` — which embeds the *contents* of every `configFileDependencies` file, plugin names, `resolve`, etc.) with the module id + source, and SHA-1s the whole string **per module**. On a large suite the invariant part dwarfs the module: in our case (~6k test files, ~30k modules transformed on a cold `experimental.fsModuleCache`) `cacheConfig` is ~100 KB, so the main thread hashes ~3 GB of identical bytes per cold run (~15 s of self time in a CPU profile of the main process, which is the bottleneck for vm-pool runs).

This hashes `NODE_ENV + version + cacheConfig` once per environment (memoized in the existing `fsEnvironmentHashMap`) and appends the 40-char digest to the per-module key material instead. Keys remain a pure function of exactly the same inputs; the only observable effect is that existing cache directories are not reused once after upgrading (the digest changes the key material), same as after any config change.

No new tests: behaviour is covered by `test/e2e/test/caching.test.ts` and `test/e2e/test/fs-module-cache-resiliency.test.ts` (both pass locally: 7/7). `eslint` clean on the file; `pnpm typecheck` shows the same pre-existing errors as `main` (unbuilt sibling packages), none in `packages/vitest`.

_Authorship disclosure: this change was written with Claude Code (AI agent) from a profile of a real-world suite, and reviewed by a human (@MarshallOfSound) before submission._

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it. _(perf-only; existing caching e2e tests cover correctness)_
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`. _(ran the two fsModuleCache e2e suites; full `test:ci` not run locally)_

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command. _(no new functionality)_

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
