### PR TITLE
feat: promote parseSpecifications out of experimental

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -584,10 +584,10 @@ Vitest will only collect tests defined in the file. It will never follow imports
 Vitest collects all `it`, `test`, `suite` and `describe` definitions even if they were not imported from the `vitest` entry point.
 :::
 
-## experimental_parseSpecifications <Version type="experimental">4.0.0</Version> <Experimental /> {#parsespecifications}
+## parseSpecifications <Version>5.0.0</Version> {#parsespecifications}
 
 ```ts
-function experimental_parseSpecifications(
+function parseSpecifications(
   specifications: TestSpecification[],
   options?: {
     concurrency?: number
@@ -596,6 +596,8 @@ function experimental_parseSpecifications(
 ```
 
 This method will [collect tests](#parsespecification) from an array of specifications. By default, Vitest will run only `os.availableParallelism()` number of specifications at a time to reduce the potential performance degradation. You can specify a different number in a second argument.
+
+This was available since Vitest 4.0.0 as experimental `experimental_parseSpecifications` method.
 
 ## experimental_clearCache <Version type="experimental">4.0.11</Version> <Experimental /> {#clearcache}
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -791,7 +791,7 @@ export class Vitest {
       }
 
       if (options?.staticParse) {
-        const testModules = await this.experimental_parseSpecifications(files, {
+        const testModules = await this.parseSpecifications(files, {
           concurrency: options.staticParseConcurrency,
         })
         return { testModules, unhandledErrors: [] }
@@ -855,7 +855,7 @@ export class Vitest {
 
       if (this.config.experimental.preParse) {
         // This populates specification.testModule with parsed information
-        await this.experimental_parseSpecifications(specifications)
+        await this.parseSpecifications(specifications)
         specifications = specifications.filter(({ testModule }) => {
           return !testModule || testModule.task.mode !== 'skip'
         })
@@ -1115,7 +1115,18 @@ export class Vitest {
     )
   }
 
-  public async experimental_parseSpecifications(specifications: TestSpecification[], options?: {
+  /**
+   * @deprecated Use `parseSpecifications` instead
+   */
+  public experimental_parseSpecifications(specifications: TestSpecification[], options?: {
+    /** @default os.availableParallelism() */
+    concurrency?: number
+  }): Promise<TestModule[]> {
+    this.logger.deprecate(`The "experimental_parseSpecifications" method is deprecated. Use "parseSpecifications" instead.`)
+    return this.parseSpecifications(specifications, options)
+  }
+
+  public async parseSpecifications(specifications: TestSpecification[], options?: {
     /** @default os.availableParallelism() */
     concurrency?: number
   }): Promise<TestModule[]> {

--- a/test/e2e/test/pre-parse.test.ts
+++ b/test/e2e/test/pre-parse.test.ts
@@ -299,7 +299,7 @@ test('test 4', { meta: { ran: true } }, () => {})
     project.createSpecification(fs.resolveFile('./b.test.js')),
   ]
 
-  await vitest.experimental_parseSpecifications(specifications)
+  await vitest.parseSpecifications(specifications)
 
   expect(buildTree(t => t.task.mode)).toMatchInlineSnapshot(`
     {


### PR DESCRIPTION
Renames `experimental_parseSpecifications` to `parseSpecifications`. The old method stays as a deprecated alias that logs a warning.