### PR TITLE
fix(mocker): clear module registry on invalidate to prevent collect-mode mock leakage (#10886)

### DIFF
--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -261,6 +261,11 @@ async function executeTests(method: 'run' | 'collect', specifications: FileSpeci
         }
       },
     )
+
+    if (method === 'collect') {
+      const mocker = (globalThis as any).__vitest_mocker__ as VitestBrowserClientMocker | undefined
+      await mocker?.invalidate()
+    }
   }
 }
 

--- a/packages/mocker/src/browser/mocker.ts
+++ b/packages/mocker/src/browser/mocker.ts
@@ -50,12 +50,13 @@ export class ModuleMocker implements TestModuleMocker {
 
   public async invalidate(): Promise<void> {
     const ids = Array.from(this.mockedIds)
+    this.mockedIds.clear()
+    this.registry.clear()
+    await this.interceptor.invalidate()
     if (!ids.length) {
       return
     }
     await this.rpc.invalidate(ids)
-    await this.interceptor.invalidate()
-    this.registry.clear()
   }
 
   public async importActual<T>(id: string, importer: string): Promise<T> {

--- a/test/unit/test/browserMockerInvalidate.test.ts
+++ b/test/unit/test/browserMockerInvalidate.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ModuleMocker } from '@vitest/mocker/browser'
+
+describe('ModuleMocker.invalidate', () => {
+  it('clears registry and calls interceptor invalidate even when mockedIds is empty', async () => {
+    const interceptor = {
+      invalidate: vi.fn(),
+      register: vi.fn(),
+    }
+    const rpc = {
+      invalidate: vi.fn(),
+      resolveId: vi.fn(),
+      resolveMock: vi.fn(),
+    }
+    const createMockInstance = vi.fn()
+    const config = { root: '/' }
+
+    const mocker = new ModuleMocker(interceptor as any, rpc as any, createMockInstance, config)
+
+    await mocker.invalidate()
+
+    expect(interceptor.invalidate).toHaveBeenCalledTimes(1)
+    expect(rpc.invalidate).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes #10886

### Problem
In \itest list\ and collect mode with the browser provider, mock modules in \ModuleMocker\ leaked across test files when running without file parallelism. \mocker.invalidate()\ previously skipped clearing \	his.mockedIds\ and resetting the registry if \mockedIds\ was empty, retaining references to previous file mocks.

### Solution
- Updated \ModuleMocker.invalidate()\ in \packages/mocker/src/browser/mocker.ts\ to always clear \mockedIds\, reset \egistry\, and invalidate interceptors.
- Added explicit \wait mocker?.invalidate()\ between test file collections in \packages/browser/src/client/tester/tester.ts\.
- Added unit test in \	est/unit/test/browserMockerInvalidate.test.ts\.