### PR TITLE
fix(core): match forceRerunTriggers across dot directories

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -28,6 +28,21 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     expect(stdout).not.toContain('not-related.test.ts')
   })
 
+  it('should run the whole test suite if file exists in dot-directory trigger', async () => {
+    const dotFileName = 'fixtures/git-changed/related/.temp/rerun.temp'
+    createFile(dotFileName, '')
+    const { stdout, stderr } = await runVitest({
+      root: join(process.cwd(), 'fixtures/git-changed/related'),
+      include: ['related.test.ts'],
+      forceRerunTriggers: ['**/.temp/**'],
+      changed: true,
+    })
+    expect(stderr).toBe('')
+    expect(stdout).toContain('1 passed')
+    expect(stdout).toContain('related.test.ts')
+    expect(stdout).not.toContain('not-related.test.ts')
+  })
+
   it('should run no tests if file does not exist', async () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')


### PR DESCRIPTION
## Problem

When running with `--changed` or in watch mode, `forceRerunTriggers` fails to match file paths when the path contains a dot-prefixed directory segment (e.g. project cloned under `.app/`, `~/.local/src/...`, or subdirectories starting with a dot).

## Root Cause

`picomatch` is invoked without `{ dot: true }` in `filterTestsBySource` (`specifications.ts`) and `handleFileChanged` (`watcher.ts`). By default (`dot: false`), picomatch globstars (`**`) do not match dot-leading path segments, preventing triggers such as `**/package.json` from matching absolute file paths containing dot directories.

## Fix

Pass `{ dot: true }` to `picomatch` when constructing matchers in `specifications.ts` and when evaluating `pm.isMatch` in `watcher.ts`.

## Testing

- Added e2e test case in `test/e2e/test/git-changed.test.ts` asserting `forceRerunTriggers` matching with dot directory paths.
- Verified `pnpm typecheck` and `pnpm lint` pass cleanly.

<!-- VITEST_AUTOMATED_PR -->