### PR TITLE
fix: share the server on self-referencing `extends`

### DIFF
--- a/docs/config/sharedviteserver.md
+++ b/docs/config/sharedviteserver.md
@@ -13,7 +13,7 @@ Inline [projects](/guide/projects) that don't modify the Vite config reuse the V
 
 This option _only_ applies to inline projects. Projects referenced as config files or directories always resolve their own Vite config and create their own server.
 
-A project still gets its own Vite server when it defines Vite-level options that change the server (`plugins`, `resolve`, and so on), when its `extends` doesn't point to the declaring config, or when it defines test options that affect the Vite config:
+A project still gets its own Vite server when it defines Vite-level options that change the server (`plugins`, `resolve`, and so on), when its `extends` doesn't point to the declaring config (`extends: true` and a path that resolves to the declaring config file are equivalent), or when it defines test options that affect the Vite config:
 
 - [`alias`](/config/alias)
 - [`browser`](/config/browser/enabled)

--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -513,7 +513,13 @@ function getOwnServerReason(
     return 'the raw `test` options of the declaring config are not available'
   }
   if (options.extends !== undefined && options.extends !== true) {
-    return '`extends` doesn\'t point to the declaring config'
+    // a path back to the declaring config means the same as `extends: true`
+    const extendsDeclaringConfig = typeof options.extends === 'string'
+      && context.parentViteConfig.configFile !== undefined
+      && resolve(context.parentConfig.root, options.extends) === context.parentViteConfig.configFile
+    if (!extendsDeclaringConfig) {
+      return '`extends` doesn\'t point to the declaring config'
+    }
   }
   for (const key in options) {
     if (key === 'test' || key === 'extends') {

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -897,6 +897,57 @@ describe('sharedViteServer', () => {
     expect(e2e.sharedViteServer).toBe(true)
   })
 
+  it('a string `extends` pointing at the declaring config keeps the server shared', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          testTimeout: 4321,
+          projects: [
+            { extends: './vitest.config.js', test: { name: 'self' } },
+            { extends: './base.config.js', test: { name: 'other' } },
+          ],
+        },
+      },
+      'base.config.js': {},
+      'basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    const root = ctx!.getRootProject()
+    const shared = Object.fromEntries(
+      ctx!.projects.map(project => [project.name, project.vite === root.vite]),
+    )
+    expect(shared).toEqual({
+      self: true,
+      other: false,
+    })
+    const self = ctx!.projects.find(project => project.name === 'self')!
+    expect(self.config.testTimeout).toBe(4321)
+  })
+
+  it('a string `extends` pointing at the container config shares the container server', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: ['./app/vitest.config.js'],
+        },
+      },
+      'app/vitest.config.js': {
+        test: {
+          name: 'app',
+          projects: [
+            { extends: './vitest.config.js', test: { name: 'unit' } },
+          ],
+        },
+      },
+      'app/basic.test.js': basicTest,
+    })
+    expect(stderr).toBe('')
+    const [unit] = ctx!.projects
+    expect(unit.name).toBe('app (unit)')
+    expect(unit.sharedViteServer).toBe(true)
+    expect(unit.vite).not.toBe(ctx!.getRootProject().vite)
+  })
+
   it('vite options that don\'t change the server don\'t prevent sharing', async () => {
     const { stderr, ctx } = await runInlineTests({
       'vitest.config.js': ts`


### PR DESCRIPTION
A string `extends` that resolves to the declaring config file now shares the Vite server, the same as `extends: true`. This was the documented idiom for inline projects before `extends: true` became the default, so many existing configs hit the conservative check and silently lost sharing.