### PR TITLE
fix(browser): report the action error when a task times out

### DIFF
--- a/packages/browser-playwright/src/locators.ts
+++ b/packages/browser-playwright/src/locators.ts
@@ -1,11 +1,7 @@
 import type {
-  UserEventClearOptions,
   UserEventClickOptions,
   UserEventDragAndDropOptions,
-  UserEventFillOptions,
   UserEventHoverOptions,
-  UserEventSelectOptions,
-  UserEventUploadOptions,
 } from 'vitest/browser'
 import {
   getByAltTextSelector,
@@ -17,7 +13,6 @@ import {
   getByTitleSelector,
   getIframeScale,
   Locator,
-  processTimeoutOptions,
   selectorEngine,
 } from '@vitest/browser/locators'
 import { page, server } from 'vitest/browser'
@@ -29,47 +24,23 @@ class PlaywrightLocator extends Locator {
   }
 
   public override click(options?: UserEventClickOptions) {
-    return super.click(processTimeoutOptions(processClickOptions(options)))
+    return super.click(processClickOptions(options))
   }
 
   public override dblClick(options?: UserEventClickOptions): Promise<void> {
-    return super.dblClick(processTimeoutOptions(processClickOptions(options)))
+    return super.dblClick(processClickOptions(options))
   }
 
   public override tripleClick(options?: UserEventClickOptions): Promise<void> {
-    return super.tripleClick(processTimeoutOptions(processClickOptions(options)))
-  }
-
-  public override selectOptions(
-    value: HTMLElement | HTMLElement[] | Locator | Locator[] | string | string[],
-    options?: UserEventSelectOptions,
-  ): Promise<void> {
-    return super.selectOptions(value, processTimeoutOptions(options))
-  }
-
-  public override clear(options?: UserEventClearOptions): Promise<void> {
-    return super.clear(processTimeoutOptions(options))
+    return super.tripleClick(processClickOptions(options))
   }
 
   public override hover(options?: UserEventHoverOptions): Promise<void> {
-    return super.hover(processTimeoutOptions(processHoverOptions(options)))
-  }
-
-  public override upload(
-    files: string | string[] | File | File[],
-    options?: UserEventUploadOptions,
-  ): Promise<void> {
-    return super.upload(files, processTimeoutOptions(options))
-  }
-
-  public override fill(text: string, options?: UserEventFillOptions): Promise<void> {
-    return super.fill(text, processTimeoutOptions(options))
+    return super.hover(processHoverOptions(options))
   }
 
   public override dropTo(target: Locator, options?: UserEventDragAndDropOptions): Promise<void> {
-    return super.dropTo(target, processTimeoutOptions(
-      processDragAndDropOptions(options),
-    ))
+    return super.dropTo(target, processDragAndDropOptions(options))
   }
 
   protected locator(selector: string) {

--- a/packages/browser/src/client/tester/action.ts
+++ b/packages/browser/src/client/tester/action.ts
@@ -77,7 +77,7 @@ class Action<T = void> implements Promise<T> {
     )
     const deadline = getBrowserState().runner._deadline
     return deadline && timeout != null
-      ? deadline.track(this.command.slice('__vitest_'.length), promise, timeout)
+      ? deadline.track(this.command.slice('__vitest_'.length), promise, timeout, this._errorSource)
       : promise
   }
 

--- a/packages/browser/src/client/tester/action.ts
+++ b/packages/browser/src/client/tester/action.ts
@@ -1,0 +1,158 @@
+import type { SerializedLocator } from './locators'
+import { getBrowserState, getWorkerState } from '../utils'
+
+export interface ActionOptions {
+  timeout?: number
+}
+
+// an array gets the options appended; a factory receives them and builds the full argument list
+type ActionArguments = unknown[] | ((options: ActionOptions | undefined) => Promise<unknown[]>)
+
+/** explicit option, then the provider default, then the remaining task time */
+export function resolveActionTimeout(options?: ActionOptions): number | undefined {
+  if (options?.timeout != null) {
+    return options.timeout
+  }
+  if (getWorkerState().config.browser.providerOptions.actionTimeout != null) {
+    return undefined
+  }
+  return getBrowserState().runner._deadline?.derive()
+}
+
+/**
+ * @deprecated the timeout is derived by the action itself; pass the options through unchanged
+ */
+export function processTimeoutOptions<T extends { timeout?: number }>(options?: T): T | undefined {
+  const timeout = resolveActionTimeout(options)
+  if (timeout == null) {
+    return options
+  }
+  return { ...options, timeout } as T
+}
+
+/**
+ * A browser command that the test awaits. The action derives its own timeout
+ * from the running task, so it fails with a descriptive error before the task does.
+ */
+class Action<T = void> implements Promise<T> {
+  public readonly [Symbol.toStringTag] = 'Action'
+  private _promise: Promise<T> | undefined
+  private _awaited = false
+  private readonly _errorSource: Error
+
+  constructor(
+    private readonly command: string,
+    private readonly args: ActionArguments,
+    private readonly options: ActionOptions | undefined,
+    errorSource?: Error,
+  ) {
+    this._errorSource = errorSource ?? new Error('STACK_TRACE_ERROR')
+    const test = getWorkerState().current
+    if (errorSource || !test || test.type !== 'test') {
+      this._promise = this.run()
+      return
+    }
+    test.onFinished ??= []
+    test.onFinished.push(() => {
+      if (!this._awaited) {
+        const error = new Error(
+          `The call was not awaited. This method is asynchronous and must be awaited; otherwise, the call will not start to avoid unhandled rejections.`,
+        )
+        error.stack = this._errorSource.stack?.replace(this._errorSource.message, error.message)
+        throw error
+      }
+    })
+  }
+
+  private async run(): Promise<T> {
+    const timeout = resolveActionTimeout(this.options)
+    const options = timeout == null ? this.options : { ...this.options, timeout }
+    const args = typeof this.args === 'function'
+      ? await this.args(options)
+      : [...this.args, options]
+    const promise = getBrowserState().commands.triggerCommand<T>(
+      this.command,
+      args,
+      this._errorSource,
+    )
+    const deadline = getBrowserState().runner._deadline
+    return deadline && timeout != null
+      ? deadline.track(this.command.slice('__vitest_'.length), promise, timeout)
+      : promise
+  }
+
+  // the command starts only when awaited, so an unawaited action cannot reject unhandled
+  private get promise(): Promise<T> {
+    this._awaited = true
+    return this._promise ??= this.run()
+  }
+
+  then<R1 = T, R2 = never>(
+    onFulfilled?: ((value: T) => R1 | PromiseLike<R1>) | null,
+    onRejected?: ((reason: any) => R2 | PromiseLike<R2>) | null,
+  ): Promise<R1 | R2> {
+    return this.promise.then(onFulfilled, onRejected)
+  }
+
+  catch<R = never>(onRejected?: ((reason: any) => R | PromiseLike<R>) | null): Promise<T | R> {
+    return this.promise.catch(onRejected)
+  }
+
+  finally(onFinally?: (() => void) | null): Promise<T> {
+    return this.promise.finally(onFinally)
+  }
+}
+
+export class LocatorAction<T = void> extends Action<T> {
+  constructor(
+    target: SerializedLocator,
+    command: string,
+    args: unknown[],
+    options?: ActionOptions,
+    errorSource?: Error,
+  ) {
+    super(command, [target, ...args], options, errorSource)
+  }
+}
+
+export class UploadAction extends Action {
+  constructor(
+    target: SerializedLocator,
+    files: string | string[] | File | File[],
+    options?: ActionOptions,
+    errorSource?: Error,
+  ) {
+    super('__vitest_upload', async options => [target, await readFiles(files), options], options, errorSource)
+  }
+}
+
+export class ScreenshotAction<T> extends Action<T> {
+  constructor(
+    name: string,
+    options: ActionOptions,
+    serialize: () => Promise<Record<string, unknown>>,
+  ) {
+    super('__vitest_screenshot', async options => [name, { ...options, ...await serialize() }], options)
+  }
+}
+
+function readFiles(files: string | string[] | File | File[]): Promise<(string | { name: string; mimeType: string; base64: string })[]> {
+  return Promise.all((Array.isArray(files) ? files : [files]).map(async (file) => {
+    if (typeof file === 'string') {
+      return file
+    }
+    const bas64String = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`))
+      reader.readAsDataURL(file)
+    })
+
+    return {
+      name: file.name,
+      mimeType: file.type,
+      // strip prefix `data:[<media-type>][;base64],`
+      base64: bas64String.slice(bas64String.indexOf(',') + 1),
+    }
+  }))
+}

--- a/packages/browser/src/client/tester/action.ts
+++ b/packages/browser/src/client/tester/action.ts
@@ -36,70 +36,76 @@ export function processTimeoutOptions<T extends { timeout?: number }>(options?: 
  */
 class Action<T = void> implements Promise<T> {
   public readonly [Symbol.toStringTag] = 'Action'
-  private _promise: Promise<T> | undefined
-  private _awaited = false
-  private readonly _errorSource: Error
+  readonly #command: string
+  readonly #args: ActionArguments
+  readonly #options: ActionOptions | undefined
+  readonly #errorSource: Error
+  #promise: Promise<T> | undefined
+  #awaited = false
 
   constructor(
-    private readonly command: string,
-    private readonly args: ActionArguments,
-    private readonly options: ActionOptions | undefined,
+    command: string,
+    args: ActionArguments,
+    options: ActionOptions | undefined,
     errorSource?: Error,
   ) {
-    this._errorSource = errorSource ?? new Error('STACK_TRACE_ERROR')
+    this.#command = command
+    this.#args = args
+    this.#options = options
+    this.#errorSource = errorSource ?? new Error('STACK_TRACE_ERROR')
     const test = getWorkerState().current
     if (errorSource || !test || test.type !== 'test') {
-      this._promise = this.run()
+      this.#promise = this.#run()
       return
     }
     test.onFinished ??= []
     test.onFinished.push(() => {
-      if (!this._awaited) {
+      if (!this.#awaited) {
         const error = new Error(
           `The call was not awaited. This method is asynchronous and must be awaited; otherwise, the call will not start to avoid unhandled rejections.`,
         )
-        error.stack = this._errorSource.stack?.replace(this._errorSource.message, error.message)
+        error.stack = this.#errorSource.stack?.replace(this.#errorSource.message, error.message)
         throw error
       }
     })
   }
 
-  private async run(): Promise<T> {
-    const timeout = resolveActionTimeout(this.options)
-    const options = timeout == null ? this.options : { ...this.options, timeout }
-    const args = typeof this.args === 'function'
-      ? await this.args(options)
-      : [...this.args, options]
+  async #run(): Promise<T> {
+    const timeout = resolveActionTimeout(this.#options)
+    const options = timeout == null ? this.#options : { ...this.#options, timeout }
+    const args = typeof this.#args === 'function'
+      ? await this.#args(options)
+      : [...this.#args, options]
     const promise = getBrowserState().commands.triggerCommand<T>(
-      this.command,
+      this.#command,
       args,
-      this._errorSource,
+      this.#errorSource,
     )
     const deadline = getBrowserState().runner._deadline
     return deadline && timeout != null
-      ? deadline.track(this.command.slice('__vitest_'.length), promise, timeout, this._errorSource)
+      ? deadline.track(this.#command.slice('__vitest_'.length), promise, timeout, this.#errorSource)
       : promise
   }
 
   // the command starts only when awaited, so an unawaited action cannot reject unhandled
-  private get promise(): Promise<T> {
-    this._awaited = true
-    return this._promise ??= this.run()
+  #start(): Promise<T> {
+    this.#awaited = true
+    return this.#promise ??= this.#run()
   }
 
   then<R1 = T, R2 = never>(
     onFulfilled?: ((value: T) => R1 | PromiseLike<R1>) | null,
     onRejected?: ((reason: any) => R2 | PromiseLike<R2>) | null,
   ): Promise<R1 | R2> {
-    return this.promise.then(onFulfilled, onRejected)
+    return this.#start().then(onFulfilled, onRejected)
   }
 
   catch<R = never>(onRejected?: ((reason: any) => R | PromiseLike<R>) | null): Promise<T | R> {
-    return this.promise.catch(onRejected)
+    return this.#start().catch(onRejected)
   }
 
   finally(onFinally?: (() => void) | null): Promise<T> {
-    return this.promise.finally(onFinally)
+    return this.#start().finally(onFinally)
   }
 }
 

--- a/packages/browser/src/client/tester/context.ts
+++ b/packages/browser/src/client/tester/context.ts
@@ -20,7 +20,8 @@ import type { BrowserTraceEntryStatus } from './trace'
 import { vi } from 'vitest'
 import { __INTERNAL, stringify } from 'vitest/internal/browser'
 import { ensureAwaited, getBrowserState, getWorkerState } from '../utils'
-import { isLocator, processTimeoutOptions, resolveUserEventWheelOptions, serializeElement } from './tester-utils'
+import { ScreenshotAction } from './action'
+import { isLocator, resolveUserEventWheelOptions, serializeElement } from './tester-utils'
 import { createBrowserTraceRangeId, recordBrowserTraceEntry } from './trace'
 
 // this file should not import anything directly, only types and utils
@@ -309,7 +310,7 @@ export const page: BrowserPage = {
       })
     })
   },
-  async screenshot(options = {}) {
+  screenshot(options = {}) {
     const currentTest = getWorkerState().current
     if (!currentTest) {
       throw new Error('Cannot take a screenshot outside of a test.')
@@ -333,28 +334,15 @@ export const page: BrowserPage = {
     const name
       = options.path || `${taskName.replace(/[^a-z0-9]/gi, '-')}-${number}.png`
 
-    const [element, ...mask] = await Promise.all([
-      options.element ? serializeElement(options.element, options) : undefined,
-      ...('mask' in options
-        ? (options.mask as Array<Element | Locator>).map(el => serializeElement(el, options))
-        : []),
-    ])
-
-    const normalizedOptions = 'mask' in options
-      ? { ...options, mask }
-      : options
-
-    return ensureAwaited(error => triggerCommand(
-      '__vitest_screenshot',
-      [
-        name,
-        processTimeoutOptions({
-          ...normalizedOptions,
-          element,
-        } as any /** TODO */),
-      ],
-      error,
-    ))
+    return new ScreenshotAction(name, options, async () => {
+      const [element, ...mask] = await Promise.all([
+        options.element ? serializeElement(options.element, options) : undefined,
+        ...('mask' in options
+          ? (options.mask as Array<Element | Locator>).map(el => serializeElement(el, options))
+          : []),
+      ])
+      return 'mask' in options ? { element, mask } : { element }
+    }) as any /** TODO */
   },
   mark<T>(
     name: string,

--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -43,6 +43,12 @@ function element<T extends HTMLElement | SVGElement | null | Locator>(elementOrL
   }, pollOptions)
 
   chai.util.flag(expectElement, '_poll.element', true)
+  if (timeout != null) {
+    chai.util.flag(expectElement, '_poll.wrap', (promise: Promise<void>, source: Error) => {
+      const name = `expect.element().${chai.util.flag(expectElement, '_name')}()`
+      return getBrowserState().runner._deadline?.track(name, promise, timeout, source) ?? promise
+    })
+  }
 
   // ask `expect.poll` to invoke trace after the assertion
   const currentTest = getWorkerState().current

--- a/packages/browser/src/client/tester/expect-element.ts
+++ b/packages/browser/src/client/tester/expect-element.ts
@@ -4,9 +4,9 @@ import type { BrowserTraceEntryStatus } from './trace'
 import { chai, expect } from 'vitest'
 import { getType } from 'vitest/internal/browser'
 import { getBrowserState, getWorkerState, now } from '../utils'
+import { resolveActionTimeout } from './action'
 import { ariaMatchers } from './aria'
 import { matchers } from './expect'
-import { processTimeoutOptions } from './tester-utils'
 import { createBrowserTraceRangeId, recordBrowserTraceEntry } from './trace'
 
 const kLocator = Symbol.for('$$vitest:locator')
@@ -16,7 +16,8 @@ function element<T extends HTMLElement | SVGElement | null | Locator>(elementOrL
     throw new Error(`Invalid element or locator: ${elementOrLocator}. Expected an instance of HTMLElement, SVGElement or Locator, received ${getType(elementOrLocator)}`)
   }
 
-  const pollOptions = processTimeoutOptions(options)
+  const timeout = resolveActionTimeout(options)
+  const pollOptions = timeout == null ? options : { ...options, timeout }
   const deadline = pollOptions?.timeout ? now() + pollOptions.timeout : undefined
   const expectElement = expect.poll(async function element(this: object): Promise<HTMLElement | SVGElement | null> {
     if (elementOrLocator instanceof Element || elementOrLocator == null) {

--- a/packages/browser/src/client/tester/locators.ts
+++ b/packages/browser/src/client/tester/locators.ts
@@ -29,11 +29,13 @@ import {
 import { page, server, utils } from 'vitest/browser'
 import { __INTERNAL, getSafeTimers } from 'vitest/internal/browser'
 import { ensureAwaited, getBrowserState, getWorkerState } from '../utils'
-import { convertElementToCssSelector, escapeForTextSelector, isLocator, processTimeoutOptions, resolveUserEventWheelOptions } from './tester-utils'
+import { LocatorAction, resolveActionTimeout, UploadAction } from './action'
+import { convertElementToCssSelector, escapeForTextSelector, isLocator, resolveUserEventWheelOptions } from './tester-utils'
 import { recordBrowserTraceEntry } from './trace'
 
 export { ensureAwaited } from '../utils'
-export { convertElementToCssSelector, getIframeScale, processTimeoutOptions } from './tester-utils'
+export { processTimeoutOptions } from './action'
+export { convertElementToCssSelector, getIframeScale } from './tester-utils'
 export {
   getByAltTextSelector,
   getByLabelSelector,
@@ -93,15 +95,15 @@ export abstract class Locator {
   }
 
   public click(options?: UserEventClickOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_click', this.serialize(), options)
+    return this.action('__vitest_click', [], options)
   }
 
   public dblClick(options?: UserEventClickOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_dblClick', this.serialize(), options)
+    return this.action('__vitest_dblClick', [], options)
   }
 
   public tripleClick(options?: UserEventClickOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_tripleClick', this.serialize(), options)
+    return this.action('__vitest_tripleClick', [], options)
   }
 
   public wheel(options: UserEventWheelOptions): Promise<void> {
@@ -126,56 +128,27 @@ export abstract class Locator {
   }
 
   public clear(options?: UserEventClearOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_clear', this.serialize(), options)
+    return this.action('__vitest_clear', [], options)
   }
 
   public hover(options?: UserEventHoverOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_hover', this.serialize(), options)
+    return this.action('__vitest_hover', [], options)
   }
 
   public unhover(options?: UserEventHoverOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_hover', { selector: 'html > body', locator: 'locator(\'body\')' }, options)
+    return this.action('__vitest_hover', [], options, { selector: 'html > body', locator: 'locator(\'body\')' })
   }
 
   public fill(text: string, options?: UserEventFillOptions): Promise<void> {
-    return this.triggerCommand<void>('__vitest_fill', this.serialize(), text, options)
+    return this.action('__vitest_fill', [text], options)
   }
 
   public upload(files: string | string[] | File | File[], options?: UserEventUploadOptions): Promise<void> {
-    return ensureAwaited(async (error) => {
-      const filesPromise = (Array.isArray(files) ? files : [files]).map(async (file) => {
-        if (typeof file === 'string') {
-          return file
-        }
-        const bas64String = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader()
-          reader.onload = () => resolve(reader.result as string)
-          reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`))
-          reader.readAsDataURL(file)
-        })
-
-        return {
-          name: file.name,
-          mimeType: file.type,
-          // strip prefix `data:[<media-type>][;base64],`
-          base64: bas64String.slice(bas64String.indexOf(',') + 1),
-        }
-      })
-      return getBrowserState().commands.triggerCommand<void>(
-        '__vitest_upload',
-        [this.serialize(), await Promise.all(filesPromise), options],
-        error,
-      )
-    })
+    return new UploadAction(this.serialize(), files, options, this._errorSource)
   }
 
   public dropTo(target: Locator, options: UserEventDragAndDropOptions = {}): Promise<void> {
-    return this.triggerCommand<void>(
-      '__vitest_dragAndDrop',
-      this.toJSON(),
-      target.toJSON(),
-      options,
-    )
+    return this.action('__vitest_dragAndDrop', [target.toJSON()], options, this.toJSON())
   }
 
   public selectOptions(
@@ -194,7 +167,7 @@ export abstract class Locator {
       }
       return v
     })
-    return this.triggerCommand('__vitest_selectOptions', this.serialize(), values, options)
+    return this.action('__vitest_selectOptions', [values], options)
   }
 
   public screenshot(options: Omit<LocatorScreenshotOptions, 'base64'> & { base64: true }): Promise<{
@@ -369,9 +342,8 @@ export abstract class Locator {
   }
 
   public async findElement(options_: SelectorOptions = {}): Promise<HTMLElement | SVGElement> {
-    const options = processTimeoutOptions(options_)
-    const timeout = options?.timeout
-    const strict = options?.strict ?? true
+    const timeout = resolveActionTimeout(options_)
+    const strict = options_?.strict ?? true
     const startTime = now()
     let intervalIndex = 0
     while (true) {
@@ -398,22 +370,19 @@ export abstract class Locator {
     }
   }
 
-  protected triggerCommand<T>(command: string, ...args: any[]): Promise<T> {
-    if (this._errorSource) {
-      return triggerCommandWithTrace<T>({
-        name: command,
-        arguments: args,
-        errorSource: this._errorSource,
-      })
-    }
-    return ensureAwaited(error => triggerCommandWithTrace<T>({
-      name: command,
-      arguments: args,
-      errorSource: error,
-    }))
+  private action(
+    command: string,
+    args: unknown[],
+    options?: { timeout?: number },
+    target: SerializedLocator = this.serialize(),
+  ): Promise<void> {
+    return new LocatorAction(target, command, args, options, this._errorSource)
   }
 }
 
+/**
+ * @deprecated
+ */
 export function triggerCommandWithTrace<T>(
   options: {
     name: string

--- a/packages/browser/src/client/tester/tester-utils.ts
+++ b/packages/browser/src/client/tester/tester-utils.ts
@@ -2,7 +2,7 @@ import type { Locator, SelectorOptions, SerializedLocator, UserEventWheelDeltaOp
 import type { BrowserRPC } from '../client'
 import type { BrowserTraceEntryStatus } from './trace'
 import { __INTERNAL } from 'vitest/internal/browser'
-import { getBrowserState, getWorkerState, now } from '../utils'
+import { getBrowserState, getWorkerState } from '../utils'
 import { createBrowserTraceRangeId, recordBrowserTraceEntry } from './trace'
 
 /* @__NO_SIDE_EFFECTS__ */
@@ -218,40 +218,6 @@ export class CommandsManager {
       },
     )
   }
-}
-
-export function processTimeoutOptions<T extends { timeout?: number }>(options_: T | undefined): T | undefined {
-  if (
-    // if timeout is set, keep it
-    (options_ && options_.timeout != null)
-  ) {
-    return options_
-  }
-  // if there is a default action timeout, use it
-  if (getWorkerState().config.browser.providerOptions.actionTimeout != null) {
-    return options_
-  }
-  const runner = getBrowserState().runner
-  const startTime = runner._currentTaskStartTime
-  // ignore timeout if this is called outside of a test
-  if (!startTime) {
-    return options_
-  }
-  const timeout = runner._currentTaskTimeout
-  if (timeout === 0 || timeout == null || timeout === Number.POSITIVE_INFINITY) {
-    return options_
-  }
-  options_ = options_ || {} as T
-  const currentTime = now()
-  const endTime = startTime + timeout
-  const remainingTime = Math.floor(endTime - currentTime)
-  // keep some buffer to process the timeout, but always hand the provider a
-  // positive value so it surfaces a descriptive, source-mapped locator error
-  // instead of letting the task timer win the race with a generic timeout;
-  // the buffer covers the provider->server->client round-trip of the rejection,
-  // which can exceed 100ms on loaded CI machines running several browsers
-  options_.timeout = Math.max(remainingTime - 250, 1)
-  return options_
 }
 
 export function getIframeScale(): number {

--- a/packages/vitest/src/integrations/chai/poll.ts
+++ b/packages/vitest/src/integrations/chai/poll.ts
@@ -212,20 +212,23 @@ export function createExpectPoll(expect: ExpectStatic): ExpectStatic['poll'] {
             }
           })
           let resultPromise: Promise<void> | undefined
+          // lets `expect.element` register the poll with the task deadline
+          const wrap = chai.util.flag(assertion, '_poll.wrap') as ((promise: Promise<void>, source: Error) => Promise<void>) | undefined
+          const start = () => resultPromise ||= wrap ? wrap(promise(), STACK_TRACE_ERROR) : promise()
           // only .then is enough to check awaited, but we type this as `Promise<void>` in global types
           // so let's follow it
           return {
             then(onFulfilled, onRejected) {
               awaited = true
-              return (resultPromise ||= promise()).then(onFulfilled, onRejected)
+              return start().then(onFulfilled, onRejected)
             },
             catch(onRejected) {
               awaited = true
-              return (resultPromise ||= promise()).catch(onRejected)
+              return start().catch(onRejected)
             },
             finally(onFinally) {
               awaited = true
-              return (resultPromise ||= promise()).finally(onFinally)
+              return start().finally(onFinally)
             },
             [Symbol.toStringTag]: 'Promise',
           } satisfies Promise<void>

--- a/packages/vitest/src/runtime/runner/context.ts
+++ b/packages/vitest/src/runtime/runner/context.ts
@@ -1,14 +1,10 @@
 import type { Awaitable } from '@vitest/utils'
 import type { RuntimeContext, SuiteCollector, Test, TestAnnotation, TestContext, VitestRunner, WriteableTestContext } from './types'
-import { getSafeTimers } from '@vitest/utils/timers'
 import { manageArtifactAttachment, recordArtifact, recordAsyncOperation } from './artifact'
+import { TaskDeadline } from './deadline'
 import { PendingError } from './errors'
 import { finishSendTasksUpdate } from './run'
 import { getRunner } from './suite'
-
-const now = globalThis.performance
-  ? globalThis.performance.now.bind(globalThis.performance)
-  : Date.now
 
 export const collectorContext: RuntimeContext = {
   tasks: [],
@@ -40,46 +36,55 @@ export function withTimeout<T extends (...args: any[]) => any>(
     return fn
   }
 
-  const { setTimeout, clearTimeout } = getSafeTimers()
-
   // this function name is used to filter error in test/e2e/test/fails.test.ts
   return (function runWithTimeout(...args: T extends (...args: infer A) => any ? A : never) {
-    const startTime = now()
     const runner = getRunner()
-    runner._currentTaskStartTime = startTime
-    runner._currentTaskTimeout = timeout
+    const previousDeadline = runner._deadline
     return new Promise((resolve_, reject_) => {
-      const timer = setTimeout(() => {
-        clearTimeout(timer)
+      let settled = false
+      const deadline = new TaskDeadline(timeout, () => {
+        // an operation derived a shorter deadline from this one,
+        // so its error describes the failure better than a generic timeout
+        const pending = deadline.settle()
+        if (pending) {
+          pending.then(rejectTimeoutError, reject)
+          return
+        }
         rejectTimeoutError()
-      }, timeout)
-      // `unref` might not exist in browser
-      timer.unref?.()
+      })
+      runner._deadline = deadline
 
-      function rejectTimeoutError() {
-        const error = makeTimeoutError(isHook, timeout, stackTraceError)
+      function rejectTimeoutError(pending?: string[]) {
+        if (settled) {
+          return
+        }
+        settled = true
+        const error = makeTimeoutError(isHook, timeout, stackTraceError, pending)
         onTimeout?.(args, error)
         reject_(error)
       }
 
       function resolve(result: unknown) {
-        runner._currentTaskStartTime = undefined
-        runner._currentTaskTimeout = undefined
-        clearTimeout(timer)
+        runner._deadline = previousDeadline
+        deadline.clear()
         // if test/hook took too long in microtask, setTimeout won't be triggered,
         // but we still need to fail the test, see
         // https://github.com/vitest-dev/vitest/issues/2920
-        if (now() - startTime >= timeout) {
+        if (deadline.exceeded()) {
           rejectTimeoutError()
           return
         }
+        settled = true
         resolve_(result)
       }
 
       function reject(error: unknown) {
-        runner._currentTaskStartTime = undefined
-        runner._currentTaskTimeout = undefined
-        clearTimeout(timer)
+        if (settled) {
+          return
+        }
+        settled = true
+        runner._deadline = previousDeadline
+        deadline.clear()
         reject_(error)
       }
 
@@ -249,10 +254,11 @@ export function createTestContext(
   return runner.extendTaskContext?.(context) || context
 }
 
-function makeTimeoutError(isHook: boolean, timeout: number, stackTraceError?: Error) {
+function makeTimeoutError(isHook: boolean, timeout: number, stackTraceError?: Error, pending?: string[]) {
+  const waiting = pending?.length ? ` while waiting for ${pending.join(', ')}` : ''
   const message = `${
     isHook ? 'Hook' : 'Test'
-  } timed out in ${timeout}ms.\nIf this is a long-running ${
+  } timed out in ${timeout}ms${waiting}.\nIf this is a long-running ${
     isHook ? 'hook' : 'test'
   }, pass a timeout value as the last argument or configure it globally with "${
     isHook ? 'hookTimeout' : 'testTimeout'

--- a/packages/vitest/src/runtime/runner/context.ts
+++ b/packages/vitest/src/runtime/runner/context.ts
@@ -1,4 +1,5 @@
 import type { Awaitable } from '@vitest/utils'
+import type { PendingOperation } from './deadline'
 import type { RuntimeContext, SuiteCollector, Test, TestAnnotation, TestContext, VitestRunner, WriteableTestContext } from './types'
 import { manageArtifactAttachment, recordArtifact, recordAsyncOperation } from './artifact'
 import { TaskDeadline } from './deadline'
@@ -54,7 +55,7 @@ export function withTimeout<T extends (...args: any[]) => any>(
       })
       runner._deadline = deadline
 
-      function rejectTimeoutError(pending?: string[]) {
+      function rejectTimeoutError(pending?: PendingOperation[]) {
         if (settled) {
           return
         }
@@ -254,8 +255,13 @@ export function createTestContext(
   return runner.extendTaskContext?.(context) || context
 }
 
-function makeTimeoutError(isHook: boolean, timeout: number, stackTraceError?: Error, pending?: string[]) {
-  const waiting = pending?.length ? ` while waiting for ${pending.join(', ')}` : ''
+function makeTimeoutError(isHook: boolean, timeout: number, stackTraceError?: Error, pending?: PendingOperation[]) {
+  const waiting = pending?.length ? ` while waiting for ${pending.map(operation => operation.name).join(', ')}` : ''
+  // point at the action the task is stuck on rather than at the task itself
+  const lastOperationSource = pending?.at(-1)?.source
+  if (lastOperationSource) {
+    stackTraceError = lastOperationSource
+  }
   const message = `${
     isHook ? 'Hook' : 'Test'
   } timed out in ${timeout}ms${waiting}.\nIf this is a long-running ${

--- a/packages/vitest/src/runtime/runner/deadline.ts
+++ b/packages/vitest/src/runtime/runner/deadline.ts
@@ -68,9 +68,15 @@ export class TaskDeadline {
     const { setTimeout } = getSafeTimers()
     const waitUntil = Math.max(...operations.map(operation => operation.endTime)) + SETTLE_GRACE
     return Promise.race([
+      // wait until all operations resolve (or the first one rejects)
       Promise.all(operations.map(operation => operation.promise)).then(() => []),
+      // or resolve after a grace period with action names for the error message (500ms)
       new Promise<string[]>(resolve => setTimeout(() => {
-        resolve(operations.filter(operation => this.operations.has(operation)).map(operation => operation.name))
+        const names = operations
+          .filter(operation => this.operations.has(operation))
+          .map(operation => operation.name)
+        resolve(names)
+      // the grace may already be in the past
       }, Math.max(waitUntil - now(), 0))),
     ])
   }

--- a/packages/vitest/src/runtime/runner/deadline.ts
+++ b/packages/vitest/src/runtime/runner/deadline.ts
@@ -1,0 +1,77 @@
+import { getSafeTimers } from '@vitest/utils/timers'
+
+const now = globalThis.performance
+  ? globalThis.performance.now.bind(globalThis.performance)
+  : Date.now
+
+// makes an operation deadline derived from the task fire before the task timer
+const DERIVED_BUFFER = 100
+// how long the task timer waits for a tracked operation past that operation's own deadline
+const SETTLE_GRACE = 500
+
+interface TrackedOperation {
+  name: string
+  promise: Promise<unknown>
+  endTime: number
+}
+
+export class TaskDeadline {
+  public readonly startTime: number = now()
+  public readonly endTime: number
+  private timer: ReturnType<typeof setTimeout>
+  private operations = new Set<TrackedOperation>()
+
+  constructor(timeout: number, onTimeout: () => void) {
+    this.endTime = this.startTime + timeout
+    const { setTimeout } = getSafeTimers()
+    this.timer = setTimeout(onTimeout, timeout)
+    // `unref` might not exist in browser
+    this.timer.unref?.()
+  }
+
+  remaining(): number {
+    return this.endTime - now()
+  }
+
+  exceeded(): boolean {
+    return now() >= this.endTime
+  }
+
+  clear(): void {
+    const { clearTimeout } = getSafeTimers()
+    clearTimeout(this.timer)
+  }
+
+  /** timeout for an operation that must fail before the task does */
+  derive(): number {
+    return Math.max(Math.floor(this.remaining()) - DERIVED_BUFFER, 1)
+  }
+
+  /** Registers an operation with its own timeout; see `settle`. */
+  track<T>(name: string, promise: Promise<T>, timeout: number): Promise<T> {
+    const operation = { name, promise, endTime: now() + timeout }
+    this.operations.add(operation)
+    promise.finally(() => this.operations.delete(operation)).catch(() => {})
+    return promise
+  }
+
+  /**
+   * Waits for the operations that were due before the task. Rejects with the
+   * error of the first one that failed, otherwise resolves with the names of
+   * the ones that did not report back in time.
+   */
+  settle(): Promise<string[]> | undefined {
+    const operations = [...this.operations].filter(operation => operation.endTime <= this.endTime)
+    if (!operations.length) {
+      return undefined
+    }
+    const { setTimeout } = getSafeTimers()
+    const waitUntil = Math.max(...operations.map(operation => operation.endTime)) + SETTLE_GRACE
+    return Promise.race([
+      Promise.all(operations.map(operation => operation.promise)).then(() => []),
+      new Promise<string[]>(resolve => setTimeout(() => {
+        resolve(operations.filter(operation => this.operations.has(operation)).map(operation => operation.name))
+      }, Math.max(waitUntil - now(), 0))),
+    ])
+  }
+}

--- a/packages/vitest/src/runtime/runner/deadline.ts
+++ b/packages/vitest/src/runtime/runner/deadline.ts
@@ -61,23 +61,27 @@ export class TaskDeadline {
   }
 
   /**
-   * Waits for the operations that were due before the task. Rejects with the
-   * error of the first one that failed, otherwise resolves with the ones
-   * that did not report back in time.
+   * Waits for the operations that were due before the task, if possible.
    */
   settle(): Promise<PendingOperation[]> | undefined {
-    const operations = [...this.operations].filter(operation => operation.endTime <= this.endTime)
-    if (!operations.length) {
+    if (!this.operations.size) {
       return undefined
     }
+    const operations = [...this.operations]
+    const pending = () => operations.filter(operation => this.operations.has(operation))
+    const due = operations.filter(operation => operation.endTime <= this.endTime)
+    if (!due.length) {
+      // return operations whose timeout is larger than task for a better stack trace
+      return Promise.resolve(operations)
+    }
     const { setTimeout } = getSafeTimers()
-    const waitUntil = Math.max(...operations.map(operation => operation.endTime)) + SETTLE_GRACE
+    const waitUntil = Math.max(...due.map(operation => operation.endTime)) + SETTLE_GRACE
     return Promise.race([
-      // wait until all operations resolve (or the first one rejects)
-      Promise.all(operations.map(operation => operation.promise)).then(() => []),
+      // wait until all due operations resolve (or the first one rejects)
+      Promise.all(due.map(operation => operation.promise)).then(pending),
       // or resolve after a grace period with the pending actions for the error (500ms)
       new Promise<PendingOperation[]>(resolve => setTimeout(() => {
-        resolve(operations.filter(operation => this.operations.has(operation)))
+        resolve(pending())
       // the grace may already be in the past
       }, Math.max(waitUntil - now(), 0))),
     ])

--- a/packages/vitest/src/runtime/runner/deadline.ts
+++ b/packages/vitest/src/runtime/runner/deadline.ts
@@ -9,8 +9,13 @@ const DERIVED_BUFFER = 100
 // how long the task timer waits for a tracked operation past that operation's own deadline
 const SETTLE_GRACE = 500
 
-interface TrackedOperation {
+export interface PendingOperation {
   name: string
+  /** error created where the operation was called, used for the timeout stack trace */
+  source?: Error
+}
+
+interface TrackedOperation extends PendingOperation {
   promise: Promise<unknown>
   endTime: number
 }
@@ -48,8 +53,8 @@ export class TaskDeadline {
   }
 
   /** Registers an operation with its own timeout; see `settle`. */
-  track<T>(name: string, promise: Promise<T>, timeout: number): Promise<T> {
-    const operation = { name, promise, endTime: now() + timeout }
+  track<T>(name: string, promise: Promise<T>, timeout: number, source?: Error): Promise<T> {
+    const operation = { name, source, promise, endTime: now() + timeout }
     this.operations.add(operation)
     promise.finally(() => this.operations.delete(operation)).catch(() => {})
     return promise
@@ -57,10 +62,10 @@ export class TaskDeadline {
 
   /**
    * Waits for the operations that were due before the task. Rejects with the
-   * error of the first one that failed, otherwise resolves with the names of
-   * the ones that did not report back in time.
+   * error of the first one that failed, otherwise resolves with the ones
+   * that did not report back in time.
    */
-  settle(): Promise<string[]> | undefined {
+  settle(): Promise<PendingOperation[]> | undefined {
     const operations = [...this.operations].filter(operation => operation.endTime <= this.endTime)
     if (!operations.length) {
       return undefined
@@ -70,12 +75,9 @@ export class TaskDeadline {
     return Promise.race([
       // wait until all operations resolve (or the first one rejects)
       Promise.all(operations.map(operation => operation.promise)).then(() => []),
-      // or resolve after a grace period with action names for the error message (500ms)
-      new Promise<string[]>(resolve => setTimeout(() => {
-        const names = operations
-          .filter(operation => this.operations.has(operation))
-          .map(operation => operation.name)
-        resolve(names)
+      // or resolve after a grace period with the pending actions for the error (500ms)
+      new Promise<PendingOperation[]>(resolve => setTimeout(() => {
+        resolve(operations.filter(operation => this.operations.has(operation)))
       // the grace may already be in the past
       }, Math.max(waitUntil - now(), 0))),
     ])

--- a/packages/vitest/src/runtime/runner/types.ts
+++ b/packages/vitest/src/runtime/runner/types.ts
@@ -4,6 +4,7 @@ import type { Statistics } from 'tinybench'
 import type { UserConsoleLog } from '../../types/general'
 import type { Bench } from '../benchmark'
 import type { SerializedConfig } from '../config'
+import type { TaskDeadline } from './deadline'
 import type { TestFixtures } from './fixture'
 import type { afterAll, afterEach, aroundAll, aroundEach, beforeAll, beforeEach } from './hooks'
 import type { kChainableContext, TypedChainableFunction } from './utils/chain'
@@ -1768,7 +1769,5 @@ export interface VitestRunner {
   /** @internal */
   _currentSpecification?: FileSpecification | undefined
   /** @internal */
-  _currentTaskStartTime?: number
-  /** @internal */
-  _currentTaskTimeout?: number
+  _deadline?: TaskDeadline | undefined
 }

--- a/test/browser/fixtures/timeout-actions/actions.test.ts
+++ b/test/browser/fixtures/timeout-actions/actions.test.ts
@@ -1,0 +1,14 @@
+import { it } from 'vitest'
+import { page } from 'vitest/browser'
+
+it('reports the action error when it arrives inside the grace', async () => {
+  await page.screenshot({ path: 'delay-200.png' })
+}, 500)
+
+it('names the pending action when it does not report back', async () => {
+  await page.screenshot({ path: 'delay-2000.png' })
+}, 500)
+
+it('does not wait for an action due after the test', async () => {
+  await page.screenshot({ path: 'delay-2000.png', timeout: 5000 })
+}, 500)

--- a/test/browser/fixtures/timeout-actions/actions.test.ts
+++ b/test/browser/fixtures/timeout-actions/actions.test.ts
@@ -9,6 +9,6 @@ it('names the pending action when it does not report back', async () => {
   await page.screenshot({ path: 'delay-2000.png' })
 }, 500)
 
-it('does not wait for an action due after the test', async () => {
+it('reports an action due after the test without waiting for it', async () => {
   await page.screenshot({ path: 'delay-2000.png', timeout: 5000 })
 }, 500)

--- a/test/browser/fixtures/timeout-actions/vitest.config.ts
+++ b/test/browser/fixtures/timeout-actions/vitest.config.ts
@@ -1,0 +1,29 @@
+import type { BrowserCommand } from 'vitest/node'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+// rejects after the timeout the action derived plus the delay encoded in the
+// file name, so the action reports back either inside or past the task's grace
+const slowScreenshot: BrowserCommand<[name: string, options: { timeout: number }]> = (_context, name, options) => {
+  const delay = Number(/delay-(\d+)/.exec(name)?.[1] ?? 0)
+  return new Promise((_resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`slow screenshot after ${delay}ms`)), options.timeout + delay)
+    timer.unref?.()
+  })
+}
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      screenshotFailures: false,
+      commands: {
+        __vitest_screenshot: slowScreenshot,
+      },
+    },
+  },
+})

--- a/test/browser/specs/timeout-actions.test.ts
+++ b/test/browser/specs/timeout-actions.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+import { instances, runBrowserTests } from './utils'
+
+test('task timeouts wait for pending actions', async () => {
+  const { errorTree, stderr } = await runBrowserTests({
+    root: './fixtures/timeout-actions',
+    project: [instances[0].browser],
+  })
+
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "actions.test.ts": {
+        "does not wait for an action due after the test": [
+          "Test timed out in 500ms.
+    If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".",
+        ],
+        "names the pending action when it does not report back": [
+          "Test timed out in 500ms while waiting for screenshot.
+    If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".",
+        ],
+        "reports the action error when it arrives inside the grace": [
+          "slow screenshot after 200ms",
+        ],
+      },
+    }
+  `)
+
+  // the timeout error points at the pending action, not at the test
+  const report = stderr.split('\n')
+  const start = report.findIndex(line => line.includes('names the pending action when it does not report back'))
+  const end = report.findIndex((line, index) => index > start && line.startsWith('⎯'))
+  expect(report.slice(start, end).join('\n')).toMatchInlineSnapshot(`
+    " FAIL  |chromium| actions.test.ts > names the pending action when it does not report back
+    Error: Test timed out in 500ms while waiting for screenshot.
+    If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+     ❯ actions.test.ts:9:14
+          7|
+          8| it('names the pending action when it does not report back', async () =…
+          9|   await page.screenshot({ path: 'delay-2000.png' })
+           |              ^
+         10| }, 500)
+         11|
+    "
+  `)
+})

--- a/test/browser/specs/timeout-actions.test.ts
+++ b/test/browser/specs/timeout-actions.test.ts
@@ -10,11 +10,11 @@ test('task timeouts wait for pending actions', async () => {
   expect(errorTree()).toMatchInlineSnapshot(`
     {
       "actions.test.ts": {
-        "does not wait for an action due after the test": [
-          "Test timed out in 500ms.
+        "names the pending action when it does not report back": [
+          "Test timed out in 500ms while waiting for screenshot.
     If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".",
         ],
-        "names the pending action when it does not report back": [
+        "reports an action due after the test without waiting for it": [
           "Test timed out in 500ms while waiting for screenshot.
     If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".",
         ],

--- a/test/unit/test/deadline.test.ts
+++ b/test/unit/test/deadline.test.ts
@@ -31,11 +31,18 @@ test('the timer calls onTimeout unless cleared', async () => {
   expect(fired).toHaveBeenCalledOnce()
 })
 
-test('settle has nothing to wait for without operations due before the task', () => {
+test('settle has nothing to wait for without operations', () => {
   const deadline = new TaskDeadline(100, noop)
   expect(deadline.settle()).toBeUndefined()
+  deadline.clear()
+})
+
+test('settle reports an operation due after the task right away', async () => {
+  const deadline = new TaskDeadline(100, noop)
   deadline.track('click', never, 5000)
-  expect(deadline.settle()).toBeUndefined()
+  const pending = await deadline.settle()
+  expect.assert(pending)
+  expect(pending.map(operation => operation.name)).toEqual(['click'])
   deadline.clear()
 })
 
@@ -65,7 +72,7 @@ test('settle reports operations that did not report back within the grace', asyn
   deadline.track('screenshot', never, 5000)
   const pending = await deadline.settle()
   expect.assert(pending)
-  expect(pending.map(operation => operation.name)).toEqual(['click'])
+  expect(pending.map(operation => operation.name)).toEqual(['click', 'screenshot'])
   expect(pending[0].source).toBe(source)
   deadline.clear()
 })

--- a/test/unit/test/deadline.test.ts
+++ b/test/unit/test/deadline.test.ts
@@ -1,0 +1,79 @@
+import { expect, test, vi } from 'vitest'
+import { TaskDeadline } from '../../../packages/vitest/src/runtime/runner/deadline'
+
+function noop() {}
+const never = new Promise<never>(noop)
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+test('derive keeps a buffer before the task deadline and stays positive', () => {
+  const deadline = new TaskDeadline(1000, noop)
+  expect(deadline.derive()).toBeLessThanOrEqual(900)
+  expect(deadline.derive()).toBeGreaterThan(850)
+  deadline.clear()
+
+  const short = new TaskDeadline(50, noop)
+  expect(short.derive()).toBe(1)
+  short.clear()
+})
+
+test('the timer calls onTimeout unless cleared', async () => {
+  const cleared = vi.fn()
+  const fired = vi.fn()
+  const deadline = new TaskDeadline(20, cleared)
+  deadline.clear()
+  const running = new TaskDeadline(20, fired)
+  await sleep(60)
+  running.clear()
+  expect(cleared).not.toHaveBeenCalled()
+  expect(fired).toHaveBeenCalledOnce()
+})
+
+test('settle has nothing to wait for without operations due before the task', () => {
+  const deadline = new TaskDeadline(100, noop)
+  expect(deadline.settle()).toBeUndefined()
+  deadline.track('click', never, 5000)
+  expect(deadline.settle()).toBeUndefined()
+  deadline.clear()
+})
+
+test('settle rejects with the error of a failed operation', async () => {
+  const deadline = new TaskDeadline(100, noop)
+  const failed = Promise.reject(new Error('slow click'))
+  failed.catch(noop)
+  deadline.track('click', failed, 10)
+  await expect(deadline.settle()).rejects.toThrow('slow click')
+  deadline.clear()
+})
+
+test('settle resolves with nothing pending once operations finish', async () => {
+  const deadline = new TaskDeadline(100, noop)
+  let finish!: () => void
+  deadline.track('click', new Promise<void>(resolve => finish = resolve), 10)
+  const settled = deadline.settle()
+  finish()
+  await expect(settled).resolves.toEqual([])
+  deadline.clear()
+})
+
+test('settle reports operations that did not report back within the grace', async () => {
+  const deadline = new TaskDeadline(100, noop)
+  const source = new Error('STACK_TRACE_ERROR')
+  deadline.track('click', never, 10, source)
+  deadline.track('screenshot', never, 5000)
+  const pending = await deadline.settle()
+  expect.assert(pending)
+  expect(pending.map(operation => operation.name)).toEqual(['click'])
+  expect(pending[0].source).toBe(source)
+  deadline.clear()
+})
+
+test('exceeded reflects the task deadline', async () => {
+  const deadline = new TaskDeadline(20, noop)
+  expect(deadline.exceeded()).toBe(false)
+  await sleep(40)
+  expect(deadline.exceeded()).toBe(true)
+  deadline.clear()
+})


### PR DESCRIPTION
A locator action derives its timeout from the running test, but its rejection travels provider -> server -> page, and on a loaded CI runner it arrived after the task timer fired. The test then failed with a generic `Hook timed out` instead of the locator error (the `timeout hooks` spec, 37 failed runs in the last week).

The runner now keeps a `TaskDeadline` per task. Browser actions are `Action` classes that derive their timeout from it and register with it; when the task timer fires, it waits (at most 500ms past the action's own deadline) for registered actions and reports their error. If an action still has not reported back, the timeout error names it.

`processTimeoutOptions` stays exported and is deprecated; the `@vitest/browser/locators` surface is unchanged.