### PR TITLE
docs: reuse button styles in migration guide

### DIFF
--- a/docs/.vitepress/components/ChangelogButton.vue
+++ b/docs/.vitepress/components/ChangelogButton.vue
@@ -7,7 +7,7 @@ defineProps<{
 </script>
 
 <template>
-  <a :href="href" class="changelog-button" target="_blank" rel="noopener noreferrer">
+  <a :href="href" class="button" target="_blank" rel="noopener noreferrer">
     <Icon icon="carbon:document" aria-hidden="true" />
     <span>Changelog</span>
     <Icon icon="carbon:arrow-up-right" class="external-icon" aria-hidden="true" />
@@ -15,42 +15,8 @@ defineProps<{
 </template>
 
 <style scoped>
-.changelog-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 0.5rem;
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-1);
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1.25rem;
-  text-decoration: none;
-  transition: background-color 150ms, border-color 150ms, transform 150ms;
-}
-
-.changelog-button:hover {
-  border-color: color-mix(in srgb, var(--color-brand) 55%, transparent);
-  background: color-mix(in srgb, var(--color-brand) 8%, var(--vp-c-bg-soft));
-  color: var(--vp-c-text-1);
-  transform: translateY(-1px);
-}
-
-.changelog-button:focus-visible {
-  outline: 2px solid var(--color-brand);
-  outline-offset: 3px;
-}
-
-.changelog-button svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.changelog-button .external-icon {
+.external-icon {
   width: 0.75rem;
   height: 0.75rem;
-  color: var(--vp-c-text-2);
 }
 </style>

--- a/docs/.vitepress/components/CopyPrompt.vue
+++ b/docs/.vitepress/components/CopyPrompt.vue
@@ -21,7 +21,7 @@ async function copyPrompt() {
 </script>
 
 <template>
-  <button type="button" class="button button--primary" @click="copyPrompt">
+  <button type="button" class="button button--brand" @click="copyPrompt">
     <Icon :icon="state === 'copied' ? 'carbon:checkmark' : 'carbon:copy'" aria-hidden="true" />
     <span>{{ label }}</span>
   </button>

--- a/docs/.vitepress/components/CopyPrompt.vue
+++ b/docs/.vitepress/components/CopyPrompt.vue
@@ -21,7 +21,7 @@ async function copyPrompt() {
 </script>
 
 <template>
-  <button type="button" class="copy-prompt" @click="copyPrompt">
+  <button type="button" class="button button--primary" @click="copyPrompt">
     <Icon :icon="state === 'copied' ? 'carbon:checkmark' : 'carbon:copy'" aria-hidden="true" />
     <span>{{ label }}</span>
   </button>
@@ -29,37 +29,3 @@ async function copyPrompt() {
     {{ state === 'copied' ? 'Prompt copied to clipboard.' : state === 'error' ? 'Could not copy prompt.' : '' }}
   </span>
 </template>
-
-<style scoped>
-.copy-prompt {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
-  border: 1px solid color-mix(in srgb, var(--color-brand) 45%, transparent);
-  border-radius: 0.5rem;
-  background: color-mix(in srgb, var(--color-brand) 10%, transparent);
-  color: var(--vp-c-text-1);
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1.25rem;
-  cursor: pointer;
-  transition: background-color 150ms, border-color 150ms, transform 150ms;
-}
-
-.copy-prompt:hover {
-  border-color: var(--color-brand);
-  background: color-mix(in srgb, var(--color-brand) 16%, transparent);
-  transform: translateY(-1px);
-}
-
-.copy-prompt:focus-visible {
-  outline: 2px solid var(--color-brand);
-  outline-offset: 3px;
-}
-
-.copy-prompt svg {
-  width: 1rem;
-  height: 1rem;
-}
-</style>

--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -39,6 +39,13 @@
   margin: 1rem 0 0.5rem;
 }
 
+.vp-doc a.button,
+.vp-doc a.button:hover {
+  color: revert-layer;
+  text-decoration: none;
+  transition: revert-layer;
+}
+
 /* credit goes to https://dylanatsmith.com/wrote/styling-the-kbd-element */
 html:not(.dark) .VPContent kbd {
   --kbd-color-background: #f7f7f7;

--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -46,6 +46,27 @@
   transition: revert-layer;
 }
 
+.button.button--brand {
+  --button-brand-outline: color-mix(in srgb, var(--color-brand) 40%, transparent);
+  background-color: var(--vp-c-tip-soft);
+  outline-color: var(--button-brand-outline);
+}
+
+.button.button--brand:hover {
+  background-color: color-mix(in srgb, var(--color-brand) 24%, transparent);
+}
+
+.dark .button.button--brand:hover {
+  color: var(--color-white);
+}
+
+/* the base reset removes the outline on a clicked button, but .button draws its border with it */
+@layer base {
+  button.button--brand:focus:not(:focus-visible) {
+    outline: 1px solid var(--button-brand-outline) !important;
+  }
+}
+
 /* credit goes to https://dylanatsmith.com/wrote/styling-the-kbd-element */
 html:not(.dark) .VPContent kbd {
   --kbd-color-background: #f7f7f7;


### PR DESCRIPTION
We already have button styles, this aligns them. The question is if we should use the one with the border or just a regular one:

`main`
<img width="489" height="189" alt="Screenshot 2026-09-09 at 12 57 36" src="https://github.com/user-attachments/assets/afc2dd59-0467-4ede-a772-d58877c207a6" />

this branch:
<img width="429" height="173" alt="Screenshot 2026-09-09 at 12 57 41" src="https://github.com/user-attachments/assets/35acf81b-fbe1-415d-9dc3-c454b965a5c5" />
