### PR TITLE
fix: match triggers in dot dirs (fix #11054)

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,7 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { createFile, editFile, resolvePath, runVitest } from '../../test-utils'
 
-const fileName = 'fixtures/git-changed/related/rerun.temp'
+const fileName = 'fixtures/git-changed/related/.project/rerun.temp/trigger'
 
 // NOTE: if there are any changes in fixtures/git-changed,
 // most tests will probably fail

--- a/test/e2e/test/watch/file-watching.test.ts
+++ b/test/e2e/test/watch/file-watching.test.ts
@@ -87,7 +87,7 @@ test('answer is 42', () => {
 test('editing force rerun trigger reruns all tests', async () => {
   const { vitest, fs } = await testUtils.runInlineTests({
     ...baseFixture,
-    'force-watch/trigger.js': 'export const trigger = false\n',
+    '.project/force-watch/trigger.js': 'export const trigger = false\n',
     'vitest.config.ts': /* ts */ `
 export default {
   test: {
@@ -100,9 +100,9 @@ export default {
   await vitest.waitForStdout('Waiting for file changes...')
   vitest.resetOutput()
 
-  fs.editFile('force-watch/trigger.js', modifyContent)
+  fs.editFile('.project/force-watch/trigger.js', modifyContent)
 
-  await vitest.waitForStdout('RERUN  ../force-watch/trigger.js')
+  await vitest.waitForStdout('RERUN  ../.project/force-watch/trigger.js')
   await vitest.waitForStdout('example.test.ts')
   await vitest.waitForStdout('math.test.ts')
   await vitest.waitForStdout('2 passed')


### PR DESCRIPTION
### Description

Prepared with Codex assistance on behalf of @wangxpych. The operator authorized this contribution but has not manually reviewed the patch or this text.

`forceRerunTriggers` is matched against absolute paths. Picomatch's default `dot: false` prevents `**` from crossing hidden directory segments, so changed and watch runs can silently miss triggers when a checkout or trigger is below a dot directory.

This enables `dot: true` at both matching sites and covers the behavior in changed and watch mode.

Resolves #11054

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.
- [x] `pnpm --filter vitest build`
- [x] `pnpm typecheck`
- [x] `CI=true pnpm lint`
- [x] Relevant e2e tests: 14 passed, 1 browser-only test skipped

The browser-only test could not launch Chromium in the local sandbox (`MachPortRendezvousServer: Permission denied`).

### Documentation
- [x] No new functionality to document.

### Changesets
- [x] The PR title describes the fix.
