### PR TITLE
docs: split migration into multiple pages, add a button to copy the prompt

### DIFF
--- a/docs/.vitepress/components/ChangelogButton.vue
+++ b/docs/.vitepress/components/ChangelogButton.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+
+defineProps<{
+  href: string
+}>()
+</script>
+
+<template>
+  <a :href="href" class="changelog-button" target="_blank" rel="noopener noreferrer">
+    <Icon icon="carbon:document" aria-hidden="true" />
+    <span>Changelog</span>
+    <Icon icon="carbon:arrow-up-right" class="external-icon" aria-hidden="true" />
+  </a>
+</template>
+
+<style scoped>
+.changelog-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.5rem;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  text-decoration: none;
+  transition: background-color 150ms, border-color 150ms, transform 150ms;
+}
+
+.changelog-button:hover {
+  border-color: color-mix(in srgb, var(--color-brand) 55%, transparent);
+  background: color-mix(in srgb, var(--color-brand) 8%, var(--vp-c-bg-soft));
+  color: var(--vp-c-text-1);
+  transform: translateY(-1px);
+}
+
+.changelog-button:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 3px;
+}
+
+.changelog-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.changelog-button .external-icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/docs/.vitepress/components/CopyPrompt.vue
+++ b/docs/.vitepress/components/CopyPrompt.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { computed, ref } from 'vue'
+
+const props = defineProps<{
+  prompt: string
+}>()
+
+const state = ref<'idle' | 'copied' | 'error'>('idle')
+const label = computed(() => state.value === 'copied' ? 'Copied' : 'Copy prompt')
+
+async function copyPrompt() {
+  try {
+    await navigator.clipboard.writeText(props.prompt)
+    state.value = 'copied'
+  }
+  catch {
+    state.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <button type="button" class="copy-prompt" @click="copyPrompt">
+    <Icon :icon="state === 'copied' ? 'carbon:checkmark' : 'carbon:copy'" aria-hidden="true" />
+    <span>{{ label }}</span>
+  </button>
+  <span class="sr-only" role="status" aria-live="polite">
+    {{ state === 'copied' ? 'Prompt copied to clipboard.' : state === 'error' ? 'Could not copy prompt.' : '' }}
+  </span>
+</template>
+
+<style scoped>
+.copy-prompt {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid color-mix(in srgb, var(--color-brand) 45%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--color-brand) 10%, transparent);
+  color: var(--vp-c-text-1);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  cursor: pointer;
+  transition: background-color 150ms, border-color 150ms, transform 150ms;
+}
+
+.copy-prompt:hover {
+  border-color: var(--color-brand);
+  background: color-mix(in srgb, var(--color-brand) 16%, transparent);
+  transform: translateY(-1px);
+}
+
+.copy-prompt:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 3px;
+}
+
+.copy-prompt svg {
+  width: 1rem;
+  height: 1rem;
+}
+</style>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1101,20 +1101,20 @@ export default ({ mode }: { mode: string }) => {
           // active-use guides further from the user's first scroll.
           {
             text: 'Migration',
-            link: '/guide/migration',
+            link: '/guide/migration/',
             collapsed: false,
             items: [
               {
                 text: 'Migrating to Vitest 5.0',
-                link: '/guide/migration#vitest-5',
+                link: '/guide/migration/',
               },
               {
                 text: 'Migrating from Jest',
-                link: '/guide/migration#jest',
+                link: '/guide/migration/jest',
               },
               {
                 text: 'Migrating from Mocha + Chai + Sinon',
-                link: '/guide/migration#mocha-chai-sinon',
+                link: '/guide/migration/mocha',
               },
             ],
           },

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -8,6 +8,8 @@ import CRoot from '../components/CRoot.vue'
 import Deprecated from '../components/Deprecated.vue'
 import Experimental from '../components/Experimental.vue'
 import Advanced from '../components/Advanced.vue'
+import ChangelogButton from '../components/ChangelogButton.vue'
+import CopyPrompt from '../components/CopyPrompt.vue'
 import CourseLink from '../components/CourseLink.vue'
 import './styles.css'
 import '@shikijs/vitepress-twoslash/style.css'
@@ -57,6 +59,8 @@ export default {
     app.component('Experimental', Experimental)
     app.component('Deprecated', Deprecated)
     app.component('Advanced', Advanced)
+    app.component('ChangelogButton', ChangelogButton)
+    app.component('CopyPrompt', CopyPrompt)
     app.component('CourseLink', CourseLink)
     app.use(TwoslashFloatingVue)
     enhanceAppWithTabs(app)

--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -32,6 +32,13 @@
   display: inline-block;
 }
 
+.migration-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0 0.5rem;
+}
+
 /* credit goes to https://dylanatsmith.com/wrote/styling-the-kbd-element */
 html:not(.dark) .VPContent kbd {
   --kbd-color-background: #f7f7f7;

--- a/docs/api/expect.md
+++ b/docs/api/expect.md
@@ -1822,7 +1822,7 @@ test('spy called after another', () => {
 ```
 
 ::: tip Migration Guide
-For a complete guide on migrating from Mocha+Chai+Sinon to Vitest, see the [Migration Guide](/guide/migration#mocha-chai-sinon).
+For a complete guide on migrating from Mocha+Chai+Sinon to Vitest, see the [Migration Guide](/guide/migration/mocha).
 :::
 
 ## toSatisfy

--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -40,7 +40,7 @@ If test body is not provided, the test is marked as `todo`.
 When a test function returns a promise, the runner will wait until it is resolved to collect async expectations. If the promise is rejected, the test will fail.
 
 ::: tip
-In Jest, `TestFunction` can also be of type `(done: DoneCallback) => void`. If this form is used, the test will not be concluded until `done` is called. You can achieve the same using an `async` function, see the [Migration guide Done Callback section](/guide/migration#done-callback).
+In Jest, `TestFunction` can also be of type `(done: DoneCallback) => void`. If this form is used, the test will not be concluded until `done` is called. You can achieve the same using an `async` function, see the [Migration guide Done Callback section](/guide/migration/jest#done-callback).
 :::
 
 ## Test Options

--- a/docs/blog/vitest-3.md
+++ b/docs/blog/vitest-3.md
@@ -41,7 +41,7 @@ Quick links:
 
 - [Docs](/)
 - Translations: [简体中文](https://cn.vitest.dev/)
-- [Migration Guide](/guide/migration)
+- [Migration Guide](https://v3.vitest.dev/guide/migration)
 - [GitHub Changelog](https://github.com/vitest-dev/vitest/releases/tag/v3.0.0)
 
 If you've not used Vitest before, we suggest reading the [Getting Started](/guide/) and [Features](/guide/features) guides first.
@@ -137,7 +137,7 @@ We have redesigned the public API available from `vitest/node` and are planning 
 
 ## Breaking changes
 
-Vitest 3 has a few small breaking changes that should not affect most users, but we advise reviewing the detailed [Migration Guide](/guide/migration.html#vitest-3) before upgrading.
+Vitest 3 has a few small breaking changes that should not affect most users, but we advise reviewing the detailed [Migration Guide](https://v3.vitest.dev/guide/migration) before upgrading.
 
 The complete list of changes is at the [Vitest 3 Changelog](https://github.com/vitest-dev/vitest/releases/tag/v3.0.0).
 

--- a/docs/blog/vitest-4.md
+++ b/docs/blog/vitest-4.md
@@ -39,7 +39,7 @@ Quick links:
 
 - [Docs](/)
 - Translations: [简体中文](https://cn.vitest.dev/)
-- [Migration Guide](/guide/migration#vitest-4)
+- [Migration Guide](https://v4.vitest.dev/guide/migration)
 - [GitHub Changelog](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0)
 
 If you've not used Vitest before, we suggest reading the [Getting Started](/guide/) and [Features](/guide/features) guides first.
@@ -329,7 +329,7 @@ Vitest 4 comes with new advanced public [API methods](/api/advanced/vitest):
 
 ## Breaking changes
 
-Vitest 4 has a few breaking changes that could affect you, so we advise reviewing the detailed [Migration Guide](/guide/migration#vitest-4) before upgrading.
+Vitest 4 has a few breaking changes that could affect you, so we advise reviewing the detailed [Migration Guide](https://v4.vitest.dev/guide/migration) before upgrading.
 
 The complete list of changes is at the [Vitest 4 Changelog](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0).
 

--- a/docs/config/testnamepattern.md
+++ b/docs/config/testnamepattern.md
@@ -38,5 +38,5 @@ describe('math', () => {
 ```
 
 ::: warning
-Before Vitest 5, the segments were joined with a single space (`math adds`) to mirror Jest. See the [migration guide](/guide/migration#vitest-5) for details.
+Before Vitest 5, the segments were joined with a single space (`math adds`) to mirror Jest. See the [migration guide](/guide/migration/#vitest-5) for details.
 :::

--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -3,17 +3,20 @@ title: Migration Guide | Guide
 outline: deep
 ---
 
-# Migration Guide
+# Migrating to Vitest 5.0 {#vitest-5}
 
 [Migrating to Vitest 4.0](https://v4.vitest.dev/guide/migration) | [Migrating to Vitest 3.0](https://v3.vitest.dev/guide/migration)
 
-## Migrating to Vitest 5.0 {#vitest-5}
+<div class="migration-actions">
+  <ChangelogButton href="https://github.com/vitest-dev/vitest/releases/tag/v5.0.0" />
+  <CopyPrompt prompt="Migrate to Vitest 5. Fetch the migration guide from https://vitest.dev/guide/migration.md and apply appropriate changes. Do not touch more files than necessary for the migration. If the current version is lower than Vitest 4, apply changes from earlier migration guides first." />
+</div>
 
 ::: warning Prerequisites
 Vitest 5.0 requires Vite >= 6.4.0 and Node.js >= 22.12.0. Before proceeding with any other migration steps, ensure your environment meets these requirements. Running Vitest 5.0 on older versions of Vite or Node.js is not supported and may result in unexpected errors.
 :::
 
-### `clearMocks` is Enabled by Default
+## `clearMocks` is Enabled by Default
 
 [`clearMocks`](/config/clearmocks) now defaults to `true`: Vitest calls [`vi.clearAllMocks()`](/api/vi#vi-clearallmocks) before every test, clearing the recorded history of every mock while leaving implementations intact.
 
@@ -52,7 +55,7 @@ export default defineConfig({
 })
 ```
 
-### `testNamePattern` Matches the `>`-Joined Full Name
+## `testNamePattern` Matches the `>`-Joined Full Name
 
 [`testNamePattern`](/config/testnamepattern) (the `-t` CLI flag) now matches against the test's full name with the suite chain and test name joined by `' > '`, the same string shown in the reporter output. Previously the segments were joined with a single space, mirroring Jest.
 
@@ -71,7 +74,7 @@ vitest -t 'math > adds' # [!code ++]
 
 To keep a pattern working regardless of the separator, match a single segment (`-t adds`) or use a wildcard between segments (`-t 'math.*adds'`).
 
-### Inline Projects Inherit the Root Config by Default
+## Inline Projects Inherit the Root Config by Default
 
 The [`extends`](/guide/projects#configuration) option now defaults to `true`: every project defined as an inline configuration in [`test.projects`](/guide/projects) inherits all options from the root configuration, including Vite options like `plugins` or `resolve.alias`. The options are merged with the same rules that applied to an explicit `extends: true` in Vitest 4:
 
@@ -119,7 +122,7 @@ export default defineConfig({
 })
 ```
 
-### Referenced Config Files Can Define Their Own Projects
+## Referenced Config Files Can Define Their Own Projects
 
 A config file referenced in [`test.projects`](/guide/projects) that declares `projects` itself now provides the [nested projects](/guide/projects#nested-projects) it declares (named `app (unit)`, `app (e2e)`, and so on) instead of running tests as a single project.
 
@@ -147,7 +150,7 @@ Since the inherited `projects` paths resolve relative to the referenced config, 
 
 Inline configurations continue to ignore the `projects` field at runtime, but it is now also excluded from their `ProjectConfig` type.
 
-### Inline Projects Share the Vite Server by Default
+## Inline Projects Share the Vite Server by Default
 
 Inline projects that don't modify the Vite config now reuse the Vite server of the config that declares them instead of resolving a new Vite config and creating a new server per project, so shared files are transformed once and tests run faster. This is controlled by the new [`sharedViteServer`](/config/sharedviteserver) option, which is enabled by default; its documentation lists the exact options that still give a project its own server.
 
@@ -169,7 +172,7 @@ export default defineConfig({
 })
 ```
 
-### Hoisted Mocking Calls Must Be at the Top Level
+## Hoisted Mocking Calls Must Be at the Top Level
 
 [`vi.mock`](/api/vi#vi-mock), [`vi.unmock`](/api/vi#vi-unmock), and [`vi.hoisted`](/api/vi#vi-hoisted) are hoisted to the top of the file and run before any surrounding code. Calling them inside a function, block, or `describe`/`test` callback previously only logged a warning. Vitest 5.0 now throws, because the call does not execute where it is written:
 
@@ -197,11 +200,11 @@ Although it appears nested, it will be hoisted and executed before anything in t
 
 The dynamic variants [`vi.doMock`](/api/vi#vi-domock) and [`vi.doUnmock`](/api/vi#vi-dounmock) are not hoisted and may still be called anywhere.
 
-### Automocked Modules Stay Automocked in the Browser
+## Automocked Modules Stay Automocked in the Browser
 
 In browser mode, the exports of an automocked module (a [`vi.mock`](/api/vi#vi-mock) call with no factory) incorrectly kept calling the real implementation instead of the auto-generated stubs. If a browser test relied on that, its exports now return `undefined` by default. Pass [`{ spy: true }`](/api/vi#vi-mock) to keep calling the real implementation while still tracking calls, or provide a factory with the behavior you need.
 
-### Class Mocks Keep Prototype Methods
+## Class Mocks Keep Prototype Methods
 
 Instances created from a class mock previously inherited from the mock's own empty `prototype`. Methods defined with the regular class syntax were `undefined` on instances, even inside the constructor, and `instanceof` checks against the implementation class failed. This affected [`vi.fn(Dog)`](/api/vi#vi-fn), `vi.spyOn(obj, 'Dog')` with or without a mock implementation, and [`.mockImplementation(class ...)`](/api/mock#mockimplementation).
 
@@ -227,7 +230,7 @@ Object.getPrototypeOf(MockedDog.prototype) // was Object.prototype, now Dog.prot
 
 Overriding methods on the mock's `prototype` still works and shadows the implementation, and [`mockReset`](/api/mock#mockreset) reverts the chain together with the implementation. See [Mocking Classes](/guide/mocking/classes) for details.
 
-### Benchmarking API Rewrite
+## Benchmarking API Rewrite
 
 The benchmarking API has been rewritten. `bench` is no longer a top-level import from `vitest`; it is a [test-context fixture](/guide/test-context#bench) accessed from inside a regular `test()`. See the [Benchmarking guide](/guide/benchmarking) for the new API.
 
@@ -257,7 +260,7 @@ test('sort', async ({ bench }) => { // [!code ++]
 - **`benchmark.outputJson` config and the `--outputJson` CLI flag** are removed. Use `--reporter=json --outputFile=<path>` to capture benchmark results; the JSON reporter now includes a `benchmarks` field on each test case.
 - **`Vitest` instance `mode` property** is now always `'test'`. The previous `'benchmark'` value is no longer used; benchmarks run inside a dedicated project of the same `Vitest` instance.
 
-### Vitest UI Requires an Authenticated URL
+## Vitest UI Requires an Authenticated URL
 
 Vitest UI now requires token authentication for the HTML page and API access. The `/__vitest__/` URL will show an error until the browser is authenticated. To authenticate, open the URL with a token printed by Vitest, as shown below. Once authenticated, the direct `/__vitest__/` URL will work correctly.
 
@@ -266,7 +269,7 @@ vitest --ui
 # UI started at http://localhost:51204/__vitest__/?token=...
 ```
 
-### Fake Timers and `setSystemTime` Now Mock `Temporal`
+## Fake Timers and `setSystemTime` Now Mock `Temporal`
 
 Vitest now mocks the [`Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) API alongside `Date`, following the [`@sinonjs/fake-timers` v15.4 update](https://github.com/sinonjs/fake-timers/blob/main/CHANGELOG.md#1540--2026-05-05). This only takes effect when `Temporal` is available on the global object, natively or through a globally installed polyfill such as `import 'temporal-polyfill/global'`.
 
@@ -291,7 +294,7 @@ Temporal.Now.instant().epochMilliseconds // 0 (was the real time in v4)
 vi.useFakeTimers({ toNotFake: ['Temporal'] })
 ```
 
-### `toThrow("")` Matches Any Error Message
+## `toThrow("")` Matches Any Error Message
 
 [`toThrow`](/api/expect#tothrow) (and its alias `toThrowError`) treats a string argument as a substring of the error message. In Vitest 4 an empty string was special-cased to the `/^$/` pattern, so it matched only an error whose message was empty. It now behaves like any other substring, and an empty string is contained in every message:
 
@@ -306,7 +309,7 @@ To assert that a thrown error has an empty message, match the pattern explicitly
 expect(() => { throw new Error('boom') }).not.toThrow(/^$/)
 ```
 
-### Assertion Types Expose Return and Received Types
+## Assertion Types Expose Return and Received Types
 
 Assertion interfaces now use two type parameters: `R` is the matcher return type and `T` is the received value type. Synchronous assertions use `void`, while assertions accessed through `.resolves`, `.rejects`, [`expect.poll`](/api/expect#poll), or [`expect.element`](/api/browser/assertions) use `Promise<void>`.
 
@@ -322,7 +325,7 @@ Assertion<Promise<void>, string> // asynchronous assertion
 
 Vitest no longer reads custom matcher declarations from the global `jest.Matchers` interface. Libraries that support both Jest and Vitest should augment `jest.Matchers` and `vitest.Matchers` separately. This only affects TypeScript declarations; registering matchers with `expect.extend` works as before.
 
-### `expect.poll` Fails When It Times Out
+## `expect.poll` Fails When It Times Out
 
 [`expect.poll`](/api/expect#poll) now rejects when its callback, or the polled assertion, does not settle within `timeout`. Previously a callback that resolved after the deadline, or an assertion that only passed on a late attempt, could still succeed. The callback now also receives an `AbortSignal` that aborts when the timeout elapses, so you can cancel in-flight work:
 
@@ -335,7 +338,7 @@ await expect.poll(async ({ signal }) => {
 
 A poll that legitimately needs more time should raise its `timeout`. Otherwise it fails with `expect.poll() function didn't resolve in time.` (or `expect.poll() assertion didn't resolve in time.`).
 
-### Unawaited Asynchronous Assertions Fail the Test
+## Unawaited Asynchronous Assertions Fail the Test
 
 Asynchronous assertions, like `resolves`, `rejects` and `toMatchFileSnapshot`, now fail the test if they are not awaited. Previously, Vitest auto-awaited them at the end of the test and printed a warning:
 
@@ -350,7 +353,7 @@ test('unawaited assertion', async () => {
 
 The reported error points to the assertion that was not awaited.
 
-### Test Titles and Inspected Values Use `pretty-format`
+## Test Titles and Inspected Values Use `pretty-format`
 
 Vitest now formats values with [`pretty-format`](https://www.npmjs.com/package/pretty-format) instead of `loupe` when it inspects them, including the values interpolated into [`test.each`](/api/test#test-each) and [`test.for`](/api/test#test-for) titles. The rendering of some values changes, so snapshots or assertions that capture inspected output may need updating.
 
@@ -366,7 +369,7 @@ test.for([{ id: 'a1' }])('case $id', ({ id }) => { /* ... */ })
 
 - The length limit for interpolated values is now controlled by the new [`taskTitleValueFormatTruncate`](/config/tasktitlevalueformattruncate) option (default `40`).
 
-### Removed `test.sequential`, `describe.sequential`, and `sequential` Options
+## Removed `test.sequential`, `describe.sequential`, and `sequential` Options
 
 Vitest 5.0 removes the deprecated `test.sequential`, `describe.sequential`, and `sequential` test options. Use `concurrent: false` when you need a test or suite to opt out of inherited or globally configured concurrency.
 
@@ -387,7 +390,7 @@ test('example', { sequential: true }, async () => { /* ... */ }) // [!code --]
 test('example', { concurrent: false }, async () => { /* ... */ }) // [!code ++]
 ```
 
-### Locators in Commands are Serialized as Objects
+## Locators in Commands are Serialized as Objects
 
 Locators forwarded to [browser commands](/api/browser/commands) are now serialized as a `SerializedLocator` object instead of a bare selector string. The object exposes two fields:
 
@@ -409,7 +412,7 @@ export async function customClick(
 }
 ```
 
-### Locators are Strict by Default
+## Locators are Strict by Default
 
 Browser locators now match the text exactly by default, requiring a full, case-sensitive match. To keep the previous behaviour, you can set [`browser.locators.exact`](/config/browser/locators#browser-locators-exact) to `false`.
 
@@ -420,7 +423,7 @@ const locator = page.getByText('Hello, World', { exact: true })
 await locator.click()
 ```
 
-### `toHaveTextContent` Now Performs Strict Equality
+## `toHaveTextContent` Now Performs Strict Equality
 
 The browser-mode [`toHaveTextContent`](/api/browser/assertions#tohavetextcontent) matcher now validates that an element's text content is exactly equal to the expected string instead of performing a partial, case-sensitive match. Regular expressions are no longer accepted. The previous behaviour, including `RegExp` support, has moved to the new [`toMatchTextContent`](/api/browser/assertions#tomatchtextcontent) matcher.
 
@@ -435,7 +438,7 @@ await expect.element(banner).toMatchTextContent(/error/i) // [!code ++]
 await expect.element(banner).toHaveTextContent('Error!')
 ```
 
-### `render` Is Async in `vitest-browser-vue` and `vitest-browser-svelte`
+## `render` Is Async in `vitest-browser-vue` and `vitest-browser-svelte`
 
 The companion component-testing packages [`vitest-browser-vue`](https://npmx.dev/package/vitest-browser-vue) and [`vitest-browser-svelte`](https://npmx.dev/package/vitest-browser-svelte) now return a promise from `render`, so the call must be awaited before you query the rendered output:
 
@@ -451,7 +454,7 @@ test('renders', async () => {
 })
 ```
 
-### Glob Coverage Thresholds No Longer Inherit `perFile`
+## Glob Coverage Thresholds No Longer Inherit `perFile`
 
 `coverage.thresholds.perFile` previously applied to every threshold set, including files matched by glob-pattern thresholds. Glob patterns now control their own per-file checking and no longer inherit the top-level `perFile` — set `perFile` on each glob that needs it.
 
@@ -472,7 +475,7 @@ export default defineConfig({
 })
 ```
 
-### Coverage `include` and `exclude` Match More Precisely
+## Coverage `include` and `exclude` Match More Precisely
 
 [`coverage.include`](/config/coverage#coverage-include) and `coverage.exclude` were matched against absolute paths with picomatch's `contains` option, which matched many more files than intended. Patterns are now matched against each file's path relative to the project root, without `contains`, and a pattern with no glob wildcard is treated as a directory that matches everything inside it:
 
@@ -488,7 +491,7 @@ export default defineConfig({
 
 Review your `include` and `exclude` patterns after upgrading and confirm the reported file set is what you expect. Files that were previously matched only by the looser behavior may no longer be included.
 
-### Config Files Are Not Looked Up From Parent Directories
+## Config Files Are Not Looked Up From Parent Directories
 
 Vitest no longer searches parent directories for config files. If you previously relied on running `vitest` from a subdirectory while using a config file from a parent directory, pass the config explicitly and scope test discovery with `--dir`. For example,
 
@@ -497,11 +500,11 @@ $ cd subdir && vitest # [!code --]
 $ cd subdir && vitest --config ../vitest.config.ts # [!code ++]
 ```
 
-### DOM Environment Global Assignments Now Update the Underlying Window
+## DOM Environment Global Assignments Now Update the Underlying Window
 
 Assignments to properties on `globalThis` or `window` in `jsdom` and `happy-dom` environments are now propagated to the underlying DOM implementation. Mutable properties such as `innerWidth` can affect APIs implemented by the DOM environment, for example `happy-dom`'s `matchMedia`.
 
-### `populateGlobal` Returns Descriptors in `originals`
+## `populateGlobal` Returns Descriptors in `originals`
 
 The `originals` map returned by [`populateGlobal`](/guide/environment#custom-environment) now holds [property descriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor) instead of plain values. This avoids invoking native lazy getters (such as Node's `localStorage`) while capturing the original, and restores them faithfully on teardown.
 
@@ -512,13 +515,13 @@ originals.forEach((value, key) => (global[key] = value)) // [!code --]
 originals.forEach((descriptor, key) => Object.defineProperty(global, key, descriptor)) // [!code ++]
 ```
 
-### Browser Orchestrator URL Requires a Session
+## Browser Orchestrator URL Requires a Session
 
 Vitest no longer serves the browser orchestrator UI from a bare `/__vitest_test__/` URL. Browser runner URLs are now session-bound and must include the `sessionId` generated by Vitest, for example `/__vitest_test__/?sessionId=...`.
 
 If you manually opened the browser preview by copying the Vite server URL or visiting `/__vitest_test__/` directly, use the URL opened or printed by Vitest instead.
 
-### `browser.api` Is Replaced by the Top-Level `api`
+## `browser.api` Is Replaced by the Top-Level `api`
 
 Browser mode now runs on a single Vite server configured by the top-level [`api`](/config/api) option; the default port in browser mode is still `63315`. The `browser.api` option is deprecated and no longer has any effect, so move its value to `api`:
 
@@ -538,7 +541,7 @@ export default defineConfig({
 
 The already deprecated `browser.isolate` option now also prints a warning at startup; its value is still applied to the top-level [`isolate`](/config/isolate) option that replaces it.
 
-### Generated Reports and Artifacts Use the `.vitest` Directory
+## Generated Reports and Artifacts Use the `.vitest` Directory
 
 Vitest now uses a single `.vitest` directory at the project root as the shared artifact root, so one `.vitest` entry in `.gitignore` is enough. Defaults that moved this major:
 
@@ -551,7 +554,7 @@ Vitest now uses a single `.vitest` directory at the project root as the shared a
 
 The `json` and `junit` reporters now write to a file by default instead of printing to stdout. If you piped the report (for example `vitest --reporter=json | jq`), read the artifact file instead, or opt back into stdout with the reporter's [`stdout` option](/guide/reporters#reporter-output) (`reporters: [['json', { stdout: true }]]`). An explicit `outputFile` is still respected and unchanged.
 
-### `toMatchScreenshot` Now Uses a Dedicated Screenshot Directory Config
+## `toMatchScreenshot` Now Uses a Dedicated Screenshot Directory Config
 
 Previously, reference screenshots for `toMatchScreenshot` did not correctly respect `browser.screenshotDirectory`. As a result, screenshots were saved in an unintended location when a custom directory was configured.
 
@@ -577,7 +580,7 @@ This has now been fixed by introducing a dedicated option: `browser.expect.toMat
 
     Then either move existing reference screenshots to the new location or regenerate them.
 
-### Worker and Concurrency Ids Are 1-based
+## Worker and Concurrency Ids Are 1-based
 
 Worker and pool identifiers now start at `1` instead of `0`. This changes the values of the `VITEST_POOL_ID` and `VITEST_WORKER_ID` environment variables, which now range from `1` to the worker count. Update any logic that derives a value from these ids, such as a per-worker database name or an array index.
 
@@ -595,7 +598,7 @@ class MyReporter implements Reporter {
 
 Node.js and browser tests run in separate pools and do not share these ids, so the same value can appear in both.
 
-### `resolveConfig` Returns the Resolved Vite Config
+## `resolveConfig` Returns the Resolved Vite Config
 
 The [`resolveConfig`](/guide/advanced/#resolveconfig) helper from `vitest/node` no longer returns a `{ vitestConfig, viteConfig }` pair. It resolves the config without creating a Vite server and returns the resolved Vite config; the fully resolved Vitest config is available on its `test` property:
 
@@ -609,7 +612,7 @@ const vitestConfig = viteConfig.test // [!code ++]
 
 The Vitest 4 limitations are gone: the returned config now includes fully resolved `projects`, and `viteConfig.test` no longer holds partially resolved options.
 
-### Package Migration
+## Package Migration
 
 The following packages are deprecated as of this release. They will no longer receive feature updates, but security fixes will continue to be backported:
 
@@ -620,7 +623,7 @@ The following packages are deprecated as of this release. They will no longer re
 
 The [`@vitest/browser-webdriverio`](https://npmx.dev/package/@vitest/browser-webdriverio) provider has been moved to the [vitest-community](https://github.com/vitest-community/vitest-webdriverio) organization. Going forward, WebdriverIO support is community-maintained and addressed on a per-issue basis. If you use it, update your dependency to the new package and report any issues in the new repository.
 
-### Removed Deprecated Entrypoints
+## Removed Deprecated Entrypoints
 
 Several entry points were marked as deprecated in Vitest 4.1. This release removes them entirely.
 
@@ -632,367 +635,3 @@ Several entry points were marked as deprecated in Vitest 4.1. This release remov
 - `vitest/suite`: use static methods on `TestRunner` from vitest instead (for example, `TestRunner.getCurrentTest()`)
 - `vitest/mocker` is removed completely, use `@vitest/mocker` package directly (this was published by accident at one point and never removed)
 - `vitest/internal/module-runner` is removed
-
-## Migrating from Jest {#jest}
-
-Vitest has been designed with a Jest compatible API, in order to make the migration from Jest as simple as possible. Despite those efforts, you may still run into the following differences:
-
-### Globals as a Default
-
-Jest has their [globals API](https://jestjs.io/docs/api) enabled by default. Vitest does not. You can either enable globals via [the `globals` configuration setting](/config/globals) or update your code to use imports from the `vitest` module instead.
-
-If you decide to keep globals disabled, be aware that common libraries like [`testing-library`](https://testing-library.com/) will not run auto DOM [cleanup](https://testing-library.com/docs/svelte-testing-library/api/#cleanup).
-
-### `mock.mockReset`
-
-Jest's [`mockReset`](https://jestjs.io/docs/mock-function-api#mockfnmockreset) replaces the mock implementation with an
-empty function that returns `undefined`.
-
-Vitest's [`mockReset`](/api/mock#mockreset) resets the mock implementation to its original.
-That is, resetting a mock created by `vi.fn(impl)` will reset the mock implementation to `impl`.
-
-### `mock.mock` is Persistent
-
-Jest will recreate the mock state when `.mockClear` is called, meaning you always need to access it as a getter. Vitest, on the other hand, holds a persistent reference to the state, meaning you can reuse it:
-
-```ts
-const mock = vi.fn()
-const state = mock.mock
-mock.mockClear()
-
-expect(state).toBe(mock.mock) // fails in Jest
-```
-
-### Module Mocks
-
-When mocking a module in Jest, the factory argument's return value is the default export. In Vitest, the factory argument has to return an object with each export explicitly defined. For example, the following `jest.mock` would have to be updated as follows:
-
-```ts
-jest.mock('./some-path', () => 'hello') // [!code --]
-vi.mock('./some-path', () => ({ // [!code ++]
-  default: 'hello', // [!code ++]
-})) // [!code ++]
-```
-
-For more details please refer to the [`vi.mock` api section](/api/vi#vi-mock).
-
-### Auto-Mocking Behaviour
-
-Unlike Jest, mocked modules in `<root>/__mocks__` are not loaded unless `vi.mock()` is called. If you need them to be mocked in every test, like in Jest, you can mock them inside [`setupFiles`](/config/setupfiles).
-
-### Importing the Original of a Mocked Package
-
-If you are only partially mocking a package, you might have previously used Jest's function `requireActual`. In Vitest, you should replace these calls with `vi.importActual`.
-
-```ts
-const { cloneDeep } = jest.requireActual('lodash/cloneDeep') // [!code --]
-const { cloneDeep } = await vi.importActual('lodash/cloneDeep') // [!code ++]
-```
-
-### Extends mocking to external libraries
-
-Where Jest does it by default, when mocking a module and wanting this mocking to be extended to other external libraries that use the same module, you should explicitly tell which 3rd-party library you want to be mocked, so the external library would be part of your source code, by using [server.deps.inline](/config/server#inline).
-
-```
-server.deps.inline: ["lib-name"]
-```
-
-### expect.getState().currentTestName
-
-Vitest's `test` names are joined with a `>` symbol to make it easier to distinguish tests from suites, while Jest uses an empty space (` `).
-
-```diff
-- `${describeTitle} ${testTitle}`
-+ `${describeTitle} > ${testTitle}`
-```
-
-The same applies to [`testNamePattern`](/config/testnamepattern) (the `-t` flag): Vitest matches against the `>`-joined full name, while Jest matches the space-joined name. Update patterns that span a suite and a test accordingly, or match a single segment (`-t adds`) or use a wildcard between segments (`-t 'math.*adds'`).
-
-```diff
-- vitest -t 'math adds'
-+ vitest -t 'math > adds'
-```
-
-### Envs
-
-Just like Jest, Vitest sets `NODE_ENV` to `test`, if it wasn't set before. Vitest also has a counterpart for `JEST_WORKER_ID` called `VITEST_POOL_ID` (always less than or equal to `maxWorkers`), so if you rely on it, don't forget to rename it. Vitest also exposes `VITEST_WORKER_ID` which is a unique ID of a running worker - this number is not affected by `maxWorkers`, and will increase with each created worker.
-
-### Replace property
-
-If you want to modify the object, you will use [replaceProperty API](https://jestjs.io/docs/jest-object#jestreplacepropertyobject-propertykey-value) in Jest, you can use [`vi.stubEnv`](/api/vi#vi-stubenv) or [`vi.spyOn`](/api/vi#vi-spyon) to do the same also in Vitest.
-
-### Done Callback
-
-Vitest does not support the callback style of declaring tests. You can rewrite them to use `async`/`await` functions, or use Promise to mimic the callback style.
-
-<!--@include: ./examples/promise-done.md-->
-
-### Hooks
-
-`beforeAll`/`beforeEach` hooks may return [teardown function](/api/hooks#beforeach) in Vitest. Because of that you may need to rewrite your hooks declarations, if they return something other than `undefined` or `null`:
-
-```ts
-beforeEach(() => setActivePinia(createTestingPinia())) // [!code --]
-beforeEach(() => { setActivePinia(createTestingPinia()) }) // [!code ++]
-```
-
-In Jest hooks are called sequentially (one after another). By default, Vitest runs hooks in a stack. To use Jest's behavior, update [`sequence.hooks`](/config/sequence#sequence-hooks) option:
-
-```ts
-export default defineConfig({
-  test: {
-    sequence: { // [!code ++]
-      hooks: 'list', // [!code ++]
-    } // [!code ++]
-  }
-})
-```
-
-### Types
-
-Vitest doesn't have an equivalent to `jest` namespace, so you will need to import types directly from `vitest`:
-
-```ts
-let fn: jest.Mock<(name: string) => number> // [!code --]
-import type { Mock } from 'vitest' // [!code ++]
-let fn: Mock<(name: string) => number> // [!code ++]
-```
-
-### Timers
-
-Vitest doesn't support Jest's legacy timers.
-
-### Timeout
-
-If you used `jest.setTimeout`, you would need to migrate to `vi.setConfig`:
-
-```ts
-jest.setTimeout(5_000) // [!code --]
-vi.setConfig({ testTimeout: 5_000 }) // [!code ++]
-```
-
-### Vue Snapshots
-
-This is not a Jest-specific feature, but if you previously were using Jest with vue-cli preset, you will need to install [`jest-serializer-vue`](https://github.com/eddyerburgh/jest-serializer-vue) package, and specify it in [`snapshotSerializers`](/config/snapshotserializers):
-
-```js [vitest.config.js]
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    snapshotSerializers: ['jest-serializer-vue']
-  }
-})
-```
-
-Otherwise your snapshots will have a lot of escaped `"` characters.
-
-### Custom Snapshot Matchers <Experimental /> <Version>4.1.3</Version> {#custom-snapshot-matcher}
-
-Jest imports snapshot composables from `jest-snapshot`. In Vitest, use `Snapshots` from `vitest` instead:
-
-```ts
-const { toMatchSnapshot } = require('jest-snapshot') // [!code --]
-import { Snapshots } from 'vitest' // [!code ++]
-const { toMatchSnapshot } = Snapshots // [!code ++]
-
-expect.extend({
-  toMatchTrimmedSnapshot(received: string, length: number) {
-    return toMatchSnapshot.call(this, received.slice(0, length))
-  },
-})
-```
-
-For inline snapshots, the same applies:
-
-```ts
-const { toMatchInlineSnapshot } = require('jest-snapshot') // [!code --]
-import { Snapshots } from 'vitest' // [!code ++]
-const { toMatchInlineSnapshot } = Snapshots // [!code ++]
-
-expect.extend({
-  toMatchTrimmedInlineSnapshot(received: string, inlineSnapshot?: string) {
-    return toMatchInlineSnapshot.call(this, received.slice(0, 10), inlineSnapshot)
-  },
-})
-```
-
-See [Custom Snapshot Matchers](/guide/snapshot#custom-snapshot-matchers) for the full guide.
-
-## Migrating from Mocha + Chai + Sinon {#mocha-chai-sinon}
-
-Vitest provides excellent support for migrating from Mocha+Chai+Sinon test suites. While Vitest uses a Jest-compatible API by default, it also provides Chai-style assertions for spy/mock testing, making migration easier.
-
-### Test Structure
-
-Mocha and Vitest have similar test structures, but with some differences:
-
-```ts
-// Mocha
-describe('suite', () => {
-  before(() => { /* setup */ })
-  after(() => { /* teardown */ })
-  beforeEach(() => { /* setup */ })
-  afterEach(() => { /* teardown */ })
-
-  it('test', () => {
-    // test code
-  })
-})
-
-// Vitest - same structure works!
-import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest'
-
-describe('suite', () => {
-  beforeAll(() => { /* setup */ })
-  afterAll(() => { /* teardown */ })
-  beforeEach(() => { /* setup */ })
-  afterEach(() => { /* teardown */ })
-
-  it('test', () => {
-    // test code
-  })
-})
-```
-
-### Assertions
-
-Vitest includes Chai assertions by default, so Chai assertions work without changes:
-
-```ts
-// Both Mocha+Chai and Vitest
-import { expect } from 'vitest' // or 'chai' in Mocha
-
-expect(value).to.equal(42)
-expect(value).to.be.true
-expect(array).to.have.lengthOf(3)
-expect(obj).to.have.property('key')
-```
-
-### Spy/Mock Assertions
-
-Vitest provides **Chai-style assertions** for spies and mocks, allowing you to migrate from Sinon without rewriting assertions:
-
-```ts
-// Before (Mocha + Chai + Sinon)
-const sinon = require('sinon')
-const chai = require('chai')
-const sinonChai = require('sinon-chai')
-chai.use(sinonChai)
-
-const spy = sinon.spy(obj, 'method')
-obj.method('arg1', 'arg2')
-
-expect(spy).to.have.been.called
-expect(spy).to.have.been.calledOnce
-expect(spy).to.have.been.calledWith('arg1', 'arg2')
-
-// After (Vitest) - same assertion syntax!
-import { expect, vi } from 'vitest'
-
-const spy = vi.spyOn(obj, 'method')
-obj.method('arg1', 'arg2')
-
-expect(spy).to.have.been.called
-expect(spy).to.have.been.calledOnce
-expect(spy).to.have.been.calledWith('arg1', 'arg2')
-```
-
-#### Complete Chai-Style Assertion Support
-
-Vitest supports all common sinon-chai assertions:
-
-| Sinon-Chai | Vitest | Description |
-|------------|--------|-------------|
-| `spy.called` | `called` | Spy was called at least once |
-| `spy.calledOnce` | `calledOnce` | Spy was called exactly once |
-| `spy.calledTwice` | `calledTwice` | Spy was called exactly twice |
-| `spy.calledThrice` | `calledThrice` | Spy was called exactly three times |
-| `spy.callCount(n)` | `callCount(n)` | Spy was called n times |
-| `spy.calledWith(...)` | `calledWith(...)` | Spy was called with specific args |
-| `spy.calledOnceWith(...)` | `calledOnceWith(...)` | Spy was called once with specific args |
-| `spy.returned(value)` | `returned` | Spy returned specific value |
-
-See the [Chai-Style Spy Assertions](/api/expect#chai-style-spy-assertions) documentation for the complete list.
-
-### Creating Spies and Mocks
-
-Replace Sinon's spy/stub/mock creation with Vitest's `vi` utilities:
-
-```ts
-// Sinon
-const sinon = require('sinon')
-const spy = sinon.spy()
-const stub = sinon.stub(obj, 'method')
-const mock = sinon.mock(obj)
-
-// Vitest
-import { vi } from 'vitest'
-const spy = vi.fn()
-const stub = vi.spyOn(obj, 'method')
-// Vitest doesn't have "mocks" - use spies instead
-```
-
-### Stubbing Return Values
-
-```ts
-// Sinon
-stub.returns(42)
-stub.onFirstCall().returns(1)
-stub.onSecondCall().returns(2)
-
-// Vitest
-stub.mockReturnValue(42)
-stub.mockReturnValueOnce(1)
-stub.mockReturnValueOnce(2)
-```
-
-### Stubbing Implementations
-
-```ts
-// Sinon
-stub.callsFake(arg => arg * 2)
-
-// Vitest
-stub.mockImplementation(arg => arg * 2)
-```
-
-### Restoring Spies
-
-```ts
-// Sinon
-spy.restore()
-sinon.restore() // restore all
-
-// Vitest
-spy.mockRestore()
-vi.restoreAllMocks() // restore all
-```
-
-### Timers
-
-Both Sinon and Vitest use `@sinonjs/fake-timers` internally:
-
-```ts
-// Sinon
-const clock = sinon.useFakeTimers()
-clock.tick(1000)
-clock.restore()
-
-// Vitest
-import { vi } from 'vitest'
-vi.useFakeTimers()
-vi.advanceTimersByTime(1000)
-vi.useRealTimers()
-```
-
-### Key Differences
-
-1. **Globals**: Mocha provides globals by default. In Vitest, either import from `vitest` or enable [`globals`](/config/globals) config
-2. **Assertion style**: You can use both Chai-style (`expect(spy).to.have.been.called`) and Jest-style (`expect(spy).toHaveBeenCalled()`)
-3. **Parallel execution**: Vitest runs tests in parallel by default, Mocha runs sequentially
-
-For more information, see:
-- [Chai-Style Spy Assertions](/api/expect#chai-style-spy-assertions)
-- [Mocking Guide](/guide/mocking)
-- [Vi API](/api/vi)

--- a/docs/guide/migration/jest.md
+++ b/docs/guide/migration/jest.md
@@ -1,0 +1,190 @@
+---
+title: Migrating from Jest | Guide
+outline: deep
+---
+
+# Migrating from Jest {#jest}
+
+Vitest has been designed with a Jest compatible API, in order to make the migration from Jest as simple as possible. Despite those efforts, you may still run into the following differences:
+
+## Globals as a Default
+
+Jest has their [globals API](https://jestjs.io/docs/api) enabled by default. Vitest does not. You can either enable globals via [the `globals` configuration setting](/config/globals) or update your code to use imports from the `vitest` module instead.
+
+If you decide to keep globals disabled, be aware that common libraries like [`testing-library`](https://testing-library.com/) will not run auto DOM [cleanup](https://testing-library.com/docs/svelte-testing-library/api/#cleanup).
+
+## `mock.mockReset`
+
+Jest's [`mockReset`](https://jestjs.io/docs/mock-function-api#mockfnmockreset) replaces the mock implementation with an
+empty function that returns `undefined`.
+
+Vitest's [`mockReset`](/api/mock#mockreset) resets the mock implementation to its original.
+That is, resetting a mock created by `vi.fn(impl)` will reset the mock implementation to `impl`.
+
+## `mock.mock` is Persistent
+
+Jest will recreate the mock state when `.mockClear` is called, meaning you always need to access it as a getter. Vitest, on the other hand, holds a persistent reference to the state, meaning you can reuse it:
+
+```ts
+const mock = vi.fn()
+const state = mock.mock
+mock.mockClear()
+
+expect(state).toBe(mock.mock) // fails in Jest
+```
+
+## Module Mocks
+
+When mocking a module in Jest, the factory argument's return value is the default export. In Vitest, the factory argument has to return an object with each export explicitly defined. For example, the following `jest.mock` would have to be updated as follows:
+
+```ts
+jest.mock('./some-path', () => 'hello') // [!code --]
+vi.mock('./some-path', () => ({ // [!code ++]
+  default: 'hello', // [!code ++]
+})) // [!code ++]
+```
+
+For more details please refer to the [`vi.mock` api section](/api/vi#vi-mock).
+
+## Auto-Mocking Behaviour
+
+Unlike Jest, mocked modules in `<root>/__mocks__` are not loaded unless `vi.mock()` is called. If you need them to be mocked in every test, like in Jest, you can mock them inside [`setupFiles`](/config/setupfiles).
+
+## Importing the Original of a Mocked Package
+
+If you are only partially mocking a package, you might have previously used Jest's function `requireActual`. In Vitest, you should replace these calls with `vi.importActual`.
+
+```ts
+const { cloneDeep } = jest.requireActual('lodash/cloneDeep') // [!code --]
+const { cloneDeep } = await vi.importActual('lodash/cloneDeep') // [!code ++]
+```
+
+## Extends mocking to external libraries
+
+Where Jest does it by default, when mocking a module and wanting this mocking to be extended to other external libraries that use the same module, you should explicitly tell which 3rd-party library you want to be mocked, so the external library would be part of your source code, by using [server.deps.inline](/config/server#inline).
+
+```
+server.deps.inline: ["lib-name"]
+```
+
+## expect.getState().currentTestName
+
+Vitest's `test` names are joined with a `>` symbol to make it easier to distinguish tests from suites, while Jest uses an empty space (` `).
+
+```diff
+- `${describeTitle} ${testTitle}`
++ `${describeTitle} > ${testTitle}`
+```
+
+The same applies to [`testNamePattern`](/config/testnamepattern) (the `-t` flag): Vitest matches against the `>`-joined full name, while Jest matches the space-joined name. Update patterns that span a suite and a test accordingly, or match a single segment (`-t adds`) or use a wildcard between segments (`-t 'math.*adds'`).
+
+```diff
+- vitest -t 'math adds'
++ vitest -t 'math > adds'
+```
+
+## Envs
+
+Just like Jest, Vitest sets `NODE_ENV` to `test`, if it wasn't set before. Vitest also has a counterpart for `JEST_WORKER_ID` called `VITEST_POOL_ID` (always less than or equal to `maxWorkers`), so if you rely on it, don't forget to rename it. Vitest also exposes `VITEST_WORKER_ID` which is a unique ID of a running worker - this number is not affected by `maxWorkers`, and will increase with each created worker.
+
+## Replace property
+
+If you want to modify the object, you will use [replaceProperty API](https://jestjs.io/docs/jest-object#jestreplacepropertyobject-propertykey-value) in Jest, you can use [`vi.stubEnv`](/api/vi#vi-stubenv) or [`vi.spyOn`](/api/vi#vi-spyon) to do the same also in Vitest.
+
+## Done Callback
+
+Vitest does not support the callback style of declaring tests. You can rewrite them to use `async`/`await` functions, or use Promise to mimic the callback style.
+
+<!--@include: ../examples/promise-done.md-->
+
+## Hooks
+
+`beforeAll`/`beforeEach` hooks may return [teardown function](/api/hooks#beforeach) in Vitest. Because of that you may need to rewrite your hooks declarations, if they return something other than `undefined` or `null`:
+
+```ts
+beforeEach(() => setActivePinia(createTestingPinia())) // [!code --]
+beforeEach(() => { setActivePinia(createTestingPinia()) }) // [!code ++]
+```
+
+In Jest hooks are called sequentially (one after another). By default, Vitest runs hooks in a stack. To use Jest's behavior, update [`sequence.hooks`](/config/sequence#sequence-hooks) option:
+
+```ts
+export default defineConfig({
+  test: {
+    sequence: { // [!code ++]
+      hooks: 'list', // [!code ++]
+    } // [!code ++]
+  }
+})
+```
+
+## Types
+
+Vitest doesn't have an equivalent to `jest` namespace, so you will need to import types directly from `vitest`:
+
+```ts
+let fn: jest.Mock<(name: string) => number> // [!code --]
+import type { Mock } from 'vitest' // [!code ++]
+let fn: Mock<(name: string) => number> // [!code ++]
+```
+
+## Timers
+
+Vitest doesn't support Jest's legacy timers.
+
+## Timeout
+
+If you used `jest.setTimeout`, you would need to migrate to `vi.setConfig`:
+
+```ts
+jest.setTimeout(5_000) // [!code --]
+vi.setConfig({ testTimeout: 5_000 }) // [!code ++]
+```
+
+## Vue Snapshots
+
+This is not a Jest-specific feature, but if you previously were using Jest with vue-cli preset, you will need to install [`jest-serializer-vue`](https://github.com/eddyerburgh/jest-serializer-vue) package, and specify it in [`snapshotSerializers`](/config/snapshotserializers):
+
+```js [vitest.config.js]
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    snapshotSerializers: ['jest-serializer-vue']
+  }
+})
+```
+
+Otherwise your snapshots will have a lot of escaped `"` characters.
+
+## Custom Snapshot Matchers <Experimental /> <Version>4.1.3</Version> {#custom-snapshot-matcher}
+
+Jest imports snapshot composables from `jest-snapshot`. In Vitest, use `Snapshots` from `vitest` instead:
+
+```ts
+const { toMatchSnapshot } = require('jest-snapshot') // [!code --]
+import { Snapshots } from 'vitest' // [!code ++]
+const { toMatchSnapshot } = Snapshots // [!code ++]
+
+expect.extend({
+  toMatchTrimmedSnapshot(received: string, length: number) {
+    return toMatchSnapshot.call(this, received.slice(0, length))
+  },
+})
+```
+
+For inline snapshots, the same applies:
+
+```ts
+const { toMatchInlineSnapshot } = require('jest-snapshot') // [!code --]
+import { Snapshots } from 'vitest' // [!code ++]
+const { toMatchInlineSnapshot } = Snapshots // [!code ++]
+
+expect.extend({
+  toMatchTrimmedInlineSnapshot(received: string, inlineSnapshot?: string) {
+    return toMatchInlineSnapshot.call(this, received.slice(0, 10), inlineSnapshot)
+  },
+})
+```
+
+See [Custom Snapshot Matchers](/guide/snapshot#custom-snapshot-matchers) for the full guide.

--- a/docs/guide/migration/mocha.md
+++ b/docs/guide/migration/mocha.md
@@ -1,0 +1,182 @@
+---
+title: Migrating from Mocha + Chai + Sinon | Guide
+outline: deep
+---
+
+# Migrating from Mocha + Chai + Sinon {#mocha-chai-sinon}
+
+Vitest provides excellent support for migrating from Mocha+Chai+Sinon test suites. While Vitest uses a Jest-compatible API by default, it also provides Chai-style assertions for spy/mock testing, making migration easier.
+
+## Test Structure
+
+Mocha and Vitest have similar test structures, but with some differences:
+
+```ts
+// Mocha
+describe('suite', () => {
+  before(() => { /* setup */ })
+  after(() => { /* teardown */ })
+  beforeEach(() => { /* setup */ })
+  afterEach(() => { /* teardown */ })
+
+  it('test', () => {
+    // test code
+  })
+})
+
+// Vitest - same structure works!
+import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest'
+
+describe('suite', () => {
+  beforeAll(() => { /* setup */ })
+  afterAll(() => { /* teardown */ })
+  beforeEach(() => { /* setup */ })
+  afterEach(() => { /* teardown */ })
+
+  it('test', () => {
+    // test code
+  })
+})
+```
+
+## Assertions
+
+Vitest includes Chai assertions by default, so Chai assertions work without changes:
+
+```ts
+// Both Mocha+Chai and Vitest
+import { expect } from 'vitest' // or 'chai' in Mocha
+
+expect(value).to.equal(42)
+expect(value).to.be.true
+expect(array).to.have.lengthOf(3)
+expect(obj).to.have.property('key')
+```
+
+## Spy/Mock Assertions
+
+Vitest provides **Chai-style assertions** for spies and mocks, allowing you to migrate from Sinon without rewriting assertions:
+
+```ts
+// Before (Mocha + Chai + Sinon)
+const sinon = require('sinon')
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+
+const spy = sinon.spy(obj, 'method')
+obj.method('arg1', 'arg2')
+
+expect(spy).to.have.been.called
+expect(spy).to.have.been.calledOnce
+expect(spy).to.have.been.calledWith('arg1', 'arg2')
+
+// After (Vitest) - same assertion syntax!
+import { expect, vi } from 'vitest'
+
+const spy = vi.spyOn(obj, 'method')
+obj.method('arg1', 'arg2')
+
+expect(spy).to.have.been.called
+expect(spy).to.have.been.calledOnce
+expect(spy).to.have.been.calledWith('arg1', 'arg2')
+```
+
+### Complete Chai-Style Assertion Support
+
+Vitest supports all common sinon-chai assertions:
+
+| Sinon-Chai | Vitest | Description |
+|------------|--------|-------------|
+| `spy.called` | `called` | Spy was called at least once |
+| `spy.calledOnce` | `calledOnce` | Spy was called exactly once |
+| `spy.calledTwice` | `calledTwice` | Spy was called exactly twice |
+| `spy.calledThrice` | `calledThrice` | Spy was called exactly three times |
+| `spy.callCount(n)` | `callCount(n)` | Spy was called n times |
+| `spy.calledWith(...)` | `calledWith(...)` | Spy was called with specific args |
+| `spy.calledOnceWith(...)` | `calledOnceWith(...)` | Spy was called once with specific args |
+| `spy.returned(value)` | `returned` | Spy returned specific value |
+
+See the [Chai-Style Spy Assertions](/api/expect#chai-style-spy-assertions) documentation for the complete list.
+
+## Creating Spies and Mocks
+
+Replace Sinon's spy/stub/mock creation with Vitest's `vi` utilities:
+
+```ts
+// Sinon
+const sinon = require('sinon')
+const spy = sinon.spy()
+const stub = sinon.stub(obj, 'method')
+const mock = sinon.mock(obj)
+
+// Vitest
+import { vi } from 'vitest'
+const spy = vi.fn()
+const stub = vi.spyOn(obj, 'method')
+// Vitest doesn't have "mocks" - use spies instead
+```
+
+## Stubbing Return Values
+
+```ts
+// Sinon
+stub.returns(42)
+stub.onFirstCall().returns(1)
+stub.onSecondCall().returns(2)
+
+// Vitest
+stub.mockReturnValue(42)
+stub.mockReturnValueOnce(1)
+stub.mockReturnValueOnce(2)
+```
+
+## Stubbing Implementations
+
+```ts
+// Sinon
+stub.callsFake(arg => arg * 2)
+
+// Vitest
+stub.mockImplementation(arg => arg * 2)
+```
+
+## Restoring Spies
+
+```ts
+// Sinon
+spy.restore()
+sinon.restore() // restore all
+
+// Vitest
+spy.mockRestore()
+vi.restoreAllMocks() // restore all
+```
+
+## Timers
+
+Both Sinon and Vitest use `@sinonjs/fake-timers` internally:
+
+```ts
+// Sinon
+const clock = sinon.useFakeTimers()
+clock.tick(1000)
+clock.restore()
+
+// Vitest
+import { vi } from 'vitest'
+vi.useFakeTimers()
+vi.advanceTimersByTime(1000)
+vi.useRealTimers()
+```
+
+## Key Differences
+
+1. **Globals**: Mocha provides globals by default. In Vitest, either import from `vitest` or enable [`globals`](/config/globals) config
+2. **Assertion style**: You can use both Chai-style (`expect(spy).to.have.been.called`) and Jest-style (`expect(spy).toHaveBeenCalled()`)
+3. **Parallel execution**: Vitest runs tests in parallel by default, Mocha runs sequentially
+
+For more information, see:
+- [Chai-Style Spy Assertions](/api/expect#chai-style-spy-assertions)
+- [Mocking Guide](/guide/mocking)
+- [Vi API](/api/vi)

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,6 +31,7 @@
     "@voidzero-dev/vitepress-theme": "^5.0.6",
     "https-localhost": "^4.7.1",
     "tinyglobby": "catalog:",
+    "tsx": "catalog:",
     "unocss": "catalog:",
     "vite": "^6.3.5",
     "vite-plugin-pwa": "^1.3.0",

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,7 +30,7 @@ The supported version ranges are automatically determined by:
 - **Previous Major** (only for its latest minor) and **Previous Minor** receives important fixes and security patches.
 - All versions before these are no longer supported.
 
-We recommend updating Vitest regularly. Check out the [Migration Guides](/guide/migration) when you update to each Major. We test new Vitest versions before releasing them through the [vitest-ecosystem-ci project](https://github.com/vitest-dev/vitest-ecosystem-ci). Most projects using Vitest should be able to quickly offer support or migrate to new versions as soon as they are released.
+We recommend updating Vitest regularly. Check out the [Migration Guides](/guide/migration/) when you update to each Major. We test new Vitest versions before releasing them through the [vitest-ecosystem-ci project](https://github.com/vitest-dev/vitest-ecosystem-ci). Most projects using Vitest should be able to quickly offer support or migrate to new versions as soon as they are released.
 
 ## Semantic Versioning Edge Cases
 
@@ -50,7 +50,7 @@ Pre-releases allow early adopters and maintainers from the Ecosystem to do integ
 
 ## Deprecations
 
-We periodically deprecate features that have been superseded by better alternatives in Minor releases. Deprecated features will continue to work with a type or logged warning. They will be removed in the next major release after entering deprecated status. The [Migration Guide](/guide/migration.html) for each major will list these removals and document an upgrade path for them.
+We periodically deprecate features that have been superseded by better alternatives in Minor releases. Deprecated features will continue to work with a type or logged warning. They will be removed in the next major release after entering deprecated status. The [Migration Guide](/guide/migration/) for each major will list these removals and document an upgrade path for them.
 
 ## Experimental Features
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ catalogs:
     tinyspy:
       specifier: ^4.0.4
       version: 4.0.4
+    tsx:
+      specifier: ^4.23.13
+      version: 4.23.13
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -324,6 +327,9 @@ importers:
       tinyglobby:
         specifier: 'catalog:'
         version: 0.2.17
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.13
       unocss:
         specifier: 'catalog:'
         version: 66.8.1(vite@8.0.11(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.103.1)(sass@1.103.1)(terser@5.48.0)(tsx@4.23.13)(yaml@2.8.2))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,7 @@ catalog:
   tinyhighlight: ^0.3.2
   tinyrainbow: ^3.1.1
   tinyspy: ^4.0.4
+  tsx: ^4.23.13
   typescript: ^5.9.3
   unocss: ^66.8.1
   vite: 8.0.11


### PR DESCRIPTION
Adds a Changelog and a Copy prompt buttons

<img width="823" height="441" alt="image" src="https://github.com/user-attachments/assets/8a5ad1ac-5768-4425-9a84-e69c6c31169e" />
