### PR TITLE
fix(coverage): tolerate an already-removed temp directory in cleanAfterRun

### DIFF
--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -345,11 +345,19 @@ export class BaseCoverageProvider {
   async cleanAfterRun(): Promise<void> {
     try {
       this.coverageFiles = new Map()
-      await fs.rm(this.coverageFilesDirectory, { recursive: true })
+
+      // Tolerate the directories being gone already, the same way `clean()`
+      // does. By this point the run's result is decided — reports are written
+      // and thresholds evaluated — so throwing here turns a passing run into
+      // a non-zero exit that looks exactly like a threshold failure.
+      await fs.rm(this.coverageFilesDirectory, { recursive: true, force: true })
 
       // Remove empty reports directory, e.g. when only text-reporter is used
-      if (readdirSync(this.options.reportsDirectory).length === 0) {
-        await fs.rm(this.options.reportsDirectory, { recursive: true })
+      if (
+        existsSync(this.options.reportsDirectory)
+        && readdirSync(this.options.reportsDirectory).length === 0
+      ) {
+        await fs.rm(this.options.reportsDirectory, { recursive: true, force: true })
       }
     }
     finally {

--- a/test/coverage-test/test/removed-coverage-directory.test.ts
+++ b/test/coverage-test/test/removed-coverage-directory.test.ts
@@ -1,0 +1,49 @@
+import { rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { beforeEach, expect } from 'vitest'
+import { sum } from '../fixtures/src/math'
+import { captureStdout, coverageTest, normalizeURL, runVitest, test } from '../utils'
+
+beforeEach(() => {
+  return captureStdout()
+})
+
+/**
+ * `onTestRunEnd` fires after the provider has read `.tmp/*.json` and before it
+ * calls `cleanAfterRun()`, which is the window where something else — a second
+ * Vitest process, a CI cleanup step, a container volume — can remove the
+ * directory out from under the cleanup.
+ */
+function removeDirectory(directory: string) {
+  return {
+    onTestRunEnd() {
+      rmSync(resolve(process.cwd(), directory), { recursive: true, force: true })
+    },
+  }
+}
+
+test('coverage temp directory removed mid-run does not fail the run', async () => {
+  const { exitCode } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    testNamePattern: 'passing test',
+    coverage: { reporter: 'text' },
+    reporters: ['default', removeDirectory('coverage/.tmp')],
+  }, { throwOnError: false })
+
+  expect(exitCode).toBe(0)
+})
+
+test('coverage reports directory removed mid-run does not fail the run', async () => {
+  const { exitCode } = await runVitest({
+    include: [normalizeURL(import.meta.url)],
+    testNamePattern: 'passing test',
+    coverage: { reporter: 'text' },
+    reporters: ['default', removeDirectory('coverage')],
+  }, { throwOnError: false })
+
+  expect(exitCode).toBe(0)
+})
+
+coverageTest('passing test', () => {
+  expect(sum(2, 3)).toBe(5)
+})


### PR DESCRIPTION
### Description

Closes #11041.

`BaseCoverageProvider.cleanAfterRun()` removed the coverage temp directory without `force`, while `clean()` a few lines above it uses `{ recursive: true, force: true, maxRetries: 10 }`:

```ts
await fs.rm(this.coverageFilesDirectory, { recursive: true })         // <-- no `force`

// Remove empty reports directory, e.g. when only text-reporter is used
if (readdirSync(this.options.reportsDirectory).length === 0) {        // <-- throws if absent
  await fs.rm(this.options.reportsDirectory, { recursive: true })
}
```

Cleanup runs after `generateReports()`, so the reports are written and the thresholds evaluated by the time it happens. If the directory was removed in the meantime — a second Vitest process, a CI cleanup step, a container volume — `fs.rm` threw `ENOENT: … lstat`, which propagated out of `Vitest.start()` and surfaced as an `Unhandled Error` with exit code 1. A run in which every test passed and every threshold was met reported as a failure. And since a genuine threshold failure also exits 1 — via `process.exitCode` in `checkThresholds()`, without throwing — the two were indistinguishable by exit code, which is the part that actually bit us: it sat in front of an `&&`-chained gate.

Removing the reports directory itself hit the same edge one line down, where `readdirSync` threw `ENOENT: … scandir`.

This makes both calls tolerate the directories being gone already, taking the same position `clean()` already takes.

### Tests

`test/coverage-test/test/removed-coverage-directory.test.ts`, modelled on the existing `empty-coverage-directory.test.ts`.

A reporter's `onTestRunEnd` fires after the provider has read `.tmp/*.json` and before it calls `cleanAfterRun()` — exactly the window — so the test needs no concurrency or timing. One case removes `coverage/.tmp`, the other removes `coverage`; both assert the run still exits 0.

Verified both ways against a local build:

- with this change — 6 passed (2 cases × `v8`, `istanbul`, `native`)
- with `packages/vitest/src/node/coverage.ts` reverted — 6 failed, each with `ENOENT: no such file or directory, lstat '…/coverage/.tmp'`

The fix lives in `BaseCoverageProvider`, so it covers every provider; the test running green across all three reflects that.

### Note on `ReportsDirectoryLock`

We reached this through the concurrent-runs path, which `main` already handles well — the second process now fails fast with a clear "already in use by another Vitest process" error. This change is about the residual case where the directory disappears for some other reason, and about not turning a decided, fully-reported run into a failure at the very last step.

Separately, and outside this PR: 4.1.x has no lock, so everything on the current stable line still gets the confusing post-report crash instead of that message. Worth a backport if you're open to it — happy to prepare one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
