### PR TITLE
fix: match forceRerunTriggers against paths under dot directories

### DIFF
--- a/packages/vitest/src/node/specifications.ts
+++ b/packages/vitest/src/node/specifications.ts
@@ -135,7 +135,8 @@ export class VitestSpecifications {
     }
 
     const forceRerunTriggers = this.vitest.config.forceRerunTriggers
-    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers) : undefined
+    // paths are absolute, so without `dot: true` a project under a dot directory matches nothing
+    const matcher = forceRerunTriggers.length ? pm(forceRerunTriggers, { dot: true }) : undefined
     if (matcher && related.some(file => matcher(file))) {
       return specs
     }

--- a/packages/vitest/src/node/watcher.ts
+++ b/packages/vitest/src/node/watcher.ts
@@ -173,7 +173,7 @@ export class VitestWatcher {
       return false
     }
 
-    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers)) {
+    if (pm.isMatch(filepath, this.vitest.config.forceRerunTriggers, { dot: true })) {
       this.vitest.state.getFilepaths().forEach(file => this.changedTests.add(file))
       return true
     }

--- a/test/e2e/test/git-changed.test.ts
+++ b/test/e2e/test/git-changed.test.ts
@@ -32,6 +32,20 @@ describe.skipIf(process.env.ECOSYSTEM_CI)('forceRerunTrigger', () => {
     const { stdout } = await run()
     expect(stdout).toContain('No test files found, exiting with code 0')
   })
+
+  it('should match a changed file under a dot directory', async () => {
+    // the triggers are matched against absolute paths, so a dot segment anywhere in
+    // the project's own path used to stop `**` from reaching the file
+    const { stdout, stderr } = await runVitest({
+      root: join(process.cwd(), 'fixtures/git-changed/related'),
+      include: ['related.test.ts'],
+      forceRerunTriggers: ['**/package.json'],
+      related: ['.config/package.json'],
+    })
+    expect(stderr).toBe('')
+    expect(stdout).toContain('1 passed')
+    expect(stdout).toContain('related.test.ts')
+  })
 })
 
 it.skipIf(process.env.ECOSYSTEM_CI)('related correctly runs only related tests', async () => {


### PR DESCRIPTION
### Description

Fixes #11054. Diagnosis and the fix direction are @digitalcostas's, from that issue — they offered a PR conditional on a maintainer confirming the semantics, and the issue has sat unanswered for two weeks, so I picked it up.

`forceRerunTriggers` are matched against **absolute** paths, but picomatch defaults to `dot: false`, so `**` refuses to cross a path segment that begins with a dot. A project checked out under one — `~/.local/src/app`, a clone into `.app/`, an agent worktree under `.claude/worktrees/…` — therefore matched *no* trigger at all:

```
default dot:false     dot dir false   plain dir true    even '**/*' false
with dot:true         dot dir true    plain dir true
```

The consequence is silent: the documented escalation to the full suite on a `package.json`, lockfile or config change simply stops happening, and `vitest run --changed` reports `No test files found` for a dependency-only change. The same project in a dot-free directory behaves correctly, so it is position-dependent and easy to miss.

The watch-mode check in `watcher.ts` has the same shape and the same blind spot, so both call sites are fixed.

### Note on `dot: true`

It lets `**` reach into dot directories generally, so a `**/package.json` trigger could now also match something like `node_modules/.pnpm/*/package.json`. In practice the inputs to both call sites are already filtered — the `--changed` list comes from git, and the watcher's paths come from a watcher that ignores `node_modules` — so I don't think this widens anything real. Happy to scope it differently (e.g. relativise the path against `root` before matching) if you'd rather not change the glob semantics.

### Tests

`test/e2e/test/git-changed.test.ts` gains a case that puts the dot segment in the changed file's path rather than relocating a whole project, which keeps the fixture where it is:

```ts
forceRerunTriggers: ['**/package.json'],
related: ['.config/package.json'],
```

On `main` it fails with exactly the reported symptom:

```
AssertionError: expected 'No test files found, exiting with cod…' to be ''
+ No test files found, exiting with code 1
```

With the fix the file passes (6 tests), as does `test/e2e/test/watch/file-watching.test.ts` (10 tests) covering the watcher call site. eslint is clean on the changed files.
