### PR TITLE
fix(reporters): keep the watch banner red while other files fail

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -451,7 +451,7 @@ export abstract class BaseReporter implements Reporter {
   }
 
   onWatcherStart(files: File[] = this.ctx.state.getFiles(), errors: unknown[] = this.ctx.state.getUnhandledErrors()): void {
-    const failed = errors.length > 0 || hasFailed(files)
+    const failed = errors.length > 0 || hasFailed(files) || this.failedUnwatchedFiles.length > 0
 
     if (failed) {
       this.log(withLabel('red', 'FAIL', 'Tests failed. Watching for file changes...'))

--- a/test/e2e/test/watch/reporter-failed.test.ts
+++ b/test/e2e/test/watch/reporter-failed.test.ts
@@ -19,13 +19,29 @@ describe.for([
     fs.editFile('./basic.test.js', code => `${code}\n`)
 
     await vitest.waitForStdout('RERUN  ../basic.test.js')
-    await vitest.waitForStdout('Waiting for file changes...')
+    await vitest.waitForStdout('Tests failed. Watching for file changes...')
 
     expect(vitest.stdout).not.toContain('log fail')
     expect(vitest.stdout).toContain('❯ failed.test.js')
     expect(vitest.stdout).toContain('× fails')
     expect(vitest.stdout).toContain('1 failed')
     expect(vitest.stdout).toContain('1 passed')
+    expect(vitest.stdout).not.toContain('PASS  Waiting for file changes')
+  })
+
+  it('returns to PASS once the failing file is fixed', async () => {
+    const { vitest, fs } = await runReporterTests(isTTY)
+
+    expect(vitest.stdout).toContain('1 failed')
+
+    vitest.resetOutput()
+
+    fs.editFile('./failed.test.js', code => code.replace('throw new Error(\'failed\')', ''))
+
+    await vitest.waitForStdout('RERUN  ../failed.test.js')
+    await vitest.waitForStdout('PASS  Waiting for file changes...')
+
+    expect(vitest.stdout).not.toContain('1 failed')
   })
 
   it('prints tests once if changed test is the same', async () => {


### PR DESCRIPTION
Fixes #10695.

On a rerun the banner reports `PASS` while the summary directly above it counts a failure:

```
 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 1 passed (2)

 PASS  Waiting for file changes...
```

`onWatcherStart` only receives the files from the run that just finished, so `hasFailed(files)` cannot see files that failed earlier and were not rerun. `reportTestSummary` already folds them in via `failedUnwatchedFiles`, which is why only the banner disagreed.

`reporter-failed.test.ts` already covered this scenario but waited for `Waiting for file changes...`, which is the PASS banner, so the old behaviour was pinned by the suite. That wait now expects the FAIL banner, and a second case covers fixing the failing file so the banner cannot get stuck red.

The discussion on #10695 also explored a separate `PREVIOUS FAILS` section. This PR does not attempt that.

Written by an AI agent (Claude Code) on behalf of @nundorn, who reviewed it before it was posted.

<!-- VITEST_AUTOMATED_PR -->
