### PR TITLE
perf(spy): reset only mocks that were called or reconfigured

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -25,10 +25,9 @@ const MOCK_RESTORE = new Set<() => void>()
 // but it makes the state slower to access and return different values
 // if you stored it before calling `mockClear` where it will be recreated
 const DIRTY_MOCK_STATES = new Set<Mock<Procedure | Constructable>>()
-const REGISTERED_MOCKS = new Set<WeakRef<Mock<Procedure | Constructable>>>()
-const MOCK_FINALIZER = new FinalizationRegistry<WeakRef<Mock<Procedure | Constructable>>>((ref) => {
-  REGISTERED_MOCKS.delete(ref)
-})
+// Mocks whose implementation, once-queue or name changed since their last
+// `mockReset()`, so `resetAllMocks()` only visits mocks that are not already reset
+const DIRTY_MOCK_CONFIGS = new Set<Mock<Procedure | Constructable>>()
 const MOCK_CONFIGS = new WeakMap<Mock<Procedure | Constructable>, MockConfig>()
 const MOCKS_BY_STATE = new WeakMap<MockContext, Mock<Procedure | Constructable>>()
 
@@ -68,9 +67,6 @@ export function createMockInstance(options: MockInstanceOption = {}): Mock<Proce
   }
   MOCK_CONFIGS.set(mock, config)
   MOCKS_BY_STATE.set(state, mock)
-  const ref = new WeakRef(mock)
-  REGISTERED_MOCKS.add(ref)
-  MOCK_FINALIZER.register(mock, ref)
 
   mock._isMockFunction = true
   mock.getMockImplementation = () => {
@@ -102,18 +98,21 @@ export function createMockInstance(options: MockInstanceOption = {}): Mock<Proce
   })
 
   mock.mockImplementation = function mockImplementation(implementation) {
+    DIRTY_MOCK_CONFIGS.add(mock)
     config.mockImplementation = implementation
     updateMockPrototype()
     return mock
   }
 
   mock.mockImplementationOnce = function mockImplementationOnce(implementation) {
+    DIRTY_MOCK_CONFIGS.add(mock)
     config.onceMockImplementations.push(implementation)
     updateMockPrototype()
     return mock
   }
 
   mock.withImplementation = function withImplementation(implementation, callback) {
+    DIRTY_MOCK_CONFIGS.add(mock)
     const previousImplementation = config.mockImplementation
     const previousOnceImplementations = config.onceMockImplementations
 
@@ -239,6 +238,7 @@ export function createMockInstance(options: MockInstanceOption = {}): Mock<Proce
       : undefined
     config.mockName = resetToMockName ? (mock.name || 'vi.fn()') : 'vi.fn()'
     config.onceMockImplementations = []
+    DIRTY_MOCK_CONFIGS.delete(mock)
     updateMockPrototype()
     return mock
   }
@@ -250,6 +250,7 @@ export function createMockInstance(options: MockInstanceOption = {}): Mock<Proce
 
   mock.mockName = function mockName(name: string) {
     if (typeof name === 'string') {
+      DIRTY_MOCK_CONFIGS.add(mock)
       config.mockName = name
     }
     return mock
@@ -777,14 +778,13 @@ export function clearAllMocks(): void {
 }
 
 export function resetAllMocks(): void {
-  for (const ref of REGISTERED_MOCKS) {
-    const mock = ref.deref()
-    if (mock) {
-      mock.mockReset()
-    }
-    else {
-      REGISTERED_MOCKS.delete(ref)
-    }
+  // `mockReset()` removes the mock from both sets, so a mock present in both
+  // is visited once.
+  for (const mock of DIRTY_MOCK_STATES) {
+    mock.mockReset()
+  }
+  for (const mock of DIRTY_MOCK_CONFIGS) {
+    mock.mockReset()
   }
 }
 

--- a/test/unit/test/mocking/vi-fn.test.ts
+++ b/test/unit/test/mocking/vi-fn.test.ts
@@ -345,6 +345,41 @@ describe('vi.fn() configuration', () => {
     expect(mock()).toBe(undefined)
   })
 
+  test('vi.resetAllMocks() only resets mocks that were called or reconfigured', () => {
+    const mocks = Array.from({ length: 100 }, () => vi.fn())
+    mocks[10]()
+    mocks[20].mockReturnValue(42)
+    mocks[30].mockReturnValueOnce(42)
+    mocks[40].mockName('named')
+    mocks[50]()
+    mocks[50].mockReturnValue(42)
+
+    const reset: number[] = []
+    for (const [index, mock] of mocks.entries()) {
+      const mockReset = mock.mockReset
+      mock.mockReset = function () {
+        reset.push(index)
+        return mockReset.call(this)
+      }
+    }
+
+    vi.resetAllMocks()
+
+    expect(reset.sort((a, b) => a - b)).toEqual([10, 20, 30, 40, 50])
+    expect(mocks[20]()).toBe(undefined)
+    expect(mocks[30]()).toBe(undefined)
+    expect(mocks[40].getMockName()).toBe('vi.fn()')
+  })
+
+  test('vi.resetAllMocks() still resets a reconfigured mock after vi.clearAllMocks()', () => {
+    const mock = vi.fn().mockReturnValue(42)
+
+    vi.clearAllMocks()
+    vi.resetAllMocks()
+
+    expect(mock()).toBe(undefined)
+  })
+
   test('vi.fn() resets the original mock implementation', () => {
     const mock = vi.fn(() => 42)
     expect(mock()).toBe(42)


### PR DESCRIPTION
### Description

`vi.resetAllMocks()` iterates `REGISTERED_MOCKS`, which holds a `WeakRef` to every mock ever created in the worker, and calls `mockReset()` on each one that is still alive. Its cost therefore grows with the number of live mocks, not with the number of mocks a test actually touched.

With `isolate: false` this becomes the dominant cost of a run. One worker executes many test files, so module-level mocks and every `vi.fn()` that is still reachable keep accumulating. `deref()` also adds each mock to the WeakRef "keep during job" list, so the mocks a test created cannot be collected until the runner yields to the event loop, which rarely happens inside a file. With `mockReset: true` every test then pays for every mock in the worker.

Measured on a large suite (364 files, 6733 tests, `pool: 'forks'`, `isolate: false`, `mockReset: true`, coverage off, 4 workers):

| Vitest                             | wall time | `resetAllMocks()` CPU across workers | max mocks visited per reset |
| ---------------------------------- | --------- | ------------------------------------ | --------------------------- |
| 4.1.11 (`Set` of strong refs)      | 671 s     | 1838 s                               | ~110,000                    |
| 5.0.0 (`WeakRef` registry, #11092) | 189 s     | 465 s                                | ~66,000                     |
| 5.0.0 + this change                | 26 s      | 0.4 s                                | 5 to 50                     |

The last row was measured with the first commit (strong `Set`s). With the weak-ref version the same suite takes 22.5 s wall time against 24.9 s for the first commit, measured back to back; see the comments below.

This PR applies the approach #11092 introduced for `clearAllMocks()` to `resetAllMocks()`:

- `DIRTY_MOCK_STATES` already tracks mocks that were called since their last `mockClear()`.
- A new `DIRTY_MOCK_CONFIGS` set tracks mocks whose config changed since their last `mockReset()`: `mockImplementation`, `mockImplementationOnce`, `withImplementation`, and `mockName` add the mock, `mockReset()` removes it. Every `mockReturnValue*`, `mockResolvedValue*`, `mockRejectedValue*`, and `mockThrow*` helper goes through one of these.
- `resetAllMocks()` iterates the two sets. `mockReset()` removes the mock from both, so a mock present in both is visited once.

A mock that is in neither set is already in its reset state, so behavior is unchanged. `clearAllMocks()` is unaffected: it still only touches `DIRTY_MOCK_STATES`, and a mock that was reconfigured but never called stays in `DIRTY_MOCK_CONFIGS` until `resetAllMocks()` sees it (covered by the new tests).

~~With this change nothing reads `REGISTERED_MOCKS` anymore, so the `WeakRef` registry and the `FinalizationRegistry` are removed. That also removes the per-mock `WeakRef` allocation and the `deref()` pass that pinned every live mock for the rest of the job. If you prefer to keep the registry for future use, that part of the diff can be dropped; the perf gain comes from the two loops in `resetAllMocks()`. The Firefox 79 note in `docs/guide/browser/index.md` that #11092 added for `WeakRef` support may no longer be needed after this; I left the docs untouched.~~

**Update (second commit, see the comments below):** the paragraph above no longer applies. Both dirty sets hold `WeakRef`s, and the `FinalizationRegistry` from #11092 stays and removes collected mocks from both sets. A mock gets its `WeakRef` the first time it is called or configured instead of at creation, so mocks that are never touched no longer get one; the `REGISTERED_MOCKS` set that held a ref to every mock is gone. Collectability of unused mocks is unchanged from #11092; this PR is about the iteration cost of `resetAllMocks()`, see #11197 (comment) by @hi-ogawa. The docs note on `WeakRef` support stays. The third commit merges `main` and adopts the `Set.prototype.add` guard from #11299 in the shared `markDirty` helper.

Related: #9492, #11092.

AI disclosure: Claude (Claude Code) assisted with drafting the change, the tests and this description; the diff was reviewed and measured by me.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Run the tests with `pnpm test:ci`.

### Documentation

- [x] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets

- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.

