### PR TITLE
fix: don't duplicte `oxc.target` if user provides a custom array

### DIFF
--- a/packages/vitest/src/node/plugins/config.ts
+++ b/packages/vitest/src/node/plugins/config.ts
@@ -72,27 +72,18 @@ export function ViteConfigPlugin(harness: PluginHarness): Plugin[] {
           },
         }
 
-        if ('rolldownVersion' in vite) {
-          // eslint-disable-next-line ts/ban-ts-comment
-          // @ts-ignore rolldown-vite only
-          config.oxc = viteConfig.oxc === false
-            ? false
-            : {
-                // eslint-disable-next-line ts/ban-ts-comment
-                // @ts-ignore rolldown-vite only
-                target: viteConfig.oxc?.target || 'node18',
-              }
+        if (viteConfig.oxc !== false) {
+          viteConfig.oxc ??= {}
+          // Lowest target Vitest supports is Node22
+          viteConfig.oxc.target ??= 'node22'
         }
-        else {
-          config.esbuild = viteConfig.esbuild === false
-            ? false
-            : {
-                // Lowest target Vitest supports is Node18
-                target: viteConfig.esbuild?.target || 'node18',
-                sourcemap: 'external',
-                // Enables using ignore hint for coverage providers with @preserve keyword
-                legalComments: 'inline',
-              }
+        if (!('rolldownVersion' in vite) && viteConfig.esbuild !== false) {
+          viteConfig.esbuild ??= {}
+          // Lowest target Vitest supports is Node22
+          viteConfig.esbuild.target ??= 'node22'
+          viteConfig.esbuild.sourcemap = 'external'
+          // Enables using ignore hint for coverage providers with @preserve keyword
+          viteConfig.esbuild.legalComments = 'inline'
         }
 
         const classNameStrategy

--- a/test/e2e/test/bail-race.test.ts
+++ b/test/e2e/test/bail-race.test.ts
@@ -6,7 +6,7 @@ import { StableTestFileOrderSorter } from '../../test-utils'
 test('cancels previous run before starting new one', async () => {
   const errors: unknown[] = []
 
-  const vitest = await createVitest('test', {
+  const vitest = await createVitest({
     maxWorkers: 1,
     maxConcurrency: 1,
     watch: false,

--- a/test/e2e/test/public.test.ts
+++ b/test/e2e/test/public.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'pathe'
 import { expect, test } from 'vitest'
 import { configDefaults } from 'vitest/config'
 import { resolveConfig } from 'vitest/node'
+import { resolveTestConfig } from '#test-utils'
 
 test('resolves the test config', async () => {
   const viteConfig = await resolveConfig()
@@ -139,4 +140,21 @@ test('coverage.changed inherits from test.changed but can be overridden', async 
   })
 
   expect(overridden.coverage.changed).toBe(false)
+})
+
+test('user oxc.target as array doesn\'t break config resolution', async () => {
+  const { config } = await resolveTestConfig({
+    $viteConfig: {
+      oxc: {
+        target: ['chrome121', 'firefox118'],
+      },
+      esbuild: {
+        target: ['chrome121', 'firefox118'],
+      },
+    },
+  })
+  expect.assert(config.oxc !== false)
+  expect.assert(config.esbuild !== false)
+  expect(config.oxc.target).toEqual(['chrome121', 'firefox118'])
+  expect(config.esbuild.target).toEqual(['chrome121', 'firefox118'])
 })


### PR DESCRIPTION
Fixes #11035