### PR TITLE
fix(config): do not duplicate a user-provided oxc/esbuild transform target

### DIFF
--- a/packages/vitest/src/node/plugins/config.ts
+++ b/packages/vitest/src/node/plugins/config.ts
@@ -7,6 +7,9 @@ import { generateScopedClassName } from '../../integrations/css/css-modules'
 import { createViteLogger, silenceImportViteIgnoreWarning } from '../viteLogger'
 import { ModuleRunnerTransform } from './runnerTransform'
 import { getDefaultResolveOptions } from './utils'
+import { resolveEsbuildOptions, resolveOxcOptions } from './transformTarget'
+
+export { resolveEsbuildOptions, resolveOxcOptions } from './transformTarget'
 
 export function ViteConfigPlugin(harness: PluginHarness): Plugin[] {
   let root: string
@@ -75,24 +78,10 @@ export function ViteConfigPlugin(harness: PluginHarness): Plugin[] {
         if ('rolldownVersion' in vite) {
           // eslint-disable-next-line ts/ban-ts-comment
           // @ts-ignore rolldown-vite only
-          config.oxc = viteConfig.oxc === false
-            ? false
-            : {
-                // eslint-disable-next-line ts/ban-ts-comment
-                // @ts-ignore rolldown-vite only
-                target: viteConfig.oxc?.target || 'node18',
-              }
+          config.oxc = resolveOxcOptions(viteConfig.oxc)
         }
         else {
-          config.esbuild = viteConfig.esbuild === false
-            ? false
-            : {
-                // Lowest target Vitest supports is Node18
-                target: viteConfig.esbuild?.target || 'node18',
-                sourcemap: 'external',
-                // Enables using ignore hint for coverage providers with @preserve keyword
-                legalComments: 'inline',
-              }
+          config.esbuild = resolveEsbuildOptions(viteConfig.esbuild)
         }
 
         const classNameStrategy

--- a/packages/vitest/src/node/plugins/transformTarget.ts
+++ b/packages/vitest/src/node/plugins/transformTarget.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolve the `oxc` options Vitest merges into the user's Vite config.
+ *
+ * Only defaults the target. A user-provided target must not be restated here:
+ * Vite merges a plugin's returned config into the user's config with
+ * `mergeConfig`, which concatenates arrays — so re-stating an array target
+ * would duplicate its entries, and OXC rejects duplicates.
+ */
+export function resolveOxcOptions(
+  oxc: { target?: string | string[] } | false | undefined,
+): { target?: string | string[] } | false {
+  if (oxc === false) {
+    return false
+  }
+  return oxc?.target ? {} : { target: 'node18' }
+}
+
+/**
+ * Resolve the `esbuild` options Vitest merges into the user's Vite config.
+ *
+ * As with `resolveOxcOptions`, a user-provided `target` is left out of the
+ * returned partial config so the merge cannot concatenate it into duplicates.
+ */
+export function resolveEsbuildOptions(
+  esbuild: { target?: string | string[] } | false | undefined,
+): { target?: string; sourcemap: 'external'; legalComments: 'inline' } | false {
+  if (esbuild === false) {
+    return false
+  }
+  return {
+    // Lowest target Vitest supports is Node18
+    ...(!esbuild?.target ? { target: 'node18' } : {}),
+    sourcemap: 'external',
+    // Enables using ignore hint for coverage providers with @preserve keyword
+    legalComments: 'inline',
+  }
+}

--- a/test/unit/test/transform-target-options.test.ts
+++ b/test/unit/test/transform-target-options.test.ts
@@ -1,0 +1,55 @@
+import { mergeConfig } from 'vite'
+import { describe, expect, it } from 'vitest'
+import { resolveEsbuildOptions, resolveOxcOptions } from '../../../packages/vitest/src/node/plugins/transformTarget'
+
+// https://github.com/vitest-dev/vitest/issues/11035
+// Vitest's config plugin re-stated a user-provided `oxc.target`. Vite merges
+// plugin-returned config into the user's config with `mergeConfig`, which
+// concatenates arrays — so an array target ended up duplicated and OXC
+// rejected it.
+
+describe('resolveOxcOptions', () => {
+  it('defaults the target when the user did not provide one', () => {
+    expect(resolveOxcOptions(undefined)).toEqual({ target: 'node18' })
+    expect(resolveOxcOptions({})).toEqual({ target: 'node18' })
+  })
+
+  it('does not restate a user-provided target', () => {
+    expect(resolveOxcOptions({ target: ['chrome121', 'firefox118'] })).toEqual({})
+    expect(resolveOxcOptions({ target: 'chrome121' })).toEqual({})
+  })
+
+  it('keeps oxc disabled when disabled by the user', () => {
+    expect(resolveOxcOptions(false)).toBe(false)
+  })
+
+  it('keeps array targets duplicate-free after a vite config merge', () => {
+    const userConfig = { oxc: { target: ['chrome121', 'firefox118'] } }
+    const merged = mergeConfig(
+      userConfig,
+      { oxc: resolveOxcOptions(userConfig.oxc) },
+    )
+    expect(merged.oxc).toEqual({ target: ['chrome121', 'firefox118'] })
+  })
+})
+
+describe('resolveEsbuildOptions', () => {
+  it('defaults the target and keeps vitest-required options', () => {
+    expect(resolveEsbuildOptions(undefined)).toEqual({
+      target: 'node18',
+      sourcemap: 'external',
+      legalComments: 'inline',
+    })
+  })
+
+  it('does not restate a user-provided target but preserves required options', () => {
+    expect(resolveEsbuildOptions({ target: ['es2020', 'chrome100'] })).toEqual({
+      sourcemap: 'external',
+      legalComments: 'inline',
+    })
+  })
+
+  it('keeps esbuild disabled when disabled by the user', () => {
+    expect(resolveEsbuildOptions(false)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description

When a Vite config sets an array transform target, Vitest fails with:

```
Error: [vitest]: Failed to set oxc.target. "target" cannot be an array with duplicate values.
```

This happens because Vitest's `vitest:config` plugin re-states the user's `oxc.target` in its returned partial config (`target: viteConfig.oxc?.target || 'node18'`). Vite merges plugin-returned config into the user's config with `mergeConfig`, which **concatenates arrays** — so `['chrome121', 'firefox118']` becomes `['chrome121', 'firefox118', 'chrome121', 'firefox118']`, and OXC rejects duplicates.

## Fix

`resolveOxcOptions` / `resolveEsbuildOptions` (new pure helpers in `packages/vitest/src/node/plugins/transformTarget.ts`) only inject the `'node18'` default when the user did not provide a target; user-provided targets are left out of the returned partial config so the merge cannot concatenate them.

The same latent duplication bug in the `esbuild` branch is fixed symmetrically.

Post-merge behavior is unchanged:
- no target configured → `node18` (same as before),
- string target → identical value,
- array target → exactly the user's entries, once.

## Testing

New unit tests in `test/unit/test/transform-target-options.test.ts` cover:
- defaulting when absent, passthrough of provided targets for both oxc and esbuild
- `false` (disabled) handling preserved
- end-to-end assertion that `mergeConfig(userConfig, { oxc: resolveOxcOptions(...) })` keeps array targets duplicate-free

All 21 tests pass across the `threads`/`forks`/`vmThreads` projects, typecheck clean:

```
Test Files  3 passed (3)
     Tests  21 passed (21)
Type Errors  no errors
```

Fixes #11035