### PR TITLE
fix: resolve ResolvedConfig exactOptionalPropertyTypes errors

### DIFF
--- a/packages/vitest/src/node/types/benchmark.ts
+++ b/packages/vitest/src/node/types/benchmark.ts
@@ -55,5 +55,5 @@ export interface BenchmarkUserOptions {
 }
 
 export type ResolvedBenchmarkOptions = Omit<Required<BenchmarkUserOptions>, 'provider'> & {
-  provider?: string | undefined
+  provider?: string
 }

--- a/packages/vitest/src/node/types/config.ts
+++ b/packages/vitest/src/node/types/config.ts
@@ -1313,7 +1313,7 @@ export interface ResolvedConfig
 
   maxWorkers: number
 
-  vmMemoryLimit?: UserConfig['vmMemoryLimit']
+  vmMemoryLimit?: string | number
   dumpDir?: string
   tagsFilter?: string[]
   mergeReportsLabel?: string


### PR DESCRIPTION
### Description

Under `exactOptionalPropertyTypes` the properties `foo?: string` and `foo?: string | undefined` behave differently and are not compatible. The way vitest builds up some properties in `ResolvedConfig` conflicts with how vite does it, causing an unavoidable error for consumers:
```
node_modules/vitest/dist/config.d.ts:35:12 - error TS2430: Interface 'ResolvedConfig' incorrectly extends interface 'Readonly<Omit<UserConfig, "assetsInclude" | "build" | "css" | "dev" | "devtools" | "environments" | "experimental" | "future" | "json" | "optimizeDeps" | "plugins" | "preview" | "server" | "worker"> & { ...; } & PluginHookUtils>'.
  The types of 'test.benchmark.provider' are incompatible between these types.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

35  interface ResolvedConfig {
              ~~~~~~~~~~~~~~
```

You'll see the error is in vite as well. In principle this could be fixed in either repo but I decided that vitest should be kept in lock step with vite.

A project to reproduce this is:
```ts
// vitest.config.ts
import { defineConfig } from "vitest/config";

export default defineConfig({});

// package.json
{
  "name": "vitest-eopt-repro",
  "private": true,
  "type": "module",
  "devDependencies": {
    "typescript": "^7.0.2",
    "vitest": "5.0.0"
  }
}

// tsconfig.json
{
  "compilerOptions": {
    "target": "esnext",
    "module": "esnext",
    "moduleResolution": "bundler",
    "strict": true,
    "exactOptionalPropertyTypes": true,
    "noEmit": true
  }
}
```

[Playground]

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [x] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

(there are no new features)

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
