### PR TITLE
fix(mocker): preserve hoisted ssr re-exports

### DIFF
--- a/packages/mocker/EXPORTS.md
+++ b/packages/mocker/EXPORTS.md
@@ -217,6 +217,10 @@ Hoist compiler hints, replace static imports with dynamic ones and update export
 
 This is required to ensure mocks are resolved before we import the user module.
 
+Module-runner integrations can supply `renderExport(name, expression)`, returning code that registers a live export getter for an imported binding re-exported through an export list. Vitest supplies this backend for Vite module-runner transforms only; native ESM output, including Browser Mode, is unchanged.
+
+`hoistMocksPlugin` returns this code in `meta.vitestHoistedExports` so the module-runner integration can prepend it **after** SSR transformation, before evaluating any static imports. Calling `hoistMocks` directly inserts the generated code before the hoisted calls.
+
 ```ts
 import { parseAst } from 'vite'
 

--- a/packages/mocker/src/node/hoistMocks.ts
+++ b/packages/mocker/src/node/hoistMocks.ts
@@ -4,6 +4,7 @@ import type {
   CallExpression,
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
+  ExportSpecifier,
   Expression,
   FunctionExpression,
   Identifier,
@@ -29,6 +30,8 @@ export interface StaticMockCall {
 
 export interface HoistMocksOptions {
   onStaticMock?: (call: StaticMockCall) => void
+  /** Emit a live export getter for an imported binding, before hoisted code runs. */
+  renderExport?: (name: string, expression: string) => string
   /**
    * List of modules that should always be imported before compiler hints.
    * @default 'vitest'
@@ -456,6 +459,51 @@ export function hoistMocks(
 
   if (!hasMockApiCall) {
     return
+  }
+
+  const { renderExport } = options
+  if (renderExport) {
+    let exports = ''
+    for (const node of ast.body as Node[]) {
+      if (node.type !== 'ExportNamedDeclaration' || node.source) {
+        continue
+      }
+      const specifiers = node.specifiers as Positioned<ExportSpecifier>[]
+      const removed = new Set(specifiers.filter((specifier) => {
+        const binding = idToImportMap.get((specifier.local as Identifier).name)
+        if (!binding) {
+          return false
+        }
+        const name = specifier.exported.type === 'Identifier'
+          ? specifier.exported.name
+          : String(specifier.exported.value)
+        exports += renderExport(name, binding)
+        return true
+      }))
+      if (!removed.size) {
+        continue
+      }
+      if (removed.size === specifiers.length) {
+        s.remove(node.start, node.end)
+        continue
+      }
+      // Remove adjacent imported specifiers together, including their separator.
+      for (let i = 0; i < specifiers.length; i++) {
+        if (!removed.has(specifiers[i])) {
+          continue
+        }
+        const start = i
+        while (removed.has(specifiers[i + 1])) {
+          i++
+        }
+        const last = i === specifiers.length - 1
+        s.remove(
+          last ? specifiers[start - 1].end : specifiers[start].start,
+          last ? specifiers[i].end : specifiers[i + 1].start,
+        )
+      }
+    }
+    s.appendLeft(hashbangEnd, exports)
   }
 
   function getNodeName(node: CallExpression) {

--- a/packages/mocker/src/node/hoistMocksPlugin.ts
+++ b/packages/mocker/src/node/hoistMocksPlugin.ts
@@ -34,19 +34,20 @@ export function hoistMocksPlugin(options: HoistMocksPluginOptions = {}): Plugin 
     `\\b(?:${utilsObjectNames.join('|')})\\s*\.\\s*(?:${Array.from(methods).join('|')})\\s*\\(`,
   )
 
-  let root: string
+  let root = options.root
 
   return {
     name: 'vitest:mocks',
     enforce: 'post',
-    configResolved(config) {
-      root = config.root
-    },
+    configResolved: options.root === undefined
+      ? (config) => { root = config.root }
+      : undefined,
     transform(code, id) {
       if (!filter(id)) {
         return
       }
       const staticMocks: StaticMockCall[] = []
+      let hoistedExports = ''
       const s = hoistMocks(code, id, this.parse, {
         regexpHoistable,
         hoistableMockMethodNames,
@@ -56,6 +57,10 @@ export function hoistMocksPlugin(options: HoistMocksPluginOptions = {}): Plugin 
         root,
         getMap: () => this.getCombinedSourcemap(),
         ...options,
+        renderExport: options.renderExport && ((name, expression) => {
+          hoistedExports += options.renderExport!(name, expression)
+          return ''
+        }),
         onStaticMock(call) {
           staticMocks.push(call)
           options.onStaticMock?.(call)
@@ -63,12 +68,12 @@ export function hoistMocksPlugin(options: HoistMocksPluginOptions = {}): Plugin 
       })
       // vite keeps `meta` across re-transforms, so always reset it
       if (!s) {
-        return { meta: { vitestStaticMocks: null } }
+        return { meta: { vitestStaticMocks: null, vitestHoistedExports: null } }
       }
       return {
         code: s.toString(),
         map: s.generateMap({ hires: 'boundary', source: cleanUrl(id) }),
-        meta: { vitestStaticMocks: staticMocks },
+        meta: { vitestStaticMocks: staticMocks, vitestHoistedExports: hoistedExports || null },
       }
     },
   }

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -299,6 +299,8 @@ class ModuleFetcher {
       __vitestTmp: cachePath,
       __vitestModuleType: moduleType,
       __vitestStaticMocks: cachedModule.staticMocks,
+      // Cached code has already passed processResultSource.
+      __vitestExportsHoisted: true,
     }
 
     // we populate the module graph to make the watch mode work because it relies on importers
@@ -476,6 +478,22 @@ function processResultSource(environment: DevEnvironment, result: FetchResult): 
 
   const node = environment.moduleGraph.getModuleById(result.id)
   if (node?.transformResult) {
+    const transform = node.transformResult
+    if (!transform.__vitestExportsHoisted) {
+      const exports = environment.pluginContainer.getModuleInfo(result.id)?.meta?.vitestHoistedExports
+      if (exports) {
+        // Register before Vite's static imports, including cyclic source re-exports.
+        // This must happen after SSR transformation and before source maps/caching.
+        transform.code = exports + transform.code
+        if (transform.map && 'version' in transform.map) {
+          transform.map = {
+            ...transform.map,
+            mappings: ';'.repeat(exports.split('\n').length - 1) + transform.map.mappings,
+          }
+        }
+      }
+      transform.__vitestExportsHoisted = true
+    }
     // this also overrides node.transformResult.code which is also what the module
     // runner does under the hood by default (we disable source maps inlining)
     inlineSourceMap(node.transformResult)
@@ -605,5 +623,7 @@ declare module 'vite' {
     __vitestModuleType?: ModuleType
     // set by the hoistMocks plugin; null when the file was not hoisted
     __vitestStaticMocks?: StaticMockCall[] | null
+    // The export prelude is already part of code; do not prepend it on repeat fetches.
+    __vitestExportsHoisted?: boolean
   }
 }

--- a/packages/vitest/src/node/plugins/mocks.ts
+++ b/packages/vitest/src/node/plugins/mocks.ts
@@ -11,24 +11,35 @@ export interface MocksPluginOptions {
 export function MocksPlugins(options: MocksPluginOptions = {}): Plugin[] {
   const normalizedDistDir = normalize(distDir)
   return [
-    hoistMocksPlugin({
-      filter(id) {
-        if (id.includes(normalizedDistDir)) {
-          return false
-        }
-        if (options.filter) {
-          return options.filter(id)
-        }
-        return true
+    {
+      name: 'vitest:mocks',
+      enforce: 'post',
+      applyToEnvironment(environment) {
+        return hoistMocksPlugin({
+          root: environment.config.root,
+          // Use the same gate as Vite's SSR transform, including emulated DOM environments.
+          renderExport: environment.config.dev.moduleRunnerTransform
+            ? (name, expression) => `__vite_ssr_exportName__(${JSON.stringify(name)}, () => { try { return ${expression} } catch {} });\n`
+            : undefined,
+          filter(id) {
+            if (id.includes(normalizedDistDir)) {
+              return false
+            }
+            if (options.filter) {
+              return options.filter(id)
+            }
+            return true
+          },
+          codeFrameGenerator(node, id, code) {
+            return generateCodeFrame(
+              code,
+              4,
+              node.start + 1,
+            )
+          },
+        })
       },
-      codeFrameGenerator(node, id, code) {
-        return generateCodeFrame(
-          code,
-          4,
-          node.start + 1,
-        )
-      },
-    }),
+    },
     automockPlugin(),
   ]
 }

--- a/test/e2e/test/configureVitest.test.ts
+++ b/test/e2e/test/configureVitest.test.ts
@@ -1,14 +1,51 @@
 import type { ViteUserConfig } from 'vitest/config'
 import type { TestProject, TestUserConfig, VitestOptions } from 'vitest/node'
 import { playwright } from '@vitest/browser-playwright'
+import { parseAst } from 'vite'
 import { expect, onTestFinished, test } from 'vitest'
 import { createVitest } from 'vitest/node'
+import { runInlineTests } from '../../test-utils'
 
 async function vitest(cliOptions: TestUserConfig, configValue: TestUserConfig = {}, viteConfig: ViteUserConfig = {}, vitestOptions: VitestOptions = {}) {
   const vitest = await createVitest('test', { ...cliOptions, config: false, watch: false }, { ...viteConfig, test: configValue as any }, vitestOptions)
   onTestFinished(() => vitest.close())
   return vitest
 }
+
+test.for(['node', 'browser'])('mock export backend follows the module-runner environment (%s)', async (mode) => {
+  const run = await runInlineTests({
+    'dependency.js': 'export const value = 1',
+    'reexport.js': `import { value } from './dependency.js'; import { vi } from 'vitest'; vi.hoisted(() => ({})); export { value }`,
+    'basic.test.js': `
+import { expect, test } from 'vitest'
+import { value } from './dependency.js'
+test('runtime starts', () => expect(value).toBe(1))
+    `,
+  }, {
+    // Keep the started server alive for the transform assertions below.
+    watch: true,
+    ...(mode === 'browser'
+      ? { browser: { enabled: true, headless: true, provider: playwright(), instances: [{ browser: 'chromium' as const }] } }
+      : {}),
+    $viteConfig: { environments: { __vitest_vm__: {} } },
+  })
+  expect(run.stderr).toBe('')
+  expect(run.testTree()).toEqual({ 'basic.test.js': { 'runtime starts': 'passed' } })
+
+  const id = run.fs.resolveFile('reexport.js')
+  for (const name of ['ssr', 'client', '__vitest_vm__']) {
+    const environment = run.ctx!.vite.environments[name]
+    const result = await environment.transformRequest(id)
+    const body = parseAst(result!.code).body
+    const exports = environment.pluginContainer.getModuleInfo(id)?.meta.vitestHoistedExports
+    const usesModuleRunner = name !== '__vitest_vm__' && (name !== 'client' || mode !== 'browser')
+    expect(exports, name).toBe(usesModuleRunner
+      ? '__vite_ssr_exportName__("value", () => { try { return __vi_import_0__.value } catch {} });\n'
+      : null)
+    expect(body.filter(node => node.type === 'ExportNamedDeclaration'), name)
+      .toHaveLength(usesModuleRunner ? 0 : 1)
+  }
+})
 
 test('can change global configuration', async () => {
   const v = await vitest({}, {}, {
@@ -254,6 +291,7 @@ test('can access browser.instances[].browser', async () => {
   const names: { browser: string; project: string }[] = []
 
   await vitest({}, {
+    include: [],
     name: 'custom-project-name',
     browser: {
       enabled: true,
@@ -308,6 +346,7 @@ test('can access project\'s browser.instances[].browser', async () => {
           },
         ],
         test: {
+          include: [],
           name: 'custom-project-name',
           browser: {
             enabled: true,

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -1,6 +1,8 @@
 import type { RunVitestConfig } from '../../test-utils'
-import path from 'node:path'
+import { unlinkSync } from 'node:fs'
+import { SourceMap } from 'node:module'
 import { playwright } from '@vitest/browser-playwright'
+import path from 'pathe'
 import { expect, test } from 'vitest'
 import { rolldownVersion } from 'vitest/node'
 import { runInlineTests, runVitest, StableTestFileOrderSorter } from '../../test-utils'
@@ -153,6 +155,188 @@ function modeToConfig(mode: string): RunVitestConfig {
   }
   return {}
 }
+
+test.for([
+  ['node', 'hoisted'],
+  ['node', 'mock'],
+  ['jsdom', 'hoisted'],
+  ['jsdom', 'mock'],
+])('imported-value re-exports retain live bindings (%s, %s)', async ([environment, trigger]) => {
+  const { stderr, thrown, errorTree } = await runInlineTests({
+    'dependency.js': `
+export let value = 1
+export { value as default }
+export const identity = {}
+export function increment() { value++ }
+export function read() { return value }
+    `,
+    'unused.js': 'export {}',
+    'reexport.ts': `
+import { vi } from 'vitest'
+export { value, value as alias, importedDefault as default, importedDefault as namedDefault, namespace, identity, local, vi }
+export { value as 'string name' }
+import importedDefault, { value, identity, read } from './dependency.js'
+import * as namespace from './dependency.js'
+${trigger === 'hoisted' ? 'vi.hoisted(() => ({}))' : 'vi.mock(\'./unused.js\', () => ({}))'}
+const local: number = 42
+export function internal() { return read() }
+    `,
+    'explicit.js': `export { value } from './dependency.js'`,
+    'basic.test.js': `
+import { expect, test } from 'vitest'
+import * as reexported from './reexport.ts'
+import * as dependency from './dependency.js'
+import * as explicit from './explicit.js'
+
+test('live imported exports and unaffected paths', () => {
+  expect(reexported.local).toBe(42)
+  expect(reexported.vi.hoisted).toBeTypeOf('function')
+  expect(reexported.internal()).toBe(1)
+  expect(explicit.value).toBe(1)
+
+  expect.soft(reexported.value).toBe(1)
+  expect.soft(reexported.alias).toBe(1)
+  expect.soft(reexported['string name']).toBe(1)
+  expect.soft(reexported.default).toBe(1)
+  expect.soft(reexported.namedDefault).toBe(1)
+  expect.soft(reexported.identity).toBe(dependency.identity)
+  expect.soft(reexported.namespace).toBe(dependency)
+
+  dependency.increment()
+  expect(reexported.internal()).toBe(2)
+  expect(explicit.value).toBe(2)
+  expect.soft(reexported.value).toBe(2)
+  expect.soft(reexported.alias).toBe(2)
+  expect.soft(reexported['string name']).toBe(2)
+  expect.soft(reexported.default).toBe(2)
+  expect.soft(reexported.namedDefault).toBe(2)
+})
+    `,
+  }, { environment })
+
+  expect(thrown).toBe(false)
+  expect(stderr).toBe('')
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.js": {
+        "live imported exports and unaffected paths": "passed",
+      },
+    }
+  `)
+})
+
+test('imported-value re-exports use the same live mock as internal imports', async () => {
+  const { stderr, testTree } = await runInlineTests({
+    'dependency.js': `throw new Error('the original must not evaluate')`,
+    'reexport.js': `
+import { vi } from 'vitest'
+import { value, identity } from './dependency.js'
+import * as namespace from './dependency.js'
+const state = vi.hoisted(() => ({ value: 1, events: ['hoisted'] }))
+vi.mock('./dependency.js', () => {
+  state.events.push('factory')
+  return { get value() { return state.value }, identity: {} }
+})
+export { value, identity, namespace }
+export function internal() { return { value, identity, namespace } }
+export function increment() { state.value++ }
+export const events = state.events
+    `,
+    'basic.test.js': `
+import { expect, test } from 'vitest'
+import * as exported from './reexport.js'
+test('order, identity and live mock updates', () => {
+  expect(exported.events).toEqual(['hoisted', 'factory'])
+  expect(exported.value).toBe(1)
+  expect(exported.identity).toBe(exported.internal().identity)
+  expect(exported.namespace).toBe(exported.internal().namespace)
+  exported.increment()
+  expect(exported.value).toBe(2)
+  expect(exported.value).toBe(exported.internal().value)
+})
+    `,
+  })
+  expect(stderr).toBe('')
+  expect(testTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.js": {
+        "order, identity and live mock updates": "passed",
+      },
+    }
+  `)
+})
+
+test.for(['dynamic', 'static'])('imported-value re-exports register getters before circular imports (%s)', async (kind) => {
+  let transforms = 0
+  const config = (): RunVitestConfig => ({
+    fsModuleCache: true,
+    $viteConfig: {
+      plugins: [{
+        name: 'count-reexport-transforms',
+        transform(_code, id) {
+          if (id.endsWith('/reexport.js')) {
+            transforms++
+          }
+        },
+      }],
+    },
+  })
+  const run = await runInlineTests({
+    'dependency.js': `
+import * as exported from './reexport.js'
+export const before = { registered: Object.hasOwn(exported, 'value'), value: exported.value }
+export const value = 1
+    `,
+    'reexport.js': `
+import { vi } from 'vitest'
+import { value${kind === 'dynamic' ? ', before' : ''} } from './dependency.js'
+vi.hoisted(() => ({}))
+export { value${kind === 'dynamic' ? ', before' : ''} }
+${kind === 'static' ? 'export { before } from \'./dependency.js\'' : ''}
+export function read() { return value }
+    `,
+    'basic.test.js': `
+import { expect, test } from 'vitest'
+import { value, before } from './reexport.js'
+test('registered before imports, undefined during TDZ, live after initialization', () => {
+  expect(before).toEqual({ registered: true, value: undefined })
+  expect(value).toBe(1)
+})
+    `,
+  }, config())
+  expect(run.stderr).toBe('')
+  expect(run.testTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.js": {
+        "registered before imports, undefined during TDZ, live after initialization": "passed",
+      },
+    }
+  `)
+  const project = run.ctx!.projects[0]
+  const environment = project.vite.environments.ssr
+  const node = environment.moduleGraph.getModuleById(path.join(run.root, 'reexport.js'))!
+  const result = node.transformResult!
+  const line = result.code.slice(0, result.code.indexOf('function read')).split('\n').length
+  const map = new SourceMap(JSON.parse(JSON.stringify(result.map)))
+  expect(map.findOrigin(line, 1).lineNumber).toBe(7)
+  expect(transforms).toBe(1)
+
+  environment.moduleGraph.invalidateModule(node)
+  const restored = await project._fetcher(node.url, undefined, environment)
+  expect(restored).toHaveProperty('cached', true)
+  if (!('tmp' in restored)) {
+    throw new Error('Expected the restored module to be cached')
+  }
+  unlinkSync(restored.tmp)
+  await project._fetcher(node.url, undefined, environment)
+  expect(node.transformResult!.code.match(/__vite_ssr_exportName__\("value",/g)).toHaveLength(1)
+
+  await run.ctx!.close()
+  const warm = await runVitest({ ...config(), root: run.root })
+  expect(warm.stderr).toBe('')
+  expect(warm.testTree()).toEqual(run.testTree())
+  expect(transforms).toBe(1)
+})
 
 test.for(['node', 'playwright'])('importOriginal for virtual modules (%s)', async (mode) => {
   const { stderr, errorTree } = await runInlineTests({

--- a/test/unit/test/injector-mock.test.ts
+++ b/test/unit/test/injector-mock.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable style/no-tabs */
 import type { Rolldown } from 'vite'
 import type { HoistMocksPluginOptions } from '../../../packages/mocker/src/node/hoistMocksPlugin'
+import { SourceMap } from 'node:module'
 import { stripVTControlCharacters } from 'node:util'
 import { parseAst } from 'vite'
 import { describe, expect, it, test, vi } from 'vitest'
@@ -285,6 +286,53 @@ vi.mock('./mock.js', () => {
       const __vi_import_0__ = await import("vue");
       import {vi} from "vitest";
       export {createApp}"
+    `)
+  })
+
+  test('renders live imported exports without changing local exports', () => {
+    const result = hoistMockAndResolve(`#!/usr/bin/env node
+export { value as first, local, namespace as middle, value as last, }
+export { local as another, value as tail, namespace as end }
+export { importedDefault as default, value as 'string name', namespace }
+import importedDefault, { value } from './dependency.js'
+import * as namespace from './dependency.js'
+import { vi } from 'vitest'
+const local = 42
+vi.hoisted(() => ({}))
+`, '/reexport.js', parse, {
+      ...hoistMocksOptions,
+      renderExport: (name, expression) => `registerExport(${JSON.stringify(name)}, () => ${expression});\n`,
+    })!
+
+    expect(() => parseAst(result.code)).not.toThrow()
+    const localLine = result.code.slice(0, result.code.indexOf('const local')).split('\n').length
+    const map = new SourceMap(JSON.parse(result.map.toString()))
+    expect(map.findOrigin(localLine, 1)).toMatchObject({
+      fileName: '/reexport.js',
+      lineNumber: 8,
+      columnNumber: 1,
+    })
+    expect(result.code).toMatchInlineSnapshot(`
+      "#!/usr/bin/env node
+      registerExport("first", () => __vi_import_0__.value);
+      registerExport("middle", () => __vi_import_1__);
+      registerExport("last", () => __vi_import_0__.value);
+      registerExport("tail", () => __vi_import_0__.value);
+      registerExport("end", () => __vi_import_1__);
+      registerExport("default", () => __vi_import_0__.default);
+      registerExport("string name", () => __vi_import_0__.value);
+      registerExport("namespace", () => __vi_import_1__);
+      vi.hoisted(() => ({}))
+      const __vi_import_0__ = await import("./dependency.js");
+      const __vi_import_1__ = await import("./dependency.js");
+      export { local, }
+      export { local as another }
+
+
+
+      import { vi } from 'vitest'
+      const local = 42
+      "
     `)
   })
 


### PR DESCRIPTION
### Description

Prepared by AI agents (Codex and Claude) for @steipete, who authorized submission; human review of the full patch and this text is unconfirmed.

Fixes imported-local re-exports becoming `undefined` when mock hoisting replaces their import declaration. For example, with `value` exported by `dependency.js`:

```js
import { value } from './dependency.js'
import { vi } from 'vitest'
vi.hoisted(() => ({}))
export { value }
```

Ordinary internal references are rewritten to namespace accesses, but the export list retains the removed local. The added regression reproduces this on current main with both `vi.hoisted` and `vi.mock`, including mutable live bindings.

The hoister now passes export registrations through plugin metadata to Vitest's existing SSR source-finalization step. They are registered after Vite's SSR transform, before static imports, sourcemaps, and caching. This preserves live bindings, same-source mock identity, and cyclic-import ordering; cached code retains the already-finalized state. Copying values would lose liveness, while static-source re-exports evaluate dependencies too early.

**Scope:** Vite module-runner output only. Native ESM/Browser imported-local re-export execution remains unchanged and unfixed. Focused local browser/native-loader sibling tests passed. Two configuration-only browser tests also stop discovering unrelated test files, avoiding their reproduced baseline teardown timeouts.

No separate issue is linked; the PR includes the executable reproduction and regression tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Focused local proof used Vitest/@vitest/mocker 5.0.0-rc.4, Vite 8.0.11, Node 24.20.0, and pnpm 11.24.0. The final seven regression cases fail on the unpatched base and pass with this patch. Full `pnpm test:ci` was not run locally.

**Upstream CI is not green:** [run 33573244517](https://github.com/vitest-dev/vitest/actions/runs/33573244517) finished with these blockers:

- [Windows unit job](https://github.com/vitest-dev/vitest/actions/runs/33573244517/job/100071594175): all 6,195 core unit tests passed, then the UI `suite report navigation` collapse assertion failed. The [unchanged base's Windows run](https://github.com/vitest-dev/vitest/actions/runs/33386072594/job/99468962636) already failed/flaked in the same UI/HTML navigation helper, but at different assertions. This establishes pre-existing instability, not an identical reproduction or confirmed cause of this failure.
- [Linux browser shard 2/2](https://github.com/vitest-dev/vitest/actions/runs/33573244517/job/100071593877): Playwright trace `retain-on-failure` timed out after 360 seconds, followed by a worker-termination timeout; the job was eventually cancelled at its 30-minute limit. Attribution remains unproven.

No timeout increases, assertion weakening, or speculative UI/trace changes were added to this SSR patch.

<details>
<summary>Local verification</summary>

Combined suites: **37/37 passed twice**, with normal parallelism and unchanged timeouts.

```bash
CI=true pnpm -C test/e2e test mocking.test.ts configureVitest.test.ts fs-module-cache-resiliency.test.ts --reporter=verbose
```

Hoister owner suite: **84 passed**.

```bash
CI=true pnpm -C test/unit test injector-mock.test.ts --project=threads --reporter=verbose
```

Both package builds, typecheck, and changed-file ESLint passed:

```bash
pnpm --filter @vitest/mocker build
```

```bash
pnpm --filter vitest build
```

```bash
pnpm typecheck
```

Coverage includes Oxc-transformed TypeScript, aliases/default/namespace/string export names, mixed export lists, static/dynamic cycles, sourcemaps, warm caches, and cache-file eviction. Existing declaration-bundling warnings and one nonfatal shutdown scan-cancellation warning were retained. No Windows or older-Vite runtime matrix was run locally.

</details>

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

The low-level renderer/metadata contract and native-output limitation are documented in `packages/mocker/EXPORTS.md`.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
