### PR TITLE
fix(reporters): report watch banner from the whole suite

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -450,8 +450,10 @@ export abstract class BaseReporter implements Reporter {
     return color(` ${duration}${c.dim('ms')}`)
   }
 
-  onWatcherStart(files: File[] = this.ctx.state.getFiles(), errors: unknown[] = this.ctx.state.getUnhandledErrors()): void {
-    const failed = errors.length > 0 || hasFailed(files)
+  onWatcherStart(_files: File[] = this.ctx.state.getFiles(), errors: unknown[] = this.ctx.state.getUnhandledErrors()): void {
+    // A rerun reports only the files it reran, so the banner reads the whole suite instead.
+    const allFiles = this.ctx.state.getFiles()
+    const failed = errors.length > 0 || hasFailed(allFiles)
 
     if (failed) {
       this.log(withLabel('red', 'FAIL', 'Tests failed. Watching for file changes...'))
@@ -465,7 +467,7 @@ export abstract class BaseReporter implements Reporter {
 
     const hints = [c.dim('press ') + c.bold('h') + c.dim(' to show help')]
 
-    if (hasFailedSnapshot(files)) {
+    if (hasFailedSnapshot(allFiles)) {
       hints.unshift(c.dim('press ') + c.bold(c.yellow('u')) + c.dim(' to update snapshot'))
     }
     else {

--- a/test/e2e/fixtures/watch-banner/failing.test.ts
+++ b/test/e2e/fixtures/watch-banner/failing.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('stays red for the whole run', () => {
+  expect(1).toBe(2)
+})

--- a/test/e2e/fixtures/watch-banner/passing.test.ts
+++ b/test/e2e/fixtures/watch-banner/passing.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('is green and gets re-run on edit', () => {
+  expect(1).toBe(1)
+})

--- a/test/e2e/fixtures/watch-banner/vitest.config.ts
+++ b/test/e2e/fixtures/watch-banner/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    reporters: [['default', { isTTY: true, summary: false }]],
+  },
+})

--- a/test/e2e/test/reporters/watch-banner.test.ts
+++ b/test/e2e/test/reporters/watch-banner.test.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'pathe'
+import { expect, test } from 'vitest'
+import { editFile, runVitest } from '../../../test-utils'
+
+const root = resolve(import.meta.dirname, '../../fixtures/watch-banner')
+
+test('watch banner stays FAIL while another file is failing', async () => {
+  const { vitest } = await runVitest({
+    root,
+    watch: true,
+    reporters: 'none',
+  })
+
+  await vitest.waitForStdout('Tests failed. Watching for file changes...')
+  vitest.resetOutput()
+
+  editFile(resolve(root, 'passing.test.ts'), content => `${content}\n`)
+
+  await vitest.waitForStdout('for file changes...')
+
+  const banner = vitest.stdout.split('\n').find(line => line.includes('for file changes'))
+  expect(banner?.trim()).toMatchInlineSnapshot(`"FAIL  Tests failed. Watching for file changes..."`)
+})
+
+test('watch banner turns PASS once the failing file is fixed', async () => {
+  const { vitest } = await runVitest({
+    root,
+    watch: true,
+    reporters: 'none',
+  })
+
+  await vitest.waitForStdout('Tests failed. Watching for file changes...')
+  vitest.resetOutput()
+
+  editFile(resolve(root, 'failing.test.ts'), content => content.replace('toBe(2)', 'toBe(1)'))
+
+  await vitest.waitForStdout('for file changes...')
+
+  const banner = vitest.stdout.split('\n').find(line => line.includes('for file changes'))
+  expect(banner?.trim()).toMatchInlineSnapshot(`"PASS  Waiting for file changes..."`)
+})


### PR DESCRIPTION
Fixes #10695.

A rerun reports `onWatcherStart` with only the files it reran (`this.state.getFiles(files)`), while the initial run passes nothing and gets all of them. So `hasFailed(files)` saw just the rerun subset: fixing one file printed a green `PASS` while other files were still failing.

The banner and the `press u` hint now read the whole suite state. The `files` argument is left in the signature for reporters that override it.

Tests: `test/e2e/test/reporters/watch-banner.test.ts` covers both directions. Reverting the change flips the first snapshot to `"PASS  Waiting for file changes..."`, which is the reported bug.

Not addressed here: the `PREVIOUS FAILS` / `RERUN` / `Summary` split suggested in the issue. Happy to follow up if you want it.

Note: `test/e2e/test/reporters/default.test.ts > project name color` fails on my machine, on `main` as well as here.

An AI was used for understanding the code, and help was taken in drafting the change and its tests.
