### PR TITLE
fix: ignore computed member calls in static collection

### DIFF
--- a/packages/vitest/src/node/ast-collect.ts
+++ b/packages/vitest/src/node/ast-collect.ts
@@ -109,6 +109,10 @@ function astParseFile(filepath: string, code: string) {
       return getName(callee.tag)
     }
     if (callee.type === 'MemberExpression') {
+      // A computed access like `it[1].call(it[2])` is not a Vitest call.
+      if (callee.computed) {
+        return null
+      }
       if (
         callee.object?.type === 'Identifier'
         && isVitestFunctionName(callee.object.name)

--- a/test/e2e/test/static-collect.test.ts
+++ b/test/e2e/test/static-collect.test.ts
@@ -42,6 +42,43 @@ test('correctly collects a simple test', async () => {
   `)
 })
 
+test('ignores lowered "using" helper calls like it[1].call(it[2])', async () => {
+  // parsers can inject this helper when lowering `using` declarations
+  const testModule = await collectTests(`
+    import { describe, test } from 'vitest'
+
+    var __callDispose = (stack, error, hasError) => {
+      var next = (it) => {
+        while (it = stack.pop()) {
+          var result = it[1] && it[1].call(it[2])
+        }
+      }
+      return next()
+    }
+
+    describe('disposable', () => {
+      test('uses a resource', () => {
+        var _stack = []
+        __callDispose(_stack)
+      })
+    })
+`)
+  expect(testModule).toMatchInlineSnapshot(`
+    {
+      "disposable": {
+        "uses a resource": {
+          "errors": [],
+          "fullName": "disposable > uses a resource",
+          "id": "1709388417_0_0",
+          "location": "14:7",
+          "mode": "run",
+          "state": "pending",
+        },
+      },
+    }
+  `)
+})
+
 test('collects tests starting with "test"', async () => {
   const testModule = await collectTests(`
     import { testSomething, testAnother } from './test-helpers'


### PR DESCRIPTION
Static collection treated a computed member call like `it[1].call(it[2])` as a Vitest call. Parsers inject this helper when they lower `using` declarations, so test files that use disposables produced bogus entries. Computed member expressions are now skipped.

Fixes https://github.com/vitest-dev/vscode/issues/804