### PR TITLE
fix(browser): type aria snapshot matchers as R (fix #11200)

### DIFF
--- a/packages/browser/jest-dom.d.ts
+++ b/packages/browser/jest-dom.d.ts
@@ -771,7 +771,7 @@ export interface TestingLibraryMatchers<R extends void | Promise<void>, T = unkn
    * @see https://vitest.dev/guide/browser/aria-snapshots
    * @see https://vitest.dev/api/expect#tomatchariasnapshot
    */
-  toMatchAriaSnapshot: () => void
+  toMatchAriaSnapshot: () => R
   /**
    * @experimental
    * @description
@@ -802,5 +802,5 @@ export interface TestingLibraryMatchers<R extends void | Promise<void>, T = unkn
    * @see https://vitest.dev/guide/browser/aria-snapshots
    * @see https://vitest.dev/api/expect#tomatchariaInlinesnapshot
    */
-  toMatchAriaInlineSnapshot: (inlineSnapshot?: string) => void
+  toMatchAriaInlineSnapshot: (inlineSnapshot?: string) => R
 }


### PR DESCRIPTION
Fixes #11200.

5.0 replaced the `Promisify<Assertion<T>>` wrapper with a per-matcher `R` return type, but two ARIA snapshot matchers in `packages/browser/jest-dom.d.ts` were missed and are still typed `void`:

- `toMatchAriaSnapshot`
- `toMatchAriaInlineSnapshot`

As a result, the awaited form the docs recommend (`await expect.element(...).toMatchAriaSnapshot()`) trips `@typescript-eslint/await-thenable` and `@typescript-eslint/no-confusing-void-expression` on otherwise green tests. Runtime is unaffected — the matchers do return promises.

Both now return `R` like the other matchers in the interface.

Verified with the repro from the issue: local `tsc --noEmit` reports `TS2322: Type 'void' is not assignable to type 'Promise<void>'.` for both matchers before the change and passes cleanly after.

---

AI disclosure: code prepared with Codex (AI) and reviewed/approved by a human contributor before opening.
