### PR TITLE
fix(coverage): reset istanbul counters after take

### DIFF
--- a/packages/coverage-istanbul/src/base.ts
+++ b/packages/coverage-istanbul/src/base.ts
@@ -5,7 +5,18 @@ import { COVERAGE_STORE_KEY } from './constants'
 export const BaseCoverageProviderModule = {
   takeCoverage(): CoverageMapData | undefined {
     // @ts-expect-error -- untyped global
-    return globalThis[COVERAGE_STORE_KEY]
+    const coverageMap = globalThis[COVERAGE_STORE_KEY] as CoverageMapData | undefined
+
+    if (!coverageMap) {
+      return
+    }
+
+    // isolate:false keeps many files in one run request. takeCoverage runs
+    // after each file; without a snapshot+reset the next take still holds
+    // earlier hits and merge double-counts them.
+    const snapshot = structuredClone(coverageMap)
+    this.startCoverage()
+    return snapshot
   },
 
   // Reset coverage map to prevent duplicate results if this is called twice in row

--- a/test/coverage-test/test/isolation.test.ts
+++ b/test/coverage-test/test/isolation.test.ts
@@ -52,6 +52,10 @@ for (const isolate of [true, false]) {
           statements: '4/4 (100%)',
         },
       })
+
+      // 100% still passes if isolate:false merge double-counts the first file.
+      // isolation-1 calls each math function once; hits must stay 1.
+      expect(Object.values(math.f)).toEqual([1, 1, 1, 1])
     })
   }
 }


### PR DESCRIPTION
### Description

`isolate: false` + `@vitest/coverage-istanbul` reports the wrong hit counts when two test files share one module.

Each file calls a different function once. The JSON report then shows the function from the first file as `2`. `isolate: true` and `@vitest/coverage-v8` stay at `1`.

`runBaseTests` starts coverage once per run request, then `takeCoverage` after every file. With `isolate: false` those files stay in the same request, so the second take still contains the first file's hits. Merge adds them again.

`#6957` already resets counters on `startCoverage`. That does not run between takes in one request. Official `isolation.test.ts` only asserted 100%, which still passes when counts are doubled.

This change snapshots the istanbul map in `takeCoverage` and then resets the live counters (same reset as `startCoverage`). Node and browser both go through `BaseCoverageProviderModule`.

I used Cursor while writing the patch. I read the diff and am opening the PR myself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] Extended `test/coverage-test/test/isolation.test.ts` so `math.f` must be `[1, 1, 1, 1]` for isolate true and false.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
