### PR TITLE
fix: forceRerunTriggers not matching when project root has dot-prefixed dir

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,11 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    // `dot: true` so a trigger like '**/package.json' still matches when the project
+    // itself lives under a dot-prefixed directory segment (e.g. `.app/`, `~/.local/src/`) -
+    // picomatch's default `dot: false` otherwise refuses to let `**` cross that segment,
+    // silently disabling every trigger. See https://github.com/vitest-dev/vitest/issues/11054
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,10 +135,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    // `dot: true` so a trigger like '**/package.json' still matches when the project
-    // itself lives under a dot-prefixed directory segment (e.g. `.app/`, `~/.local/src/`) -
-    // picomatch's default `dot: false` otherwise refuses to let `**` cross that segment,
-    // silently disabling every trigger. See https://github.com/vitest-dev/vitest/issues/11054
+    // dot: true, otherwise `**` won't cross a dot-prefixed root dir (#11054)
     const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,8 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    // `dot: true` for the same reason as the `related` check in specifications.ts:
-    // otherwise a dot-prefixed project directory segment silently breaks every trigger.
+    // dot: true, see specifications.ts (#11054)
     if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,9 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    // `dot: true` for the same reason as the `related` check in specifications.ts:
+    // otherwise a dot-prefixed project directory segment silently breaks every trigger.
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -37,8 +37,6 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
 })
 
 // https://github.com/vitest-dev/vitest/issues/11054
-// picomatch's default `dot: false` refuses to let `**` cross a dot-prefixed directory
-// segment, so a project checked out under e.g. `.app/` silently ignored every trigger.
 it.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTriggers matches when project root has a dot-prefixed directory segment', async () => {
   const dotRoot = resolve(process.cwd(), `.vitest-test-${crypto.randomUUID()}`)
   const fs = useFS(dotRoot, {

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -1,7 +1,9 @@
+import { webcrypto as crypto } from 'node:crypto'
 import { join } from 'node:path'
+import { resolve } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
-import { createFile, editFile, resolvePath, runVitest } from '../../test-utils'
+import { createFile, editFile, resolvePath, runVitest, useFS } from '../../test-utils'
 
 const fileName = 'fixtures/git-changed/related/rerun.temp'
 
@@ -32,6 +34,32 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
   })
+})
+
+// https://github.com/vitest-dev/vitest/issues/11054
+// picomatch's default `dot: false` refuses to let `**` cross a dot-prefixed directory
+// segment, so a project checked out under e.g. `.app/` silently ignored every trigger.
+it.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTriggers matches when project root has a dot-prefixed directory segment', async () => {
+  const dotRoot = resolve(process.cwd(), `.vitest-test-${crypto.randomUUID()}`)
+  const fs = useFS(dotRoot, {
+    'sample.test.ts': `
+      import { expect, it } from 'vitest'
+      it('passes', () => {
+        expect(1).toBe(1)
+      })
+    `,
+    'trigger.txt': 'x',
+  })
+
+  const { stdout, stderr } = await runVitest({
+    root: fs.root,
+    include: ['sample.test.ts'],
+    related: 'trigger.txt',
+    forceRerunTriggers: ['**/trigger.txt'],
+  })
+
+  expect(stderr).toBe('')
+  expect(stdout).toContain('1 passed')
 })
 
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {


### PR DESCRIPTION
Written by an AI agent (Claude Code) on behalf of @TLSRUF, who directed and authorized this work but has not personally reviewed the diff line-by-line.

Resolves #11054

## What's wrong

Both `forceRerunTriggers` call sites use `picomatch` with its default `dot: false`:

- `specifications.ts` (the `--changed`/`related` check): `pm(forceRerunTriggers)`
- `watcher.ts` (the watch-mode check): `pm.isMatch(filepath, forceRerunTriggers)`

`dot: false` makes `**` refuse to cross a path segment that starts with a dot. If the project root itself lives under a dot-prefixed directory (a clone into `.app/`, `~/.local/src/…`, an agent worktree under `.claude/worktrees/…`), every absolute path handed to the matcher contains that segment, so **every** trigger — including vitest's own default `**/package.json`/`**/vitest.config.*`/etc. — silently fails to match. `--changed` then quietly reports `No test files found` for e.g. a lockfile-only change instead of escalating to the full suite, with no warning that anything went wrong.

Full root-cause writeup + reproduction repo in #11054 (credit to the original report for pinning down both call sites and the exact fix).

## Fix

Pass `{ dot: true }` at both call sites so a trigger matches regardless of what the project directory happens to be named.

## Testing

- Added a regression test in `test/e2e/test/git-changed.test.ts`: builds a temp project under a dot-prefixed root (`.vitest-test-<uuid>`) via `useFS`, runs vitest with `related` + `forceRerunTriggers`, and asserts the suite runs instead of `No test files found`.
- Verified the test actually catches the regression: temporarily reverted the `specifications.ts` change and confirmed the new test fails with the exact symptom from the issue (`No test files found, exiting with code 1`); restored the fix and confirmed it passes again.
- `test/e2e/test/git-changed.test.ts` (6/6) and `test/e2e/test/watch/file-watching.test.ts` (9/9, 1 browser test skipped) both pass, including the existing `editing force rerun trigger reruns all tests` watch-mode test — no regression.
- `eslint` clean on the 3 changed files.
- `tsc` type-checks the e2e test file clean (full-repo `pnpm typecheck` has one unrelated pre-existing error in `test/unit/test/web-worker-node.test.ts` from a package I didn't build locally — untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)