### PR TITLE
refactor(ui): consolidate unocss style to use class

### DIFF
--- a/packages/ui/client/components/BrowserIframe.vue
+++ b/packages/ui/client/components/BrowserIframe.vue
@@ -58,18 +58,18 @@ const scale = computed(() =>
 </script>
 
 <template>
-  <div id="browser-frame" h="full" flex="~ col">
-    <div p="3" h-10 flex="~ gap-2" items-center bg-header border="b base">
+  <div id="browser-frame" class="h-full flex flex-col">
+    <div class="p-3 h-10 flex gap-2 items-center bg-header border-b border-base">
       <IconButton
         v-show="panels.navigation <= 15"
         v-tooltip.bottom="'Show Navigation Panel'"
         title="Show Navigation Panel"
-        rotate-180
+        class="rotate-180"
         icon="i-carbon:side-panel-close"
         @click="showNavigationPanel()"
       />
       <div class="i-carbon-content-delivery-network" />
-      <span pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate>Browser UI</span>
+      <span class="pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate">Browser UI</span>
       <IconButton
         v-show="detailsPosition === 'right' && !detailsPanelVisible"
         v-tooltip.bottom="'Show Details Panel'"
@@ -78,7 +78,7 @@ const scale = computed(() =>
         @click="detailsPanelVisible = true"
       />
     </div>
-    <div p="l3 y2 r2" flex="~ gap-2" items-center bg-header border="b-2 base">
+    <div class="pl-3 py-2 pr-2 flex gap-2 items-center bg-header border-base border-b-2">
       <!-- TODO: these are only for preview (thank you Storybook!), we need to support more different and custom sizes (as a dropdown) -->
       <IconButton
         v-tooltip.bottom="'Small mobile'"
@@ -101,7 +101,7 @@ const scale = computed(() =>
         :active="isViewport('tablet')"
         @click="changeViewport('tablet')"
       />
-      <span class="pointer-events-none" text-sm>
+      <span class="pointer-events-none text-sm">
         {{ viewport[0] }}x{{ viewport[1] }}px
         <span v-if="scale < 100">({{ scale }}%)</span>
       </span>

--- a/packages/ui/client/components/ClosedDetailsHeader.vue
+++ b/packages/ui/client/components/ClosedDetailsHeader.vue
@@ -4,13 +4,9 @@ import DetailsHeaderButtons from '~/components/DetailsHeaderButtons.vue'
 
 <template>
   <div
-    p="2"
-    flex="~ gap-2"
-    items-center
-    bg-header
-    border="b base"
+    class="p-2 flex gap-2 items-center bg-header border-b border-base"
   >
-    <div flex-1 />
+    <div class="flex-1" />
     <DetailsHeaderButtons />
   </div>
 </template>

--- a/packages/ui/client/components/CodeMirrorContainer.vue
+++ b/packages/ui/client/components/CodeMirrorContainer.vue
@@ -71,10 +71,7 @@ onMounted(async () => {
 
 <template>
   <div
-    relative
-    font-mono
-    text-sm
-    class="codemirror-scrolls"
+    class="codemirror-scrolls relative font-mono text-sm"
     :class="{
       'codemirror-busy': saving,
       'codemirror-hide-cursor': readOnly,

--- a/packages/ui/client/components/ConnectionOverlay.vue
+++ b/packages/ui/client/components/ConnectionOverlay.vue
@@ -10,36 +10,25 @@ import {
 <template>
   <template v-if="!isConnected">
     <div
-      fixed
-      inset-0
-      p2
-      z-10
-      select-none
-      text="center sm"
-      bg="overlay"
-      backdrop-blur-sm
-      backdrop-saturate-0
+      class="fixed inset-0 p2 z-10 select-none text-center text-sm bg-overlay backdrop-blur-sm backdrop-saturate-0"
       @click="client.reconnect"
     >
       <div
-        h-full
-        flex="~ col gap-2"
-        items-center
-        justify-center
+        class="h-full flex flex-col gap-2 items-center justify-center"
         :class="isConnecting ? 'animate-pulse' : ''"
       >
         <div
-          text="5xl"
+          class="text-5xl"
           :class="
             isConnecting
               ? 'i-carbon:renew animate-spin animate-reverse'
               : 'i-carbon-wifi-off'
           "
         />
-        <div text-2xl>
+        <div class="text-2xl">
           {{ isConnecting ? "Connecting..." : "Disconnected" }}
         </div>
-        <div text-lg op50>
+        <div class="text-lg op50">
           Check your terminal or start a new server with `{{
             browserState
               ? `vitest --browser=${browserState.config.browser.name}`

--- a/packages/ui/client/components/Coverage.vue
+++ b/packages/ui/client/components/Coverage.vue
@@ -4,13 +4,13 @@ import { browserState } from '~/composables/client'
 </script>
 
 <template>
-  <div h="full" flex="~ col">
-    <div p="3" h-10 flex="~ gap-2" items-center bg-header border="b base">
+  <div class="h-full flex flex-col">
+    <div class="p-3 h-10 flex gap-2 items-center bg-header border-b border-base">
       <div class="i-carbon:folder-details-reference" />
-      <span pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate>Coverage</span>
+      <span class="pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate">Coverage</span>
       <DetailsHeaderButtons v-if="browserState" />
     </div>
-    <div flex-auto py-1 bg-white>
+    <div class="flex-auto py-1 bg-white">
       <iframe id="vitest-ui-coverage" src="./coverage/index.html" />
     </div>
   </div>

--- a/packages/ui/client/components/Dashboard.vue
+++ b/packages/ui/client/components/Dashboard.vue
@@ -5,13 +5,13 @@ import TestsFilesContainer from './dashboard/TestsFilesContainer.vue'
 </script>
 
 <template>
-  <div h="full" flex="~ col">
-    <div p="3" h-10 flex="~ gap-2" items-center bg-header border="b base">
+  <div class="h-full flex flex-col">
+    <div class="p-3 h-10 flex gap-2 items-center bg-header border-b border-base">
       <div class="i-carbon-dashboard" />
-      <span pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate>Dashboard</span>
+      <span class="pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate">Dashboard</span>
       <DetailsHeaderButtons v-if="browserState" />
     </div>
-    <div class="scrolls" flex-auto py-1>
+    <div class="scrolls flex-auto py-1">
       <TestsFilesContainer />
     </div>
   </div>

--- a/packages/ui/client/components/FailureScreenshot.vue
+++ b/packages/ui/client/components/FailureScreenshot.vue
@@ -40,7 +40,7 @@ function openScreenshot() {
 
 <template>
   <template v-if="screenshotUrl">
-    <div flex="~ gap-2 items-center">
+    <div class="flex gap-2 items-center">
       <IconButton
         v-tooltip.bottom="'View screenshot error'"
         class="!op-100"

--- a/packages/ui/client/components/FileDetails.vue
+++ b/packages/ui/client/components/FileDetails.vue
@@ -95,28 +95,23 @@ const tags = computed(() => {
 <template>
   <div
     v-if="current"
-    flex
-    flex-col
-    h-full
-    max-h-full
-    overflow-hidden
+    class="flex flex-col h-full max-h-full overflow-hidden"
     data-testid="file-detail"
   >
     <div>
-      <div p="2" h-10 flex="~ gap-2" items-center bg-header border="b base">
+      <div class="p-2 h-10 flex gap-2 items-center bg-header border-b border-base">
         <StatusIcon :state="current.result?.state" :mode="current.mode" :failed-snapshot="failedSnapshot" />
-        <div v-if="isTypecheck" v-tooltip.bottom="'This is a typecheck test. It won\'t report results of the runtime tests'" class="i-logos:typescript-icon" flex-shrink-0 />
-        <span v-if="label" class="rounded-sm px-1 text-xs font-light bg-cyan-500/20 text-cyan-700 dark:text-cyan-300" flex-shrink-0>{{ label }}</span>
+        <div v-if="isTypecheck" v-tooltip.bottom="'This is a typecheck test. It won\'t report results of the runtime tests'" class="i-logos:typescript-icon flex-shrink-0" />
+        <span v-if="label" class="rounded-sm px-1 text-xs font-light bg-cyan-500/20 text-cyan-700 dark:text-cyan-300 flex-shrink-0">{{ label }}</span>
         <span
           v-if="current?.file.projectName"
-          class="rounded-full py-0.5 px-2 text-xs font-light"
+          class="rounded-full py-0.5 px-2 text-xs font-light cursor-default"
           :style="projectBadgeStyle"
-          cursor-default
         >
           {{ current.file.projectName }}
         </span>
-        <div flex-1 font-light overflow-hidden text-sm flex>
-          <span op-50 truncate>
+        <div class="flex-1 font-light overflow-hidden text-sm flex">
+          <span class="op-50 truncate">
             {{ testTitle }}
           </span>
 
@@ -124,12 +119,9 @@ const tags = computed(() => {
             v-for="tag of tags"
             :key="tag.name"
             v-tooltip.bottom="tag.description"
-            class="rounded-full ml-2 px-2 text-xs font-light"
+            class="rounded-full ml-2 px-2 text-xs font-light cursor-default flex items-center"
             :style="{ backgroundColor: tag.bg, color: tag.text, border: `1px solid ${tag.border}` }"
             :title="tag.description"
-            cursor-default
-            flex
-            items-center
           >
             {{ tag.name }}
           </span>
@@ -146,10 +138,9 @@ const tags = computed(() => {
           <DetailsHeaderButtons v-if="browserState" />
         </div>
       </div>
-      <div flex="~" items-center bg-header border="b-2 base" text-sm h-41px>
+      <div class="flex items-center bg-header border-base border-b-2 text-sm h-41px">
         <button
-          tab-button
-          class="flex items-center gap-2"
+          class="flex items-center gap-2 tab-button"
           :class="{ 'tab-button-active': viewMode == null }"
           data-testid="btn-report"
           @click="changeViewMode(null)"
@@ -158,9 +149,8 @@ const tags = computed(() => {
           Report
         </button>
         <button
-          tab-button
           data-testid="btn-graph"
-          class="flex items-center gap-2"
+          class="flex items-center gap-2 tab-button"
           :class="{ 'tab-button-active': viewMode === 'graph' }"
           @click="changeViewMode('graph')"
         >
@@ -168,9 +158,8 @@ const tags = computed(() => {
           Module Graph
         </button>
         <button
-          tab-button
           data-testid="btn-code"
-          class="flex items-center gap-2"
+          class="flex items-center gap-2 tab-button"
           :class="{ 'tab-button-active': viewMode === 'editor' }"
           @click="changeViewMode('editor')"
         >
@@ -178,9 +167,8 @@ const tags = computed(() => {
           {{ draft ? "*&#160;" : "" }}Code
         </button>
         <button
-          tab-button
           data-testid="btn-console"
-          class="flex items-center gap-2"
+          class="flex items-center gap-2 tab-button"
           :class="{
             'tab-button-active': viewMode === 'console',
             'op20': viewMode !== 'console' && consoleCount === 0,
@@ -193,7 +181,7 @@ const tags = computed(() => {
       </div>
     </div>
 
-    <div flex flex-col flex-1 overflow="hidden">
+    <div class="flex flex-col flex-1 overflow-hidden">
       <FileDetailsModuleGraph
         v-if="viewMode === 'graph'"
         :key="`graph:${current.id}`"

--- a/packages/ui/client/components/FileDetailsModuleGraph.vue
+++ b/packages/ui/client/components/FileDetailsModuleGraph.vue
@@ -40,8 +40,8 @@ const graph = computed(() => {
 </script>
 
 <template>
-  <div flex-1 overflow-hidden>
-    <div v-if="isLoading" h-full flex items-center justify-center op-70>
+  <div class="flex-1 overflow-hidden">
+    <div v-if="isLoading" class="h-full flex items-center justify-center op-70">
       Loading module graph...
     </div>
     <ViewModuleGraph

--- a/packages/ui/client/components/FilterStatus.vue
+++ b/packages/ui/client/components/FilterStatus.vue
@@ -25,17 +25,16 @@ function toggle() {
       :class="[
         modelValue ? 'i-carbon:checkbox-checked-filled' : 'i-carbon:checkbox',
       ]"
-      text-lg
-      flex-shrink-0
+      class="text-lg flex-shrink-0"
       aria-hidden="true"
     />
     <input
       v-model="modelValue"
       type="checkbox"
       :disabled="disabled"
-      sr-only
+      class="sr-only"
     >
-    <span flex-1 ms-2 select-none whitespace-nowrap truncate>{{ label }}</span>
+    <span class="flex-1 ms-2 select-none whitespace-nowrap truncate">{{ label }}</span>
   </label>
 </template>
 

--- a/packages/ui/client/components/IconAction.vue
+++ b/packages/ui/client/components/IconAction.vue
@@ -7,12 +7,8 @@ defineProps<{
 <template>
   <button
     type="button"
-    dark="op75"
-    bg="gray-200 dark:#111"
-    hover="op100"
-    rounded-1
-    p-0.5
+    class="dark:op75 bg-gray-200 dark:bg-#111 hover:op100 rounded-1 p-0.5"
   >
-    <span block :class="icon" op65 class="dark:op85 hover:op100" />
+    <span :class="icon" class="dark:op85 hover:op100 block op65" />
   </button>
 </template>

--- a/packages/ui/client/components/IconButton.vue
+++ b/packages/ui/client/components/IconButton.vue
@@ -14,9 +14,8 @@ defineProps<{
     :disabled="disabled"
     class="w-1.4em h-1.4em flex rounded"
     :class="{
-      'op10': disabled && !active,
+      'op10': disabled,
       'op70': !disabled,
-      'op100': disabled && active,
       'bg-gray-500:35': active,
       'hover:bg-active hover:op100': !disabled && !active,
     }"

--- a/packages/ui/client/components/IconButton.vue
+++ b/packages/ui/client/components/IconButton.vue
@@ -11,14 +11,18 @@ defineProps<{
   <button
     :aria-label="title"
     role="button"
-    :opacity="disabled ? 10 : 70"
-    rounded
     :disabled="disabled"
-    :hover="disabled || active ? '' : 'bg-active op100'"
-    class="w-1.4em h-1.4em flex" :class="[{ 'bg-gray-500:35 op100': active }]"
+    class="w-1.4em h-1.4em flex rounded"
+    :class="{
+      'op10': disabled && !active,
+      'op70': !disabled,
+      'op100': disabled && active,
+      'bg-gray-500:35': active,
+      'hover:bg-active hover:op100': !disabled && !active,
+    }"
   >
     <slot>
-      <span :class="icon" ma block />
+      <span :class="icon" class="ma block" />
     </slot>
   </button>
 </template>

--- a/packages/ui/client/components/ModuleGraphImportBreakdown.vue
+++ b/packages/ui/client/components/ModuleGraphImportBreakdown.vue
@@ -61,10 +61,10 @@ function ellipsisFile(moduleId: string) {
 
 <template>
   <div class="overflow-auto max-h-120">
-    <h1 my-2 mx-4>
-      Import Duration Breakdown <span op-70>(ordered by Total Time)</span>
+    <h1 class="my-2 mx-4">
+      Import Duration Breakdown <span class="op-70">(ordered by Total Time)</span>
     </h1>
-    <table my-2 mx-4 text-sm font-light op-90>
+    <table class="my-2 mx-4 text-sm font-light op-90">
       <thead>
         <tr>
           <th>
@@ -90,13 +90,13 @@ function ellipsisFile(moduleId: string) {
           >
             {{ row.relativeFile }}
           </td>
-          <td pr-2 :class="row.selfTimeClass">
+          <td class="pr-2" :class="row.selfTimeClass">
             {{ row.formattedSelfTime }}
           </td>
-          <td pr-2 :class="row.totalTimeClass">
+          <td class="pr-2" :class="row.totalTimeClass">
             {{ row.formattedTotalTime }}
           </td>
-          <td pr-2 :class="row.totalTimeClass">
+          <td class="pr-2" :class="row.totalTimeClass">
             {{ Math.round((row.totalTime / imports[0].totalTime) * 100) }}%
           </td>
         </tr>

--- a/packages/ui/client/components/ModuleTransformResultView.vue
+++ b/packages/ui/client/components/ModuleTransformResultView.vue
@@ -208,9 +208,9 @@ onKeyStroke('Escape', () => {
 </script>
 
 <template>
-  <div w-350 max-w-screen h-full flex flex-col>
-    <div p-4 relative>
-      <div flex justify-between>
+  <div class="w-350 max-w-screen h-full flex flex-col">
+    <div class="p-4 relative">
+      <div class="flex justify-between">
         <p>
           <IconButton
             v-if="canUndo"
@@ -220,8 +220,8 @@ onKeyStroke('Escape', () => {
             @click="goBack()"
           />
           Module Info
-          <VueTooltip class="inline" cursor-help>
-            <Badge type="custom" ml-1 :style="{ backgroundColor: `var(--color-node-${type})` }">
+          <VueTooltip class="inline cursor-help">
+            <Badge type="custom" class="ml-1" :style="{ backgroundColor: `var(--color-node-${type})` }">
               {{ type }}
             </Badge>
             <template #popper>
@@ -234,16 +234,16 @@ onKeyStroke('Escape', () => {
               </template>
             </template>
           </VueTooltip>
-          <VueTooltip v-if="isCached === true" class="inline" cursor-help>
-            <Badge type="tip" ml-2>
+          <VueTooltip v-if="isCached === true" class="inline cursor-help">
+            <Badge type="tip" class="ml-2">
               cached
             </Badge>
             <template #popper>
               This module is cached on the file system under `fsModuleCachePath` ("node_modules/.vitest-cache" by default).
             </template>
           </VueTooltip>
-          <VueTooltip v-if="isCached === false" class="inline" cursor-help>
-            <Badge type="warning" ml-2>
+          <VueTooltip v-if="isCached === false" class="inline cursor-help">
+            <Badge type="warning" class="ml-2">
               not cached
             </Badge>
             <template #popper>
@@ -252,8 +252,8 @@ onKeyStroke('Escape', () => {
             </template>
           </VueTooltip>
         </p>
-        <div mr-8 flex gap-2 items-center>
-          <VueTooltip v-if="durations.selfTime != null && durations.external !== true" class="inline" cursor-help>
+        <div class="mr-8 flex gap-2 items-center">
+          <VueTooltip v-if="durations.selfTime != null && durations.external !== true" class="inline cursor-help">
             <Badge :type="getImportDurationType(durations.selfTime)">
               self: {{ formatTime(durations.selfTime) }}
             </Badge>
@@ -261,7 +261,7 @@ onKeyStroke('Escape', () => {
               It took {{ formatPreciseTime(durations.selfTime) }} to import this module, excluding static imports.
             </template>
           </VueTooltip>
-          <VueTooltip v-if="durations.totalTime != null" class="inline" cursor-help>
+          <VueTooltip v-if="durations.totalTime != null" class="inline cursor-help">
             <Badge :type="getImportDurationType(durations.totalTime)">
               total: {{ formatTime(durations.totalTime) }}
             </Badge>
@@ -269,7 +269,7 @@ onKeyStroke('Escape', () => {
               It took {{ formatPreciseTime(durations.totalTime) }} to import the whole module, including static imports.
             </template>
           </VueTooltip>
-          <VueTooltip v-if="result && 'transformTime' in result && result.transformTime" class="inline" cursor-help>
+          <VueTooltip v-if="result && 'transformTime' in result && result.transformTime" class="inline cursor-help">
             <Badge :type="getImportDurationType(result.transformTime)">
               transform: {{ formatTime(result.transformTime) }}
             </Badge>
@@ -279,32 +279,29 @@ onKeyStroke('Escape', () => {
           </VueTooltip>
         </div>
       </div>
-      <p op50 font-mono text-sm>
+      <p class="op50 font-mono text-sm">
         {{ id }}
       </p>
       <IconButton
         icon="i-carbon-close"
-        absolute
-        top-5px
-        right-5px
-        text-2xl
+        class="absolute top-5px right-5px text-2xl"
         @click="emit('close')"
       />
     </div>
-    <div v-if="!result" p-5>
+    <div v-if="!result" class="p-5">
       No transform result found for this module.
     </div>
     <template v-else>
-      <div grid="~ rows-[min-content_auto]" overflow-hidden flex-auto :class="{ 'cols-2': code != null }">
-        <div p="x3 y-1" bg-overlay border="base b t r">
+      <div class="grid grid-rows-[min-content_auto] overflow-hidden flex-auto" :class="{ 'cols-2': code != null }">
+        <div class="px-3 py-1 bg-overlay border-base border-b border-t border-r">
           Source
         </div>
-        <div v-if="code != null" p="x3 y-1" bg-overlay border="base b t">
+        <div v-if="code != null" class="px-3 py-1 bg-overlay border-base border-b border-t">
           Transformed
         </div>
         <CodeMirrorContainer
           :key="id"
-          h-full
+          class="h-full"
           :model-value="source"
           read-only
           :options="{ lineNumbers: true }"
@@ -313,7 +310,7 @@ onKeyStroke('Escape', () => {
         />
         <CodeMirrorContainer
           v-if="code != null"
-          h-full
+          class="h-full"
           :model-value="code"
           read-only
           :options="{ lineNumbers: true }"
@@ -321,7 +318,7 @@ onKeyStroke('Escape', () => {
         />
       </div>
       <div v-if="sourceMap.mappings !== ''">
-        <div p="x3 y-1" bg-overlay border="base b t">
+        <div class="px-3 py-1 bg-overlay border-base border-b border-t">
           Source map (v{{ sourceMap.version }})
         </div>
         <CodeMirrorContainer

--- a/packages/ui/client/components/Navigation.vue
+++ b/packages/ui/client/components/Navigation.vue
@@ -68,10 +68,10 @@ function getRerunTooltip(filteredFiles: RunnerTestFile[] | undefined) {
 
 <template>
   <!-- TODO: have test tree so the folders are also nested: test -> filename -> suite -> test -->
-  <Explorer border="r base" :on-item-click="clickOnTask" :nested="true" @run="onRunAll">
+  <Explorer class="border-r border-base" :on-item-click="clickOnTask" :nested="true" @run="onRunAll">
     <template #header="{ filteredFiles }">
-      <img w-6 h-6 :src="logoUrl" alt="Vitest logo">
-      <span font-light text-sm flex-1>Vitest</span>
+      <img class="w-6 h-6" :src="logoUrl" alt="Vitest logo">
+      <span class="font-light text-sm flex-1">Vitest</span>
       <div class="flex text-lg">
         <IconButton
           v-show="!shouldShowExpandAll"
@@ -95,8 +95,7 @@ function getRerunTooltip(filteredFiles: RunnerTestFile[] | undefined) {
           v-show="(coverageConfigured && !coverageEnabled) || !dashboardVisible"
           v-tooltip.bottom="'Dashboard'"
           title="Show dashboard"
-          class="!animate-100ms"
-          animate-count-1
+          class="!animate-100ms animate-count-1"
           icon="i-carbon:dashboard"
           @click="showDashboard(true)"
         />
@@ -107,7 +106,7 @@ function getRerunTooltip(filteredFiles: RunnerTestFile[] | undefined) {
         >
           <div class="i-carbon:folder-off ma" />
           <template #popper>
-            <div class="op100 gap-1 p-y-1" grid="~ items-center cols-[1.5em_1fr]">
+            <div class="op100 gap-1 py-1 grid items-center grid-cols-[1.5em_1fr]">
               <div class="i-carbon:information-square w-1.5em h-1.5em" />
               <div>Coverage enabled but missing html reporter.</div>
               <div style="grid-column: 2">
@@ -122,8 +121,7 @@ function getRerunTooltip(filteredFiles: RunnerTestFile[] | undefined) {
           v-tooltip.bottom="'Coverage'"
           :disabled="disableCoverage"
           title="Show coverage"
-          class="!animate-100ms"
-          animate-count-1
+          class="!animate-100ms animate-count-1"
           icon="i-carbon:folder-details-reference"
           @click="showCoverage()"
         />

--- a/packages/ui/client/components/ProgressBar.vue
+++ b/packages/ui/client/components/ProgressBar.vue
@@ -32,48 +32,29 @@ const widthPending = computed(() => {
 
 <template>
   <div
-    absolute
-    t-0
-    l-0
-    r-0
-    z-index-1031
-    pointer-events-none
-    p-0
-    h-3px
-    grid="~ auto-cols-max"
-    justify-items-center
-    w-screen
+    class="absolute pointer-events-none p-0 h-3px grid auto-cols-max justify-items-center w-screen"
     :class="classes"
   >
-    <div h-3px relative overflow-hidden class="px-0" w-screen>
+    <div class="px-0 h-3px relative overflow-hidden w-screen">
       <div
-        absolute
-        l-0
-        t-0
-        bg-red-700 dark:bg-red-500
-        h-3px
+        class="absolute bg-red-700 dark:bg-red-500 h-3px"
+
         :class="classes"
         :style="`width: ${widthFailed}px;`"
       >
         &#160;
       </div>
       <div
-        absolute
-        l-0
-        t-0
-        bg-green-700 dark:bg-green-500
-        h-3px
+        class="absolute bg-green-700 dark:bg-green-500 h-3px"
+
         :class="classes"
         :style="`left: ${widthFailed}px; width: ${widthPass}px;`"
       >
         &#160;
       </div>
       <div
-        absolute
-        l-0
-        t-0
-        bg-yellow-700 dark:bg-yellow-500
-        h-3px
+        class="absolute bg-yellow-700 dark:bg-yellow-500 h-3px"
+
         :class="classes"
         :style="`left: ${widthPass + widthFailed}px; width: ${widthPending}px;`"
       >

--- a/packages/ui/client/components/ResultsPanel.vue
+++ b/packages/ui/client/components/ResultsPanel.vue
@@ -16,22 +16,12 @@ const open = ref(true)
     @toggle="open = ($event.target as any).open"
   >
     <div
-      p="y1"
-      text-sm
-      bg-base
-      items-center
-      z-5
-      gap-2
+      class="py-1 text-sm bg-base items-center z-5 gap-2 w-full flex select-none sticky -top-1"
       :class="color"
-      w-full
-      flex
-      select-none
-      sticky
-      top="-1"
     >
-      <div flex-1 h-1px border="base b" op80 />
+      <div class="flex-1 h-1px border-base border-b op80" />
       <slot name="summary" :open="open" />
-      <div flex-1 h-1px border="base b" op80 />
+      <div class="flex-1 h-1px border-base border-b op80" />
     </div>
     <slot />
   </div>

--- a/packages/ui/client/components/StatusIcon.vue
+++ b/packages/ui/client/components/StatusIcon.vue
@@ -12,48 +12,34 @@ defineProps<{
   <div
     v-if="state === 'pass'"
     data-testid="status-icon-pass"
-    text-green-700 dark:text-green-500
-    flex-shrink-0
-    i-carbon:checkmark
+    class="text-green-700 dark:text-green-500 flex-shrink-0 i-carbon:checkmark"
   />
   <div
     v-else-if="failedSnapshot"
     v-tooltip.right="'Contains failed snapshot'"
     data-testid="status-icon-failed-snapshot"
-    text-red-700 dark:text-red-500
-    flex-shrink-0
-    i-carbon:compare
+    class="text-red-700 dark:text-red-500 flex-shrink-0 i-carbon:compare"
   />
   <div
     v-else-if="state === 'fail'"
     data-testid="status-icon-fail"
-    text-red-700 dark:text-red-500
-    flex-shrink-0
-    i-carbon:close
+    class="text-red-700 dark:text-red-500 flex-shrink-0 i-carbon:close"
   />
   <div
     v-else-if="mode === 'todo'"
     v-tooltip.right="'Todo'"
     data-testid="status-icon-todo"
-    text-gray-500
-    flex-shrink-0
-    i-carbon:document-blank
+    class="text-gray-500 flex-shrink-0 i-carbon:document-blank"
   />
   <div
     v-else-if="mode === 'skip' || state === 'skip'"
     v-tooltip.right="'Skipped'"
     data-testid="status-icon-skip"
-    text-gray-500
-    flex-shrink-0
-    i-carbon:redo
-    rotate-90
+    class="text-gray-500 flex-shrink-0 i-carbon:redo rotate-90"
   />
   <div
     v-else
     data-testid="status-icon-running"
-    text-yellow-700 dark:text-yellow-500
-    flex-shrink-0
-    i-carbon:circle-dash
-    animate-spin
+    class="text-yellow-700 dark:text-yellow-500 flex-shrink-0 i-carbon:circle-dash animate-spin"
   />
 </template>

--- a/packages/ui/client/components/artifacts/Artifacts.vue
+++ b/packages/ui/client/components/artifacts/Artifacts.vue
@@ -45,35 +45,29 @@ const handledArtifacts = computed<readonly HandledArtifact[]>(() => {
   <TraceArtifacts :test="test" />
 
   <template v-if="handledArtifacts.length">
-    <h1 m-2>
+    <h1 class="m-2">
       Test Artifacts
     </h1>
     <div
       v-for="{ artifact, component, props }, index of handledArtifacts"
       :key="artifact.type + index"
-      bg="yellow-500/10"
-      text="yellow-500 sm"
-      p="x3 y2"
-      m-2
-      rounded
+      class="bg-yellow-500/10 text-sm text-yellow-500 px-3 py-2 m-2 rounded"
       role="note"
     >
-      <div flex="~ gap-2 items-center justify-between" overflow-hidden>
+      <div class="flex gap-2 items-center justify-between overflow-hidden">
         <div>
           <span
             v-if="artifact.location && artifact.location.file === test.file.filepath"
             v-tooltip.bottom="'Open in Editor'"
             title="Open in Editor"
-            class="flex gap-1 text-yellow-500/80 cursor-pointer"
-            ws-nowrap
+            class="flex gap-1 text-yellow-500/80 cursor-pointer ws-nowrap"
             @click="openLocation(test, artifact.location)"
           >
             {{ getLocationString(artifact.location) }}
           </span>
           <span
             v-else-if="artifact.location && artifact.location.file !== test.file.filepath"
-            class="flex gap-1 text-yellow-500/80"
-            ws-nowrap
+            class="flex gap-1 text-yellow-500/80 ws-nowrap"
           >
             {{ getLocationString(artifact.location) }}
           </span>

--- a/packages/ui/client/components/dashboard/DashboardEntry.vue
+++ b/packages/ui/client/components/dashboard/DashboardEntry.vue
@@ -3,12 +3,12 @@
 </script>
 
 <template>
-  <div p-2 text-center flex>
+  <div class="p-2 text-center flex">
     <div>
-      <div text-4xl min-w-2em>
+      <div class="text-4xl min-w-2em">
         <slot name="body" />
       </div>
-      <div text-md>
+      <div>
         <slot name="header" />
       </div>
     </div>

--- a/packages/ui/client/components/dashboard/ErrorEntry.vue
+++ b/packages/ui/client/components/dashboard/ErrorEntry.vue
@@ -7,20 +7,20 @@ defineProps<{
 </script>
 
 <template>
-  <h4 bg="red500/10" p-1 mb-1 mt-2 rounded>
-    <span font-bold>
+  <h4 class="bg-red500/10 p-1 mb-1 mt-2 rounded">
+    <span class="font-bold">
       {{ error.name || error.nameStr || 'Unknown Error' }}<template v-if="error.message">:</template>
     </span>
     {{ error.message }}
   </h4>
-  <p v-if="error.stacks?.length" class="scrolls" text="xs" font-mono mx-1 my-2 pb-2 overflow-auto>
-    <span v-for="(frame, i) in error.stacks" :key="i" whitespace-pre :font-bold="i === 0 ? '' : null">❯ {{ frame.method }} {{ frame.file }}:<span text="red500/70">{{ frame.line }}:{{ frame.column }}</span><br></span>
+  <p v-if="error.stacks?.length" class="scrolls text-xs font-mono mx-1 my-2 pb-2 overflow-auto">
+    <span v-for="(frame, i) in error.stacks" :key="i" class="whitespace-pre" :class="{ 'font-bold': i === 0 }">❯ {{ frame.method }} {{ frame.file }}:<span class="text-red500/70">{{ frame.line }}:{{ frame.column }}</span><br></span>
   </p>
-  <p v-if="error.VITEST_TEST_PATH" text="sm" mb-2>
-    This error originated in <span font-bold>{{ error.VITEST_TEST_PATH }}</span> test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
+  <p v-if="error.VITEST_TEST_PATH" class="text-sm mb-2">
+    This error originated in <span class="font-bold">{{ error.VITEST_TEST_PATH }}</span> test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
   </p>
-  <div v-if="error.VITEST_TEST_NAME" text="sm" mb-2>
-    The last test to run before this error was "<span font-bold>{{ error.VITEST_TEST_NAME }}</span>. This means either:<br>
+  <div v-if="error.VITEST_TEST_NAME" class="text-sm mb-2">
+    The last test to run before this error was "<span class="font-bold">{{ error.VITEST_TEST_NAME }}</span>. This means either:<br>
     <ul>
       <li>
         The error was thrown while Vitest was running this test

--- a/packages/ui/client/components/dashboard/TestFilesEntry.vue
+++ b/packages/ui/client/components/dashboard/TestFilesEntry.vue
@@ -7,23 +7,16 @@ import ErrorEntry from './ErrorEntry.vue'
 <template>
   <div
     data-testid="test-files-entry"
-    grid="~ cols-[min-content_1fr_min-content]"
-    items-center
-    gap="x-2 y-3"
-    p="x4"
-    relative
-    font-light
-    w-80
-    op80
+    class="grid grid-cols-[min-content_1fr_min-content] items-center gap-x-2 gap-y-3 px-4 relative font-light w-80 op80"
   >
-    <div i-carbon-document />
+    <div class="i-carbon-document" />
     <div>Files</div>
     <div class="number" data-testid="num-files">
       {{ explorerTree.summary.files }}
     </div>
 
     <template v-if="explorerTree.summary.filesSuccess">
-      <div i-carbon-checkmark />
+      <div class="i-carbon-checkmark" />
       <div>Pass</div>
       <div class="number">
         {{ explorerTree.summary.filesSuccess }}
@@ -31,70 +24,65 @@ import ErrorEntry from './ErrorEntry.vue'
     </template>
 
     <template v-if="explorerTree.summary.filesSkipped">
-      <div i-carbon:redo rotate-90 />
+      <div class="i-carbon:redo rotate-90" />
       <div>
         Skip
       </div>
-      <div class="number" text-purple-700 dark:text-purple-400>
+      <div class="number text-purple-700 dark:text-purple-400">
         {{ explorerTree.summary.filesSkipped }}
       </div>
     </template>
 
     <template v-if="explorerTree.summary.filesFailed">
-      <div i-carbon-close />
+      <div class="i-carbon-close" />
       <div>
         Fail
       </div>
-      <div class="number" text-red-700 dark:text-red-500>
+      <div class="number text-red-700 dark:text-red-500">
         {{ explorerTree.summary.filesFailed }}
       </div>
     </template>
 
     <template v-if="explorerTree.summary.filesSnapshotFailed">
-      <div i-carbon-compare />
+      <div class="i-carbon-compare" />
       <div>
         Snapshot Fail
       </div>
-      <div class="number" text-red-700 dark:text-red-500>
+      <div class="number text-red-700 dark:text-red-500">
         {{ explorerTree.summary.filesSnapshotFailed }}
       </div>
     </template>
 
     <template v-if="unhandledErrors.length">
-      <div i-carbon-checkmark-outline-error />
+      <div class="i-carbon-checkmark-outline-error" />
       <div>
         Errors
       </div>
-      <div class="number" text-red-700 dark:text-red-500>
+      <div class="number text-red-700 dark:text-red-500">
         {{ unhandledErrors.length }}
       </div>
     </template>
 
-    <div i-carbon-timer />
+    <div class="i-carbon-timer" />
     <div>Time</div>
     <div class="number" data-testid="run-time">
       {{ explorerTree.summary.time }}
     </div>
   </div>
   <template v-if="unhandledErrors.length">
-    <div bg="red500/10" text="red500" p="x3 y2" max-w-xl m-2 rounded>
-      <h3 text-center mb-2>
+    <div class="bg-red500/10 text-red500 px-3 py-2 max-w-xl m-2 rounded">
+      <h3 class="text-center mb-2">
         Unhandled Errors
       </h3>
-      <p text="sm" font-thin mb-2 data-testid="unhandled-errors">
+      <p class="text-sm font-thin mb-2" data-testid="unhandled-errors">
         Vitest caught {{ unhandledErrors.length }} error{{ unhandledErrors.length > 1 ? 's' : '' }} during the test run.<br>
         This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
       </p>
       <details
         data-testid="unhandled-errors-details"
-        class="scrolls unhandled-errors"
-        text="sm"
-        font-thin
-        pe-2.5
-        open:max-h-52
-        overflow-auto
+        class="scrolls unhandled-errors text-sm font-thin pe-2.5 open:max-h-52 overflow-auto"
       >
-        <summary font-bold cursor-pointer>
+        <summary class="font-bold cursor-pointer">
           Errors
         </summary>
         <ErrorEntry v-for="(e, idx) in unhandledErrors" :key="idx" :error="e" />

--- a/packages/ui/client/components/dashboard/TestsEntry.vue
+++ b/packages/ui/client/components/dashboard/TestsEntry.vue
@@ -19,12 +19,10 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
 </script>
 
 <template>
-  <div flex="~ wrap" justify-evenly gap-2 p="x-4" relative data-testid="tests-entry">
+  <div class="flex flex-wrap justify-evenly gap-2 px-4 relative" data-testid="tests-entry">
     <DashboardEntry
-      text-green-700 dark:text-green-500
+      class="text-green-700 dark:text-green-500 cursor-pointer hover:op80"
       data-testid="pass-entry"
-      cursor-pointer
-      hover="op80"
       @click="toggleFilter('success')"
     >
       <template #header>
@@ -37,8 +35,7 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
     <DashboardEntry
       :class="{ 'text-red-700 dark:text-red-500': explorerTree.summary.testsFailed, 'op50': !explorerTree.summary.testsFailed }"
       data-testid="fail-entry"
-      cursor-pointer
-      hover="op80"
+      class="cursor-pointer hover:op80"
       @click="toggleFilter('failed')"
     >
       <template #header>
@@ -50,7 +47,7 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
     </DashboardEntry>
     <DashboardEntry
       v-if="explorerTree.summary.testsExpectedFail"
-      text-cyan-700 dark:text-cyan-500
+      class="text-cyan-700 dark:text-cyan-500"
       data-testid="expected-fail-entry"
     >
       <template #header>
@@ -62,10 +59,8 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
     </DashboardEntry>
     <DashboardEntry
       v-if="explorerTree.summary.testsSkipped"
-      text-purple-700 dark:text-purple-400
+      class="text-purple-700 dark:text-purple-400 cursor-pointer hover:op80"
       data-testid="skipped-entry"
-      cursor-pointer
-      hover="op80"
       @click="toggleFilter('skipped')"
     >
       <template #header>
@@ -77,7 +72,7 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
     </DashboardEntry>
     <DashboardEntry
       v-if="explorerTree.summary.testsTodo"
-      op50
+      class="op50"
       data-testid="todo-entry"
     >
       <template #header>
@@ -90,8 +85,7 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
     <DashboardEntry
       :tail="true"
       data-testid="total-entry"
-      cursor-pointer
-      hover="op80"
+      class="cursor-pointer hover:op80"
       @click="toggleFilter('total')"
     >
       <template #header>
@@ -103,10 +97,8 @@ function toggleFilter(type: 'success' | 'failed' | 'skipped' | 'slow' | 'total')
     </DashboardEntry>
     <DashboardEntry
       v-if="explorerTree.summary.testsSlow"
-      text-yellow-700 dark:text-yellow-500
+      class="text-yellow-700 dark:text-yellow-500 cursor-pointer hover:op80"
       data-testid="slow-entry"
-      cursor-pointer
-      hover="op80"
       @click="toggleFilter('slow')"
     >
       <template #header>

--- a/packages/ui/client/components/dashboard/TestsFilesContainer.vue
+++ b/packages/ui/client/components/dashboard/TestsFilesContainer.vue
@@ -6,13 +6,13 @@ import TestsEntry from './TestsEntry.vue'
 </script>
 
 <template>
-  <div gap-0 flex="~ col gap-4" h-full justify-center items-center>
+  <div class="flex flex-col gap-4 h-full justify-center items-center">
     <template v-if="explorerTree.summary.files === 0 && finished">
       <div class="text-gray-5">
         No tests found
       </div>
     </template>
-    <section aria-labelledby="tests" m="y-4 x-2">
+    <section aria-labelledby="tests" class="my-4 mx-2">
       <TestsEntry />
     </section>
     <TestFilesEntry />

--- a/packages/ui/client/components/explorer/Explorer.vue
+++ b/packages/ui/client/components/explorer/Explorer.vue
@@ -65,21 +65,17 @@ const {
 </script>
 
 <template>
-  <div h="full" flex="~ col">
+  <div class="h-full flex flex-col">
     <div>
-      <div p="2" h-10 flex="~ gap-2" items-center bg-header border="b base">
+      <div class="p-2 h-10 flex gap-2 items-center bg-header border-b border-base">
         <slot name="header" :filtered-files="isFiltered || isFilteredByStatus ? filteredFiles : undefined" />
       </div>
       <div
         v-if="enableProjects"
-        p="l3 y2 r2"
-        bg-header
-        border="b-2 base"
-        grid="~ cols-[auto_auto_minmax(0,1fr)_auto] gap-x-2 gap-y-1"
-        items-center
+        class="pl-3 py-2 pr-2 bg-header border-base border-b-2 grid grid-cols-[auto_auto_minmax(0,1fr)_auto] gap-x-2 gap-y-1 items-center"
       >
-        <div class="i-carbon:workspace" flex-shrink-0 />
-        <label for="project-select" text-sm>
+        <div class="i-carbon:workspace flex-shrink-0" />
+        <label for="project-select" class="text-sm">
           Projects
         </label>
         <div class="relative flex-1">
@@ -87,18 +83,7 @@ const {
             id="project-select"
             ref="selectProjectRef"
             v-model="currentProject"
-            w-full
-            appearance-none
-            bg-base
-            text-base
-            border="~ base rounded"
-            pl-2
-            pr-8
-            py-1
-            text-sm
-            cursor-pointer
-            hover:bg-active
-            class="outline-none"
+            class="outline-none w-full appearance-none bg-base text-base border-base border rounded pl-2 pr-8 py-1 text-sm cursor-pointer hover:bg-active"
           >
             <option :value="ALL_PROJECTS" class="text-base bg-base">
               All Projects
@@ -124,14 +109,10 @@ const {
         />
       </div>
       <div
-        p="l3 y2 r2"
-        bg-header
-        border="b-2 base"
-        grid="~ cols-[auto_auto_minmax(0,1fr)_auto] gap-x-2"
-        items-center
+        class="pl-3 py-2 pr-2 bg-header border-base border-b-2 grid grid-cols-[auto_auto_minmax(0,1fr)_auto] gap-x-2 items-center"
       >
-        <div class="i-carbon:arrows-vertical" flex-shrink-0 />
-        <label for="project-sort" text-sm>
+        <div class="i-carbon:arrows-vertical flex-shrink-0" />
+        <label for="project-sort" class="text-sm">
           Sort by
         </label>
         <div class="relative flex-1">
@@ -139,18 +120,7 @@ const {
             id="project-sort"
             ref="sortProjectRef"
             v-model="projectSort"
-            w-full
-            appearance-none
-            bg-base
-            text-base
-            border="~ base rounded"
-            pl-2
-            pr-8
-            py-1
-            text-sm
-            cursor-pointer
-            hover:bg-active
-            class="outline-none"
+            class="outline-none w-full appearance-none bg-base text-base border-base border rounded pl-2 pr-8 py-1 text-sm cursor-pointer hover:bg-active"
           >
             <option value="default" class="text-base bg-base">
               Default
@@ -179,24 +149,15 @@ const {
         />
       </div>
       <div
-        p="l3 y2 r2"
-        flex="~ gap-2"
-        items-center
-        bg-header
-        border="b-2 base"
+        class="pl-3 py-2 pr-2 flex gap-2 items-center bg-header border-base border-b-2"
       >
-        <div class="i-carbon:search" flex-shrink-0 />
+        <div class="i-carbon:search flex-shrink-0" />
         <input
           ref="searchBox"
           v-model="search"
           placeholder="Search... (e.g. test name, tag:expression)"
-          outline="none"
-          bg="transparent"
-          font="light"
-          text="sm"
-          flex-1
-          pl-1
-          :op="search.length ? '100' : '50'"
+          class="outline-none bg-transparent font-light text-sm flex-1 pl-1"
+          :class="search.length ? 'op100' : 'op50'"
           @keydown.esc="clearSearch(false)"
           @keydown.enter="emit('run', isFiltered || isFilteredByStatus ? filteredFiles : undefined)"
         >
@@ -209,15 +170,11 @@ const {
         />
       </div>
       <div
-        p="l3 y2 r2"
-        items-center
-        bg-header
-        border="b-2 base"
-        flex="~ wrap gap-x-4 justify-between"
+        class="pl-3 py-2 pr-2 items-center bg-header border-base border-b-2 flex flex-wrap justify-between gap-x-4"
       >
-        <div min-w-full flex="~ gap-2 items-center">
-          <div aria-hidden="true" class="i-carbon:filter" flex-shrink-0 />
-          <div flex-grow-1 text-sm>
+        <div class="min-w-full flex gap-2 items-center">
+          <div aria-hidden="true" class="i-carbon:filter flex-shrink-0" />
+          <div class="flex-grow-1 text-sm">
             Filter
           </div>
           <IconButton
@@ -235,8 +192,8 @@ const {
         <FilterStatus v-model="filter.slow" :label="`Slow${slowTime}`" />
       </div>
     </div>
-    <div flex-auto py-1 overflow-hidden>
-      <ResultsPanel h-full flex="~ col">
+    <div class="flex-auto py-1 overflow-hidden">
+      <ResultsPanel class="h-full flex flex-col">
         <template v-if="initialized" #summary>
           <div
             data-testid="explorer-summary"
@@ -245,14 +202,14 @@ const {
               ? 'flex'
               : 'grid grid-cols-[auto_min-content_auto] grid-rows-[min-content_min-content]'"
           >
-            <span text-red-700 dark:text-red-500>
+            <span class="text-red-700 dark:text-red-500">
               FAIL ({{ testsTotal.failed }})
             </span>
             <span>/</span>
-            <span v-if="!isReport" text-yellow-700 dark:text-yellow-500>
+            <span v-if="!isReport" class="text-yellow-700 dark:text-yellow-500">
               RUNNING ({{ testsTotal.running }})
             </span>
-            <span text-green-700 dark:text-green-500>
+            <span class="text-green-700 dark:text-green-500">
               PASS ({{ testsTotal.success }})
             </span>
             <span>/</span>
@@ -263,21 +220,16 @@ const {
         </template>
         <!-- empty-state -->
         <template v-if="(isFiltered || isFilteredByStatus || !!currentProjectName) && uiEntries.length === 0">
-          <div v-if="initialized" flex="~ col" items-center p="x4 y4" font-light>
-            <div v-if="searchMatcher.error" text-red text-center>
+          <div v-if="initialized" class="flex flex-col items-center px-4 py-4 font-light">
+            <div v-if="searchMatcher.error" class="text-red text-center">
               {{ searchMatcher.error }}
             </div>
-            <div v-else op30>
+            <div v-else class="op30">
               No matched test
             </div>
             <button
               type="button"
-              font-light
-              text-sm
-              border="~ gray-400/50 rounded"
-              p="x2 y0.5"
-              m="t2"
-              op="50"
+              class="font-light text-sm border rounded border-gray-400/50 px-2 py-0.5 mt-2 op-50"
               :class="disableClearSearch ? null : 'hover:op100'"
               :disabled="disableClearSearch"
               @click.passive="clearSearch(true)"
@@ -286,12 +238,7 @@ const {
             </button>
             <button
               type="button"
-              font-light
-              text-sm
-              border="~ gray-400/50 rounded"
-              p="x2 y0.5"
-              m="t2"
-              op="50"
+              class="font-light text-sm border rounded border-gray-400/50 px-2 py-0.5 mt-2 op-50"
               :class="disableFilter ? null : 'hover:op100'"
               :disabled="disableFilter"
               @click.passive="clearFilter(true)"
@@ -300,28 +247,22 @@ const {
             </button>
             <button
               type="button"
-              font-light
-              op="50 hover:100"
-              text-sm
-              border="~ gray-400/50 rounded"
-              p="x2 y0.5"
-              m="t2"
+              class="font-light op-50 hover:op-100 text-sm border rounded border-gray-400/50 px-2 py-0.5 mt-2"
               @click.passive="clearAll"
             >
               Clear All
             </button>
           </div>
-          <div v-else flex="~ col" items-center p="x4 y4" font-light>
+          <div v-else class="flex flex-col items-center px-4 py-4 font-light">
             <div class="i-carbon:circle-dash animate-spin" />
-            <div op30>
+            <div class="op30">
               Loading...
             </div>
           </div>
         </template>
         <template v-else>
           <RecycleScroller
-            class="scrolls"
-            flex-auto
+            class="scrolls flex-auto"
             key-field="id"
             :item-size="28"
             :items="uiEntries"

--- a/packages/ui/client/components/explorer/ExplorerItem.vue
+++ b/packages/ui/client/components/explorer/ExplorerItem.vue
@@ -185,15 +185,7 @@ const tagsBgGradient = computed(() => {
 <template>
   <div
     v-if="task"
-    items-center
-    p="x-2 y-1"
-    grid="~ rows-1 items-center gap-x-2"
-    w-full
-    h-28px
-    border-rounded
-    hover="bg-active"
-    cursor-pointer
-    class="item-wrapper"
+    class="item-wrapper items-center py-1 px-2 grid gap-x-2 grid-rows-1 w-full h-28px rounded hover:bg-active cursor-pointer"
     :style="gridStyles"
     :aria-label="name"
     :data-current="current"
@@ -214,11 +206,11 @@ const tagsBgGradient = computed(() => {
         <div class="op40" :class="opened ? 'i-carbon:chevron-down' : 'i-carbon:chevron-right'" />
       </button>
     </div>
-    <StatusIcon :state="state" :mode="task.mode" :failed-snapshot="failedSnapshot" w-4 />
-    <div flex items-baseline gap-2 overflow-hidden>
-      <div v-if="type === 'file' && typecheck" v-tooltip.bottom="'This is a typecheck test. It won\'t report results of the runtime tests'" class="i-logos:typescript-icon" flex-shrink-0 />
-      <span v-if="type === 'file' && label" class="rounded-sm px-1 text-xs font-light bg-cyan-500/20 text-cyan-700 dark:text-cyan-300" flex-shrink-0>{{ label }}</span>
-      <span text-sm truncate font-light>
+    <StatusIcon :state="state" :mode="task.mode" :failed-snapshot="failedSnapshot" class="w-4" />
+    <div class="flex items-baseline gap-2 overflow-hidden">
+      <div v-if="type === 'file' && typecheck" v-tooltip.bottom="'This is a typecheck test. It won\'t report results of the runtime tests'" class="i-logos:typescript-icon flex-shrink-0" />
+      <span v-if="type === 'file' && label" class="rounded-sm px-1 text-xs font-light bg-cyan-500/20 text-cyan-700 dark:text-cyan-300 flex-shrink-0">{{ label }}</span>
+      <span class="text-sm truncate font-light">
         <span v-if="type === 'file' && projectName" class="rounded-full py-0.5 px-2 mr-1 text-xs" :style="projectBadgeStyle">
           {{ projectName }}
         </span>
@@ -226,14 +218,14 @@ const tagsBgGradient = computed(() => {
       </span>
       <span
         v-if="typeof duration === 'number'"
-        text="xs"
+        class="text-xs"
         :class="slow ? 'text-yellow-700 dark:text-yellow-500' : 'op20'"
         style="white-space: nowrap"
       >
         {{ duration > 0 ? duration : '< 1' }}ms
       </span>
     </div>
-    <div gap-1 justify-end items-center flex-grow-1 pl-1 class="test-actions">
+    <div class="test-actions gap-1 justify-end items-center flex-grow-1 pl-1">
       <!-- <div
         v-if="tagsBorderGradient"
         text-xs
@@ -267,7 +259,7 @@ const tagsBgGradient = computed(() => {
           @click.prevent.stop="showDetails"
         />
         <template #popper>
-          <div v-if="disableShowDetails" class="op100 gap-1 p-y-1" grid="~ items-center cols-[1.5em_1fr]">
+          <div v-if="disableShowDetails" class="op100 gap-1 py-1 grid items-center grid-cols-[1.5em_1fr]">
             <div class="i-carbon:information-square w-1.5em h-1.5em" />
             <div>{{ showDetailsTooltip }}: this feature is not available, you have disabled <span class="text-[#add467]">includeTaskLocation</span> in your configuration file.</div>
             <div style="grid-column: 2">
@@ -285,7 +277,7 @@ const tagsBgGradient = computed(() => {
         data-testid="btn-run-test"
         :title="runButtonTitle"
         icon="i-carbon:play-filled-alt"
-        text-green-700 dark:text-green-500
+        class="text-green-700 dark:text-green-500"
         :disabled="config.api?.allowExec === false"
         @click.prevent.stop="onRun(task)"
       />

--- a/packages/ui/client/components/trace/TraceView.vue
+++ b/packages/ui/client/components/trace/TraceView.vue
@@ -198,9 +198,7 @@ function onSplitpanesResized({ panes }: SplitpanesResizedPayload) {
   >
     <Pane :size="traceViewSplitSizes[0]" min-size="20">
       <div
-        class="h-full min-h-0 p-4"
-        flex="~ col gap-1"
-        overflow-auto
+        class="h-full min-h-0 p-4 flex flex-col gap-1 overflow-auto"
         role="listbox"
         aria-label="Trace steps"
       >
@@ -238,7 +236,7 @@ function onSplitpanesResized({ panes }: SplitpanesResizedPayload) {
               />
             </span>
             <div class="min-w-0 flex-1">
-              <div truncate data-testid="trace-step-name">
+              <div class="truncate" data-testid="trace-step-name">
                 {{ formatStepName(step) }}
               </div>
               <div class="text-xs opacity-60 truncate">
@@ -256,7 +254,7 @@ function onSplitpanesResized({ panes }: SplitpanesResizedPayload) {
       </div>
     </Pane>
     <Pane :size="traceViewSplitSizes[1]" min-size="20">
-      <div class="h-full min-h-0" flex="~ col" overflow-auto>
+      <div class="h-full min-h-0 flex flex-col overflow-auto">
         <iframe
           v-if="selectedStep"
           ref="iframeEl"

--- a/packages/ui/client/components/trace/TraceViewPane.vue
+++ b/packages/ui/client/components/trace/TraceViewPane.vue
@@ -22,10 +22,10 @@ const selectedAttemptKey = computed({
 </script>
 
 <template>
-  <div data-testid="trace-view" h-full min-h-0 flex="~ col">
-    <div p="3" h-10 flex="~ gap-2" items-center bg-header border="b base">
+  <div data-testid="trace-view" class="h-full min-h-0 flex flex-col">
+    <div class="p-3 h-10 flex gap-2 items-center bg-header border-b border-base">
       <div class="i-carbon:data-vis-4" />
-      <span pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate>Trace Viewer</span>
+      <span class="pl-1 font-bold text-sm flex-auto ws-nowrap overflow-hidden truncate">Trace Viewer</span>
       <select
         v-if="traceAttempts.length > 1"
         v-model="selectedAttemptKey"

--- a/packages/ui/client/components/views/ScreenshotError.vue
+++ b/packages/ui/client/components/views/ScreenshotError.vue
@@ -15,32 +15,29 @@ onKeyStroke('Escape', () => {
 </script>
 
 <template>
-  <div w-350 max-w-screen h-full flex flex-col>
-    <div p-4 relative border="base b">
+  <div class="w-350 max-w-screen h-full flex flex-col">
+    <div class="p-4 relative border-base border-b">
       <p>Screenshot error</p>
-      <p op50 font-mono text-sm>
+      <p class="op50 font-mono text-sm">
         {{ file }}
       </p>
-      <p op50 font-mono text-sm>
+      <p class="op50 font-mono text-sm">
         {{ name }}
       </p>
       <IconButton
         icon="i-carbon:close"
         title="Close"
-        absolute
-        top-5px
-        right-5px
-        text-2xl
+        class="absolute top-5px right-5px text-2xl"
         @click="emit('close')"
       />
     </div>
 
-    <div class="scrolls" grid="~ cols-1 rows-[min-content]" p-4>
+    <div class="scrolls grid grid-cols-1 grid-rows-[min-content] p-4">
       <img
         v-if="url"
         :src="url"
         :alt="`Screenshot error for '${name}' test in file '${file}'`"
-        border="base t r b l dotted red-500"
+        class="border-base border-t border-r border-b border-dotted border-red-500 border-l"
       >
       <div v-else>
         Something was wrong, the image cannot be resolved.

--- a/packages/ui/client/components/views/ViewConsoleOutput.vue
+++ b/packages/ui/client/components/views/ViewConsoleOutput.vue
@@ -27,8 +27,8 @@ function getTaskName(id?: string) {
 </script>
 
 <template>
-  <div v-if="formattedLogs?.length" h-full class="scrolls" flex flex-col data-testid="logs">
-    <div v-for="{ taskId, type, time, content } of formattedLogs" :key="taskId" font-mono>
+  <div v-if="formattedLogs?.length" class="scrolls h-full flex flex-col" data-testid="logs">
+    <div v-for="{ taskId, type, time, content } of formattedLogs" :key="taskId" class="font-mono">
       <ViewConsoleOutputEntry
         :task-name="getTaskName(taskId)"
         :type="type"
@@ -37,7 +37,7 @@ function getTaskName(id?: string) {
       />
     </div>
   </div>
-  <div v-else p6>
-    Log something in your test and it would print here. (e.g. <pre inline>console.log(foo)</pre>)
+  <div v-else class="p6">
+    Log something in your test and it would print here. (e.g. <pre class="inline">console.log(foo)</pre>)
   </div>
 </template>

--- a/packages/ui/client/components/views/ViewConsoleOutputEntry.vue
+++ b/packages/ui/client/components/views/ViewConsoleOutputEntry.vue
@@ -14,10 +14,9 @@ function formatTime(t: number) {
 </script>
 
 <template>
-  <div border="b base" p-4>
+  <div class="border-b border-base p-4">
     <div
-      text-xs
-      mb-1
+      class="text-xs mb-1"
       :class="type === 'stderr' ? 'text-red-600 dark:text-red-300' : 'op30'"
     >
       {{ formatTime(time) }} | {{ taskName }} | {{ type }}

--- a/packages/ui/client/components/views/ViewEditor.vue
+++ b/packages/ui/client/components/views/ViewEditor.vue
@@ -460,7 +460,7 @@ onBeforeUnmount(clearListeners)
   <CodeMirrorContainer
     ref="editor"
     v-model="code"
-    h-full
+    class="h-full"
     :read-only="isReport || !config.api?.allowWrite"
     :saving="saving"
     :options="{

--- a/packages/ui/client/components/views/ViewModuleGraph.vue
+++ b/packages/ui/client/components/views/ViewModuleGraph.vue
@@ -410,13 +410,11 @@ function bindOnClick(
 </script>
 
 <template>
-  <div h-full min-h-75 flex-1 overflow="hidden">
+  <div class="h-full min-h-75 flex-1 overflow-hidden">
     <div>
-      <div flex items-center gap-2 px-3 py-2>
+      <div class="flex items-center gap-2 px-3 py-2">
         <div
-          flex="~ gap-1"
-          items-center
-          select-none
+          class="flex gap-1 items-center select-none"
         >
           <div class="pr-2">
             {{ filteredGraph.nodes.length }}/{{ graph.nodes.length }} {{ filteredGraph.nodes.length === 1 ? 'module' : 'modules' }}
@@ -427,23 +425,14 @@ function bindOnClick(
             type="checkbox"
           >
           <label
-            font-light
-            text-sm
-            ws-nowrap
-            overflow-hidden
-            select-none
-            truncate
+            class="font-light text-sm ws-nowrap overflow-hidden select-none truncate border-b-2 border-$cm-namespace"
             for="hide-node-modules"
-            border-b-2
-            border="$cm-namespace"
           >Hide node_modules</label>
         </div>
         <div
           v-for="node of controller?.nodeTypes.sort()"
           :key="node"
-          flex="~ gap-1"
-          items-center
-          select-none
+          class="flex gap-1 items-center select-none"
         >
           <input
             :id="`type-${node}`"
@@ -452,24 +441,14 @@ function bindOnClick(
             @change="setFilter(node, ($event as any).target.checked)"
           >
           <label
-            font-light
-            text-sm
-            ws-nowrap
-            overflow-hidden
-            capitalize
-            select-none
-            truncate
+            class="font-light text-sm ws-nowrap overflow-hidden capitalize select-none truncate border-b-2"
             :for="`type-${node}`"
-            border-b-2
             :style="{ 'border-color': `var(--color-node-${node})` }"
           >{{ node }} Modules</label>
         </div>
-        <div flex-auto />
+        <div class="flex-auto" />
         <div
-          flex="~ gap-2"
-          items-center
-          text-xs
-          opacity-60
+          class="flex gap-2 items-center text-xs opacity-60"
         >
           <span>Click on node: details • Right-click/Shift: expand graph</span>
         </div>

--- a/packages/ui/client/components/views/ViewReport.vue
+++ b/packages/ui/client/components/views/ViewReport.vue
@@ -48,20 +48,16 @@ const isFile = computed(() => 'filepath' in props.suite)
 </script>
 
 <template>
-  <div h-full class="scrolls">
+  <div class="scrolls h-full">
     <template v-if="failed.length">
       <div v-for="task of failed" :id="task.id" :key="task.id">
         <div
-          bg="red-500/10"
-          text="red-500 sm"
-          p="x3 y2"
-          m-2
-          rounded
+          class="bg-red-500/10 text-sm text-red-500 px-3 py-2 m-2 rounded"
           :style="{
             'margin-left': `${2 * (task as LeveledTask).level + 0.5}rem`,
           }"
         >
-          <div flex="~ gap-2 items-center">
+          <div class="flex gap-2 items-center">
             <span>{{ task.name }}</span>
             <FailureScreenshot :task="task" />
           </div>
@@ -79,7 +75,7 @@ const isFile = computed(() => 'filepath' in props.suite)
       </div>
     </template>
     <template v-else>
-      <div bg="green-500/10" text="green-500 sm" p="x4 y2" m-2 rounded>
+      <div class="bg-green-500/10 text-sm text-green-500 px-4 py-2 m-2 rounded">
         All tests passed in this {{ isFile ? 'file' : 'suite' }}
       </div>
     </template>

--- a/packages/ui/client/components/views/ViewTestReport.vue
+++ b/packages/ui/client/components/views/ViewTestReport.vue
@@ -35,14 +35,10 @@ const meta = computed(() => {
 </script>
 
 <template>
-  <div h-full class="scrolls">
+  <div class="scrolls h-full">
     <div v-if="failed">
       <div
-        bg="red-500/10"
-        text="red-500 sm"
-        p="x3 y2"
-        m-2
-        rounded
+        class="bg-red-500/10 text-sm text-red-500 px-3 py-2 m-2 rounded"
       >
         <FailureScreenshot :task="test" />
         <template v-if="test.result?.errors && config.root">
@@ -58,27 +54,23 @@ const meta = computed(() => {
       </div>
     </div>
     <template v-else>
-      <div bg="green-500/10" text="green-500 sm" p="x4 y2" m-2 rounded>
+      <div class="bg-green-500/10 text-sm text-green-500 px-4 py-2 m-2 rounded">
         The test has passed without any errors
       </div>
     </template>
     <template v-if="test.annotations.length">
-      <h1 m-2>
+      <h1 class="m-2">
         Test Annotations
       </h1>
       <div
         v-for="annotation of test.annotations"
         :key="annotation.type + annotation.message"
-        bg="yellow-500/10"
-        text="yellow-500 sm"
-        p="x3 y2"
-        m-2
-        rounded
+        class="bg-yellow-500/10 text-sm text-yellow-500 px-3 py-2 m-2 rounded"
         role="note"
       >
-        <div flex="~ gap-2 items-center justify-between" overflow-hidden>
-          <div class="flex gap-2" overflow-hidden>
-            <span class="font-bold" ws-nowrap truncate>{{ annotation.type }}</span>
+        <div class="flex gap-2 items-center justify-between overflow-hidden">
+          <div class="flex gap-2 overflow-hidden">
+            <span class="font-bold ws-nowrap truncate">{{ annotation.type }}</span>
             <button
               v-if="annotation.type === 'traces' && annotation.attachment"
               class="flex gap-1 items-center text-yellow-500/80 cursor-pointer"
@@ -104,16 +96,14 @@ const meta = computed(() => {
               v-if="annotation.location && annotation.location.file === test.file.filepath"
               v-tooltip.bottom="'Open in Editor'"
               title="Open in Editor"
-              class="flex gap-1 text-yellow-500/80 cursor-pointer"
-              ws-nowrap
+              class="flex gap-1 text-yellow-500/80 cursor-pointer ws-nowrap"
               @click="openLocation(test, annotation.location)"
             >
               {{ getLocationString(annotation.location) }}
             </span>
             <span
               v-else-if="annotation.location && annotation.location.file !== test.file.filepath"
-              class="flex gap-1 text-yellow-500/80"
-              ws-nowrap
+              class="flex gap-1 text-yellow-500/80 ws-nowrap"
             >
               {{ getLocationString(annotation.location) }}
             </span>
@@ -132,23 +122,17 @@ const meta = computed(() => {
     </template>
     <Artifacts :test="test" />
     <template v-if="meta.length">
-      <h1 m-2>
+      <h1 class="m-2">
         Test Meta
       </h1>
       <div
-        bg="gray/10"
-        text="black-100 sm"
-        p="x3 y2"
-        m-2
-        rounded
-        class="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-2"
-        overflow-hidden
+        class="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-2 bg-gray/10 text-sm px-3 py-2 m-2 rounded overflow-hidden"
       >
         <template v-for="([name, content]) of meta" :key="name">
-          <div font-bold ws-nowrap truncate py-2>
+          <div class="font-bold ws-nowrap truncate py-2">
             {{ name }}
           </div>
-          <pre overflow-auto bg="gray/30" rounded p-2>{{ content }}</pre>
+          <pre class="overflow-auto bg-gray/30 rounded p-2">{{ content }}</pre>
         </template>
       </div>
     </template>

--- a/packages/ui/client/pages/index.vue
+++ b/packages/ui/client/pages/index.vue
@@ -82,7 +82,7 @@ function allowBrowserEvents() {
 
 <template>
   <ProgressBar />
-  <div h-screen w-screen overflow="hidden">
+  <div class="h-screen w-screen overflow-hidden">
     <Splitpanes
       class="pt-4px"
       @resized="onMainResized"
@@ -102,8 +102,7 @@ function allowBrowserEvents() {
         </transition>
         <template v-else>
           <div
-            flex="~ col"
-            h-full
+            class="flex flex-col h-full"
           >
             <Splitpanes
               id="details-splitpanes"
@@ -136,7 +135,7 @@ function allowBrowserEvents() {
                 :size="detailSizes[1]"
                 min-size="10"
               >
-                <div h-full overflow-hidden>
+                <div class="h-full overflow-hidden">
                   <Dashboard v-if="dashboardVisible" key="summary" />
                   <Coverage
                     v-else-if="coverageVisible"

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import Vue from '@vitejs/plugin-vue'
 import { resolve } from 'pathe'
-import { presetAttributify, presetIcons, presetWind3, transformerDirectives } from 'unocss'
+import { presetIcons, presetWind3, transformerDirectives } from 'unocss'
 import Unocss from 'unocss/vite'
 import { defineConfig } from 'vite'
 import { resolveApiToken } from '../vitest/src/node/config/apiToken'
@@ -20,7 +20,7 @@ export default defineConfig({
   plugins: [
     Vue(),
     Unocss({
-      presets: [presetWind3(), presetAttributify(), presetIcons()],
+      presets: [presetWind3(), presetIcons()],
       content: {
         pipeline: {
           include: [


### PR DESCRIPTION
### Description

Vitest UI uses unocss `presetAttributify` https://unocss.dev/presets/attributify, but personally it has been difficult to skim styling logic vs non-styling logic. This PR proposes to use `class` form consistently and remove attributify.

Previously, the authoring was already inconsistent and stats looked like this:

```
Across 50 Vue files in packages/ui/client on the current branch:

   Style used in file                     Files    Share
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━  ━━━━━━━
   Both classes and utility attributes       30      60%
  ─────────────────────────────────────  ───────  ───────
   Classes only                              12      24%
  ─────────────────────────────────────  ───────  ───────
   Utility attributes only                    5      10%
  ─────────────────────────────────────  ───────  ───────
   Neither                                    3       6%

  72 elements mix both styles on the same tag. Attribute styling appears in 35 files overall.
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] Please, don't make changes to `pnpm-lock.yaml` unless you introduce a new test example.
- [ ] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests
- [ ] Run the tests with `pnpm test:ci`.

### Documentation
- [ ] If you introduce new functionality, document it. You can run documentation with `pnpm run docs` command.

### Changesets
- [x] Changes in changelog are generated from PR name. Please, make sure that it explains your changes in an understandable manner. Please, prefix changeset messages with `feat:`, `fix:`, `perf:`, `docs:`, or `chore:`.
