### PR TITLE
feat!: parse files statically in vitest list by default

### DIFF
--- a/docs/api/advanced/vitest.md
+++ b/docs/api/advanced/vitest.md
@@ -185,17 +185,21 @@ This method is called automatically by [`startVitest`](/guide/advanced/tests) if
 ## collect
 
 ```ts
-function collect(filters?: string[]): Promise<TestRunResult>
+function collect(
+  filters?: string[],
+  options?: {
+    staticParse?: boolean
+    staticParseConcurrency?: number
+  }
+): Promise<TestRunResult>
 ```
 
-Execute test files without running test callbacks. `collect` returns unhandled errors and an array of [test modules](/api/advanced/test-module). It accepts string filters to match the test files - these are the same filters that [CLI supports](/guide/filtering#cli).
+Based on `staticParse`, this will either statically analyse test files to collect them (the default) or run the code without executing test callbacks. `collect` returns unhandled errors and an array of [test modules](/api/advanced/test-module). It accepts string filters to match the test files - these are the same filters that [CLI supports](/guide/filtering#cli).
 
 This method resolves tests specifications based on the config `include`, `exclude`, and `includeSource` values. Read more at [`project.globTestFiles`](/api/advanced/test-project#globtestfiles). If `--changed` flag was specified, the list will be filtered to include only files that changed.
 
 ::: warning
-Note that Vitest doesn't use static analysis to collect tests. Vitest will run every test file in isolation, just like it runs regular tests.
-
-This makes this method very slow, unless you disable isolation before collecting tests.
+Note that since Vitest 5, the tests are collected by static analysis by default. If disabled via the second option, Vitest will run every test file in isolation, just like it runs regular tests. This would make this method very slow, unless you disable isolation manually before collecting tests.
 :::
 
 ## start

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -121,7 +121,7 @@ tests/test1.test.ts
 tests/test2.test.ts
 ```
 
-Since Vitest 4.1, you may pass `--static-parse` to [parse test files](/api/advanced/vitest#parsespecifications) instead of running them to collect tests. Vitest parses test files with limited concurrency, defaulting to `os.availableParallelism()`. You can change it via the `--static-parse-concurrency` option.
+Since Vitest 5, `vitest list` [parses test files](/api/advanced/vitest#parsespecifications) statically instead of running them to collect tests. Pass `--no-static-parse` to run the files instead. Vitest parses test files with limited concurrency, defaulting to `os.availableParallelism()`. You can change it via the `--static-parse-concurrency` option.
 
 ### `vitest doctor`
 

--- a/packages/vitest/src/node/cli/cli-api.ts
+++ b/packages/vitest/src/node/cli/cli-api.ts
@@ -30,12 +30,12 @@ export interface CliOptions extends UserConfig {
   filesOnly?: boolean
   /**
    * Parse files statically instead of running them to collect tests
-   * @experimental
+   * @default true
    */
   staticParse?: boolean
   /**
    * How many tests to process at the same time
-   * @experimental
+   * @default os.availableParallelism()
    */
   staticParseConcurrency?: number
 

--- a/packages/vitest/src/node/cli/cli-config.ts
+++ b/packages/vitest/src/node/cli/cli-config.ts
@@ -1023,7 +1023,8 @@ export const collectCliOptionsConfig: VitestCLIOptions = {
     description: 'Print only test files with out the test cases',
   },
   staticParse: {
-    description: 'Parse files statically instead of running them to collect tests (default: false)',
+    description: 'Parse files statically instead of running them to collect tests (default: true)',
+    default: true,
   },
   staticParseConcurrency: {
     description: 'How many tests to process at the same time (default: os.availableParallelism())',

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -762,7 +762,7 @@ export class Vitest {
     })
   }
 
-  async collect(filters?: string[], options?: { staticParse?: boolean; staticParseConcurrency?: number }): Promise<TestRunResult> {
+  async collect(filters?: string[], options: { staticParse?: boolean; staticParseConcurrency?: number } = {}): Promise<TestRunResult> {
     return this._traces.$('vitest.collect', async (collectSpan) => {
       const filenamePattern = filters && filters?.length > 0 ? filters : []
       collectSpan.setAttribute('vitest.collect.filters', filenamePattern)
@@ -790,7 +790,7 @@ export class Vitest {
         return { testModules: [], unhandledErrors: [] }
       }
 
-      if (options?.staticParse) {
+      if (options.staticParse !== false) {
         const testModules = await this.experimental_parseSpecifications(files, {
           concurrency: options.staticParseConcurrency,
         })

--- a/test/e2e/test/__snapshots__/list.test.ts.snap
+++ b/test/e2e/test/__snapshots__/list.test.ts.snap
@@ -29,6 +29,16 @@ exports[`correctly outputs all tests with args: "--browser.enabled" 1`] = `
 "
 `;
 
+exports[`correctly outputs all tests with args: "--no-static-parse" 1`] = `
+"basic.test.ts > basic suite > inner suite > some test
+basic.test.ts > basic suite > inner suite > another test
+basic.test.ts > basic suite > basic test
+basic.test.ts > outside test
+math.test.ts > 1 plus 1
+math.test.ts > failing test
+"
+`;
+
 exports[`correctly outputs all tests with args: "--pool=forks" 1`] = `
 "basic.test.ts > basic suite > inner suite > some test
 basic.test.ts > basic suite > inner suite > another test
@@ -59,24 +69,14 @@ math.test.ts > failing test
 "
 `;
 
-exports[`correctly outputs all tests with args: "--static-parse" 1`] = `
+exports[`correctly outputs all tests with args: "--typecheck" 1`] = `
 "basic.test.ts > basic suite > inner suite > some test
 basic.test.ts > basic suite > inner suite > another test
 basic.test.ts > basic suite > basic test
 basic.test.ts > outside test
 math.test.ts > 1 plus 1
 math.test.ts > failing test
-"
-`;
-
-exports[`correctly outputs all tests with args: "--typecheck" 1`] = `
-"type.test-d.ts > 1 plus 1
-basic.test.ts > basic suite > inner suite > some test
-basic.test.ts > basic suite > inner suite > another test
-basic.test.ts > basic suite > basic test
-basic.test.ts > outside test
-math.test.ts > 1 plus 1
-math.test.ts > failing test
+type.test-d.ts > 1 plus 1
 "
 `;
 

--- a/test/e2e/test/list.test.ts
+++ b/test/e2e/test/list.test.ts
@@ -9,7 +9,7 @@ test.each([
   ['--browser.enabled'],
   ['--typecheck'],
   ['--typecheck.only'],
-  ['--static-parse'],
+  ['--no-static-parse'],
 ])('correctly outputs all tests with args: "%s"', async (...args) => {
   const { stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', ...args)
   expect(stdout).toMatchSnapshot()
@@ -21,7 +21,7 @@ test.each([
   ['json', '--json'],
   ['json with a file', '--json=./list.json'],
 ])('%s output shows error', async (_, ...args) => {
-  const { stderr, stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', '-c=fail.config.ts', ...args)
+  const { stderr, stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', '-c=fail.config.ts', '--no-static-parse', ...args)
   expect(stdout).toBe('')
   expect(stderr).toMatchSnapshot()
   expect(exitCode).toBe(1)
@@ -33,27 +33,51 @@ test('correctly outputs json', async () => {
     "[
       {
         "name": "basic suite > inner suite > some test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 5,
+          "column": 5
+        }
       },
       {
         "name": "basic suite > inner suite > another test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 9,
+          "column": 5
+        }
       },
       {
         "name": "basic suite > basic test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 14,
+          "column": 3
+        }
       },
       {
         "name": "outside test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 19,
+          "column": 1
+        }
       },
       {
         "name": "1 plus 1",
-        "file": "<root>/fixtures/list/math.test.ts"
+        "file": "<root>/fixtures/list/math.test.ts",
+        "location": {
+          "line": 5,
+          "column": 1
+        }
       },
       {
         "name": "failing test",
-        "file": "<root>/fixtures/list/math.test.ts"
+        "file": "<root>/fixtures/list/math.test.ts",
+        "location": {
+          "line": 9,
+          "column": 1
+        }
       }
     ]
     "
@@ -88,27 +112,51 @@ test('correctly saves json', async () => {
     "[
       {
         "name": "basic suite > inner suite > some test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 5,
+          "column": 5
+        }
       },
       {
         "name": "basic suite > inner suite > another test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 9,
+          "column": 5
+        }
       },
       {
         "name": "basic suite > basic test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 14,
+          "column": 3
+        }
       },
       {
         "name": "outside test",
-        "file": "<root>/fixtures/list/basic.test.ts"
+        "file": "<root>/fixtures/list/basic.test.ts",
+        "location": {
+          "line": 19,
+          "column": 1
+        }
       },
       {
         "name": "1 plus 1",
-        "file": "<root>/fixtures/list/math.test.ts"
+        "file": "<root>/fixtures/list/math.test.ts",
+        "location": {
+          "line": 5,
+          "column": 1
+        }
       },
       {
         "name": "failing test",
-        "file": "<root>/fixtures/list/math.test.ts"
+        "file": "<root>/fixtures/list/math.test.ts",
+        "location": {
+          "line": 9,
+          "column": 1
+        }
       }
     ]"
   `)


### PR DESCRIPTION
`vitest list` and `vitest.collect()` now collect tests with static analysis by default instead of running the test files. Pass `--no-static-parse` (or `staticParse: false`) to keep the old behaviour.

The list tests that check runtime collection errors now pass `--no-static-parse` explicitly; the previous `--static-parse` case is replaced with `--no-static-parse` so both modes stay covered.