### PR TITLE
feat(ui): toggle trace target highlight 

### DIFF
--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -15,7 +15,6 @@ const entries = computed(() => props.trace.entries)
 const selectedStep = computed(() => entries.value[props.selection.selectedStepIndex])
 
 const iframeEl = ref<HTMLIFrameElement>()
-let highlightEl: HTMLElement | undefined
 const iframeSandbox = computed(() => {
   // Canvas replay needs scripts for rrweb's image.onload -> drawImage path,
   // but allow-same-origin + allow-scripts gives replayed app HTML more capability.
@@ -64,7 +63,6 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
     return
   }
   const { serialized, selectorId, viewport, scroll, pseudoClassIds } = step.snapshot
-  highlightEl = undefined
   iframe.style.width = `${viewport.width}px`
   iframe.style.height = `${viewport.height}px`
   // Rebuild snapshot into iframe contentDocument — pattern from rrweb replayer:
@@ -109,7 +107,6 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
       iframe.contentWindow!.requestAnimationFrame(() => {
         const rect = (el as Element).getBoundingClientRect()
         const overlay = doc.createElement('div')
-        highlightEl = overlay
         overlay.setAttribute('data-testid', 'trace-view-highlight')
         overlay.style.cssText = `
           position: fixed;
@@ -131,8 +128,10 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
 }, { immediate: true })
 
 watch(showTraceSelectorHighlight, (show) => {
-  if (highlightEl) {
-    highlightEl.style.display = show ? '' : 'none'
+  const overlay = iframeEl.value?.contentDocument
+    ?.querySelector<HTMLElement>('[data-testid="trace-view-highlight"]')
+  if (overlay) {
+    overlay.style.display = show ? '' : 'none'
   }
 })
 

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -4,12 +4,11 @@ import { createCache, createMirror, rebuild } from 'rrweb-snapshot'
 import { Pane, Splitpanes } from 'splitpanes'
 import { computed, ref, watch } from 'vue'
 import { openLocation } from '~/composables/location'
-import { getTraceEntryClass, selectActiveTraceStep } from '~/composables/trace-view'
+import { getTraceEntryClass, selectActiveTraceStep, showTraceSelectorHighlight } from '~/composables/trace-view'
 
 const props = defineProps<{
   trace: NormalizedBrowserTraceData
   selection: TraceSelection
-  showTargetHighlight: boolean
 }>()
 
 const entries = computed(() => props.trace.entries)
@@ -124,14 +123,14 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
           border: 2px solid #3b82f6;
           box-sizing: border-box;
         `
-        overlay.style.display = props.showTargetHighlight ? '' : 'none'
+        overlay.style.display = showTraceSelectorHighlight.value ? '' : 'none'
         doc.documentElement.appendChild(overlay)
       })
     }
   }
 }, { immediate: true })
 
-watch(() => props.showTargetHighlight, (show) => {
+watch(showTraceSelectorHighlight, (show) => {
   if (highlightEl) {
     highlightEl.style.display = show ? '' : 'none'
   }

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -9,12 +9,14 @@ import { getTraceEntryClass, selectActiveTraceStep } from '~/composables/trace-v
 const props = defineProps<{
   trace: NormalizedBrowserTraceData
   selection: TraceSelection
+  showTargetHighlight: boolean
 }>()
 
 const entries = computed(() => props.trace.entries)
 const selectedStep = computed(() => entries.value[props.selection.selectedStepIndex])
 
 const iframeEl = ref<HTMLIFrameElement>()
+let highlightEl: HTMLElement | undefined
 const iframeSandbox = computed(() => {
   // Canvas replay needs scripts for rrweb's image.onload -> drawImage path,
   // but allow-same-origin + allow-scripts gives replayed app HTML more capability.
@@ -63,6 +65,7 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
     return
   }
   const { serialized, selectorId, viewport, scroll, pseudoClassIds } = step.snapshot
+  highlightEl = undefined
   iframe.style.width = `${viewport.width}px`
   iframe.style.height = `${viewport.height}px`
   // Rebuild snapshot into iframe contentDocument — pattern from rrweb replayer:
@@ -107,6 +110,7 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
       iframe.contentWindow!.requestAnimationFrame(() => {
         const rect = (el as Element).getBoundingClientRect()
         const overlay = doc.createElement('div')
+        highlightEl = overlay
         overlay.setAttribute('data-testid', 'trace-view-highlight')
         overlay.style.cssText = `
           position: fixed;
@@ -120,11 +124,18 @@ watch([selectedStep, iframeEl], ([step, iframe]) => {
           border: 2px solid #3b82f6;
           box-sizing: border-box;
         `
+        overlay.style.display = props.showTargetHighlight ? '' : 'none'
         doc.documentElement.appendChild(overlay)
       })
     }
   }
 }, { immediate: true })
+
+watch(() => props.showTargetHighlight, (show) => {
+  if (highlightEl) {
+    highlightEl.style.display = show ? '' : 'none'
+  }
+})
 
 function getStepButtonClass(step: NormalizedBrowserTraceEntry, index: number) {
   const selected = props.selection.selectedStepIndex === index

--- a/packages/ui/client/components/trace/TraceViewPane.vue
+++ b/packages/ui/client/components/trace/TraceViewPane.vue
@@ -2,7 +2,7 @@
 import type { TraceSelection } from '~/composables/trace-view'
 import { computed } from 'vue'
 import IconButton from '~/components/IconButton.vue'
-import { closeTrace, getSelectedTrace, getTraceAttemptLabel, showTraceTargetHighlight } from '~/composables/trace-view'
+import { closeTrace, getSelectedTrace, getTraceAttemptLabel, showTraceSelectorHighlight } from '~/composables/trace-view'
 import TraceView from './TraceView.vue'
 
 const props = defineProps<{
@@ -27,7 +27,7 @@ const attemptLabel = computed(() => trace.value ? getTraceAttemptLabel(trace.val
       </span>
       <label class="flex items-center gap-1 text-xs ws-nowrap select-none cursor-pointer">
         <input
-          v-model="showTraceTargetHighlight"
+          v-model="showTraceSelectorHighlight"
           type="checkbox"
         >
         <span>Show highlight</span>
@@ -43,7 +43,6 @@ const attemptLabel = computed(() => trace.value ? getTraceAttemptLabel(trace.val
       v-if="trace"
       :trace="trace"
       :selection="selection"
-      :show-target-highlight="showTraceTargetHighlight"
     />
     <div v-else class="text-sm opacity-50 p-4">
       No trace found

--- a/packages/ui/client/components/trace/TraceViewPane.vue
+++ b/packages/ui/client/components/trace/TraceViewPane.vue
@@ -2,7 +2,7 @@
 import type { TraceSelection } from '~/composables/trace-view'
 import { computed } from 'vue'
 import IconButton from '~/components/IconButton.vue'
-import { closeTrace, getSelectedTrace, getTraceAttemptLabel } from '~/composables/trace-view'
+import { closeTrace, getSelectedTrace, getTraceAttemptLabel, showTraceTargetHighlight } from '~/composables/trace-view'
 import TraceView from './TraceView.vue'
 
 const props = defineProps<{
@@ -11,6 +11,7 @@ const props = defineProps<{
 
 const trace = computed(() => getSelectedTrace(props.selection))
 const attemptLabel = computed(() => trace.value ? getTraceAttemptLabel(trace.value) : '')
+const highlightButtonLabel = computed(() => `${showTraceTargetHighlight.value ? 'Hide' : 'Show'} target highlight`)
 </script>
 
 <template>
@@ -26,6 +27,14 @@ const attemptLabel = computed(() => trace.value ? getTraceAttemptLabel(trace.val
         {{ attemptLabel }}
       </span>
       <IconButton
+        v-tooltip.bottom="highlightButtonLabel"
+        :title="highlightButtonLabel"
+        :active="showTraceTargetHighlight"
+        :aria-pressed="showTraceTargetHighlight"
+        icon="i-carbon:view"
+        @click="showTraceTargetHighlight = !showTraceTargetHighlight"
+      />
+      <IconButton
         v-tooltip.bottom="'Close Trace Viewer'"
         title="Close Trace Viewer"
         icon="i-carbon:close"
@@ -36,6 +45,7 @@ const attemptLabel = computed(() => trace.value ? getTraceAttemptLabel(trace.val
       v-if="trace"
       :trace="trace"
       :selection="selection"
+      :show-target-highlight="showTraceTargetHighlight"
     />
     <div v-else class="text-sm opacity-50 p-4">
       No trace found

--- a/packages/ui/client/components/trace/TraceViewPane.vue
+++ b/packages/ui/client/components/trace/TraceViewPane.vue
@@ -11,7 +11,6 @@ const props = defineProps<{
 
 const trace = computed(() => getSelectedTrace(props.selection))
 const attemptLabel = computed(() => trace.value ? getTraceAttemptLabel(trace.value) : '')
-const highlightButtonLabel = computed(() => `${showTraceTargetHighlight.value ? 'Hide' : 'Show'} target highlight`)
 </script>
 
 <template>
@@ -26,14 +25,13 @@ const highlightButtonLabel = computed(() => `${showTraceTargetHighlight.value ? 
       >
         {{ attemptLabel }}
       </span>
-      <IconButton
-        v-tooltip.bottom="highlightButtonLabel"
-        :title="highlightButtonLabel"
-        :active="showTraceTargetHighlight"
-        :aria-pressed="showTraceTargetHighlight"
-        icon="i-carbon:view"
-        @click="showTraceTargetHighlight = !showTraceTargetHighlight"
-      />
+      <label class="flex items-center gap-1 text-xs ws-nowrap select-none cursor-pointer">
+        <input
+          v-model="showTraceTargetHighlight"
+          type="checkbox"
+        >
+        <span>Show highlight</span>
+      </label>
       <IconButton
         v-tooltip.bottom="'Close Trace Viewer'"
         title="Close Trace Viewer"

--- a/packages/ui/client/composables/trace-view.ts
+++ b/packages/ui/client/composables/trace-view.ts
@@ -30,6 +30,7 @@ export interface NormalizedBrowserTraceEntry extends BrowserTraceEntry {
 }
 
 export const activeTraceView = ref<TraceSelection>()
+
 export const showTraceSelectorHighlight = useLocalStorage(
   'vitest-ui_trace-selector-highlight',
   true,

--- a/packages/ui/client/composables/trace-view.ts
+++ b/packages/ui/client/composables/trace-view.ts
@@ -30,8 +30,8 @@ export interface NormalizedBrowserTraceEntry extends BrowserTraceEntry {
 }
 
 export const activeTraceView = ref<TraceSelection>()
-export const showTraceTargetHighlight = useLocalStorage(
-  'vitest-ui_trace-target-highlight',
+export const showTraceSelectorHighlight = useLocalStorage(
+  'vitest-ui_trace-selector-highlight',
   true,
 )
 

--- a/packages/ui/client/composables/trace-view.ts
+++ b/packages/ui/client/composables/trace-view.ts
@@ -1,5 +1,6 @@
 import type { RunnerTestCase, RunnerTestFile, TestArtifact } from 'vitest'
 import type { BrowserTraceData, BrowserTraceEntry } from '../../../browser/src/client/tester/trace'
+import { useLocalStorage } from '@vueuse/core'
 import { computed, ref, watch, watchEffect } from 'vue'
 import { getProjectConfigByName } from '~/utils/task'
 import { browserState, client, config } from './client'
@@ -29,6 +30,10 @@ export interface NormalizedBrowserTraceEntry extends BrowserTraceEntry {
 }
 
 export const activeTraceView = ref<TraceSelection>()
+export const showTraceTargetHighlight = useLocalStorage(
+  'vitest-ui_trace-target-highlight',
+  true,
+)
 
 function getTraceAttemptKey(trace: BrowserTraceData): string {
   return `${trace.repeats}:${trace.retry}`

--- a/test/ui/test/trace.spec.ts
+++ b/test/ui/test/trace.spec.ts
@@ -192,7 +192,21 @@ async function testBasic(page: Page) {
   await expect(traceFrame.getByRole('button', { name: 'Simple' })).toBeVisible()
 
   // verify selector highlight
-  await expect(traceFrame.getByTestId('trace-view-highlight')).toBeVisible()
+  const traceHighlight = traceFrame.getByTestId('trace-view-highlight')
+  const hideHighlightButton = traceView.getByRole('button', { name: 'Hide target highlight' })
+  await expect(traceHighlight).toBeVisible()
+  await expect(hideHighlightButton).toHaveAttribute('aria-pressed', 'true')
+
+  // hide selector highlight and persist preference across reloads
+  await hideHighlightButton.click()
+  await expect(traceHighlight).toBeHidden()
+  const showHighlightButton = traceView.getByRole('button', { name: 'Show target highlight' })
+  await expect(showHighlightButton).toHaveAttribute('aria-pressed', 'false')
+  await page.reload()
+  await expect(traceView).toBeVisible()
+  await expect(traceHighlight).toBeHidden()
+  await showHighlightButton.click()
+  await expect(traceHighlight).toBeVisible()
 
   // selecting 2nd trace step with keyboard and verify again
   await traceSteps.nth(0).press('ArrowDown')

--- a/test/ui/test/trace.spec.ts
+++ b/test/ui/test/trace.spec.ts
@@ -193,19 +193,18 @@ async function testBasic(page: Page) {
 
   // verify selector highlight
   const traceHighlight = traceFrame.getByTestId('trace-view-highlight')
-  const hideHighlightButton = traceView.getByRole('button', { name: 'Hide target highlight' })
+  const showHighlightCheckbox = traceView.getByRole('checkbox', { name: 'Show highlight' })
   await expect(traceHighlight).toBeVisible()
-  await expect(hideHighlightButton).toHaveAttribute('aria-pressed', 'true')
+  await expect(showHighlightCheckbox).toBeChecked()
 
   // hide selector highlight and persist preference across reloads
-  await hideHighlightButton.click()
+  await showHighlightCheckbox.uncheck()
   await expect(traceHighlight).toBeHidden()
-  const showHighlightButton = traceView.getByRole('button', { name: 'Show target highlight' })
-  await expect(showHighlightButton).toHaveAttribute('aria-pressed', 'false')
   await page.reload()
   await expect(traceView).toBeVisible()
   await expect(traceHighlight).toBeHidden()
-  await showHighlightButton.click()
+  await expect(showHighlightCheckbox).not.toBeChecked()
+  await showHighlightCheckbox.check()
   await expect(traceHighlight).toBeVisible()
 
   // selecting 2nd trace step with keyboard and verify again


### PR DESCRIPTION
### Description

When using a trace view for quick visual preview, the blue locator highlight overlay makes it hard to judge the visual. This PR adds a checkbox to allow toggling the overlay on UI viewer side.

https://github.com/user-attachments/assets/d885cd47-c1d7-40cb-8117-2c0e19bba92c

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
