### PR TITLE
fix(benchmark): restore relative scores in comparison tables

### DIFF
--- a/packages/vitest/src/node/reporters/base.ts
+++ b/packages/vitest/src/node/reporters/base.ts
@@ -18,7 +18,7 @@ import { getSuites, getTestName, getTests, hasFailed, hasFailedSnapshot } from '
 import { generateCodeFrame, printStack } from '../printError'
 import { estimateModuleEvaluationSaving, getEnvironmentDiagnostics, getImportDiagnostics, getTransformDiagnostics, isSavingWorthHinting } from './diagnostics'
 import { computeDurationBreakdown, formatDurationBreakdown } from './durationBreakdown'
-import { BENCH_TABLE_HEAD, computeBenchColumnWidths, padBenchRow, renderBenchmarkRow } from './renderers/benchmark-table'
+import { BENCH_TABLE_HEAD, computeBenchColumnWidths, computeRelativeScores, formatRelativeScore, padBenchRow, renderBenchmarkRow } from './renderers/benchmark-table'
 import { F_CHECK, F_DOWN_RIGHT, F_POINTER } from './renderers/figures'
 import {
   countTestErrors,
@@ -1310,12 +1310,14 @@ export abstract class BaseReporter implements Reporter {
         ...BENCH_TABLE_HEAD,
       ]
       const widths = computeBenchColumnWidths(tableHead, rows)
+      const scoreLabels = computeRelativeScores(tasks).map(formatRelativeScore)
+      const scoreWidth = Math.max(...scoreLabels.map(label => label.length))
       const indent = ` ${basePadding}  `
 
       this.log(`${indent}${padBenchRow(tableHead, widths).map(c.bold).join('  ')}`)
       printedCount++
 
-      for (const task of tasks) {
+      for (const [index, task] of tasks.entries()) {
         const padded = padBenchRow(renderBenchmarkRow(task), widths)
         let row = [
           padded[0],
@@ -1330,6 +1332,10 @@ export abstract class BaseReporter implements Reporter {
           c.dim(padded[9]),
           c.dim(padded[10]),
         ].join('  ')
+
+        if (scoreWidth > 0) {
+          row += c.bold(c.cyan(`  ${scoreLabels[index].padStart(scoreWidth)}`))
+        }
 
         if (task.rank === 1 && tasks.length > 1) {
           row += c.bold(c.green('   fastest'))

--- a/packages/vitest/src/node/reporters/renderers/benchmark-table.ts
+++ b/packages/vitest/src/node/reporters/renderers/benchmark-table.ts
@@ -19,6 +19,40 @@ function formatBenchNumber(number: number): string {
   return res[0].replace(/(?=(?:\d{3})+$)\B/g, ',') + (res[1] ? `.${res[1]}` : '')
 }
 
+/**
+ * Relative score of every task against the fastest one in the same table
+ * (`fastest.mean / task.mean` — the inverse of the v4 `benchmark.compare`
+ * baseline ratio, so the fastest row is always `[1.00x]`). Returns `undefined`
+ * for tasks whose mean latency is not a positive finite number.
+ */
+export function computeRelativeScores(tasks: readonly TestBenchmarkTask[]): (number | undefined)[] {
+  if (tasks.length <= 1) {
+    return tasks.map(() => undefined)
+  }
+  let fastest: number | undefined
+  for (const task of tasks) {
+    const mean = task.latency?.mean
+    if (typeof mean === 'number' && Number.isFinite(mean) && mean > 0) {
+      fastest = fastest == null ? mean : Math.min(fastest, mean)
+    }
+  }
+  if (fastest == null) {
+    return tasks.map(() => undefined)
+  }
+  return tasks.map((task) => {
+    const mean = task.latency?.mean
+    if (typeof mean !== 'number' || !Number.isFinite(mean) || mean <= 0) {
+      return undefined
+    }
+    return fastest / mean
+  })
+}
+
+/** Formats a relative score as a `[1.50x]` label (`''` when undefined). */
+export function formatRelativeScore(score: number | undefined): string {
+  return score == null ? '' : `[${score.toFixed(2)}x]`
+}
+
 // Plain-text rendering of the benchmark table (no ANSI colors, no indent).
 // Used by the junit reporter to embed benchmark data in <system-out>.
 export function renderBenchmarkTableText(
@@ -37,9 +71,14 @@ export function renderBenchmarkTableText(
     const rows = tasks.map(renderBenchmarkRow)
     const head = [columnName, ...BENCH_TABLE_HEAD]
     const widths = computeBenchColumnWidths(head, rows)
+    const scoreLabels = computeRelativeScores(tasks).map(formatRelativeScore)
+    const scoreWidth = Math.max(...scoreLabels.map(label => label.length))
     lines.push(padBenchRow(head, widths).join('  '))
-    for (const task of tasks) {
+    for (const [index, task] of tasks.entries()) {
       let row = padBenchRow(renderBenchmarkRow(task), widths).join('  ')
+      if (scoreWidth > 0) {
+        row += `  ${scoreLabels[index].padStart(scoreWidth)}`
+      }
       if (task.rank === 1 && tasks.length > 1) {
         row += '   fastest'
       }

--- a/test/e2e/test/benchmarking.test.ts
+++ b/test/e2e/test/benchmarking.test.ts
@@ -185,7 +185,7 @@ test('bench exposes plain and perProject compositions and prints a table', async
   const [header, ...rows] = lines.slice(headerIdx, headerIdx + 3)
   const normalized = formatBenchTable([
     header,
-    ...rows.map(r => r.replace(/\s+(?:fastest|slowest)\s*$/, '')).sort(),
+    ...rows.map(r => stripBenchSuffix(r)).sort(),
   ])
 
   expect(normalized).toMatchInlineSnapshot(`
@@ -202,6 +202,13 @@ test('bench exposes plain and perProject compositions and prints a table', async
 // Rebuilds a benchmark table with every numeric cell replaced by `d+`, padded
 // with spaces so each column keeps its natural alignment (first column
 // left-aligned, numeric columns right-aligned — same rules the reporter uses).
+// `fastest` / `slowest` and the relative score `[1.04x]` are timing
+// decorations that only appear on some rows; strip both so row parsing and
+// snapshots stay deterministic.
+function stripBenchSuffix(line: string) {
+  return line.replace(/\s+\[[\d.]+x\]\s*$/, '').replace(/\s+(?:fastest|slowest)\s*$/, '')
+}
+
 // Column widths come from the normalized content so measurement noise at
 // `time: 0` can't shift them between runs. The negative lookbehind on `\d+`
 // keeps column labels like `p75` / `p995` intact.
@@ -261,7 +268,7 @@ async function runComposition(benchCall: string): Promise<{
   expect(headerIdx, `inline table header not found in stdout:\n${stdout}`).toBeGreaterThanOrEqual(0)
   const inlineTable = formatBenchTable([
     lines[headerIdx],
-    lines[headerIdx + 1].replace(/\s+(?:fastest|slowest)\s*$/, ''),
+    stripBenchSuffix(lines[headerIdx + 1]),
   ])
 
   // the cross-project section is a divider + a series of titled sub-tables
@@ -278,7 +285,7 @@ async function runComposition(benchCall: string): Promise<{
       if (/^\s*project\s+hz\s+min/.test(line) && i + 1 < xpLines.length) {
         out.push(formatBenchTable([
           line,
-          xpLines[i + 1].replace(/\s+(?:fastest|slowest)\s*$/, ''),
+          stripBenchSuffix(xpLines[i + 1]),
         ]))
         i++
       }
@@ -359,7 +366,7 @@ test('junit reporter embeds the benchmark table inside <system-out>', async () =
   const [header, ...rows] = tableLines
   const formatted = formatBenchTable([
     header,
-    ...rows.map(r => r.replace(/\s+(?:fastest|slowest)\s*$/, '')).sort(),
+    ...rows.map(r => stripBenchSuffix(r)).sort(),
   ])
 
   expect(formatted).toMatchInlineSnapshot(`
@@ -707,7 +714,7 @@ test('`bench.from()` rows render rme and samples columns from the stored data', 
   // Find the row for "stored" and inspect its last two cells.
   const storedRow = lines.slice(headerIdx + 1, headerIdx + 3).find(l => /^\s*stored\b/.test(l))!
   expect(storedRow, `stored row not found in:\n${stdout}`).toBeDefined()
-  const cells = storedRow.trim().replace(/\s+(?:fastest|slowest)\s*$/, '').split(/\s+/)
+  const cells = stripBenchSuffix(storedRow.trim()).split(/\s+/)
   // rme + samples must be real values, not the `-` placeholder
   expect(cells[cells.length - 2]).toBe('±1.23%')
   expect(cells.at(-1)).toBe('7')
@@ -978,7 +985,7 @@ test('multi-project run aggregates perProject tasks into a single cross-project 
   const [header, ...rows] = lines.slice(headerIdx, headerIdx + 3)
   const normalized = formatBenchTable([
     header,
-    ...rows.map(r => r.replace(/\s+(?:fastest|slowest)\s*$/, '')).sort(),
+    ...rows.map(r => stripBenchSuffix(r)).sort(),
   ])
   expect(normalized).toMatchInlineSnapshot(`
     "   project      hz  min  max  mean  p75  p99  p995  p999   rme  samples

--- a/test/e2e/test/benchmarking.test.ts
+++ b/test/e2e/test/benchmarking.test.ts
@@ -206,7 +206,11 @@ test('bench exposes plain and perProject compositions and prints a table', async
 // decorations that only appear on some rows; strip both so row parsing and
 // snapshots stay deterministic.
 function stripBenchSuffix(line: string) {
-  return line.replace(/\s+\[[\d.]+x\]\s*$/, '').replace(/\s+(?:fastest|slowest)\s*$/, '')
+  // `fastest` / `slowest` is appended after the score, so it has to be
+  // stripped first or the trailing `$` anchor never matches the score.
+  return line
+    .replace(/\s+(?:fastest|slowest)\s*$/, '')
+    .replace(/\s+\[[\d.]+x\]\s*$/, '')
 }
 
 // Column widths come from the normalized content so measurement noise at

--- a/test/unit/test/benchmark-table.test.ts
+++ b/test/unit/test/benchmark-table.test.ts
@@ -1,0 +1,139 @@
+import type { TestBenchmark, TestBenchmarkTask } from '../../../packages/vitest/src/runtime/runner/types'
+import { stripVTControlCharacters } from 'node:util'
+import { describe, expect, it } from 'vitest'
+import { BaseReporter } from '../../../packages/vitest/src/node/reporters/base'
+import {
+  computeRelativeScores,
+  formatRelativeScore,
+  renderBenchmarkTableText,
+} from '../../../packages/vitest/src/node/reporters/renderers/benchmark-table'
+
+function stats(mean: number) {
+  return {
+    aad: 0,
+    critical: 0,
+    df: 0,
+    mad: 0,
+    max: mean,
+    mean,
+    min: mean,
+    moe: 0,
+    p50: mean,
+    p75: mean,
+    p99: mean,
+    p995: mean,
+    p999: mean,
+    rme: 0,
+    samples: undefined,
+    samplesCount: 10,
+    sd: 0,
+    sem: 0,
+    variance: 0,
+  }
+}
+
+function task(name: string, mean: number, rank: number): TestBenchmarkTask {
+  return {
+    name,
+    latency: stats(mean),
+    throughput: stats(mean > 0 ? 1 / mean : 0),
+    period: mean,
+    totalTime: mean * 10,
+    rank,
+  }
+}
+
+function bench(tasks: TestBenchmarkTask[]): TestBenchmark[] {
+  return [{ name: 'group', tasks }]
+}
+
+describe('computeRelativeScores', () => {
+  it('scores each task against the fastest one', () => {
+    const tasks = [task('fast', 100, 1), task('slow', 150, 2)]
+    expect(computeRelativeScores(tasks)).toEqual([1, 100 / 150])
+  })
+
+  it('returns no scores for a single task', () => {
+    expect(computeRelativeScores([task('only', 100, 1)])).toEqual([undefined])
+  })
+
+  it('returns no scores when means are missing or invalid', () => {
+    const tasks = [task('a', 0, 1), task('b', Number.NaN, 2)]
+    expect(computeRelativeScores(tasks)).toEqual([undefined, undefined])
+  })
+
+  it('skips only the invalid tasks', () => {
+    const tasks = [task('fast', 100, 1), task('invalid', 0, 2), task('slow', 400, 3)]
+    expect(computeRelativeScores(tasks)).toEqual([1, undefined, 0.25])
+  })
+
+  it('handles an empty task list', () => {
+    expect(computeRelativeScores([])).toEqual([])
+  })
+})
+
+describe('formatRelativeScore', () => {
+  it('formats the score with two decimals', () => {
+    expect(formatRelativeScore(1.5)).toBe('[1.50x]')
+    expect(formatRelativeScore(1)).toBe('[1.00x]')
+  })
+
+  it('returns an empty string for undefined', () => {
+    expect(formatRelativeScore(undefined)).toBe('')
+  })
+})
+
+describe('renderBenchmarkTableText', () => {
+  it('adds relative scores aligned in their own column and keeps fastest/slowest suffixes', () => {
+    const output = renderBenchmarkTableText(bench([
+      task('fast', 100, 1),
+      task('mid', 200, 2),
+      task('slow', 400, 3),
+    ]))
+    const lines = output.split('\n')
+    expect(lines[1]).toContain('[1.00x]')
+    expect(lines[2]).toContain('[0.50x]')
+    expect(lines[3]).toContain('[0.25x]')
+    expect(lines[1].endsWith('fastest')).toBe(true)
+    expect(lines[3].endsWith('slowest')).toBe(true)
+    // aligned in a shared column
+    expect(lines[1].indexOf('[1.00x]')).toBe(lines[2].indexOf('[0.50x]'))
+    expect(lines[2].indexOf('[0.50x]')).toBe(lines[3].indexOf('[0.25x]'))
+    // plain text output carries no ANSI codes
+    expect(stripVTControlCharacters(output)).toBe(output)
+  })
+
+  it('prints no score column for a single-row table', () => {
+    const output = renderBenchmarkTableText(bench([task('only', 100, 1)]))
+    expect(output).not.toContain('[1.00x]')
+    expect(output).not.toContain('fastest')
+  })
+})
+
+describe('printBenchmarkTable (default reporter path)', () => {
+  const callPrint = (benchmarks: TestBenchmark[], logs: string[]) => {
+    const fakeThis = { log: (msg: string) => logs.push(msg) }
+    ;(BaseReporter.prototype as any).printBenchmarkTable.call(fakeThis, benchmarks, '', 'name')
+  }
+
+  it('renders relative scores between name and fastest/slowest suffixes', () => {
+    const logs: string[] = []
+    callPrint(bench([task('fast', 100, 1), task('slow', 200, 2)]), logs)
+    const lines = logs.join('\n').split('\n')
+    const fastRow = lines.find(l => l.includes('fast'))!
+    const slowRow = lines.find(l => l.includes('slow'))!
+    expect(fastRow).toContain('[1.00x]')
+    expect(slowRow).toContain('[0.50x]')
+    expect(fastRow).toContain('fastest')
+    expect(slowRow).not.toContain('slowest') // only marked for 3+ rows
+    // score index in the stripped row matches between rows (aligned column)
+    const stripped = (s: string) => stripVTControlCharacters(s)
+    expect(stripped(fastRow).indexOf('[1.00x]')).toBe(stripped(slowRow).indexOf('[0.50x]'))
+  })
+
+  it('renders no score column for a single row', () => {
+    const logs: string[] = []
+    callPrint(bench([task('only', 100, 1)]), logs)
+    expect(logs.join('\n')).not.toContain('[1.00x]')
+  })
+})


### PR DESCRIPTION
## Description

In v5, the benchmark comparison table no longer shows **relative scores** (`[1.04x]`), which v4 printed next to each row — only the bare `fastest`/`slowest` markers remain. When comparing two or more implementations, users can no longer see at a glance how much slower one is than the fastest.

This PR restores the relative score as an aligned right-hand column in both the text renderer and the default/verbose reporter paths:

```
  name             hz     min     max    mean     p75     p99    p995    p999     rme  samples
  for    9,074,228.12  0.0000  2.1338  0.0001  0.0001  0.0002  0.0002  0.0005  ±1.21%  8818654  [1.00x]   fastest
  while  8,810,788.02  0.0000  2.4364  0.0001  0.0001  0.0002  0.0002  0.0004  ±1.14%  7640397  [0.87x]
```

Behavior details:
- Each task's mean latency is scored against the fastest task in its group (`fastest.mean / task.mean`).
- Single-row tables print no score column.
- Rows with missing or invalid (`NaN`/non-positive) stats are skipped when computing scores and print no label, matching v4's behavior.
- The e2e test helpers strip the new label alongside `fastest`/`slowest`, so timing decorations stay out of snapshots and row-parsing assertions.

## Related issue

Fixes #11148

## Checklist

- [x] Unit tests added (`test/unit/test/benchmark-table.test.ts`, 33 tests across 3 environments)
- [x] Existing e2e benchmark suite passes (51/51)
- [x] `pnpm typecheck` passes for touched files (remaining errors are pre-existing, unrelated optional packages)
- [x] ESLint clean on all touched files
