### PR TITLE
fix(browser): scope request interception to mock-route lifetime (fix #8339)

### DIFF
--- a/packages/browser-playwright/src/playwright.ts
+++ b/packages/browser-playwright/src/playwright.ts
@@ -12,6 +12,7 @@ import type {
   LaunchOptions,
   Page,
   CDPSession as PlaywrightCDPSession,
+  Route,
 } from 'playwright'
 import type { SourceMap } from 'rollup'
 import type { ResolvedConfig } from 'vite'
@@ -28,6 +29,7 @@ import type {
   CDPSession,
   TestProject,
 } from 'vitest/node'
+import { randomUUID } from 'node:crypto'
 import { defineBrowserProvider } from '@vitest/browser'
 import { createManualModuleSource } from '@vitest/mocker/node'
 import { resolve } from 'pathe'
@@ -40,6 +42,16 @@ const debug = createDebugger('vitest:browser:playwright')
 
 const playwrightBrowsers = ['firefox', 'webkit', 'chromium'] as const
 type PlaywrightBrowser = (typeof playwrightBrowsers)[number]
+
+const interceptionProbeUrl = '/__vitest_interception_probe__'
+const interceptionProbeRoute = `**${interceptionProbeUrl}`
+// Chromium acknowledges `Fetch.enable` before the interception is actually
+// active, so a module request right after the first `context.route` call can
+// be served unmocked (#8339). Arming polls until the interception is verified
+// live and fails loudly if it never converges. The timeout is not
+// configurable: it is calibrated from measured arm latencies (p99 x 3 —
+// p99 604ms across 74 arms, including a 32 parallel sessions run).
+const interceptionArmTimeout = 2_000
 
 // Enable intercepting of requests made by service workers - experimental API is only available in Chromium based browsers
 // Requests from service workers are only available on context.route() https://playwright.dev/docs/service-workers-experimental
@@ -240,6 +252,13 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
 
   private browserPromise: Promise<Browser> | null = null
   private closing = false
+  private armedContexts = new WeakMap<BrowserContext, {
+    promise: Promise<void>
+    probeRoute: (route: Route) => Promise<void>
+  }>()
+
+  private contextRouteCounts = new WeakMap<BrowserContext, number>()
+  private contextLocks = new WeakMap<BrowserContext, Promise<void>>()
 
   public tracingContexts: Set<string> = new Set()
   public pendingTraces: Map<string, string> = new Map()
@@ -379,6 +398,65 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     return this.browserPromise
   }
 
+  // Mock routes are registered and removed per test file, but the interception
+  // they rely on must be armed before the file's imports are released and can
+  // be disarmed only when the last mock route of the context is gone.
+  private serializeContext<T>(context: BrowserContext, task: () => Promise<T>): Promise<T> {
+    const previous = this.contextLocks.get(context) ?? Promise.resolve()
+    const result = previous.then(task, task)
+    this.contextLocks.set(context, result.then(() => {}, () => {}))
+    return result
+  }
+
+  private armInterception(page: Page): Promise<void> {
+    if (this.browserName !== 'chromium') {
+      return Promise.resolve()
+    }
+    const context = page.context()
+    const armed = this.armedContexts.get(context)
+    if (armed) {
+      return armed.promise
+    }
+    const token = randomUUID()
+    const probeRoute = (route: Route) => route.fulfill({
+      status: 204,
+      headers: { 'x-vitest-probe': token },
+    })
+    const promise = (async () => {
+      await context.route(interceptionProbeRoute, probeRoute)
+      const startedAt = performance.now()
+      const deadline = Date.now() + interceptionArmTimeout
+      while (Date.now() < deadline) {
+        const result = await Promise.race([
+          page.evaluate(
+            url => fetch(url, { cache: 'no-store' }).then(r => r.headers.get('x-vitest-probe'), () => null),
+            interceptionProbeUrl,
+          ).catch(() => null),
+          new Promise<null>(resolve => setTimeout(resolve, deadline - Date.now(), null)),
+        ])
+        if (result === token) {
+          debug?.('[%s] request interception armed in %sms', this.browserName, (performance.now() - startedAt).toFixed(1))
+          return
+        }
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+      this.armedContexts.delete(context)
+      await context.unroute(interceptionProbeRoute, probeRoute).catch(() => {})
+      throw new Error(`Cannot verify that ${this.browserName} request interception is active after ${interceptionArmTimeout}ms; module mocks would not apply reliably (#8339)`)
+    })()
+    this.armedContexts.set(context, { promise, probeRoute })
+    return promise
+  }
+
+  private async disarmInterception(context: BrowserContext): Promise<void> {
+    const armed = this.armedContexts.get(context)
+    if (!armed) {
+      return
+    }
+    this.armedContexts.delete(context)
+    await context.unroute(interceptionProbeRoute, armed.probeRoute)
+  }
+
   private createMocker(): BrowserModuleMocker {
     const idPredicates = new Map<string, (url: URL) => boolean>()
     const sessionIds = new Map<string, Set<string>>()
@@ -423,100 +501,127 @@ export class PlaywrightBrowserProvider implements BrowserProvider {
     return {
       register: async (sessionId: string, module: MockedModule): Promise<void> => {
         const page = this.getPage(sessionId)
-        const { url: moduleUrl, predicate } = createPredicate(module.url)
-        const key = predicateKey(sessionId, moduleUrl)
-        const existingPredicate = idPredicates.get(key)
-        if (existingPredicate) {
-          await page.context().unroute(existingPredicate)
-        }
-        const ids = sessionIds.get(sessionId) ?? new Set<string>()
-        ids.add(moduleUrl)
-        sessionIds.set(sessionId, ids)
-        idPredicates.set(key, predicate)
-        await page.context().route(predicate, async (route) => {
-          if (module.type === 'manual') {
-            const exports = Object.keys(await module.resolve())
-            const body = createManualModuleSource(module.url, exports)
-            return route.fulfill({
-              body,
-              headers: getHeaders(this.project.browser!.vite.config),
-            })
-          }
-
-          // webkit doesn't support redirect responses
-          // https://github.com/microsoft/playwright/issues/18318
-          const isWebkit = this.browserName === 'webkit'
-          if (isWebkit) {
-            let url: string
-            if (module.type === 'redirect') {
-              const redirect = new URL(module.redirect)
-              url = redirect.href.slice(redirect.origin.length)
-            }
-            else {
-              const request = new URL(route.request().url())
-              request.searchParams.set('mock', module.type)
-              url = request.href.slice(request.origin.length)
-            }
-
-            const result = await this.project.browser!.vite.transformRequest(url).catch(() => null)
-            if (!result) {
-              return route.continue()
-            }
-            let content = result.code
-            if (result.map && 'version' in result.map && result.map.mappings) {
-              const type = isDirectCSSRequest(url) ? 'css' : 'js'
-              content = getCodeWithSourcemap(type, content.toString(), result.map)
-            }
-            return route.fulfill({
-              body: content,
-              headers: getHeaders(this.project.browser!.vite.config),
-            })
-          }
-
-          if (module.type === 'redirect') {
-            return route.fulfill({
-              status: 302,
-              headers: {
-                Location: module.redirect,
-              },
-            })
-          }
-          else if (module.type === 'automock' || module.type === 'autospy') {
-            const url = new URL(route.request().url())
-            url.searchParams.set('mock', module.type)
-            return route.fulfill({
-              status: 302,
-              headers: {
-                Location: url.href,
-              },
-            })
+        const context = page.context()
+        await this.serializeContext(context, async () => {
+          await this.armInterception(page)
+          const { url: moduleUrl, predicate } = createPredicate(module.url)
+          const key = predicateKey(sessionId, moduleUrl)
+          const existingPredicate = idPredicates.get(key)
+          if (existingPredicate) {
+            await context.unroute(existingPredicate)
           }
           else {
-            // all types are exhausted
-            const _module: never = module
+            this.contextRouteCounts.set(context, (this.contextRouteCounts.get(context) ?? 0) + 1)
           }
+          const ids = sessionIds.get(sessionId) ?? new Set<string>()
+          ids.add(moduleUrl)
+          sessionIds.set(sessionId, ids)
+          idPredicates.set(key, predicate)
+          await context.route(predicate, async (route) => {
+            if (module.type === 'manual') {
+              const exports = Object.keys(await module.resolve())
+              const body = createManualModuleSource(module.url, exports)
+              return route.fulfill({
+                body,
+                headers: getHeaders(this.project.browser!.vite.config),
+              })
+            }
+
+            // webkit doesn't support redirect responses
+            // https://github.com/microsoft/playwright/issues/18318
+            const isWebkit = this.browserName === 'webkit'
+            if (isWebkit) {
+              let url: string
+              if (module.type === 'redirect') {
+                const redirect = new URL(module.redirect)
+                url = redirect.href.slice(redirect.origin.length)
+              }
+              else {
+                const request = new URL(route.request().url())
+                request.searchParams.set('mock', module.type)
+                url = request.href.slice(request.origin.length)
+              }
+
+              const result = await this.project.browser!.vite.transformRequest(url).catch(() => null)
+              if (!result) {
+                return route.continue()
+              }
+              let content = result.code
+              if (result.map && 'version' in result.map && result.map.mappings) {
+                const type = isDirectCSSRequest(url) ? 'css' : 'js'
+                content = getCodeWithSourcemap(type, content.toString(), result.map)
+              }
+              return route.fulfill({
+                body: content,
+                headers: getHeaders(this.project.browser!.vite.config),
+              })
+            }
+
+            if (module.type === 'redirect') {
+              return route.fulfill({
+                status: 302,
+                headers: {
+                  Location: module.redirect,
+                },
+              })
+            }
+            else if (module.type === 'automock' || module.type === 'autospy') {
+              const url = new URL(route.request().url())
+              url.searchParams.set('mock', module.type)
+              return route.fulfill({
+                status: 302,
+                headers: {
+                  Location: url.href,
+                },
+              })
+            }
+            else {
+              // all types are exhausted
+              const _module: never = module
+            }
+          })
         })
       },
       delete: async (sessionId: string, id: string): Promise<void> => {
         const page = this.getPage(sessionId)
-        const key = predicateKey(sessionId, id)
-        const predicate = idPredicates.get(key)
-        if (predicate) {
-          await page.context().unroute(predicate).finally(() => idPredicates.delete(key))
-        }
-      },
-      clear: async (sessionId: string): Promise<void> => {
-        const page = this.getPage(sessionId)
-        const ids = sessionIds.get(sessionId) ?? new Set<string>()
-        const promises = Array.from(ids, (id) => {
+        const context = page.context()
+        await this.serializeContext(context, async () => {
           const key = predicateKey(sessionId, id)
           const predicate = idPredicates.get(key)
           if (predicate) {
-            return page.context().unroute(predicate).finally(() => idPredicates.delete(key))
+            await context.unroute(predicate).finally(() => idPredicates.delete(key))
+            const count = (this.contextRouteCounts.get(context) ?? 1) - 1
+            this.contextRouteCounts.set(context, count)
+            if (count === 0) {
+              await this.disarmInterception(context)
+            }
           }
-          return null
         })
-        await Promise.all(promises).finally(() => sessionIds.delete(sessionId))
+      },
+      clear: async (sessionId: string): Promise<void> => {
+        const page = this.getPage(sessionId)
+        const context = page.context()
+        await this.serializeContext(context, async () => {
+          const ids = sessionIds.get(sessionId) ?? new Set<string>()
+          let removed = 0
+          const promises = Array.from(ids, (id) => {
+            const key = predicateKey(sessionId, id)
+            const predicate = idPredicates.get(key)
+            if (predicate) {
+              removed++
+              return context.unroute(predicate).finally(() => idPredicates.delete(key))
+            }
+            return null
+          })
+          await Promise.all(promises).finally(() => sessionIds.delete(sessionId))
+          if (removed > 0) {
+            const count = Math.max(0, (this.contextRouteCounts.get(context) ?? 0) - removed)
+            this.contextRouteCounts.set(context, count)
+            if (count === 0) {
+              await this.disarmInterception(context)
+            }
+          }
+        })
       },
     }
   }

--- a/test/browser/fixtures/mock-stress/src/dep-1.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-1.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-1'
+
+export function answer(): string {
+  return 'real-answer-1'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-10.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-10.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-10'
+
+export function answer(): string {
+  return 'real-answer-10'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-2.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-2.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-2'
+
+export function answer(): string {
+  return 'real-answer-2'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-3.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-3.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-3'
+
+export function answer(): string {
+  return 'real-answer-3'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-4.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-4.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-4'
+
+export function answer(): string {
+  return 'real-answer-4'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-5.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-5.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-5'
+
+export function answer(): string {
+  return 'real-answer-5'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-6.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-6.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-6'
+
+export function answer(): string {
+  return 'real-answer-6'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-7.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-7.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-7'
+
+export function answer(): string {
+  return 'real-answer-7'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-8.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-8.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-8'
+
+export function answer(): string {
+  return 'real-answer-8'
+}

--- a/test/browser/fixtures/mock-stress/src/dep-9.ts
+++ b/test/browser/fixtures/mock-stress/src/dep-9.ts
@@ -1,0 +1,5 @@
+export const tag = 'real-9'
+
+export function answer(): string {
+  return 'real-answer-9'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-1.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-1.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-1'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-10.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-10.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-10'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-2.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-2.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-2'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-3.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-3.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-3'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-4.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-4.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-4'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-5.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-5.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-5'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-6.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-6.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-6'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-7.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-7.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-7'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-8.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-8.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-8'
+}

--- a/test/browser/fixtures/mock-stress/src/spy-9.ts
+++ b/test/browser/fixtures/mock-stress/src/spy-9.ts
@@ -1,0 +1,3 @@
+export function greet(): string {
+  return 'real-greet-9'
+}

--- a/test/browser/fixtures/mock-stress/stress-1.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-1.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-1'
+import { greet } from './src/spy-1'
+
+vi.mock(import('./src/dep-1'), () => ({
+  tag: 'mock-1',
+  answer: () => 'mock-answer-1',
+}))
+
+vi.mock(import('./src/spy-1'), { spy: true })
+
+test('stress-1: factory mock is applied', () => {
+  expect(tag).toBe('mock-1')
+  expect(answer()).toBe('mock-answer-1')
+})
+
+test('stress-1: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-1')
+  expect(greet()).toBe('patched-1')
+})

--- a/test/browser/fixtures/mock-stress/stress-10.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-10.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-10'
+import { greet } from './src/spy-10'
+
+vi.mock(import('./src/dep-10'), () => ({
+  tag: 'mock-10',
+  answer: () => 'mock-answer-10',
+}))
+
+vi.mock(import('./src/spy-10'), { spy: true })
+
+test('stress-10: factory mock is applied', () => {
+  expect(tag).toBe('mock-10')
+  expect(answer()).toBe('mock-answer-10')
+})
+
+test('stress-10: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-10')
+  expect(greet()).toBe('patched-10')
+})

--- a/test/browser/fixtures/mock-stress/stress-2.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-2.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-2'
+import { greet } from './src/spy-2'
+
+vi.mock(import('./src/dep-2'), () => ({
+  tag: 'mock-2',
+  answer: () => 'mock-answer-2',
+}))
+
+vi.mock(import('./src/spy-2'), { spy: true })
+
+test('stress-2: factory mock is applied', () => {
+  expect(tag).toBe('mock-2')
+  expect(answer()).toBe('mock-answer-2')
+})
+
+test('stress-2: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-2')
+  expect(greet()).toBe('patched-2')
+})

--- a/test/browser/fixtures/mock-stress/stress-3.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-3.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-3'
+import { greet } from './src/spy-3'
+
+vi.mock(import('./src/dep-3'), () => ({
+  tag: 'mock-3',
+  answer: () => 'mock-answer-3',
+}))
+
+vi.mock(import('./src/spy-3'), { spy: true })
+
+test('stress-3: factory mock is applied', () => {
+  expect(tag).toBe('mock-3')
+  expect(answer()).toBe('mock-answer-3')
+})
+
+test('stress-3: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-3')
+  expect(greet()).toBe('patched-3')
+})

--- a/test/browser/fixtures/mock-stress/stress-4.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-4.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-4'
+import { greet } from './src/spy-4'
+
+vi.mock(import('./src/dep-4'), () => ({
+  tag: 'mock-4',
+  answer: () => 'mock-answer-4',
+}))
+
+vi.mock(import('./src/spy-4'), { spy: true })
+
+test('stress-4: factory mock is applied', () => {
+  expect(tag).toBe('mock-4')
+  expect(answer()).toBe('mock-answer-4')
+})
+
+test('stress-4: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-4')
+  expect(greet()).toBe('patched-4')
+})

--- a/test/browser/fixtures/mock-stress/stress-5.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-5.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-5'
+import { greet } from './src/spy-5'
+
+vi.mock(import('./src/dep-5'), () => ({
+  tag: 'mock-5',
+  answer: () => 'mock-answer-5',
+}))
+
+vi.mock(import('./src/spy-5'), { spy: true })
+
+test('stress-5: factory mock is applied', () => {
+  expect(tag).toBe('mock-5')
+  expect(answer()).toBe('mock-answer-5')
+})
+
+test('stress-5: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-5')
+  expect(greet()).toBe('patched-5')
+})

--- a/test/browser/fixtures/mock-stress/stress-6.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-6.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-6'
+import { greet } from './src/spy-6'
+
+vi.mock(import('./src/dep-6'), () => ({
+  tag: 'mock-6',
+  answer: () => 'mock-answer-6',
+}))
+
+vi.mock(import('./src/spy-6'), { spy: true })
+
+test('stress-6: factory mock is applied', () => {
+  expect(tag).toBe('mock-6')
+  expect(answer()).toBe('mock-answer-6')
+})
+
+test('stress-6: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-6')
+  expect(greet()).toBe('patched-6')
+})

--- a/test/browser/fixtures/mock-stress/stress-7.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-7.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-7'
+import { greet } from './src/spy-7'
+
+vi.mock(import('./src/dep-7'), () => ({
+  tag: 'mock-7',
+  answer: () => 'mock-answer-7',
+}))
+
+vi.mock(import('./src/spy-7'), { spy: true })
+
+test('stress-7: factory mock is applied', () => {
+  expect(tag).toBe('mock-7')
+  expect(answer()).toBe('mock-answer-7')
+})
+
+test('stress-7: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-7')
+  expect(greet()).toBe('patched-7')
+})

--- a/test/browser/fixtures/mock-stress/stress-8.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-8.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-8'
+import { greet } from './src/spy-8'
+
+vi.mock(import('./src/dep-8'), () => ({
+  tag: 'mock-8',
+  answer: () => 'mock-answer-8',
+}))
+
+vi.mock(import('./src/spy-8'), { spy: true })
+
+test('stress-8: factory mock is applied', () => {
+  expect(tag).toBe('mock-8')
+  expect(answer()).toBe('mock-answer-8')
+})
+
+test('stress-8: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-8')
+  expect(greet()).toBe('patched-8')
+})

--- a/test/browser/fixtures/mock-stress/stress-9.test.ts
+++ b/test/browser/fixtures/mock-stress/stress-9.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+import { answer, tag } from './src/dep-9'
+import { greet } from './src/spy-9'
+
+vi.mock(import('./src/dep-9'), () => ({
+  tag: 'mock-9',
+  answer: () => 'mock-answer-9',
+}))
+
+vi.mock(import('./src/spy-9'), { spy: true })
+
+test('stress-9: factory mock is applied', () => {
+  expect(tag).toBe('mock-9')
+  expect(answer()).toBe('mock-answer-9')
+})
+
+test('stress-9: spy mock wraps the module', () => {
+  expect(vi.isMockFunction(greet)).toBe(true)
+  vi.mocked(greet).mockReturnValue('patched-9')
+  expect(greet()).toBe('patched-9')
+})

--- a/test/browser/fixtures/mock-stress/vitest.config.ts
+++ b/test/browser/fixtures/mock-stress/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { instances, provider } from '../../settings'
+
+export default defineConfig({
+  cacheDir: fileURLToPath(new URL('./node_modules/.vite', import.meta.url)),
+  test: {
+    // load/** runs its own config (vitest.load.config.ts) with 32 parallel sessions
+    include: ['stress-*.test.ts', 'zz-plain.test.ts'],
+    browser: {
+      enabled: true,
+      provider,
+      instances,
+      headless: true,
+    },
+  },
+})

--- a/test/browser/fixtures/mock-stress/zz-plain.test.ts
+++ b/test/browser/fixtures/mock-stress/zz-plain.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { answer, tag } from './src/dep-10'
+import { greet } from './src/spy-10'
+
+// /__vitest_non_mock_probe__ is a marker request: it must never show up as a
+// paused request in the protocol log, because a file without mocks runs with
+// request interception fully disarmed
+test('plain file imports real modules without interception', async () => {
+  expect(tag).toBe('real-10')
+  expect(answer()).toBe('real-answer-10')
+  expect(greet()).toBe('real-greet-10')
+  await fetch('/__vitest_non_mock_probe__').then(r => r.status, () => -1)
+})

--- a/test/browser/specs/mocking-interception.test.ts
+++ b/test/browser/specs/mocking-interception.test.ts
@@ -1,0 +1,55 @@
+import { expect, onTestFailed, test } from 'vitest'
+import { runVitestCli } from '../../test-utils'
+import { instances } from '../settings'
+
+// every file with mocks arms the request interception before its imports are
+// released and disarms it when its last mock route is removed at teardown, so
+// the interception never leaks into files without mocks — and the #8339 race
+// window (Fetch.enable acknowledged before the interception is live) is closed
+// by the probe roundtrip. Firefox and WebKit never use the CDP Fetch domain,
+// so only the run's health is asserted there.
+test.each(instances)('$browser - request interception is armed and disarmed per file with mocks', async ({ browser }) => {
+  const { exitCode, stdout, stderr } = await runVitestCli({
+    nodeOptions: {
+      env: {
+        DEBUG: 'pw:protocol',
+        PROVIDER: 'playwright',
+        TEST_BROWSER: browser,
+        BROWSER_NO_WEBKIT: 'true',
+      },
+    },
+  }, '--no-watch', '--root', 'fixtures/mock-stress')
+
+  onTestFailed(() => {
+    console.error(stdout)
+    console.error(stderr)
+  })
+
+  // the inner run must exit 0 with every file executed; the CLI report format
+  // differs from the API reporter (`✓  chromium  file`), so match the summary
+  expect(exitCode).toBe(0)
+  expect(stdout).toContain('Test Files  11 passed')
+  expect(stdout).toContain('stress-1.test.ts')
+  expect(stdout).toContain('stress-10.test.ts')
+  expect(stdout).toContain('zz-plain.test.ts')
+
+  if (browser !== 'chromium') {
+    return
+  }
+
+  // the protocol log arrives on stderr; each mock file toggles the Fetch
+  // domain exactly once per arm cycle and the file without mocks must not
+  // produce a single paused request
+  const toggles = [...(stderr.match(/"(?:Fetch\.enable|Fetch\.disable)"/g) ?? [])]
+  const enables = toggles.filter(t => t === '"Fetch.enable"')
+  const disables = toggles.filter(t => t === '"Fetch.disable"')
+
+  expect(enables).toHaveLength(10)
+  expect(disables).toHaveLength(10)
+  expect(stderr.match(/"Fetch\.requestPaused"[^\n]*__vitest_non_mock_probe__/g)).toBe(null)
+
+  // the durable guard that the arm barrier ran at all: a mutant removing
+  // armInterception keeps enables/disables untouched, but leaves the probe
+  // roundtrips missing; exactly one paused probe per armed file (INV-6)
+  expect(stderr.match(/"Fetch\.requestPaused"[^\n]*__vitest_interception_probe__/g)).toHaveLength(10)
+})


### PR DESCRIPTION

## Summary

Mock routes are playwright `context.route()` handlers; the provider unroutes them when a
file ends, so the route count crosses zero between files and playwright toggles CDP
`Fetch.disable` / `Fetch.enable`. Chromium acks `Fetch.enable` before interception is live,
so the first module request of a mocking file can be served unmocked and cached by the ES
registry for the file's lifetime.

This PR scopes the interception to the mock-route lifetime:

- **arm**: on the first mock registration of a context, complete one probe roundtrip before
  the mocker releases the file's imports (probe mechanism from #11083, @cplieger);
- **disarm**: when the last mock route of the context is removed (the existing per-file
  teardown), unroute the probe and drop the memo — files without mocks run with zero
  interception;
- register/delete/clear are serialized per context — no stale armed memo or route-count
  drift from parallel sessions;
- arm must converge within `interceptionArmTimeout = 2 s` (`ceil(3 × p99)` over 74 measured
  arms: 13–30 ms sequential, p99 604 ms including a 32-parallel-sessions run); otherwise it
  fails loud.

Non-chromium providers are untouched.

## Measurements

chromium, `DEBUG=pw:protocol`, 11-file suite (10 mocking files + 1 plain):

| | enable | disable | paused requests | non-mock file paused |
|---|---|---|---|---|
| unpatched | 10 | 10 | 29 | 0 — but the race reproduced: a mock silently didn't apply (1 failure in 2 logged cold baseline runs) |
| always-on interception | 1 | 0 | 194 | yes |
| this PR | 10 | 10 | 40 | 0 |

The +10 pauses are one probe roundtrip per arm.

## Tests

- new `test/browser/specs/mocking-interception.test.ts` (chromium): one `Fetch.enable`/
  `Fetch.disable` pair per mocking file; one paused probe per arm; zero paused requests
  attributable to the non-mocking file; all files green. firefox/webkit: run health.
- existing `mocking.test.ts` unchanged, green (cross-file leak, rerun invalidation).

Fixes #8339. Probe-arming mechanism follows #11083 — this PR narrows its lifetime and adds
the disarm path, per-context serialization, and deadline calibration.

