### PR TITLE
fix: exit 1 when vitest list fails collection (fix #11145)

### DIFF
--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -801,6 +801,9 @@ export class Vitest {
         const testModules = await this.parseSpecifications(files, {
           concurrency: options.staticParseConcurrency,
         })
+        if (hasFailed(testModules.map(testModule => testModule.task))) {
+          process.exitCode = 1
+        }
         return { testModules, unhandledErrors: [] }
       }
 

--- a/test/e2e/test/__snapshots__/list.test.ts.snap
+++ b/test/e2e/test/__snapshots__/list.test.ts.snap
@@ -19,6 +19,11 @@ Error: top level error
 "
 `;
 
+exports[`basic output shows error with static parsing 1`] = `
+"Error: No test suite found in file <root>/fixtures/list/top-level-error.test.ts
+"
+`;
+
 exports[`correctly outputs all tests with args: "--browser.enabled" 1`] = `
 "[chromium] basic.test.ts > basic suite > inner suite > some test
 [chromium] basic.test.ts > basic suite > inner suite > another test
@@ -104,6 +109,11 @@ Error: top level error
 "
 `;
 
+exports[`json output shows error with static parsing 1`] = `
+"Error: No test suite found in file <root>/fixtures/list/top-level-error.test.ts
+"
+`;
+
 exports[`json with a file output shows error 1`] = `
 "Error: describe error
  ❯ describe-error.test.ts:4:9
@@ -120,5 +130,10 @@ Error: top level error
        |       ^
       2|
 
+"
+`;
+
+exports[`json with a file output shows error with static parsing 1`] = `
+"Error: No test suite found in file <root>/fixtures/list/top-level-error.test.ts
 "
 `;

--- a/test/e2e/test/list.test.ts
+++ b/test/e2e/test/list.test.ts
@@ -27,6 +27,17 @@ test.each([
   expect(exitCode).toBe(1)
 })
 
+test.each([
+  ['basic'],
+  ['json', '--json'],
+  ['json with a file', '--json=./list.json'],
+])('%s output shows error with static parsing', async (_, ...args) => {
+  const { stderr, stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', '-c=fail.config.ts', ...args)
+  expect(stdout).toBe('')
+  expect(relative(stderr)).toMatchSnapshot()
+  expect(exitCode).toBe(1)
+})
+
 test('correctly outputs json', async () => {
   const { stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', '--json')
   expect(relative(stdout)).toMatchInlineSnapshot(`


### PR DESCRIPTION
### Description

Resolves #11145

`vitest list` prints a collection error and exits 0 when it parses files statically, the default since #11088. `--no-static-parse` exits 1 for the same file.

`Vitest.collect()` only sets the exit code in the branch that calls `collectTests`. This adds the same `hasFailed` check to the static branch. It has to live in `collect()`, since `start()` also calls `parseSpecifications` to filter specifications for a normal run.

### Tests

#11088 moved the only exit code assertion in `list.test.ts` onto `--no-static-parse`. I added the same cases for the default path. They fail on main with `expected +0 to be 1`.

I used Claude Code while investigating this. I reproduced the bug and reviewed the fix myself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] No new functionality, nothing to document.

### Changesets
- [x] The PR title explains the change.
