### PR TITLE
fix(expect): avoid subset equality in matchers (fix #11071)

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -633,10 +633,16 @@ export function subsetEquality(
           const result
             = object != null
               && hasPropertyInObject(object, key)
-              && equals(object[key], subset[key], [
-                ...filteredCustomTesters,
-                subsetEqualityWithContext(seenReferences),
-              ])
+              && equals(
+                object[key],
+                subset[key],
+                isAsymmetric(subset[key])
+                  ? filteredCustomTesters
+                  : [
+                      ...filteredCustomTesters,
+                      subsetEqualityWithContext(seenReferences),
+                    ],
+              )
           // The main goal of using seenReference is to avoid circular node on tree.
           // It will only happen within a parent and its child, not a node and nodes next to it (same level)
           // We should keep the reference for a parent and its child only

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -196,6 +196,14 @@ describe('jest-expect', () => {
     }).toThrowErrorMatchingInlineSnapshot(`[AssertionError: expected { sum: 0.30000000000000004 } to deeply equal { sum: NumberCloseTo 0.4 (2 digits) }]`)
   })
 
+  it('checks every expected property in arrayContaining inside toMatchObject', () => {
+    expect({ records: [{ id: 1 }] }).not.toMatchObject({
+      records: expect.arrayContaining([
+        { id: 1, required: 'value' },
+      ]),
+    })
+  })
+
   it('asymmetric matchers and equality testers', () => {
     // iterable equality testers
     expect([new Set(['x'])]).toEqual(


### PR DESCRIPTION
### Description

Prepared by an AI agent using Codex on behalf of @dawNotPoi. The operator authorized this contribution but has not individually reviewed this text.

`toMatchObject` passed its recursive subset equality tester into nested asymmetric matchers. That made `expect.arrayContaining` accept an object that omitted a required property.

This keeps custom equality testers available while letting asymmetric matchers apply their own equality semantics.

Resolves #11071

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check Allow edits by maintainers to make review process faster.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Validated with:
- `CI=true pnpm test jest-expect.test.ts` in threads and forks
- `CI=true pnpm test expect.test.ts`
- `pnpm lint:fix`
- `CI=true pnpm lint`
- `pnpm typecheck`
- `pnpm build`

The full unit run had 2,064 passing tests. `handled-unhandled.test.ts` failed in this WSL environment with two `uncaughtException` listeners instead of one, including when rerun alone.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

<!-- VITEST_AUTOMATED_PR -->