### PR TITLE
fix(vm): link module graphs one at a time

### DIFF
--- a/packages/vitest/src/runtime/vm/esm-executor.ts
+++ b/packages/vitest/src/runtime/vm/esm-executor.ts
@@ -92,6 +92,7 @@ export class EsmExecutor {
   private moduleCache = new Map<string, VMModule | Promise<VMModule>>()
 
   private esmLinkMap = new WeakMap<VMModule, Promise<void>>()
+  private linkQueue: Promise<void> = Promise.resolve()
   private context: vm.Context
 
   #httpIp = IPnumber('127.0.0.0')
@@ -109,16 +110,7 @@ export class EsmExecutor {
     if (m.status === 'errored') {
       throw m.error
     }
-    if (m.status === 'unlinked') {
-      this.esmLinkMap.set(
-        m,
-        m.link((identifier, referencer) =>
-          this.executor.resolveModule(identifier, referencer.identifier),
-        ),
-      )
-    }
-
-    await this.esmLinkMap.get(m)
+    await this.linkModule(m)
 
     if (m.status === 'linked') {
       await m.evaluate()
@@ -126,6 +118,31 @@ export class EsmExecutor {
 
     return m
   }
+
+  // Roots are linked one at a time: Node's link() does not wait for a
+  // dependency that another root is still linking, and instantiate() then
+  // fails on it. Sharing the queue with all roots keeps cycle handling to
+  // Node's own single-root linker, which never has to wait.
+  private linkModule(m: VMModule): Promise<void> {
+    const pending = this.esmLinkMap.get(m)
+    if (pending) {
+      return pending
+    }
+    if (m.status !== 'unlinked' && m.status !== 'linking') {
+      return Promise.resolve()
+    }
+    const linking = this.linkQueue.then(() => {
+      if (m.status === 'unlinked') {
+        return m.link(this.linker)
+      }
+    })
+    this.esmLinkMap.set(m, linking)
+    this.linkQueue = linking.catch(() => {})
+    return linking
+  }
+
+  private linker = (identifier: string, referencer: VMModule): Promise<VMModule> =>
+    this.executor.resolveModule(identifier, referencer.identifier)
 
   public async createEsModule(
     fileURL: string,

--- a/test/e2e/test/vm-threads.test.ts
+++ b/test/e2e/test/vm-threads.test.ts
@@ -102,6 +102,43 @@ test('vm pools report errors from modules covered by the graph prewarm', async (
   expect(stderr).toContain('does-not-exist.js')
 })
 
+// Node's link() does not wait for a dependency that another root is still
+// linking. The shared module needs an import that resolves asynchronously
+// (here a Vite-transformed stylesheet) to open the window
+test.for(['vmThreads', 'vmForks'] as const)(
+  '%s links a dependency shared by concurrent imports once',
+  async (pool) => {
+    const { stderr, exitCode } = await runInlineTests({
+      'node_modules/shared-dep/package.json': JSON.stringify({
+        name: 'shared-dep',
+        type: 'module',
+        exports: { './a': './a.js', './b': './b.js' },
+      }),
+      'node_modules/shared-dep/a.js': `export { value } from './shared.js'; export const fromA = 'a'`,
+      'node_modules/shared-dep/b.js': `export { value } from './shared.js'; export const fromB = 'b'`,
+      'node_modules/shared-dep/shared.js': `import './style.css'; export const value = 'shared'`,
+      'node_modules/shared-dep/style.css': `.a { color: red }`,
+      'basic.test.js': `
+        import { expect, test } from 'vitest'
+
+        test('concurrent imports share a dependency', async () => {
+          const [a, b] = await Promise.all([
+            import('shared-dep/a'),
+            import('shared-dep/b'),
+          ])
+          expect(a.fromA).toBe('a')
+          expect(b.fromB).toBe('b')
+          expect(a.value).toBe('shared')
+          expect(b.value).toBe('shared')
+        })
+      `,
+    }, { pool })
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+  },
+)
+
 // The module-sync condition was added in Node 22.12/20.19 when require(esm)
 // was unflagged. The fix uses the _resolveFilename conditions option which
 // is only available on Node 22.12+. Node 20 is unfixable and reaches EOL


### PR DESCRIPTION
Two concurrent `import()`s of modules that share a dependency fail in `vmThreads`/`vmForks` with `request for '<dep>' can not be resolved on module '<importer>' that is not linked` when the shared module has an import that resolves asynchronously (a Vite-transformed stylesheet, `.wasm`, a network module).

Node's `link()` does not wait for a dependency that another root is still linking, so the second root's `instantiate()` throws. Root modules are now linked one at a time; evaluation is not serialized. Node's own single-root linker keeps handling cycles.

Same class of bug as jestjs/jest#16394. Vitest does not need the sync walk for `import()`, so the fix stays on the async path and covers Node 22.