### PR TITLE
fix(expect): do not leak subset equality into asymmetric matchers

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -630,13 +630,24 @@ export function subsetEquality(
 
             seenReferences.set(subset[key], true)
           }
+          // an asymmetric matcher runs its own comparison, and subset
+          // semantics must not leak into it: inside `arrayContaining`, for
+          // one, the sample is compared as the left-hand side, so a subset
+          // tester would let an actual element satisfy a sample that has
+          // more fields than it
           const result
             = object != null
               && hasPropertyInObject(object, key)
-              && equals(object[key], subset[key], [
-                ...filteredCustomTesters,
-                subsetEqualityWithContext(seenReferences),
-              ])
+              && equals(
+                object[key],
+                subset[key],
+                isAsymmetric(subset[key])
+                  ? filteredCustomTesters
+                  : [
+                      ...filteredCustomTesters,
+                      subsetEqualityWithContext(seenReferences),
+                    ],
+              )
           // The main goal of using seenReference is to avoid circular node on tree.
           // It will only happen within a parent and its child, not a node and nodes next to it (same level)
           // We should keep the reference for a parent and its child only

--- a/test/unit/test/expect.test.ts
+++ b/test/unit/test/expect.test.ts
@@ -795,3 +795,42 @@ describe('Standard Schema', () => {
     })
   })
 })
+
+// https://github.com/vitest-dev/vitest/issues/11071
+describe('asymmetric matchers nested in toMatchObject', () => {
+  test('arrayContaining does not ignore fields of the expected element', () => {
+    expect(() =>
+      expect({ records: [{ id: 1 }] }).toMatchObject({
+        records: expect.arrayContaining([{ id: 1, required: 'missing' }]),
+      }),
+    ).toThrow()
+
+    expect({ records: [{ id: 1, required: 'present' }] }).toMatchObject({
+      records: expect.arrayContaining([{ id: 1, required: 'present' }]),
+    })
+  })
+
+  test('arrayContaining still allows extra fields on the actual element', () => {
+    expect({ records: [{ id: 1, extra: true }] }).toMatchObject({
+      records: expect.arrayContaining([{ id: 1, extra: true }]),
+    })
+  })
+
+  test('nested plain objects keep subset semantics', () => {
+    expect({ user: { name: 'John', age: 30 } }).toMatchObject({
+      user: { name: 'John' },
+    })
+  })
+
+  test('objectContaining is unaffected', () => {
+    expect({ user: { name: 'John', age: 30 } }).toMatchObject({
+      user: expect.objectContaining({ name: 'John' }),
+    })
+
+    expect(() =>
+      expect({ user: { name: 'John' } }).toMatchObject({
+        user: expect.objectContaining({ name: 'John', age: 30 }),
+      }),
+    ).toThrow()
+  })
+})


### PR DESCRIPTION
### Description

`toMatchObject` compares with `subsetEquality`, which passes itself down as a custom tester so that nested plain objects keep subset semantics. That tester was also handed to any asymmetric matcher found in the expected object — and a matcher runs its own comparison with whatever testers it is given.

`ArrayContaining` compares its sample as the left-hand side ([`equals(item, another, customTesters)`](https://github.com/vitest-dev/vitest/blob/main/packages/expect/src/jest-asymmetric-matchers.ts#L212)), so with a subset tester in play an actual element only had to be a *subset* of the sample. Every field the sample declared beyond those present on the actual element was ignored:

```ts
expect({ records: [{ id: 1 }] }).toMatchObject({
  records: expect.arrayContaining([{ id: 1, required: 'must not match without this' }]),
})
// passes — but the actual record has no `required` field
```

Jest fails this correctly, because its matchers use the testers they were constructed with rather than ones propagated into them.

Reported in #11071 by @KalininAndreyVictorovich.

### The fix

`subsetEquality` no longer adds its own recursive tester when the expected value at a key is an asymmetric matcher. The matcher then compares with the plain testers, as it does outside `toMatchObject`.

Deliberately scoped so that nothing else moves:

- nested **plain** objects keep subset semantics
- an actual element may still carry **extra** fields the sample does not mention
- `objectContaining`, which does its own subset-style check, is unaffected

### How I verified it

Four tests in `test/unit/test/expect.test.ts`. The first fails without this change (`expected [Function] to throw an error`) and passes with it; the other three pass **both** with and without, which is the point — they pin the behaviour that must *not* change.

`vitest run --root test/unit test/expect.test.ts test/diff.test.ts` → 237 passed, 3 expected fail, 0 failures. The full `test/unit` suite is also clean against this change: the only failures on my machine are `@vitest/web-worker` resolution (a package I had not built locally) and one `jsdom-options` timeout that passes in isolation at 3.0s against a 5s limit — neither touches matcher behaviour.

`eslint` is clean on both changed files.
