### PR TITLE
fix(types): derive assertion types from the chai module (fix #11144)

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { MockInstance } from '@vitest/spy'
+import type * as chai from 'chai'
 import type { Formatter } from 'tinyrainbow'
 import type { AsymmetricMatcher } from './jest-asymmetric-matchers'
 import type { diff, getMatcherUtils, stringify } from './jest-matcher-utils'
@@ -627,8 +628,12 @@ export interface JestAssertion<R extends void | Promise<void>, T = unknown> exte
   toHaveNthReturnedWith: <E>(nthCall: number, value: E) => R
 }
 
+// `Chai.Assertion` is an ambient global that is not guaranteed to be part of
+// the consumer's program, unlike the types imported from the `chai` module
+type ChaiAssertion = InstanceType<typeof chai.Assertion>
+
 type VitestAssertion<A, R extends void | Promise<void>, T = unknown> = {
-  [K in keyof A]: A[K] extends Chai.Assertion
+  [K in keyof A]: A[K] extends ChaiAssertion
     ? Assertion<R, T>
     : A[K] extends (...args: any[]) => any
       ? R extends Promise<void> ? PromisifyFunction<A[K]> : A[K]
@@ -646,7 +651,7 @@ type PromisifyFunction<T> = T extends (...args: infer A) => infer R
 export type PromisifyAssertion<T> = Assertion<Promise<void>, Awaited<T>>
 
 export interface Assertion<R extends void | Promise<void> = void, T = unknown>
-  extends VitestAssertion<Chai.Assertion, R, T>,
+  extends VitestAssertion<ChaiAssertion, R, T>,
   JestAssertion<R, T>,
   ChaiMockAssertion<R, T>,
   Matchers<R, T> {

--- a/test/unit/test/expect.test-d.ts
+++ b/test/unit/test/expect.test-d.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-lone-blocks */
+/* eslint-disable ts/no-unused-expressions */
 
 import { expect, test } from 'vitest'
 
@@ -184,5 +185,9 @@ test('expect.* allows asymmetrict mattchers with different types', async () => {
 })
 
 test('chai assertion', async () => {
+  expect('a').not.toBe('b')
+  expect(1).to.eq(1)
+  expect(1).to.not.equal(2)
+  expect(true).to.be.true
   await (expect(Promise.resolve('a')).resolves.eq('a') satisfies Promise<(type: string, message?: string) => Chai.Assertion>)
 })


### PR DESCRIPTION
### Description

Vitest currently derives Chai chainables from the ambient `Chai.Assertion` namespace. When that namespace isn't available in the consumer program, the mapped assertion type loses all Chai chainables — not just `.not`.

For example, both of these fail:

```ts
expect('a').not.toBe('b')
expect(1).to.eq(1)
```

This changes the assertion typing to derive the Chai assertion interface directly from the `chai` module instead of depending on the ambient namespace being merged into the consumer program.

I also added type coverage for `.not` and representative Chai chains.

fix #11144

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

Assisted by Claude Code.
