### PR TITLE
fix(expect): fix `toMatchObject` with asymmetric matchers

### DIFF
--- a/packages/expect/src/jest-utils.ts
+++ b/packages/expect/src/jest-utils.ts
@@ -77,12 +77,18 @@ function asymmetricMatch(a: any, b: any, customTesters: Array<Tester>) {
     return undefined
   }
 
+  // subset equality is directional: it asks whether the second argument is
+  // contained in the first. A matcher runs its own comparison and may pass its
+  // sample as the first argument (`arrayContaining` does), which would flip
+  // that question around, so it must not inherit a subset tester.
+  const testers = customTesters.filter(tester => !isSubsetEqualityTester(tester))
+
   if (asymmetricA) {
-    return a.asymmetricMatch(b, customTesters)
+    return a.asymmetricMatch(b, testers)
   }
 
   if (asymmetricB) {
-    return b.asymmetricMatch(a, customTesters)
+    return b.asymmetricMatch(a, testers)
   }
 }
 
@@ -604,6 +610,19 @@ function isObjectWithKeys(a: any) {
   )
 }
 
+const subsetEqualityTesters = new WeakSet<Tester>()
+
+function registerSubsetEqualityTester<T extends (...args: any[]) => any>(
+  tester: T,
+): T {
+  subsetEqualityTesters.add(tester as unknown as Tester)
+  return tester
+}
+
+function isSubsetEqualityTester(tester: Tester): boolean {
+  return tester === subsetEquality || subsetEqualityTesters.has(tester)
+}
+
 export function subsetEquality(
   object: unknown,
   subset: unknown,
@@ -617,7 +636,7 @@ export function subsetEquality(
   // there are circular references in the subset passed to it.
   const subsetEqualityWithContext
     = (seenReferences: WeakMap<object, boolean> = new WeakMap()) =>
-      (object: any, subset: any): boolean | undefined => {
+      registerSubsetEqualityTester((object: any, subset: any): boolean | undefined => {
         if (!isObjectWithKeys(subset)) {
           return undefined
         }
@@ -645,7 +664,7 @@ export function subsetEquality(
           seenReferences.delete(subset[key])
           return result
         })
-      }
+      })
 
   return subsetEqualityWithContext()(object, subset)
 }

--- a/test/unit/test/jest-expect.test.ts
+++ b/test/unit/test/jest-expect.test.ts
@@ -226,6 +226,35 @@ describe('jest-expect', () => {
     )
   })
 
+  // https://github.com/vitest-dev/vitest/issues/11071
+  it('asymmetric matchers do not inherit subset equality', () => {
+    // `toMatchObject` compares with `subsetEquality`, which is directional.
+    // An asymmetric matcher runs its own comparison and `arrayContaining`
+    // passes its sample as the left-hand side, so forwarding a subset tester
+    // made the sample the "object" and the actual element the "subset" --
+    // every field the sample declared beyond the actual element was ignored.
+    expect({ records: [{ id: 1 }] }).not.toMatchObject({
+      records: expect.arrayContaining([{ id: 1, required: 'x' }]),
+    })
+    expect([{ id: 1 }]).not.toMatchObject(
+      expect.arrayContaining([{ id: 1, required: 'x' }]),
+    )
+
+    // an actual element still has to match the sample exactly, and extra
+    // fields on it are still not allowed
+    expect({ records: [{ id: 1, required: 'x' }] }).toMatchObject({
+      records: expect.arrayContaining([{ id: 1, required: 'x' }]),
+    })
+    expect({ records: [{ id: 1, extra: true }] }).not.toMatchObject({
+      records: expect.arrayContaining([{ id: 1 }]),
+    })
+
+    // nested plain objects in the expected value keep subset semantics
+    expect({ user: { name: 'John', age: 30 } }).toMatchObject({
+      user: { name: 'John' },
+    })
+  })
+
   it('asymmetric matchers negate', () => {
     expect('bar').toEqual(expect.not.stringContaining('zoo'))
     expect('bar').toEqual(expect.not.stringMatching(/zoo/))


### PR DESCRIPTION
### Description

Written by an AI agent (Claude Code) on behalf of @ShreeBohara, who has reviewed it.

Resolves #11071

`toMatchObject` compares with `subsetEquality`, which is directional — it asks whether its second argument is contained in its first. That tester was forwarded into any asymmetric matcher found in the expected value.

`ArrayContaining` compares its sample as the left-hand side ([`equals(item, another, customTesters)`](https://github.com/vitest-dev/vitest/blob/main/packages/expect/src/jest-asymmetric-matchers.ts#L212)), so the sample became the "object" and the actual element the "subset". Every field the sample declared beyond those present on the actual element was ignored:

```js
// passed before this change
expect({ records: [{ id: 1 }] }).toMatchObject({
  records: expect.arrayContaining([{ id: 1, required: 'x' }]),
})
```

The fix filters subset testers out where they are handed to a matcher, in `asymmetricMatch`. One detail made this less obvious than it looks: the contextual testers `subsetEquality` spawns for circular-reference tracking are fresh closures rather than the exported function, so filtering by `tester !== subsetEquality` alone does not remove them. They are registered as they are created and matched by identity.

Doing it in `asymmetricMatch` rather than at the `subsetEquality` recursion covers the case where the matcher is the root expected value and the exported `subsetEquality` arrives directly from `toMatchObject`:

```js
// also passed before this change
expect([{ id: 1 }]).toMatchObject(
  expect.arrayContaining([{ id: 1, required: 'x' }]),
)
```

Testers that are not subset testers still reach matchers, so `iterableEquality` and the `toStrictEqual` testers behave as before — the existing `asymmetric matchers and equality testers` test covers that and still passes.

I checked the resulting behaviour against `jest` `expect@30.2` across the nested and root forms, `Set`/`Map` elements, `expect.any`, extra fields on the actual element, `objectContaining`, and plain subset matching. All of them agree.

### Note on #11093

[#11093](https://github.com/vitest-dev/vitest/pull/11093) was opened first for the same issue and takes the narrower approach of skipping the subset tester inside the `subsetEquality` recursion. That fixes the nested form; applying it locally, the root-level form above still passes. Mentioning it so you can take whichever shape you prefer rather than reviewing these blind — no criticism of that PR intended.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

`test/unit` passes (7657 tests), `tsc -p tsconfig.check.json` and eslint are clean. In `pnpm test:ci` the only failures are in `test/coverage-test`: 38 files fail with `browserType.launch: Executable doesn't exist` because Playwright browsers are not installed locally, and `on-failure.test.ts` contains a deliberately failing fixture. I have not been able to run the browser-mode coverage tests.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

No new functionality; this restores the documented `toMatchObject` behaviour.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
