### PR TITLE
fix(runner): skip retries when it.fails meets expectation

### DIFF
--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -738,12 +738,12 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
         return
       }
 
-      if (test.result.state === 'pass') {
+      if (metExpectation(test)) {
         break
       }
 
       if (retryCount < retry) {
-        const shouldRetry = passesRetryCondition(test, test.result.errors)
+        const shouldRetry = passesRetryCondition(test, retryErrors(test))
 
         if (!shouldRetry) {
           break
@@ -766,9 +766,8 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   // if test is marked to be failed, flip the result unless `TestSyntaxError` is present
   if (test.fails) {
     if (test.result.state === 'pass') {
-      const error = processError(new Error('Expect test to fail'))
       test.result.state = 'fail'
-      test.result.errors = [error]
+      test.result.errors = [expectedToFailError()]
     }
     else if (!test.result.errors?.some(e => e.__vitest_test_syntax_error__)) {
       test.result.state = 'pass'
@@ -784,6 +783,27 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
   await runner.onAfterRunTask?.(test)
 
   updateTask('test-finished', test, runner)
+}
+
+function expectedToFailError(): TestError {
+  return processError(new Error('Expect test to fail'))
+}
+
+function metExpectation(test: Test): boolean {
+  const result = test.result!
+  if (!test.fails) {
+    return result.state === 'pass'
+  }
+  return result.state === 'fail'
+    && !result.errors?.some(e => e.__vitest_test_syntax_error__)
+}
+
+function retryErrors(test: Test): TestError[] | undefined {
+  const result = test.result!
+  if (test.fails && result.state === 'pass') {
+    return [expectedToFailError()]
+  }
+  return result.errors
 }
 
 function failTask(result: TaskResult, err: unknown, diffOptions: DiffOptions | undefined) {

--- a/test/e2e/test/retry.test.ts
+++ b/test/e2e/test/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { runInlineTests, runVitest, ts } from '../../test-utils'
 
 function run(testNamePattern: string) {
   return runVitest({
@@ -23,5 +23,65 @@ describe('retry', () => {
     expect(stdout).toContain('expected 2 to be 4')
     expect(stdout).toContain('expected 3 to be 4')
     expect(stdout).toContain('1 failed')
+  })
+})
+
+describe('retry with test.fails', () => {
+  test('an erroring test.fails test meets its expectation and is not retried', async () => {
+    const { stdout } = await runInlineTests({
+      'fails-retry.test.ts': ts`
+        import { expect, test } from 'vitest'
+        let attempts = 0
+        test.fails('meets the expectation', { retry: 2 }, () => {
+          attempts++
+          throw new Error('expected failure')
+        })
+        test('ran only once', () => {
+          expect(attempts).toBe(1)
+        })
+      `,
+    })
+
+    expect(stdout).toContain('1 passed | 1 expected fail')
+  })
+
+  test('a passing test.fails test is retried and reported as failed', async () => {
+    const { stdout, stderr } = await runInlineTests({
+      'fails-retry.test.ts': ts`
+        import { expect, test } from 'vitest'
+        let attempts = 0
+        test.fails('never meets the expectation', { retry: 2 }, () => {
+          attempts++
+        })
+        test('ran the initial attempt and both retries', () => {
+          expect(attempts).toBe(3)
+        })
+      `,
+    })
+
+    expect(stderr).toContain('Expect test to fail')
+    expect(stdout).toContain('1 failed')
+    expect(stdout).toContain('1 passed')
+  })
+
+  test('a retry condition is matched against the missing failure', async () => {
+    const { stdout } = await runInlineTests({
+      'fails-retry.test.ts': ts`
+        import { expect, test } from 'vitest'
+        let matched = 0
+        test.fails('condition matches', { retry: { count: 2, condition: /Expect test to fail/ } }, () => {
+          matched++
+        })
+        let unmatched = 0
+        test.fails('condition does not match', { retry: { count: 2, condition: /something else/ } }, () => {
+          unmatched++
+        })
+        test('only the matching one is retried', () => {
+          expect([matched, unmatched]).toEqual([3, 1])
+        })
+      `,
+    })
+
+    expect(stdout).toContain('1 passed')
   })
 })

--- a/test/unit/test/on-finished.test.ts
+++ b/test/unit/test/on-finished.test.ts
@@ -187,12 +187,6 @@ describe('retry fail', () => {
         "(0, 0) run",
         "(0, 0) finish",
         "(0, 0) fail",
-        "(1, 0) run",
-        "(1, 0) finish",
-        "(1, 0) fail",
-        "(2, 0) run",
-        "(2, 0) finish",
-        "(2, 0) fail",
       ]
     `)
   })

--- a/test/unit/test/repeats.test.ts
+++ b/test/unit/test/repeats.test.ts
@@ -40,7 +40,7 @@ const retryNumbers: number[] = []
 
 describe('testing repeats with retry', () => {
   describe('normal test', () => {
-    const result = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    const result = [1, 1, 1, 1, 1]
     test.fails('test 1', { repeats: 4, retry: 1 }, () => {
       retryNumbers.push(1)
       expect(1).toBe(2)

--- a/test/unit/test/retry.test.ts
+++ b/test/unit/test/retry.test.ts
@@ -20,7 +20,7 @@ it('retry test fails', { retry: 10 }, () => {
 
 it('result', () => {
   expect(count1).toEqual(3)
-  expect(count2).toEqual(2)
+  expect(count2).toEqual(1)
   expect(count3).toEqual(3)
 })
 


### PR DESCRIPTION
Written by an AI agent on behalf of @shahidbeig-a11y, who has reviewed it.

Fixes #11068

### Description

`it.fails` tests had their result inverted only after the retry loop in `runTest`, so the retry decision used the raw attempt state:

- a `fails` test that threw (meeting its expectation) was retried unnecessarily;
- a `fails` test that passed (its actual failure mode) broke out of the loop early and was never retried.

The retry decision now checks whether the attempt met the test's expectation via `metExpectation()`. For `fails` tests, a thrown attempt meets the expectation and is not retried; a passing attempt is retried. The result is still inverted once after the loop so hooks and repeats see the real attempt state.

`retryErrors()` supplies the `Expect test to fail` error for retry `condition` matching when a `fails` test passes.

### Tests
- [x] `test/unit/test/retry.test.ts`
- [x] `test/unit/test/repeats.test.ts`
- [x] `test/unit/test/on-finished.test.ts`
- [x] `test/e2e/test/retry.test.ts` (new regression tests for `test.fails` + retry)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Documentation
- [x] No new functionality — bug fix only.

### Changesets
- [x] PR title uses `fix:` prefix for changelog generation.