### PR TITLE
fix: don't treat bare specifiers as Vitest imports when dist is outside the root

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
+++ b/packages/vitest/src/runtime/moduleRunner/cachedResolver.ts
@@ -9,6 +9,22 @@ const normalizedDistDir = normalize(distDir)
 const relativeIds: Record<string, string> = {}
 const externalizeMap = new Map<string, string>()
 
+// The dist directory is only "relative" to the root when it actually lives inside
+// it (e.g. <root>/node_modules/.pnpm/vitest/dist). In a monorepo Vitest is usually
+// hoisted above the project root, and slicing would then produce an unrelated
+// suffix of the dist path (e.g. "st" or "t") that matches bare specifiers such as
+// "stream" or "tls" by prefix, externalizing them to <root>/stream.
+function getRelativeDistDir(root: string): string {
+  const normalizedRoot = normalize(root)
+  // drop a trailing slash so it is not counted twice when slicing
+  const base = normalizedRoot.endsWith('/')
+    ? normalizedRoot.slice(0, -1)
+    : normalizedRoot
+  return normalizedDistDir.startsWith(`${base}/`)
+    ? normalizedDistDir.slice(base.length)
+    : ''
+}
+
 // all Vitest imports always need to be externalized
 export function getCachedVitestImport(
   id: string,
@@ -24,7 +40,7 @@ export function getCachedVitestImport(
   // always externalize Vitest because we import from there before running tests
   // so we already have it cached by Node.js
   const root = state().config.root
-  const relativeRoot = relativeIds[root] ?? (relativeIds[root] = normalizedDistDir.slice(root.length))
+  const relativeRoot = relativeIds[root] ?? (relativeIds[root] = getRelativeDistDir(root))
   if (id.includes(distDir) || id.includes(normalizedDistDir)) {
     const { file, postfix } = splitFileAndPostfix(id)
     const externalize = id.startsWith('file://')

--- a/test/unit/test/cached-vitest-import.test.ts
+++ b/test/unit/test/cached-vitest-import.test.ts
@@ -1,0 +1,67 @@
+import type { WorkerGlobalState } from '../../../packages/vitest/src/types/worker'
+import { normalize } from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { distDir } from '../../../packages/vitest/src/paths'
+import { getCachedVitestImport } from '../../../packages/vitest/src/runtime/moduleRunner/cachedResolver'
+
+// `distDir` is built with node:path, so it is back-slashed on Windows, while the
+// resolver compares against the pathe-normalized form (as does `config.root`).
+const normalizedDistDir = normalize(distDir)
+
+function stateWithRoot(root: string): () => WorkerGlobalState {
+  return () => ({ config: { root } }) as WorkerGlobalState
+}
+
+describe('getCachedVitestImport', () => {
+  it('does not treat a bare Node builtin as a Vitest import when dist is outside the root', () => {
+    // A root that is *not* an ancestor of the dist directory, but whose length is
+    // two characters shorter, so `distDir.slice(root.length)` yields "st" — the
+    // last two characters of ".../dist". That is how a monorepo package root
+    // behaves when Vitest is hoisted above it.
+    const root = `/${'a'.repeat(normalizedDistDir.length - 3)}`
+    expect(normalizedDistDir.slice(root.length)).toBe('st')
+
+    expect(getCachedVitestImport('stream', stateWithRoot(root))).toBeNull()
+    expect(getCachedVitestImport('stream/promises', stateWithRoot(root))).toBeNull()
+  })
+
+  it('does not treat an unrelated bare specifier as a Vitest import', () => {
+    const root = `/${'b'.repeat(normalizedDistDir.length - 2)}`
+    expect(normalizedDistDir.slice(root.length)).toBe('t')
+
+    expect(getCachedVitestImport('tls', stateWithRoot(root))).toBeNull()
+    expect(getCachedVitestImport('timers', stateWithRoot(root))).toBeNull()
+  })
+
+  it('does not match a sibling directory whose name is a prefix of the root', () => {
+    // e.g. root .../node_modules/vite, dist .../node_modules/vitest/dist:
+    // slicing without a path boundary would yield "st/dist".
+    const vitestDir = normalizedDistDir.slice(0, normalizedDistDir.lastIndexOf('/'))
+    const siblingRoot = vitestDir.slice(0, -2)
+    expect(normalizedDistDir.startsWith(siblingRoot)).toBe(true)
+
+    expect(getCachedVitestImport('stream', stateWithRoot(siblingRoot))).toBeNull()
+  })
+
+  it('still externalizes ids relative to a root that contains the dist directory', () => {
+    // Vitest installed inside the project, e.g. <root>/node_modules/.pnpm/vitest/dist
+    const root = normalizedDistDir.slice(0, normalizedDistDir.lastIndexOf('/'))
+    const relativeId = `${normalizedDistDir.slice(root.length)}/index.js`
+
+    const result = getCachedVitestImport(relativeId, stateWithRoot(root))
+    expect(result).not.toBeNull()
+    expect(result!.externalize).toContain('index.js')
+  })
+
+  it('still externalizes absolute dist ids and bare vitest specifiers', () => {
+    const root = normalize('/some/unrelated/project/root')
+
+    expect(
+      getCachedVitestImport(`${distDir}/index.js`, stateWithRoot(root)),
+    ).not.toBeNull()
+    expect(getCachedVitestImport('vitest', stateWithRoot(root))).toEqual({
+      externalize: 'vitest',
+      type: 'module',
+    })
+  })
+})


### PR DESCRIPTION
### Description

In a monorepo, a bare Node builtin import such as `import { PassThrough } from "stream"` can fail with:

```
Error: Cannot find module '/path/to/repo/packages/asset-service/stream'
imported from /path/to/repo/node_modules/vitest/dist/module-evaluator.js
```

...while `import { PassThrough } from "node:stream"` works, and the same file works in a sibling package.

#### Root cause

`getCachedVitestImport` in `packages/vitest/src/runtime/moduleRunner/cachedResolver.ts` computes:

```ts
const relativeRoot = relativeIds[root] ?? (relativeIds[root] = normalizedDistDir.slice(root.length))
```

This assumes the dist directory lives **inside** the project root (the comment below it refers to `/node_modules/.pnpm/vitest/dist`). In a monorepo, Vitest is hoisted to the repository root while `config.root` is the *package* directory, so `distDir` is not under `root`. The slice then returns an arbitrary **suffix of the dist path**, which is subsequently used as a prefix test:

```ts
if (relativeRoot && relativeRoot !== '/' && id.startsWith(relativeRoot)) {
  const path = join(root, file)
  const externalize = `${pathToFileURL(path)}${postfix}`   // -> file://<root>/stream
```

Because `relativeRoot` is always a suffix of `…/vitest/dist`, the only values that collide with real specifiers are `"t"` and `"st"` — which are prefixes of the builtins `timers`, `tls`, `trace_events`, `tty`, `stream` and `string_decoder`.

Node builtins are the only ids that reach this function unresolved (everything else is resolved to an absolute path first), so the impact is limited to bare builtin imports — but it is silent and confusing when it hits.

**The affected builtins depend on the character length of the project root**, so the same repository breaks differently depending on where it is checked out. Observed in one monorepo:

| `relativeRoot` | root length | builtins shadowed |
| --- | --- | --- |
| `"st"` | 81 | `stream`, `string_decoder` |
| `"t"` | 82 | `timers`, `tls`, `trace_events`, `tty` |

`node:`-prefixed specifiers never match a `…/vitest/dist` suffix, which is why they always work.

### Minimal reproduction

```bash
mkdir -p /tmp/mono/packages/asset-service/src && cd /tmp/mono
echo '{ "name": "mono", "private": true, "version": "1.0.0" }' > package.json
npm install vitest@latest

cd packages/asset-service
echo '{ "name": "asset-service", "private": true, "version": "1.0.0", "type": "module" }' > package.json
printf 'import { defineConfig } from "vitest/config";\nexport default defineConfig({ test: { environment: "node", include: ["src/**/*.test.ts"] } });\n' > vitest.config.ts
printf 'import { PassThrough } from "stream";\nimport { expect, it } from "vitest";\nit("bare stream", () => { expect(typeof PassThrough).toBe("function"); });\n' > src/bare.test.ts

/tmp/mono/node_modules/.bin/vitest run src/bare.test.ts
```

The directory name `asset-service` is chosen so that `distDir.slice(root.length) === "st"`; with `/tmp/mono` the package path is 32 characters and the dist path is 34. Renaming the package directory to a different length makes the failure disappear.

Reproduced on 3.2.0 → 3.2.7, 4.1.11 and 5.0.0. Not present in 2.0.5, 3.0.0 or 3.1.0 (the code was introduced in 3.2.0).

### Fix

Only derive the relative dist path when the dist directory is genuinely inside the root; otherwise leave it empty so the branch is skipped. The intended `<root>/node_modules/.pnpm/vitest/dist` case is unchanged.

Two details worth noting:

- the comparison is done on a **path boundary**, so a sibling directory whose name is a prefix of the root no longer matches either — with `root=<...>/node_modules/vite` and `dist=<...>/node_modules/vitest/dist` the old slice produced `"st/dist"`
- `root` is normalized before comparing, because `distDir` is built with `node:path` (back-slashed on Windows) while `config.root` comes from `pathe`

### Tests

`test/unit/test/cached-vitest-import.test.ts` covers both directions:

- bare builtins (`stream`, `stream/promises`, `tls`, `timers`) are **not** externalized when dist is outside the root
- a sibling directory whose name is a prefix of the root does not match
- ids relative to a root that *does* contain dist are still externalized, as are absolute dist ids and bare `vitest` specifiers

Reverting just the implementation change and re-running gives **3 failed / 2 passed**: the three guards fail, while the two "still externalizes" tests keep passing — i.e. the change only removes the broken path and leaves the intended behaviour intact.

### Verification

- `test/unit`: 649 files / 7701 tests passed, no failures
- `test/workspaces`: 20 files / 25 tests, and 1 file / 3 tests, passed
- `test/node-runner`: 1 passed, 0 failed
- `test/e2e`: run against both `main` and this branch. The set of failing **files** is identical. Each apparently-new failure was reproduced on unmodified `main` individually (`group-order`, `list`, `no-unexpected-logging`, `vm-threads`, `snapshots/domain-aria-inline`); `list` and `vm-threads` are flaky locally (2/1/0 and pass/pass/fail across repeated runs) and the `vm-threads` failure is `ReferenceError: gc is not defined`. These look environment-related on my machine rather than related to this change.
- Pre-existing `tsc` errors in `src/node/pools/browser.ts` (`Property 'send' does not exist on type 'CDPSession'`) are present on `main` as well and are unrelated.

Marked as a draft: I would appreciate a maintainer sanity-check on whether returning `''` is preferable to leaving the value `undefined`/skipping the cache entry, and whether you would like the test placed somewhere other than `test/unit`.
