### PR TITLE
docs: document TZ limitation in thread pools

### DIFF
--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -8,3 +8,7 @@ outline: deep
 - **Type:** `Partial<NodeJS.ProcessEnv>`
 
 Environment variables available on `process.env` and `import.meta.env` during tests. These variables will not be available in the main process (in `globalSetup`, for example).
+
+::: warning
+`TZ` set here does not change the time zone in `threads` and `vmThreads` pools. See [Time Zone Does Not Change in Worker Threads](/guide/common-errors#time-zone-does-not-change-in-worker-threads).
+:::

--- a/docs/config/pool.md
+++ b/docs/config/pool.md
@@ -13,7 +13,7 @@ Pool used to run tests in.
 
 ## threads
 
-Enable multi-threading. When using threads you are unable to use process related APIs such as `process.chdir()`. Some libraries written in native languages, such as `Prisma`, `bcrypt` and `canvas`, have problems when running in multiple threads and run into segfaults. In these cases it is advised to use `forks` pool instead.
+Enable multi-threading. When using threads you are unable to use process related APIs such as `process.chdir()`. Changing `process.env.TZ` [does not affect the time zone](/guide/common-errors#time-zone-does-not-change-in-worker-threads) in a worker thread. Some libraries written in native languages, such as `Prisma`, `bcrypt` and `canvas`, have problems when running in multiple threads and run into segfaults. In these cases it is advised to use `forks` pool instead.
 
 ## forks
 

--- a/docs/guide/common-errors.md
+++ b/docs/guide/common-errors.md
@@ -122,6 +122,37 @@ vitest --pool=forks
 ```
 :::
 
+## Time Zone Does Not Change in Worker Threads
+
+Setting `process.env.TZ` in a setup file or in a test, or setting `TZ` via [`env`](/config/env), has no effect on `Date` in `pool: 'threads'` and `pool: 'vmThreads'`. Node.js applies `TZ` only when the main thread sets it. A worker thread sees the new value on `process.env`, but keeps the time zone of the main process.
+
+```ts
+process.env.TZ = 'Asia/Tokyo'
+new Date('2026-01-01T00:00:00Z').getHours() // 9 in forks, unchanged in threads
+```
+
+Set the time zone before workers start. Use the shell, the config file, or [`globalSetup`](/config/globalsetup); all of them run in the main process and work in every pool.
+
+::: code-group
+```bash [CLI]
+TZ=Asia/Tokyo vitest
+```
+```ts [vitest.config.js]
+import { defineConfig } from 'vitest/config'
+
+process.env.TZ = 'Asia/Tokyo'
+
+export default defineConfig({})
+```
+```ts [globalSetup.js]
+export default function () {
+  process.env.TZ = 'Asia/Tokyo'
+}
+```
+:::
+
+If tests need different time zones at runtime, use `pool: 'forks'` or `pool: 'vmForks'`, where each worker is a separate process, or pass the `timeZone` option to `Intl.DateTimeFormat` instead of changing `TZ`.
+
 ## Unhandled Promise Rejection
 
 This error happens when a Promise rejects but no `.catch()` handler or `await` is attached to it before the microtask queue flushes. This behavior comes from JavaScript itself and is not specific to Vitest. Learn more in the [Node.js documentation](https://nodejs.org/api/process.html#event-unhandledrejection).


### PR DESCRIPTION
## Description

Node.js does not apply `process.env.TZ` in a worker thread, so setting it in `env`, a setup file, or a test has no effect on `Date` in `threads` and `vmThreads` pools.

Adds a "Common Errors" section with the cause and the fixes (shell, config file, `globalSetup`), and links to it from the `env` and `pool` config pages.