### PR TITLE
fix: match benchmark parent project (fix #11149)

### DIFF
--- a/packages/vitest/src/node/projects/resolveProjects.ts
+++ b/packages/vitest/src/node/projects/resolveProjects.ts
@@ -1046,7 +1046,9 @@ function expandBenchmarksInEntries(
     result.push({
       viteConfig: entry.viteConfig, // shared with non-benchmark counterpart
       projectConfig: benchmarkConfig,
-      ancestors: entry.ancestors,
+      ancestors: benchmarkOnly && entry.projectConfig.name
+        ? [...(entry.ancestors ?? []), entry.projectConfig.name]
+        : entry.ancestors,
       sharedServer: entry.sharedServer,
     })
   }

--- a/test/e2e/test/benchmarking.test.ts
+++ b/test/e2e/test/benchmarking.test.ts
@@ -911,6 +911,57 @@ test('`vitest bench` CLI invocation filters to the cloned benchmark project', as
   expect(projectNames).toEqual(['bench'])
 })
 
+test('`vitest bench --project` filters by the configured project name', async () => {
+  const structure = {
+    'vitest.config.js': {
+      test: {
+        projects: [
+          { test: { name: '@workspace/test' } },
+          { test: { name: '@workspace/other' } },
+        ],
+      },
+    },
+    'x.bench.ts': /* ts */`
+      import { test, inject } from 'vitest'
+      test('x', async ({ bench }) => {
+        await bench('a', () => {}).run(inject('options'))
+      })
+`,
+  } satisfies Parameters<typeof runInlineTests>[0]
+
+  const selected = await runInlineTests(
+    structure,
+    {
+      project: '@workspace/test',
+      $cliOptions: { benchmarkOnly: true },
+      provide: { options: fastBenchOptions },
+    },
+  )
+  expect(selected.stderr).toBe('')
+  expect(selected.ctx?.projects.map(project => project.name)).toEqual(['@workspace/test (bench)'])
+
+  const regular = await runInlineTests(
+    structure,
+    {
+      project: '@workspace/test',
+      passWithNoTests: true,
+    },
+  )
+  expect(regular.thrown).toBe(false)
+  expect(regular.ctx?.projects.map(project => project.name)).toEqual(['@workspace/test'])
+
+  const excluded = await runInlineTests(
+    structure,
+    {
+      project: '!@workspace/test',
+      $cliOptions: { benchmarkOnly: true },
+      provide: { options: fastBenchOptions },
+    },
+  )
+  expect(excluded.stderr).toBe('')
+  expect(excluded.ctx?.projects.map(project => project.name)).toEqual(['@workspace/other (bench)'])
+})
+
 test('json reporter surfaces benchmarks on each assertion result', async () => {
   const { stderr, root } = await runInlineTests(
     {


### PR DESCRIPTION
Written by Codex on behalf of @copley, who reviewed and approved this pull request.

## Summary

- let benchmark-only project clones match their configured parent project name
- preserve matching by the generated ` (bench)` name
- cover positive selection, exclusion, and unchanged ordinary test-mode behavior

## Root cause

Benchmark expansion adds the ` (bench)` suffix before project filtering. The filter therefore only sees the generated name, so `vitest bench --project=@workspace/test` no longer matches a project configured as `@workspace/test`.

In benchmark-only mode this records the configured project name as an ancestor of its benchmark clone. That reuses the existing project-filter matcher and keeps exclusion semantics consistent.

Fixes #11149.

## Verification

- reproduced on `7c818153add03b0bca54453a54e76961dd5be18d`
- focused benchmark regression passed
- adjacent benchmarking and project suites: 112 passed
- `pnpm --filter vitest build`
- `pnpm build`
- `CI=true pnpm lint`
- `pnpm typecheck`
- `pnpm test`: 216 files passed; 2576 tests passed, 21 expected failures, 75 skipped, 25 todo
