### PR TITLE
perf(vm): let environments opt out of the module graph prewarm

### DIFF
--- a/docs/guide/environment.md
+++ b/docs/guide/environment.md
@@ -49,6 +49,9 @@ import type { Environment } from 'vitest/runtime'
 export default <Environment>{
   name: 'custom',
   viteEnvironment: 'ssr',
+  // optional - set to false when "setupVM" is fast, so vm pools
+  // do not transform the import graph while it runs
+  prewarmModules: true,
   // optional - only if you support "vmForks" or "vmThreads" pools
   async setupVM() {
     const vm = await import('node:vm')

--- a/packages/vitest/src/integrations/env/node.ts
+++ b/packages/vitest/src/integrations/env/node.ts
@@ -41,6 +41,7 @@ function populateNodeGlobals() {
 export default <Environment>{
   name: 'node',
   viteEnvironment: 'ssr',
+  prewarmModules: false,
   // this is largely copied from jest's node environment
   async setupVM() {
     populateNodeGlobals()

--- a/packages/vitest/src/runtime/workers/vm.ts
+++ b/packages/vitest/src/runtime/workers/vm.ts
@@ -37,15 +37,14 @@ export async function runVmTests(method: 'run' | 'collect', state: WorkerGlobalS
   state.environment = environment
 
   // let the server transform this file's import graph while this worker is
-  // busy importing the environment package (jsdom takes ~0.5s per worker) —
-  // the server is otherwise idle during that window on a cold start. The
-  // transforms also land in the `fetchWarmModules` snapshot, so the worker's
-  // own fetches short-circuit to disk reads. Failures are ignored: the
-  // worker's own fetch reports them with the proper import context.
-  rpc.prewarmModuleGraph(
-    environment.viteEnvironment || environment.name,
-    ctx.files.map(file => file.filepath),
-  ).catch(() => {})
+  // busy setting up the environment (jsdom takes ~0.5s per worker) —
+  // the server is otherwise idle during that window on a cold start.
+  if (environment.prewarmModules !== false) {
+    rpc.prewarmModuleGraph(
+      environment.viteEnvironment || environment.name,
+      ctx.files.map(file => file.filepath),
+    ).catch(() => {})
+  }
 
   if (!environment.setupVM) {
     const envName = ctx.environment.name

--- a/packages/vitest/src/types/environment.ts
+++ b/packages/vitest/src/types/environment.ts
@@ -22,6 +22,14 @@ export interface Environment {
    * By default, fallbacks to `name`.
    */
   viteEnvironment?: 'client' | 'ssr' | ({} & string)
+  /**
+   * Let the server transform the test file's import graph while `setupVM`
+   * runs. Only worth it when `setupVM` is slow (jsdom, happy-dom): otherwise
+   * the transforms compete with the worker's own module requests.
+   *
+   * @default `true`
+   */
+  prewarmModules?: boolean
   setupVM?: (options: Record<string, any>) => Awaitable<VmEnvironmentReturn>
   setup: (
     global: any,


### PR DESCRIPTION
The vm pool prewarm from #10744 only pays off while the server is idle during a slow `setupVM` (jsdom, happy-dom). With the `node` environment there is no such window, so the walk competes with the worker's own fetches: on the benchmarks' `micro-utils` app (5 files) warm `vmThreads` went from 0.27s on 4.1.10 to 0.33s, `node-library` from 0.53s to 0.55s.

Adds `prewarmModules?: boolean` to `Environment` (default `true`) and sets it to `false` on the built-in `node` environment. Custom environments with a cheap `setupVM` can opt out the same way.

Warm medians on micro-utils after the change, 4.1.10 vs this PR: `vmThreads` 0.28s vs 0.28s, `vmForks` 0.29s vs 0.29s, `vmThreads` + jsdom 0.61s vs 0.56s (prewarm still on). node-library `vmThreads` 0.53s vs 0.49s.