### PR TITLE
fix(coverage-v8): skip non-file URLs in coverage remapping

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -450,7 +450,19 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
         }
       }
 
-      if (this.isIncluded(fileURLToPath(result.url))) {
+      // V8 can report coverage entries whose URL is not a `file:` URL
+      // (e.g. `about:/…` injected by RSC virtual modules, `data:` inline
+      // modules). `fileURLToPath` throws `ERR_INVALID_URL_SCHEME` on those
+      // and aborts the whole coverage run, so skip them here.
+      let filePath: string
+      try {
+        filePath = fileURLToPath(result.url)
+      }
+      catch {
+        continue
+      }
+
+      if (this.isIncluded(filePath)) {
         scriptCoverages.push({ ...result, url: decodeURIComponent(result.url) })
       }
     }

--- a/test/coverage-test/test/non-file-urls.unit.test.ts
+++ b/test/coverage-test/test/non-file-urls.unit.test.ts
@@ -1,0 +1,44 @@
+import type { BaseCoverageProvider, CoverageOptions } from 'vitest/node'
+import { Writable } from 'node:stream'
+import { expect, onTestFinished, test } from 'vitest'
+import { createVitest } from 'vitest/node'
+
+test('convertCoverage skips non-file: URLs without throwing', async () => {
+  const provider = await init({ include: ['**/*.ts'] })
+
+  // Coverage entries whose URL is not a `file:` URL (e.g. `about:/…` injected
+  // by RSC virtual modules, `data:` inline modules, `blob:` workers). Without
+  // the guard around `fileURLToPath`, this would throw `ERR_INVALID_URL_SCHEME`
+  // and abort the entire coverage run.
+  const rawCoverage = {
+    result: [
+      { url: 'about:/React/Server/fake.js', functions: [], scriptId: '1' },
+      { url: 'data:text/javascript,console.log(1)', functions: [], scriptId: '2' },
+      { url: 'blob:https://example.com/abc', functions: [], scriptId: '3' },
+      { url: 'not-a-url', functions: [], scriptId: '4' },
+    ],
+  }
+
+  const rootProject = (provider as any).ctx.getRootProject()
+
+  await expect(
+    (provider as any).convertCoverage(rawCoverage, rootProject, 'ssr'),
+  ).resolves.toBeDefined()
+})
+
+async function init(options: Partial<CoverageOptions>) {
+  const vitest = await createVitest('test', {
+    config: false,
+    include: ['dont-match-anything'],
+    coverage: {
+      ...options,
+      enabled: true,
+      provider: 'v8',
+    },
+  }, {}, { stdout: new Writable() })
+
+  onTestFinished(() => vitest.close())
+  await vitest.standalone()
+
+  return vitest.coverageProvider as unknown as BaseCoverageProvider
+}


### PR DESCRIPTION
Fixes #11036

`V8CoverageProvider.convertCoverage` called `fileURLToPath(result.url)` unconditionally. Non-`file:` URLs (`about:/`, `data:`, `blob:`) threw `ERR_INVALID_URL_SCHEME` and aborted the whole coverage run. This wraps the call in `try/catch` and skips those entries.

Regression test added at `test/coverage-test/test/non-file-urls.unit.test.ts`, verified to fail before the fix (`TypeError: The URL must be of scheme file`) and pass after.

Repro: [stevez/nextcov-example @ `rsc-poc-repro`](https://github.com/stevez/nextcov-example/tree/rsc-poc-repro).

AI-assisted with GitHub Copilot CLI (Claude Opus 4.7), reviewed and pushed by @stevez.

<!-- VITEST_AUTOMATED_PR -->
