### PR TITLE
fix(vitest): match forceRerunTriggers in dot-named directories

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -34,6 +34,18 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
   })
 })
 
+it.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTriggers matches files under a dot-named directory', async () => {
+  const { stdout, stderr } = await runVitest({
+    related: '/tmp/.hidden-vitest-root/package.json',
+    root: './fixtures/git-changed/related',
+    include: ['related.test.ts'],
+    forceRerunTriggers: ['**/package.json'],
+  })
+  expect(stderr).toBe('')
+  expect(stdout).toContain('1 passed')
+  expect(stdout).toContain('related.test.ts')
+})
+
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {
   const { stdout, stderr } = await runVitest({
     related: 'src/sourceA.ts',


### PR DESCRIPTION
## Summary

`forceRerunTriggers` is matched against absolute paths with picomatch's default `dot: false`. If any directory segment starts with a dot (`.app/`, `~/.local/src`, `.claude/worktrees`), `**` never crosses it, so even `**/package.json` and `**/*` fail to match. `--changed` then skips the documented full-suite escalation with no warning.

This passes `{ dot: true }` at both match sites (`filterTestsBySource` and the watcher) so a trigger fires regardless of where the project is checked out.

## Test

`vitest run test/git-changed.test.ts -t "dot-named directory"` in `test/e2e`

On main the related path `/tmp/.hidden-vitest-root/package.json` does not match `**/package.json` and the run reports no test files. With this change the trigger fires and `related.test.ts` runs.

Fixes #11054
