### PR TITLE
fix: apply queued mocks from doMock() in queue order (fixes #10706)

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
+++ b/packages/vitest/src/runtime/moduleRunner/bareModuleMocker.ts
@@ -152,35 +152,38 @@ export class BareModuleMocker implements TestModuleMocker {
       return
     }
 
+    const pendingIds = BareModuleMocker.pendingIds
+    BareModuleMocker.pendingIds = []
+
     const resolveMock = async (mock: PendingSuiteMock) => {
-      const { id, url, external } = await this.resolveId(
-        mock.id,
-        mock.importer,
-      )
-      if (mock.action === 'unmock') {
-        this.unmockPath(id)
-      }
-      if (mock.action === 'mock') {
-        this.mockPath(
-          mock.id,
-          id,
-          url,
-          external,
-          mock.type,
-          mock.factory,
-        )
-      }
+      const resolved = await this.resolveId(mock.id, mock.importer)
+      return { mock, ...resolved }
     }
 
     // group consecutive mocks of the same action type together,
     // resolve in parallel inside each group, but run groups sequentially
     // to preserve mock/unmock ordering
-    const groups = groupByConsecutiveAction(BareModuleMocker.pendingIds)
+    const groups = groupByConsecutiveAction(pendingIds)
     for (const group of groups) {
-      await Promise.all(group.map(resolveMock))
+      // apply in queue order: two mocks of the same path can resolve out of
+      // order, and the last queued one must win
+      const resolvedGroup = await Promise.all(group.map(resolveMock))
+      for (const { mock, id, url, external } of resolvedGroup) {
+        if (mock.action === 'unmock') {
+          this.unmockPath(id)
+        }
+        if (mock.action === 'mock') {
+          this.mockPath(
+            mock.id,
+            id,
+            url,
+            external,
+            mock.type,
+            mock.factory,
+          )
+        }
+      }
     }
-
-    BareModuleMocker.pendingIds = []
   }
 
   // public method to avoid circular dependency

--- a/test/e2e/test/mocking.test.ts
+++ b/test/e2e/test/mocking.test.ts
@@ -363,6 +363,43 @@ ${importChecks}
   `)
 })
 
+test('the last doMock of the same path wins', async () => {
+  // repeats doMock twice for the same path without an import in between
+  //   vi.doMock('/mock-lib-0', () => ({ value: 'first' }));
+  //   vi.doMock('/mock-lib-0', () => ({ value: 'second' }));
+  //   ...
+  // then, the last registered factory should be used
+  //   import('/mock-lib-0') // => { value: 'second' }
+  const N = 20
+  const mockEntries = Array.from({ length: N }, (_, i) => `\
+vi.doMock('/mock-lib-${i}', () => ({ value: 'first' }));
+vi.doMock('/mock-lib-${i}', () => ({ value: 'second' }));
+`).join('\n')
+  const importChecks = Array.from({ length: N }, (_, i) => `\
+await expect(import('/mock-lib-${i}')).resolves.toEqual({ value: 'second' });
+`).join('\n')
+
+  const { stderr, errorTree } = await runInlineTests({
+    './basic.test.js': `
+import { test, expect, vi } from 'vitest'
+
+test('duplicate mock of the same path (last one should win)', async () => {
+${mockEntries}
+${importChecks}
+})
+    `,
+  })
+
+  expect(stderr).toBe('')
+  expect(errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.js": {
+        "duplicate mock of the same path (last one should win)": "passed",
+      },
+    }
+  `)
+})
+
 test.for([
   'node',
   'playwright',


### PR DESCRIPTION
### Description

Calls to doMock() push onto a queue which is drained on the next import in `resolveMocks()`. The queue resolves in parallel with Promise.all, and then each item registers its mock when `resolveId` comes back. So if several entries are trying to mock the same path (eg a first one in a shared helper, and a second one which wants to override it), sometimes the first mock will resolve after the second mock and the override is lost.

Resolves #10706

Disclaimers: First, I used Claude code to write the patch, but I reviewed the content in depth, made sure I understood the issue and the approach. Finally I checked it was fixing the intermittent failures we currently see on https://github.com/mozilla/firefox-devtools-mcp/
Second, there was a previous PR for this issue: PR #10737 from https://github.com/weifanglab . It was also used as a reference to tune this patch. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
See #10706
- [X] Ideally, include a test that fails without this PR but passes with it.
Added `the last doMock of the same path wins` 
- [X] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
Not touched here.
- [X] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.
Checked.

### Tests
- [X] Run the tests with `pnpm test:ci`.
Done, no failures

### Documentation
- [X] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.
Not a new functionality, just a bug fix.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
