### PR TITLE
fix(ui): hide running count in static reports

### DIFF
--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -240,8 +240,7 @@ const {
         <template v-if="initialized" #summary>
           <div
             data-testid="explorer-summary"
-            items-center
-            gap-x-1
+            class="items-center gap-x-1"
             :class="isReport
               ? 'flex'
               : 'grid grid-cols-[auto_min-content_auto] grid-rows-[min-content_min-content]'"

--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -4,7 +4,7 @@ import { hideAllPoppers } from 'floating-vue'
 import { computed, ref } from 'vue'
 
 import { RecycleScroller } from 'vue-virtual-scroller'
-import { availableProjects, config } from '~/composables/client'
+import { availableProjects, config, isReport } from '~/composables/client'
 import { useSearch } from '~/composables/explorer/search'
 import { ALL_PROJECTS, projectSort } from '~/composables/explorer/state'
 import { activeFileId, selectedTest } from '~/composables/params'
@@ -238,12 +238,19 @@ const {
     <div flex-auto py-1 overflow-hidden>
       <ResultsPanel h-full flex="~ col">
         <template v-if="initialized" #summary>
-          <div grid="~ items-center gap-x-1 cols-[auto_min-content_auto] rows-[min-content_min-content]">
+          <div
+            data-testid="explorer-summary"
+            items-center
+            gap-x-1
+            :class="isReport
+              ? 'flex'
+              : 'grid grid-cols-[auto_min-content_auto] grid-rows-[min-content_min-content]'"
+          >
             <span text-red-700 dark:text-red-500>
               FAIL ({{ testsTotal.failed }})
             </span>
             <span>/</span>
-            <span text-yellow-700 dark:text-yellow-500>
+            <span v-if="!isReport" text-yellow-700 dark:text-yellow-500>
               RUNNING ({{ testsTotal.running }})
             </span>
             <span text-green-700 dark:text-green-500>

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -589,6 +589,17 @@ async function testDashboardFilter(page: Page) {
 }
 
 async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
+  const summary = page.getByTestId('explorer-summary')
+  const running = summary.getByText(/RUNNING/)
+
+  await expect(summary).toHaveCSS('display', options.mode === 'static' ? 'flex' : 'grid')
+  if (options.mode === 'static') {
+    await expect(running).toHaveCount(0)
+  }
+  else {
+    await expect(running).toBeVisible()
+  }
+
   // match all files when no filter
   await page.getByPlaceholder('Search...').fill('')
   await page.getByText(`PASS (${TEST_COUNTS.files.pass})`).click()

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -590,9 +590,9 @@ async function testDashboardFilter(page: Page) {
 
 async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
   const summary = page.getByTestId('explorer-summary')
-  const running = summary.getByText(/RUNNING/)
 
-  await expect(summary).toHaveCSS('display', options.mode === 'static' ? 'flex' : 'grid')
+  // Static reports only contain completed test results.
+  const running = summary.getByText(/RUNNING/)
   if (options.mode === 'static') {
     await expect(running).toHaveCount(0)
   }


### PR DESCRIPTION
Just realized static HTML reports is showing `RUNNING (0)`, but this is meaningless. This PR hides it and tweaks layout from 2x2 to flat.

_After (left) and Before (right)_

<img width="1041" height="716" alt="image" src="https://github.com/user-attachments/assets/c97c8e28-1517-43f1-b1d8-77e3d0d8b5b2" />

