### PR TITLE
fix: parse browser define values (fix #11164)

### DIFF
--- a/packages/vitest/src/node/plugins/testConfig.ts
+++ b/packages/vitest/src/node/plugins/testConfig.ts
@@ -154,7 +154,15 @@ export function TestConfigPlugin(
             resolvedTestConfig._scriptDefines = sharedServer.scriptDefines
           }
           else if (isBrowserEnabled) {
-            resolvedTestConfig.defines = config.define || {}
+            // Vite 8 (dev) defines these as globals. `config.define` holds
+            // JSON-stringified source (`JSON.stringify("BAR")` → `'"BAR"'`).
+            // Assigning that string to `globalThis` wraps the value in extra
+            // quotes (#11164). Parse like Node, but leave `config.define`
+            // intact so Vite can still replace.
+            const { defines } = deleteDefineConfig({
+              define: { ...config.define },
+            })
+            resolvedTestConfig.defines = defines
           }
           else {
             const { defines, scriptDefines } = deleteDefineConfig(config)

--- a/test/e2e/fixtures/config/browser-define/basic.test.ts
+++ b/test/e2e/fixtures/config/browser-define/basic.test.ts
@@ -1,6 +1,9 @@
 import { test, expect } from 'vitest'
 
+declare const FOO: string
+
 test('passes', () => {
+  expect(FOO).toBe('BAR')
   expect(process.env.TEST_PROCESS_ENV).toBe('PROCESS_OK')
   expect(import.meta.env.TEST_META_ENV).toBe('META_OK')
 })

--- a/test/e2e/fixtures/config/browser-define/vitest.config.ts
+++ b/test/e2e/fixtures/config/browser-define/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 
 let config = defineConfig({
   define: {
+    'FOO': JSON.stringify('BAR'),
     'process.env.TEST_PROCESS_ENV': JSON.stringify('PROCESS_OK'),
     'import.meta.env.TEST_META_ENV': JSON.stringify('META_OK'),
   },

--- a/test/e2e/test/config/browser-configs.test.ts
+++ b/test/e2e/test/config/browser-configs.test.ts
@@ -1297,10 +1297,11 @@ describe('[e2e] workspace configs are affected by the CLI options', () => {
 
 test('browser root', async () => {
   process.env.BROWSER_DEFINE_TEST_PROJECT = 'false'
-  const { testTree, stderr } = await runVitest({
+  const { testTree, stderr, ctx } = await runVitest({
     root: './fixtures/config/browser-define',
   })
   expect(stderr).toBe('')
+  expect(ctx!.projects[0].config.defines.FOO).toBe('BAR')
   expect(testTree()).toMatchInlineSnapshot(`
     {
       "basic.test.ts": {
@@ -1312,10 +1313,11 @@ test('browser root', async () => {
 
 test('browser project', async () => {
   process.env.BROWSER_DEFINE_TEST_PROJECT = 'true'
-  const { testTree, stderr } = await runVitest({
+  const { testTree, stderr, ctx } = await runVitest({
     root: './fixtures/config/browser-define',
   })
   expect(stderr).toBe('')
+  expect(ctx!.projects[0].config.defines.FOO).toBe('BAR')
   expect(testTree()).toMatchInlineSnapshot(`
     {
       "basic.test.ts": {


### PR DESCRIPTION
Closes #11164

## Bug

In Vitest 5 browser mode, `define: { FOO: JSON.stringify("BAR") }` makes `FOO` evaluate to `"BAR"` (quotes included). Node tests on the same config get `BAR`. Vitest 4 was fine in both.

Repro from the issue: expected `'BAR'`, received `'"BAR"'`.

## Why

Node tests run `define` values through `deleteDefineConfig`, which `JSON.parse`s the Vite snippets before assigning them to `globalThis`.

Browser mode skipped that and copied `config.define` through as-is. Vite 8 (dev) also defines those entries as globals. `JSON.stringify("BAR")` is the source snippet `'"BAR"'`. Assigning that string to `globalThis.FOO` wraps the value in extra quotes. `setupDefines` then overwrites the correctly evaluated global.

Dotted keys (`process.env.*`, `import.meta.env.*`) were never stored on `config.defines` in Node; they still go through Vite replacement in the browser. Only dot-less identifiers were wrong.

## Fix

Parse browser `define` values the same way Node does. Leave `config.define` on the Vite config so replacement still happens.

    const { defines } = deleteDefineConfig({
      define: { ...config.define },
    })
    resolvedTestConfig.defines = defines

The clone is so we do not strip `define` from the browser Vite server.

## Tests

Extended `test/e2e/fixtures/config/browser-define`:

- `FOO: JSON.stringify("BAR")` → `expect(FOO).toBe("BAR")`
- root browser config and `test.projects` wrapper (the issue shape)
- `ctx.projects[0].config.defines.FOO === "BAR"` (not `'"BAR"'`)
- existing `process.env` / `import.meta.env` cases unchanged

    pnpm --filter @vitest/test-e2e test test/config/browser-configs.test.ts -t 'browser root|browser project'