### PR TITLE
fix: unwrap re-exported CJS defaults (fix #11162)

### DIFF
--- a/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
+++ b/packages/vitest/src/runtime/moduleRunner/moduleEvaluator.ts
@@ -270,11 +270,12 @@ export class VitestModuleEvaluator implements ModuleEvaluator {
       },
     })
 
+    const shouldInterop = (value: unknown) => this.shouldInterop(module.file, { default: value })
     const moduleProxy = {
       set exports(value) {
         span.addEvent('`module.exports` is assigned directly, copying all properties to `exports`')
         exportAll(cjsExports, value)
-        exportsObject.default = value
+        exportsObject.default = shouldInterop(value) ? getDefaultExport(value) : value
         moduleExports = value
       },
       get exports() {
@@ -600,6 +601,13 @@ function defineExport(exports: any, key: string | symbol, value: () => any) {
 export function isPrimitive(v: any): boolean {
   const isObject = typeof v === 'object' || typeof v === 'function'
   return !isObject || v == null
+}
+
+function getDefaultExport(value: any) {
+  if (!isPrimitive(value) && value.__esModule && 'default' in value) {
+    return value.default
+  }
+  return value
 }
 
 function interopModule(mod: any) {

--- a/test/unit/src/cjs/reexport-default-source.cjs
+++ b/test/unit/src/cjs/reexport-default-source.cjs
@@ -1,0 +1,5 @@
+'use strict'
+
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.default = function reexportedDefault() {}
+exports.named = 'named'

--- a/test/unit/src/cjs/reexport-default.cjs
+++ b/test/unit/src/cjs/reexport-default.cjs
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./reexport-default-source.cjs')

--- a/test/unit/test/module.test.ts
+++ b/test/unit/test/module.test.ts
@@ -30,6 +30,9 @@ import * as primitiveAll from '../src/cjs/primitive-cjs'
 import * as prototypeCjs from '../src/cjs/prototype-cjs'
 
 // @ts-expect-error is not typed with imports
+import * as reexportedDefaultCjs from '../src/cjs/reexport-default.cjs'
+
+// @ts-expect-error is not typed with imports
 import * as prototypeEsm from '../src/esm/esm.js'
 
 // @ts-expect-error is not typed with imports
@@ -80,6 +83,11 @@ it('should work when using module.exports cjs', () => {
   expect(cjs.b).toBe(2)
   expect(a).toBe(1)
   expect(b).toBe(2)
+})
+
+it('interops module.exports assigned from an __esModule require', () => {
+  expect(reexportedDefaultCjs.default).toBeTypeOf('function')
+  expect(reexportedDefaultCjs.named).toBe('named')
 })
 
 it('works with bare exports cjs', () => {


### PR DESCRIPTION
Written by an AI agent on behalf of @dvd233, who reviewed and approved this pull request before submission.

### Description

Unwrap the default export when an inlined CommonJS module assigns an `__esModule` object through `module.exports = require(...)`.

This keeps `deps.interopDefault` consistent with direct `exports.default` assignments while preserving named exports and the `interopDefault: false` opt-out.

Resolves #11162

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

Validated locally with:
- `pnpm --filter vitest build`
- `pnpm --filter @vitest/test-unit test module.test.ts` (54 tests)
- `pnpm typecheck`
- `CI=true pnpm lint`
- `pnpm knip`

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

Not applicable: this restores the documented `deps.interopDefault` behavior.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
