### PR TITLE
fix: accept awaited value in vi.when thenResolve

### DIFF
--- a/packages/vitest/src/integrations/mock/when.ts
+++ b/packages/vitest/src/integrations/mock/when.ts
@@ -85,7 +85,7 @@ type CalledWithInstance<ReturnType, Fn extends Procedure> = When<Fn> & {
    * @param options - Optional behavior configuration.
    * @returns The same {@linkcode when|vi.when} instance for chaining.
    */
-  thenResolve: (value: ReturnType, options?: BehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
+  thenResolve: (value: Awaited<ReturnType>, options?: BehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
 
   /**
    * Schedules a synchronous return value for a single call with the registered arguments, then removes the behavior.
@@ -103,7 +103,7 @@ type CalledWithInstance<ReturnType, Fn extends Procedure> = When<Fn> & {
    * @param options - Optional behavior configuration.
    * @returns The same {@linkcode when|vi.when} instance for chaining.
    */
-  thenResolveOnce: (value: ReturnType, options?: OnceBehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
+  thenResolveOnce: (value: Awaited<ReturnType>, options?: OnceBehaviorOptions | undefined) => CalledWithInstance<ReturnType, Fn>
 
   /**
    * Schedules a thrown error for when the spy is called with the registered arguments.

--- a/test/unit/test/mocking/vi-when.test.ts
+++ b/test/unit/test/mocking/vi-when.test.ts
@@ -136,6 +136,27 @@ describe('vi.when()', () => {
       expect(w).toHaveBeenExhausted()
     })
 
+    test('resolves with an unwrapped value for an async function', async () => {
+      const spy = vi.fn<(...args: FnData['args']) => Promise<FnData['value']>>()
+
+      const args: FnData['args'] = ['a', 0]
+      const value: FnData['value'] = 97
+
+      const w = vi.when(spy)
+        .calledWith(...args)
+        .thenResolve(value)
+        .thenResolveOnce(value)
+
+      expect(w).not.toHaveBeenExhausted()
+
+      await expect(spy(...args)).resolves.toBe(value)
+      await expect(spy(...args)).resolves.toBe(value)
+
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      expect(w).toHaveBeenExhausted()
+    })
+
     test('rejects a promise when using `toReject`', async () => {
       const spy = vi.fn<Fn>()
 


### PR DESCRIPTION
`thenResolve` and `thenResolveOnce` now accept `Awaited<ReturnType>`, the same as `mockResolvedValue`.

Fixes #11017