### PR TITLE
fix(coverage): skip non-file URLs when converting v8 coverage

### DIFF
--- a/packages/coverage-v8/src/provider.ts
+++ b/packages/coverage-v8/src/provider.ts
@@ -449,6 +449,13 @@ export class V8CoverageProvider extends BaseCoverageProvider implements Coverage
         }
       }
 
+      // V8 can report scripts that are not backed by a file, e.g. "about:", "data:"
+      // or "blob:" URLs coming from virtual modules. `fileURLToPath` throws on those.
+      if (!result.url.startsWith(FILE_PROTOCOL)) {
+        debug('Skipping non-file URL %s', result.url)
+        continue
+      }
+
       if (this.isIncluded(fileURLToPath(result.url))) {
         scriptCoverages.push({ ...result, url: decodeURIComponent(result.url) })
       }

--- a/test/coverage-test/test/non-file-urls.unit.test.ts
+++ b/test/coverage-test/test/non-file-urls.unit.test.ts
@@ -1,0 +1,61 @@
+import type { CoverageMap } from '@vitest/istanbul-lib-coverage'
+import { Writable } from 'node:stream'
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'pathe'
+import { expect, onTestFinished, test } from 'vitest'
+import { createVitest } from 'vitest/node'
+
+// V8 can report scripts that have no file behind them, e.g. "about:" URLs from
+// vitest-plugin-rsc, "data:" inline modules or "blob:" workers. Those used to
+// crash the whole coverage run with ERR_INVALID_URL_SCHEME.
+// See https://github.com/vitest-dev/vitest/issues/11036
+test.each([
+  'about:/React/Server/some-virtual-module',
+  'data:text/javascript,export const a = 1',
+  'blob:nodedata:0ac1a2e2-1b06-4b4a-9c6c-2ba1c0b3fd2f',
+])('non-file url %s does not crash coverage conversion', async (url) => {
+  const { convertCoverage } = await init()
+  const file = resolve(import.meta.dirname, '../fixtures/src/even.ts')
+
+  const coverageMap = await convertCoverage([
+    { url, scriptId: '1', functions: [], startOffset: 0 },
+    {
+      url: pathToFileURL(file).href,
+      scriptId: '2',
+      startOffset: 0,
+      functions: [
+        {
+          functionName: 'isEven',
+          isBlockCoverage: true,
+          ranges: [{ startOffset: 0, endOffset: 60, count: 1 }],
+        },
+      ],
+    },
+  ])
+
+  // The file-backed script is still processed
+  expect(coverageMap.files()).toContain(file)
+})
+
+async function init() {
+  const vitest = await createVitest('test', {
+    config: false,
+    include: ['dont-match-anything'],
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      include: ['**/fixtures/src/**'],
+      reporter: [],
+    },
+  }, {}, { stdout: new Writable() })
+
+  onTestFinished(() => vitest.close())
+  await vitest.standalone()
+
+  const provider = vitest.coverageProvider as any
+
+  return {
+    convertCoverage: (result: unknown[]): Promise<CoverageMap> =>
+      provider.convertCoverage({ result }, vitest.getRootProject(), 'ssr'),
+  }
+}


### PR DESCRIPTION
### Description

Fixes #11036.

`V8CoverageProvider.convertCoverage` calls `fileURLToPath(result.url)` unconditionally:

```ts
if (this.isIncluded(fileURLToPath(result.url))) {
```

If V8 reports a script whose URL is not a `file:` URL, `fileURLToPath` throws `TypeError: The URL must be of scheme file` (`ERR_INVALID_URL_SCHEME`) and the **entire** coverage run aborts — not just the offending entry. Real-world sources of such URLs:

- `about:/React/Server/...` injected by `vitest-plugin-rsc`
- `data:` inline modules
- `blob:` worker scripts

`filterResult` in `packages/coverage-v8/src/index.ts` already drops non-`file://` URLs at the `takeCoverage` stage, so the primary path is protected. But coverage entries that never pass through `filterResult` still reach `convertCoverage`: merged blob reports (`--merge-reports`), externally written coverage JSON, and subprocess writers. Those still crash today.

### Change

Skip non-`file:` entries in `convertCoverage` (with a `debug` line) instead of letting `fileURLToPath` throw, so the remaining file-backed scripts are still converted and reported.

```ts
// V8 can report scripts that are not backed by a file, e.g. "about:", "data:"
// or "blob:" URLs coming from virtual modules. `fileURLToPath` throws on those.
if (!result.url.startsWith(FILE_PROTOCOL)) {
  debug('Skipping non-file URL %s', result.url)
  continue
}
```

The check runs *after* the browser-mode URL normalization block just above it, so browser `/@fs` and root-relative URLs — which are rewritten to `file://` there — are unaffected.

### Test

`test/coverage-test/test/non-file-urls.unit.test.ts` drives `convertCoverage` with a mixed batch: one non-file entry (parameterized over `about:`, `data:` and `blob:`) plus one real file-backed script, and asserts the file-backed script still lands in the coverage map.

Verified it is a real regression test — on `main` without the provider change it fails with exactly the reported error:

```
Serialized Error: { code: 'ERR_INVALID_URL_SCHEME' }
 Test Files  1 failed (1)
      Tests  3 failed (3)
```

and passes with it:

```
 ✓ |unit| test/non-file-urls.unit.test.ts > non-file url about:/React/Server/some-virtual-module does not crash coverage conversion
 ✓ |unit| test/non-file-urls.unit.test.ts > non-file url data:text/javascript,export const a = 1 does not crash coverage conversion
 ✓ |unit| test/non-file-urls.unit.test.ts > non-file url blob:nodedata:0ac1a2e2-... does not crash coverage conversion
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### Validation

- `pnpm build` — ok
- `vitest run --project unit --project v8` in `test/coverage-test`: **156 passed, 1 skipped**, 1 failure in `test/on-failure.test.ts` (inline snapshot of the coverage summary text). That failure reproduces on an unmodified checkout of `main` as well, so it is pre-existing and unrelated to this change.
- `eslint` clean on both touched files.
