### PR TITLE
fix(types): make public declarations self-contained

### DIFF
--- a/packages/browser/context.d.ts
+++ b/packages/browser/context.d.ts
@@ -1,5 +1,5 @@
 import { SerializedConfig } from 'vitest'
-import { StringifyOptions, CDPSession, BrowserCommands } from 'vitest/internal/browser'
+import { StringifyOptions, CDPSession, BrowserCommands, BrowserTraceEntryKind, MarkOptions } from 'vitest/internal/browser'
 import { ARIARole } from './aria-role.js'
 import {} from './matchers.js'
 import { __ivyaAriaTypes } from '@vitest/browser/internal/vendor-types'
@@ -18,7 +18,7 @@ export type BufferEncoding =
   | 'binary'
   | 'hex'
 
-export { CDPSession };
+export { BrowserTraceEntryKind, CDPSession, MarkOptions };
 
 export interface ScreenshotOptions extends SelectorOptions {
   /**
@@ -40,22 +40,6 @@ export interface ScreenshotOptions extends SelectorOptions {
    * @default true
    */
   save?: boolean
-}
-
-export type BrowserTraceEntryKind = 'action' | 'expect' | 'mark' | 'lifecycle'
-
-export interface MarkOptions {
-  /**
-   * Optional stack string used to resolve marker location.
-   * Useful for wrapper libraries that need to forward the end-user callsite.
-   */
-  stack?: string
-
-  /**
-   * Optional marker kind that's used to categorize the marker in the trace viewer.
-   * @default 'mark'
-   */
-  kind?: BrowserTraceEntryKind
 }
 
 interface StandardScreenshotComparators {

--- a/packages/vitest/browser/context.d.ts
+++ b/packages/vitest/browser/context.d.ts
@@ -4,4 +4,4 @@ export * from '@vitest/browser-playwright/context'
 export * from '@vitest/browser-webdriverio/context'
 // @ts-ignore -- @vitest/browser-preview might not be installed
 export * from '@vitest/browser-preview/context'
-export { BrowserCommands, CDPSession, FsOptions } from 'vitest/internal/browser'
+export { BrowserCommands, BrowserTraceEntryKind, CDPSession, FsOptions, MarkOptions } from 'vitest/internal/browser'

--- a/packages/vitest/config.d.ts
+++ b/packages/vitest/config.d.ts
@@ -1,3 +1,1 @@
-// ensure `@vitest/expect` provides `chai` types
-import type {} from '@vitest/expect'
 export * from './dist/config.js'

--- a/packages/vitest/src/public/browser.ts
+++ b/packages/vitest/src/public/browser.ts
@@ -48,6 +48,22 @@ export interface CDPSession {
   // methods are defined by the provider type augmentation
 }
 
+export type BrowserTraceEntryKind = 'action' | 'expect' | 'mark' | 'lifecycle'
+
+export interface MarkOptions {
+  /**
+   * Optional stack string used to resolve marker location.
+   * Useful for wrapper libraries that need to forward the end-user callsite.
+   */
+  stack?: string
+
+  /**
+   * Optional marker kind that's used to categorize the marker in the trace viewer.
+   * @default 'mark'
+   */
+  kind?: BrowserTraceEntryKind
+}
+
 /**
  * @internal
  */


### PR DESCRIPTION
## Summary

- remove the accidental `@vitest/expect` import from the public config declaration
- expose `MarkOptions` and `BrowserTraceEntryKind` through the core browser types
- re-export the browser trace types from `vitest/browser`

Closes #11140

## Tests

- `pnpm lint:fix`
- `pnpm --filter @vitest/browser build:node`
- `pnpm --filter @vitest/test-integration-dts-config test`
- `pnpm --filter @vitest/test-integration-dts-browser-playwright test`
- verified the packed package in an isolated TypeScript consumer without `@vitest/expect` or a browser provider

## AI disclosure

This change was prepared with assistance from OpenAI Codex GPT 5.6sol and manually reviewed before submission.