### PR TITLE
perf(expect): lazily format spy matcher failures

### DIFF
--- a/packages/expect/src/jest-expect.ts
+++ b/packages/expect/src/jest-expect.ts
@@ -608,14 +608,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const pass = spy.mock.calls.some(callArg => equalsArgumentArray(callArg, args))
     const isNot = utils.flag(this, 'negate') as boolean
 
-    const msg = utils.getMessage(this, [
-      pass,
-      `expected "${spyName}" to be called with arguments: #{exp}`,
-      `expected "${spyName}" to not be called with arguments: #{exp}`,
-      args,
-    ])
-
     if ((pass && isNot) || (!pass && !isNot)) {
+      const msg = utils.getMessage(this, [
+        pass,
+        `expected "${spyName}" to be called with arguments: #{exp}`,
+        `expected "${spyName}" to not be called with arguments: #{exp}`,
+        args,
+      ])
       throw new AssertionError(formatCalls(spy, msg, args))
     }
   })
@@ -627,14 +626,13 @@ export const JestChaiExpect: ChaiPlugin = (chai, utils) => {
     const pass = hasCallWithArgs && callCount === 1
     const isNot = utils.flag(this, 'negate') as boolean
 
-    const msg = utils.getMessage(this, [
-      pass,
-      `expected "${spyName}" to be called once with arguments: #{exp}`,
-      `expected "${spyName}" to not be called once with arguments: #{exp}`,
-      args,
-    ])
-
     if ((pass && isNot) || (!pass && !isNot)) {
+      const msg = utils.getMessage(this, [
+        pass,
+        `expected "${spyName}" to be called once with arguments: #{exp}`,
+        `expected "${spyName}" to not be called once with arguments: #{exp}`,
+        args,
+      ])
       throw new AssertionError(formatCalls(spy, msg, args))
     }
   })


### PR DESCRIPTION
Note from real person. Using sol to generate this, but it seems like a pretty straight forward lazy win.

### Description

Codex assisted with this PR; I reviewed the changes and benchmark results.

`toHaveBeenCalledWith` and `toHaveBeenCalledExactlyOnceWith` were formatting their expected arguments even when the assertion passed. This moves message formatting into the existing failure branches without changing equality or failure output.

| Payload | Matcher | Before | After | Matcher time saved |
|---|---|---:|---:|---:|
| React `SyntheticEvent` | `toHaveBeenCalledWith` | 383,944/s | 703,818/s | 45.4% |
| React `SyntheticEvent` | `toHaveBeenCalledExactlyOnceWith` | 385,298/s | 711,024/s | 45.8% |
| 100-field object | `toHaveBeenCalledWith` | 251,809/s | 716,349/s | 64.8% |
| 100-field object | `toHaveBeenCalledExactlyOnceWith` | 251,694/s | 715,157/s | 64.8% |

Measured on Node 26.8.1 with 10 samples of 20,000 passing assertions after a 5,000-assertion warmup.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-on-pull-requests/collaborating-on-repositories-with-code-quality-features/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
