### PR TITLE
docs: voidzero theme doesn't have a slot in production, only in dev

### DIFF
--- a/docs/.vitepress/components/OldDocument.vue
+++ b/docs/.vitepress/components/OldDocument.vue
@@ -9,21 +9,18 @@
 </template>
 
 <style>
-.docs-layout,
-.marketing-layout {
+:root {
   --vp-old-document-height: 96px;
 }
 
 @media (min-width: 455px) {
-  .docs-layout,
-  .marketing-layout {
+  :root {
     --vp-old-document-height: 64px;
   }
 }
 
 @media (min-width: 960px) {
-  .docs-layout,
-  .marketing-layout {
+  :root {
     --vp-old-document-height: 32px;
   }
 }
@@ -62,12 +59,12 @@
 }
 
 @media (min-width: 1024px) {
-  .docs-layout:has(.old-document) {
+  :root:has(.docs-layout) {
     --vp-banner-height: var(--vp-old-document-height);
     --vp-layout-top-height: var(--vp-old-document-height);
   }
 
-  .docs-layout .old-document {
+  :root:has(.docs-layout) .old-document {
     position: fixed;
     top: 0;
   }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,7 +3,7 @@ import TwoslashFloatingVue from '@shikijs/vitepress-twoslash/client'
 import { inBrowser } from 'vitepress'
 import VitestTheme from '@voidzero-dev/vitepress-theme/src/vitest'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
-import { h } from 'vue'
+import { Fragment, h } from 'vue'
 import Version from '../components/Version.vue'
 import CRoot from '../components/CRoot.vue'
 import Deprecated from '../components/Deprecated.vue'
@@ -54,9 +54,10 @@ function getRedirectPath(url: URL) {
 export default {
   extends: VitestTheme as unknown as any,
   Layout() {
-    return h(VitestTheme.Layout, null, {
-      'layout-top': () => h(OldDocument),
-    })
+    return h(Fragment, null, [
+      h(OldDocument),
+      h(VitestTheme.Layout),
+    ])
   },
   enhanceApp({ app }) {
     app.component('Version', Version)


### PR DESCRIPTION
Seems weird, but on production landing page doesn't render the warning. Checked both dev and serve now