### PR TITLE
fix: match forceRerunTriggers in dot directories (fix #11054)

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,11 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    // Absolute paths may include a `.dot` directory segment; picomatch's
+    // default `dot: false` makes `**` skip those (see #11054).
+    const matcher = forceRerunTriggers.length
+      ? pm(forceRerunTriggers, { dot: true })
+      : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -1,4 +1,7 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { join as patheJoin } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
 import { createFile, editFile, resolvePath, runVitest } from '../../test-utils'
@@ -32,6 +35,30 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
   })
+})
+
+// Fixes #11054 — picomatch `dot: false` (the default) will not let `**` cross a
+// path segment that starts with `.`, so `--changed` / `related` silently skip
+// forceRerunTriggers when the project lives under `.app/`, `~/.local/…`, etc.
+it.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTriggers match files under a dot-named directory', async () => {
+  const dotDir = patheJoin(tmpdir(), '.vitest-force-rerun-dot')
+  mkdirSync(dotDir, { recursive: true })
+  const pkg = patheJoin(dotDir, 'package.json')
+  writeFileSync(pkg, '{}\n')
+  try {
+    const { stdout, stderr } = await runVitest({
+      root: join(process.cwd(), 'fixtures/git-changed/related'),
+      include: ['related.test.ts'],
+      forceRerunTriggers: ['**/package.json'],
+      related: [pkg],
+    })
+    expect(stderr).toBe('')
+    expect(stdout).toContain('1 passed')
+    expect(stdout).toContain('related.test.ts')
+  }
+  finally {
+    rmSync(dotDir, { recursive: true, force: true })
+  }
 })
 
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {


### PR DESCRIPTION
Written by an AI agent (Grok) on behalf of @r3wretrhy.

### Description

Fixes #11054.

`filterTestsBySource` and the watcher match `forceRerunTriggers` against **absolute** paths with picomatch's default `dot: false`. If any directory segment starts with `.` (a clone into `.app/`, `~/.local/src/…`, an agent worktree under `.claude/worktrees/…`), `**` will not cross that segment. Default triggers such as `**/package.json` then never match, and `--changed` reports `No test files found` for a lockfile-only change. The same project in a dot-free directory escalates correctly.

Coverage already compiles its globs with `{ dot: true }`. This uses the same option at both `forceRerunTriggers` sites.

### Tests

Added `forceRerunTriggers match files under a dot-named directory` in `test/e2e/test/git-changed.test.ts`. It points `related` at a `package.json` under `os.tmpdir()/.vitest-force-rerun-dot/` with trigger `**/package.json`.

- On `main`: stderr is `No test files found, exiting with code 1`
- With this change: `1 passed` on `related.test.ts`

Ran:

```
pnpm --filter @vitest/test-e2e exec vitest run test/git-changed.test.ts
```

### Checklist
- [x] References an issue discussed ahead of time (#11054)
- [x] Includes a test that fails without this PR but passes with it
- [x] Did not change `pnpm-lock.yaml`
- [x] Allow edits by maintainers
