### PR TITLE
fix: avoid retrying expected failures (fix #11068)

### DIFF
--- a/packages/vitest/src/runtime/runner/run.ts
+++ b/packages/vitest/src/runtime/runner/run.ts
@@ -742,6 +742,10 @@ async function runTest(test: Test, runner: VitestRunner): Promise<void> {
         break
       }
 
+      if (test.fails) {
+        break
+      }
+
       if (retryCount < retry) {
         const shouldRetry = passesRetryCondition(test, test.result.errors)
 

--- a/test/unit/test/retry.test.ts
+++ b/test/unit/test/retry.test.ts
@@ -7,9 +7,9 @@ it('retry test', { retry: 2 }, () => {
 })
 
 let count2 = 0
-it.fails('retry test fails', { retry: 1 }, () => {
+it.fails('does not retry an expected failure', { retry: 2 }, () => {
   count2 += 1
-  expect(count2).toBe(3)
+  expect(1).toBe(2)
 })
 
 let count3 = 0
@@ -20,7 +20,7 @@ it('retry test fails', { retry: 10 }, () => {
 
 it('result', () => {
   expect(count1).toEqual(3)
-  expect(count2).toEqual(2)
+  expect(count2).toEqual(1)
   expect(count3).toEqual(3)
 })
 


### PR DESCRIPTION
### Description

`test.fails` currently retries after the test fails as expected, causing the test body and its side effects to run more than once. Stop the retry loop after an expected failure and add regression coverage that verifies the test body runs only once when retries are configured.

Resolves #11068

AI assistance: Codex was used during implementation and testing; I reviewed and approved the changes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

The following focused checks were run locally:

- `pnpm --filter vitest build`
- `vitest test/retry.test.ts` across the threads, forks, and vmThreads projects
- `pnpm lint`
- `pnpm typecheck`

### Documentation
- [x] No documentation change is needed for this bug fix.

### Changesets
- [x] The PR title describes the fix and uses the `fix:` prefix.
