### PR TITLE
fix: propagate --maxWorkers to projects

### DIFF
--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -65,6 +65,7 @@ const PROJECT_CLI_OVERRIDES = [
   'inspect',
   'inspectBrk',
   'fileParallelism',
+  'maxWorkers',
   'tagsFilter',
   'browser',
   'experimental',

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -685,6 +685,21 @@ describe('nested projects', () => {
     expect(ctx!.projects.map(project => project.config.testTimeout)).toEqual([999])
   })
 
+  it('cli --maxWorkers reaches projects', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: [
+            { test: { name: 'unit' } },
+          ],
+        },
+      },
+      'basic.test.js': basicTest,
+    }, { $cliOptions: { maxWorkers: 3 } })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.config.maxWorkers)).toEqual([3])
+  })
+
   it('benchmark projects are created for nested projects', async () => {
     const { stderr, ctx } = await runInlineTests({
       'vitest.config.js': {

--- a/test/e2e/test/reporters/merge-reports.test.ts
+++ b/test/e2e/test/reporters/merge-reports.test.ts
@@ -876,22 +876,22 @@ test("works on browser", () => {
     mergeReports: resolve(root, '.vitest/blob'),
   })
   expect(trimReporterOutput(result.stdout)).toMatchInlineSnapshot(`
-    "✓ |node|  linux  basic.test.ts > always good <time>
-     ✓ |node|  linux  basic.test.ts > works on node <time>
-     × |node|  linux  basic.test.ts > works on browser <time>
-       → expected 'undefined' not to be 'undefined' // Object.is equality
-     ✓ |browser (chromium)|  linux  basic.test.ts > always good <time>
+    "✓ |browser (chromium)|  linux  basic.test.ts > always good <time>
      × |browser (chromium)|  linux  basic.test.ts > works on node <time>
        → expected 'object' to be 'undefined' // Object.is equality
      ✓ |browser (chromium)|  linux  basic.test.ts > works on browser <time>
-     ✓ |node|  macos  basic.test.ts > always good <time>
-     ✓ |node|  macos  basic.test.ts > works on node <time>
-     × |node|  macos  basic.test.ts > works on browser <time>
+     ✓ |node|  linux  basic.test.ts > always good <time>
+     ✓ |node|  linux  basic.test.ts > works on node <time>
+     × |node|  linux  basic.test.ts > works on browser <time>
        → expected 'undefined' not to be 'undefined' // Object.is equality
      ✓ |browser (chromium)|  macos  basic.test.ts > always good <time>
      × |browser (chromium)|  macos  basic.test.ts > works on node <time>
        → expected 'object' to be 'undefined' // Object.is equality
      ✓ |browser (chromium)|  macos  basic.test.ts > works on browser <time>
+     ✓ |node|  macos  basic.test.ts > always good <time>
+     ✓ |node|  macos  basic.test.ts > works on node <time>
+     × |node|  macos  basic.test.ts > works on browser <time>
+       → expected 'undefined' not to be 'undefined' // Object.is equality
 
      Test Files  4 failed (4)
           Tests  4 failed | 8 passed (12)
@@ -901,19 +901,6 @@ test("works on browser", () => {
   expect(result.stderr).toMatchInlineSnapshot(`
     "
     ⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
-
-     FAIL  |node|  linux  basic.test.ts > works on browser
-     FAIL  |node|  macos  basic.test.ts > works on browser
-    AssertionError: expected 'undefined' not to be 'undefined' // Object.is equality
-     ❯ basic.test.ts:11:29
-          9|
-         10| test("works on browser", () => {
-         11|   expect(typeof window).not.toBe('undefined')
-           |                             ^
-         12| })
-         13|
-
-    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯
 
      FAIL  |browser (chromium)|  linux  basic.test.ts > works on node
     AssertionError: expected 'object' to be 'undefined' // Object.is equality
@@ -928,6 +915,19 @@ test("works on browser", () => {
            |                         ^
           8| })
           9|
+
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯
+
+     FAIL  |node|  linux  basic.test.ts > works on browser
+     FAIL  |node|  macos  basic.test.ts > works on browser
+    AssertionError: expected 'undefined' not to be 'undefined' // Object.is equality
+     ❯ basic.test.ts:11:29
+          9|
+         10| test("works on browser", () => {
+         11|   expect(typeof window).not.toBe('undefined')
+           |                             ^
+         12| })
+         13|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯
 


### PR DESCRIPTION
Closes #11051.

**Problem**

`PROJECT_CLI_OVERRIDES` in `node/projects/resolveProjects.ts` is the allowlist of CLI options copied into each project's config. `maxWorkers` is not in it, so with `projects` declared the flag is accepted and silently has no effect, while the equivalent option inside a project's own config works.

`resolveProjects.ts` later reads `clonedConfig.maxWorkers` when sizing the pool, so an absent override leaves it `undefined` and the CLI value never arrives.

Credit to @hamodywe, who pinpointed the allowlist in the issue thread.

**Solution**

Add `maxWorkers` to the allowlist. One line.

**Tests**

Added `cli --maxWorkers reaches projects` to `test/e2e/test/projects.test.ts`, mirroring the existing `cli overrides reach nested projects` case for `testTimeout` directly above it. It fails on `main` with `expected [ undefined ] to deeply equal [ 3 ]` and passes with this change. Reverting only the production line while keeping the test reproduces the failure as an assertion, so the test genuinely exercises the fix.

**One existing snapshot needed updating — please sanity-check this bit**

`merge reports with projects and labels` went red. The cause is the fix working: `runVitest` passes `maxWorkers: 1` to the inner run (test-utils/index.ts:207), and with the override now propagating, the inner projects honour it instead of defaulting to CPU-based parallelism. They therefore finish in a different order and the merged report lists the browser project before node within each label group.

The previous snapshot only held because the option was being dropped. I have updated it to the ordering CI observed. I could not run that test locally — it needs Playwright browsers, and on my machine it fails on unmodified `main` too — so I took the expected output from the CI diff rather than regenerating it. Worth a second pair of eyes on whether that reordering is acceptable, or whether the report should sort projects deterministically instead.

**AI disclosure**

Per CONTRIBUTING: Claude assisted with the investigation and with drafting this description. I verified the allowlist omission, the `clonedConfig.maxWorkers` read path, and the test results myself.
