### PR TITLE
feat: promote clearCache out of experimental

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -597,13 +597,15 @@ function experimental_parseSpecifications(
 
 This method will [collect tests](#parsespecification) from an array of specifications. By default, Vitest will run only `os.availableParallelism()` number of specifications at a time to reduce the potential performance degradation. You can specify a different number in a second argument.
 
-## experimental_clearCache <Version type="experimental">4.0.11</Version> <Experimental /> {#clearcache}
+## clearCache <Version>5.0.0</Version> {#clearcache}
 
 ```ts
-function experimental_clearCache(): Promise<void>
+function clearCache(): Promise<void>
 ```
 
 Deletes all Vitest caches, including [`fsModuleCache`](/config/fsmodulecache).
+
+This was available since Vitest 4.0.11 as experimental `experimental_clearCache` method.
 
 ## experimental_getSourceModuleDiagnostic <Version type="experimental">4.0.15</Version> <Experimental /> {#getsourcemodulediagnostic}
 

--- a/packages/vitest/src/node/cli/cli-api.ts
+++ b/packages/vitest/src/node/cli/cli-api.ts
@@ -151,7 +151,7 @@ export async function startVitest(
       await ctx.listTags()
     }
     else if (ctx.config.clearCache) {
-      await ctx.experimental_clearCache()
+      await ctx.clearCache()
     }
     else if (ctx.config.mergeReports) {
       await ctx.mergeReports()

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -670,10 +670,17 @@ export class Vitest {
   }
 
   /**
-   * Deletes all Vitest caches, including the `fsModuleCache`.
-   * @experimental
+   * @deprecated Use `clearCache` instead.
    */
-  public async experimental_clearCache(): Promise<void> {
+  public experimental_clearCache(): Promise<void> {
+    this.logger.deprecate(`The "experimental_clearCache" method is deprecated. Use "clearCache" instead.`)
+    return this.clearCache()
+  }
+
+  /**
+   * Deletes all Vitest caches, including the `fsModuleCache`.
+   */
+  public async clearCache(): Promise<void> {
     await this.cache.results.clearCache()
     await this._fsCache.clearCache()
   }

--- a/test/e2e/test/caching.test.ts
+++ b/test/e2e/test/caching.test.ts
@@ -60,7 +60,7 @@ test('if no cache key generator is defined, the hash is invalid', async () => {
       {
         async onInit(vitest) {
           // make sure cache is empty
-          await vitest.experimental_clearCache()
+          await vitest.clearCache()
         },
       },
     ],
@@ -106,7 +106,7 @@ test('if cache key generator is defined, the hash is valid', async () => {
       {
         async onInit(vitest) {
           // make sure cache is empty
-          await vitest.experimental_clearCache()
+          await vitest.clearCache()
         },
       },
     ],
@@ -150,7 +150,7 @@ test('if cache key generator bails out, the file is not cached', async () => {
       {
         async onInit(vitest) {
           // make sure cache is empty
-          await vitest.experimental_clearCache()
+          await vitest.clearCache()
         },
       },
     ],


### PR DESCRIPTION
Renames `experimental_clearCache` to `clearCache`. The old method stays as a deprecated alias that logs a warning.