### PR TITLE
fix: propagate --hookTimeout to projects

### DIFF
--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -50,6 +50,7 @@ const PROJECT_CLI_OVERRIDES = [
   'allowOnly',
   'sequence',
   'testTimeout',
+  'hookTimeout',
   'pool',
   'update',
   'globals',

--- a/test/e2e/test/projects.test.ts
+++ b/test/e2e/test/projects.test.ts
@@ -700,6 +700,21 @@ describe('nested projects', () => {
     expect(ctx!.projects.map(project => project.config.maxWorkers)).toEqual([3])
   })
 
+  it('cli --hookTimeout reaches projects', async () => {
+    const { stderr, ctx } = await runInlineTests({
+      'vitest.config.js': {
+        test: {
+          projects: [
+            { test: { name: 'unit', hookTimeout: 2222 } },
+          ],
+        },
+      },
+      'basic.test.js': basicTest,
+    }, { $cliOptions: { hookTimeout: 999 } })
+    expect(stderr).toBe('')
+    expect(ctx!.projects.map(project => project.config.hookTimeout)).toEqual([999])
+  })
+
   it('benchmark projects are created for nested projects', async () => {
     const { stderr, ctx } = await runInlineTests({
       'vitest.config.js': {


### PR DESCRIPTION
### Description

`--hookTimeout` set on the CLI is silently ignored by projects. `PROJECT_CLI_OVERRIDES` lists the CLI options that override per-project test config; `testTimeout` is there, `hookTimeout` is not, so a root `--hook-timeout=999` never reaches a project and the project's own value (or the default) wins.

`hookTimeout` is per-project config — it's read as `runner.config.hookTimeout` in the runtime runner and serialized per-project in `serializeConfig.ts` — so the project's copy is the one that takes effect.

Note that `teardownTimeout` is deliberately *not* included: it's only read from the root config (`core.ts`, `pools/pool.ts`), never per-project.

Follows the same shape as #11102.

### Tests

Added `cli --hookTimeout reaches projects` next to the existing `testTimeout` / `maxWorkers` cases. The project sets `hookTimeout: 2222` explicitly, so the test proves the CLI value wins rather than coinciding with a default.

Without the one-line change it fails with `expected [ 2222 ] to deeply equal [ 999 ]`; with it, all 58 tests in `projects.test.ts` pass. `typecheck` and `eslint` are clean.

### AI disclosure

Per CONTRIBUTING: this was written with AI assistance (Claude). I reviewed the change, ran the tests locally, and will respond to review myself.
