### PR TITLE
fix(coverage): tolerate a missing temp dir on cleanup

### DIFF
--- a/packages/vitest/src/node/coverage.ts
+++ b/packages/vitest/src/node/coverage.ts
@@ -345,11 +345,11 @@ export class BaseCoverageProvider {
   async cleanAfterRun(): Promise<void> {
     try {
       this.coverageFiles = new Map()
-      await fs.rm(this.coverageFilesDirectory, { recursive: true })
+      await fs.rm(this.coverageFilesDirectory, { recursive: true, force: true, maxRetries: 10 })
 
       // Remove empty reports directory, e.g. when only text-reporter is used
-      if (readdirSync(this.options.reportsDirectory).length === 0) {
-        await fs.rm(this.options.reportsDirectory, { recursive: true })
+      if (existsSync(this.options.reportsDirectory) && readdirSync(this.options.reportsDirectory).length === 0) {
+        await fs.rm(this.options.reportsDirectory, { recursive: true, force: true, maxRetries: 10 })
       }
     }
     finally {

--- a/test/coverage-test/test/temporary-files.unit.test.ts
+++ b/test/coverage-test/test/temporary-files.unit.test.ts
@@ -19,6 +19,18 @@ test('clean() acquires the reportsDirectory lock and cleanAfterRun() releases it
   expect(existsSync(lockFile)).toBe(false)
 })
 
+test('cleanAfterRun() tolerates the temporary directory being gone', async () => {
+  const { provider, reportsDirectory, lockFile } = createProvider()
+
+  await provider.clean(true)
+
+  rmSync(reportsDirectory, { recursive: true, force: true })
+
+  await expect(provider.cleanAfterRun()).resolves.toBeUndefined()
+
+  expect(existsSync(lockFile)).toBe(false)
+})
+
 test('clean() is re-entrant for the same process (e.g. watch mode reruns)', async () => {
   const { provider } = createProvider()
 


### PR DESCRIPTION
Fixes #11041

### Problem

`cleanAfterRun()` removes the coverage temp directory without `force`, and calls `readdirSync` on the reports directory without checking that it exists, while `clean()` a few lines above uses `{ recursive: true, force: true, maxRetries: 10 }`.

If either directory is already gone when cleanup runs, `fs.rm` throws `ENOENT: … lstat`. That propagates out of `Vitest.start()`, so the CLI prints it as an unhandled error and sets `process.exitCode = 1`.

The timing is what makes it awkward: `cleanAfterRun()` runs *after* `generateReports()`, so the reports are written and thresholds already evaluated. A run where every test passed and every threshold was met still exits non-zero, and because a genuine threshold failure also exits 1, the two are indistinguishable by exit code.

### Fix

Match what `clean()` already does, and check the reports directory exists before reading it.

Reproduced directly against the two versions of the block, with the directory removed beforehand:

```
old -> THREW ENOENT: no such file or directory, lstat '…'
new -> ok
```

### Testing

Added a case to `test/coverage-test/test/temporary-files.unit.test.ts`, next to the existing `clean()` / `cleanAfterRun()` tests: after `clean()`, the reports directory is removed externally, then `cleanAfterRun()` must resolve and must still release the lock.

Reverting `coverage.ts` and rebuilding fails that test with the ENOENT, so it covers the change rather than restating current behaviour. The file passes at 6 tests, and `pnpm lint` is clean on both files.

---

AI disclosure, per CONTRIBUTING.md: this change was written with the assistance of Claude (Claude Code), driven and reviewed by me. Happy to answer anything about it.

<!-- VITEST_AUTOMATED_PR -->
