### PR TITLE
fix(vitest): accept awaited return type in vi.when().thenResolve

### DIFF
--- a/packages/vitest/src/integrations/mock/when.ts
+++ b/packages/vitest/src/integrations/mock/when.ts
@@ -85,7 +85,7 @@ type CalledWithInstance<ReturnType, Fn extends Procedure> = When<Fn> & {
    * @param options - Optional behavior configuration.
    * @returns The same {@linkcode when|vi.when} instance for chaining.
    */
-  thenResolve: (value: ReturnType, options?: BehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
+  thenResolve: (value: Awaited<ReturnType>, options?: BehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
 
   /**
    * Schedules a synchronous return value for a single call with the registered arguments, then removes the behavior.
@@ -103,7 +103,7 @@ type CalledWithInstance<ReturnType, Fn extends Procedure> = When<Fn> & {
    * @param options - Optional behavior configuration.
    * @returns The same {@linkcode when|vi.when} instance for chaining.
    */
-  thenResolveOnce: (value: ReturnType, options?: OnceBehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
+  thenResolveOnce: (value: Awaited<ReturnType>, options?: OnceBehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
 
   /**
    * Schedules a thrown error for when the spy is called with the registered arguments.

--- a/test/unit/test/mocking/vi-when.test.ts
+++ b/test/unit/test/mocking/vi-when.test.ts
@@ -136,6 +136,25 @@ describe('vi.when()', () => {
       expect(w).toHaveBeenExhausted()
     })
 
+    test('resolves an unwrapped value for an async mock using `thenResolve`', async () => {
+      const spy = vi.fn<(input: string) => Promise<string>>()
+
+      const w = vi.when(spy)
+        .calledWith('easter-egg')
+        .thenResolve('bar')
+
+      expect(w).not.toHaveBeenExhausted()
+
+      await expect(spy('easter-egg')).resolves.toBe('bar')
+
+      expect(spy).toHaveBeenLastCalledWith('easter-egg')
+      expect(spy).toHaveLastResolvedWith('bar')
+
+      expect(spy).toHaveBeenCalledOnce()
+
+      expect(w).toHaveBeenExhausted()
+    })
+
     test('rejects a promise when using `toReject`', async () => {
       const spy = vi.fn<Fn>()
 


### PR DESCRIPTION
## Description

`vi.when(spy).calledWith(...).thenResolve(value)` currently requires `value` to be the full `ReturnType`, forcing callers to write `Promise.resolve('bar')` for async mocks. This changes `thenResolve` and `thenResolveOnce` to accept `Awaited<ReturnType>`, matching the existing `mockResolvedValue` / `mockResolvedValueOnce` signatures in `@vitest/spy`.

The runtime path already wraps the value in `Promise.resolve(...)` (`when.ts` case `'resolve'`), so this is purely a type-level fix — no behavior change.

## Before

```ts
vi.when(spy).calledWith('easter-egg').thenResolve(Promise.resolve('bar')) // required
```

## After

```ts
vi.when(spy).calledWith('easter-egg').thenResolve('bar') // works
```

## Related

Closes #11017