### PR TITLE
fix: invalidate resolved setup files (fix #11073)

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleRunner.ts
@@ -108,7 +108,7 @@ export class VitestModuleRunner
     return exports
   }
 
-  public async import(rawId: string): Promise<any> {
+  public async import(rawId: string, options?: { invalidate?: boolean }): Promise<any> {
     const resolved = await this._otel.$(
       'vitest.module.resolve_id',
       {
@@ -128,7 +128,14 @@ export class VitestModuleRunner
         return result
       },
     )
-    return super.import(resolved ? resolved.url : rawId)
+    const url = resolved ? resolved.url : rawId
+    if (options?.invalidate) {
+      const module = this.evaluatedModules.getModuleByUrl(url)
+      if (module?.evaluated) {
+        this.evaluatedModules.invalidateModule(module)
+      }
+    }
+    return super.import(url)
   }
 
   public async fetchModule(url: string, importer?: string): Promise<EvaluatedModuleNode> {

--- a/packages/vitest/src/runtime/moduleRunner/testModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/testModuleRunner.ts
@@ -4,5 +4,5 @@ import type { ModuleExecutionInfo } from './moduleDebug'
 export interface TestModuleRunner {
   moduleExecutionInfo?: ModuleExecutionInfo
   mocker?: TestModuleMocker
-  import: <T = any>(moduleId: string) => Promise<T>
+  import: <T = any>(moduleId: string, options?: { invalidate?: boolean }) => Promise<T>
 }

--- a/packages/vitest/src/runtime/runners/test.ts
+++ b/packages/vitest/src/runtime/runners/test.ts
@@ -1,9 +1,9 @@
 import type { SpanOptions } from '@opentelemetry/api'
 import type { ExpectStatic } from '@vitest/expect'
-import type { ModuleRunner } from 'vite/module-runner'
 import type { Traces } from '../../utils/traces'
 import type { Bench } from '../benchmark'
 import type { SerializedConfig } from '../config'
+import type { TestModuleRunner } from '../moduleRunner/testModuleRunner'
 import type {
   CancelReason,
   File,
@@ -36,7 +36,7 @@ import { getWorkerState } from '../utils'
 export class TestRunner implements VitestTestRunner {
   private snapshotClient = getSnapshotClient()
   private workerState = getWorkerState()
-  private moduleRunner!: ModuleRunner
+  private moduleRunner!: TestModuleRunner
   private cancelRun = false
 
   private assertionsErrors = new WeakMap<Readonly<Task>, Error>()
@@ -63,10 +63,6 @@ export class TestRunner implements VitestTestRunner {
   }
 
   importFile(filepath: string, source: VitestRunnerImportSource): unknown {
-    const moduleNode = this.workerState.evaluatedModules.getModuleById(filepath)
-    if (moduleNode && (source === 'setup' || moduleNode.evaluated)) {
-      this.workerState.evaluatedModules.invalidateModule(moduleNode)
-    }
     return this._otel.$(
       `vitest.module.import_${source === 'setup' ? 'setup' : 'spec'}`,
       {
@@ -78,7 +74,8 @@ export class TestRunner implements VitestTestRunner {
         if (!this.viteModuleRunner) {
           filepath = `${filepath}?vitest=${Date.now()}`
         }
-        return this.moduleRunner.import(filepath)
+        const options = this.viteModuleRunner ? { invalidate: true } : undefined
+        return this.moduleRunner.import(filepath, options)
       },
     )
   }

--- a/test/e2e/test/setup-files.test.ts
+++ b/test/e2e/test/setup-files.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs'
 import { describe, expect, it, test } from 'vitest'
-import { editFile, runVitest } from '../../test-utils'
+import { editFile, runInlineTests, runVitest } from '../../test-utils'
 
 test.each(['threads', 'vmThreads'])('%s: print stdout and stderr correctly when called in the setup file', async (pool) => {
   const { stdout, stderr } = await runVitest({
@@ -79,6 +79,55 @@ it('setup files resolution in nested folder with bare name', async () => {
     {
       "basic.test.ts": {
         "basic": "passed",
+      },
+    }
+  `)
+})
+
+it('re-evaluates an extensionless setup file when isolation is disabled', async () => {
+  const { stderr, testTree } = await runInlineTests({
+    'vitest.config.js': `
+      export default {
+        test: {
+          isolate: false,
+          maxWorkers: 1,
+          setupFiles: ['./setup'],
+        },
+      }
+    `,
+    'setup.js': `
+      import { beforeEach } from 'vitest'
+
+      beforeEach(() => {
+        globalThis.setupFileHookCalled = true
+      })
+    `,
+    'a.test.js': `
+      import { expect, test } from 'vitest'
+
+      test('runs setup hook in a', () => {
+        expect(globalThis.setupFileHookCalled).toBe(true)
+        globalThis.setupFileHookCalled = false
+      })
+    `,
+    'b.test.js': `
+      import { expect, test } from 'vitest'
+
+      test('runs setup hook in b', () => {
+        expect(globalThis.setupFileHookCalled).toBe(true)
+        globalThis.setupFileHookCalled = false
+      })
+    `,
+  })
+
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "a.test.js": {
+        "runs setup hook in a": "passed",
+      },
+      "b.test.js": {
+        "runs setup hook in b": "passed",
       },
     }
   `)


### PR DESCRIPTION
### Description

Resolve setup module IDs before invalidation so extensionless setup files are re-evaluated with non-isolated workers.

Resolves #11073