### PR TITLE
docs: consolidate ui and html reporter guide 

### DIFF
--- a/docs/guide/browser/trace-view.md
+++ b/docs/guide/browser/trace-view.md
@@ -44,7 +44,11 @@ vitest --browser.traceView
 
 :::
 
-When `browser.traceView` is enabled, tests with recorded traces can be opened in the trace viewer from the [browser UI](/config/browser/ui), [Vitest UI](/guide/ui), and [HTML reporter](/guide/reporters#html-reporter). The viewer has two resizable panes:
+When `browser.traceView` is enabled, tests with recorded traces can be opened in the trace viewer from the [browser UI](/config/browser/ui), [Vitest UI](/guide/ui), and [HTML reporter](/guide/reporters#html-reporter).
+
+With the HTML reporter enabled, the [Vitest VS Code extension](https://github.com/vitest-dev/vscode#trace-view) adds an **Open Trace View** action to tests in the Testing view and editor gutter.
+
+The viewer has two resizable panes:
 
 - **Step list** (left) — every recorded action, assertion, mark, and lifecycle entry, with name, timing, selector, and source location. Failed actions and assertions are highlighted in red.
 - **DOM snapshot** (right) — a reconstruction of the page at the selected step. The interacted element is highlighted in blue.

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -534,7 +534,7 @@ export default defineConfig({
 
 ### HTML Reporter
 
-Generates an HTML file to view test results through an interactive [GUI](/guide/ui). After the file has been generated, Vitest will keep a local development server running and provide a link to view the report in a browser.
+Generates a static version of [Vitest UI](/guide/ui#html-reporter) that can be reviewed after the test process exits. See the [HTML Reporter guide](/guide/ui#html-reporter) for local preview, CI artifacts, and sharing workflows.
 
 The report artifact root can be specified using the reporter's `outputDir` option. The report entry is written to `<outputDir>/index.html` and the UI assets files live under `<outputDir>/ui/`. By default `outputDir` is `.vitest`, the shared Vitest artifact directory, so attachments (`.vitest/attachments`) and coverage (`.vitest/coverage`) are reused without being copied.
 

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -534,9 +534,9 @@ export default defineConfig({
 
 ### HTML Reporter
 
-Generates a static version of [Vitest UI](/guide/ui#html-reporter) that can be reviewed after the test process exits. See the [HTML Reporter guide](/guide/ui#html-reporter) for local preview, CI artifacts, and sharing workflows.
+Generates a static version of [Vitest UI](/guide/ui) that can be reviewed after the test process exits. See the [HTML Reporter guide](/guide/ui#html-reporter) for local preview, CI artifacts, and sharing workflows.
 
-The report artifact root can be specified using the reporter's `outputDir` option. The report entry is written to `<outputDir>/index.html` and the UI assets files live under `<outputDir>/ui/`. By default `outputDir` is `.vitest`, the shared Vitest artifact directory, so attachments (`.vitest/attachments`) and coverage (`.vitest/coverage`) are reused without being copied.
+The report artifact root can be specified using the reporter's `outputDir` option and the report entry is written to `<outputDir>/index.html`. By default `outputDir` is the shared Vitest artifact directory `.vitest`, so attachments (`.vitest/attachments`) and coverage (`.vitest/coverage`) are reused without being copied.
 
 :::code-group
 ```bash [CLI]

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -552,32 +552,7 @@ export default defineConfig({
 ```
 :::
 
-Set `singleFile` to generate a self-contained HTML report:
-
-```ts [vitest.config.ts]
-export default defineConfig({
-  test: {
-    reporters: [
-      ['html', { singleFile: true }],
-    ],
-  },
-})
-```
-
-When `singleFile` is enabled, Vitest inlines the UI assets, metadata, and test attachments into a single self-contained `index.html`. This makes the report easy to share, upload, or download as one artifact instead of preserving the whole `html` output directory.
-
-::: warning
-`singleFile` has two caveats:
-
-- The file can grow very large because everything is embedded inline — slow to open, memory-hungry, and possibly over the size limits of artifact viewers or static hosts.
-- Coverage HTML reports are not inlined yet and remain as separate files.
-
-Prefer the default multi-file report when the suite has many or large attachments, or when you need coverage included in the bundle.
-:::
-
-::: tip
-This reporter requires installed [`@vitest/ui`](/guide/ui) package.
-:::
+Use `singleFile` to produce one portable HTML file. See [Share as a Single File](/guide/ui#share-as-a-single-file) for configuration and limitations.
 
 ### TAP Reporter
 

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -534,7 +534,7 @@ export default defineConfig({
 
 ### HTML Reporter
 
-Generates a static version of [Vitest UI](/guide/ui) that can be reviewed after the test process exits. See the [HTML Reporter guide](/guide/ui#html-reporter) for local preview, CI artifacts, and sharing workflows.
+Generates a static version of [Vitest UI](/guide/ui) for reviewing completed test runs. See the [HTML Reporter guide](/guide/ui#html-reporter) for local preview, CI artifacts, and sharing workflows.
 
 The report artifact root can be specified using the reporter's `outputDir` option and the report entry is written to `<outputDir>/index.html`. By default `outputDir` is the shared Vitest artifact directory `.vitest`.
 

--- a/docs/guide/reporters.md
+++ b/docs/guide/reporters.md
@@ -536,7 +536,9 @@ export default defineConfig({
 
 Generates a static version of [Vitest UI](/guide/ui) that can be reviewed after the test process exits. See the [HTML Reporter guide](/guide/ui#html-reporter) for local preview, CI artifacts, and sharing workflows.
 
-The report artifact root can be specified using the reporter's `outputDir` option and the report entry is written to `<outputDir>/index.html`. By default `outputDir` is the shared Vitest artifact directory `.vitest`, so attachments (`.vitest/attachments`) and coverage (`.vitest/coverage`) are reused without being copied.
+The report artifact root can be specified using the reporter's `outputDir` option and the report entry is written to `<outputDir>/index.html`. By default `outputDir` is the shared Vitest artifact directory `.vitest`.
+
+Use `singleFile` to produce one portable HTML file. See [Share as a Single File](/guide/ui#share-as-a-single-file) for configuration and limitations.
 
 :::code-group
 ```bash [CLI]
@@ -551,8 +553,6 @@ export default defineConfig({
 })
 ```
 :::
-
-Use `singleFile` to produce one portable HTML file. See [Share as a Single File](/guide/ui#share-as-a-single-file) for configuration and limitations.
 
 ### TAP Reporter
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -37,10 +37,6 @@ Use the `html` reporter from the command line or in your Vitest configuration:
 
 ::: code-group
 
-```bash [CLI]
-vitest run --reporter=html
-```
-
 ```ts [vitest.config.ts]
 import { defineConfig } from 'vitest/config'
 
@@ -49,6 +45,10 @@ export default defineConfig({
     reporters: ['html'],
   },
 })
+```
+
+```bash [CLI]
+vitest run --reporter=html
 ```
 
 :::

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -119,9 +119,15 @@ When you use `singleFile: true`, you can upload the report as a single file and 
 
 ```yaml
 - uses: actions/upload-artifact@v7
+  id: upload-report
   with:
     path: .vitest/index.html
     archive: false
+
+- name: Link HTML report
+  run: echo "::notice title=Vitest HTML report::$REPORT_URL"
+  env:
+    REPORT_URL: ${{ steps.upload-report.outputs.artifact-url }}
 ```
 
 ## Coverage

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -4,7 +4,7 @@ title: Vitest UI | Guide
 
 # Vitest UI
 
-Vitest UI is a visual interface for exploring your test results. You can use it interactively while tests run or generate the same interface as a static HTML report to review after the test process exits.
+Vitest UI is a visual interface for exploring your test results. You can use it interactively while tests run or as a static HTML report for reviewing completed runs.
 
 Vitest UI is optional, so you'll need to install it with:
 
@@ -12,9 +12,12 @@ Vitest UI is optional, so you'll need to install it with:
 npm i -D @vitest/ui
 ```
 
+<img alt="Vitest UI" img-light src="/ui-1-light.png">
+<img alt="Vitest UI" img-dark src="/ui-1-dark.png">
+
 ## Interactive UI
 
-The interactive UI runs alongside Vitest's development server. Start it by passing the `--ui` flag:
+The interactive UI runs alongside Vitest's development server and requires [watch mode](/config/watch), which is enabled by default. Start it by passing the `--ui` flag:
 
 ```bash
 vitest --ui
@@ -26,18 +29,9 @@ Then you can visit the Vitest UI at <a href="http://localhost:51204/__vitest__/"
 Vitest UI access is protected. If the direct URL shows an error, open the URL with a token printed by Vitest in the terminal, for example `http://localhost:51204/__vitest__/?token=...`.
 :::
 
-::: warning
-The interactive UI requires a running Vite server, so make sure to run Vitest in `watch` mode (the default). To review results after the test process exits, use the [HTML Reporter](#html-reporter).
-:::
-
-<img alt="Vitest UI" img-light src="/ui-1-light.png">
-<img alt="Vitest UI" img-dark src="/ui-1-dark.png">
-
-You can check your coverage report in Vitest UI: see [Vitest UI Coverage](/guide/coverage#vitest-ui) for more details.
-
 ## HTML Reporter
 
-The HTML reporter generates a static version of Vitest UI from a completed test run. It is useful for run mode, CI, and automated workflows where results are reviewed after the test process exits.
+The HTML reporter writes test results to a static version of Vitest UI. It is useful for run mode, CI, and automated workflows where results are reviewed later.
 
 Use the `html` reporter from the command line or in your Vitest configuration:
 
@@ -59,21 +53,19 @@ export default defineConfig({
 
 :::
 
-When [`browser.traceView`](/guide/browser/trace-view) is enabled, the report also preserves recorded browser interactions so they can be replayed later in the trace viewer.
-
-::: warning
-If you still want to see how your tests are running in real time in the terminal, add `configDefaults.reporters` to the `reporters` option: `['html', ...configDefaults.reporters]`.
+::: tip Keep terminal output
+Configuring the HTML reporter replaces the default terminal reporter. To keep terminal output, [include Vitest's default reporters](/guide/reporters#default-configuration).
 :::
 
 ### Preview Locally
 
-To preview the generated report, use the [vite preview](https://vitejs.dev/guide/cli.html#vite-preview) command:
+By default, the report entry is written to `.vitest/index.html`. You can configure the artifact directory with the HTML reporter's `outputDir` option.
+
+To preview the default output, use the [vite preview](https://vitejs.dev/guide/cli.html#vite-preview) command:
 
 ```sh
 npx vite preview --outDir .vitest
 ```
-
-You can configure the output location with the HTML reporter's `outputDir` option. It points to the report artifact root, and the report entry is written to `<outputDir>/index.html`. The default value is `.vitest`, the shared Vitest artifact directory.
 
 ### Share as a Single File
 
@@ -125,6 +117,14 @@ When you use `singleFile: true`, you can upload the report as a single file and 
     path: .vitest/index.html
     archive: false
 ```
+
+## Coverage
+
+Vitest UI displays coverage results in both the interactive UI and HTML reports. See [Vitest UI Coverage](/guide/coverage#vitest-ui) for setup and usage.
+
+## Trace View
+
+Vitest UI replays recorded browser interactions when [`browser.traceView`](/guide/browser/trace-view) is enabled. The interactive UI streams trace entries as tests run, while HTML reports preserve recorded traces for later review.
 
 ## Module Graph
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -75,7 +75,30 @@ npx vite preview --outDir .vitest
 
 You can configure the output location with the HTML reporter's `outputDir` option. It points to the report artifact root, and the report entry is written to `<outputDir>/index.html`. The default value is `.vitest`, the shared Vitest artifact directory.
 
-See the [HTML reporter options](/guide/reporters#html-reporter) for configuring `outputDir` and generating a portable report with `singleFile`.
+### Share as a Single File
+
+Set `singleFile` to generate a self-contained HTML report:
+
+```ts [vitest.config.ts]
+export default defineConfig({
+  test: {
+    reporters: [
+      ['html', { singleFile: true }],
+    ],
+  },
+})
+```
+
+When `singleFile` is enabled, Vitest inlines the UI assets, metadata, and test attachments into a single self-contained `index.html`. This makes the report easy to share, upload, or download as one artifact instead of preserving the whole output directory.
+
+::: warning
+`singleFile` has two caveats:
+
+- The file can grow very large because everything is embedded inline. It can be slow to open, memory-hungry, or exceed the size limits of artifact viewers and static hosts.
+- Coverage HTML reports are not inlined yet and remain as separate files.
+
+Prefer the default multi-file report when the suite has many or large attachments, or when you need coverage included in the bundle.
+:::
 
 ### View Reports from CI
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -17,7 +17,9 @@ npm i -D @vitest/ui
 
 ## Live UI
 
-The Live UI runs alongside Vitest's development server and requires [watch mode](/config/watch), which is enabled by default. Start it by passing the `--ui` flag:
+The Live UI runs alongside Vitest's development server and requires [watch mode](/config/watch), which is enabled by default. It stays connected to the running Vitest process, so results update as tests rerun. You can also rerun selected tests, update failed snapshots, and edit test files directly from the UI.
+
+Start it by passing the `--ui` flag:
 
 ```bash
 vitest --ui
@@ -31,7 +33,7 @@ Vitest UI access is protected. If the direct URL shows an error, open the URL wi
 
 ## HTML Reporter
 
-The HTML reporter writes test results to a static version of Vitest UI. It is useful for run mode, CI, and automated workflows where results are reviewed later.
+The HTML reporter writes test results to a static version of Vitest UI. The result views remain navigable, but the report is read-only and cannot rerun tests, update snapshots, or edit test files. It is useful for run mode, CI, and automated workflows where results are reviewed later.
 
 Use the `html` reporter from the command line or in your Vitest configuration:
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -4,13 +4,17 @@ title: Vitest UI | Guide
 
 # Vitest UI
 
-Powered by Vite, Vitest also has a dev server under the hood when running the tests. This allows Vitest to provide a beautiful UI to view and interact with your tests. The Vitest UI is optional, so you'll need to install it with:
+Vitest UI is a visual interface for exploring your test results. You can use it interactively while tests run or generate the same interface as a static HTML report to review after the test process exits.
+
+Vitest UI is optional, so you'll need to install it with:
 
 ```bash
 npm i -D @vitest/ui
 ```
 
-Then you can start the tests with UI by passing the `--ui` flag:
+## Interactive UI
+
+The interactive UI runs alongside Vitest's development server. Start it by passing the `--ui` flag:
 
 ```bash
 vitest --ui
@@ -23,13 +27,25 @@ Vitest UI access is protected. If the direct URL shows an error, open the URL wi
 :::
 
 ::: warning
-The UI is interactive and requires a running Vite server, so make sure to run Vitest in `watch` mode (the default). Alternatively, you can generate a static HTML report that looks identical to the Vitest UI by specifying `html` in config's `reporters` option.
+The interactive UI requires a running Vite server, so make sure to run Vitest in `watch` mode (the default). To review results after the test process exits, use the [HTML Reporter](#html-reporter).
 :::
 
 <img alt="Vitest UI" img-light src="/ui-1-light.png">
 <img alt="Vitest UI" img-dark src="/ui-1-dark.png">
 
-UI can also be used as a reporter. Use `'html'` reporter in your Vitest configuration to generate HTML output and preview the results of your tests:
+You can check your coverage report in Vitest UI: see [Vitest UI Coverage](/guide/coverage#vitest-ui) for more details.
+
+## HTML Reporter
+
+The HTML reporter generates a static version of Vitest UI from a completed test run. It is useful for run mode, CI, and automated workflows where results are reviewed after the test process exits.
+
+Use the `html` reporter from the command line or in your Vitest configuration:
+
+::: code-group
+
+```bash [CLI]
+vitest run --reporter=html
+```
 
 ```ts [vitest.config.ts]
 import { defineConfig } from 'vitest/config'
@@ -41,25 +57,28 @@ export default defineConfig({
 })
 ```
 
-You can check your coverage report in Vitest UI: see [Vitest UI Coverage](/guide/coverage#vitest-ui) for more details.
+:::
+
+When [`browser.traceView`](/guide/browser/trace-view) is enabled, the report also preserves recorded browser interactions so they can be replayed later in the trace viewer.
 
 ::: warning
 If you still want to see how your tests are running in real time in the terminal, add `configDefaults.reporters` to the `reporters` option: `['html', ...configDefaults.reporters]`.
 :::
 
-::: tip
-To preview your HTML report, you can use the [vite preview](https://vitejs.dev/guide/cli.html#vite-preview) command:
+### Preview Locally
+
+To preview the generated report, use the [vite preview](https://vitejs.dev/guide/cli.html#vite-preview) command:
 
 ```sh
 npx vite preview --outDir .vitest
 ```
 
 You can configure the output location with the HTML reporter's `outputDir` option. It points to the report artifact root, and the report entry is written to `<outputDir>/index.html`. The default value is `.vitest`, the shared Vitest artifact directory.
-:::
 
-If you need a portable report that can be opened or shared as one file, see [`singleFile`](/guide/reporters#html-reporter) in the HTML reporter documentation.
+See the [HTML reporter options](/guide/reporters#html-reporter) for configuring `outputDir` and generating a portable report with `singleFile`.
 
-::: tip
+### View Reports from CI
+
 To view the HTML report from CI, for example in GitHub Actions, upload the output directory as an artifact:
 
 ```yaml
@@ -75,7 +94,7 @@ To view the HTML report from CI, for example in GitHub Actions, upload the outpu
 
 This adds a link to the job summary. Click it to open the report in [Vitest Viewer](https://viewer.vitest.dev/) directly in the browser. You can also download the artifact manually and extract it, then run `vite preview` locally as above.
 
-When you use `singleFile: true`, you can upload the report as a single file and it will become viewable directly GitHub artifacts with `archive: false` option:
+When you use `singleFile: true`, you can upload the report as a single file and view it directly from GitHub artifacts with the `archive: false` option:
 
 ```yaml
 - uses: actions/upload-artifact@v7
@@ -83,7 +102,6 @@ When you use `singleFile: true`, you can upload the report as a single file and 
     path: .vitest/index.html
     archive: false
 ```
-:::
 
 ## Module Graph
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -15,9 +15,9 @@ npm i -D @vitest/ui
 <img alt="Vitest UI" img-light src="/ui-1-light.png">
 <img alt="Vitest UI" img-dark src="/ui-1-dark.png">
 
-## Interactive UI
+## Live UI
 
-The interactive UI runs alongside Vitest's development server and requires [watch mode](/config/watch), which is enabled by default. Start it by passing the `--ui` flag:
+The Live UI runs alongside Vitest's development server and requires [watch mode](/config/watch), which is enabled by default. Start it by passing the `--ui` flag:
 
 ```bash
 vitest --ui
@@ -142,11 +142,11 @@ When you use `singleFile: true`, you can upload the report as a single file and 
 
 ## Coverage
 
-Vitest UI displays coverage results in both the interactive UI and HTML reports. See [Vitest UI Coverage](/guide/coverage#vitest-ui) for setup and usage.
+Vitest UI displays coverage results in both the Live UI and HTML reports. See [Vitest UI Coverage](/guide/coverage#vitest-ui) for setup and usage.
 
 ## Trace View
 
-Vitest UI replays recorded browser interactions when [`browser.traceView`](/guide/browser/trace-view) is enabled. The interactive UI streams trace entries as tests run, while HTML reports preserve recorded traces for later review.
+Vitest UI replays recorded browser interactions when [`browser.traceView`](/guide/browser/trace-view) is enabled. The Live UI streams trace entries as tests run, while HTML reports preserve recorded traces for later review.
 
 ## Module Graph
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -67,6 +67,8 @@ To preview the default output, use the [vite preview](https://vitejs.dev/guide/c
 npx vite preview --outDir .vitest
 ```
 
+Open the URL printed by Vite in your browser. Alternatively, VS Code's Integrated Browser can open `.vitest/index.html` directly without a preview server.
+
 ### Share as a Single File
 
 Set `singleFile` to generate a self-contained HTML report:
@@ -82,6 +84,8 @@ export default defineConfig({
 ```
 
 When `singleFile` is enabled, Vitest inlines the UI assets, metadata, and test attachments into a single self-contained `index.html`. This makes the report easy to share, upload, or download as one artifact instead of preserving the whole output directory.
+
+Because everything is inlined, you can open `<outputDir>/index.html` directly in a browser with a `file://` URL. No preview server is required.
 
 ::: warning
 `singleFile` has two caveats:

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -127,7 +127,7 @@ To view the HTML report from CI, for example in GitHub Actions, upload the outpu
 
 This adds the report link as a notice annotation on the workflow run. Click it to open the report in [Vitest Viewer](https://viewer.vitest.dev/) directly in the browser. You can also download the artifact manually and extract it, then run `vite preview` locally as above.
 
-When you use `singleFile: true`, you can upload the report as a single file and view it directly from GitHub artifacts with the `archive: false` option:
+When you use `singleFile: true`, you can upload the report as a single file and view it directly from GitHub artifacts with the [`archive: false` option](https://github.com/actions/upload-artifact#upload-an-individual-file-unzipped):
 
 ```yaml
 - uses: actions/upload-artifact@v7

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -67,7 +67,7 @@ To preview the default output, use the [vite preview](https://vitejs.dev/guide/c
 npx vite preview --outDir .vitest
 ```
 
-Open the URL printed by Vite in your browser. Alternatively, VS Code's Integrated Browser can open `.vitest/index.html` directly without a preview server.
+Open the URL printed by Vite in your browser. Alternatively, [VS Code's Integrated Browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) can open `.vitest/index.html` directly without a preview server.
 
 ### Share as a Single File
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -55,6 +55,16 @@ export default defineConfig({
 
 ::: tip Keep terminal output
 Configuring the HTML reporter replaces the default terminal reporter. To keep terminal output, [include Vitest's default reporters](/guide/reporters#default-configuration).
+
+```ts [vitest.config.ts]
+import { configDefaults, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    reporters: ['html', ...configDefaults.reporters],
+  },
+})
+```
 :::
 
 ### Preview Locally

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -107,11 +107,13 @@ To view the HTML report from CI, for example in GitHub Actions, upload the outpu
     name: vitest-report
     path: .vitest/
 
-- name: Viewer link in summary
-  run: echo "[View HTML report](https://viewer.vitest.dev/?url=${{ steps.upload-report.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+- name: Link HTML report
+  run: echo "::notice title=Vitest HTML report::$REPORT_URL"
+  env:
+    REPORT_URL: https://viewer.vitest.dev/?url=${{ steps.upload-report.outputs.artifact-url }}
 ```
 
-This adds a link to the job summary. Click it to open the report in [Vitest Viewer](https://viewer.vitest.dev/) directly in the browser. You can also download the artifact manually and extract it, then run `vite preview` locally as above.
+This adds the report link as a notice annotation on the workflow run. Click it to open the report in [Vitest Viewer](https://viewer.vitest.dev/) directly in the browser. You can also download the artifact manually and extract it, then run `vite preview` locally as above.
 
 When you use `singleFile: true`, you can upload the report as a single file and view it directly from GitHub artifacts with the `archive: false` option:
 


### PR DESCRIPTION
- related https://github.com/vitest-dev/vscode/pull/811

Currently I see some issues with how html reporter is treated in the doc:
- the html reporter usage is scattered both in `/guide/ui` and `/guide/reporters`.
- Vitest UI describes watch mode `--ui` as a main use case and html reporter is mentioned on the side.

To address this, this PR updates `/guide/ui` to treat both `--ui` and `--reporter=html` in equal ground and also highlight the differences. The html reporter specific usage details are also consolidated in `/guide/ui.html#html-reporter` and `/guide/reporters` will references it as a main document.

Also along with this, it adds some new doc mentions for:
- html reporter local preview on vscode integrated browser or `file://` on real browser with `singleFile`.
- vscode extension trace view feature.

Preview: https://deploy-preview-11169--vitest-dev.netlify.app/guide/ui.html
