### PR TITLE
fix: keep parse error details in static collection (fix #11150)

### DIFF
--- a/packages/vitest/src/node/ast-collect.ts
+++ b/packages/vitest/src/node/ast-collect.ts
@@ -12,6 +12,7 @@ import { createIndexLocationsMap } from '../utils/base'
 import { createDebugger } from '../utils/debugger'
 import { calculateSuiteHash, createFileTask as createFileTaskOriginal, createTaskName } from '../utils/tasks'
 import { detectCodeBlock } from '../utils/test-helpers'
+import { toRollupError } from './environments/fetchModule'
 
 interface ParsedFile extends File {
   start: number
@@ -323,28 +324,16 @@ export function createFailedFileTask(project: TestProject, filepath: string, err
     end: 0,
     result: {
       state: 'fail',
-      errors: serializeError(project, error),
+      errors: serializeError(error),
     },
   }
   file.file = file
   return file
 }
 
-function serializeError(ctx: TestProject, error: any): TestError[] {
-  if ('errors' in error && 'pluginCode' in error) {
-    const errors = error.errors.map((e: any) => {
-      return {
-        name: error.name,
-        message: e.text,
-        stack: e.location
-          ? `${error.name}: ${e.text}\n  at ${relative(ctx.config.root, e.location.file)}:${e.location.line}:${e.location.column}`
-          : '',
-      }
-    })
-    return errors
-  }
+function serializeError(error: any): TestError[] {
   return [
-    {
+    toRollupError(error) ?? {
       name: error.name,
       stack: error.stack,
       message: error.message,

--- a/packages/vitest/src/node/environments/fetchModule.ts
+++ b/packages/vitest/src/node/environments/fetchModule.ts
@@ -2,7 +2,7 @@ import type { Span } from '@opentelemetry/api'
 import type { StaticMockCall } from '@vitest/mocker/node'
 import type { DevEnvironment, EnvironmentModuleNode, Rollup, TransformResult } from 'vite'
 import type { FetchFunctionOptions, FetchResult } from 'vite/module-runner'
-import type { FetchCachedFileSystemResult, ModuleType, VitestFetchResult } from '../../types/general'
+import type { FetchCachedFileSystemResult, ModuleType, TestError, VitestFetchResult } from '../../types/general'
 import type { OTELCarrier, Traces } from '../../utils/traces'
 import type { FileSystemModuleCache } from '../cache/fsModuleCache'
 import type { VitestResolver } from '../resolver'
@@ -575,17 +575,16 @@ function extractSourceMap(code: string): null | Rollup.SourceMap {
 }
 
 // serialize rollup error on server to preserve details as a test error
-export function handleRollupError(e: unknown): never {
+export function toRollupError(e: unknown): TestError | undefined {
   if (
     e instanceof Error
     && ('plugin' in e || 'frame' in e || 'id' in e)
   ) {
-    // eslint-disable-next-line no-throw-literal
-    throw {
+    return {
       name: e.name,
       message: e.message,
       stack: e.stack,
-      cause: e.cause,
+      cause: e.cause as TestError | undefined,
       __vitest_rollup_error__: {
         plugin: (e as any).plugin,
         id: (e as any).id,
@@ -594,7 +593,10 @@ export function handleRollupError(e: unknown): never {
       },
     }
   }
-  throw e
+}
+
+export function handleRollupError(e: unknown): never {
+  throw toRollupError(e) ?? e
 }
 
 declare module 'vite' {

--- a/test/e2e/fixtures/list-parse-error/broken.test.ts
+++ b/test/e2e/fixtures/list-parse-error/broken.test.ts
@@ -1,0 +1,4 @@
+import { expect, it } from 'vitest'
+
+it('unterminated', () => {
+  expect(1).toBe(1)

--- a/test/e2e/fixtures/list-parse-error/ok.test.ts
+++ b/test/e2e/fixtures/list-parse-error/ok.test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from 'vitest'
+
+it('works', () => {
+  expect(1).toBe(1)
+})

--- a/test/e2e/fixtures/list-parse-error/vitest.config.ts
+++ b/test/e2e/fixtures/list-parse-error/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['broken.test.ts', 'ok.test.ts'],
+  },
+})

--- a/test/e2e/test/list.test.ts
+++ b/test/e2e/test/list.test.ts
@@ -38,6 +38,15 @@ test.each([
   expect(exitCode).toBe(1)
 })
 
+test('output shows the details of a transform error', async () => {
+  const { stderr, stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list-parse-error')
+  expect(stdout).toBe('')
+  expect(stderr).toContain('Error: Transform failed with 1 error:')
+  expect(stderr).toContain('Plugin: vite:')
+  expect(stderr).toContain('broken.test.ts')
+  expect(exitCode).toBe(1)
+})
+
 test('correctly outputs json', async () => {
   const { stdout, exitCode } = await runVitestCli('list', '-r=./fixtures/list', '--json')
   expect(relative(stdout)).toMatchInlineSnapshot(`

--- a/test/e2e/test/static-collect.test.ts
+++ b/test/e2e/test/static-collect.test.ts
@@ -1543,6 +1543,15 @@ test('invalid @module-tag throws and error', async () => {
   `)
 })
 
+test('reports the details of a transform error', async () => {
+  const testModule = await collectTestModule(`it('unterminated', () => {`)
+
+  const [error] = testModule.errors()
+  expect(error.message.split('\n')[0]).toBe('Transform failed with 1 error:')
+  expect(error.__vitest_rollup_error__).toMatchObject({ id: 'simple.test.ts' })
+  expect((error.__vitest_rollup_error__ as any).plugin).toBeTypeOf('string')
+})
+
 test('collects tests with runIf modifier', async () => {
   const testModule = await collectTests(`
     import { test } from 'vitest'


### PR DESCRIPTION
### Description

Resolves #11150

When `vitest list` parses files statically, the default since #11088, a file that fails to parse prints `{ name: 'Error', message: undefined, stack: '', stacks: [] }` instead of the error.

`serializeError` in ast-collect reads esbuild's `e.text` and `e.location` from every entry of a Vite transform error. Vite 8 transforms with oxc, whose entries carry `message` and `loc`, so both come out undefined and `printErrorMessage` dumps the raw object.

Rather than teach ast-collect a second field shape, this reuses what the runtime path already does. `handleRollupError` is split into `toRollupError`, which returns the serialized error or undefined, and `handleRollupError`, which throws it. Static collection now produces the same `__vitest_rollup_error__` payload, so the output matches a normal run.

Resolve errors are unaffected. They carry `pluginCode` but no `errors` array, so they never took the removed branch.

One behaviour change worth naming. A file with several errors now yields one `TestError` holding Vite's combined summary, rather than one entry per error. The runtime path already behaved that way, and Vite caps that summary at five.

### Tests

`static-collect.test.ts` covers the API path through `experimental_parseSpecification`. `list.test.ts` covers the CLI with a new `fixtures/list-parse-error`. Both fail on main, the first with `Cannot read properties of undefined (reading 'split')`.

I ran both under Vite 8 (oxc) and Vite 7 (esbuild) via `pnpm override-vite7`, plus `rollup-error.test.ts` on each to cover the helper split.

This is not from my change, but `correctly outputs all tests with args: "--no-static-parse"` fails on main for me too. That snapshot depends on file order, and math.test.ts sorts first locally.

I used Claude Code while investigating this. I reproduced the bug and reviewed the fix myself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] No new functionality, nothing to document.

### Changesets
- [x] The PR title explains the change.
