### PR TITLE
fix(vm): fall back to compiling from source when a module's code cache is rejected

### DIFF
--- a/packages/vitest/src/runtime/vm/code-cache.ts
+++ b/packages/vitest/src/runtime/vm/code-cache.ts
@@ -50,21 +50,14 @@ export class CodeCache {
     this.entries.delete(identifier)
   }
 
-  /**
-   * Drops every entry. V8 validates cached data against a hash of its current
-   * flags, so everything stored before a runtime flag change would be rejected.
-   */
   clear(): void {
     this.entries.clear()
   }
 }
 
 /**
- * The `node:v8` module handed to code running inside the vm context:
- * `setFlagsFromString` changes the flag hash V8 checks cached data against, so
- * the wrapped version empties the code cache right after the real call. The
- * executors still handle a rejection (flags can change through paths this does
- * not see), this only keeps the common case from compiling everything twice.
+ * `node:v8` as seen inside the vm context: changing V8 flags invalidates every
+ * code cache produced so far, so `setFlagsFromString` also empties ours.
  */
 export function createV8ModuleWithCacheReset<T extends { setFlagsFromString: (flags: string) => void }>(
   v8: T,

--- a/packages/vitest/src/runtime/vm/code-cache.ts
+++ b/packages/vitest/src/runtime/vm/code-cache.ts
@@ -49,4 +49,31 @@ export class CodeCache {
   delete(identifier: string): void {
     this.entries.delete(identifier)
   }
+
+  /**
+   * Drops every entry. V8 validates cached data against a hash of its current
+   * flags, so everything stored before a runtime flag change would be rejected.
+   */
+  clear(): void {
+    this.entries.clear()
+  }
+}
+
+/**
+ * The `node:v8` module handed to code running inside the vm context:
+ * `setFlagsFromString` changes the flag hash V8 checks cached data against, so
+ * the wrapped version empties the code cache right after the real call. The
+ * executors still handle a rejection (flags can change through paths this does
+ * not see), this only keeps the common case from compiling everything twice.
+ */
+export function createV8ModuleWithCacheReset<T extends { setFlagsFromString: (flags: string) => void }>(
+  v8: T,
+  codeCache: CodeCache,
+): T {
+  const patched = Object.create(Object.getPrototypeOf(v8), Object.getOwnPropertyDescriptors(v8)) as T
+  patched.setFlagsFromString = function setFlagsFromString(flags: string): void {
+    v8.setFlagsFromString(flags)
+    codeCache.clear()
+  }
+  return patched
 }

--- a/packages/vitest/src/runtime/vm/commonjs-executor.ts
+++ b/packages/vitest/src/runtime/vm/commonjs-executor.ts
@@ -4,6 +4,7 @@ import type { VMSyntheticModule } from './types'
 import { Module as _Module, createRequire, isBuiltin } from 'node:module'
 import vm from 'node:vm'
 import { basename, dirname, extname } from 'pathe'
+import { createV8ModuleWithCacheReset } from './code-cache'
 import {
   activeImportModuleDynamically,
   interopCommonJsModule,
@@ -510,6 +511,12 @@ export class CommonjsExecutor {
     if (identifier === 'node:module' || identifier === 'module') {
       const module = new this.Module('/module.js') // path should not matter
       module.exports = this.Module
+      this.builtinCache[normalized] = module
+      return module.exports
+    }
+    if (normalized === 'v8' && this.codeCache) {
+      const module = new this.Module('/v8.js')
+      module.exports = createV8ModuleWithCacheReset(moduleExports, this.codeCache)
       this.builtinCache[normalized] = module
       return module.exports
     }

--- a/packages/vitest/src/runtime/vm/esm-executor.ts
+++ b/packages/vitest/src/runtime/vm/esm-executor.ts
@@ -1,6 +1,6 @@
 import type vm from 'node:vm'
 import type { ExternalModulesExecutor, SyncModuleDisposition } from '../external-executor'
-import type { VMModule, VMSourceTextModule, VMSyntheticModule } from './types'
+import type { SourceTextModuleOptions, VMModule, VMSourceTextModule, VMSyntheticModule } from './types'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { VITEST_VM_CONTEXT_SYMBOL } from '../moduleRunner/startVitestModuleRunner'
@@ -164,11 +164,10 @@ export class EsmExecutor {
     code: string,
   ): VMSourceTextModule {
     const codeCache = this.executor.codeCache
-    const cachedData = codeCache?.get(fileURL, code)
-    const m = new SourceTextModule(code, {
+    let cachedData = codeCache?.get(fileURL, code)
+    const options: SourceTextModuleOptions = {
       identifier: fileURL,
       context: this.context,
-      cachedData,
       // static callbacks: Node keeps them registered for as long as the
       // module's host-defined-options symbol is alive, so a closure here would
       // retain this executor (and the whole test file's world) beyond the
@@ -176,10 +175,30 @@ export class EsmExecutor {
       // at call time instead.
       importModuleDynamically: staticImportModuleDynamically,
       initializeImportMeta: staticInitializeImportMeta,
-    })
+    }
+    let m: VMSourceTextModule | undefined
+    if (cachedData) {
+      try {
+        m = new SourceTextModule(code, { ...options, cachedData })
+      }
+      catch (error: any) {
+        // Unlike `vm.Script` (which only sets `cachedDataRejected`), a module
+        // throws when V8 rejects the cache - e.g. after a test changed V8 flags
+        // at runtime with `v8.setFlagsFromString()`, which alters the flag hash
+        // the cache is checked against for the rest of the worker's life.
+        // Drop the entry and compile from source.
+        if (error?.code !== 'ERR_VM_MODULE_CACHED_DATA_REJECTED') {
+          throw error
+        }
+        codeCache!.delete(fileURL)
+        cachedData = undefined
+      }
+    }
+    m ??= new SourceTextModule(code, options)
     // the code cache of a SourceTextModule must be created before evaluation
     if (!cachedData) {
-      codeCache?.store(fileURL, code, () => m.createCachedData())
+      const created = m
+      codeCache?.store(fileURL, code, () => created.createCachedData())
     }
     return m
   }

--- a/packages/vitest/src/runtime/vm/esm-executor.ts
+++ b/packages/vitest/src/runtime/vm/esm-executor.ts
@@ -182,11 +182,8 @@ export class EsmExecutor {
         m = new SourceTextModule(code, { ...options, cachedData })
       }
       catch (error: any) {
-        // Unlike `vm.Script` (which only sets `cachedDataRejected`), a module
-        // throws when V8 rejects the cache - e.g. after a test changed V8 flags
-        // at runtime with `v8.setFlagsFromString()`, which alters the flag hash
-        // the cache is checked against for the rest of the worker's life.
-        // Drop the entry and compile from source.
+        // unlike vm.Script, a module throws when V8 rejects the cache (e.g. the
+        // V8 flags changed at runtime): compile from source instead
         if (error?.code !== 'ERR_VM_MODULE_CACHED_DATA_REJECTED') {
           throw error
         }

--- a/test/e2e/test/vm-threads.test.ts
+++ b/test/e2e/test/vm-threads.test.ts
@@ -530,13 +530,9 @@ test.for(['vmThreads', 'vmForks'] as const)(
   },
 )
 
-// The V8 code cache of an externalized ES module is reused for the next file
-// on the same worker. A test that changes V8 flags at runtime (a common way to
-// get `gc()` in a test) alters the flag hash V8 checks cached data against, and
-// unlike `vm.Script` a `SourceTextModule` throws when its cache is rejected.
-// Through `node:v8` inside the context the cache is cleared up front; a flag
-// change vitest cannot see (here: the worker realm's own `v8` binding) is
-// caught when the module is created and it is compiled from source instead.
+// changing V8 flags at runtime invalidates the module code cache shared across
+// files on a worker: via the context's `node:v8` the cache is cleared up front,
+// via anything else (here the worker realm's binding) the rejection is caught
 test.for([
   ['vmThreads', 'context'],
   ['vmForks', 'context'],
@@ -547,7 +543,6 @@ test.for([
   async ([pool, from]) => {
     const setFlags = from === 'context'
       ? `v8.setFlagsFromString('--expose-gc')`
-      // the un-patched builtin, reached around the vm context's module system
       : `process.getBuiltinModule('node:v8').setFlagsFromString('--expose-gc')`
     const testFile = `
       import v8 from 'node:v8'

--- a/test/e2e/test/vm-threads.test.ts
+++ b/test/e2e/test/vm-threads.test.ts
@@ -529,3 +529,41 @@ test.for(['vmThreads', 'vmForks'] as const)(
     expect(exitCode).toBe(0)
   },
 )
+
+// The V8 code cache of an externalized ES module is reused for the next file
+// on the same worker. A test that changes V8 flags at runtime (a common way to
+// get `gc()` in a test) alters the flag hash V8 checks cached data against, and
+// unlike `vm.Script` a `SourceTextModule` throws when its cache is rejected —
+// the executor must fall back to compiling from source.
+test.for(['vmThreads', 'vmForks'] as const)(
+  '%s survives a rejected module code cache after a runtime V8 flag change',
+  async (pool) => {
+    const testFile = `
+      import v8 from 'node:v8'
+      import { expect, test } from 'vitest'
+      import { answer } from 'esm-dep'
+
+      test('imports the external module', () => {
+        expect(answer).toBe(42)
+        v8.setFlagsFromString('--expose-gc')
+      })
+    `
+    const { stderr, exitCode } = await runInlineTests({
+      'node_modules/esm-dep/package.json': JSON.stringify({
+        name: 'esm-dep',
+        type: 'module',
+        main: './index.js',
+      }),
+      'node_modules/esm-dep/index.js': `export const answer = 42\n${'// padding so V8 emits a code cache\n'.repeat(200)}`,
+      'a.test.js': testFile,
+      'b.test.js': testFile,
+      'c.test.js': testFile,
+    }, {
+      pool,
+      maxWorkers: 1,
+    })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  },
+)

--- a/test/e2e/test/vm-threads.test.ts
+++ b/test/e2e/test/vm-threads.test.ts
@@ -533,11 +533,22 @@ test.for(['vmThreads', 'vmForks'] as const)(
 // The V8 code cache of an externalized ES module is reused for the next file
 // on the same worker. A test that changes V8 flags at runtime (a common way to
 // get `gc()` in a test) alters the flag hash V8 checks cached data against, and
-// unlike `vm.Script` a `SourceTextModule` throws when its cache is rejected —
-// the executor must fall back to compiling from source.
-test.for(['vmThreads', 'vmForks'] as const)(
-  '%s survives a rejected module code cache after a runtime V8 flag change',
-  async (pool) => {
+// unlike `vm.Script` a `SourceTextModule` throws when its cache is rejected.
+// Through `node:v8` inside the context the cache is cleared up front; a flag
+// change vitest cannot see (here: the worker realm's own `v8` binding) is
+// caught when the module is created and it is compiled from source instead.
+test.for([
+  ['vmThreads', 'context'],
+  ['vmForks', 'context'],
+  ['vmThreads', 'worker realm'],
+  ['vmForks', 'worker realm'],
+] as const)(
+  '%s survives a runtime V8 flag change from the %s',
+  async ([pool, from]) => {
+    const setFlags = from === 'context'
+      ? `v8.setFlagsFromString('--expose-gc')`
+      // the un-patched builtin, reached around the vm context's module system
+      : `process.getBuiltinModule('node:v8').setFlagsFromString('--expose-gc')`
     const testFile = `
       import v8 from 'node:v8'
       import { expect, test } from 'vitest'
@@ -545,7 +556,7 @@ test.for(['vmThreads', 'vmForks'] as const)(
 
       test('imports the external module', () => {
         expect(answer).toBe(42)
-        v8.setFlagsFromString('--expose-gc')
+        ${setFlags}
       })
     `
     const { stderr, exitCode } = await runInlineTests({

--- a/test/unit/test/vm-code-cache.test.ts
+++ b/test/unit/test/vm-code-cache.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { CodeCache } from '../../../packages/vitest/src/runtime/vm/code-cache.js'
+import { CodeCache, createV8ModuleWithCacheReset } from '../../../packages/vitest/src/runtime/vm/code-cache.js'
 
 test('returns the stored data only for the exact same source', () => {
   const cache = new CodeCache()
@@ -60,4 +60,25 @@ test('delete removes the entry', () => {
 
   cache.store('/mod.js', 'source', produce)
   expect(produce).toHaveBeenCalledTimes(2)
+})
+
+test('the vm-context v8 module clears the cache when flags change', () => {
+  const cache = new CodeCache()
+  const flags: string[] = []
+  const realV8 = {
+    setFlagsFromString: (flag: string) => {
+      flags.push(flag)
+    },
+    other: 1,
+  }
+  const patched = createV8ModuleWithCacheReset(realV8, cache)
+
+  cache.store('/mod.js', 'source', () => Buffer.from('cached'))
+  patched.setFlagsFromString('--expose-gc')
+
+  expect(flags).toEqual(['--expose-gc'])
+  expect(cache.get('/mod.js', 'source')).toBeUndefined()
+  expect(patched.other).toBe(1)
+  expect(patched).not.toBe(realV8)
+  expect(realV8.setFlagsFromString).not.toBe(patched.setFlagsFromString)
 })


### PR DESCRIPTION
> [!NOTE]
> This PR was made with assistance from Claude in both identifying the issue and generating the patch 

### Description

The vm ESM executor's V8 code cache for externalized ES modules (#10744) broke every later file on a worker once any test changed V8 flags at runtime (e.g. v8.setFlagsFromString('--expose-gc')), because SourceTextModule throws ERR_VM_MODULE_CACHED_DATA_REJECTED on a flag-hash mismatch rather than just setting cachedDataRejected like vm.Script... Now we catch it and compile from source

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ x Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
