### PR TITLE
fix(snapshot): report obsolete keys next to skipped tests (fix #11157)

### DIFF
--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -147,10 +147,13 @@ export default class SnapshotState {
 
   markSnapshotsAsCheckedForTest(testName: string): void {
     this._uncheckedKeys.forEach((uncheckedKey) => {
+      if (!uncheckedKey.startsWith(testName)) {
+        return
+      }
       // skip snapshots with following keys
       //   testName n
       //   testName > xxx n (this is for toMatchSnapshot("xxx") API)
-      if (/ \d+$| > /.test(uncheckedKey.slice(testName.length))) {
+      if (/^ \d+$|^ > /.test(uncheckedKey.slice(testName.length))) {
         this._uncheckedKeys.delete(uncheckedKey)
       }
     })

--- a/packages/snapshot/src/port/state.ts
+++ b/packages/snapshot/src/port/state.ts
@@ -147,13 +147,13 @@ export default class SnapshotState {
 
   markSnapshotsAsCheckedForTest(testName: string): void {
     this._uncheckedKeys.forEach((uncheckedKey) => {
-      if (!uncheckedKey.startsWith(testName)) {
-        return
-      }
       // skip snapshots with following keys
       //   testName n
       //   testName > xxx n (this is for toMatchSnapshot("xxx") API)
-      if (/^ \d+$|^ > /.test(uncheckedKey.slice(testName.length))) {
+      if (
+        uncheckedKey.startsWith(testName)
+        && /^ \d+$|^ > /.test(uncheckedKey.slice(testName.length))
+      ) {
         this._uncheckedKeys.delete(uncheckedKey)
       }
     })

--- a/test/e2e/snapshots/skip-test.test.ts
+++ b/test/e2e/snapshots/skip-test.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { expect, test } from 'vitest'
-import { runVitest } from '../../test-utils'
+import { runInlineTests, runVitest } from '../../test-utils'
 
 test('snapshots in skipped test/suite is not obsolete', async () => {
   // create snapshot on first run
@@ -112,5 +112,94 @@ test('handle obsoleteness of toMatchSnapshot("custom message")', async () => {
 
     exports[\`custom b > z 1\`] = \`0\`;
     "
+  `)
+})
+
+test('obsolete snapshots are still reported when another test is skipped', async () => {
+  const structure = {
+    'basic.test.ts': `
+      import { expect, it } from 'vitest'
+
+      it.skip('a', () => {
+        expect(0).toMatchSnapshot()
+      })
+
+      it('b', () => {
+        expect(1).toMatchSnapshot()
+      })
+    `,
+    '__snapshots__/basic.test.ts.snap': `// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[\`a 1\`] = \`0\`;
+
+exports[\`b 1\`] = \`1\`;
+
+exports[\`removed test 1\`] = \`2\`;
+`,
+  }
+
+  const failed = await runInlineTests(structure, { update: 'none' })
+  expect(failed.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "__module_errors__": [
+          "Obsolete snapshots found when no snapshot update is expected.
+    · removed test 1
+    ",
+        ],
+        "a": "skipped",
+        "b": "passed",
+      },
+    }
+  `)
+
+  const updated = await runInlineTests(structure, { update: true })
+  expect(fs.readFileSync(path.join(updated.root, '__snapshots__/basic.test.ts.snap'), 'utf-8')).toMatchInlineSnapshot(`
+    "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+    exports[\`a 1\`] = \`0\`;
+
+    exports[\`b 1\`] = \`1\`;
+    "
+  `)
+})
+
+test('skipped test does not hide obsolete snapshots of a test with a longer name', async () => {
+  const result = await runInlineTests({
+    'basic.test.ts': `
+      import { expect, it } from 'vitest'
+
+      it.skip('foo', () => {
+        expect(0).toMatchSnapshot()
+        expect(0).toMatchSnapshot('custom')
+      })
+
+      it('bar', () => {
+        expect(1).toMatchSnapshot()
+      })
+    `,
+    '__snapshots__/basic.test.ts.snap': `// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[\`bar 1\`] = \`1\`;
+
+exports[\`foo 1\`] = \`0\`;
+
+exports[\`foo > custom 1\`] = \`0\`;
+
+exports[\`foobar 1\`] = \`0\`;
+`,
+  }, { update: 'none' })
+  expect(result.errorTree()).toMatchInlineSnapshot(`
+    {
+      "basic.test.ts": {
+        "__module_errors__": [
+          "Obsolete snapshots found when no snapshot update is expected.
+    · foobar 1
+    ",
+        ],
+        "bar": "passed",
+        "foo": "skipped",
+      },
+    }
   `)
 })

--- a/test/e2e/snapshots/skip-test.test.ts
+++ b/test/e2e/snapshots/skip-test.test.ts
@@ -153,7 +153,7 @@ exports[\`removed test 1\`] = \`2\`;
     }
   `)
 
-  const updated = await runInlineTests(structure, { update: true })
+  const updated = await runInlineTests(structure, { update: 'all' })
   expect(fs.readFileSync(path.join(updated.root, '__snapshots__/basic.test.ts.snap'), 'utf-8')).toMatchInlineSnapshot(`
     "// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 


### PR DESCRIPTION
### Description

Resolves #11157

`markSnapshotsAsCheckedForTest` runs for every skipped test and removes that test's own keys from the unchecked set. It tests `/ \d+$| > /` against `key.slice(testName.length)` with no check that the key starts with `testName`, so any key longer than the skipped test's name is removed too. One `it.skip` silences every obsolete snapshot in the file.

This restores the prefix check that #7126 dropped and anchors the remainder, so a skipped `foo` no longer claims `foobar 1` either. Keys shaped `<name> <n>` and `<name> > <custom> <n>` still match.

### Tests

Two inline cases in `test/e2e/snapshots/skip-test.test.ts`. A stale key next to a skipped test is reported under `update: 'none'` and removed under `update: true`, and a skipped `foo` does not hide `foobar 1`. Both fail on main. The existing cases in that file, including the custom-message one from #7126, still pass.

I used Claude Code while investigating this. I reproduced the bug and reviewed the fix myself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] No new functionality, nothing to document.

### Changesets
- [x] The PR title explains the change.
