### PR TITLE
test(ui): improve explorer filter assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,15 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
+      - name: Upload Playwright traces
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() && matrix.suite == 'unit' }}
+        with:
+          name: playwright-traces-${{ matrix.os }}-node-${{ matrix.node_version }}
+          path: test/ui/test-results/**/trace.zip
+          if-no-files-found: ignore
+          retention-days: 1
+
   # runner.test.ts is the heaviest spec (~28% of the suite, ~70% of whichever
   # shard it lands in). Windows isolates it in its own job and shards the other
   # 32 specs; Ubuntu shards the whole suite 2 ways (runner rides in one shard).

--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -238,7 +238,7 @@ const {
     <div flex-auto py-1 overflow-hidden>
       <ResultsPanel h-full flex="~ col">
         <template v-if="initialized" #summary>
-          <div grid="~ items-center gap-x-1 cols-[auto_min-content_auto] rows-[min-content_min-content]">
+          <div data-testid="explorer-summary" grid="~ items-center gap-x-1 cols-[auto_min-content_auto] rows-[min-content_min-content]">
             <span text-red-700 dark:text-red-500>
               FAIL ({{ testsTotal.failed }})
             </span>

--- a/test/ui/fixtures/main/node/skipped.test.ts
+++ b/test/ui/fixtures/main/node/skipped.test.ts
@@ -1,0 +1,3 @@
+import { test } from 'vitest'
+
+test.skip('skipped test', () => {})

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     },
   ],
   use: {
-    trace: process.env.CI ? 'on-first-retry' : undefined,
+    trace: process.env.CI ? 'retain-on-failure' : undefined,
   },
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       name: 'chromium',
       // Keep enough rows rendered for tests that access the explorer without filtering.
-      use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 1300 } },
+      use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 2000 } },
     },
   ],
   use: {

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     {
       name: 'chromium',
       // Keep enough rows rendered for tests that access the explorer without filtering.
-      use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 2000 } },
+      use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 1600 } },
     },
   ],
   use: {

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      // increase viewport height so virtual scroller renders all explorer items
+      // Keep all fixture rows rendered; increase this when adding explorer fixtures.
       use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 1300 } },
     },
   ],

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      // Keep all fixture rows rendered; increase this when adding explorer fixtures.
+      // Keep enough rows rendered for tests that access the explorer without filtering.
       use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 1300 } },
     },
   ],

--- a/test/ui/playwright.config.ts
+++ b/test/ui/playwright.config.ts
@@ -5,8 +5,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      // Keep enough rows rendered for tests that access the explorer without filtering.
-      use: { ...devices['Desktop Chrome'], viewport: { width: 800, height: 1600 } },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   use: {

--- a/test/ui/test/helper.ts
+++ b/test/ui/test/helper.ts
@@ -71,8 +71,9 @@ export function getExplorerItem(page: Page, name: string) {
 }
 
 export async function openExplorerItem(page: Page, name: string) {
-  await getExplorerItem(page, name).scrollIntoViewIfNeeded()
-  await getExplorerItem(page, name).dispatchEvent('click')
+  const item = getExplorerItem(page, name)
+  await item.scrollIntoViewIfNeeded()
+  await item.getByText(name, { exact: true }).click()
 }
 
 export async function openExplorerFileItem(page: Page, name: string) {

--- a/test/ui/test/helper.ts
+++ b/test/ui/test/helper.ts
@@ -66,6 +66,7 @@ export async function assertTestCounts(page: Page, { pass, fail, skip = 0 }: { p
 }
 
 export function getExplorerItem(page: Page, name: string) {
+  // The virtual scroller keeps recycled rows in the DOM with visibility hidden.
   return page.locator('[data-testid="explorer-item"]:visible').and(page.getByLabel(name, { exact: true }))
 }
 

--- a/test/ui/test/merge-reports.spec.ts
+++ b/test/ui/test/merge-reports.spec.ts
@@ -65,14 +65,12 @@ test.describe('html reporter', () => {
     const editorButton = page.getByTestId('btn-code')
     const editor = page.getByTestId('editor')
 
-    await item1.hover()
-    await item1.getByTestId('btn-open-details').click()
+    await item1.click()
     await editorButton.click()
     await expect(editor).toContainText(`test('ok'`)
     await expect(getAnnotation(editor, 'test-linux')).toBeVisible()
 
-    await item2.hover()
-    await item2.getByTestId('btn-open-details').click()
+    await item2.click()
     await editorButton.click()
     await expect(editor).toContainText(`test('ok'`)
     await expect(getAnnotation(editor, 'test-macos')).toBeVisible()

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -506,6 +506,7 @@ async function testError(page: Page) {
 async function testSuiteReport(page: Page) {
   const report = page.getByTestId('report')
 
+  await page.getByPlaceholder('Search...').fill('suite-report')
   await getExplorerItem(page, 'suite-report.test.ts').click()
   await expect(report).toContainText('before-all-marker')
   await expect(report).toContainText('direct-child-marker')

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -537,7 +537,7 @@ async function testTagsFilter(page: Page) {
   await page.getByPlaceholder('Search...').fill('tag:db')
 
   // only one test with the tag "db"
-  await expect(page.getByText('PASS (1)')).toBeVisible()
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 1, skip: '--' })
   await expect(getExplorerItem(page, 'has tags')).toBeVisible()
 
   await page.getByPlaceholder('Search...').fill('tag:db && !flaky')
@@ -589,48 +589,73 @@ async function testDashboardFilter(page: Page) {
 }
 
 async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
+  const failFilter = page.getByRole('checkbox', { name: 'Fail', exact: true }).locator('..')
+  const passFilter = page.getByRole('checkbox', { name: 'Pass', exact: true }).locator('..')
+  const onlyTestsFilter = page.getByRole('checkbox', { name: 'Only Tests', exact: true }).locator('..')
+
   // match all files when no filter
   await page.getByPlaceholder('Search...').fill('')
-  await page.getByText(`PASS (${TEST_COUNTS.files.pass})`).click()
-  await expect(page.getByTestId('results-panel').getByText('sample.test.ts', { exact: true })).toBeVisible()
+  await expectExplorerSummary(page, { fail: TEST_COUNTS.files.fail, running: 0, pass: TEST_COUNTS.files.pass, skip: '--' })
+  await expect(getExplorerItem(page, 'sample.test.ts')).toBeVisible()
+
+  // "Only Tests" mode text search excludes test file name matches
+  await page.getByPlaceholder('Search...').fill('sample.test.ts')
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 1, skip: '--' })
+  await expect(getExplorerItem(page, 'sample.test.ts')).toBeVisible()
+  await expect(getExplorerItem(page, 'add')).toBeVisible()
+  await onlyTestsFilter.click()
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 0, skip: 0 })
+  await expect(getExplorerItem(page, 'sample.test.ts')).toHaveCount(0)
+  await expect(getExplorerItem(page, 'add')).toHaveCount(0)
+
+  // match all individual tests when no search
+  await page.getByPlaceholder('Search...').fill('')
+  await expectExplorerSummary(page, {
+    fail: TEST_COUNTS.fail,
+    running: 0,
+    pass: TEST_COUNTS.pass,
+    skip: TEST_COUNTS.skip,
+  })
+  await onlyTestsFilter.click()
 
   // match nothing
   await page.getByPlaceholder('Search...').fill('nothing')
-  await page.getByText('No matched test').click()
+  await expect(page.getByTestId('results-panel').getByText('No matched test')).toBeVisible()
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 0, skip: '--' })
 
   // searching "add" will match "sample.test.ts" since it includes a test case named "add"
   await page.getByPlaceholder('Search...').fill('add')
-  await page.getByText('PASS (1)').click()
-  await expect(page.getByTestId('results-panel').getByText('sample.test.ts', { exact: true })).toBeVisible()
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 1, skip: '--' })
+  await expect(getExplorerItem(page, 'sample.test.ts')).toBeVisible()
 
   // match only failing files when fail filter applied
   await page.getByPlaceholder('Search...').fill('')
-  await page.getByText(/^Fail$/, { exact: true }).click()
-  await page.getByText(`FAIL (${TEST_COUNTS.files.fail})`).click()
-  await expect(page.getByTestId('results-panel').getByText('error.test.ts', { exact: true })).toBeVisible()
-  await expect(page.getByTestId('results-panel').getByText('sample.test.ts', { exact: true })).toBeHidden()
+  await failFilter.click()
+  await expectExplorerSummary(page, { fail: TEST_COUNTS.files.fail, running: 0, pass: 0, skip: '--' })
+  await expect(getExplorerItem(page, 'error.test.ts')).toBeVisible()
+  await expect(getExplorerItem(page, 'sample.test.ts')).toHaveCount(0)
 
-  // match only pass files when fail filter applied
+  // match only pass files when pass filter applied
   await page.getByPlaceholder('Search...').fill('console')
-  await page.getByText(/^Fail$/, { exact: true }).click()
-  await page.locator('span').filter({ hasText: /^Pass$/ }).click()
-  await page.getByText('PASS (1)').click()
-  await expect(page.getByTestId('results-panel').getByText('console.test.ts', { exact: true })).toBeVisible()
-  await expect(page.getByTestId('results-panel').getByText('sample.test.ts', { exact: true })).toBeHidden()
+  await failFilter.click()
+  await passFilter.click()
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 1, skip: '--' })
+  await expect(getExplorerItem(page, 'console.test.ts')).toBeVisible()
+  await expect(getExplorerItem(page, 'sample.test.ts')).toHaveCount(0)
 
   // html entities in task names are escaped
-  await page.locator('span').filter({ hasText: /^Pass$/ }).click()
+  await passFilter.click()
   await page.getByPlaceholder('Search...').fill('<MyComponent />')
   // for some reason, the tree is collapsed by default: we need to click on the nav buttons to expand it
   await page.getByTestId('collapse-all').click()
   await page.getByTestId('expand-all').click()
-  await expect(page.getByText('<MyComponent />')).toBeVisible()
-  await expect(page.getByTestId('results-panel').getByText('task-name.test.ts', { exact: true })).toBeVisible()
+  await expect(getExplorerItem(page, '<MyComponent />')).toBeVisible()
+  await expect(getExplorerItem(page, 'task-name.test.ts')).toBeVisible()
 
   // html entities in task names are escaped
   await page.getByPlaceholder('Search...').fill('<>\'"')
-  await expect(page.getByText('<>\'"')).toBeVisible()
-  await expect(page.getByTestId('results-panel').getByText('task-name.test.ts', { exact: true })).toBeVisible()
+  await expect(getExplorerItem(page, '<>\'"')).toBeVisible()
+  await expect(getExplorerItem(page, 'task-name.test.ts')).toBeVisible()
 
   // pass files with special chars
   await page.getByPlaceholder('Search...').fill('char () - Square root of nine (9)')
@@ -641,6 +666,15 @@ async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
     await testItem.getByLabel('Run current test').click()
     await expect(page.getByText('The test has passed without any errors')).toBeVisible()
   }
+}
+
+async function expectExplorerSummary(
+  page: Page,
+  expected: { fail: number; running: number; pass: number; skip: number | '--' },
+) {
+  await expect(page.getByTestId('explorer-summary')).toHaveText(
+    `FAIL (${expected.fail}) / RUNNING (${expected.running}) PASS (${expected.pass}) / SKIP (${expected.skip})`,
+  )
 }
 
 async function testFilterInitiallyInvisibleItem(page: Page) {

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -506,32 +506,31 @@ async function testError(page: Page) {
 async function testSuiteReport(page: Page) {
   const report = page.getByTestId('report')
 
-  await page.getByPlaceholder('Search...').fill('suite-report')
-  await getExplorerItem(page, 'suite-report.test.ts').click()
+  await openExplorerItem(page, 'suite-report.test.ts')
   await expect(report).toContainText('before-all-marker')
   await expect(report).toContainText('direct-child-marker')
   await expect(report).toContainText('nested-child-marker')
 
-  const successfulSuite = getExplorerItem(page, 'successful suite')
-  await successfulSuite.click()
+  await openExplorerItem(page, 'successful suite')
   await expect(page.getByTestId('report')).toContainText('All tests passed in this suite')
 
-  await getExplorerItem(page, 'hook failure suite').click()
+  await openExplorerItem(page, 'hook failure suite')
   await expect(report).toContainText('before-all-marker')
   await expect(report).not.toContainText('direct-child-marker')
 
-  await getExplorerItem(page, 'child failure suite').click()
+  await openExplorerItem(page, 'child failure suite')
   await expect(report).toContainText('failing child')
   await expect(report).toContainText('direct-child-marker')
   await expect(report).not.toContainText('before-all-marker')
 
-  await getExplorerItem(page, 'nested failure suite').click()
+  await openExplorerItem(page, 'nested failure suite')
   await expect(report).toContainText('failing nested suite')
   await expect(report).toContainText('failing nested child')
   await expect(report).toContainText('nested-child-marker')
   await expect(report).not.toContainText('direct-child-marker')
 
   // test that the suite can be collapsed and expanded
+  const successfulSuite = getExplorerItem(page, 'successful suite')
   await expect(getExplorerItem(page, 'successful child')).toBeVisible()
   await successfulSuite.getByRole('button', { name: 'Collapse successful suite', exact: true }).click()
   await expect(getExplorerItem(page, 'successful child')).not.toBeVisible()

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -635,10 +635,15 @@ async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
   await expect(getExplorerItem(page, 'error.test.ts')).toBeVisible()
   await expect(getExplorerItem(page, 'sample.test.ts')).toHaveCount(0)
 
-  // match only pass files when pass filter applied
-  await page.getByPlaceholder('Search...').fill('console')
+  // match a failed file through its passing child
+  await page.getByPlaceholder('Search...').fill('successful child')
   await failFilter.click()
   await passFilter.click()
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 0, skip: '--' })
+  await expect(getExplorerItem(page, 'suite-report.test.ts')).toBeVisible()
+
+  // match only pass files when pass filter applied
+  await page.getByPlaceholder('Search...').fill('console')
   await expectExplorerSummary(page, { fail: 0, running: 0, pass: 1, skip: '--' })
   await expect(getExplorerItem(page, 'console.test.ts')).toBeVisible()
   await expect(getExplorerItem(page, 'sample.test.ts')).toHaveCount(0)

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -156,6 +156,7 @@ test.describe('ui', () => {
     await expect(getExplorerItem(page, 'aa-first-file.test.ts')).toBeVisible()
     await expect(getExplorerItem(page, 'zz-last-file.test.ts')).not.toBeVisible()
 
+    // Keep the last fixture row in view; increase this when adding explorer fixtures.
     await page.setViewportSize({ width: 1000, height: 2000 })
 
     await expect(getExplorerItem(page, 'zz-last-file.test.ts')).toBeInViewport()

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -10,10 +10,11 @@ import { assertDownloadAttachment, assertImageAttachment, assertTestCounts, getE
 const TEST_COUNTS = {
   pass: 21,
   fail: 5,
-  skip: 1,
+  skip: 2,
   files: {
     pass: 9,
     fail: 3,
+    skip: 1,
   },
 }
 
@@ -155,7 +156,7 @@ test.describe('ui', () => {
     await expect(getExplorerItem(page, 'aa-first-file.test.ts')).toBeVisible()
     await expect(getExplorerItem(page, 'zz-last-file.test.ts')).not.toBeVisible()
 
-    await page.setViewportSize({ width: 1000, height: 1600 })
+    await page.setViewportSize({ width: 1000, height: 2000 })
 
     await expect(getExplorerItem(page, 'zz-last-file.test.ts')).toBeInViewport()
   })
@@ -597,6 +598,11 @@ async function testFilter(page: Page, options: { mode: 'ui' | 'static' }) {
   await page.getByPlaceholder('Search...').fill('')
   await expectExplorerSummary(page, { fail: TEST_COUNTS.files.fail, running: 0, pass: TEST_COUNTS.files.pass, skip: '--' })
   await expect(getExplorerItem(page, 'sample.test.ts')).toBeVisible()
+
+  // count skipped files when filtered
+  await page.getByPlaceholder('Search...').fill('skipped.test.ts')
+  await expectExplorerSummary(page, { fail: 0, running: 0, pass: 0, skip: '--' })
+  await expect(getExplorerItem(page, 'skipped.test.ts')).toBeVisible()
 
   // "Only Tests" mode text search excludes test file name matches
   await page.getByPlaceholder('Search...').fill('sample.test.ts')

--- a/test/ui/test/ui.spec.ts
+++ b/test/ui/test/ui.spec.ts
@@ -18,6 +18,9 @@ const TEST_COUNTS = {
   },
 }
 
+// Keep enough main fixture rows rendered for tests that access the explorer without filtering.
+test.use({ viewport: { width: 800, height: 1600 } })
+
 test.describe('ui', () => {
   let vitest: Vitest | undefined
   let pageUrl: string


### PR DESCRIPTION
### Description

Current explorer tree filter coverage is weak and also the assertions are inconsistent. This PR introduces a helper to standardize assertions and also increases coverage for the summary count and "Only Tests" filter mode.

This stack shows the behavior change of next PR better.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
