### PR TITLE
fix: correct typos in error message and comments

### DIFF
--- a/packages/browser/src/client/tester/tester-utils.ts
+++ b/packages/browser/src/client/tester/tester-utils.ts
@@ -175,7 +175,7 @@ export class CommandsManager {
         if (hasActiveTraceView) {
           // Covers provider-backed actionability/waiting after command dispatch.
           // Local pre-command resolution, such as serializeElement/findElement paths
-          // is not coverd within by this action trace range.
+          // is not covered within by this action trace range.
           await recordBrowserTraceEntry(currentTest, {
             name: actionTraceGroupName,
             kind: 'action',

--- a/packages/browser/src/node/index.ts
+++ b/packages/browser/src/node/index.ts
@@ -180,7 +180,7 @@ body {
         next()
       })
       // strip _vitest_original query added by importActual so that
-      // the plugin pipeline sees the original import id (e.g. virtual modules's load hook).
+      // the plugin pipeline sees the original import id (e.g. virtual modules' load hook).
       server.middlewares.use((req, _res, next) => {
         if (
           req.url?.includes('_vitest_original')

--- a/packages/snapshot/src/client.ts
+++ b/packages/snapshot/src/client.ts
@@ -328,7 +328,7 @@ export class SnapshotClient {
     }
 
     // TODO: should `all` mode ignore parse error?
-    // Sielently hiding the error and creating snaphsot full scratch isn't good either.
+    // Silently hiding the error and creating snapshot full scratch isn't good either.
     // Users can fix or purge the broken snapshot manually and that decision affects how domain snapshot gets updated.
     const matchResult = expectedSnapshot.data !== undefined
       ? adapter.match(stableResult.captured, adapter.parseExpected(expectedSnapshot.data))

--- a/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
+++ b/packages/vitest/src/node/reporters/renderers/windowedRenderer.ts
@@ -2,7 +2,7 @@ import type { Writable } from 'node:stream'
 import type { Vitest } from '../../core'
 import { stripVTControlCharacters } from 'node:util'
 
-/** Minimum time between two renders, no matter how many scheduled renderes were called */
+/** Minimum time between two renders, no matter how many scheduled renders were called */
 const DEFAULT_RENDER_THRESHOLD_MS = 100
 
 /** Interval between automatic renders. If no test state changes happened, this will increase just duration field */

--- a/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
+++ b/packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts
@@ -145,7 +145,7 @@ export function startVitestModuleRunner(options: ContextModuleRunnerOptions): Vi
         }
 
         // strip _vitest_original query added by importActual so that
-        // the plugin pipeline sees the original import id (e.g. virtual modules's load hook)
+        // the plugin pipeline sees the original import id (e.g. virtual modules' load hook)
         const isImportActual = id.includes('_vitest_original')
         if (isImportActual) {
           id = removeQuery(id, '_vitest_original')

--- a/packages/vitest/src/runtime/runner/utils/tags.ts
+++ b/packages/vitest/src/runtime/runner/utils/tags.ts
@@ -36,7 +36,7 @@ export function validateTags(config: SerializedConfig, tags: string[]): void {
 
 export function createNoTagsError(availableTags: TestTagDefinition[], tag: string, prefix = 'tag'): never {
   if (!availableTags.length) {
-    throw new Error(`The Vitest config does't define any "tags", cannot apply "${tag}" ${prefix} for this test. See: https://vitest.dev/guide/test-tags`)
+    throw new Error(`The Vitest config doesn't define any "tags", cannot apply "${tag}" ${prefix} for this test. See: https://vitest.dev/guide/test-tags`)
   }
   throw new Error(`The ${prefix} "${tag}" is not defined in the configuration. Available tags are:\n${availableTags
     .map(t => `- ${t.name}${t.description ? `: ${t.description}` : ''}`)

--- a/test/e2e/test/test-tags.test.ts
+++ b/test/e2e/test/test-tags.test.ts
@@ -156,7 +156,7 @@ test('throws an error if no tags are defined in the config, but in the test', as
     ⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
 
      FAIL  basic.test.js [ basic.test.js ]
-    Error: The Vitest config does't define any "tags", cannot apply "unknown" tag for this test. See: https://vitest.dev/guide/test-tags
+    Error: The Vitest config doesn't define any "tags", cannot apply "unknown" tag for this test. See: https://vitest.dev/guide/test-tags
      ❯ basic.test.js:2:9
           1|
           2|         test('test 1', { tags: ['unknown'] }, () => {})

--- a/test/e2e/test/test-tags.test.ts
+++ b/test/e2e/test/test-tags.test.ts
@@ -211,7 +211,7 @@ test('throws an error if tag is not defined in the config, but in --tags-filter 
     },
     { fails: true },
   )
-  expect(stderr).toContain('The Vitest config does\'t define any "tags", cannot apply "unknown" tag pattern for this test. See: https://vitest.dev/guide/test-tags')
+  expect(stderr).toContain('The Vitest config doesn\'t define any "tags", cannot apply "unknown" tag pattern for this test. See: https://vitest.dev/guide/test-tags')
 })
 
 test('defining a tag available only in one project', async () => {

--- a/test/unit/test/test-tags-filter.test.ts
+++ b/test/unit/test/test-tags-filter.test.ts
@@ -476,7 +476,7 @@ describe('createTagsFilter', () => {
 
     test('throws error when no tags defined', () => {
       expect(() => createTagsFilter(['foo'], [])).toThrow(
-        'The Vitest config does\'t define any "tags"',
+        'The Vitest config doesn\'t define any "tags"',
       )
     })
 


### PR DESCRIPTION
### Description

Corrects typos in one error message and several comments:

- `packages/vitest/src/runtime/runner/utils/tags.ts`: error message `does't` -> `doesn't` (shown when `tags` are used but not configured)
- `test/e2e/test/test-tags.test.ts`: update the inline snapshot that asserts that error message
- `packages/snapshot/src/client.ts`: `Sielently` -> `Silently`, `snaphsot` -> `snapshot`
- `packages/browser/src/client/tester/tester-utils.ts`: `coverd` -> `covered`
- `packages/vitest/src/node/reporters/renderers/windowedRenderer.ts`: `renderes` -> `renders`
- `packages/browser/src/node/index.ts` and `packages/vitest/src/runtime/moduleRunner/startVitestModuleRunner.ts`: `modules's` -> `modules'`

Typo candidates were found with spell-check tooling; changes were assisted by Codex (AI) and reviewed and approved by a human before opening.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
