### PR TITLE
fix: apply `fails` inversion before retries

### DIFF
--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -737,28 +737,16 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
         return
       }
 
-      // if the test is marked to be failed, flip the result of this attempt
-      // before deciding whether to retry, so that an erroring attempt counts
-      // as meeting the expectation while a passing attempt is the failure
-      // mode that can be retried. A `TestSyntaxError` is never flipped.
-      if (test.fails) {
-        if (test.result.state === 'pass') {
-          const error = processError(new Error('Expect test to fail'))
-          test.result.state = 'fail'
-          test.result.errors = [error]
-        }
-        else if (!test.result.errors?.some(e => e.__vitest_test_syntax_error__)) {
-          test.result.state = 'pass'
-          test.result.errors = undefined
-        }
-      }
-
-      if (test.result.state === 'pass') {
+      // `fails` inverts what a satisfactory attempt looks like, so the retry
+      // decision has to be made against the expectation rather than the raw
+      // state. The result itself is still inverted once, after the loop, so
+      // that `onTestFailed` and later repeats keep seeing the real state.
+      if (metExpectation(test)) {
         break
       }
 
       if (retryCount < retry) {
-        const shouldRetry = passesRetryCondition(test, test.result.errors)
+        const shouldRetry = passesRetryCondition(test, retryErrors(test))
 
         if (!shouldRetry) {
           break
@@ -778,6 +766,18 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
     }
   }
 
+  // if test is marked to be failed, flip the result unless `TestSyntaxError` is present
+  if (test.fails) {
+    if (test.result.state === 'pass') {
+      test.result.state = 'fail'
+      test.result.errors = [expectedToFailError()]
+    }
+    else if (!test.result.errors?.some(e => e.__vitest_test_syntax_error__)) {
+      test.result.state = 'pass'
+      test.result.errors = undefined
+    }
+  }
+
   cleanupRunningTest()
   setCurrentTest(undefined)
 
@@ -786,6 +786,43 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   await runner.onAfterRunTask?.(test)
 
   updateTask('test-finished', test, runner)
+}
+
+function expectedToFailError(): TestError {
+  return processError(new Error('Expect test to fail'))
+}
+
+/**
+ * Whether the attempt that just finished met the test's expectation, and so
+ * should not be retried.
+ *
+ * For a `fails` test the expectation is inverted: an attempt that threw has met
+ * it and there is nothing left to re-check, while an attempt that passed is the
+ * failure mode `retry` exists for. A `TestSyntaxError` is never inverted, so it
+ * can never meet the expectation.
+ */
+function metExpectation(test: Test): boolean {
+  const result = test.result!
+  if (!test.fails) {
+    return result.state === 'pass'
+  }
+  return result.state === 'fail'
+    && !result.errors?.some(e => e.__vitest_test_syntax_error__)
+}
+
+/**
+ * The errors the retry decision reasons about.
+ *
+ * A `fails` test that passed has no error of its own, but its failure is the
+ * missing failure, so the retry `condition` is matched against the same error
+ * the test is finally reported with instead of against nothing.
+ */
+function retryErrors(test: Test): TestError[] | undefined {
+  const result = test.result!
+  if (test.fails && result.state === 'pass') {
+    return [expectedToFailError()]
+  }
+  return result.errors
 }
 
 function failTask(result: TaskResult, err: unknown, diffOptions: DiffOptions | undefined) {

--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -737,6 +737,22 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
         return
       }
 
+      // if the test is marked to be failed, flip the result of this attempt
+      // before deciding whether to retry, so that an erroring attempt counts
+      // as meeting the expectation while a passing attempt is the failure
+      // mode that can be retried. A `TestSyntaxError` is never flipped.
+      if (test.fails) {
+        if (test.result.state === 'pass') {
+          const error = processError(new Error('Expect test to fail'))
+          test.result.state = 'fail'
+          test.result.errors = [error]
+        }
+        else if (!test.result.errors?.some(e => e.__vitest_test_syntax_error__)) {
+          test.result.state = 'pass'
+          test.result.errors = undefined
+        }
+      }
+
       if (test.result.state === 'pass') {
         break
       }
@@ -759,19 +775,6 @@ export async function runTest(test: Test, runner: VitestRunner): Promise<void> {
 
       // update retry info
       updateTask('test-retried', test, runner)
-    }
-  }
-
-  // if test is marked to be failed, flip the result unless `TestSyntaxError` is present
-  if (test.fails) {
-    if (test.result.state === 'pass') {
-      const error = processError(new Error('Expect test to fail'))
-      test.result.state = 'fail'
-      test.result.errors = [error]
-    }
-    else if (!test.result.errors?.some(e => e.__vitest_test_syntax_error__)) {
-      test.result.state = 'pass'
-      test.result.errors = undefined
     }
   }
 

--- a/test/e2e/test/retry.test.ts
+++ b/test/e2e/test/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { runInlineTests, runVitest, ts } from '../../test-utils'
 
 function run(testNamePattern: string) {
   return runVitest({
@@ -23,5 +23,44 @@ describe('retry', () => {
     expect(stdout).toContain('expected 2 to be 4')
     expect(stdout).toContain('expected 3 to be 4')
     expect(stdout).toContain('1 failed')
+  })
+})
+
+describe('retry with test.fails', () => {
+  test('an erroring test.fails test meets its expectation and is not retried', async () => {
+    const { stdout } = await runInlineTests({
+      'fails-retry.test.ts': ts`
+        import { expect, test } from 'vitest'
+        let attempts = 0
+        test.fails('meets the expectation', { retry: 2 }, () => {
+          attempts++
+          throw new Error('expected failure')
+        })
+        test('ran only once', () => {
+          expect(attempts).toBe(1)
+        })
+      `,
+    })
+
+    expect(stdout).toContain('1 passed | 1 expected fail')
+  })
+
+  test('a passing test.fails test is retried and reported as failed', async () => {
+    const { stdout, stderr } = await runInlineTests({
+      'fails-retry.test.ts': ts`
+        import { expect, test } from 'vitest'
+        let attempts = 0
+        test.fails('never meets the expectation', { retry: 2 }, () => {
+          attempts++
+        })
+        test('ran the initial attempt and both retries', () => {
+          expect(attempts).toBe(3)
+        })
+      `,
+    })
+
+    expect(stderr).toContain('Expect test to fail')
+    expect(stdout).toContain('1 failed')
+    expect(stdout).toContain('1 passed')
   })
 })

--- a/test/e2e/test/retry.test.ts
+++ b/test/e2e/test/retry.test.ts
@@ -63,4 +63,25 @@ describe('retry with test.fails', () => {
     expect(stdout).toContain('1 failed')
     expect(stdout).toContain('1 passed')
   })
+
+  test('a retry condition is matched against the missing failure', async () => {
+    const { stdout } = await runInlineTests({
+      'fails-retry.test.ts': ts`
+        import { expect, test } from 'vitest'
+        let matched = 0
+        test.fails('condition matches', { retry: { count: 2, condition: /Expect test to fail/ } }, () => {
+          matched++
+        })
+        let unmatched = 0
+        test.fails('condition does not match', { retry: { count: 2, condition: /something else/ } }, () => {
+          unmatched++
+        })
+        test('only the matching one is retried', () => {
+          expect([matched, unmatched]).toEqual([3, 1])
+        })
+      `,
+    })
+
+    expect(stdout).toContain('1 passed')
+  })
 })

--- a/test/unit/test/on-finished.test.ts
+++ b/test/unit/test/on-finished.test.ts
@@ -182,17 +182,13 @@ describe('retry fail', () => {
   })
 
   it('assert', () => {
+    // the first attempt already threw, which is what `fails` expects, so the
+    // two retries are not spent
     expect(state).toMatchInlineSnapshot(`
       [
         "(0, 0) run",
         "(0, 0) finish",
         "(0, 0) fail",
-        "(1, 0) run",
-        "(1, 0) finish",
-        "(1, 0) fail",
-        "(2, 0) run",
-        "(2, 0) finish",
-        "(2, 0) fail",
       ]
     `)
   })

--- a/test/unit/test/repeats.test.ts
+++ b/test/unit/test/repeats.test.ts
@@ -40,7 +40,9 @@ const retryNumbers: number[] = []
 
 describe('testing repeats with retry', () => {
   describe('normal test', () => {
-    const result = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    // the body always throws, so each repeat meets the `fails` expectation on
+    // its first attempt and the retry is not spent
+    const result = [1, 1, 1, 1, 1]
     test.fails('test 1', { repeats: 4, retry: 1 }, () => {
       retryNumbers.push(1)
       expect(1).toBe(2)

--- a/test/unit/test/retry.test.ts
+++ b/test/unit/test/retry.test.ts
@@ -6,6 +6,7 @@ it('retry test', { retry: 2 }, () => {
   expect(count1).toBe(3)
 })
 
+// this always throws, which is what `fails` expects, so it is never retried
 let count2 = 0
 it.fails('retry test fails', { retry: 1 }, () => {
   count2 += 1
@@ -20,7 +21,7 @@ it('retry test fails', { retry: 10 }, () => {
 
 it('result', () => {
   expect(count1).toEqual(3)
-  expect(count2).toEqual(2)
+  expect(count2).toEqual(1)
   expect(count3).toEqual(3)
 })
 


### PR DESCRIPTION
### Description

Resolves #11068 (analysis in [this comment](https://github.com/vitest-dev/vitest/issues/11068#issuecomment-5448100230)).

A test marked with `fails` had its result inverted only **after** the retry loop in `runTest`, so the retry decision saw the raw state:

- an attempt that threw — meaning the expectation was met — was retried `retry` times for nothing, then reported as passed with a misleading `(retry xN)`;
- an attempt that passed — the actual failure mode of a `fails` test — broke out of the loop and was never retried.

### What changed

The retry decision now asks whether the attempt met the test's *expectation*, rather than whether it passed. `metExpectation` inverts that question for `fails`; a `TestSyntaxError` still never satisfies it, exactly as before.

The result itself is still inverted **once**, after the loop, by the same block as before. That part matters: my first attempt at this inverted `test.result` in place on every attempt, which fixed the counts but also changed state the rest of the loop reads. The attempt state is sticky across repeats (`state !== 'fail'` is what promotes it to `'pass'`), so inverting a repeat's failure hid it from the next repeat and silently dropped an `onTestFailed` call that used to fire — `repeats fail` in `test/unit/test/on-finished.test.ts` caught it. Deciding without mutating leaves `onTestFailed` and later repeats seeing the attempt's real state.

One consequence needed handling: a `fails` test that *passes* has no error of its own, and `passesRetryCondition` returns `false` when there is no error, so it would still never be retried. `retryErrors` hands the retry decision the same `Expect test to fail` error the test is finally reported with, so a `retry.condition` matches against the missing failure instead of against nothing.

### The three updated tests are the behaviour change, not collateral

Each of these asserted the old "retry an erroring `fails` test" behaviour:

| test | was | now |
|---|---|---|
| `test/unit/test/retry.test.ts` — `retry test fails`, `{ retry: 1 }` | 2 attempts | 1 |
| `test/unit/test/repeats.test.ts` — `{ repeats: 4, retry: 1 }` | 10 runs | 5 |
| `test/unit/test/on-finished.test.ts` — `retry fail`, `{ retry: 2 }` | 3 attempts | 1 |

`repeats fail` in the same file is **unchanged**, which is the check that the inversion is no longer leaking into hooks.

### Verification

Local, Windows, on a tree built from this branch:

- `test/e2e/test/retry.test.ts` — 5/5. Three of these count actual attempts: an erroring `fails` test with `{ retry: 2 }` runs once (was 3×); a passing one runs 3× and is reported failed (was 1×); and with `condition`, `[matched, unmatched]` is `[3, 1]`, so the condition is matched against the expectation failure and a non-matching condition still suppresses the retry.
- Full `test/unit` across `threads`, `forks` and `vmThreads` — 6112 passed, 63 expected fail. The only failure is `test/jest-mock.test.ts > spies on classes`, which fails identically on an unmodified build of the same tree.
- `eslint` clean on all five changed files; `tsc -p tsconfig.check.json` reports nothing in them.

**AI disclosure (per CONTRIBUTING):** this PR was prepared with the assistance of Claude Code. The human author reviewed the change and the verification, and will respond to review personally.

*Branch note: the branch is based on an Aug 7 upstream commit because the access token used here lacks the `workflow` scope needed to push upstream commits that touch `.github/workflows/`; the compare against `main` shows exactly the intended files and applies cleanly.*

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`. (Ran `test/unit` in all three pools and `test/e2e/test/retry.test.ts` locally — see Verification above. Full `test:ci` relies on CI.)

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command. (No new functionality — bug fix.)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
