### PR TITLE
fix: drop doubled words and fix a moved-file doc link

### DIFF
--- a/packages/spy/src/index.ts
+++ b/packages/spy/src/index.ts
@@ -287,7 +287,7 @@ export function fn<T extends Procedure | Constructable = Procedure>(
     // we pass this down so getMockImplementation() always returns the value
     mockImplementation: originalImplementation,
     // special case so that .mockReset() resets the value to
-    // the the originalImplementation instead of () => undefined
+    // the originalImplementation instead of () => undefined
     resetToMockImplementation: true,
   }) as Mock<T>
 }

--- a/packages/ui/explorer.md
+++ b/packages/ui/explorer.md
@@ -31,7 +31,7 @@ Whereas collecting and searching are complex operations, expanding/collapsing no
 Old [ws-client](client/composables/client/index.ts) logic was traversing the full tree to update all the nodes in the ui on every `onTaskUpdate` callback (was using reactive `idsMap` in the `ws-client` state).
 The new logic will traverse only the task files in the task result provided in the `onTaskUpdate` callback, that's a huge improvement in performance.
 
-The main change in the new logic is about using `requestAnimationFrame` to collect ui updates every 100ms, collecting all changes received in `onTaskUpdate` callback. On every loop, the [uiEntries](client/composables/state.ts) will be recreated with collected changes, the virtual scroller will handle the updates properly.
+The main change in the new logic is about using `requestAnimationFrame` to collect ui updates every 100ms, collecting all changes received in `onTaskUpdate` callback. On every loop, the [uiEntries](client/composables/explorer/state.ts) will be recreated with collected changes, the virtual scroller will handle the updates properly.
 
 The logic is implemented in [collect](client/composables/explorer/collector.ts) function and the `requestAnimationFrame` loop configured in the [tree class](client/composables/explorer/tree.ts), `runCollect` function.
 

--- a/packages/vitest/src/node/core.ts
+++ b/packages/vitest/src/node/core.ts
@@ -599,7 +599,7 @@ export class Vitest {
    */
   public getRootProject(): TestProject {
     if (!this.coreWorkspaceProject) {
-      throw new Error(`Root project is not initialized. This means that the Vite server was not established yet and the the workspace config is not resolved.`)
+      throw new Error(`Root project is not initialized. This means that the Vite server was not established yet and the workspace config is not resolved.`)
     }
     return this.coreWorkspaceProject
   }


### PR DESCRIPTION
Three small fixes:

- `packages/vitest/src/node/core.ts`: the root-project `Error` message read "and **the the** workspace config is not resolved"
- `packages/spy/src/index.ts`: comment "**the the** originalImplementation"
- `packages/ui/explorer.md`: linked `client/composables/state.ts`, which moved to `client/composables/explorer/state.ts"

Per AGENTS.md: reviewed and manually approved by the human submitter before opening.